### PR TITLE
feat/94 Timeline vertical space

### DIFF
--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue';
 import Co2LanguageSelector from 'src/components/atoms/Co2LanguageSelector.vue';
 import { useAuthStore } from 'src/stores/auth';
 import { useRouter } from 'vue-router';
-import Co2Timeline from '../organisms/layout/Co2Timeline.vue';
 import { useRoute } from 'vue-router';
 import { useTimelineStore } from 'src/stores/modules';
 import { Module } from 'src/constant/modules';
@@ -205,10 +204,6 @@ const isInBackOfficeRoute = computed(() => isBackOfficeRoute(route));
           @click="toggleState"
         />
       </q-toolbar>
-      <q-separator />
-    </template>
-    <template v-if="route.name === 'module'">
-      <Co2Timeline />
       <q-separator />
     </template>
   </q-header>

--- a/frontend/src/css/02-tokens/_components.scss
+++ b/frontend/src/css/02-tokens/_components.scss
@@ -74,6 +74,7 @@ $timeline-item-size: opt.$tokens-spacing-24 !default;
 $timeline-item-selected-size: opt.$tokens-spacing-16 !default;
 $timeline-item-selected-bg: opt.$tokens-colors-grey-scale-grey-600 !default;
 $timeline-item-border-weight: opt.$tokens-spacing-1 !default;
+$timeline-border-color: opt.$tokens-colors-grey-scale-grey-300 !default;
 $timeline-item-default-icon: opt.$tokens-colors-grey-scale-grey-600 !default;
 $timeline-item-default-bg: opt.$tokens-colors-grey-scale-grey-600 !default;
 $timeline-item-default-border-color: opt.$tokens-colors-grey-scale-grey-600 !default;

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -1,33 +1,37 @@
 <template>
-  <q-page class="module-page">
-    <module-title
-      :type="currentModuleType"
-      :has-description="currentModuleConfig.hasDescription"
-      :has-description-subtext="currentModuleConfig.hasDescriptionSubtext"
-      :has-tooltip="currentModuleConfig.hasTooltip"
-    />
-    <module-charts :type="currentModuleType" />
-    <!-- module tables iteration -->
-    <module-table-section
-      v-if="currentModuleType === MODULES.EquipmentElectricConsumption"
-      :type="currentModuleType"
-      :data="data"
-      :loading="loading"
-      :error="error"
-      :unit-id="unit"
-      :year="year"
-    />
-    <!-- module summary -->
-    <module-total-result
-      v-if="
-        (
-          [MODULES.EquipmentElectricConsumption, MODULES.MyLab] as Module[]
-        ).includes(currentModuleType)
-      "
-      :data="data?.totals?.total_kg_co2eq"
-      :type="currentModuleType"
-    />
-    <module-navigation :current-module="currentModuleType" />
+  <q-page>
+    <Co2Timeline />
+    <q-separator />
+    <div class="module-page">
+      <module-title
+        :type="currentModuleType"
+        :has-description="currentModuleConfig.hasDescription"
+        :has-description-subtext="currentModuleConfig.hasDescriptionSubtext"
+        :has-tooltip="currentModuleConfig.hasTooltip"
+      />
+      <module-charts :type="currentModuleType" />
+      <!-- module tables iteration -->
+      <module-table-section
+        v-if="currentModuleType === MODULES.EquipmentElectricConsumption"
+        :type="currentModuleType"
+        :data="data"
+        :loading="loading"
+        :error="error"
+        :unit-id="unit"
+        :year="year"
+      />
+      <!-- module summary -->
+      <module-total-result
+        v-if="
+          (
+            [MODULES.EquipmentElectricConsumption, MODULES.MyLab] as Module[]
+          ).includes(currentModuleType)
+        "
+        :data="data?.totals?.total_kg_co2eq"
+        :type="currentModuleType"
+      />
+      <module-navigation :current-module="currentModuleType" />
+    </div>
   </q-page>
 </template>
 
@@ -44,6 +48,7 @@ import { Module, MODULES } from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
 import { ModuleConfig } from 'src/constant/moduleConfig';
 import { MODULES_CONFIG } from 'src/constant/module-config';
+import Co2Timeline from 'src/components/organisms/layout/Co2Timeline.vue';
 
 const $route = useRoute();
 const currentModuleType = computed(() => $route.params.module as Module);

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -12,6 +12,7 @@ import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonF
 import DistibutionsChart from 'src/components/charts/results/DistibutionsChart.vue';
 import { formatNumber } from 'src/utils/number';
 
+import Co2Timeline from 'src/components/organisms/layout/Co2Timeline.vue';
 const { t } = useI18n();
 
 // Use global colorblindMode directly as single source of truth
@@ -44,201 +45,207 @@ const getUncertainty = (
 </script>
 
 <template>
-  <q-page class="page-grid">
-    <q-card flat bordered class="q-pa-xl">
-      <div class="flex justify-between items-center">
-        <div>
-          <h2 class="text-h2 text-weight-medium">
-            {{ $t('results_title') }}
-          </h2>
-          <span class="text-body1 text-secondary">{{
-            $t('results_subtitle')
-          }}</span>
-        </div>
-
-        <div class="flex column justify-between">
-          <q-btn
-            color="accent"
-            icon="download"
-            :label="$t('results_download_pdf')"
-            unelevated
-            no-caps
-            size="md"
-            class="text-weight-medium q-mb-md"
-          />
-          <div class="flex column">
-            <q-checkbox
-              v-model="colorblindMode"
-              :label="$t('results_colorblind_mode')"
-              color="accent"
-              class="text-weight-medium"
-              size="xs"
-            />
-            <q-checkbox
-              v-model="viewUncertainties"
-              :label="$t('results_view_uncertainties')"
-              color="accent"
-              class="text-weight-medium"
-              size="xs"
-            />
-          </div>
-        </div>
-      </div>
-    </q-card>
-    <q-card flat class="grid-3-col">
-      <BigNumber
-        :title="$t('results_total_unit_carbon_footprint')"
-        number="37'250"
-        :comparison="$t('results_equivalent_to_car', { km: '10\'000' })"
-        comparison-highlight="10'000"
-        color="negative"
-      >
-        <template #tooltip>tip</template>
-      </BigNumber>
-      <BigNumber
-        :title="$t('results_carbon_footprint_per_fte')"
-        number="8.2"
-        :comparison="$t('results_paris_agreement_budget')"
-        comparison-highlight="2t CO₂-eq"
-        color="negative"
-      >
-        <template #tooltip>tooltip</template>
-      </BigNumber>
-      <BigNumber
-        :title="$t('results_unit_carbon_footprint')"
-        number="-11.3%"
-        :unit="$t('results_compared_to', { year: '2022' })"
-        color="positive"
-        :comparison="$t('results_value_of', { value: '42\'500' })"
-        comparison-highlight="42'500 t CO₂-eq"
-      >
-        <template #tooltip>tooltip</template>
-      </BigNumber>
-    </q-card>
-    <q-card flat class="grid-2-col">
-      <ModuleCarbonFootprintChart />
-
-      <ChartContainer :title="$t('results_carbon_footprint_per_person')">
-        <template #tooltip>tooltip</template>
-        <CarbonFootPrintPerPersonChart />
-      </ChartContainer>
-    </q-card>
-    <div class="q-mt-xl">
-      <q-card bordered flat class="q-pa-xl">
-        <div class="flex justify-between items-center">
-          <div>
-            <h2 class="text-h2 text-weight-medium">
-              {{ $t('results_by_category_title') }}
-            </h2>
-            <span class="text-body1 text-secondary">{{
-              $t('results_by_category_subtitle', { year: '2024' })
-            }}</span>
-          </div>
-        </div>
-      </q-card>
-      <template v-for="module in MODULES_LIST" :key="module">
-        <q-card flat bordered class="q-pa-none q-mt-xl">
-          <q-expansion-item expand-separator default-opened>
-            <template #header>
-              <div class="flex justify-between items-center">
-                <module-icon
-                  :name="module"
-                  size="md"
-                  color="accent"
-                  class="q-mr-sm"
-                />
-                <div class="text-h5 text-weight-medium">{{ $t(module) }}</div>
-                <q-badge
-                  v-if="getModuleConfig(module)?.uncertainty"
-                  outline
-                  rounded
-                  :color="
-                    getUncertainty(getModuleConfig(module)?.uncertainty).color
-                  "
-                  :label="
-                    getUncertainty(getModuleConfig(module)?.uncertainty).label
-                  "
-                  class="q-ml-sm"
-                />
-              </div>
-            </template>
-            <q-separator />
-
-            <div class="q-pa-lg">
-              <q-card
-                v-if="getModuleConfig(module)?.resultBigNumbers"
-                flat
-                class="grid-3-col q-mb-lg"
-              >
-                <BigNumber
-                  v-for="(bigNumber, id) in getModuleConfig(module)
-                    ?.resultBigNumbers"
-                  :key="id"
-                  :title="$t(bigNumber.titleKey)"
-                  :number="getNumberValue(module, bigNumber.numberKey)"
-                  :unit="
-                    bigNumber.unitKey
-                      ? $t(bigNumber.unitKey, bigNumber.unitParams || {})
-                      : undefined
-                  "
-                  :comparison="
-                    bigNumber.comparisonKey
-                      ? $t(
-                          bigNumber.comparisonKey,
-                          bigNumber.comparisonParams || {},
-                        )
-                      : undefined
-                  "
-                  :comparison-highlight="bigNumber.comparisonHighlight"
-                  :color="bigNumber.color"
-                >
-                  <template #tooltip>
-                    {{
-                      bigNumber.tooltipKey
-                        ? $t(bigNumber.tooltipKey)
-                        : 'tooltip'
-                    }}
-                  </template>
-                </BigNumber>
-              </q-card>
-              <q-card flat bordered>
-                <q-card-section class="flex items-center q-mb-xs">
-                  <q-icon name="o_info" size="xs" color="primary">
-                    <q-tooltip
-                      v-if="$slots.tooltip"
-                      anchor="center right"
-                      self="top right"
-                      class="u-tooltip"
-                    >
-                      <slot name="tooltip"></slot>
-                    </q-tooltip>
-                  </q-icon>
-                  <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
-                    {{ $t('results_equipment_distribution_title') }}
-                  </span>
-                </q-card-section>
-                <q-card-section class="chart-container">
-                  <DistibutionsChart />
-                </q-card-section>
-              </q-card>
-            </div>
-          </q-expansion-item>
-        </q-card>
-      </template>
-    </div>
-    <div class="q-mt-xl">
+  <q-page>
+    <Co2Timeline />
+    <q-separator />
+    <div class="page-grid">
       <q-card flat bordered class="q-pa-xl">
         <div class="flex justify-between items-center">
           <div>
             <h2 class="text-h2 text-weight-medium">
-              {{ $t('results_objectives_2040_title') }}
+              {{ $t('results_title') }}
             </h2>
             <span class="text-body1 text-secondary">{{
-              $t('results_objectives_2040_subtitle')
+              $t('results_subtitle')
             }}</span>
+          </div>
+
+          <div class="flex column justify-between">
+            <q-btn
+              color="accent"
+              icon="download"
+              :label="$t('results_download_pdf')"
+              unelevated
+              no-caps
+              size="md"
+              class="text-weight-medium q-mb-md"
+            />
+            <div class="flex column">
+              <q-checkbox
+                v-model="colorblindMode"
+                :label="$t('results_colorblind_mode')"
+                color="accent"
+                class="text-weight-medium"
+                size="xs"
+              />
+              <q-checkbox
+                v-model="viewUncertainties"
+                :label="$t('results_view_uncertainties')"
+                color="accent"
+                class="text-weight-medium"
+                size="xs"
+              />
+            </div>
           </div>
         </div>
       </q-card>
+      <q-card flat class="grid-3-col">
+        <BigNumber
+          :title="$t('results_total_unit_carbon_footprint')"
+          number="37'250"
+          :comparison="$t('results_equivalent_to_car', { km: '10\'000' })"
+          comparison-highlight="10'000"
+          color="negative"
+        >
+          <template #tooltip>tip</template>
+        </BigNumber>
+        <BigNumber
+          :title="$t('results_carbon_footprint_per_fte')"
+          number="8.2"
+          :comparison="$t('results_paris_agreement_budget')"
+          comparison-highlight="2t CO₂-eq"
+          color="negative"
+        >
+          <template #tooltip>tooltip</template>
+        </BigNumber>
+        <BigNumber
+          :title="$t('results_unit_carbon_footprint')"
+          number="-11.3%"
+          :unit="$t('results_compared_to', { year: '2022' })"
+          color="positive"
+          :comparison="$t('results_value_of', { value: '42\'500' })"
+          comparison-highlight="42'500 t CO₂-eq"
+        >
+          <template #tooltip>tooltip</template>
+        </BigNumber>
+      </q-card>
+      <q-card flat class="grid-2-col">
+        <ModuleCarbonFootprintChart />
+
+        <ChartContainer :title="$t('results_carbon_footprint_per_person')">
+          <template #tooltip>tooltip</template>
+          <CarbonFootPrintPerPersonChart />
+        </ChartContainer>
+      </q-card>
+      <div class="q-mt-xl">
+        <q-card bordered flat class="q-pa-xl">
+          <div class="flex justify-between items-center">
+            <div>
+              <h2 class="text-h2 text-weight-medium">
+                {{ $t('results_by_category_title') }}
+              </h2>
+              <span class="text-body1 text-secondary">{{
+                $t('results_by_category_subtitle', { year: '2024' })
+              }}</span>
+            </div>
+          </div>
+        </q-card>
+        <template v-for="module in MODULES_LIST" :key="module">
+          <q-card flat bordered class="q-pa-none q-mt-xl">
+            <q-expansion-item expand-separator default-opened>
+              <template #header>
+                <div class="flex justify-between items-center">
+                  <module-icon
+                    :name="module"
+                    size="md"
+                    color="accent"
+                    class="q-mr-sm"
+                  />
+                  <div class="text-h5 text-weight-medium">{{ $t(module) }}</div>
+                  <q-badge
+                    v-if="getModuleConfig(module)?.uncertainty"
+                    outline
+                    rounded
+                    :color="
+                      getUncertainty(getModuleConfig(module)?.uncertainty).color
+                    "
+                    :label="
+                      getUncertainty(getModuleConfig(module)?.uncertainty).label
+                    "
+                    class="q-ml-sm"
+                  />
+                </div>
+              </template>
+              <q-separator />
+
+              <div class="q-pa-lg">
+                <q-card
+                  v-if="getModuleConfig(module)?.resultBigNumbers"
+                  flat
+                  class="grid-3-col q-mb-lg"
+                >
+                  <BigNumber
+                    v-for="(bigNumber, id) in getModuleConfig(module)
+                      ?.resultBigNumbers"
+                    :key="id"
+                    :title="$t(bigNumber.titleKey)"
+                    :number="getNumberValue(module, bigNumber.numberKey)"
+                    :unit="
+                      bigNumber.unitKey
+                        ? $t(bigNumber.unitKey, bigNumber.unitParams || {})
+                        : undefined
+                    "
+                    :comparison="
+                      bigNumber.comparisonKey
+                        ? $t(
+                            bigNumber.comparisonKey,
+                            bigNumber.comparisonParams || {},
+                          )
+                        : undefined
+                    "
+                    :comparison-highlight="bigNumber.comparisonHighlight"
+                    :color="bigNumber.color"
+                  >
+                    <template #tooltip>
+                      {{
+                        bigNumber.tooltipKey
+                          ? $t(bigNumber.tooltipKey)
+                          : 'tooltip'
+                      }}
+                    </template>
+                  </BigNumber>
+                </q-card>
+                <q-card flat bordered>
+                  <q-card-section class="flex items-center q-mb-xs">
+                    <q-icon name="o_info" size="xs" color="primary">
+                      <q-tooltip
+                        v-if="$slots.tooltip"
+                        anchor="center right"
+                        self="top right"
+                        class="u-tooltip"
+                      >
+                        <slot name="tooltip"></slot>
+                      </q-tooltip>
+                    </q-icon>
+                    <span
+                      class="text-body1 text-weight-medium q-ml-sm q-mb-none"
+                    >
+                      {{ $t('results_equipment_distribution_title') }}
+                    </span>
+                  </q-card-section>
+                  <q-card-section class="chart-container">
+                    <DistibutionsChart />
+                  </q-card-section>
+                </q-card>
+              </div>
+            </q-expansion-item>
+          </q-card>
+        </template>
+      </div>
+      <div class="q-mt-xl">
+        <q-card flat bordered class="q-pa-xl">
+          <div class="flex justify-between items-center">
+            <div>
+              <h2 class="text-h2 text-weight-medium">
+                {{ $t('results_objectives_2040_title') }}
+              </h2>
+              <span class="text-body1 text-secondary">{{
+                $t('results_objectives_2040_subtitle')
+              }}</span>
+            </div>
+          </div>
+        </q-card>
+      </div>
     </div>
   </q-page>
 </template>


### PR DESCRIPTION
## What does this change?
Moves the Co2Timeline component from the fixed header (Co2Header.vue) to the module page content (ModulePage.vue), allowing it to scroll with the page instead of remaining fixed at the top.

## Why is this needed?
The fixed header was taking up too much vertical space, reducing the area available for viewing tables and other module information. By moving the timeline to scrollable content, users get more screen real estate for the actual module data while still having access to the timeline when needed.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

- Related to #94 