### PR TITLE
feat235(table): densify table

### DIFF
--- a/frontend/src/css/05-components/_organisms/_table.scss
+++ b/frontend/src/css/05-components/_organisms/_table.scss
@@ -3,6 +3,7 @@
 .co2-table {
   border: 1px solid tokens.$table-border-color;
   border-radius: tokens.$table-border-radius;
+  font-size: tokens.$text-size-sm;
 
   .q-table td {
     border: none;

--- a/frontend/src/css/05-components/quasar-overrides/_q-table.scss
+++ b/frontend/src/css/05-components/quasar-overrides/_q-table.scss
@@ -1,0 +1,14 @@
+.q-table th,
+.q-table td {
+  padding: 4px 2px;
+}
+
+.q-table th:first-child,
+.q-table td:first-child {
+  padding-left: 16px;
+}
+
+.q-table th:last-child,
+.q-table td:last-child {
+  padding-right: 16px;
+}

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -34,6 +34,7 @@
   @import './05-components/quasar-overrides/q-btn';
   @import './05-components/quasar-overrides/q-tooltip';
   @import './05-components/quasar-overrides/q-dialog';
+  @import './05-components/quasar-overrides/q-table';
 }
 
 @layer components {


### PR DESCRIPTION
## What does this change?
Overrides table cell padding to make tables denser, particularly for tables with many columns. The padding is now applied globally to all `.q-table` cells with reduced spacing (`4px 2px` instead of default), and fixes CSS specificity linting errors.

## Why is this needed?
- **Better space utilization**: Reduces cell padding to allow tables with many columns to fit more data horizontally
- **Improved readability**: Dense tables help users see more columns at once without horizontal scrolling
Please check the type that applies:

- [x] 🐛 Bug fix

## Related issues

- Closes #235 

