### PR TITLE
fix(module): disable CSV upload when module is validated

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -10,6 +10,7 @@
         no-caps
         size="sm"
         class="text-weight-medium"
+        :disable="isDisabled"
         @click="onUploadCsv"
       />
       <q-btn
@@ -309,7 +310,7 @@ import { useI18n } from 'vue-i18n';
 import ModuleForm from './ModuleForm.vue';
 import ModuleInlineSelect from './ModuleInlineSelect.vue';
 import { QInput, QSelect, useQuasar } from 'quasar';
-import { useModuleStore } from 'src/stores/modules';
+import { useModuleStore, useTimelineStore } from 'src/stores/modules';
 import { useAuthStore } from 'src/stores/auth';
 import { useBackofficeDataManagement } from 'src/stores/backofficeDataManagement';
 import type { JobUpdatePayload } from 'src/stores/backofficeDataManagement';
@@ -324,7 +325,7 @@ import type {
 import { enumSubmodule } from 'src/constant/modules';
 
 import { MODULES, SUBMODULE_EXTERNAL_CLOUD_TYPES } from 'src/constant/modules';
-
+import { MODULE_STATES } from 'src/constant/moduleStates';
 import { nOrDash } from 'src/utils/number';
 
 function getNumericRules(col: TableViewColumn) {
@@ -512,6 +513,7 @@ const props = withDefaults(defineProps<ModuleTableProps>(), {
   hasTopBar: true,
 });
 const moduleStore = useModuleStore();
+const timelineStore = useTimelineStore();
 
 // Permission check: can user edit this module?
 const canEdit = computed(() => {
@@ -527,8 +529,11 @@ const canEdit = computed(() => {
   );
 });
 
-// Combine prop disable with permission check
-const isDisabled = computed(() => props.disable || !canEdit.value);
+const isDisabled = computed(
+  () =>
+    timelineStore.itemStates[props.moduleType] === MODULE_STATES.Validated ||
+    !canEdit.value,
+);
 
 const filterTerm = ref('');
 const confirmDelete = ref(false);


### PR DESCRIPTION
## What does this change?
Disables the CSV upload button when a module is in "Validated" state by checking the module's validation status from the timeline store.

## Why is this needed?
Users should not be able to upload new CSV data to modules that have already been validated. This prevents accidental data modifications that could compromise the validated state and maintains data integrity in the audit trail.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #422 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
