### PR TITLE
#195 feat: add link to all documentation, add link in a text, change doc button

### DIFF
--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -76,11 +76,11 @@ const isInSystemRoute = computed(() => isSystemRoute(route));
       <Co2LanguageSelector />
 
       <q-btn
-        v-if="hasBackOfficeAccess"
+        v-if="hasBackOfficeAccess && isInBackOfficeRoute"
         icon="o_article"
         color="grey-4"
         text-color="primary"
-        :label="$t('documentation_button_label')"
+        :label="$t('documentation_backoffice_button_label')"
         unelevated
         no-caps
         outline
@@ -91,11 +91,11 @@ const isInSystemRoute = computed(() => isSystemRoute(route));
       />
 
       <q-btn
-        v-if="hasSystemAccess"
+        v-if="hasSystemAccess && isInSystemRoute"
         icon="o_article"
         color="grey-4"
         text-color="primary"
-        :label="$t('documentation_button_label')"
+        :label="$t('documentation_dev_button_label')"
         unelevated
         no-caps
         outline
@@ -106,7 +106,7 @@ const isInSystemRoute = computed(() => isSystemRoute(route));
       />
 
       <q-btn
-        v-if="!hasSystemAccess && !hasBackOfficeAccess"
+        v-if="!isInBackOfficeRoute && !isInSystemRoute"
         icon="o_article"
         color="grey-4"
         text-color="primary"

--- a/frontend/src/i18n/backoffice_documentation_editing.ts
+++ b/frontend/src/i18n/backoffice_documentation_editing.ts
@@ -5,11 +5,11 @@ export default {
   },
   documentation_editing_translation_description: {
     en: 'Link to the translation files in the repository of the CO₂ calculator application. Make your changes directly on GitHub and ask for a Pull Request. For more information see the backoffice documentation section; Changing texts.',
-    fr: 'Lien vers les fichiers de traduction dans le dépôt de l’application Calculateur CO₂. Effectuez vos modifications directement sur GitHub et demandez une Pull Request. Pour plus d’informations, consultez la section documentation du back-office ; Modifier les textes.',
+    fr: 'Lien vers les fichiers de traduction dans le repository de l’application Calculateur CO₂. Effectuez vos modifications directement sur GitHub et demandez une Pull Request. Pour plus d’informations, consultez la section documentation du back-office ; Modifier les textes.',
   },
   documentation_editing_translation_description_part_1: {
     en: 'Link to the translation files in the repository of the CO₂ calculator application. Make your changes directly on GitHub and ask for a Pull Request. For more information see the backoffice documentation section; ',
-    fr: 'Lien vers les fichiers de traduction dans le dépôt de l’application Calculateur CO₂. Effectuez vos modifications directement sur GitHub et demandez une Pull Request. Pour plus d’informations, consultez la section documentation du back-office ; ',
+    fr: 'Lien vers les fichiers de traduction dans le repository de l’application Calculateur CO₂. Effectuez vos modifications directement sur GitHub et demandez une Pull Request. Pour plus d’informations, consultez la section documentation du back-office ; ',
   },
   documentation_editing_translation_description_link_text: {
     en: 'Changing texts',
@@ -37,7 +37,7 @@ export default {
   },
   documentation_editing_calculator_user_documentation_description: {
     en: 'Repository link to the user documentation of the CO₂ calculator application.',
-    fr: 'Lien vers le dépôt de la documentation utilisateur-ice de l’application Calculateur CO₂.',
+    fr: 'Lien vers le repository de la documentation utilisateur-ice de l’application Calculateur CO₂.',
   },
 
   documentation_editing_calculator_backoffice_documentation_title: {

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -196,6 +196,14 @@ export default {
     en: 'Documentation',
     fr: 'Documentation',
   },
+  documentation_backoffice_button_label: {
+    en: 'Back-office Documentation',
+    fr: 'Documentation Back-office',
+  },
+  documentation_dev_button_label: {
+    en: 'Developer Documentation',
+    fr: 'Documentation Développeur',
+  },
   common_add_button: {
     en: 'Add',
     fr: 'Ajouter',

--- a/frontend/src/pages/back-office/DocumentationEditingPage.vue
+++ b/frontend/src/pages/back-office/DocumentationEditingPage.vue
@@ -147,7 +147,7 @@ const docRows = computed(() => [
       'documentation_editing_calculator_backoffice_documentation_description',
     ),
     githubUrl:
-      'https://github.com/EPFL-ENAC/co2-calculator-backoffice-doc/tree/main/docs',
+      'https://github.com/EPFL-ENAC/co2-calculator-back-office-doc/tree/main/docs',
   },
   {
     topic: t('documentation_editing_calculator_developer_documentation_title'),


### PR DESCRIPTION
## What does this change?

The documentation editing back-office section with all documentation github repository linked.
The button documentation change by role.
Add a link in a Text in documentation editing

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Testing checklist

- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Code quality checklist

- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Related issues

- Related to #195 


