### PR TITLE
feat/234 add module navigation component with prev/next links

### DIFF
--- a/frontend/src/components/organisms/module/ModuleNavigation.vue
+++ b/frontend/src/components/organisms/module/ModuleNavigation.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { Module, MODULES_LIST } from 'src/constant/modules';
+import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
+
+const props = defineProps<{
+  currentModule: Module;
+}>();
+
+const $route = useRoute();
+
+const currentIndex = computed(() => {
+  return MODULES_LIST.indexOf(props.currentModule);
+});
+
+const isLastModule = computed(() => {
+  return currentIndex.value === MODULES_LIST.length - 1;
+});
+
+const previousModule = computed(() => {
+  if (currentIndex.value > 0) {
+    return MODULES_LIST[currentIndex.value - 1];
+  }
+  return null;
+});
+
+const nextModule = computed(() => {
+  if (currentIndex.value < MODULES_LIST.length - 1) {
+    return MODULES_LIST[currentIndex.value + 1];
+  }
+  return null;
+});
+
+const previousModuleRoute = computed(() => {
+  if (!previousModule.value) return null;
+  return {
+    name: 'module',
+    params: {
+      language: $route.params.language,
+      unit: $route.params.unit,
+      year: $route.params.year,
+      module: previousModule.value,
+    },
+  };
+});
+
+const nextModuleRoute = computed(() => {
+  if (!nextModule.value) return null;
+  return {
+    name: 'module',
+    params: {
+      language: $route.params.language,
+      unit: $route.params.unit,
+      year: $route.params.year,
+      module: nextModule.value,
+    },
+  };
+});
+
+// Build route for results page
+const resultsRoute = computed(() => {
+  return {
+    name: 'results',
+    params: {
+      language: $route.params.language,
+      unit: $route.params.unit,
+      year: $route.params.year,
+    },
+  };
+});
+</script>
+
+<template>
+  <div class="module-navigation">
+    <router-link
+      v-if="previousModule"
+      :to="previousModuleRoute"
+      class="module-navigation__link module-navigation__link--previous"
+    >
+      <q-icon name="chevron_left" class="chevron-left" size="sm" />
+
+      <span class="text-body2 text-weight-medium">{{
+        $t(previousModule!)
+      }}</span>
+      <module-icon :name="previousModule" />
+    </router-link>
+    <router-link
+      v-if="nextModule"
+      :to="nextModuleRoute"
+      class="module-navigation__link module-navigation__link--next"
+    >
+      <module-icon :name="nextModule" />
+      <span class="text-body2 text-weight-medium">{{ $t(nextModule!) }}</span>
+      <q-icon name="chevron_right" class="chevron-right" size="sm" />
+    </router-link>
+    <q-btn
+      v-if="isLastModule"
+      :to="resultsRoute"
+      class="module-navigation__link module-navigation__link--next text-weight-medium"
+      icon="bar_chart"
+      :label="$t('results_btn')"
+      color="info"
+      unelevated
+      no-caps
+      size="md"
+    >
+    </q-btn>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.module-navigation {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+
+  &__link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    color: inherit;
+
+    transition: background-color 0.2s;
+
+    &:hover {
+      .chevron-left {
+        transform: translateX(-0.25rem);
+      }
+      .chevron-right {
+        transform: translateX(0.25rem);
+      }
+    }
+
+    &--previous {
+      margin-right: auto;
+    }
+
+    .chevron-left {
+      transition: transform 0.2s;
+    }
+    .chevron-right {
+      transition: transform 0.2s;
+    }
+  }
+}
+</style>

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -27,6 +27,7 @@
       :data="data?.totals?.total_kg_co2eq"
       :type="currentModuleType"
     />
+    <module-navigation :current-module="currentModuleType" />
   </q-page>
 </template>
 
@@ -38,6 +39,7 @@ import ModuleTitle from 'src/components/organisms/module/ModuleTitle.vue';
 import ModuleCharts from 'src/components/organisms/module/ModuleCharts.vue';
 import ModuleTableSection from 'src/components/organisms/module/ModuleTableSection.vue';
 import ModuleTotalResult from 'src/components/organisms/module/ModuleTotalResult.vue';
+import ModuleNavigation from 'src/components/organisms/module/ModuleNavigation.vue';
 import { Module, MODULES } from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
 import { ModuleConfig } from 'src/constant/moduleConfig';


### PR DESCRIPTION
## What does this change?
Adds a new `ModuleNavigation` component that provides previous/next navigation between modules and a results button on the final module.

## Why is this needed?
Users need an intuitive way to navigate sequentially through learning modules without returning to the module list. This improves the learning flow and user experience by providing clear navigation controls at the bottom of each module.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

Related to #234 