### PR TITLE
feat(frontend): add module threshold configuration

### DIFF
--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { MODULE_CARDS } from 'src/constant/moduleCards';
+import {
+  MODULES_THRESHOLD_TYPES,
+  type ModuleThreshold,
+} from 'src/constant/modules';
+import ModuleThresholdInput from 'src/components/organisms/data-management/ModuleThresholdInput.vue';
+
+const props = defineProps<{
+  modelValue: ModuleThreshold;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: ModuleThreshold): void;
+}>();
+
+const selected = computed({
+  get: () => props.modelValue,
+  set: (val: ModuleThreshold) => {
+    emit('update:modelValue', val);
+  },
+});
+const card = computed(() =>
+  MODULE_CARDS.find((c) => c.module === selected.value.module),
+);
+const expanded = ref(false);
+</script>
+
+<template>
+  <q-card v-if="card" flat bordered class="q-pa-none">
+    <q-expansion-item v-model="expanded" expand-separator>
+      <template #header>
+        <q-item-section avatar>
+          <q-icon :name="card.icon" color="accent" />
+        </q-item-section>
+        <q-item-section class="text-h4 text-weight-medium">
+          {{ $t(card.module) }}
+        </q-item-section>
+        <q-item-section v-if="!expanded" class="text-caption text-grey-6">
+          {{
+            $t(`threshold_${selected.threshold.type}_summary`, {
+              value: selected.threshold.value ?? '??',
+            })
+          }}
+        </q-item-section>
+      </template>
+      <q-card>
+        <q-card-section>
+          <div class="row">
+            <div
+              v-for="type in MODULES_THRESHOLD_TYPES"
+              :key="type"
+              class="col-xs-12 col-lg-4 q-pa-md"
+            >
+              <module-threshold-input v-model="selected" :type="type" />
+            </div>
+          </div>
+        </q-card-section>
+      </q-card>
+    </q-expansion-item>
+  </q-card>
+</template>

--- a/frontend/src/components/organisms/data-management/ModuleThresholdInput.vue
+++ b/frontend/src/components/organisms/data-management/ModuleThresholdInput.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ModuleThreshold, ThresholdType } from 'src/constant/modules';
+
+const props = defineProps<{
+  modelValue: ModuleThreshold;
+  type: ThresholdType;
+}>();
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: ModuleThreshold): void;
+}>();
+
+const selected = computed({
+  get: () => props.modelValue,
+  set: (val: ModuleThreshold) => {
+    emit('update:modelValue', val);
+  },
+});
+
+const isModuleType = computed(
+  () => selected.value.threshold.type === props.type,
+);
+
+function onSelect() {
+  if (isModuleType.value) {
+    return;
+  }
+  selected.value.threshold.type = props.type;
+  onTypeChange();
+}
+
+function onTypeChange() {
+  if (props.type === 'median') {
+    selected.value.threshold.value = undefined;
+    return;
+  }
+  selected.value.threshold.value = 0;
+}
+function onValueChange() {
+  if (
+    selected.value.threshold.type !== 'median' &&
+    typeof selected.value.threshold.value !== 'number'
+  ) {
+    // ensure not undefined value or empty string
+    selected.value.threshold.value = 0;
+  }
+}
+</script>
+
+<template>
+  <q-card
+    flat
+    bordered
+    class="q-px-lg card"
+    :class="isModuleType ? 'active' : ''"
+    @click="onSelect"
+  >
+    <q-banner
+      inline-actions
+      class="q-pa-none"
+      style="background-color: transparent"
+    >
+      <span class="text-h5 text-weight-medium">
+        {{ $t(`threshold_${type}_title`) }}
+      </span>
+
+      <template #action>
+        <q-radio
+          v-model="selected.threshold.type"
+          :val="type"
+          :color="isModuleType ? 'accent' : 'grey-5'"
+          @update:model-value="onTypeChange"
+        />
+      </template>
+    </q-banner>
+    <div class="text-body2 text-secondary">
+      {{ $t(`threshold_${type}_description`) }}
+    </div>
+    <q-card-actions
+      v-if="selected.threshold.type === type"
+      class="q-my-lg q-pa-none card-footer"
+    >
+      <q-input
+        v-if="type !== 'median'"
+        v-model.number="selected.threshold.value"
+        :disable="!isModuleType"
+        type="number"
+        min="0"
+        :label="$t(`threshold_${type}_value`)"
+        dense
+        outlined
+        class="bg-white"
+        @update:model-value="onValueChange"
+      />
+      <div v-else class="text-body2">
+        <q-icon name="circle" size="xs" class="q-mr-sm" color="positive" />
+        {{ $t('threshold_median_info') }}
+      </div>
+    </q-card-actions>
+  </q-card>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  min-height: 180px;
+  position: relative;
+}
+.card-footer {
+  position: absolute;
+  bottom: 0;
+}
+.active {
+  background-color: rgba($accent, 0.04);
+  border-color: $accent;
+}
+</style>

--- a/frontend/src/constant/modules.ts
+++ b/frontend/src/constant/modules.ts
@@ -23,3 +23,17 @@ export type Module = (typeof MODULES)[keyof typeof MODULES];
 export const MODULES_LIST: Module[] = Object.values(MODULES);
 
 export const MODULES_PATTERN = MODULES_LIST.join('|');
+
+export const MODULES_THRESHOLD_TYPES = ['fixed', 'median', 'top'] as const;
+
+export type ThresholdType = (typeof MODULES_THRESHOLD_TYPES)[number];
+
+export interface Threshold {
+  type: ThresholdType;
+  value?: number;
+}
+
+export interface ModuleThreshold {
+  module: Module;
+  threshold: Threshold;
+}

--- a/frontend/src/i18n/en-US/index.ts
+++ b/frontend/src/i18n/en-US/index.ts
@@ -20,7 +20,7 @@ export default {
   [MODULES.Infrastructure]: 'Infrastructure',
   [MODULES_DESCRIPTIONS.Infrastructure]:
     "Define your lab's physical footprint across EPFL buildings and spaces.",
-  [MODULES.EquipmentElectricConsumption]: 'Equipment Electric Con...',
+  [MODULES.EquipmentElectricConsumption]: 'Equipment Electric Consumption',
   [MODULES_DESCRIPTIONS.EquipmentElectricConsumption]:
     'List lab equipment with wattage to calculate electricity-related CO₂',
   [MODULES.Purchase]: 'Purchases',
@@ -136,4 +136,19 @@ export default {
   module_management_consequence_important:
     'Important: References to these modules in documentation pages and explanatory texts must be manually removed via the Business Manager (Full) interface',
   module_management_save_button: 'Save',
+  threshold_fixed_title: 'Fixed Threshold',
+  threshold_fixed_description:
+    'Define a fixed threshold. Any value above this will be flagged in red.',
+  threshold_fixed_value: 'Fixed Value (kg CO₂-eq)',
+  threshold_fixed_summary: 'Fixed threshold of {value} kg CO₂-eq',
+  threshold_median_title: 'Median-based Threshold',
+  threshold_median_description:
+    'Automatically flag emissions above the median value. Adjusts based on all laboratory data.',
+  threshold_median_info: 'Automatic',
+  threshold_median_summary: 'Median-based threshold',
+  threshold_top_title: 'Top Values Threshold',
+  threshold_top_description:
+    'Flag the highest emissions. Enter the number of top values.',
+  threshold_top_value: 'Top Values Count',
+  threshold_top_summary: 'Top {value} values threshold',
 };

--- a/frontend/src/i18n/fr-CH/index.ts
+++ b/frontend/src/i18n/fr-CH/index.ts
@@ -138,4 +138,19 @@ export default {
   module_management_consequence_important:
     'Important : Les références à ces modules dans les pages de documentation et les textes explicatifs doivent être supprimées manuellement via l’interface Business Manager (Complet)',
   module_management_save_button: 'Enregistrer',
+  threshold_fixed_title: 'Seuil Fixe',
+  threshold_fixed_description:
+    'Définis un seuil fixe. Toute valeur supérieure sera signalée en rouge.',
+  threshold_fixed_value: 'Valeur fixe (kg CO₂-éq)',
+  threshold_fixed_summary: 'Seuil fixe de {value} kg CO₂-éq',
+  threshold_median_title: 'Seuil basé sur la médiane',
+  threshold_median_description:
+    'Signale automatiquement les émissions supérieures à la valeur médiane. S’ajuste en fonction de toutes les données des laboratoires.',
+  threshold_median_info: 'Automatique',
+  threshold_median_summary: 'Seuil basé sur la médiane',
+  threshold_top_title: 'Seuil des valeurs les plus élevées',
+  threshold_top_description:
+    'Signale les émissions les plus élevées. Entrez le nombre de valeurs les plus élevées.',
+  threshold_top_value: 'Nombre de valeurs les plus élevées',
+  threshold_top_summary: '{value} valeurs les plus élevées',
 };

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -1,10 +1,33 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
+import { MODULES_LIST } from 'src/constant/modules';
 import NavigationHeader from 'src/components/organisms/NavigationHeader.vue';
+import { type ModuleThreshold } from 'src/constant/modules';
+import ModuleConfig from 'src/components/organisms/data-management/ModuleConfig.vue';
+
+const moduleThresholds = ref(
+  MODULES_LIST.reduce(
+    (acc, module) => {
+      acc[module] = {
+        module,
+        threshold: { type: 'fixed', value: 0 },
+      };
+      return acc;
+    },
+    {} as { [key: string]: ModuleThreshold },
+  ),
+);
 </script>
 
 <template>
   <q-page>
     <navigation-header :item="BACKOFFICE_NAV.BACKOFFICE_DATA_MANAGEMENT" />
+
+    <div class="q-my-xl q-px-xl">
+      <template v-for="(module, idx) in MODULES_LIST" :key="idx">
+        <module-config v-model="moduleThresholds[module]" class="q-mb-lg" />
+      </template>
+    </div>
   </q-page>
 </template>

--- a/frontend/src/pages/system/ModuleManagementPage.vue
+++ b/frontend/src/pages/system/ModuleManagementPage.vue
@@ -42,7 +42,7 @@ import NavigationHeader from 'src/components/organisms/NavigationHeader.vue';
         :key="moduleCard.module"
         class="q-mb-md"
       >
-        <div q-card class="container full-width q-mx-lg">
+        <q-card flat class="container full-width q-mx-lg">
           <div class="flex row justify-between items-center">
             <div>
               <div class="flex items-center q-mb-xs">
@@ -71,7 +71,7 @@ import NavigationHeader from 'src/components/organisms/NavigationHeader.vue';
               />
             </div>
           </div>
-        </div>
+        </q-card>
       </div>
 
       <q-btn


### PR DESCRIPTION
## What does this change?

Components for configuring the module thresholds. No backend.

## Why is this needed?

Part of the data management page.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## How to test this

http://localhost:9000/en/back-office/data-management

- [x] I've tested this change locally
- [ ] Steps to test: (describe if needed)

## Screenshots (if applicable)

Expandable items (with summary when closed):

<img width="976" height="576" alt="image" src="https://github.com/user-attachments/assets/8462ab2b-e498-46e8-9d6c-66ad42a0265f" />

Selection in cards:

<img width="1133" height="304" alt="image" src="https://github.com/user-attachments/assets/0ad7ac74-9120-44fc-a448-b0d829cc45e7" />


## Related issues

- Related to #43
