### PR TITLE
fix/213 minor UI and tooltip adjustments

### DIFF
--- a/frontend/src/components/molecules/BigNumber.vue
+++ b/frontend/src/components/molecules/BigNumber.vue
@@ -39,7 +39,7 @@ const comparisonParts = computed(() => {
 <template>
   <q-card class="container container--pa-none">
     <q-card-section class="flex items-center q-mb-xs">
-      <q-icon name="o_info" size="xs" color="primary">
+      <q-icon v-if="$slots.tooltip" name="o_info" size="xs" color="primary">
         <q-tooltip
           v-if="$slots.tooltip"
           anchor="center right"

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -315,8 +315,8 @@ export default {
     fr: "Empreinte carbone de l'unité",
   },
   results_total_unit_carbon_footprint_tooltip: {
-    en: 'Total carbon footprint of the unit including all modules',
-    fr: "Empreinte carbone totale de l'unité incluant tous les modules",
+    en: 'Calculated with the value of 0.34 kg CO₂-eq / km',
+    fr: 'Calculé avec la valeur de 0.34 kg CO₂-eq / km',
   },
   results_carbon_footprint_per_fte_tooltip: {
     en: 'Carbon footprint per Full-Time Equivalent (FTE) employee',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -44,25 +44,8 @@ const getUncertainty = (
 };
 
 const downloadPDF = () => {
-  // Get the HTML content of the current page
-  const htmlContent = document.documentElement.outerHTML;
-
-  // Create a blob with the HTML content
-  const blob = new Blob([htmlContent], { type: 'text/html' });
-
-  // Create a download link
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = 'results-page.html';
-
-  // Trigger the download
-  document.body.appendChild(link);
-  link.click();
-
-  // Clean up
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Open browser print dialog where user can save as PDF
+  window.print();
 };
 </script>
 
@@ -120,7 +103,9 @@ const downloadPDF = () => {
           comparison-highlight="0.34 kg CO₂-eq/km"
           color="negative"
         >
-          <template #tooltip>tip</template>
+          <template #tooltip>{{
+            $t('results_total_unit_carbon_footprint_tooltip')
+          }}</template>
         </BigNumber>
         <BigNumber
           :title="$t('results_carbon_footprint_per_fte')"
@@ -149,14 +134,11 @@ const downloadPDF = () => {
           "
           :comparison-highlight="`${formatNumber(48)}t CO₂-eq`"
         >
-          <template #tooltip>tooltip</template>
         </BigNumber>
       </q-card>
       <q-card flat class="grid-2-col">
-        <ChartContainer :title="$t('results_module_carbon_footprint')">
-          <template #tooltip>tooltip</template>
-          <ModuleCarbonFootprintChart />
-        </ChartContainer>
+        <ModuleCarbonFootprintChart />
+
         <ChartContainer :title="$t('results_carbon_footprint_per_person')">
           <template #tooltip>tooltip</template>
           <CarbonFootPrintPerPersonChart />


### PR DESCRIPTION
## What does this change?
- Makes tooltips optional by only displaying the info icon when a tooltip slot is provided
- Updates the wording of the total unit carbon footprint tooltip
- Simplifies the PDF download action by using the browser print dialog
- Cleans up unused tooltip slots in the Results page

## Why is this needed?
- Avoids displaying an info icon when no tooltip content is available
- Aligns tooltip copy with the latest calculation assumptions
- Provides a more reliable and user-friendly way to export results as PDF
- Reduces unnecessary markup and improves UI consistency

- Related to #213 


