### PR TITLE
fix(CICD): fix deploy task script url

### DIFF
--- a/.github/workflows/deploy-quay.yml
+++ b/.github/workflows/deploy-quay.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@2.7.0
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v2.7.0
     secrets:
       token: ${{ secrets.CD_TOKEN }}
       registry_token: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
## What does this change?

Fix the path to [epfl-enac-build-push-deploy-action](https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action/tree/v2.7.0)

## Why is this needed?

Deploy-quay github action not working...

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Code quality checklist

- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## For UI changes only

- [ ] Screenshots/GIFs/videos included below
- [ ] WCAG Level AA accessibility verified
- [ ] Keyboard navigation works correctly
- [ ] Tested on mobile, tablet, and desktop
- [ ] Focus indicators visible

## Screenshots (if applicable)

<!-- For UI changes, drag & drop screenshots here -->

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
