### PR TITLE
fix: update Codecov badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make build         # Build projects
 
 ### Code Quality
 
-[![Codecov](https://codecov.io/gh/EPFL-ENAC/epfl-calculator-co2/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/EPFL-ENAC/epfl-calculator-co2)
+[![Codecov](https://codecov.io/gh/EPFL-ENAC/co2-calculator/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/EPFL-ENAC/co2-calculator)
 
 ### Security & Status
 


### PR DESCRIPTION
This pull request updates the Codecov badge link in the `README.md` to point to the correct repository. This ensures that code coverage metrics are accurately reported for the current project. 

* Updated the Codecov badge URL in `README.md` to reference the `co2-calculator` repository instead of the previous `epfl-calculator-co2` repository.