### PR TITLE
fix: change documentation backoffice name

### DIFF
--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -193,8 +193,8 @@ export default {
     fr: 'Documentation',
   },
   documentation_backoffice_button_label: {
-    en: 'Back-office Documentation',
-    fr: 'Documentation Back-office',
+    en: 'Guidance',
+    fr: 'Guide',
   },
   documentation_dev_button_label: {
     en: 'Developer Documentation',


### PR DESCRIPTION
## What does this change?
Change documentaion back-office name



## Related issues

- Closes #288 
