### PR TITLE
Feat/frontend/9 internationalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **Access the platform:**
 
 - **dev:** [https://co2-calculator-dev.epfl.ch/](https://co2-calculator-dev.epfl.ch/)
+- **stage:** [https://co2-calculator-stage.epfl.ch/](https://co2-calculator-stage.epfl.ch/)]
 - **pre-production:** [https://co2-calculator.epfl.ch/](https://co2-calculator.epfl.ch/)
 
 > **Note:** Pre-production serves internal releases (v0.x.x) until final v1.0.0 public release. Production environment will activate with v1.0.0.
@@ -85,6 +86,53 @@ make build         # Build projects
 ### Tech Stack
 
 See [TECH STACK](./TECH_SPEC.md) for detailed technical specifications.
+
+## Localization (i18n)
+
+The application supports multiple languages through internationalization (i18n) files located in the frontend.
+
+### Translation Files
+
+Translation strings are stored as TypeScript objects in:
+
+- **English (US):** `frontend/src/i18n/en-US/index.ts`
+- **French (CH):** `frontend/src/i18n/fr-CH/index.ts`
+
+### Modifying Translations
+
+To add or update translation strings:
+
+1. **Add/update keys in both locale files** - Ensure translation keys are identical across all locales:
+
+```typescript
+// frontend/src/i18n/en-US/index.ts
+export default {
+  my_new_key: "My English text",
+  // ...
+};
+
+// frontend/src/i18n/fr-CH/index.ts
+export default {
+  my_new_key: "Mon texte en français",
+  // ...
+};
+```
+
+2. **Use descriptive key names** - Follow the pattern `component_element_purpose` (e.g., `login_button_submit`)
+3. **Never remove keys still in use** - Check component usage before removing any translation key
+4. **Test locally** - Run `cd frontend && make dev` to verify translations display correctly
+
+### Contributing Translations
+
+All translation changes must be submitted via GitHub pull request:
+
+1. Create a feature branch from `main`
+2. Make your changes to the translation files
+3. Commit with a conventional commit message (e.g., `feat(i18n): add dashboard translations`)
+4. Push your branch and open a pull request
+5. Ensure CI checks pass (run `make ci` locally first)
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines and code of conduct.
 
 ## Contributing
 


### PR DESCRIPTION
## What does this change?

Add i18n section to README.md

## Why is this needed?

Contributors will need to propose changes themself

## Success Criteria fullfiled

- [x] Documentation clearly describe the work of internationalisation
- [x] Key features are functional (cf #49 )
- [x] English and French bases are functional (cf #49) 

## Type of change

- 📝 Documentation update

## Related issues

- Closes #9
- Related to #9
