### PR TITLE
fix/236 tooltip correction

### DIFF
--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -416,7 +416,7 @@ const chartOption = computed((): EChartsOption => {
       },
     },
     {
-      name: t('charts-it-subcategory'),
+      name: t('charts-equipment-it'),
       type: 'bar' as const,
       stack: 'total',
       encode: {
@@ -476,7 +476,7 @@ const chartOption = computed((): EChartsOption => {
       },
     },
     {
-      name: t('charts-it-category'),
+      name: t('charts-infrastructure-it'),
       type: 'bar' as const,
       stack: 'total',
       encode: {
@@ -583,10 +583,6 @@ const chartOption = computed((): EChartsOption => {
     ...additionalSeriesData.value,
   ];
 
-  const seriesNameToKey = Object.fromEntries(
-    seriesArray.map((s) => [s.name, s.encode.y]),
-  ) as Record<string, string>;
-
   return {
     tooltip: {
       trigger: 'axis',
@@ -617,16 +613,14 @@ const chartOption = computed((): EChartsOption => {
             value?: number | number[];
             data?: Record<string, unknown>;
           };
-          const key = seriesNameToKey[p.seriesName || ''];
-          const val =
-            (data && key
-              ? Number(data[key])
-              : Array.isArray(p.value)
-                ? p.value[1]
-                : p.value) || 0;
-          if (val > 0) {
-            tooltip += `${p.marker || ''} ${p.seriesName}: <strong>${val.toFixed(1)} </strong><br/>`;
-            total += val;
+          // Find series by name to get its key
+          const series = seriesArray.find((s) => s.name === p.seriesName);
+          const key = series?.encode.y;
+
+          const dataValue = Number(data[key]) || 0;
+          if (dataValue > 0) {
+            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${dataValue.toFixed(1)} </strong><br/>`;
+            total += dataValue;
           }
         });
 

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -645,8 +645,8 @@ export default {
     fr: 'Services',
   },
   'charts-other-purchases-subcategory': {
-    en: 'Other Purchases',
-    fr: 'Autres achats',
+    en: 'Other Equipment',
+    fr: 'Autre équipement',
   },
   'charts-gc-subcategory': {
     en: 'GC',
@@ -681,12 +681,17 @@ export default {
     fr: 'Éclairage',
   },
   'charts-scientific-subcategory': {
-    en: 'Scientific',
-    fr: 'Scientifique',
+    en: 'Scientific Equipment',
+    fr: 'Équipement scientifique',
   },
-  'charts-it-subcategory': {
+
+  'charts-equipment-it': {
+    en: 'IT Equipment',
+    fr: 'IT Équipement',
+  },
+  'charts-infrastructure-it': {
     en: 'IT',
-    fr: 'Informatique',
+    fr: 'IT',
   },
   'charts-scitas-subcategory': {
     en: 'SCITAS',


### PR DESCRIPTION
## What does this change?
- Renames chart series to distinguish between "IT Equipment" and "IT Infrastructure" categories
- Simplifies tooltip calculation logic by removing intermediate mapping object
- Updates translation keys for better clarity and consistency

## Why is this needed?
The previous naming ("charts-it-subcategory" and "charts-it-category") was ambiguous and didn't clearly distinguish between IT equipment and IT infrastructure. The tooltip logic also used an unnecessary intermediate mapping object that made the code harder to follow. This change improves code clarity and makes the chart labels more descriptive.

- Related to #236 
