### PR TITLE
Task/76/107 edit modal

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -2,8 +2,7 @@
 
 from fastapi import APIRouter
 
-from app.api.v1 import auth, backoffice, resources, unit_results, units, users
-from app.api.v1 import auth, modules, resources, unit_results, units, users
+from app.api.v1 import auth, backoffice, modules, resources, unit_results, units, users
 
 api_router = APIRouter()
 

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -13,6 +13,7 @@
           :rows="rows"
           :loading="loading"
           :error="error"
+          :form-inputs="submodule.formInputs"
         />
       </div>
       <q-separator />

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -98,7 +98,7 @@ export const equipmentElectricConsumption: ModuleConfig = {
           icon: 'o_category',
           type: 'select',
           required: true,
-          ratio: '1/3',
+          ratio: '1/2',
           options: [
             { value: 'agitator', label: 'Agitator' },
             { value: 'centrifuge', label: 'Centrifuge' },
@@ -111,21 +111,12 @@ export const equipmentElectricConsumption: ModuleConfig = {
           type: 'select',
           required: true,
           min: 0,
-          ratio: '1/3',
+          ratio: '1/2',
           options: [
             { value: '500', label: '500' },
             { value: '800', label: '800' },
             { value: '300', label: '300' },
           ],
-        },
-        {
-          id: 'sci_quantity',
-          label: 'Quantity',
-          icon: 'o_shopping_cart',
-          type: 'number',
-          required: true,
-          min: 0,
-          ratio: '1/3',
         },
         {
           id: 'sci_act_usage',
@@ -257,14 +248,6 @@ export const equipmentElectricConsumption: ModuleConfig = {
           label: 'Equipment Name',
           type: 'text',
           required: true,
-        },
-        {
-          id: 'it_quantity',
-          label: 'Quantity',
-          type: 'number',
-          required: true,
-          min: 1,
-          ratio: '1/3',
         },
         {
           id: 'it_power',

--- a/frontend/src/css/05-components/quasar-overrides/_q-dialog.scss
+++ b/frontend/src/css/05-components/quasar-overrides/_q-dialog.scss
@@ -1,0 +1,6 @@
+@media (width >= 600px) {
+  .q-dialog__inner--minimized > div {
+    max-width: none;
+    width: inherit;
+  }
+}

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -33,6 +33,7 @@
   @import './05-components/quasar-overrides/q-btn-timeline-button';
   @import './05-components/quasar-overrides/q-btn';
   @import './05-components/quasar-overrides/q-tooltip';
+  @import './05-components/quasar-overrides/q-dialog';
 }
 
 @layer components {

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -353,6 +353,10 @@ export default {
     en: 'Are you sure you want to delete {item}? This action cannot be undone.',
     fr: 'Êtes-vous sûr de vouloir supprimer {item} ? Cette action est irréversible.',
   },
+  common_edit_dialog_title: {
+    en: 'Edit {item}',
+    fr: 'Éditer {item}',
+  },
   common_delete: {
     en: 'Delete',
     fr: 'Supprimer',
@@ -360,5 +364,9 @@ export default {
   common_cancel: {
     en: 'Cancel',
     fr: 'Annuler',
+  },
+  common_save: {
+    en: 'Save',
+    fr: 'Enregistrer',
   },
 };


### PR DESCRIPTION
This pull request adds inline editing functionality to the module table, allowing users to edit row data through a dialog form. The main changes involve integrating the `ModuleForm` component into the table, managing dialog state, and passing row data for editing.

**Inline Editing Functionality**

* Added a dialog (`q-dialog`) to `ModuleTable.vue` that displays the `ModuleForm` for editing a row, with props for input configuration and row data.
* Implemented functions to handle opening the edit dialog with the selected row's data (`openEditDialog`) and closing the dialog on form submission (`onEditSubmit`). [[1]](diffhunk://#diff-13d2891a8a8e754560769423609360dcde6a6a1f8255c6edb5a4ad4fe3c5586cL162-R180) [[2]](diffhunk://#diff-13d2891a8a8e754560769423609360dcde6a6a1f8255c6edb5a4ad4fe3c5586cR227-R242)
* Added an edit button to each table row that triggers the edit dialog with the corresponding row's data.

**Component and Prop Updates**

* Updated `ModuleForm.vue` to accept a new prop `rowData` and emit an `edit` event to support editing existing rows. The form initializes its fields with the provided row data when available.
* Changed the pagination slot syntax in `ModuleTable.vue` to use the new Vue slot shorthand.