### PR TITLE
#297 missing title equipment and unit name in header

### DIFF
--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -14,7 +14,15 @@ const route = useRoute();
 
 const unitName = computed(() => {
   if (!route.params.unit) return '';
-  return decodeURIComponent(route.params.unit as string);
+  const unit = decodeURIComponent(route.params.unit as string);
+  // Extract name from format: {id}-{name}
+  // The name part is everything after the first dash
+  const parts = unit.split('-');
+  if (parts.length > 1) {
+    // Join all parts except the first (which is the ID) and replace dashes with spaces
+    return parts.slice(1).join('-').replace(/-/g, ' ');
+  }
+  return unit;
 });
 
 const year = computed(() => {

--- a/frontend/src/i18n/equipment_electric_consumption.ts
+++ b/frontend/src/i18n/equipment_electric_consumption.ts
@@ -56,7 +56,23 @@ Classe: veuillez mettre à jour la classe si celle de votre inventaire n'est pas
     en: 'Other Equipment ({count}) | Other Equipments ({count})',
     fr: 'Autre équipement ({count}) | Autres équipements ({count})',
   },
-
+  [`${MODULES.EquipmentElectricConsumption}-scientific-form-title`]: {
+    en: 'Add Scientific Equipment',
+    fr: 'Ajouter un équipement scientifique',
+  },
+  [`${MODULES.EquipmentElectricConsumption}-it-form-title`]: {
+    en: 'Add IT Equipment',
+    fr: 'Ajouter un équipement informatique',
+  },
+  [`${MODULES.EquipmentElectricConsumption}-other-form-title`]: {
+    en: 'Add Other Equipment',
+    fr: 'Ajouter un autre équipement',
+  },
+  [`${MODULES.EquipmentElectricConsumption}-scientific-form-title-info-label`]:
+    {
+      en: 'Remember to update your inventory: if you add an item manually this year, it will not be carried over next year unless you have included it in your inventory.',
+      fr: 'Pensez à mettre à jour votre inventaire : si vous ajoutez un élément manuellement cette année, il ne sera pas repris l’année prochaine, sauf si vous l’avez intégré dans votre inventaire.',
+    },
   [`${MODULES.EquipmentElectricConsumption}.tooltips.power`]: {
     en: 'The average power is indicated by class. It may not fully represent the power of your equipment, in which case please contact us. Please note that we do not want the maximum power value, which can be very different from the average power.',
     fr: "La puissance moyenne est indiquée par classe. il est possible qu'elle ne soit pas totalement représentative de celle de votre équipement, auquel cas merci de nous contacter. Attention, nous ne voulons pas avoir la valeur de puissance maximale qui peut être très différente de la puissance moyenne.",


### PR DESCRIPTION
## What does this change?

It adds a name for all input form in equipment. 
It also remove the unit-id in the header


## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Testing checklist

- [ ] I've tested this change locally
- [x] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced


## Related issues
- Related to #297 


