### PR TITLE
fix/265 correct tonnes displaying in equipment table 

### DIFF
--- a/backend/app/schemas/equipment.py
+++ b/backend/app/schemas/equipment.py
@@ -74,7 +74,10 @@ class ModuleTotals(BaseModel):
         None, description="Total annual energy consumption"
     )
     total_kg_co2eq: Optional[float] = Field(
-        None, description="Total annual CO2 emissions"
+        None, description="Total annual CO2 emissions in kg CO2-eq"
+    )
+    total_tonnes_co2eq: Optional[float] = Field(
+        None, description="Total annual CO2 emissions in tonnes CO2-eq"
     )
     total_annual_fte: Optional[float] = Field(
         None, description="Total full-time equivalent (FTE) associated"

--- a/backend/app/services/equipment_service.py
+++ b/backend/app/services/equipment_service.py
@@ -171,6 +171,7 @@ async def get_module_data(
         total_items=total_items,
         total_annual_consumption_kwh=round(total_kwh, 2),
         total_kg_co2eq=round(total_co2, 2),
+        total_tonnes_co2eq=round(total_co2 / 1000, 2) if total_co2 else None,
         total_annual_fte=None,  # FTE not applicable for equipment
     )
 

--- a/backend/app/services/headcount_service.py
+++ b/backend/app/services/headcount_service.py
@@ -167,6 +167,7 @@ class HeadcountService:
             total_items=total_items,
             total_annual_fte=round(total_annual_fte, 2),
             total_kg_co2eq=None,
+            total_tonnes_co2eq=None,
             total_annual_consumption_kwh=None,
         )
 

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -130,6 +130,7 @@ const baseModuleFields: ModuleField[] = [
     type: 'number',
     hideIn: {
       form: true,
+      table: true,
     },
     sortable: true,
     align: 'left',

--- a/frontend/src/constant/modules.ts
+++ b/frontend/src/constant/modules.ts
@@ -191,6 +191,7 @@ export interface Totals {
   total_items: number;
   total_annual_consumption_kwh?: number;
   total_kg_co2eq?: number;
+  total_tonnes_co2eq?: number;
   total_annual_fte?: number;
 }
 

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -75,7 +75,7 @@ const totalResult = computed(() => {
   if (currentModuleType.value === MODULES.MyLab) {
     return moduleStore.state.data?.totals?.total_annual_fte;
   }
-  return moduleStore.state.data?.totals?.total_kg_co2eq;
+  return moduleStore.state.data?.totals?.total_tonnes_co2eq;
 });
 
 const AuthorizedModules: Module[] = [


### PR DESCRIPTION
## What does this change?
Adds a new `total_tonnes_co2eq` field to display CO2 emissions in tonnes instead of kilograms across the application. The backend now calculates and returns both kg and tonnes values, while the frontend displays tonnes in module totals for better readability of larger emission values.


## Why is this needed?
CO2 emissions values in kilograms can become large and harder to read quickly (e.g., 150,000 kg vs 150 tonnes). Displaying emissions in tonnes provides a more standard and user-friendly representation, especially for enterprise-level emissions reporting where values are typically expressed in tonnes CO2-eq.

- Related to #
