### PR TITLE
Ci test/deploy mkdocs via artifact

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -3,13 +3,24 @@ name: deploy-mkdocs
 on:
   push:
     branches:
-      - master 
       - main
       - 'ci-test/**'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,9 +38,22 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
-      - name: Configure Git Credentials
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-      - name: Build Docs
-        run: uv run mkdocs gh-deploy --force
+      - name: Build MkDocs site
+        run: uv run mkdocs build --strict --site-dir site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What does this change?

Instead of pushing to gh-pages branch which pollute the git, we use gh-pages artifacts

## Type of change

- [x] 🔧 Configuration change

## How to test this

<!-- How can reviewers verify this works? -->

- [x] I've tested this change locally, and on the ci
- [ ] Steps to test: merge to main, since we only run docs on main

## Related issues

No issue
