### PR TITLE
fix/281 restore centered layout for Safari page container

### DIFF
--- a/frontend/src/components/organisms/module/ModuleNavigation.vue
+++ b/frontend/src/components/organisms/module/ModuleNavigation.vue
@@ -110,11 +110,14 @@ const resultsRoute = computed(() => {
 </template>
 
 <style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
 .module-navigation {
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  width: 100%;
+  width: tokens.$layout-page-width;
+  margin: 0 auto;
 
   &__link {
     display: flex;

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -102,7 +102,7 @@ watch(
   align-items: start;
   grid-auto-rows: max-content;
   width: 100%;
-  max-width: tokens.$layout-page-width;
+
   // center the page
   justify-self: center; // center within the parent grid cell
 }


### PR DESCRIPTION
## What does this change?
Apply width constraint and auto margins to module navigation to ensure
proper centering across browsers, particularly Safari.

## Why is this needed?
The Safari page container was no longer centered after previous changes.
This fix restores proper centering by:
- Adding explicit width constraint and auto margins to module navigation
- Removing redundant max-width from module page container

- Closes #
- Related to #281 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
