### PR TITLE
fix/standby

### DIFF
--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -62,7 +62,7 @@ const baseModuleFields: ModuleField[] = [
   },
   {
     id: 'pas_usage',
-    label: 'Passive Usage',
+    label: 'Standby Usage',
     type: 'number',
     required: true,
     min: 0,
@@ -90,7 +90,7 @@ const baseModuleFields: ModuleField[] = [
   },
   {
     id: 'pas_power',
-    label: 'Passive Power',
+    label: 'Standby Power',
     type: 'number',
     required: true,
     min: 0,


### PR DESCRIPTION
This pull request makes minor updates to the labels for two fields in the equipment electric consumption module configuration. The changes clarify the terminology by replacing "Passive" with "Standby" for both usage and power fields.