### PR TITLE
fix(helm chart): set securityContext optionnal

### DIFF
--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -26,8 +26,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "co2-calculator.serviceAccountName" . }}
+      {{- with .Values.backend.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       
       initContainers:
         {{- if .Values.database.waitForPostgres.enabled }}

--- a/helm/templates/frontend-deployment.yaml
+++ b/helm/templates/frontend-deployment.yaml
@@ -25,8 +25,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.frontend.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: frontend
           image: {{ include "co2-calculator.frontend.image" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,9 +57,9 @@ backend:
   podAnnotations: {}
 
   podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-    fsGroup: 1000
+    # runAsNonRoot: true
+    # runAsUser: 1000
+    # fsGroup: 1000
 
   securityContext:
     allowPrivilegeEscalation: false
@@ -174,9 +174,9 @@ frontend:
   podAnnotations: {}
 
   podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 101
-    fsGroup: 101
+    # runAsNonRoot: true
+    # runAsUser: 101
+    # fsGroup: 101
 
   securityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
## What does this change?

Set backend and frontend pod securityContext as optional

## Why is this needed?

Let Openshift define its own uid/gid

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
