### PR TITLE
feat(delete dialog)76/delete confirmation dialog

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -84,6 +84,10 @@
               square
               size="xs"
               class="square-button"
+              @click="
+                deleteItemName = getItemName(slotProps.row);
+                confirmDelete = true;
+              "
             />
           </template>
           <template v-else>
@@ -97,6 +101,60 @@
       <div class="text-center q-pa-md">No data available</div>
     </template>
   </q-table>
+
+  <q-dialog v-model="confirmDelete" persistent>
+    <q-card class="column modal modal--md">
+      <q-card-section class="flex justify-between items-center">
+        <div class="text-h4 text-weight-medium">
+          {{
+            $t('common_delete_dialog_title', {
+              item: deleteItemName || 'this item',
+            })
+          }}
+        </div>
+        <q-btn
+          v-close-popup
+          flat
+          size="md"
+          icon="o_close"
+          color="grey-6"
+          class="text-weight-medium"
+        />
+      </q-card-section>
+      <q-separator />
+      <q-card-section class="q-py-lg q-px-md">
+        <span class="text-body1">
+          {{
+            $t('common_delete_dialog_description', {
+              item: deleteItemName || 'this item',
+            })
+          }}
+        </span>
+      </q-card-section>
+      <q-separator />
+      <q-card-actions class="q-py-lg q-px-md row q-gutter-sm">
+        <q-btn
+          color="grey-4"
+          text-color="primary"
+          :label="$t('common_cancel')"
+          unelevated
+          no-caps
+          outline
+          size="md"
+          class="text-weight-medium col"
+          @click="confirmDelete = false"
+        />
+        <q-btn
+          color="accent"
+          :label="$t('common_delete')"
+          unelevated
+          no-caps
+          size="md"
+          class="text-weight-medium col"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
 </template>
 
 <script setup lang="ts">
@@ -120,6 +178,9 @@ const pagination = ref({
   page: 1,
   rowsPerPage: 20,
 });
+
+const confirmDelete = ref(false);
+const deleteItemName = ref<string>('');
 
 // simple local rows by default (can be passed via prop)
 // const rows = ref(props.rows ?? []);
@@ -147,5 +208,9 @@ function renderCell(row: ModuleRow, col: { field: string }) {
   const val = row[col.field];
   if (val === undefined || val === null) return '-';
   return String(val);
+}
+
+function getItemName(row: ModuleRow): string {
+  return row.name ? String(row.name) : String(row.id || 'this item');
 }
 </script>

--- a/frontend/src/css/03-layout/_modal.scss
+++ b/frontend/src/css/03-layout/_modal.scss
@@ -1,13 +1,13 @@
 @use '../02-tokens/decisions' as dec;
 
 .modal {
-  min-width: dec.$modal-width-md;
+  width: dec.$modal-width-md;
 
   &--lg {
-    min-width: dec.$modal-width-lg;
+    width: dec.$modal-width-lg;
   }
 
   &--sm {
-    min-width: dec.$modal-width-sm;
+    width: dec.$modal-width-sm;
   }
 }

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -345,4 +345,20 @@ export default {
     en: 'Edit Module',
     fr: 'Éditer le module',
   },
+  common_delete_dialog_title: {
+    en: 'Delete {item}',
+    fr: 'Supprimer {item}',
+  },
+  common_delete_dialog_description: {
+    en: 'Are you sure you want to delete {item}? This action cannot be undone.',
+    fr: 'Êtes-vous sûr de vouloir supprimer {item} ? Cette action est irréversible.',
+  },
+  common_delete: {
+    en: 'Delete',
+    fr: 'Supprimer',
+  },
+  common_cancel: {
+    en: 'Cancel',
+    fr: 'Annuler',
+  },
 };


### PR DESCRIPTION

## What does this change?
Adds a confirmation dialog to the ModuleTable component to prevent accidental deletions, with full bilingual support and improved modal sizing.


## Why is this needed?
- **Prevent Data Loss**: Protects users from accidentally deleting important data
- **Better UX**: Provides clear confirmation with item name displayed
- **Accessibility**: Bilingual support ensures all users understand the action
- **Best Practices**: Follows standard UI patterns for destructive actions
- **User Confidence**: Users can safely interact with delete buttons knowing they'll be asked to confirm

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Code quality checklist

- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## For UI changes only

- [ ] Screenshots/GIFs/videos included below
- [ ] WCAG Level AA accessibility verified
- [ ] Keyboard navigation works correctly
- [ ] Tested on mobile, tablet, and desktop
- [ ] Focus indicators visible

## Screenshots (if applicable)
'/var/folders/d4/4b3tj0b91f11859d9v4rwxz9mhjcg_/T/TemporaryItems/NSIRD_screencaptureui_xbO9zC/Screenshot 2025-12-03 at 13.15.12.png'

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.

