### PR TITLE
fix(#76-backend): calculate based on hours/week

### DIFF
--- a/backend/app/services/equipment_service.py
+++ b/backend/app/services/equipment_service.py
@@ -431,8 +431,8 @@ async def create_equipment(
             )
         calc_payload = calculate_equipment_emission_versioned(
             {
-                "act_usage_pct": equipment.active_usage_pct or 0,
-                "pas_usage_pct": equipment.passive_usage_pct or 0,
+                "act_usage": equipment.active_usage_pct or 0,
+                "pas_usage": equipment.passive_usage_pct or 0,
                 "act_power_w": equipment.active_power_w or 0,
                 "pas_power_w": equipment.standby_power_w or 0,
                 "status": equipment.status,
@@ -575,8 +575,8 @@ async def update_equipment(
         await equipment_repo.retire_current_emission(session, updated_equipment.id)
         calc_payload = calculate_equipment_emission_versioned(
             {
-                "act_usage_pct": updated_equipment.active_usage_pct or 0,
-                "pas_usage_pct": updated_equipment.passive_usage_pct or 0,
+                "act_usage": updated_equipment.active_usage_pct or 0,
+                "pas_usage": updated_equipment.passive_usage_pct or 0,
                 "act_power_w": updated_equipment.active_power_w or 0,
                 "pas_power_w": updated_equipment.standby_power_w or 0,
                 "status": updated_equipment.status,

--- a/backend/tests/integration/services/test_calculation_service_integration.py
+++ b/backend/tests/integration/services/test_calculation_service_integration.py
@@ -217,8 +217,8 @@ class TestSubmoduleAndModuleAggregation:
             {
                 "id": 1,
                 "name": "Desktop 1",
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "kg_co2eq": 31.39,
@@ -247,7 +247,7 @@ class TestSubmoduleAndModuleAggregation:
 
         assert summary["total_items"] == 3
         assert summary["total_kg_co2eq"] == 98.39
-        assert summary["annual_consumption_kwh"] > 700  # Realistic range
+        assert summary["annual_consumption_kwh"] == 570.44  # 251.16 + 209.04 + 110.24
 
     def test_complete_module_with_multiple_submodules(self):
         """Test complete module calculation with realistic submodule structure."""
@@ -297,24 +297,24 @@ class TestSubmoduleAndModuleAggregation:
         """Test aggregation with mixed equipment statuses."""
         items = [
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "kg_co2eq": 31.39,
                 "status": "In service",
             },
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "kg_co2eq": 0.0,  # Not in service
                 "status": "Decommissioned",
             },
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "kg_co2eq": 31.39,
@@ -338,8 +338,8 @@ class TestVersionedCalculationIntegration:
     ):
         """Test versioned calculation using emission factor from database."""
         equipment_data = {
-            "act_usage_pct": 25,
-            "pas_usage_pct": 75,
+            "act_usage": 42,
+            "pas_usage": 126,
             "act_power_w": 100,
             "pas_power_w": 5,
             "status": "In service",
@@ -364,8 +364,8 @@ class TestVersionedCalculationIntegration:
     ):
         """Test versioned calculations with different emission factors."""
         equipment_data = {
-            "act_usage_pct": 25,
-            "pas_usage_pct": 75,
+            "act_usage": 42,
+            "pas_usage": 126,
             "act_power_w": 100,
             "pas_power_w": 5,
             "status": "In service",
@@ -408,8 +408,8 @@ class TestEnrichmentWithRealisticWorkflow:
                 "id": 1,
                 "name": "Desktop Computer - Office 101",
                 "category": "desktop",
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "status": "In service",
@@ -447,8 +447,9 @@ class TestEnrichmentWithRealisticWorkflow:
         # Verify all items have CO2 calculations
         assert all("kg_co2eq" in item for item in enriched_items)
         assert enriched_items[0]["kg_co2eq"] == 31.39
-        assert enriched_items[1]["kg_co2eq"] == 7.59
-        assert enriched_items[2]["kg_co2eq"] == 327.6
+        assert enriched_items[1]["kg_co2eq"] == 4.52
+        # Server: 100hrs * 300W * 52 / 1000 * 0.125 = 195.0
+        assert enriched_items[2]["kg_co2eq"] == 195.0
 
         # Verify original data is preserved
         assert enriched_items[0]["name"] == "Desktop Computer - Office 101"
@@ -459,22 +460,22 @@ class TestEnrichmentWithRealisticWorkflow:
         """Test complete workflow: enrich items then calculate summary."""
         equipment_items = [
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "status": "In service",
             },
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "status": "In service",
             },
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "status": "In service",
@@ -550,8 +551,8 @@ class TestEdgeCasesAndBoundaryConditions:
         num_items = 1000
         items = [
             {
-                "act_usage": 25,
-                "pas_usage": 75,
+                "act_usage": 42,
+                "pas_usage": 126,
                 "act_power": 100,
                 "pas_power": 5,
                 "kg_co2eq": 31.39,


### PR DESCRIPTION
This pull request updates the equipment usage model from percentage-based to hours-per-week-based, standardizing how usage is represented and validated throughout the backend. It also updates calculation logic and tests to reflect this change, ensuring consistency and correctness in emissions calculations.

**Schema and Validation Updates:**

* Changed `act_usage` and `pas_usage` fields in `EquipmentItemResponse`, `EquipmentCreateRequest`, `EquipmentUpdateRequest`, and `EquipmentDetailResponse` models to represent hours per week instead of percentages, and updated their descriptions and validation ranges to use `settings.HOURS_PER_WEEK`. Added model-level validation to ensure total usage does not exceed hours per week. (`[[1]](diffhunk://#diff-f141688ae41245935b0eb002b32cf760da694ce5d0a99a3af30a667df27c9542L18-R23)`, `[[2]](diffhunk://#diff-f141688ae41245935b0eb002b32cf760da694ce5d0a99a3af30a667df27c9542L106-R119)`, `[[3]](diffhunk://#diff-f141688ae41245935b0eb002b32cf760da694ce5d0a99a3af30a667df27c9542R144-R156)`, `[[4]](diffhunk://#diff-f141688ae41245935b0eb002b32cf760da694ce5d0a99a3af30a667df27c9542L154-R186)`, `[[5]](diffhunk://#diff-f141688ae41245935b0eb002b32cf760da694ce5d0a99a3af30a667df27c9542R210-R222)`, `[[6]](diffhunk://#diff-f141688ae41245935b0eb002b32cf760da694ce5d0a99a3af30a667df27c9542L198-R241)`)

**Calculation Logic Changes:**

* Updated the calculation service to expect and process usage values in hours per week rather than percentages, removing conversion logic and updating function arguments and documentation accordingly. (`[[1]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cL95-R96)`, `[[2]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cL128-R132)`, `[[3]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cR141-R147)`, `[[4]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cL198-R196)`, `[[5]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cL269-R260)`, `[[6]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cL279-R271)`, `[[7]](diffhunk://#diff-ab74c8ba5a2e40690f0899c28440575f74c7dbf5cb4cfb6b17244f59260bad8cL307-R291)`)

**Service Layer Updates:**

* Modified equipment creation and update service methods to pass usage values in hours per week to the calculation functions, aligning with the new schema. (`[[1]](diffhunk://#diff-5ad2dda4e0545c7e2b7a4fc46c9536225db2acd3224081992c2cb6229fc12b31L434-R435)`, `[[2]](diffhunk://#diff-5ad2dda4e0545c7e2b7a4fc46c9536225db2acd3224081992c2cb6229fc12b31L578-R579)`)

**Test Adjustments:**

* Updated integration tests to use hours-per-week values for usage fields and adjusted expected calculation results to match the new logic. (`[[1]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL220-R221)`, `[[2]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL250-R250)`, `[[3]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL300-R317)`, `[[4]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL341-R342)`, `[[5]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL367-R368)`, `[[6]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL411-R412)`, `[[7]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL450-R452)`, `[[8]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL462-R478)`, `[[9]](diffhunk://#diff-5d4445e2cabbab89135e89a766d8e053cdb43fc04aa33109cb213cb3c5a892edL553-R555)`)