### PR TITLE
feat: added test login entry point and role for development #114

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run backend tests
-        run: make test
+      - name: Run backend tests (with coverage)
+        run: make test-cov-xml
 
       - name: Upload coverage reports
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: EPFL-ENAC/co2-calculator
           flags: backend
           directory: ./backend
           fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,18 @@ clean: ## Remove all build artifacts and dependencies
 	@echo "✅ Clean complete!"
 
 # =============================================================================
+# Development - Database Services
+# =============================================================================
+
+.PHONY: run-db
+run-db:
+	docker compose up -d --pull=always postgres
+
+.PHONY: stop-db
+stop-db:
+	docker compose down
+
+# =============================================================================
 # CI/CD - Validation Commands
 # =============================================================================
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ make build         # Build projects
 
 ## 📊 Project Information
 
+### Code Quality
+
+[![Codecov](https://codecov.io/gh/EPFL-ENAC/epfl-calculator-co2/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/EPFL-ENAC/epfl-calculator-co2)
+
 ### Security & Status
 
 [![Security](https://img.shields.io/github/actions/workflow/status/EPFL-ENAC/co2-calculator/security.yml?branch=main&label=security&logo=github&style=flat-square)](https://github.com/EPFL-ENAC/co2-calculator/actions/workflows/security.yml)

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -85,16 +85,16 @@ type-check: ## Run type checking with mypy
 .PHONY: test
 test: ## Run tests
 	@set -e; \
-	$(PYTEST) tests/ -v
+	$(PYTEST) tests/ -v --cov=app --cov-report=term-missing --cov-fail-under=60
 
 .PHONY: test-cov
 test-cov: ## Run tests with coverage
 	@set -e; \
-	$(PYTEST) tests/ --cov=app --cov-report=html --cov-report=term-missing
+	$(PYTEST) tests/ --cov=app --cov-report=html --cov-report=term-missing  --cov-fail-under=60
 
 .PHONY: test-cov-xml
 test-cov-xml: ## Run tests with coverage and output XML report
-	$(PYTEST) tests/ --cov=app --cov-report=xml --cov-report=term-missing
+	$(PYTEST) tests/ --cov=app --cov-report=xml --cov-report=term-missing  --cov-fail-under=60
 
 .PHONY: dev
 dev: install ## Start backend development server

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -92,6 +92,10 @@ test-cov: ## Run tests with coverage
 	@set -e; \
 	$(PYTEST) tests/ --cov=app --cov-report=html --cov-report=term-missing
 
+.PHONY: test-cov-xml
+test-cov-xml: ## Run tests with coverage and output XML report
+	$(PYTEST) tests/ --cov=app --cov-report=xml --cov-report=term-missing
+
 .PHONY: dev
 dev: install ## Start backend development server
 	@if [ ! -f .env ]; then \

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -104,7 +104,8 @@ def login_test(role: str = "co2.user.std"):
         )
 
     # Create a fake user ID and email based on role
-    user_id = f"testuser_{role}"
+    sanitized_role = role.replace('\r\n', '').replace('\n', '')
+    user_id = f"testuser_{sanitized_role}"
     email = "testuser@example.com"
     sciper = 999999
 
@@ -113,7 +114,7 @@ def login_test(role: str = "co2.user.std"):
         extra={
             "email": email,
             "has_sciper": bool(sciper),
-            "role": role,
+            "role": sanitized_role,
         },
     )
 

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -104,7 +104,7 @@ def login_test(role: str = "co2.user.std"):
         )
 
     # Create a fake user ID and email based on role
-    sanitized_role = role.replace('\r\n', '').replace('\n', '')
+    sanitized_role = role.replace("\r\n", "").replace("\n", "")
     user_id = f"testuser_{sanitized_role}"
     email = "testuser@example.com"
     sciper = 999999

--- a/backend/tests/integration/core/test_role_provider_config.py
+++ b/backend/tests/integration/core/test_role_provider_config.py
@@ -1,0 +1,69 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from app.core.role_provider import get_role_provider
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestRoleProviderIntegration:
+    """Integration tests for role provider system."""
+
+    @pytest.mark.asyncio
+    async def test_default_provider_full_workflow(self):
+        """Test complete workflow with DefaultRoleProvider."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_PLUGIN = "default"
+
+            provider = get_role_provider()
+            userinfo = {
+                "email": "user@epfl.ch",
+                "roles": [
+                    "co2.user.std@unit:100",
+                    "co2.user.principal@unit:200",
+                    "co2.backoffice.admin@global",
+                ],
+            }
+
+            roles = await provider.get_roles(userinfo, 123456)
+
+            assert len(roles) == 3
+            assert all("role" in role and "on" in role for role in roles)
+
+    @pytest.mark.asyncio
+    async def test_accred_provider_full_workflow(self):
+        """Test complete workflow with AccredRoleProvider."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_PLUGIN = "accred"
+            mock_settings.ACCRED_API_URL = "https://api-test.epfl.ch"
+            mock_settings.ACCRED_API_USERNAME = "user"
+            mock_settings.ACCRED_API_KEY = "key"
+
+            mock_response = {
+                "authorizations": [
+                    {
+                        "name": "co2.user.std",
+                        "state": "active",
+                        "accredunitid": "100",
+                    }
+                ]
+            }
+
+            provider = get_role_provider()
+
+            with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response_obj = Mock()
+                mock_response_obj.json.return_value = mock_response
+                mock_client.__aenter__.return_value = mock_client
+                mock_client.get.return_value = mock_response_obj
+
+                mock_client_class.return_value = mock_client
+
+                roles = await provider.get_roles({}, 123456)
+
+            assert len(roles) == 1
+            assert roles[0]["role"] == "co2.user.std"

--- a/backend/tests/unit/core/test_role_provider.py
+++ b/backend/tests/unit/core/test_role_provider.py
@@ -1,0 +1,565 @@
+"""Unit and integration tests for role provider plugin system.
+
+Tests cover both DefaultRoleProvider and AccredRoleProvider with 100% coverage.
+"""
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from app.core.role_provider import (
+    AccredRoleProvider,
+    DefaultRoleProvider,
+    get_role_provider,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_settings():
+    """Fixture providing mock settings."""
+    settings = Mock()
+    settings.ACCRED_API_URL = "https://api.epfl.ch"
+    settings.ACCRED_API_USERNAME = "test_user"
+    settings.ACCRED_API_KEY = "test_key"
+    settings.ROLE_PROVIDER_PLUGIN = "default"
+    return settings
+
+
+@pytest.fixture
+def mock_logger():
+    """Fixture providing mock logger."""
+    return Mock()
+
+
+@pytest.fixture
+def sample_userinfo() -> Dict[str, Any]:
+    """Fixture providing sample userinfo dict."""
+    return {
+        "email": "user@epfl.ch",
+        "sciper": 352707,
+        "roles": [
+            "co2.user.std@unit:12345",
+            "co2.user.principal@unit:12345",
+            "co2.backoffice.admin@global",
+        ],
+    }
+
+
+@pytest.fixture
+def sample_sciper() -> int:
+    """Fixture providing sample SCIPER number."""
+    return 352707
+
+
+# ============================================================================
+# DefaultRoleProvider Tests
+# ============================================================================
+
+
+class TestDefaultRoleProvider:
+    """Test suite for DefaultRoleProvider."""
+
+    @pytest.mark.asyncio
+    async def test_parse_roles_with_unit_scope(self, sample_userinfo, sample_sciper):
+        """Test parsing roles with unit scope."""
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(sample_userinfo, sample_sciper)
+
+        assert len(roles) == 3
+        assert roles[0] == {"role": "co2.user.std", "on": {"unit": "12345"}}
+        assert roles[1] == {"role": "co2.user.principal", "on": {"unit": "12345"}}
+        assert roles[2] == {"role": "co2.backoffice.admin", "on": "global"}
+
+    @pytest.mark.asyncio
+    async def test_parse_roles_with_global_scope(self, sample_sciper):
+        """Test parsing roles with global scope."""
+        userinfo = {
+            "email": "admin@epfl.ch",
+            "roles": ["co2.backoffice.admin@global"],
+        }
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {"role": "co2.backoffice.admin", "on": "global"}
+
+    @pytest.mark.asyncio
+    async def test_parse_roles_no_roles_in_jwt(self, sample_sciper):
+        """Test handling of missing roles in JWT."""
+        userinfo = {"email": "user@epfl.ch"}
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert roles == []
+
+    @pytest.mark.asyncio
+    async def test_parse_roles_empty_roles_list(self, sample_sciper):
+        """Test handling of empty roles list."""
+        userinfo = {"email": "user@epfl.ch", "roles": []}
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert roles == []
+
+    @pytest.mark.asyncio
+    async def test_skip_non_string_role(self, sample_sciper):
+        """Test that non-string roles are skipped."""
+        userinfo = {
+            "email": "user@epfl.ch",
+            "roles": [
+                123,  # Invalid: not a string
+                "co2.user.std@unit:12345",
+            ],
+        }
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {"role": "co2.user.std", "on": {"unit": "12345"}}
+
+    @pytest.mark.asyncio
+    async def test_skip_role_without_scope(self, sample_sciper):
+        """Test that roles without @ scope are skipped."""
+        userinfo = {
+            "email": "user@epfl.ch",
+            "roles": [
+                "co2.user.std",  # Invalid: no @
+                "co2.user.std@unit:12345",
+            ],
+        }
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {"role": "co2.user.std", "on": {"unit": "12345"}}
+
+    @pytest.mark.asyncio
+    async def test_skip_role_with_invalid_scope_format(self, sample_sciper):
+        """Test that roles with invalid scope format are skipped."""
+        userinfo = {
+            "email": "user@epfl.ch",
+            "roles": [
+                "co2.user.std@invalid",  # Invalid: no colon in scope
+                "co2.user.std@unit:12345",
+            ],
+        }
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {"role": "co2.user.std", "on": {"unit": "12345"}}
+
+    @pytest.mark.asyncio
+    async def test_parse_role_with_whitespace(self, sample_sciper):
+        """Test that whitespace in roles is trimmed."""
+        userinfo = {
+            "email": "user@epfl.ch",
+            "roles": [" co2.user.std @ unit : 12345 "],
+        }
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {"role": "co2.user.std", "on": {"unit": "12345"}}
+
+    @pytest.mark.asyncio
+    async def test_parse_multiple_roles_with_different_units(self, sample_sciper):
+        """Test parsing multiple roles with different unit scopes."""
+        userinfo = {
+            "email": "user@epfl.ch",
+            "roles": [
+                "co2.user.std@unit:12345",
+                "co2.user.principal@unit:67890",
+                "co2.user.secondary@unit:11111",
+            ],
+        }
+        provider = DefaultRoleProvider()
+        roles = await provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 3
+        assert roles[0]["on"] == {"unit": "12345"}
+        assert roles[1]["on"] == {"unit": "67890"}
+        assert roles[2]["on"] == {"unit": "11111"}
+
+
+# ============================================================================
+# AccredRoleProvider Tests
+# ============================================================================
+
+
+class TestAccredRoleProvider:
+    """Test suite for AccredRoleProvider."""
+
+    @pytest.fixture
+    def accred_provider(self):
+        """Fixture providing an AccredRoleProvider instance."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ACCRED_API_URL = "https://api.epfl.ch"
+            mock_settings.ACCRED_API_USERNAME = "test_user"
+            mock_settings.ACCRED_API_KEY = "test_key"
+            provider = AccredRoleProvider()
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_accred_fetch_roles_with_unit_authorizations(
+        self, accred_provider, sample_sciper
+    ):
+        """Test fetching roles from Accred API with unit authorizations."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": "co2.user.std",
+                    "state": "active",
+                    "accredunitid": "12345",
+                },
+                {
+                    "name": "co2.user.principal",
+                    "state": "active",
+                    "accredunitid": "67890",
+                },
+            ]
+        }
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 2
+        assert roles[0] == {"role": "co2.user.std", "on": {"unit": "12345"}}
+        assert roles[1] == {"role": "co2.user.principal", "on": {"unit": "67890"}}
+
+    @pytest.mark.asyncio
+    async def test_accred_fetch_roles_with_global_admin(
+        self, accred_provider, sample_sciper
+    ):
+        """Test fetching global admin role from Accred API."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": "co2.backoffice.admin",
+                    "state": "active",
+                    "accredunitid": "12345",
+                }
+            ]
+        }
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {"role": "co2.backoffice.admin", "on": "global"}
+
+    @pytest.mark.asyncio
+    async def test_accred_fetch_roles_with_backoffice_std(
+        self, accred_provider, sample_sciper
+    ):
+        """Test fetching backoffice.std role with affiliation scope."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": "co2.backoffice.std",
+                    "state": "active",
+                    "accredunitid": "12345",
+                    "reason": {"resource": {"sortpath": "Engineering"}},
+                }
+            ]
+        }
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0] == {
+            "role": "co2.backoffice.std",
+            "on": {"affiliation": "Engineering"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_accred_no_authorizations_found(self, accred_provider, sample_sciper):
+        """Test handling of empty authorizations list."""
+        mock_response = {"authorizations": []}
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert roles == []
+
+    @pytest.mark.asyncio
+    async def test_accred_skip_non_co2_authorization(
+        self, accred_provider, sample_sciper
+    ):
+        """Test that non-co2 authorizations are skipped."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": "other.role",
+                    "state": "active",
+                    "accredunitid": "12345",
+                },
+                {
+                    "name": "co2.user.std",
+                    "state": "active",
+                    "accredunitid": "12345",
+                },
+            ]
+        }
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+        assert roles[0]["role"] == "co2.user.std"
+
+    @pytest.mark.asyncio
+    async def test_accred_skip_inactive_authorization(
+        self, accred_provider, sample_sciper
+    ):
+        """Test that inactive authorizations are skipped."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": "co2.user.std",
+                    "state": "inactive",
+                    "accredunitid": "12345",
+                },
+                {
+                    "name": "co2.user.std",
+                    "state": "active",
+                    "accredunitid": "12345",
+                },
+            ]
+        }
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+
+    @pytest.mark.asyncio
+    async def test_accred_skip_authorization_without_accredunitid(
+        self, accred_provider, sample_sciper
+    ):
+        """Test that authorizations without accredunitid are skipped."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": "co2.user.std",
+                    "state": "active",
+                },
+                {
+                    "name": "co2.user.std",
+                    "state": "active",
+                    "accredunitid": "12345",
+                },
+            ]
+        }
+
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert len(roles) == 1
+
+    @pytest.mark.asyncio
+    async def test_accred_http_status_error(self, accred_provider, sample_sciper):
+        """Test handling of HTTP status errors from Accred API."""
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.status_code = 401
+
+            error = httpx.HTTPStatusError(
+                "Unauthorized",
+                request=Mock(),
+                response=mock_response_obj,
+            )
+
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = error
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert roles == []
+
+    @pytest.mark.asyncio
+    async def test_accred_request_error(self, accred_provider, sample_sciper):
+        """Test handling of request errors from Accred API."""
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            error = httpx.RequestError("Connection error")
+
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = error
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert roles == []
+
+    @pytest.mark.asyncio
+    async def test_accred_unexpected_error(self, accred_provider, sample_sciper):
+        """Test handling of unexpected errors from Accred API."""
+        userinfo = {}
+
+        with patch("app.core.role_provider.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            error = ValueError("Unexpected error")
+
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = error
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles(userinfo, sample_sciper)
+
+        assert roles == []
+
+    def test_accred_missing_credentials(self):
+        """Test AccredRoleProvider initialization with missing credentials."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ACCRED_API_URL = None
+            mock_settings.ACCRED_API_USERNAME = "user"
+            mock_settings.ACCRED_API_KEY = "key"
+
+            provider = AccredRoleProvider()
+            assert provider.api_url is None
+
+    @pytest.mark.asyncio
+    async def test_accred_missing_credentials_get_roles(self):
+        """Test get_roles returns empty list when credentials are missing."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ACCRED_API_URL = None
+            mock_settings.ACCRED_API_USERNAME = "user"
+            mock_settings.ACCRED_API_KEY = "key"
+
+            provider = AccredRoleProvider()
+            roles = await provider.get_roles({}, 123456)
+
+        assert roles == []
+
+
+# ============================================================================
+# Factory Function Tests
+# ============================================================================
+
+
+class TestGetRoleProvider:
+    """Test suite for get_role_provider factory function."""
+
+    def test_get_default_role_provider(self):
+        """Test that DefaultRoleProvider is returned for 'default' type."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_PLUGIN = "default"
+
+            provider = get_role_provider()
+
+            assert isinstance(provider, DefaultRoleProvider)
+
+    def test_get_accred_role_provider(self):
+        """Test that AccredRoleProvider is returned for 'accred' type."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_PLUGIN = "accred"
+            mock_settings.ACCRED_API_URL = "https://api.epfl.ch"
+            mock_settings.ACCRED_API_USERNAME = "user"
+            mock_settings.ACCRED_API_KEY = "key"
+
+            provider = get_role_provider()
+
+            assert isinstance(provider, AccredRoleProvider)
+
+    def test_get_unknown_role_provider_fallback_to_default(self):
+        """Test that unknown provider type falls back to DefaultRoleProvider."""
+        with patch("app.core.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_PLUGIN = "unknown"
+
+            provider = get_role_provider()
+
+            assert isinstance(provider, DefaultRoleProvider)

--- a/backend/tests/unit/v1/test_unit_auth.py
+++ b/backend/tests/unit/v1/test_unit_auth.py
@@ -1,0 +1,254 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import app.api.v1.auth as auth_module
+from app.api.v1.auth import router as auth_router
+from app.main import app
+
+app.include_router(auth_router, prefix="/api/v1/auth")
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_login_redirect(monkeypatch):
+    mock_authorize_redirect = AsyncMock(return_value="redirected")
+    monkeypatch.setattr(
+        auth_module.oauth.co2_oauth_provider,
+        "authorize_redirect",
+        mock_authorize_redirect,
+    )
+    request = MagicMock()
+    request.url_for = lambda x: "http://test/callback"
+    request.headers = {}
+    result = await auth_module.login(request)
+    assert result == "redirected"
+    mock_authorize_redirect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_success(monkeypatch):
+    mock_token = {
+        "userinfo": {
+            "email": "test@example.com",
+            "uniqueid": "123456",
+        }
+    }
+    mock_authorize_access_token = AsyncMock(return_value=mock_token)
+    monkeypatch.setattr(
+        auth_module.oauth.co2_oauth_provider,
+        "authorize_access_token",
+        mock_authorize_access_token,
+    )
+    mock_role_provider = MagicMock()
+    mock_role_provider.get_roles = AsyncMock(return_value=["user"])
+    monkeypatch.setattr(auth_module, "get_role_provider", lambda: mock_role_provider)
+    mock_upsert_user = AsyncMock(
+        return_value=MagicMock(
+            id="1", email="test@example.com", sciper=123456, roles=["user"]
+        )
+    )
+    monkeypatch.setattr(auth_module, "upsert_user", mock_upsert_user)
+    db = MagicMock()
+    request = MagicMock()
+    request.url_for = lambda x: "http://test/callback"
+    response = await auth_module.auth_callback(request, db)
+    assert isinstance(response, auth_module.RedirectResponse)
+    assert response.status_code == status.HTTP_302_FOUND
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_no_userinfo(monkeypatch):
+    mock_token = {"userinfo": None}
+    monkeypatch.setattr(
+        auth_module.oauth.co2_oauth_provider,
+        "authorize_access_token",
+        AsyncMock(return_value=mock_token),
+    )
+    db = MagicMock()
+    request = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.auth_callback(request, db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["email", "uniqueid"])
+async def test_auth_callback_missing_fields(monkeypatch, field):
+    userinfo = {"email": None, "uniqueid": None}
+    if field == "email":
+        userinfo["uniqueid"] = "123456"
+    else:
+        userinfo["email"] = "test@example.com"
+    mock_token = {"userinfo": userinfo}
+    monkeypatch.setattr(
+        auth_module.oauth.co2_oauth_provider,
+        "authorize_access_token",
+        AsyncMock(return_value=mock_token),
+    )
+    db = MagicMock()
+    request = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.auth_callback(request, db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_exception(monkeypatch):
+    monkeypatch.setattr(
+        auth_module.oauth.co2_oauth_provider,
+        "authorize_access_token",
+        AsyncMock(side_effect=Exception("fail")),
+    )
+    db = MagicMock()
+    request = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.auth_callback(request, db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_get_me_success(monkeypatch):
+    mock_decode_jwt = MagicMock(return_value={"sub": "1"})
+    monkeypatch.setattr(auth_module, "decode_jwt", mock_decode_jwt)
+    mock_user = MagicMock(
+        id="1", is_active=True, email="test@example.com", sciper=123456, roles=["user"]
+    )
+    mock_get_user_by_id = AsyncMock(return_value=mock_user)
+    monkeypatch.setattr(auth_module, "get_user_by_id", mock_get_user_by_id)
+    mock_role_provider = MagicMock()
+    mock_role_provider.get_roles = AsyncMock(return_value=["user"])
+    monkeypatch.setattr(auth_module, "get_role_provider", lambda: mock_role_provider)
+    db = MagicMock()
+    result = await auth_module.get_me(auth_token="token", db=db)
+    assert result == mock_user
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [None, {"sub": None}])
+async def test_get_me_invalid_token(monkeypatch, payload):
+    monkeypatch.setattr(auth_module, "decode_jwt", MagicMock(return_value=payload))
+    db = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.get_me(auth_token="token", db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_attr", ["is_active", "email", "sciper"])
+async def test_get_me_user_missing(monkeypatch, user_attr):
+    monkeypatch.setattr(auth_module, "decode_jwt", MagicMock(return_value={"sub": "1"}))
+    mock_user = MagicMock(
+        id="1", is_active=True, email="test@example.com", sciper=123456, roles=["user"]
+    )
+    setattr(mock_user, user_attr, False if user_attr == "is_active" else None)
+    mock_get_user_by_id = AsyncMock(return_value=mock_user)
+    monkeypatch.setattr(auth_module, "get_user_by_id", mock_get_user_by_id)
+    db = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.get_me(auth_token="token", db=db)
+    assert exc.value.status_code in [
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_me_no_token():
+    db = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.get_me(auth_token=None, db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_get_me_exception(monkeypatch):
+    monkeypatch.setattr(
+        auth_module, "decode_jwt", MagicMock(side_effect=Exception("fail"))
+    )
+    db = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.get_me(auth_token="token", db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_success(monkeypatch):
+    monkeypatch.setattr(
+        auth_module,
+        "decode_jwt",
+        MagicMock(return_value={"type": "refresh", "sub": "1"}),
+    )
+    mock_user = MagicMock(
+        id="1", is_active=True, email="test@example.com", sciper=123456
+    )
+    monkeypatch.setattr(
+        auth_module, "get_user_by_id", AsyncMock(return_value=mock_user)
+    )
+    monkeypatch.setattr(auth_module, "_set_auth_cookies", MagicMock())
+    db = MagicMock()
+    response = MagicMock()
+    result = await auth_module.refresh_token(
+        refresh_token="token", response=response, db=db
+    )
+    assert result["message"] == "Token refreshed successfully"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [None, {"type": "access"}, {"sub": None}])
+async def test_refresh_token_invalid_payload(monkeypatch, payload):
+    monkeypatch.setattr(auth_module, "decode_jwt", MagicMock(return_value=payload))
+    db = MagicMock()
+    response = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.refresh_token(refresh_token="token", response=response, db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_user_missing(monkeypatch):
+    monkeypatch.setattr(
+        auth_module,
+        "decode_jwt",
+        MagicMock(return_value={"type": "refresh", "sub": "1"}),
+    )
+    monkeypatch.setattr(auth_module, "get_user_by_id", AsyncMock(return_value=None))
+    db = MagicMock()
+    response = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.refresh_token(refresh_token="token", response=response, db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_no_token():
+    db = MagicMock()
+    response = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.refresh_token(refresh_token=None, response=response, db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_exception(monkeypatch):
+    monkeypatch.setattr(
+        auth_module, "decode_jwt", MagicMock(side_effect=Exception("fail"))
+    )
+    db = MagicMock()
+    response = MagicMock()
+    with pytest.raises(auth_module.HTTPException) as exc:
+        await auth_module.refresh_token(refresh_token="token", response=response, db=db)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_logout(client):
+    response = client.post("/api/v1/auth/logout")
+    assert response.status_code == 200
+    assert response.json()["message"] == "Logged out successfully"

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -2,6 +2,7 @@ import ky from 'ky';
 
 export const API_BASE_URL = '/api/v1/';
 export const API_LOGIN_URL = '/api/v1/auth/login';
+export const API_LOGIN_TEST_URL = '/api/v1/auth/login-test';
 export const API_ME_URL = 'auth/me';
 export const API_REFRESH_URL = 'auth/refresh';
 export const API_LOGOUT_URL = 'auth/logout';

--- a/frontend/src/components/organisms/login/LoginCard.vue
+++ b/frontend/src/components/organisms/login/LoginCard.vue
@@ -8,12 +8,32 @@ const authStore = useAuthStore();
 const { loading } = storeToRefs(authStore);
 const { t } = useI18n();
 
+interface Props {
+  mode?: 'test' | 'prod';
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  mode: 'prod',
+});
+
 const form = ref(null);
+const role = ref('co2.user.std');
+
+const roleOptions = computed(() => [
+  'co2.user.std',
+  'co2.backoffice.admin',
+  'co2.backoffice.std',
+]);
+const isTestMode = computed(() => props.mode === 'test');
 
 function validate() {
   form.value.validate().then((success) => {
     if (success) {
-      authStore.login();
+      if (props.mode === 'test') {
+        authStore.login_test(role.value);
+      } else {
+        authStore.login();
+      }
     } else {
       console.log('Form is invalid');
     }
@@ -43,6 +63,18 @@ const buttonLabel = computed(() => {
           width="125px"
         />
         <h2 class="text-weight-medium">{{ $t('login_title') }}</h2>
+      </div>
+
+      <div v-if="isTestMode">
+        <q-select
+          v-model="role"
+          filled
+          :options="roleOptions"
+          :label="$t('login_test_role_label')"
+          :disable="loading"
+          dense
+          class="full-width"
+        />
       </div>
 
       <!-- submit button -->

--- a/frontend/src/i18n/en-US/index.ts
+++ b/frontend/src/i18n/en-US/index.ts
@@ -7,6 +7,7 @@ export default {
   login_title: 'CO₂ Calculator',
   login_button_submit: 'Login',
   login_button_loading: 'Connecting...',
+  login_test_role_label: 'Test Role',
   calculator_title: 'CO₂ Calculator',
 
   home: 'Home',

--- a/frontend/src/i18n/fr-CH/index.ts
+++ b/frontend/src/i18n/fr-CH/index.ts
@@ -7,6 +7,7 @@ export default {
   login_title: 'CO₂ Calculator',
   login_button_submit: 'Log in',
   login_button_loading: 'Logging in...',
+  login_test_role_label: 'Rôle de test',
   calculator_title: 'CO₂ Calculator',
   home: 'Home',
   [MODULES.MyLab]: 'My Laboratory',

--- a/frontend/src/pages/app/LoginTestPage.vue
+++ b/frontend/src/pages/app/LoginTestPage.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import LoginCard from 'src/components/organisms/login/LoginCard.vue';
+</script>
+
+<template>
+  <q-page class="login-page row items-center justify-evenly">
+    <login-card mode="test"></login-card>
+  </q-page>
+</template>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -12,6 +12,7 @@ const SIMULATION_ID_PATTERN = '[^/]+';
 
 // Route name constants
 export const LOGIN_ROUTE_NAME = 'login';
+export const LOGIN_TEST_ROUTE_NAME = 'login-test';
 export const HOME_ROUTE_NAME = 'home';
 export const WORKSPACE_SETUP_ROUTE_NAME = 'workspace-setup';
 export const WORKSPACE_ROUTE_NAME = 'workspace';
@@ -57,6 +58,15 @@ const routes: RouteRecordRaw[] = [
             component: () => import('pages/app/LoginPage.vue'),
             meta: {
               note: 'User authentication - Login page',
+              breadcrumb: false,
+            },
+          },
+          {
+            path: 'login-test',
+            name: LOGIN_TEST_ROUTE_NAME,
+            component: () => import('pages/app/LoginTestPage.vue'),
+            meta: {
+              note: 'Test User authentication - Login page',
               breadcrumb: false,
             },
           },

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import { api, API_LOGIN_URL, API_LOGOUT_URL } from 'src/api/http';
+import {
+  api,
+  API_LOGIN_URL,
+  API_LOGOUT_URL,
+  API_LOGIN_TEST_URL,
+} from 'src/api/http';
 import { Router } from 'vue-router';
 import { computed } from 'vue';
 
@@ -29,6 +34,10 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  function login_test(role: string) {
+    window.location.replace(`${API_LOGIN_TEST_URL}?role=${role}`);
+  }
+
   function login() {
     window.location.replace(API_LOGIN_URL);
   }
@@ -55,6 +64,7 @@ export const useAuthStore = defineStore('auth', () => {
     loading,
     getUser,
     login,
+    login_test,
     logout,
     isAuthenticated,
   };

--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -58,6 +58,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "co2-calculator.databaseSecretName" . }}
                   key: {{ .Values.database.existingSecret.keys.user }}
+          resources:
+            {{- toYaml .Values.backend.initContainers.waitForPostgres.resources | nindent 12 }}
         {{- end }}
       containers:
         - name: backend

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -112,6 +112,16 @@ backend:
       accredApiUsernameKey: ACCRED_API_USERNAME # Key in the existing secret for Accred API username
       accredApiUrlKey: ACCRED_API_URL  # Key in the existing secret for Accred API URL
 
+  initContainers:
+    waitForPostgres:
+      resources: # Resources for the wait-for-postgres init container
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+
   migrations:
     enabled: true  # Run database migrations via init container
 


### PR DESCRIPTION
## What does this change?

API changes:

* `/v1/auth/login-test` endpoint with role parameter, make a JWT token for `testuser`
* `/v1/auth/me` makes the roles according to the testuser from the JWT token

Frontend:

* `login-test` page added

## Why is this needed?

Allow testing with fake test users, providing role. Only when `DEBUG` is True.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## How to test this

1. Go to http://localhost:9000/en/login-test
2. Select role
3. Login

=> You are identified as testuser with selected role.

- [x] I've tested this change locally
- [ ] Steps to test: (describe if needed)

## Screenshots (if applicable)

<img width="513" height="329" alt="image" src="https://github.com/user-attachments/assets/05e2e338-5914-4278-a7d0-148d9fe0b217" />


## Related issues

- Closes #114
- Related to #43
