### PR TITLE
chore(CICD): use quay registry

### DIFF
--- a/.github/workflows/deploy-quay.yml
+++ b/.github/workflows/deploy-quay.yml
@@ -1,0 +1,36 @@
+# https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action#readme
+name: deploy-quay
+
+"on":
+  push:
+    branches:
+      - dev
+      - stage
+      - "ci-test/**"
+    tags: ["v*.*.*"]
+
+jobs:
+  deploy:
+    permissions:
+      contents: read
+      packages: write
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@2.7.0
+    secrets:
+      token: ${{ secrets.CD_TOKEN }}
+      registry_token: ${{ secrets.QUAY_TOKEN }}
+    with:
+      # Optional inputs can be passed here
+      ORG: epfl
+      REPO: co2-calculator
+      build_context: '[ "./frontend", "./backend" ]' # context paths to build
+      argo_repository: "['EPFL-ENAC/openshift-app-config']"
+      registry: quay-its.epfl.ch
+      registry_path: svc1751
+      registry_username: svc1751+ghaction
+  # publish-chart:
+  #   uses: ./.github/workflows/publish_chart.yaml
+  #   needs:
+  #     - deploy
+  #   with:
+  #     registry: "epfl-enac/co2-calculator"
+  #     name: "co2-calculator"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
       ORG: epfl
       REPO: co2-calculator
       build_context: '[ "./frontend", "./backend" ]' # context paths to build
-      argo_repository: "['EPFL-ENAC/enack8s-app-config', 'EPFL-ENAC/openshift-app-config']"
   publish-chart:
     uses: ./.github/workflows/publish_chart.yaml
     needs:


### PR DESCRIPTION
## What does this change?

Push docker images to OpenShift Quay registry instread of GitHub (FIX #324)

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Code quality checklist

- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## For UI changes only

- [ ] Screenshots/GIFs/videos included below
- [ ] WCAG Level AA accessibility verified
- [ ] Keyboard navigation works correctly
- [ ] Tested on mobile, tablet, and desktop
- [ ] Focus indicators visible

## Screenshots (if applicable)

<!-- For UI changes, drag & drop screenshots here -->

## Related issues

- Closes #324
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
