### PR TITLE
fix(home): show dash for unstarted modules on homepage

### DIFF
--- a/frontend/src/i18n/home.ts
+++ b/frontend/src/i18n/home.ts
@@ -115,4 +115,8 @@ export default {
     en: 'Simulations',
     fr: 'Simulations',
   },
+  home_validate_module_message: {
+    en: 'Please validate module',
+    fr: 'Veuillez valider le module',
+  },
 } as const;

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -82,8 +82,8 @@ export default {
     fr: 'Voyages professionnels ',
   },
   [MODULES_DESCRIPTIONS.ProfessionalTravel]: {
-    en: 'Estimate the impact of your professional travel',
-    fr: 'Estimez l’impact de vos voyages professionnels',
+    en: 'Record travel by plane and train, along with their associated emissions. ',
+    fr: 'Enregistrez les déplacements en avion et en train, ainsi que les émissions associées.',
   },
   [`${MODULES.ProfessionalTravel}-title-subtext`]: {
     en: "This module allows you to estimate and visualize the impact of your (or your unit's) travel by train and plane.",

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { MODULES } from 'src/constant/modules';
 import { MODULE_CARDS } from 'src/constant/moduleCards';
 import type { ModuleCard } from 'src/constant/moduleCards';
-import { getBadgeForStatus } from 'src/constant/moduleStates';
+import { getBadgeForStatus, MODULE_STATES } from 'src/constant/moduleStates';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useAuthStore } from 'src/stores/auth';
@@ -233,7 +233,10 @@ const modulesCounterText = computed(() =>
               />
             </div>
             <div
-              v-if="moduleCard.value || moduleTotals?.[moduleCard.module]"
+              v-if="
+                timelineStore.itemStates[moduleCard.module] !==
+                MODULE_STATES.Default
+              "
               class="row q-gutter-xs text-body1 items-baseline"
             >
               <p class="text-weight-medium q-mb-none">
@@ -242,6 +245,12 @@ const modulesCounterText = computed(() =>
               <p class="text-body2 text-secondary q-mb-none">
                 {{ $t('module_total_result_title_unit') }}
               </p>
+            </div>
+            <div
+              v-else
+              class="row q-gutter-xs text-body1 text-grey-4 items-baseline"
+            >
+              <p class="text-weight-medium q-mb-none">—</p>
             </div>
           </div>
         </q-card>


### PR DESCRIPTION
## What does this change?
Display a dash placeholder ("—") for module totals on the homepage when modules are in their default/unvalidated state, instead of showing nothing or attempting to display totals.

## Why is this needed?
Previously, the homepage would show module totals based on whether `moduleCard.value` or `moduleTotals` existed, which could result in empty/inconsistent display states. This change provides clearer visual feedback to users that a module hasn't been validated yet, improving UX consistency.
---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
