### PR TITLE
fix(i18n): use URL encoding for email addresses to prevent vue-i18n parsing errors

### DIFF
--- a/frontend/src/i18n/home.ts
+++ b/frontend/src/i18n/home.ts
@@ -52,8 +52,8 @@ export default {
     fr: 'nous contacter',
   },
   home_intro_5_contact_link_url: {
-    en: 'mailto:sustainability@epfl.ch',
-    fr: 'mailto:sustainability@epfl.ch',
+    en: 'mailto:sustainability%40epfl.ch',
+    fr: 'mailto:sustainability%40epfl.ch',
   },
   home_intro_5_part_3: {
     en: '.',


### PR DESCRIPTION
## What does this change?
This PR fixes a production syntax error caused by vue-i18n's parser misinterpreting the `@` symbol in email addresses as a linked message reference.

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
