### PR TITLE
feat/257-note

### DIFF
--- a/backend/app/schemas/data_entry.py
+++ b/backend/app/schemas/data_entry.py
@@ -101,6 +101,7 @@ class DataEntryResponseGen(DataEntryBase):
     """Response schema for DataEntry items."""
 
     id: int
+    note: Optional[str] = None
 
 
 # == =========== DTO BASE ================================= #

--- a/frontend/src/components/molecules/NoteDialog.vue
+++ b/frontend/src/components/molecules/NoteDialog.vue
@@ -99,7 +99,7 @@ watch(
 );
 
 function onSave() {
-  emit('save', localNote.value);
+  emit('save', localNote.value.trim());
   emit('update:modelValue', false);
 }
 

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -735,29 +735,24 @@ function validateForm() {
   return ok;
 }
 
-function onSubmit() {
-  if (!validateForm()) {
-    return;
-  }
-  // Normalize payload types (numbers remain numbers, booleans kept, empty -> null/string)
+function buildPayload(): Record<
+  string,
+  string | number | boolean | null | Option
+> {
   const payload: Record<string, string | number | boolean | null | Option> = {};
 
-  // Fields to exclude from submission (read-only display fields)
   const excludedFields = [
     'origin_location_data',
     'destination_location_data',
-    'origin', // Display-only field for table
-    'destination', // Display-only field for table
-    'round_trip', // Direction input field (not backend field)
-    'distance_km', // Read-only calculated field
-    'kg_co2eq', // Read-only calculated field
+    'origin',
+    'destination',
+    'round_trip',
+    'distance_km',
+    'kg_co2eq',
   ];
 
   Object.keys(form).forEach((k) => {
-    // Skip excluded fields
-    if (excludedFields.includes(k)) {
-      return;
-    }
+    if (excludedFields.includes(k)) return;
 
     const cfg = visibleFields.value.find((i) => i.id === k);
     const effectiveType = cfg?.type;
@@ -770,8 +765,6 @@ function onSubmit() {
     }
   });
 
-  // Include location IDs for professional travel when creating new entries
-  // Only include if we have location IDs (from autocomplete selection)
   if (
     !props.rowData &&
     form.origin_location_id !== undefined &&
@@ -781,7 +774,12 @@ function onSubmit() {
     payload.destination_location_id = form.destination_location_id as number;
   }
 
-  emit('submit', payload);
+  return payload;
+}
+
+function onSubmit() {
+  if (!validateForm()) return;
+  emit('submit', buildPayload());
   reset();
 }
 
@@ -885,12 +883,15 @@ function clearOriginAndDestination() {
 }
 
 function openAddNoteDialog() {
+  if (!validateForm()) return;
   addNoteDialogOpen.value = true;
 }
 
 function saveNote(note: string) {
-  // TODO: persist the note
-  void note;
+  const payload = buildPayload();
+  if (note) payload.note = note;
+  emit('submit', payload);
+  reset();
 }
 </script>
 <style scoped lang="scss">

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -160,18 +160,22 @@
             "
           >
             <q-btn
-              icon="o_add_comment"
-              color="grey-4"
-              text-color="primary"
+              :icon="slotProps.row.note ? 'o_comment' : 'o_add_comment'"
+              :color="slotProps.row.note ? 'accent' : 'grey-4'"
+              :text-color="slotProps.row.note ? 'white' : 'primary'"
               :disable="isDisabled"
               unelevated
               no-caps
               dense
               round
-              outline
+              :outline="!slotProps.row.note"
               class="q-mr-sm"
               @click="openNoteDialog(slotProps.row)"
-            />
+            >
+              <q-tooltip v-if="slotProps.row.note" class="tooltip">
+                {{ slotProps.row.note }}
+              </q-tooltip>
+            </q-btn>
             <q-btn
               v-if="canEdit"
               icon="o_delete"
@@ -260,8 +264,9 @@
   <NoteDialog
     v-model="noteDialogOpen"
     :note="noteDialogCurrentNote"
-    mode="edit"
+    :mode="noteDialogCurrentNote ? 'edit' : 'add'"
     @save="saveNote"
+    @delete="deleteNote"
   />
 
   <q-dialog v-model="confirmDelete" class="modal modal--md" persistent>
@@ -389,10 +394,48 @@ function openNoteDialog(row: ModuleRow) {
   noteDialogOpen.value = true;
 }
 
-function saveNote(note: string) {
-  // TODO: persist the note for noteDialogRowId.value
-  void note;
-  noteDialogRowId.value = null;
+async function saveNote(note: string) {
+  if (noteDialogRowId.value == null) return;
+  try {
+    await moduleStore.patchItem(
+      props.moduleType as Module,
+      props.submoduleType,
+      props.unitId,
+      String(props.year),
+      noteDialogRowId.value,
+      { note },
+    );
+  } catch {
+    $q.notify({
+      color: 'negative',
+      message: $t('common_save_error'),
+      position: 'top',
+    });
+  } finally {
+    noteDialogRowId.value = null;
+  }
+}
+
+async function deleteNote() {
+  if (noteDialogRowId.value == null) return;
+  try {
+    await moduleStore.patchItem(
+      props.moduleType as Module,
+      props.submoduleType,
+      props.unitId,
+      String(props.year),
+      noteDialogRowId.value,
+      { note: null },
+    );
+  } catch {
+    $q.notify({
+      color: 'negative',
+      message: $t('common_save_error'),
+      position: 'top',
+    });
+  } finally {
+    noteDialogRowId.value = null;
+  }
 }
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100, 200, 1000];
 

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -226,7 +226,7 @@ export default {
   },
   common_comment_entry_title: {
     en: 'Comment Entry',
-    fr: 'Commenter l\'entrée',
+    fr: "Commenter l'entrée",
   },
   common_edit_comment_title: {
     en: 'Edit Comment',
@@ -237,8 +237,12 @@ export default {
     fr: 'Commentaire...',
   },
   common_note_hint: {
-    en: '*The note is personal and won\'t be shared with anyone outside the unit',
-    fr: '*La note est personnelle et ne sera partagée avec personne en dehors de l\'unité',
+    en: "*The note is personal and won't be shared with anyone outside the unit",
+    fr: "*La note est personnelle et ne sera partagée avec personne en dehors de l'unité",
+  },
+  common_save_error: {
+    en: 'Failed to save. Please try again.',
+    fr: 'Échec de la sauvegarde. Veuillez réessayer.',
   },
   common_actions: {
     en: 'Actions',


### PR DESCRIPTION
## What does this change?
Introduces a reusable NoteDialog component and wires it up across ModuleForm and ModuleTable to allow users to add, edit, and delete personal notes on data entries. The note field is also exposed in the backend response schema.

## Why is this needed?
Users need a way to annotate individual data entries with personal context or remarks without affecting the shared data. Previously the "Add with note" button was disabled and there was no way to attach or manage notes on existing rows.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #257 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
