### PR TITLE
fix(backend): make test user on refresh and get current user calls #114

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -14,10 +14,10 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.role_provider import get_role_provider
 from app.core.security import (
-    _make_test_user,
     create_access_token,
     create_refresh_token,
     decode_jwt,
+    make_test_user,
 )
 from app.repositories.user_repo import get_user_by_id, upsert_user
 from app.schemas.user import UserRead
@@ -281,7 +281,7 @@ async def get_me(
 
         # Check it is a test user in DEBUG mode
         if settings.DEBUG and user_id.startswith("testuser_"):
-            return _make_test_user(user_id)
+            return make_test_user(user_id)
 
         # Get user from database
         user = await get_user_by_id(db, user_id)
@@ -373,7 +373,7 @@ async def refresh_token(
         user = None
         # Check it is a test user in DEBUG mode
         if settings.DEBUG and user_id.startswith("testuser_"):
-            user = _make_test_user(user_id)
+            user = make_test_user(user_id)
         else:
             user = await get_user_by_id(db, user_id)
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -84,7 +84,7 @@ async def get_current_user(
 
     # Check it is a test user in DEBUG mode
     if settings.DEBUG and user_id.startswith("testuser_"):
-        return _make_test_user(user_id)
+        return make_test_user(user_id)
 
     user = await get_user_by_id(db, user_id)
     if user is None:
@@ -107,7 +107,7 @@ async def get_current_active_user(
     return user
 
 
-def _make_test_user(user_id: str) -> User:
+def make_test_user(user_id: str) -> User:
     """Helper to create a test user object in DEBUG mode."""
     requested_role = user_id[len("testuser_") :]
     roles: List[dict] = []


### PR DESCRIPTION
## What does this change?

Make sure further authentication calls are consistent with the test user (do not query the user repo).

## Why is this needed?

`/login-test` was failing on units request.

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## How to test this

Works only in an private browser, otherwise the frontend always attemps to call `/login` which ends up with the oauth2 user if already logged in the id provider.

- [x] I've tested this change locally
- [ ] Steps to test: (describe if needed)
