### PR TITLE
chore(build-frontend): correct npm ci without postinstall

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 # Install dependencies
-RUN npm ci
+# Skip postinstall scripts to avoid running any build steps prematurely
+RUN npm ci --ignore-scripts
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
This pull request makes a minor adjustment to the Docker build process for the frontend. The change ensures that postinstall scripts are not run during dependency installation, preventing any premature build steps.

* Docker build process: Updated the `RUN npm ci` command in `frontend/Dockerfile` to include `--ignore-scripts`, which skips postinstall scripts during dependency installation.