### PR TITLE
feat(frontend): add annual data import component, no backend

### DIFF
--- a/frontend/src/components/organisms/data-management/AnnualDataImport.vue
+++ b/frontend/src/components/organisms/data-management/AnnualDataImport.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { MODULES_LIST } from 'src/constant/modules';
+
+interface Props {
+  year: number;
+}
+defineProps<Props>();
+</script>
+
+<template>
+  <q-card flat bordered class="q-pa-md q-mb-xl">
+    <div class="text-h5 text-weight-medium">
+      <q-icon name="file_download" color="accent" size="sm" class="on-left" />
+      <span>{{ $t('data_management_annual_data_import') }}</span>
+    </div>
+    <div class="q-my-md">
+      {{ $t('data_management_annual_data_import_hint') }}
+    </div>
+    <div>
+      <q-banner inline-actions class="q-px-none">
+        <template #action>
+          <q-btn
+            no-caps
+            outline
+            color="secondary"
+            icon="file_download"
+            size="sm"
+            :label="$t('data_management_download_csv_templates')"
+            class="text-weight-medium"
+          />
+          <q-btn
+            no-caps
+            color="accent"
+            icon="file_upload"
+            size="sm"
+            :label="$t('data_management_upload_csv_files')"
+            class="text-weight-medium on-right"
+          />
+          <q-btn
+            no-caps
+            color="accent"
+            icon="file_copy"
+            size="sm"
+            :label="$t('data_management_copy_previous_year')"
+            class="text-weight-medium on-right"
+          />
+        </template>
+        <div>
+          {{
+            $t('data_management_data_imports_count', {
+              count: MODULES_LIST.length,
+            })
+          }}
+        </div>
+      </q-banner>
+      <q-markup-table flat bordered>
+        <thead>
+          <tr>
+            <th align="left">{{ $t('data_management_category') }}</th>
+            <th align="left">
+              {{ $t('data_management_description') }}
+            </th>
+            <th align="left">{{ $t('data_management_data') }}</th>
+            <th align="left">{{ $t('data_management_factor') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="module in MODULES_LIST" :key="module">
+            <td class="text-weight-medium" align="left">{{ $t(module) }}</td>
+            <td align="left"></td>
+            <td align="left">
+              <div class="q-mb-sm">
+                <q-icon name="warning" size="xs" color="warning" />
+                <span class="q-ml-sm text-negative">{{
+                  $t('data_management_no_data')
+                }}</span>
+              </div>
+              <div>
+                <q-btn
+                  no-caps
+                  color="accent"
+                  icon="file_upload"
+                  size="sm"
+                  :label="$t('data_management_upload_csv_files')"
+                  class="text-weight-medium"
+                />
+                <q-btn
+                  no-caps
+                  color="accent"
+                  icon="link"
+                  size="sm"
+                  :label="$t('data_management_connect_api')"
+                  class="text-weight-medium on-right"
+                />
+                <q-btn
+                  no-caps
+                  color="accent"
+                  icon="file_copy"
+                  size="sm"
+                  :label="$t('data_management_copy_previous_year')"
+                  class="text-weight-medium on-right"
+                />
+              </div>
+            </td>
+            <td align="left">
+              <div class="q-mb-sm">
+                <q-icon name="warning" size="xs" color="warning" />
+                <span class="q-ml-sm text-negative">{{
+                  $t('data_management_no_data')
+                }}</span>
+              </div>
+              <div>
+                <q-btn
+                  no-caps
+                  color="accent"
+                  icon="file_upload"
+                  size="sm"
+                  :label="$t('data_management_upload_csv_files')"
+                  class="text-weight-medium"
+                />
+                <q-btn
+                  no-caps
+                  color="accent"
+                  icon="link"
+                  size="sm"
+                  :label="$t('data_management_connect_api')"
+                  class="text-weight-medium on-right"
+                />
+                <q-btn
+                  no-caps
+                  color="accent"
+                  icon="file_copy"
+                  size="sm"
+                  :label="$t('data_management_copy_previous_year')"
+                  class="text-weight-medium on-right"
+                />
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </q-markup-table>
+    </div>
+  </q-card>
+</template>

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -9,6 +9,7 @@ import ModuleThresholdInput from 'src/components/organisms/data-management/Modul
 
 const props = defineProps<{
   modelValue: ModuleThreshold;
+  year: number;
 }>();
 
 const emit = defineEmits<{

--- a/frontend/src/components/organisms/data-management/ModulesConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModulesConfig.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { MODULES_LIST } from 'src/constant/modules';
+import { type ModuleThreshold } from 'src/constant/modules';
+import ModuleConfig from 'src/components/organisms/data-management/ModuleConfig.vue';
+
+interface Props {
+  year: number;
+}
+defineProps<Props>();
+
+const moduleThresholds = ref(
+  MODULES_LIST.reduce(
+    (acc, module) => {
+      acc[module] = {
+        module,
+        threshold: { type: 'fixed', value: 0 },
+      };
+      return acc;
+    },
+    {} as { [key: string]: ModuleThreshold },
+  ),
+);
+</script>
+
+<template>
+  <div>
+    <template v-for="module in MODULES_LIST" :key="module">
+      <module-config
+        v-model="moduleThresholds[module]"
+        :year="year"
+        class="q-mb-lg"
+      />
+    </template>
+  </div>
+</template>

--- a/frontend/src/i18n/backoffice.ts
+++ b/frontend/src/i18n/backoffice.ts
@@ -83,4 +83,60 @@ export default {
     en: 'Using top-N threshold: {value}',
     fr: 'Seuil Top-N utilisé : {value}',
   },
+  data_management_reporting_year: {
+    en: 'Reporting Year',
+    fr: 'Année de rapport',
+  },
+  data_management_reporting_year_hint: {
+    en: 'Select the year to view module completion data for that reporting period.',
+    fr: "Sélectionnez l'année pour afficher les données d'achèvement du module pour cette période de rapport.",
+  },
+  data_management_annual_data_import: {
+    en: 'Annual Data Import',
+    fr: 'Importation annuelle des données',
+  },
+  data_management_annual_data_import_hint: {
+    en: 'Annual import of emission factors and other data necessary for CO2-eq calculation (equipment lists, coefficients, etc.) via CSV data import interfaces.',
+    fr: "Importation annuelle des facteurs d'émission et d'autres données nécessaires au calcul du CO2-éq (listes d'équipements, coefficients, etc.) via des interfaces d'importation de données CSV.",
+  },
+  data_management_data_imports_count: {
+    en: 'Data Imports ({count})',
+    fr: 'Importations de données ({count})',
+  },
+  data_management_category: {
+    en: 'Category',
+    fr: 'Catégorie',
+  },
+  data_management_description: {
+    en: 'Description',
+    fr: 'Description',
+  },
+  data_management_factor: {
+    en: 'Factor',
+    fr: 'Facteur',
+  },
+  data_management_data: {
+    en: 'Data',
+    fr: 'Données',
+  },
+  data_management_download_csv_templates: {
+    en: 'Download CSV Templates',
+    fr: 'Télécharger les modèles CSV',
+  },
+  data_management_upload_csv_files: {
+    en: 'Upload CSV Files',
+    fr: 'Téléverser les fichiers CSV',
+  },
+  data_management_connect_api: {
+    en: 'Connect API',
+    fr: "Connecter l'API",
+  },
+  data_management_copy_previous_year: {
+    en: 'Copy Previous Year',
+    fr: "Copier l'année précédente",
+  },
+  data_management_no_data: {
+    en: 'No data available for this year.',
+    fr: 'Aucune donnée disponible pour cette année.',
+  },
 } as const;

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -1,22 +1,13 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
-import { MODULES_LIST } from 'src/constant/modules';
 import NavigationHeader from 'src/components/organisms/NavigationHeader.vue';
-import { type ModuleThreshold } from 'src/constant/modules';
-import ModuleConfig from 'src/components/organisms/data-management/ModuleConfig.vue';
+import AnnualDataImport from 'src/components/organisms/data-management/AnnualDataImport.vue';
+import ModulesConfig from 'src/components/organisms/data-management/ModulesConfig.vue';
 
-const moduleThresholds = ref(
-  MODULES_LIST.reduce(
-    (acc, module) => {
-      acc[module] = {
-        module,
-        threshold: { type: 'fixed', value: 0 },
-      };
-      return acc;
-    },
-    {} as { [key: string]: ModuleThreshold },
-  ),
+const availableYears = ref<number[]>([2022, 2023, 2024]);
+const selectedYear = ref<number>(
+  availableYears.value[availableYears.value.length - 1],
 );
 </script>
 
@@ -25,9 +16,25 @@ const moduleThresholds = ref(
     <navigation-header :item="BACKOFFICE_NAV.BACKOFFICE_DATA_MANAGEMENT" />
 
     <div class="q-my-xl q-px-xl">
-      <template v-for="(module, idx) in MODULES_LIST" :key="idx">
-        <module-config v-model="moduleThresholds[module]" class="q-mb-lg" />
-      </template>
+      <q-card flat bordered class="q-pa-md q-mb-xl">
+        <div class="text-h5">{{ $t('data_management_reporting_year') }}</div>
+        <q-select
+          v-model="selectedYear"
+          :options="availableYears"
+          outlined
+          dense
+          class="q-my-md"
+        >
+          <template #prepend>
+            <q-icon name="event" color="accent" size="xs" />
+          </template>
+        </q-select>
+        <div>
+          {{ $t('data_management_reporting_year_hint') }}
+        </div>
+      </q-card>
+      <annual-data-import :year="selectedYear" />
+      <modules-config :year="selectedYear" />
     </div>
   </q-page>
 </template>


### PR DESCRIPTION
## What does this change?

* Year selector added
* Annual data import table added, there is one line per module for now
* Modules config parent component added

## Why is this needed?

Fake UI for further spec refinement.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## How to test this

http://localhost:9000/en/back-office/data-management

- [x] I've tested this change locally
- [ ] Steps to test: (describe if needed)

## Screenshots (if applicable)

<img width="1301" height="880" alt="image" src="https://github.com/user-attachments/assets/350be8d2-7ec3-4004-99c9-f33309c19f07" />

## Related issues

- Related to #43
