### PR TITLE
fix(db-drop): set drop db with force

### DIFF
--- a/backend/scripts/manage_db.py
+++ b/backend/scripts/manage_db.py
@@ -41,23 +41,24 @@ def drop_db(db_name):
     # This now returns a URL Object with the correct password and user 'postgres'
     default_db_url = get_default_db_url()
     print(f"Dropping database using URL: {default_db_url}")
+    print(f"Dropping database: {db_name}")
 
     # create_engine accepts the URL object directly
     engine = create_engine(default_db_url, isolation_level="AUTOCOMMIT")
 
     with engine.connect() as conn:
         # Terminate existing connections
-        conn.execute(
-            text(
-                """
-                SELECT pg_terminate_backend(pid)
-                FROM pg_stat_activity
-                WHERE datname = :db_name AND pid <> pg_backend_pid();
-                """
-            ),
-            {"db_name": db_name},
-        )
-        conn.execute(text(f"DROP DATABASE IF EXISTS {db_name}"))
+        # conn.execute(
+        #     text(
+        #         """
+        #         SELECT pg_terminate_backend(pid)
+        #         FROM pg_stat_activity
+        #         WHERE datname = :db_name AND pid <> pg_backend_pid();
+        #         """
+        #     ),
+        #     {"db_name": db_name},
+        # )
+        conn.execute(text(f"DROP DATABASE IF EXISTS {db_name} with (force);"))
     engine.dispose()
 
 


### PR DESCRIPTION
## What does this change?

Allow make db-drop to work on xaas postgres db.

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
