### PR TITLE
feat(frontend-module-equipement-electric): add module charts

### DIFF
--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -1,0 +1,27 @@
+<template>
+  <q-card flat class="container">
+    <q-card-section class="text-center module-charts">
+      <h2 class="text-h3 q-mb-none text-bold text-uppercase">
+        {{ $t(`${props.type}-charts-title`) }}
+      </h2>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  type: string;
+}>();
+</script>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.module-charts {
+  padding: tokens.$graph-card-padding; // Example padding, adjust as needed
+  color: tokens.$graph-color-primary; // Use your token for secondary text
+  font-weight: tokens.$graph-font-weight;
+  font-size: tokens.$graph-font-size;
+  line-height: tokens.$graph-line-height;
+}
+</style>

--- a/frontend/src/css/02-tokens/_components.scss
+++ b/frontend/src/css/02-tokens/_components.scss
@@ -242,3 +242,10 @@ $sidebar-border-width: opt.$tokens-spacing-1 !default;
 $sidebar-border-color: opt.$tokens-colors-grey-scale-grey-400 !default;
 $sidebar-color: opt.$tokens-colors-base-black !default;
 $sidebar-item-gap: opt.$tokens-spacing-8 !default;
+
+// Graph Cards
+$graph-card-padding: opt.$tokens-spacing-16 !default;
+$graph-color-primary: opt.$tokens-colors-leman !default;
+$graph-font-weight: opt.$tokens-typography-font-weight-medium !default;
+$graph-font-size: opt.$tokens-typography-font-size-sm !default;
+$graph-line-height: opt.$tokens-typography-line-height-sm !default;

--- a/frontend/src/i18n/equipmentelectricconsumption.ts
+++ b/frontend/src/i18n/equipmentelectricconsumption.ts
@@ -19,4 +19,8 @@ Usage actif et usage standby: veuillez remplir les heures d'utilisation de chaqu
 Sous-classe: choisissez la sous-classe pour les équipements où cette information est nécessaire.
 Classe: veuillez mettre à jour la classe si celle de votre inventaire n'est pas appropriée. Attention, vous devrez répercuter ce changement lors de votre prochaine mise à jour de l'inventaire, car celle-ci ne se fait pas automatiquement à travers le Calculateur CO₂.`,
   },
+  [`${MODULES.EquipmentElectricConsumption}-charts-title`]: {
+    en: 'Charts',
+    fr: 'Graphiques',
+  },
 } as const;

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -1,6 +1,7 @@
 <template>
   <q-page class="module-page">
     <module-title :type="currentModuleType" />
+    <module-charts :type="currentModuleType" />
   </q-page>
 </template>
 
@@ -9,6 +10,7 @@ import { useRoute } from 'vue-router';
 import { computed } from 'vue';
 
 import ModuleTitle from 'src/components/organisms/module/ModuleTitle.vue';
+import ModuleCharts from 'src/components/organisms/module/ModuleCharts.vue';
 const $route = useRoute();
 const currentModuleType = computed(() => $route.params.module as string);
 </script>
@@ -16,6 +18,9 @@ const currentModuleType = computed(() => $route.params.module as string);
 <style scoped lang="scss">
 @use 'src/css/02-tokens' as tokens;
 .module-page {
-  padding-top: tokens.$layout-page-padding-y;
+  padding-top: tokens.$template-padding-y;
+  gap: tokens.$template-gap;
+  display: flex;
+  flex-direction: column;
 }
 </style>


### PR DESCRIPTION
## What does this change?
This pull request introduces a new `ModuleCharts` component to the module page, providing a titled section for displaying charts with consistent styling and localization. It also adds new design tokens for graph cards and updates layout styles for improved spacing and structure.

**Feature Addition: Module Charts Section**
* Added new `ModuleCharts.vue` component to display a chart title based on the module type, using localized strings for English and French. (`frontend/src/components/organisms/module/ModuleCharts.vue`, `frontend/src/i18n/equipmentelectricconsumption.ts`) [[1]](diffhunk://#diff-07a88593f8a9c769d6ef37f563a8d253a5fb228253ebb8e2c8663500654cbe6fR1-R27) [[2]](diffhunk://#diff-a187a0d4faae1007959aae8aadd8755a6185ef255f499b466ef9364d35ebb780R22-R25)
* Integrated `ModuleCharts` into the module page, ensuring it appears below the module title and receives the correct module type. (`frontend/src/pages/app/ModulePage.vue`) [[1]](diffhunk://#diff-65cc74e3e07ac016ebae78292474cd4566360d2d2e25bf9c0f531ee613d7d114R4) [[2]](diffhunk://#diff-65cc74e3e07ac016ebae78292474cd4566360d2d2e25bf9c0f531ee613d7d114R13-R24)

**Design Tokens and Styling**
* Introduced new SCSS tokens for graph card padding, color, font weight, font size, and line height, enabling consistent styling for chart sections. (`frontend/src/css/02-tokens/_components.scss`)
* Updated module page layout styles for improved spacing, using new template padding and gap tokens, and switching to a column flex layout. (`frontend/src/pages/app/ModulePage.vue`)
## Type of change

Please check the type that applies:

- [x] ✨ New feature
## Screenshots (if applicable)

<img width="1379" height="578" alt="Screenshot 2025-11-28 at 16 39 07" src="https://github.com/user-attachments/assets/580d7481-dcb1-48c9-ad7b-a80e5a22b1c3" />

## Related issues

- Closes #
- Related to #106 #75

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
