### PR TITLE
fix(translation): correct modules counter translation key on home page

### DIFF
--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -261,6 +261,10 @@ export default {
     en: 'Edit',
     fr: 'Editer',
   },
+  home_modules_counter: {
+    en: 'Modules ({count})',
+    fr: 'Modules ({count})',
+  },
   results_units: {
     en: 'kg CO₂-eq',
     fr: 'kg CO₂-éq',

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -7,7 +7,7 @@ import { MODULE_CARDS } from 'src/constant/moduleCards';
 const { t } = useI18n();
 
 const modulesCounterText = computed(() =>
-  t('workspace_setup_unit_counter', {
+  t('home_modules_counter', {
     count: Object.keys(MODULES).length + 1,
   }),
 );
@@ -110,9 +110,9 @@ const homeIntroWithLinks = computed(() => {
     </div>
 
     <div>
-      <span class="text-h5 text-weight-medium q-mb-md">{{
-        modulesCounterText
-      }}</span>
+      <div class="text-h5 text-weight-medium q-mb-sm">
+        {{ modulesCounterText }}
+      </div>
       <div class="grid-3-col">
         <q-card
           v-for="moduleCard in MODULE_CARDS"


### PR DESCRIPTION
## What does this change?
- Replace incorrect workspace_setup_unit_counter with home_modules_counter
- Add proper home_modules_counter translation key

## Why is this needed?
The home page was using the wrong translation key (`workspace_setup_unit_counter`) meant for a different context. This caused confusion and made the code harder to maintain. Using a dedicated `home_modules_counter` key makes the intent clear and ensures proper separation of concerns between different UI sections.


## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Testing checklist
- [x] I've tested this change locally

## Screenshots (if applicable)
<img width="1297" height="132" alt="Screenshot 2025-12-02 at 11 01 37" src="https://github.com/user-attachments/assets/869fbfa6-f152-484e-95df-ae5cdd4bb3d4" />


## Related issues

- Closes #
- Related to #13

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
