### PR TITLE
feat/434 standardize number formatting for CO2 emissions and FTE

### DIFF
--- a/frontend/src/boot/i18n.ts
+++ b/frontend/src/boot/i18n.ts
@@ -3,7 +3,12 @@ import { createI18n } from 'vue-i18n';
 import { Cookies } from 'quasar';
 import { LOCALE_MAP, Language } from 'src/constant/languages';
 import messages from 'src/i18n';
-import { nOrDash } from 'src/utils/number';
+import {
+  nOrDash,
+  formatTonnesCO2,
+  formatKgCO2,
+  formatFTE,
+} from 'src/utils/number';
 
 const LOCALE_COOKIE_KEY = 'locale';
 
@@ -104,4 +109,7 @@ export const i18n = createI18n({
 export default boot(({ app }) => {
   app.use(i18n);
   app.config.globalProperties.$nOrDash = nOrDash;
+  app.config.globalProperties.$formatTonnesCO2 = formatTonnesCO2;
+  app.config.globalProperties.$formatKgCO2 = formatKgCO2;
+  app.config.globalProperties.$formatFTE = formatFTE;
 });

--- a/frontend/src/components/charts/TreeMapModuleChart.vue
+++ b/frontend/src/components/charts/TreeMapModuleChart.vue
@@ -14,6 +14,7 @@ import VChart from 'vue-echarts';
 import EvolutionOverTimeChart from './EvolutionOverTimeChart.vue';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { formatTonnesForChart } from 'src/utils/number';
 
 const { t } = useI18n();
 const moduleStore = useModuleStore();
@@ -173,7 +174,7 @@ const chartOption = computed((): EChartsOption => {
         }
 
         let tooltip = `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:${color};"></span><strong>${categoryName}</strong><br/>`;
-        tooltip += `${className}: <strong>${value.toFixed(0)}</strong>`;
+        tooltip += `${className}: <strong>${formatTonnesForChart(value)}</strong>`;
 
         return tooltip;
       },

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -26,6 +26,8 @@ use([
   GraphicComponent,
 ]);
 
+import { formatTonnesForChart } from 'src/utils/number';
+
 const props = defineProps<{
   viewUncertainties?: boolean;
   perPersonBreakdown?: Record<string, number> | null;
@@ -369,16 +371,16 @@ const chartOption = computed((): EChartsOption => {
           const dataValue = Number(data?.[key]) || 0;
 
           if (dataValue > 0) {
-            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${dataValue.toFixed(1)} </strong><br/>`;
+            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
             total += dataValue;
           }
         });
 
-        let totalDisplay = total.toFixed(1);
+        let totalDisplay = formatTonnesForChart(total);
         if (showUncertainties && data) {
           const stdDev = Number(data.stdDev) || 0;
           if (stdDev > 0)
-            totalDisplay = `${total.toFixed(1)} ± ${stdDev.toFixed(1)}`;
+            totalDisplay = `${formatTonnesForChart(total)} ± ${formatTonnesForChart(stdDev)}`;
         }
 
         return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -27,6 +27,7 @@ use([
 ]);
 
 import type { EmissionBreakdownResponse } from 'src/stores/modules';
+import { formatTonnesForChart } from 'src/utils/number';
 
 const props = defineProps<{
   viewUncertainties?: boolean;
@@ -434,12 +435,12 @@ const chartOption = computed((): EChartsOption => {
 
           const dataValue = Number(data[key]) || 0;
           if (dataValue > 0) {
-            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${dataValue.toFixed(1)} </strong><br/>`;
+            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
             total += dataValue;
           }
         });
 
-        let totalDisplay = total.toFixed(1);
+        let totalDisplay = formatTonnesForChart(total);
         if (showUncertainties && data) {
           const stdDev = Math.sqrt(
             allStdDevKeys.value.reduce(
@@ -448,7 +449,7 @@ const chartOption = computed((): EChartsOption => {
             ),
           );
           if (stdDev > 0)
-            totalDisplay = `${total.toFixed(1)} ± ${stdDev.toFixed(1)}`;
+            totalDisplay = `${formatTonnesForChart(total)} ± ${formatTonnesForChart(stdDev)}`;
         }
 
         return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;

--- a/frontend/src/components/organisms/module/ModuleTotalResult.vue
+++ b/frontend/src/components/organisms/module/ModuleTotalResult.vue
@@ -16,13 +16,7 @@
             }}
           </div>
           <h1 class="text-h1 text-weight-bold q-mb-none">
-            {{
-              $nOrDash(data, {
-                options: {
-                  ...moduleConfig?.numberFormatOptions,
-                },
-              })
-            }}
+            {{ moduleConfig.totalFormatter(data) }}
           </h1>
           <p class="text-body2 text-secondary q-mb-none">
             {{ $t('module_total_result_title_unit', { type: type }) }}

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -1,4 +1,5 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
+import { formatTonnesCO2 } from 'src/utils/number';
 import type {
   Module,
   EquipmentElectricConsumptionSubType,
@@ -183,6 +184,7 @@ export const equipmentElectricConsumption: ModuleConfig = {
   hasSubmodules: true,
   isCollapsible: true,
   uncertainty: 'high',
+  totalFormatter: formatTonnesCO2,
 
   formStructure: 'perSubmodule',
 

--- a/frontend/src/constant/module-config/external-cloud-and-ai.ts
+++ b/frontend/src/constant/module-config/external-cloud-and-ai.ts
@@ -1,4 +1,5 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
+import { formatTonnesCO2 } from 'src/utils/number';
 import {
   SUBMODULE_EXTERNAL_CLOUD_TYPES,
   MODULES,
@@ -153,6 +154,7 @@ export const externalCloudAndAi: ModuleConfig = {
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,
   },
+  totalFormatter: formatTonnesCO2,
   submodules: [
     {
       id: SUBMODULE_EXTERNAL_CLOUD_TYPES.external_clouds,

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { MODULES, MODULES_THRESHOLD_TYPES } from 'src/constant/modules';
+import { formatFTE } from 'src/utils/number';
 import type { Module } from 'src/constant/modules';
 
 // Define an icon map to convert string keys to SVG icons
@@ -88,9 +89,10 @@ export const headcount: ModuleConfig = {
     value: 1000000, // FTE; implicit coloring only
   },
   numberFormatOptions: {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
   },
+  totalFormatter: formatFTE,
   submodules: [
     {
       id: 'member',

--- a/frontend/src/constant/module-config/infrastructure.ts
+++ b/frontend/src/constant/module-config/infrastructure.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { SUBMODULE_INFRASTRUCTURE_TYPES } from 'src/constant/modules';
+import { formatTonnesCO2 } from 'src/utils/number';
 import type { InfrastructureSubType } from 'src/constant/modules';
 
 const buildingFields: ModuleField[] = [
@@ -43,6 +44,7 @@ export const infrastructure: ModuleConfig = {
   description: 'Track infrastructure-related emissions',
   hasSubmodules: true,
   formStructure: 'perSubmodule',
+  totalFormatter: formatTonnesCO2,
   submodules: [
     {
       id: 'sub_building',

--- a/frontend/src/constant/module-config/internal-services.ts
+++ b/frontend/src/constant/module-config/internal-services.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { SUBMODULE_INTERNAL_SERVICES_TYPES } from 'src/constant/modules';
+import { formatTonnesCO2 } from 'src/utils/number';
 
 import type { InternalServicesSubType } from 'src/constant/modules';
 const rootFields: ModuleField[] = [
@@ -133,6 +134,7 @@ export const internalServices: ModuleConfig = {
   description: 'Categorize and track waste streams',
   hasSubmodules: true,
   formStructure: 'single',
+  totalFormatter: formatTonnesCO2,
   moduleFields: rootFields,
   submodules: [
     {

--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { MODULES, MODULES_THRESHOLD_TYPES } from 'src/constant/modules';
+import { formatTonnesCO2 } from 'src/utils/number';
 import type { ProfessionalTravelSubType } from 'src/constant/modules';
 
 const moduleFields: ModuleField[] = [
@@ -168,6 +169,7 @@ export const professionalTravel: ModuleConfig = {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   },
+  totalFormatter: formatTonnesCO2,
   unit: 't CO₂-eq',
   threshold: {
     type: MODULES_THRESHOLD_TYPES[0],

--- a/frontend/src/constant/module-config/purchase.ts
+++ b/frontend/src/constant/module-config/purchase.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { PurchaseSubType, SUBMODULE_PURCHASE_TYPES } from '../modules';
+import { formatTonnesCO2 } from 'src/utils/number';
 
 const goodsFields: ModuleField[] = [
   {
@@ -42,6 +43,7 @@ export const purchase: ModuleConfig = {
   description: 'Track purchased goods and materials',
   hasSubmodules: true,
   formStructure: 'perSubmodule',
+  totalFormatter: formatTonnesCO2,
   submodules: [
     {
       id: 'sub_goods',

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -118,6 +118,7 @@ export interface ModuleConfig {
   type: string;
   name?: string;
   numberFormatOptions?: Intl.NumberFormatOptions;
+  totalFormatter: (value: number | string | null | undefined) => string;
   description?: string;
   hasDescription: boolean;
   hasDescriptionSubtext?: boolean;

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -18,7 +18,7 @@ import { PermissionAction } from 'src/constant/permissions';
 import type { Module } from 'src/constant/modules';
 import { useTimelineStore } from 'src/stores/modules';
 import { useModuleStore } from 'src/stores/modules';
-import { nOrDash } from 'src/utils/number';
+import { formatTonnesCO2 } from 'src/utils/number';
 
 const { t } = useI18n();
 const workspaceStore = useWorkspaceStore();
@@ -142,7 +142,7 @@ const modulesCounterText = computed(() =>
           />
           <div class="column items-end">
             <p class="text-h1 text-weight-medium q-mb-none">
-              {{ nOrDash(validatedTotals?.total_tonnes_co2eq) }}
+              {{ formatTonnesCO2(validatedTotals?.total_tonnes_co2eq) }}
             </p>
             <p class="text-secondary text-body2 q-mb-none">
               {{ $t('tco2eq') }}
@@ -253,10 +253,9 @@ const modulesCounterText = computed(() =>
             >
               <p class="text-weight-medium q-mb-none">
                 {{
-                  nOrDash(moduleCardTotals[moduleCard.module], {
-                    options:
-                      MODULES_CONFIG[moduleCard.module]?.numberFormatOptions,
-                  })
+                  MODULES_CONFIG[moduleCard.module].totalFormatter(
+                    moduleCardTotals[moduleCard.module],
+                  )
                 }}
               </p>
               <p class="text-body2 text-secondary q-mb-none">

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -22,9 +22,6 @@ import { MODULES, Module } from 'src/constant/modules';
 import { MODULE_STATES, getModuleTypeId } from 'src/constant/moduleStates';
 const { t } = useI18n();
 
-const FORMAT_1_DECIMAL = {
-  options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-};
 const FORMAT_INTEGER = {
   options: { minimumFractionDigits: 0, maximumFractionDigits: 0 },
 };
@@ -108,9 +105,6 @@ const viewUncertainties = ref(false);
 const compareYears = ref(false);
 
 const getModuleConfig = (module: string) => MODULES_CONFIG[module];
-const getModuleFormatOptions = (module: string) => ({
-  options: getModuleConfig(module)?.numberFormatOptions,
-});
 
 const getUncertainty = (
   uncertainty?: string,
@@ -192,10 +186,7 @@ const downloadPDF = () => {
         <BigNumber
           :title="$t('results_total_unit_carbon_footprint')"
           :number="
-            $nOrDash(
-              resultsSummary.unit_totals.total_tonnes_co2eq,
-              FORMAT_INTEGER,
-            )
+            $formatTonnesCO2(resultsSummary.unit_totals.total_tonnes_co2eq)
           "
           :comparison="
             $t('results_equivalent_to_car', {
@@ -216,10 +207,7 @@ const downloadPDF = () => {
         <BigNumber
           :title="$t('results_carbon_footprint_per_fte')"
           :number="
-            $nOrDash(
-              resultsSummary.unit_totals.tonnes_co2eq_per_fte,
-              FORMAT_INTEGER,
-            )
+            $formatTonnesCO2(resultsSummary.unit_totals.tonnes_co2eq_per_fte)
           "
           :comparison="
             $t('results_paris_agreement_value', {
@@ -260,13 +248,12 @@ const downloadPDF = () => {
             "
             :comparison="
               $t('results_compared_to_value_of', {
-                value: `${$nOrDash(
+                value: `${$formatTonnesCO2(
                   resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
-                  FORMAT_1_DECIMAL,
                 )}${$t('results_units_tonnes')}`,
               })
             "
-            :comparison-highlight="`${$nOrDash(
+            :comparison-highlight="`${$formatTonnesCO2(
               resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
             )}${$t('results_units_tonnes')}`"
           >
@@ -367,9 +354,8 @@ const downloadPDF = () => {
                         })
                       "
                       :number="
-                        $nOrDash(
+                        getModuleConfig(module).totalFormatter(
                           getModuleResult(module)!.total_tonnes_co2eq,
-                          getModuleFormatOptions(module),
                         )
                       "
                       :comparison="
@@ -397,9 +383,8 @@ const downloadPDF = () => {
                     <BigNumber
                       :title="$t('results_carbon_footprint_per_fte')"
                       :number="
-                        $nOrDash(
+                        getModuleConfig(module).totalFormatter(
                           getModuleResult(module)!.tonnes_co2eq_per_fte,
-                          getModuleFormatOptions(module),
                         )
                       "
                       :comparison="
@@ -448,13 +433,15 @@ const downloadPDF = () => {
                         "
                         :comparison="
                           $t('results_compared_to_value_of', {
-                            value: `${$nOrDash(
+                            value: `${getModuleConfig(module).totalFormatter(
                               getModuleResult(module)!
                                 .previous_year_total_tonnes_co2eq,
                             )}${$t('results_units_tonnes')}`,
                           })
                         "
-                        :comparison-highlight="`${$nOrDash(
+                        :comparison-highlight="`${getModuleConfig(
+                          module,
+                        ).totalFormatter(
                           getModuleResult(module)!
                             .previous_year_total_tonnes_co2eq,
                         )}${$t('results_units_tonnes')}`"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,9 +1,17 @@
-import { nOrDash } from 'src/utils/number';
+import {
+  nOrDash,
+  formatTonnesCO2,
+  formatKgCO2,
+  formatFTE,
+} from 'src/utils/number';
 import { i18n } from 'src/boot/i18n';
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     $nOrDash: typeof nOrDash;
+    $formatTonnesCO2: typeof formatTonnesCO2;
+    $formatKgCO2: typeof formatKgCO2;
+    $formatFTE: typeof formatFTE;
     $t: typeof i18n.global.t;
     $n: typeof i18n.global.n;
   }

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -42,3 +42,36 @@ export function nOrDash(
   // @ts-expect-error -- vue-i18n types issue
   return i18n.global.n(numValue, key, locale) || defaultNumberValue;
 }
+
+export function formatTonnesCO2(
+  value: number | string | null | undefined,
+): string {
+  if (value === null || value === undefined || value === '') {
+    return defaultNumberValue;
+  }
+  const numValue = typeof value === 'string' ? Number(value) : value;
+  if (!Number.isFinite(numValue)) {
+    return defaultNumberValue;
+  }
+  const options: Intl.NumberFormatOptions =
+    Math.abs(numValue) < 1
+      ? { minimumFractionDigits: 1, maximumFractionDigits: 1 }
+      : { minimumFractionDigits: 0, maximumFractionDigits: 0 };
+  return nOrDash(numValue, { options });
+}
+
+export function formatKgCO2(value: number | string | null | undefined): string {
+  return nOrDash(value, {
+    options: { minimumFractionDigits: 0, maximumFractionDigits: 0 },
+  });
+}
+
+export function formatFTE(value: number | string | null | undefined): string {
+  return nOrDash(value, {
+    options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+  });
+}
+
+export function formatTonnesForChart(value: number): string {
+  return Math.abs(value) >= 1 ? value.toFixed(0) : value.toFixed(1);
+}


### PR DESCRIPTION
## What does this change?
Standardizes number formatting across the platform by introducing a suite of specialized formatting utilities and integrating them into the global Vue instance and module configurations.

New Formatting Utilities: Added formatTonnesCO2, formatKgCO2, formatFTE, and formatTonnesForChart to src/utils/number.ts. These handle edge cases like small values (abs < 1) by automatically adjusting decimal precision.

Global Integration: Registered these formatters as global properties ($formatTonnesCO2, etc.) in the i18n boot file, making them accessible in all templates without local imports.

Config-Driven Formatting: Added a totalFormatter property to the ModuleConfig interface. This allows modules like Headcount to automatically use FTE formatting while carbon-related modules use CO₂ formatting.

UI Consistency: Refactored ResultsPage, HomePage, and all ECharts components (TreeMap and Bar charts) to use these standard formatters, ensuring that a value of 0.5 tCO2e doesn't get rounded to 1 or 0 unexpectedly.

## Why is this needed?
Previously, formatting was fragmented; some components used .toFixed(1), others used $nOrDash with local config objects, and some had no precision at all. This led to:

Visual bugs: Small but significant emissions (e.g., 0.2 tonnes) appearing as "0" due to lack of decimals.

Inconsistency: The "Total" card might show a different precision than the chart tooltip for the same data point.

Code Duplication: Formatting logic was repeated across multiple pages and constants.

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues

- Closes #434  

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
