### PR TITLE
feat(frontend-module-table): add inline input for module-table

### DIFF
--- a/frontend/src/components/atoms/ModuleIcon.vue
+++ b/frontend/src/components/atoms/ModuleIcon.vue
@@ -6,10 +6,11 @@ const props = withDefaults(
   defineProps<{
     name: string;
     size?: 'sm' | 'md' | 'lg';
-    color?: string;
+    color?: string; // e.g., 'primary', 'accent', 'grey-8';
   }>(),
   {
     size: 'md',
+    color: 'accent',
   },
 );
 

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -33,7 +33,7 @@
     no-data-label="No items"
     :pagination="pagination"
   >
-    <template v-slot:pagination="scope">
+    <template #pagination="scope">
       <q-btn
         icon="chevron_left"
         color="grey-8"
@@ -62,7 +62,18 @@
           :props="slotProps"
           :align="col.align"
         >
-          <template v-if="col.name === 'action'">
+          <template v-if="col.editableInline">
+            <component
+              :is="col.inputComponent"
+              v-model="slotProps.row[col.field]"
+              :options="col.options || []"
+              dense
+              hide-bottom-space
+              outlined
+              class="inline-input"
+            ></component>
+          </template>
+          <template v-else-if="col.name === 'action'">
             <!-- Placeholder for action buttons, etc. -->
             <q-btn
               icon="o_edit"
@@ -161,6 +172,7 @@
 import { computed, ref } from 'vue';
 import type { TableColumn } from 'src/constant/moduleConfig';
 import { useI18n } from 'vue-i18n';
+import { QInput, QSelect } from 'quasar';
 
 const { t: $t } = useI18n();
 
@@ -182,6 +194,12 @@ const pagination = ref({
 const confirmDelete = ref(false);
 const deleteItemName = ref<string>('');
 
+// Component map to convert strings to component references
+const componentMap = {
+  QInput,
+  QSelect,
+};
+
 // simple local rows by default (can be passed via prop)
 // const rows = ref(props.rows ?? []);
 
@@ -192,6 +210,9 @@ const qCols = computed(() => {
     field: c.key,
     sortable: !!c.sortable,
     align: c.align ?? 'left',
+    inputComponent: c.inputTypeName ? componentMap[c.inputTypeName] : QInput,
+    editableInline: !!c.editableInline,
+    options: c.options || undefined,
   }));
 
   baseCols.push({
@@ -200,6 +221,9 @@ const qCols = computed(() => {
     field: 'action',
     align: 'right',
     sortable: false,
+    inputComponent: QInput,
+    editableInline: false,
+    options: undefined,
   });
   return baseCols;
 });

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -7,7 +7,7 @@
   >
     <q-separator />
     <q-card-section class="q-pa-none">
-      <div class="q-mx-lg q-my-xl" v-if="submodule.tableColumns">
+      <div v-if="submodule.tableColumns" class="q-mx-lg q-my-xl">
         <module-table
           :columns="submodule.tableColumns"
           :rows="rows"

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -36,6 +36,8 @@ export const equipmentElectricConsumption: ModuleConfig = {
           type: 'select',
           sortable: true,
           align: 'left',
+          inputTypeName: 'QSelect',
+          editableInline: true,
         },
         {
           key: 'act_usage',
@@ -44,6 +46,8 @@ export const equipmentElectricConsumption: ModuleConfig = {
           unit: '%',
           sortable: true,
           align: 'right',
+          inputTypeName: 'QInput',
+          editableInline: true,
         },
         {
           key: 'pas_usage',
@@ -52,6 +56,8 @@ export const equipmentElectricConsumption: ModuleConfig = {
           unit: '%',
           sortable: true,
           align: 'right',
+          inputTypeName: 'QInput',
+          editableInline: true,
         },
         {
           key: 'act_power',

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -27,6 +27,9 @@ export interface TableColumn {
   type: ColumnType;
   unit?: string;
   sortable?: boolean;
+  inputTypeName?: string;
+  editableInline?: boolean;
+  options?: Array<{ value: string; label: string }>;
   align?: 'left' | 'right' | 'center';
 }
 


### PR DESCRIPTION
This pull request introduces inline editing capability for table cells in the `ModuleTable` component, allowing certain columns to be edited directly within the table. The changes include updating the column configuration to specify editable fields and their input types, mapping input types to Vue components, and rendering the appropriate input components conditionally in the table.

**Inline editing feature:**

* Added `inputTypeName` and `editableInline` properties to the `TableColumn` interface in `moduleConfig.ts` to define which columns are editable and what input component to use.
* Updated the equipment electric consumption module configuration to mark specific columns as editable inline and specify their input types (`qInput`, `qSelect`). [[1]](diffhunk://#diff-940f4ea104c528b6222266a78a03c3ab7583bd39161583333fc55d2f0d8ac197R39-R40) [[2]](diffhunk://#diff-940f4ea104c528b6222266a78a03c3ab7583bd39161583333fc55d2f0d8ac197R49-R50) [[3]](diffhunk://#diff-940f4ea104c528b6222266a78a03c3ab7583bd39161583333fc55d2f0d8ac197R59-R60)
* In `ModuleTable.vue`, mapped `inputTypeName` values to actual Quasar input components using a `componentMap`, and injected these into the column definitions. [[1]](diffhunk://#diff-13d2891a8a8e754560769423609360dcde6a6a1f8255c6edb5a4ad4fe3c5586cR153-R154) [[2]](diffhunk://#diff-13d2891a8a8e754560769423609360dcde6a6a1f8255c6edb5a4ad4fe3c5586cR174-R182)

**Table rendering improvements:**

* Updated the cell rendering logic in `ModuleTable.vue` to display the appropriate input component for editable columns, using the `editableInline` property.
* Changed the slot syntax for pagination to the shorthand format for consistency with Vue 3 style.
* Imported `QInput` and `QSelect` from Quasar to support dynamic input component rendering.
* Ensured the action column is not editable inline and defaults to using `QInput` as its input component.