### PR TITLE
chore: rollback to uvicorn for opentelemetry

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -47,11 +47,13 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONFAULTHANDLER=1 \
     HOST=0.0.0.0 \
     PORT=8000 \
-    WORKERS=1
+    WORKERS=1 \
+    OTEL_PYTHON_FORK_SAFE=true
 
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
   CMD wget -qO- http://127.0.0.1:${PORT}/health || exit 1
 
-CMD ["opentelemetry-instrument", "python", "-m", "app.main"]
+# Use environment variables in CMD
+CMD ["sh", "-c", "exec opentelemetry-instrument uvicorn app.main:app --host $HOST --port $PORT --workers $WORKERS"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,15 +75,18 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: co2-backend
-    command: >
-      sh -c "
-        alembic upgrade head &&
-        opentelemetry-instrument python -m app.main
-      "
-    env_file:
-      - ./backend/.env
     environment:
       DEBUG: "True"
+      HOST: "0.0.0.0"
+      PORT: "8000"
+      WORKERS: "1"
+    command: >
+      sh -c '
+        alembic upgrade head &&
+        exec opentelemetry-instrument uvicorn app.main:app --host $$HOST --port $$PORT --workers $$WORKERS
+      '
+    env_file:
+      - ./backend/.env
     # volumes:
     #   - ./app:/app/app:ro
     labels:


### PR DESCRIPTION
This pull request updates the backend service startup process to use Uvicorn directly with environment-based configuration, improving flexibility and compatibility with OpenTelemetry instrumentation. The most important changes are:

**Backend container startup and configuration:**

* Modified the backend `Dockerfile` to set the `OTEL_PYTHON_FORK_SAFE` environment variable, which helps ensure OpenTelemetry works correctly in multi-worker environments.
* Updated the `CMD` in the `Dockerfile` to launch the app using `uvicorn` via `opentelemetry-instrument`, passing host, port, and worker settings from environment variables for greater configurability.

**Docker Compose service definition:**

* Moved key environment variables (`DEBUG`, `HOST`, `PORT`, `WORKERS`) into the `environment` section of `docker-compose.yml` for clearer configuration management.
* Updated the backend service `command` in `docker-compose.yml` to use `uvicorn` with the same environment-based configuration, ensuring consistency with the Dockerfile and better support for process control and instrumentation.