### PR TITLE
feat235(page width)/make page wider for dense table

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -59,7 +59,7 @@
           :key="col.name"
           :props="scope"
           :align="col.align"
-          class="q-pa-md"
+          class="q-pa-xs"
         >
           <span>{{ col.label }}</span>
           <q-icon
@@ -172,12 +172,12 @@
     </template>
 
     <template #no-data>
-      <div class="text-center q-pa-md">No data available</div>
+      <div class="text-center q-pa-sm">No data available</div>
     </template>
   </q-table>
 
   <q-dialog v-model="editDialogOpen" persistent>
-    <q-card style="width: 1200px; max-width: 90vw">
+    <q-card style="width: 1320px; max-width: 90vw">
       <q-card-section class="flex justify-between items-center">
         <div class="text-h4 text-weight-medium">
           {{

--- a/frontend/src/css/02-tokens/_options.scss
+++ b/frontend/src/css/02-tokens/_options.scss
@@ -72,7 +72,7 @@ $tokens-colors-red-highlight: #fbeceb !default;
 $tokens-colors-red-highlight-200: #f4c6c2 !default;
 
 // Layout
-$tokens-layout-page-width: 75rem !default;
+$tokens-layout-page-width: 1320px !default;
 $tokens-layout-lg-modal-width: 75rem !default;
 $tokens-layout-md-modal-width: 30rem !default;
 $tokens-layout-sm-modal-width: 20rem !default;

--- a/frontend/src/css/02-tokens/_quasar-bridge.scss
+++ b/frontend/src/css/02-tokens/_quasar-bridge.scss
@@ -187,7 +187,7 @@ $rating-grade-color: opt.$tokens-colors-status-yellow !default;
 // Breakpoints
 $breakpoint-xs: 599px !default; // Mobile max-width
 $breakpoint-sm: 1199px !default; // Tablet max-width
-$breakpoint-md: 1200px !default; // Desktop min-width (effectively desktop and above)
+$breakpoint-md: 1320px !default; // Desktop min-width (effectively desktop and above)
 $breakpoint-lg: 1919px !default; // Large desktop (kept for compatibility)
 
 // Z-index

--- a/frontend/src/css/03-layout/_grid.scss
+++ b/frontend/src/css/03-layout/_grid.scss
@@ -15,7 +15,7 @@
 
 $breakpoint-mobile: q.$breakpoint-xs + 1;
 $breakpoint-tablet: q.$breakpoint-sm;
-$breakpoint-desktop: 1200px;
+$breakpoint-desktop: 1320px;
 
 .grid-1-col {
   display: grid;

--- a/frontend/src/i18n/infrastructure.ts
+++ b/frontend/src/i18n/infrastructure.ts
@@ -7,6 +7,6 @@ export default {
   },
   [MODULES_DESCRIPTIONS.Infrastructure]: {
     en: "Define your lab's physical footprint across EPFL buildings and spaces.",
-    fr: "Bâtiments etc",
+    fr: 'Bâtiments etc',
   },
 } as const;

--- a/frontend/src/pages/back-office/DocumentationEditingPage.vue
+++ b/frontend/src/pages/back-office/DocumentationEditingPage.vue
@@ -232,7 +232,7 @@ const columns: QTableColumn[] = [
 
 <style scoped lang="scss">
 .page {
-  max-width: 1200px;
+  max-width: 1320px;
 }
 </style>
 


### PR DESCRIPTION
## What does this change?
Increases the main page container width from 1200px to 1320px across the application, adjusts breakpoints accordingly, and optimizes spacing in tables and modals.

## Why is this needed?
Modern screens are larger and 1320px is a more contemporary standard (Bootstrap's container-xl default). This provides a more spacious layout while maintaining readability and better utilizes available screen space.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues
- Related to #235 