### PR TITLE
feat/252 result visibility

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -145,6 +145,12 @@ OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 
 
 # -----------------------------------------------------------------------------
+# CO2 Calculation Constants
+# -----------------------------------------------------------------------------
+# CO2 emissions per km driven by car, in kg CO2eq (used for "equivalent car km" display)
+# CO2_PER_KM_KG=0.34
+
+# -----------------------------------------------------------------------------
 # Formula Version Configuration
 # -----------------------------------------------------------------------------
 FORMULA_VERSION_SHA256_SHORT=12ac4b6fde65760a5c84f7ab56a518cde056c09c

--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -132,10 +132,16 @@ async def get_module(
             carbon_report_module_id=carbon_report_module_id,
         )
     # if need other subtotal do it here
-    total_kg_co2eq = sum(module_data.stats.values())
+    total_kg_co2eq = (
+        sum(v for v in module_data.stats.values() if v is not None)
+        if module_data.stats
+        else None
+    )
     module_data.totals = ModuleTotals(
         total_kg_co2eq=total_kg_co2eq,
-        total_tonnes_co2eq=total_kg_co2eq / 1000.0,
+        total_tonnes_co2eq=total_kg_co2eq / 1000.0
+        if total_kg_co2eq is not None
+        else None,
         total_annual_consumption_kwh=None,
         total_annual_fte=total_annual_fte,
     )

--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_active_user, get_db
+from app.core.config import get_settings
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import check_module_permission as _check_module_permission
@@ -73,14 +74,16 @@ async def get_validated_totals(
     }
 
 
-@router.get("/{unit_id}/{year}/{module_id}/stats", response_model=dict[str, float])
+@router.get(
+    "/{unit_id}/{year}/{module_id}/stats", response_model=dict[str, float | None]
+)
 async def get_module_stats(
     unit_id: int,
     year: int,
     module_id: str,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
-) -> dict[str, float]:
+) -> dict[str, float | None]:
     """
     Get module statistics such as total items and submodules.
 
@@ -100,7 +103,7 @@ async def get_module_stats(
         f"unit_id={sanitize(unit_id)}, year={sanitize(year)}"
     )
 
-    stats: dict[str, float] = {}
+    stats: dict[str, float | None] = {}
     carbon_report_module: CarbonReportModuleRead = await CarbonReportModuleService(
         db
     ).get_carbon_report_by_year_and_unit(
@@ -121,9 +124,6 @@ async def get_module_stats(
     return stats
 
 
-CO2_PER_KM_KG = 0.34
-
-
 @router.get("/{carbon_report_id}/results-summary", response_model=dict)
 async def get_results_summary(
     carbon_report_id: int,
@@ -139,33 +139,44 @@ async def get_results_summary(
     """
     logger.info(f"GET results summary: carbon_report_id={sanitize(carbon_report_id)}")
 
-    raw = await UnitTotalsService(db).get_results_summary(carbon_report_id)
+    try:
+        raw = await UnitTotalsService(db).get_results_summary(carbon_report_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Carbon report {carbon_report_id} not found",
+        )
 
-    current_emissions: dict[str, float] = raw["current_emissions"]
-    current_fte: dict[str, float] = raw["current_fte"]
-    prev_emissions: dict[str, float] = raw["prev_emissions"]
+    current_emissions: dict[str, float | None] = raw["current_emissions"]
+    current_fte: dict[str, float | None] = raw["current_fte"]
+    prev_emissions: dict[str, float | None] = raw["prev_emissions"]
 
-    # Total FTE from headcount module (module_type_id "1")
-    total_fte = current_fte.get("1", 0.0)
+    # Total FTE from headcount module
+    headcount_key = str(ModuleTypeEnum.headcount.value)
+    total_fte = current_fte.get(headcount_key)
 
     # --- Per-module results (no rounding — frontend handles display) ---
     module_results: list[dict] = []
     for module_key, kg_co2eq in current_emissions.items():
+        if kg_co2eq is None:
+            continue
         total_tonnes = kg_co2eq / 1000
-        tonnes_per_fte = (total_tonnes / total_fte) if total_fte > 0 else None
-        equivalent_car_km = kg_co2eq / CO2_PER_KM_KG
+        tonnes_per_fte = (
+            (total_tonnes / total_fte) if total_fte and total_fte > 0 else None
+        )
+        equivalent_car_km = kg_co2eq / get_settings().CO2_PER_KM_KG
 
         prev_kg = prev_emissions.get(module_key)
-        prev_tonnes = prev_kg / 1000 if prev_kg else None
+        prev_tonnes = prev_kg / 1000 if prev_kg is not None else None
         year_comparison = None
-        if prev_kg and prev_kg > 0:
+        if prev_kg is not None and prev_kg > 0:
             year_comparison = (kg_co2eq - prev_kg) / prev_kg * 100
 
         module_results.append(
             {
                 "module_type_id": int(module_key),
                 "total_tonnes_co2eq": total_tonnes,
-                "total_fte": total_fte if module_key == "1" else None,
+                "total_fte": total_fte if module_key == headcount_key else None,
                 "tonnes_co2eq_per_fte": tonnes_per_fte,
                 "equivalent_car_km": equivalent_car_km,
                 "previous_year_total_tonnes_co2eq": prev_tonnes,
@@ -174,25 +185,34 @@ async def get_results_summary(
         )
 
     # --- Unit totals (sum across all modules, no rounding) ---
-    total_kg = sum(current_emissions.values()) if current_emissions else 0.0
-    total_prev_kg = sum(prev_emissions.values()) if prev_emissions else None
-    total_tonnes = total_kg / 1000
-    total_tonnes_per_fte = (total_tonnes / total_fte) if total_fte > 0 else None
-    total_car_km = total_kg / CO2_PER_KM_KG
+    non_none_emissions = [v for v in current_emissions.values() if v is not None]
+    non_none_prev = [v for v in prev_emissions.values() if v is not None]
+    total_kg: float | None = sum(non_none_emissions) if non_none_emissions else None
+    total_prev_kg: float | None = sum(non_none_prev) if non_none_prev else None
+    total_tonnes_all = total_kg / 1000 if total_kg is not None else None
+    total_tonnes_per_fte = (
+        (total_tonnes_all / total_fte)
+        if total_tonnes_all is not None and total_fte and total_fte > 0
+        else None
+    )
+    total_car_km = (
+        total_kg / get_settings().CO2_PER_KM_KG if total_kg is not None else None
+    )
     total_year_comparison = None
-    if total_prev_kg and total_prev_kg > 0:
+    if total_prev_kg is not None and total_kg is not None and total_prev_kg > 0:
         total_year_comparison = (total_kg - total_prev_kg) / total_prev_kg * 100
 
     return {
         "unit_totals": {
-            "total_tonnes_co2eq": total_tonnes,
+            "total_tonnes_co2eq": total_tonnes_all,
             "total_fte": total_fte,
             "tonnes_co2eq_per_fte": total_tonnes_per_fte,
             "equivalent_car_km": total_car_km,
             "previous_year_total_tonnes_co2eq": (
-                total_prev_kg / 1000 if total_prev_kg else None
+                total_prev_kg / 1000 if total_prev_kg is not None else None
             ),
             "year_comparison_percentage": total_year_comparison,
         },
+        "co2_per_km_kg": get_settings().CO2_PER_KM_KG,
         "module_results": module_results,
     }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -137,6 +137,12 @@ class Settings(BaseSettings):
         description="Weeks per year for annual CO2 calculation",
     )
 
+    # CO2 Calculation Constants
+    CO2_PER_KM_KG: float = Field(
+        default=0.34,
+        description="CO2 per km in kg",
+    )
+
     # Loki (optional)
     LOKI_ENABLED: bool = False
     LOKI_URL: Optional[str] = None  # e.g. http://loki:3100

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -1,6 +1,6 @@
 """Data entry emission repository for database operations."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from sqlalchemy import Select
 from sqlmodel import col, func, select
@@ -63,7 +63,7 @@ class DataEntryEmissionRepository:
         carbon_report_module_id,
         aggregate_by: str = "emission_type_id",
         aggregate_field: str = "kg_co2eq",
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Optional[float]]:
         """Aggregate DataEntryEmission data by emission_type_id
                 SELECT
             dee.*
@@ -97,10 +97,10 @@ class DataEntryEmissionRepository:
         rows = result.all()
 
         # 3. Format the results
-        aggregation: Dict[str, float] = {}
+        aggregation: Dict[str, Optional[float]] = {}
         for key, total_count in rows:
             label = str(key) if key is not None else "unknown"
-            aggregation[label] = float(total_count or 0.0)
+            aggregation[label] = total_count
 
         return aggregation
 

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -408,7 +408,7 @@ class DataEntryRepository:
         carbon_report_module_id,
         aggregate_by: str = "data_entry_type_id",
         aggregate_field: str = "fte",
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Optional[float]]:
         """Aggregate DataEntry data by submodule or function.
                 SELECT
             dee.*
@@ -447,15 +447,16 @@ class DataEntryRepository:
         rows = result.all()
 
         # 3. Format the results
-        aggregation: Dict[str, float] = {}
+        aggregation: Dict[str, Optional[float]] = {}
         for key, total_count in rows:
             label = str(key) if key is not None else "unknown"
             # special edge case for headcount : TO BE FIX by PM
             if aggregate_by == "function":
                 label = get_function_role(label)
             if label not in aggregation:
-                aggregation[label] = 0.0
-            aggregation[label] += float(total_count or 0.0)
+                aggregation[label] = None
+            if total_count is not None:
+                aggregation[label] = (aggregation[label] or 0.0) + total_count
 
         return aggregation
 
@@ -510,6 +511,6 @@ class DataEntryRepository:
         aggregation: Dict[str, float] = {}
         for key, total in rows:
             label = str(key) if key is not None else "unknown"
-            aggregation[label] = float(total or 0.0)
+            aggregation[label] = float(total)
 
         return aggregation

--- a/backend/app/schemas/carbon_report_response.py
+++ b/backend/app/schemas/carbon_report_response.py
@@ -68,5 +68,7 @@ class ModuleResponse(BaseModel):
     data_entry_types_total_items: Dict[int, int] = Field(
         ..., description="Total items per data entry type ID"
     )
-    stats: Optional[dict[str, float]] = Field(None, description="Module statistics")
+    stats: Optional[dict[str, float | None]] = Field(
+        None, description="Module statistics"
+    )
     totals: ModuleTotals = Field(..., description="Module totals")

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -172,7 +172,7 @@ class DataEntryEmissionService:
         carbon_report_module_id: int,
         aggregate_by: str = "emission_type_id",
         aggregate_field: str = "kg_co2eq",
-    ) -> dict[str, float]:
+    ) -> dict[str, float | None]:
         """Get aggregated emission statistics for a carbon report module."""
         stats = await self.repo.get_stats(
             carbon_report_module_id,

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -42,7 +42,7 @@ class DataEntryService:
         carbon_report_module_id: int,
         aggregate_by: str = "data_entry_type_id",
         aggregate_field: str = "fte",
-    ) -> dict[str, float]:
+    ) -> dict[str, float | None]:
         """Get module statistics such as total items and submodules."""
         return await self.repo.get_stats(
             carbon_report_module_id=carbon_report_module_id,

--- a/backend/app/services/unit_totals_service.py
+++ b/backend/app/services/unit_totals_service.py
@@ -135,10 +135,6 @@ class UnitTotalsService:
         Returns:
             [{"year": 2023, "kg_co2eq": 61700.0}, ...]
         """
-        from app.repositories.data_entry_emission_repo import (
-            DataEntryEmissionRepository,
-        )
-
         return await DataEntryEmissionRepository(
             self.session
         ).get_validated_totals_by_unit(unit_id=unit_id)

--- a/docs/implementation-plans/440-validated-totals-endpoint.md
+++ b/docs/implementation-plans/440-validated-totals-endpoint.md
@@ -1,11 +1,12 @@
-# Validated Modules Totals — Two Endpoints
+# Validated Modules Totals & Results Summary
 
 ## Context
 
-We need two new endpoints to display validated module emissions:
+We need endpoints to display validated module emissions:
 
 1. **WorkspaceSetupPage / YearSelector** — needs total tCO2eq per year (all years at once) for a given unit
 2. **HomePage** — needs per-module breakdown of tCO2eq for a specific carbon report, plus the total and FTE from headcount
+3. **ResultsPage** — needs a rich per-module summary with tonnes, FTE per FTE, equivalent car km, and year-over-year comparison
 
 The existing aggregation endpoints only handle equipment and don't filter by validation status. Headcount has no `DataEntryEmission` records — FTE is stored in `DataEntry.data["fte"]` and must be queried separately via `DataEntryRepository`.
 
@@ -118,64 +119,184 @@ The endpoint:
 
 ---
 
+## Endpoint 3: ResultsPage — full results summary
+
+**Route:** `GET /modules-stats/{carbon_report_id}/results-summary`
+
+**Purpose:** Provide a comprehensive results summary for the dedicated ResultsPage, including unit-wide totals, per-module breakdowns with car-km equivalents and year-over-year comparison.
+
+**Response:**
+
+```json
+{
+  "unit_totals": {
+    "total_tonnes_co2eq": 61.7,
+    "total_fte": 25.5,
+    "tonnes_co2eq_per_fte": 2.42,
+    "equivalent_car_km": 181470.6,
+    "previous_year_total_tonnes_co2eq": 58.2,
+    "year_comparison_percentage": 6.01
+  },
+  "co2_per_km_kg": 0.34,
+  "module_results": [
+    {
+      "module_type_id": 2,
+      "total_tonnes_co2eq": 15.0,
+      "total_fte": null,
+      "tonnes_co2eq_per_fte": 0.59,
+      "equivalent_car_km": 44117.6,
+      "previous_year_total_tonnes_co2eq": 14.2,
+      "year_comparison_percentage": 5.63
+    }
+  ]
+}
+```
+
+- `co2_per_km_kg` is the configurable `CO2_PER_KM_KG` env variable (default `0.34`), returned so the frontend can display the conversion factor in tooltips
+- `unit_totals` aggregates across all validated modules
+- `module_results` is a list of per-module entries; headcount module includes `total_fte`, others have `total_fte: null`
+- `year_comparison_percentage` is `null` when no previous year data exists
+- `equivalent_car_km = kg_co2eq / CO2_PER_KM_KG`
+
+### 3a. Service: [unit_totals_service.py](backend/app/services/unit_totals_service.py)
+
+`get_results_summary(carbon_report_id: int) -> dict`
+
+Orchestrates all data fetching (3–5 DB queries total):
+
+1. Loads `CarbonReport` by id → gets `unit_id` and `year`
+2. Looks up previous year's `CarbonReport` via `CarbonReportRepository.get_by_unit_and_year(unit_id, year - 1)`
+3. Fetches current emissions per module: `DataEntryEmissionRepository.get_stats_by_carbon_report_id(carbon_report_id)`
+4. Fetches current FTE per module: `DataEntryRepository.get_stats_by_carbon_report_id(carbon_report_id)`
+5. If previous report exists, fetches previous emissions per module
+
+Returns raw data dict for the endpoint to format:
+
+```python
+{
+    "current_emissions": {"2": 15000.0, "4": 41700.0},   # module_type_id → kg
+    "current_fte": {"1": 25.5},                            # module_type_id → fte
+    "prev_emissions": {"2": 14200.0, "4": 40000.0},       # empty dict if no prev year
+}
+```
+
+### 3b. Endpoint: [carbon_report_module_stats.py](backend/app/api/v1/carbon_report_module_stats.py)
+
+`GET /{carbon_report_id}/results-summary` — mounted at `/modules-stats` prefix.
+
+The endpoint handles all formatting/conversion:
+
+- Calls `UnitTotalsService(db).get_results_summary(carbon_report_id)` for raw data
+- For each module in `current_emissions`, computes:
+  - `total_tonnes = kg_co2eq / 1000`
+  - `tonnes_per_fte = total_tonnes / total_fte` (if FTE available)
+  - `equivalent_car_km = kg_co2eq / settings.CO2_PER_KM_KG`
+  - `year_comparison = (current - prev) / prev * 100` (if previous year exists)
+- Aggregates `unit_totals` by summing across all modules
+- Returns `co2_per_km_kg` from `Settings.CO2_PER_KM_KG` so the frontend can display it
+
+### 3c. Configuration: `CO2_PER_KM_KG`
+
+New environment variable in `backend/app/core/config.py`:
+
+```python
+CO2_PER_KM_KG: float = Field(
+    default=0.34,
+    description="CO2 per km in kg",
+)
+```
+
+Also documented in `.env.example`.
+
+---
+
 ## Frontend
 
-### Store: [modules.ts](frontend/src/stores/modules.ts)
+### API layer: [modules.ts](frontend/src/api/modules.ts)
 
-Both API functions live in the **Pinia store** (`useModuleStore`), not in `api/modules.ts`. They call the backend via `api.get()` directly.
+The API module defines TypeScript interfaces and fetch functions:
 
 **Interfaces:**
 
 ```typescript
-interface ValidatedTotalsResponse {
-  modules: Record<number, number>;
+interface ModuleResult {
+  module_type_id: number;
   total_tonnes_co2eq: number;
-  total_fte: number;
+  total_fte: number | null;
+  tonnes_co2eq_per_fte: number | null;
+  equivalent_car_km: number;
+  previous_year_total_tonnes_co2eq: number | null;
+  year_comparison_percentage: number | null;
 }
 
-interface YearlyValidatedEmission {
-  year: number;
-  total_tonnes_co2eq: number;
+interface ResultsSummary {
+  unit_totals: {
+    total_tonnes_co2eq: number | null;
+    total_fte: number | null;
+    tonnes_co2eq_per_fte: number | null;
+    equivalent_car_km: number | null;
+    previous_year_total_tonnes_co2eq: number | null;
+    year_comparison_percentage: number | null;
+  };
+  co2_per_km_kg: number;
+  module_results: ModuleResult[];
 }
 ```
 
-**Function 1:** `getYearlyValidatedEmissions(unitId: number)` — calls `GET /unit/{unitId}/yearly-validated-emissions`, stores result in `state.yearlyValidatedEmissions` (`YearlyValidatedEmission[]`).
+**Function:** `getResultsSummary(carbonReportId: number)` — calls `GET /modules-stats/{carbonReportId}/results-summary`.
 
-**Function 2:** `getValidatedTotals(carbonReportId: number)` — calls `GET /modules-stats/{carbonReportId}/validated-totals`, stores result in `state.validatedTotals` (`ValidatedTotalsResponse | null`). Caches by `carbonReportId` to avoid redundant fetches.
+### Store: [modules.ts](frontend/src/stores/modules.ts)
 
-### Integration: WorkspaceSetupPage / YearSelector
+The Pinia store (`useModuleStore`) contains functions for endpoint 1 (yearly emissions):
 
-- `WorkspaceSetupPage.vue` calls `moduleStore.getYearlyValidatedEmissions(unit.id)` in `handleUnitSelect`, alongside fetching carbon reports
-- A `yearRows` computed property maps `state.yearlyValidatedEmissions` into `YearData[]` by matching each year's emissions to the available carbon report years
-- The `YearSelector.vue` component receives `yearRows` as a prop and displays tCO2eq per year in a table column
+**Function:** `getYearlyValidatedEmissions(unitId: number)` — calls `GET /unit/{unitId}/yearly-validated-emissions`, stores result in `state.yearlyValidatedEmissions`.
 
-### Integration: HomePage
+### ResultsPage: [ResultsPage.vue](frontend/src/pages/app/ResultsPage.vue)
 
-- `HomePage.vue` calls `moduleStore.getValidatedTotals(carbonReportId)` reactively via a computed property (triggers when `currentCarbonReportId` changes)
-- `validatedTotals?.total_tonnes_co2eq` is displayed as the year total
-- A `moduleCardTotals` computed maps `validatedTotals.modules` to per-module-card values using `getModuleTypeId(module)` lookups
+Dedicated results page that consumes the `results-summary` endpoint:
+
+- Calls `getResultsSummary(carbonReportId)` on mount and when `selectedCarbonReport` changes
+- **Unit-wide totals section** with 3 `BigNumber` cards:
+  - Total carbon footprint (tonnes CO2eq) with car-km equivalent
+  - Carbon footprint per FTE with Paris Agreement reference (2 tonnes)
+  - Year-over-year % change with previous year comparison
+- **Per-module breakdown** using expansion panels for each module (excluding headcount):
+  - Each module shows 3 `BigNumber` cards (same metrics as unit totals but module-scoped)
+  - Professional travel modules additionally show `ModuleCharts` when validated
+  - Non-validated modules show a placeholder card prompting validation
+- `co2_per_km_kg` value from the response is used in tooltips to explain the car-km conversion factor
+- Supports colorblind mode toggle, uncertainty badges, and year comparison toggle
+- PDF download via `window.print()`
 
 ---
 
 ## Files Modified
 
-| File                                                   | Change                                                                              |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| `backend/app/repositories/data_entry_emission_repo.py` | Add `get_validated_totals_by_unit()` + `get_stats_by_carbon_report_id()`            |
-| `backend/app/repositories/data_entry_repo.py`          | Add `get_stats_by_carbon_report_id()`                                               |
-| `backend/app/services/unit_totals_service.py`          | Add `get_validated_emissions_by_unit()`                                             |
-| `backend/app/services/data_entry_emission_service.py`  | Add `get_stats_by_carbon_report_id()` (delegates to repo)                           |
-| `backend/app/services/data_entry_service.py`           | Add `get_stats_by_carbon_report_id()` (delegates to repo)                           |
-| `backend/app/api/v1/unit_results.py`                   | Add `GET /{unit_id}/yearly-validated-emissions` endpoint                            |
-| `backend/app/api/v1/carbon_report_module_stats.py`     | Add `GET /{carbon_report_id}/validated-totals` endpoint                             |
-| `frontend/src/stores/modules.ts`                       | Add `getYearlyValidatedEmissions()` + `getValidatedTotals()`, interfaces, and state |
-| `frontend/src/pages/app/WorkspaceSetupPage.vue`        | Call `getYearlyValidatedEmissions` on unit selection, compute `yearRows`            |
-| `frontend/src/pages/app/HomePage.vue`                  | Call `getValidatedTotals` reactively, display totals and per-module cards           |
+| File                                                   | Change                                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `backend/app/core/config.py`                           | Add `CO2_PER_KM_KG` setting (default 0.34)                                                 |
+| `backend/.env.example`                                 | Document `CO2_PER_KM_KG`                                                                   |
+| `backend/app/repositories/data_entry_emission_repo.py` | Add `get_validated_totals_by_unit()` + `get_stats_by_carbon_report_id()`                   |
+| `backend/app/repositories/data_entry_repo.py`          | Add `get_stats_by_carbon_report_id()`                                                      |
+| `backend/app/repositories/carbon_report_repo.py`       | Add `get_by_unit_and_year()`                                                               |
+| `backend/app/services/unit_totals_service.py`          | Add `get_validated_emissions_by_unit()` + `get_results_summary()`                          |
+| `backend/app/services/data_entry_emission_service.py`  | Add `get_stats_by_carbon_report_id()` (delegates to repo)                                  |
+| `backend/app/services/data_entry_service.py`           | Add `get_stats_by_carbon_report_id()` (delegates to repo)                                  |
+| `backend/app/api/v1/unit_results.py`                   | Add `GET /{unit_id}/yearly-validated-emissions` endpoint                                   |
+| `backend/app/api/v1/carbon_report_module_stats.py`     | Add `GET /{carbon_report_id}/validated-totals` + `GET /{carbon_report_id}/results-summary` |
+| `frontend/src/api/modules.ts`                          | Add `ResultsSummary`, `ModuleResult` interfaces + `getResultsSummary()` function           |
+| `frontend/src/stores/modules.ts`                       | Add `getYearlyValidatedEmissions()`, interfaces, and state                                 |
+| `frontend/src/pages/app/ResultsPage.vue`               | Full results page consuming `results-summary` endpoint                                     |
+| `frontend/src/types.ts`                                | Add `ModuleResult` type reference                                                          |
 
 ## Verification
 
 1. Call `GET /api/v1/unit/{id}/yearly-validated-emissions` — verify response is a plain JSON array of per-year totals from validated modules only
 2. Call `GET /api/v1/modules-stats/{carbon_report_id}/validated-totals` — verify `modules` is a map keyed by `module_type_id` (int) with correct values
-3. Non-validated modules (status 0 or 1) must not appear in either endpoint
-4. Headcount FTE must come from `DataEntry.data["fte"]`, not from `DataEntryEmission`
-5. A unit with no validated modules returns an empty array / zero totals
+3. Call `GET /api/v1/modules-stats/{carbon_report_id}/results-summary` — verify `unit_totals`, `module_results[]`, and `co2_per_km_kg` are present and correctly computed
+4. Non-validated modules (status 0 or 1) must not appear in any endpoint
+5. Headcount FTE must come from `DataEntry.data["fte"]`, not from `DataEntryEmission`
+6. A unit with no validated modules returns an empty array / zero totals
+7. `equivalent_car_km` uses the configurable `CO2_PER_KM_KG` value (default 0.34)
+8. Year-over-year comparison returns `null` when no previous year data exists
+9. ResultsPage displays placeholder cards for modules that are not yet validated

--- a/frontend/src/api/modules.ts
+++ b/frontend/src/api/modules.ts
@@ -55,6 +55,7 @@ export interface ResultsSummary {
     previous_year_total_tonnes_co2eq: number | null;
     year_comparison_percentage: number | null;
   };
+  co2_per_km_kg: number;
   module_results: ModuleResult[];
 }
 

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -8,7 +8,6 @@ import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
 import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
-import { nOrDash } from 'src/utils/number';
 import {
   getResultsSummary,
   type ResultsSummary,
@@ -29,6 +28,20 @@ const FORMAT_1_DECIMAL = {
 const FORMAT_INTEGER = {
   options: { minimumFractionDigits: 0, maximumFractionDigits: 0 },
 };
+
+const co2PerKmKg = computed(() => resultsSummary.value?.co2_per_km_kg ?? 0);
+
+const percentChangeFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+  signDisplay: 'always',
+});
+
+function formatPercentChange(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return percentChangeFormatter.format(value / 100);
+}
 
 const workspaceStore = useWorkspaceStore();
 const timelineStore = useTimelineStore();
@@ -170,34 +183,23 @@ const downloadPDF = () => {
         <BigNumber
           :title="$t('results_total_unit_carbon_footprint')"
           :number="
-            resultsSummary.unit_totals.total_tonnes_co2eq != null
-              ? nOrDash(
-                  resultsSummary.unit_totals.total_tonnes_co2eq,
-                  FORMAT_INTEGER,
-                )
-              : '-'
+            $nOrDash(
+              resultsSummary.unit_totals.total_tonnes_co2eq,
+              FORMAT_INTEGER,
+            )
           "
           :comparison="
-            resultsSummary.unit_totals.equivalent_car_km != null
-              ? $t('results_equivalent_to_car', {
-                  km: nOrDash(
-                    resultsSummary.unit_totals.equivalent_car_km,
-                    FORMAT_INTEGER,
-                  ),
-                  value: `${nOrDash(0.34)}`,
-                })
-              : ''
+            $t('results_equivalent_to_car', {
+              km: $n(resultsSummary.unit_totals.equivalent_car_km),
+              value: `${$nOrDash(co2PerKmKg)}`,
+            })
           "
-          :comparison-highlight="
-            resultsSummary.unit_totals.equivalent_car_km != null
-              ? `${nOrDash(resultsSummary.unit_totals.equivalent_car_km, FORMAT_INTEGER)}km`
-              : ''
-          "
+          :comparison-highlight="`${$n(resultsSummary.unit_totals.equivalent_car_km)}km`"
           color="negative"
         >
           <template #tooltip>{{
             $t('results_total_unit_carbon_footprint_tooltip', {
-              value: nOrDash(0.34),
+              value: $nOrDash(co2PerKmKg),
               unit: $t('results_kg_co2eq_per_km'),
             })
           }}</template>
@@ -205,19 +207,17 @@ const downloadPDF = () => {
         <BigNumber
           :title="$t('results_carbon_footprint_per_fte')"
           :number="
-            resultsSummary.unit_totals.tonnes_co2eq_per_fte != null
-              ? nOrDash(
-                  resultsSummary.unit_totals.tonnes_co2eq_per_fte,
-                  FORMAT_INTEGER,
-                )
-              : '-'
+            $nOrDash(
+              resultsSummary.unit_totals.tonnes_co2eq_per_fte,
+              FORMAT_INTEGER,
+            )
           "
           :comparison="
             $t('results_paris_agreement_value', {
-              value: `${nOrDash(2)}${$t('results_units_tonnes')}`,
+              value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
             })
           "
-          :comparison-highlight="`${nOrDash(2)}${$t('results_units_tonnes')}`"
+          :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
           color="negative"
         >
           <template #tooltip>{{
@@ -233,9 +233,9 @@ const downloadPDF = () => {
           <BigNumber
             :title="$t('results_unit_carbon_footprint')"
             :number="
-              resultsSummary.unit_totals.year_comparison_percentage != null
-                ? `${resultsSummary.unit_totals.year_comparison_percentage > 0 ? '+' : ''}${nOrDash(resultsSummary.unit_totals.year_comparison_percentage, FORMAT_1_DECIMAL)}%`
-                : '-'
+              formatPercentChange(
+                resultsSummary.unit_totals.year_comparison_percentage,
+              )
             "
             :unit="
               $t('results_compared_to', {
@@ -250,26 +250,16 @@ const downloadPDF = () => {
                   : 'negative'
             "
             :comparison="
-              resultsSummary.unit_totals.previous_year_total_tonnes_co2eq !=
-              null
-                ? $t('results_compared_to_value_of', {
-                    value: `${nOrDash(
-                      resultsSummary.unit_totals
-                        .previous_year_total_tonnes_co2eq,
-                      FORMAT_1_DECIMAL,
-                    )}${$t('results_units_tonnes')}`,
-                  })
-                : ''
+              $t('results_compared_to_value_of', {
+                value: `${$nOrDash(
+                  resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
+                  FORMAT_1_DECIMAL,
+                )}${$t('results_units_tonnes')}`,
+              })
             "
-            :comparison-highlight="
-              resultsSummary.unit_totals.previous_year_total_tonnes_co2eq !=
-              null
-                ? `${nOrDash(
-                    resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
-                    FORMAT_1_DECIMAL,
-                  )}${$t('results_units_tonnes')}`
-                : ''
-            "
+            :comparison-highlight="`${$nOrDash(
+              resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
+            )}${$t('results_units_tonnes')}`"
           >
           </BigNumber>
         </div>
@@ -354,21 +344,21 @@ const downloadPDF = () => {
                         })
                       "
                       :number="
-                        nOrDash(
+                        $nOrDash(
                           getModuleResult(module)!.total_tonnes_co2eq,
                           getModuleFormatOptions(module),
                         )
                       "
                       :comparison="
                         $t('results_equivalent_to_car', {
-                          km: nOrDash(
+                          km: $nOrDash(
                             getModuleResult(module)!.equivalent_car_km,
                             FORMAT_INTEGER,
                           ),
-                          value: `${nOrDash(0.34)}`,
+                          value: `${$nOrDash(co2PerKmKg)}`,
                         })
                       "
-                      :comparison-highlight="`${nOrDash(
+                      :comparison-highlight="`${$nOrDash(
                         getModuleResult(module)!.equivalent_car_km,
                         FORMAT_INTEGER,
                       )}km`"
@@ -376,7 +366,7 @@ const downloadPDF = () => {
                     >
                       <template #tooltip>{{
                         $t('results_total_unit_carbon_footprint_tooltip', {
-                          value: nOrDash(0.34),
+                          value: $nOrDash(co2PerKmKg),
                           unit: $t('results_kg_co2eq_per_km'),
                         })
                       }}</template>
@@ -384,19 +374,17 @@ const downloadPDF = () => {
                     <BigNumber
                       :title="$t('results_carbon_footprint_per_fte')"
                       :number="
-                        getModuleResult(module)!.tonnes_co2eq_per_fte != null
-                          ? nOrDash(
-                              getModuleResult(module)!.tonnes_co2eq_per_fte,
-                              getModuleFormatOptions(module),
-                            )
-                          : '-'
+                        $nOrDash(
+                          getModuleResult(module)!.tonnes_co2eq_per_fte,
+                          getModuleFormatOptions(module),
+                        )
                       "
                       :comparison="
                         $t('results_paris_agreement_value', {
-                          value: `${nOrDash(2)}${$t('results_units_tonnes')}`,
+                          value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
                         })
                       "
-                      :comparison-highlight="`${nOrDash(2)}${$t('results_units_tonnes')}`"
+                      :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
                       color="negative"
                     >
                       <template #tooltip>{{
@@ -417,10 +405,9 @@ const downloadPDF = () => {
                           })
                         "
                         :number="
-                          getModuleResult(module)!.year_comparison_percentage !=
-                          null
-                            ? `${getModuleResult(module)!.year_comparison_percentage! > 0 ? '+' : ''}${nOrDash(getModuleResult(module)!.year_comparison_percentage, getModuleFormatOptions(module))}%`
-                            : '-'
+                          formatPercentChange(
+                            getModuleResult(module)!.year_comparison_percentage,
+                          )
                         "
                         :unit="
                           $t('results_compared_to', {
@@ -437,27 +424,17 @@ const downloadPDF = () => {
                               : 'negative'
                         "
                         :comparison="
-                          getModuleResult(module)!
-                            .previous_year_total_tonnes_co2eq != null
-                            ? $t('results_compared_to_value_of', {
-                                value: `${nOrDash(
-                                  getModuleResult(module)!
-                                    .previous_year_total_tonnes_co2eq,
-                                  getModuleFormatOptions(module),
-                                )}${$t('results_units_tonnes')}`,
-                              })
-                            : ''
+                          $t('results_compared_to_value_of', {
+                            value: `${$nOrDash(
+                              getModuleResult(module)!
+                                .previous_year_total_tonnes_co2eq,
+                            )}${$t('results_units_tonnes')}`,
+                          })
                         "
-                        :comparison-highlight="
+                        :comparison-highlight="`${$nOrDash(
                           getModuleResult(module)!
-                            .previous_year_total_tonnes_co2eq != null
-                            ? `${nOrDash(
-                                getModuleResult(module)!
-                                  .previous_year_total_tonnes_co2eq,
-                                getModuleFormatOptions(module),
-                              )}${$t('results_units_tonnes')}`
-                            : ''
-                        "
+                            .previous_year_total_tonnes_co2eq,
+                        )}${$t('results_units_tonnes')}`"
                       >
                       </BigNumber>
                     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     $nOrDash: typeof nOrDash;
     $t: typeof i18n.global.t;
+    $n: typeof i18n.global.n;
   }
 }
 


### PR DESCRIPTION
## What does this change?

Introduces a new `/results-summary` endpoint on the `carbon_report_module_stats` router that returns unit-wide and per-module CO₂ figures (total tCO₂eq, FTE, tCO₂eq/FTE, equivalent car-km, and year-over-year comparison) for a given carbon report.

On the backend, `UnitTotalsService.get_results_summary` orchestrates fetching current and previous-year emissions from `DataEntryEmissionRepository` and FTE data from `DataEntryRepository`, then the endpoint computes all derived metrics (no rounding — deferred to the frontend).

On the frontend, `ResultsPage.vue` is updated to call the new endpoint via `getResultsSummary()` (typed in `src/api/modules.ts`) instead of the old `unit/{id}/{year}/totals` route. The `getModuleResult` helper maps frontend module keys to backend `module_type_id` values using the existing `getModuleTypeId` utility.


## Why is this needed?
The previous `ResultsPage` fetched from a legacy unit-level endpoint that did not provide per-module breakdowns, FTE ratios, or previous-year comparisons. This change aligns the results page with the full set of metrics required by the UI and makes the data contract explicit through TypeScript interfaces (`ResultsSummary`, `ModuleResult`).

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues
- Related to #252 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
