### PR TITLE
feat(helm chart): add PodDisruptionBudget

### DIFF
--- a/helm/templates/backend-pdb.yaml
+++ b/helm/templates/backend-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.backend.enabled .Values.backend.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "co2-calculator.fullname" . }}-backend
+  labels:
+    {{- include "co2-calculator.componentLabels" (dict "ctx" . "component" "backend") | nindent 4 }}
+spec:
+  minAvailable:  {{ .Values.backend.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "backend") | nindent 6 }}
+{{- end }}

--- a/helm/templates/frontend-pdb.yaml
+++ b/helm/templates/frontend-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.frontend.enabled .Values.frontend.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "co2-calculator.fullname" . }}-frontend
+  labels:
+    {{- include "co2-calculator.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.frontend.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "frontend") | nindent 6 }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,6 +96,10 @@ backend:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -208,6 +212,10 @@ frontend:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
 
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## What does this change?

Add PodDisruptionBudget in helm chart for frontend and backend.

## Why is this needed?

[PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/):  *Limit the number of concurrent disruptions that your application experiences, allowing for higher availability while permitting the cluster administrator to manage the clusters nodes.*

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
