### PR TITLE
feat/228 refactor Pagination/Limit/Filter for Tables and Summary Views

### DIFF
--- a/backend/app/seed_emission_factors.py
+++ b/backend/app/seed_emission_factors.py
@@ -152,4 +152,5 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    # run script on /app/api/v1/table_power.csv
     asyncio.run(main())

--- a/backend/app/seed_equipment.py
+++ b/backend/app/seed_equipment.py
@@ -434,4 +434,5 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    # run script on /app/api/v1/synth_data.csv
     asyncio.run(main())

--- a/docs/implementation-plans/228-refactor-pagination-limit-filter.md
+++ b/docs/implementation-plans/228-refactor-pagination-limit-filter.md
@@ -1,0 +1,168 @@
+# Implementation Plan: Refactor Pagination & Lazy Loading for Equipment Module
+
+## Overview
+
+Implement lazy loading with per-submodule pagination and sorting. Load only summary totals on initial page load, then fetch individual submodule data when users expand collapsible sections.
+
+## Requirements
+
+1. Modify existing endpoint to return totals only when `preview_limit=0`
+2. Load only totals on page load, fetch submodule data on expansion
+3. Per-submodule state: independent sort/filter/pagination
+4. Default limit: 20, changing sort/pagination resets to page 1
+5. After mutations, refetch only affected submodule
+6. No test coverage needed
+
+---
+
+## Implementation Steps
+
+### Backend (3 files)
+
+#### 1. Repository Layer
+
+**File**: [backend/app/repositories/equipment_repo.py:119-188](backend/app/repositories/equipment_repo.py#L119-L188)
+
+- Add `sort_by` and `sort_order` parameters to `get_equipment_with_emissions()`
+- Create field mapping dict: `{"id": Equipment.id, "name": Equipment.name, "kg_co2eq": EquipmentEmission.kg_co2eq, ...}`
+- Apply dynamic `ORDER BY` based on sort parameters
+
+#### 2. Service Layer
+
+**File**: [backend/app/services/equipment_service.py:35-263](backend/app/services/equipment_service.py#L35-L263)
+
+**In `get_module_data()`**:
+
+- When `preview_limit=0`, skip item fetching, return empty items arrays with summaries only
+
+**In `get_submodule_data()`**:
+
+- Add `sort_by` and `sort_order` parameters
+- Pass to repository layer
+
+#### 3. API Layer
+
+**File**: [backend/app/api/v1/modules.py:22-143](backend/app/api/v1/modules.py#L22-L143)
+
+- Update `preview_limit` Query validator: `ge=0` (allow 0)
+- Pass `sort_by` and `sort_order` from submodule endpoint to service layer
+
+---
+
+### Frontend (4 files)
+
+#### 4. Store
+
+**File**: [frontend/src/stores/modules.ts](frontend/src/stores/modules.ts)
+
+**State**: Add `loadedSubmodules: Record<string, boolean>`
+
+**New method**: `getModuleTotals()` - calls endpoint with `preview_limit=0`
+
+**Update `getSubmoduleData()`**:
+
+- Add `sortBy` and `sortOrder` parameters
+- Build query string with sort params
+- Mark as loaded: `state.loadedSubmodules[submoduleId] = true`
+
+**New helper**: `findSubmoduleForEquipment(equipmentId)` - searches loaded data to find which submodule contains equipment
+
+**Update mutations** (`postItem`, `patchItem`, `deleteItem`):
+
+- Find affected submodule using helper
+- Refetch only that submodule with current pagination/sort state
+- Also call `getModuleTotals()` to refresh counts
+
+**Exports**: Add `getModuleTotals`
+
+#### 5. ModulePage
+
+**File**: [frontend/src/pages/app/ModulePage.vue:68-86](frontend/src/pages/app/ModulePage.vue#L68-L86)
+
+- Replace `moduleStore.getModuleData()` with `moduleStore.getModuleTotals()`
+
+#### 6. SubModuleSection
+
+**File**: [frontend/src/components/organisms/module/SubModuleSection.vue](frontend/src/components/organisms/module/SubModuleSection.vue)
+
+**Template**:
+
+- Add `@before-show="onExpand"` to q-expansion-item
+- Pass to ModuleTable: `:loading="submoduleLoading"`, `:pagination-data="paginationData"`, `:submodule-id="submodule.id"`
+- Add handlers: `@page-change="onPageChange"`, `@sort-change="onSortChange"`
+
+**Script**:
+
+- Add computed: `submoduleData`, `submoduleLoading`, `submoduleError`, `submoduleCount`, `paginationData` (all read from store state)
+- Add methods:
+  - `onExpand()`: Check `loadedSubmodules[id]`, fetch if not loaded
+  - `onPageChange(page)`: Call `getSubmoduleData()` with new page
+  - `onSortChange(sortBy, sortOrder)`: Call `getSubmoduleData()` with sort, reset to page 1
+- Update `rows` computed: Use `submoduleData.value?.items`
+
+#### 7. ModuleTable
+
+**File**: [frontend/src/components/organisms/module/ModuleTable.vue](frontend/src/components/organisms/module/ModuleTable.vue)
+
+**Props**: Add `submoduleId?: string`, `paginationData?: { page, limit, total, sortBy?, sortOrder? }`
+
+**Emits**: Add `page-change`, `sort-change`
+
+**Pagination**:
+
+- Remove local `pagination` ref
+- Replace with computed that uses `props.paginationData` (server-side) or fallback to local state
+
+**Template**: Add `@request="onRequest"` to q-table
+
+**Handler**: `onRequest()` - emit `page-change` or `sort-change` based on user action
+
+---
+
+## Data Flow
+
+**Initial Load**: `ModulePage → getModuleTotals() → GET /modules?preview_limit=0 → Display collapsed headers with counts`
+
+**Expand**: `onExpand() → Check loaded → getSubmoduleData(page=1, limit=20) → GET /modules/.../sub_scientific?page=1&limit=20 → Display table`
+
+**Paginate**: `Click next → emit('page-change', 2) → getSubmoduleData(page=2) → Table updates`
+
+**Sort**: `Click column → emit('sort-change', 'name', 'asc') → getSubmoduleData(page=1, sortBy='name') → Table sorted`
+
+**Mutate**: `postItem() → POST → findSubmodule → refetch that submodule + totals → Table updates`
+
+---
+
+## Critical Files (7 total)
+
+### Backend
+
+1. [backend/app/repositories/equipment_repo.py](backend/app/repositories/equipment_repo.py)
+2. [backend/app/services/equipment_service.py](backend/app/services/equipment_service.py)
+3. [backend/app/api/v1/modules.py](backend/app/api/v1/modules.py)
+
+### Frontend
+
+4. [frontend/src/stores/modules.ts](frontend/src/stores/modules.ts)
+5. [frontend/src/pages/app/ModulePage.vue](frontend/src/pages/app/ModulePage.vue)
+6. [frontend/src/components/organisms/module/SubModuleSection.vue](frontend/src/components/organisms/module/SubModuleSection.vue)
+7. [frontend/src/components/organisms/module/ModuleTable.vue](frontend/src/components/organisms/module/ModuleTable.vue)
+
+---
+
+## Edge Cases
+
+- Re-expand: Check `loadedSubmodules`, skip if already loaded
+- Errors: Display in table, retry on collapse/re-expand
+- Loading: Show spinner during fetch
+- Empty submodule: Show "No data", form available
+- Sort persistence: State maintained across collapse/expand
+
+## Success Criteria
+
+✅ Initial load fetches only totals
+✅ Lazy load on first expansion only
+✅ Independent pagination per submodule
+✅ Sorting resets to page 1
+✅ Mutations refetch only affected submodule + totals
+✅ Loading/error states displayed

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -3,12 +3,13 @@
     v-if="submodule.tableNameKey"
     :label="
       $t(submodule.tableNameKey, {
-        count: data?.submodules?.[submodule.id]?.count || 0,
+        count: submoduleCount || 0,
       })
     "
     flat
     header-class="text-h5 text-weight-medium"
     class="q-mb-md container container--pa-none module-submodule-section q-mb-xl"
+    @before-show="onExpand"
   >
     <q-separator />
     <q-card-section class="q-pa-none">
@@ -16,14 +17,18 @@
         <module-table
           :module-fields="submodule.moduleFields"
           :rows="rows"
-          :loading="loading"
-          :error="error"
+          :loading="submoduleLoading"
+          :error="submoduleError"
           :module-type="moduleType"
           :submodule-type="submoduleType as any"
           :unit-id="unitId"
           :year="year"
           :threshold="threshold"
           :has-top-bar="submodule.hasTableTopBar"
+          :pagination-data="paginationData"
+          :submodule-id="submodule.id"
+          @page-change="onPageChange"
+          @sort-change="onSortChange"
         />
       </div>
       <q-separator />
@@ -85,12 +90,108 @@ type SubModuleSectionProps = ConditionalSubmoduleProps & CommonProps;
 
 const props = defineProps<SubModuleSectionProps>();
 
+// Normalize submodule ID (remove 'sub_' prefix for store keys)
+const normalizedSubmoduleId = computed(() => {
+  return props.submodule.id.startsWith('sub_')
+    ? props.submodule.id.replace('sub_', '')
+    : props.submodule.id;
+});
+
+const submoduleData = computed(() => {
+  return moduleStore.state.dataSubmodule[normalizedSubmoduleId.value] ?? null;
+});
+
+const submoduleLoading = computed(() => {
+  return (
+    moduleStore.state.loadingSubmodule[normalizedSubmoduleId.value] ?? false
+  );
+});
+
+const submoduleError = computed(() => {
+  return moduleStore.state.errorSubmodule[normalizedSubmoduleId.value] ?? null;
+});
+
+const submoduleCount = computed(() => {
+  return (
+    submoduleData.value?.count ??
+    props.data?.submodules?.[props.submodule.id]?.count ??
+    0
+  );
+});
+
+const paginationData = computed(() => {
+  return (
+    moduleStore.state.paginationSubmodule[normalizedSubmoduleId.value] ?? null
+  );
+});
+
 const rows = computed(() => {
-  const items = props.data?.submodules?.[props.submodule.id]?.items ?? [];
+  const items = submoduleData.value?.items ?? [];
   // ensure stable id for q-table row-key
   return (items as ModuleItem[]).map((it, i) => ({
     id: it.id ?? `${props.submodule.id}_${i}`,
     ...it,
   }));
 });
+
+const submoduleType = computed(() => {
+  switch (props.submodule.id) {
+    case 'sub_scientific':
+      return 'scientific';
+    case 'sub_it':
+      return 'it';
+    case 'sub_other':
+      return 'other';
+    default:
+      return undefined as unknown as 'scientific' | 'it' | 'other' | undefined;
+  }
+});
+
+function onExpand() {
+  const isLoaded =
+    moduleStore.state.loadedSubmodules[normalizedSubmoduleId.value];
+
+  if (!isLoaded) {
+    // Fetch submodule data with default pagination
+    moduleStore.getSubmoduleData(
+      props.moduleType,
+      props.unitId,
+      String(props.year),
+      normalizedSubmoduleId.value,
+      1, // page
+      50, // limit
+    );
+  }
+}
+
+function onPageChange(page: number) {
+  const pagination = paginationData.value;
+
+  moduleStore.getSubmoduleData(
+    props.moduleType,
+    props.unitId,
+    String(props.year),
+    normalizedSubmoduleId.value,
+    page,
+    pagination?.limit ?? 50,
+    pagination?.sortedBy,
+    pagination?.sortOrder,
+  );
+}
+
+function onSortChange(sortBy: string, sortOrder: string) {
+  const pagination = paginationData.value;
+
+  // Reset to page 1 when sorting changes
+  moduleStore.getSubmoduleData(
+    props.moduleType,
+    props.unitId,
+    String(props.year),
+    normalizedSubmoduleId.value,
+    1, // Reset to page 1
+    pagination?.limit ?? 50,
+    sortBy,
+    sortOrder,
+  );
+}
 </script>

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -85,7 +85,7 @@ const getData = () => {
     moduleStore.state.error = null;
     return;
   }
-  moduleStore.getModuleData(currentModuleType.value, unit.value, year.value);
+  moduleStore.getModuleTotals(currentModuleType.value, unit.value, year.value);
 };
 
 onMounted(getData);


### PR DESCRIPTION
## What does this change?

This PR implements server-side pagination and sorting for equipment submodules, significantly improving performance and UX for large datasets.

**Backend changes:**
- Add `sort_by` and `sort_order` query parameters to equipment/submodule endpoints
- Support sorting by equipment fields (id, name, status, etc.) and emission metrics (kg_co2eq, annual_kwh)
- Allow `preview_limit=0` to fetch summary data without items (for module totals)
- Implement field mapping for sortable columns in equipment repository

**Frontend changes:**
- Implement lazy loading: submodule data fetches only when expansion panel opens
- Add server-side pagination with page change handling in ModuleTable
- Add sorting support with column header clicks
- Split `getModuleData` into `getModuleTotals` (preview_limit=0) and `getSubmoduleData`
- Track loaded submodules to prevent redundant API calls
- Maintain pagination/sort state across CRUD operations (create, update, delete)
- Refetch affected submodule after mutations to reflect changes

## Why is this needed?

**Performance:** Previously, all equipment items for all submodules were fetched upfront, leading to:
- Slow initial page loads with large datasets
- Unnecessary data transfer for collapsed submodules
- Client-side pagination limitations

**User Experience:** This change provides:
- Faster initial page load (only fetches totals)
- On-demand data loading when users expand sections
- Sortable columns for better data exploration
- Proper pagination for large equipment lists

**Scalability:** Server-side pagination and sorting allow the application to handle thousands of equipment items efficiently.


- Related to #228 
