### PR TITLE
chore(backend): fix url __str__ rendering

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -27,12 +27,11 @@ if (
     or url.drivername == "postgres"
     or url.drivername == "postgresql+psycopg"
 ) and not url.drivername.endswith("+asyncpg"):
-    # Add async driver + optional query params
+    # Just change the driver, keep everything else
     url = url.set(drivername="postgresql+psycopg")
-    settings.DB_URL = str(url)
 
-# Set the database URL from settings
-config.set_main_option("sqlalchemy.url", settings.DB_URL)
+# IMPORTANT: Use render_as_string to preserve the actual password
+config.set_main_option("sqlalchemy.url", url.render_as_string(hide_password=False))
 
 # Interpret the config file for Python logging
 if config.config_file_name is not None:


### PR DESCRIPTION
This pull request updates the database URL handling logic for both Alembic migrations and SQLAlchemy engine creation, ensuring that the actual password is always preserved in connection strings and that async drivers are applied more consistently. The changes improve security, reliability, and maintainability by avoiding accidental password masking and by preserving existing query parameters.

**Database connection string handling:**

* In `backend/alembic/env.py`, the Alembic configuration now uses `url.render_as_string(hide_password=False)` to ensure the actual password is included in the database URL, rather than potentially masking it.
* In `backend/app/db.py`, the logic for setting async drivers for SQLite and PostgreSQL has been refactored to avoid unnecessary reassignment and to preserve existing query parameters. The final database URL is now rendered with the actual password using `url.render_as_string(hide_password=False)`, and passed directly to `create_async_engine`.