### PR TITLE
fix(release-please): add config file for pre-bump major

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,6 @@
 on:
   push:
-    branches:
-      - main
-
+    branches: ['main', 'ci-test/**']
 permissions:
   contents: write
   pull-requests: write
@@ -19,9 +17,4 @@ jobs:
           # (PAT) and configured it as a GitHub action secret named
           # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options #https://github.com/googleapis/release-please-action?tab=readme-ov-file#release-types-supported
           release-type: node
-          initial-version: 0.1.0
-          bump-minor-pre-major: true
-          package-name: co2-calculator


### PR DESCRIPTION
## What does this change?
This pull request updates the configuration for the `release-please` GitHub Action workflow to support running releases on both the `main` branch and any branch matching the `ci-test/**` pattern. It also removes several configuration options related to release management.

Workflow trigger changes:

* The `release-please` workflow will now run on pushes to both `main` and any branch matching `ci-test/**`, making it easier to test release automation on feature or CI test branches.

Release configuration simplification:

* Removed several release management options: `initial-version`, `bump-minor-pre-major`, and `package-name`, streamlining the workflow configuration for simpler releases.
## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix HOT FIX


---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
