### PR TITLE
fix(docs): correct broken relative links to prevent strict mode build failures

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -83,6 +83,12 @@ nav:
 
   - Backend:
       - Overview: backend/01-overview.md
+      - Architecture: backend/02-ARCHITECTURE.md
+      - File Structure: backend/03-FILE_STRUCTURE.md
+      - Quick Start: backend/04-README.md
+      - Request Flow: backend/05-REQUEST_FLOW.md
+      - Permission System: backend/06-PERMISSION-SYSTEM.md
+      - "Developer Guide: Permissions": backend/07-DEVELOPER-GUIDE-PERMISSIONS.md
 
   - Database:
       - Overview: database/01-overview.md

--- a/docs/src/backend/07-DEVELOPER-GUIDE-PERMISSIONS.md
+++ b/docs/src/backend/07-DEVELOPER-GUIDE-PERMISSIONS.md
@@ -255,7 +255,7 @@ require_permission("modules.equipment", "edit")              # Edit equipment da
 
 ### Examples from Codebase
 
-#### Example 1: Headcount Endpoints ([app/api/v1/headcounts.py](../../../../backend/app/api/v1/headcounts.py))
+#### Example 1: Headcount Endpoints ([app/api/v1/headcounts.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/api/v1/headcounts.py))
 
 ```python
 @router.get(
@@ -283,7 +283,7 @@ async def get_headcounts(
     return headcounts
 ```
 
-#### Example 2: User Management ([app/api/v1/backoffice.py](../../../../backend/app/api/v1/backoffice.py))
+#### Example 2: User Management ([app/api/v1/backoffice.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/api/v1/backoffice.py))
 
 ```python
 @router.get("/users", response_model=List[UserRead])
@@ -304,7 +304,7 @@ async def list_users(
     pass
 ```
 
-#### Example 3: File Access ([app/api/v1/files.py](../../../../backend/app/api/v1/files.py))
+#### Example 3: File Access ([app/api/v1/files.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/api/v1/files.py))
 
 ```python
 @router.get(
@@ -451,7 +451,7 @@ class HeadcountRepository:
 
 ### Example from HeadcountService
 
-Full example from [app/services/headcount_service.py](../../../../backend/app/services/headcount_service.py):
+Full example from [app/services/headcount_service.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/services/headcount_service.py):
 
 ```python
 from app.services.authorization_service import get_data_filters
@@ -589,7 +589,7 @@ async def update_resource(
 
 ### Professional Travel Example
 
-Professional travel has complex resource-level rules defined in [app/core/policy.py](../../../../backend/app/core/policy.py):
+Professional travel has complex resource-level rules defined in [app/core/policy.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/core/policy.py):
 
 #### Rules
 
@@ -643,7 +643,7 @@ async def update_professional_travel(
     return updated_trip
 ```
 
-#### Policy Logic ([app/core/policy.py](../../../../backend/app/core/policy.py#L146-L205))
+#### Policy Logic ([app/core/policy.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/core/policy.py#L146-L205))
 
 ```python
 async def _evaluate_resource_access_policy(input_data: dict) -> dict:
@@ -692,7 +692,7 @@ async def _evaluate_resource_access_policy(input_data: dict) -> dict:
 
 To add custom business rules for a new resource type:
 
-1. Add policy logic in `_evaluate_resource_access_policy()` in [app/core/policy.py](../../../../backend/app/core/policy.py)
+1. Add policy logic in `_evaluate_resource_access_policy()` in [app/core/policy.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/core/policy.py)
 2. Check resource type and apply rules:
 
 ```python
@@ -1149,7 +1149,7 @@ async def update_trip(
    }
    ```
 
-4. **Check role-to-permission mapping** - Look in [app/utils/permissions.py](../../../../backend/app/utils/permissions.py) to see if the role grants the permission.
+4. **Check role-to-permission mapping** - Look in [app/utils/permissions.py](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/utils/permissions.py) to see if the role grants the permission.
 
 5. **Check for typos** - Ensure permission path matches exactly (case-sensitive).
 


### PR DESCRIPTION
## What does this change?
- Updates mkdocs.yml navigation to include all backend documentation pages
- Replaces relative file paths with GitHub permalink URLs

## Why is this needed?
- Relative links to backend code files were breaking the documentation build in strict mode
- GitHub permalinks ensure links remain valid and point to the correct file locations
- Complete navigation structure makes all backend docs accessible through the documentation site


## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
