### PR TITLE
feat/211 numbers format

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -280,6 +280,7 @@ import ModuleInlineSelect from './ModuleInlineSelect.vue';
 import { QInput, QSelect, useQuasar } from 'quasar';
 import { useModuleStore } from 'src/stores/modules';
 import type { Module, Threshold } from 'src/constant/modules';
+import { formatNumber } from 'src/utils/number';
 
 const { t: $t } = useI18n();
 const $q = useQuasar();
@@ -404,11 +405,13 @@ function renderCell(row: ModuleRow, col: { field: string; name: string }) {
   const val = row[col.field];
   if (val === undefined || val === null || val === '') return '-';
   if (col.name === 'kg_co2eq') {
-    const n = Number(val);
-    if (!Number.isFinite(n)) return '-';
-    return n.toFixed(0);
+    return formatNumber(val as number, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
   }
-  return String(val);
+  // Check if the value is a number and format it
+  return formatNumber(val as number);
 }
 
 function getItemName(row: ModuleRow): string {

--- a/frontend/src/components/organisms/module/ModuleTotalResult.vue
+++ b/frontend/src/components/organisms/module/ModuleTotalResult.vue
@@ -10,7 +10,7 @@
            second line: kg CO₂-eq -->
       <div class="text-h3 module-total-result__value">
         <h1 class="text-h1 text-weight-bold q-mb-none">
-          {{ new Intl.NumberFormat().format(data) }}
+          {{ formatNumber(data) }}
         </h1>
         <p class="text-body2 text-secondary q-mb-none">
           {{ $t('results_units') }}
@@ -22,6 +22,7 @@
 
 <script setup lang="ts">
 import { Module } from 'src/constant/modules';
+import { formatNumber } from 'src/utils/number';
 
 defineProps<{
   type: Module;

--- a/frontend/src/components/organisms/workspace-selector/YearSelector.vue
+++ b/frontend/src/components/organisms/workspace-selector/YearSelector.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import type { QTableColumn } from 'quasar';
 import { useI18n } from 'vue-i18n';
+import { formatNumber } from 'src/utils/number';
 
 const ROWS_PER_PAGE = 20;
 
@@ -77,7 +78,7 @@ const columns = computed<QTableColumn[]>(() => [
         <!-- kg CO2 -->
         <q-td key="kgco2" :props="props" class="text-center">
           <span class="text-weight-medium"
-            >{{ props.row.kgco2.toLocaleString() }}kg</span
+            >{{ formatNumber(props.row.kgco2) }}kg</span
           >
         </q-td>
       </q-tr>

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -17,11 +17,13 @@ const viewUncertainties = ref(false);
 
 const getModuleConfig = (module: string) => MODULES_CONFIG[module];
 
+import { formatNumber } from 'src/utils/number';
+
 // TODO: Replace with actual backend data when available
 // This function will get the number value from backend response using numberKey
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getNumberValue = (_module: string, _numberKey: string): string => {
-  return "37'250";
+  return formatNumber(37250);
 };
 
 const getUncertainty = (

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -1,0 +1,30 @@
+/**
+ * Formats a number using Swiss German locale (de-CH)
+ * This ensures consistent number formatting throughout the app:
+ * - Thousands separator: apostrophe (')
+ * - Decimal separator: dot (.)
+ *
+ * Example: 10750.64 -> "10'750.64"
+ *
+ * @param value - The number to format
+ * @param options - Optional Intl.NumberFormatOptions for customization
+ *   - For integers: { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+ *   - For specific decimals: { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+ * @returns Formatted number string
+ */
+export function formatNumber(
+  value: number | string | null | undefined,
+  options?: Intl.NumberFormatOptions,
+): string {
+  if (value === null || value === undefined || value === '') {
+    return '-';
+  }
+
+  const numValue = typeof value === 'string' ? Number(value) : value;
+
+  if (!Number.isFinite(numValue)) {
+    return '-';
+  }
+
+  return new Intl.NumberFormat('de-CH', options).format(numValue);
+}


### PR DESCRIPTION
## What does this change?
Replaces manual number formatting implementations across the application with a centralized `formatNumber` utility function. Updates ModuleTable, ModuleTotalResult, YearSelector, and ResultsPage components to use consistent number formatting.

## Why is this needed?
Previously, different parts of the application used inconsistent number formatting methods (`toFixed()`, `toLocaleString()`, `Intl.NumberFormat`, manual string formatting). This led to:
- Inconsistent thousand separators and decimal handling across the UI
- Code duplication and maintenance burden
- Potential localization issues
- Harder to enforce a consistent number display standard

Centralizing this logic ensures uniform number presentation throughout the application and makes future formatting changes easier to implement.

- Related to #211 
