### PR TITLE
chore(ci): remove continue on fail for backend security

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Run Safety check
         run: uvx uv-audit --verbose
-        continue-on-error: true
+        continue-on-error: false
 
       - name: Run Bandit security linter
         run: uvx bandit -r ./app/ -x tests,.venv   
-        continue-on-error: true
+        continue-on-error: false
 
   codeql:
     name: CodeQL Analysis


### PR DESCRIPTION
## What does this change?

This pull request updates the security workflow configuration to enforce stricter failure handling for security checks. The most important change is that the workflow will now fail if either the Safety or Bandit checks encounter errors, rather than continuing on error.



## Why is this needed?


Security workflow enforcement:

* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL56-R60): Changed `continue-on-error` from `true` to `false` for both the Safety check and Bandit security linter steps, ensuring that the workflow fails if these security checks do not pass.


## Type of change

Please check the type that applies:

- [x] 🔧 Configuration change

## How to test this


- [x] I've tested this change locally
- [x] Steps to test: look at the github workflows

## Related issues

- Related to #6
