### PR TITLE
483/refactor(professional-travel): replace trips  with separate plane and train submodules

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -106,7 +106,6 @@ async def get_module(
         f"year={sanitize(year)}, preview_limit={sanitize(preview_limit)}"
     )
     module_key = module_id.replace("-", "_")
-    # TODO: remove once migration done in frontend
     carbon_report_module_id = await get_carbon_report_id(
         unit_id=unit_id,
         year=year,
@@ -173,7 +172,7 @@ async def get_stats_by_class(
     current_user: User = Depends(get_current_active_user),
 ) -> List:
     """
-    Get travel emissions aggregated by transport_mode and cabin_class.
+    Get travel emissions aggregated by travel category and cabin_class.
 
     Returns treemap-format data for charts.
     """
@@ -202,7 +201,7 @@ async def get_evolution_over_time(
     current_user: User = Depends(get_current_active_user),
 ) -> List:
     """
-    Get travel emissions aggregated by year and transport_mode for a unit.
+    Get travel emissions aggregated by year and category for a unit.
     """
     await _check_module_permission(current_user, "professional-travel", "view")
 
@@ -262,7 +261,6 @@ async def get_submodule(
     )
 
     module_key = module_id.replace("-", "_")
-    # TODO: remove once migration done in frontend
     carbon_report_module_id = await get_carbon_report_id(
         unit_id=unit_id,
         year=year,
@@ -548,7 +546,6 @@ async def update(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Submodule not supported for update",
         )
-    # TODO: remove once migration done in frontend
     carbon_report_module_id = await get_carbon_report_id(
         unit_id=unit_id,
         year=year,

--- a/backend/app/api/v1/locations.py
+++ b/backend/app/api/v1/locations.py
@@ -32,7 +32,7 @@ async def search_locations(
     transport_mode: Optional[TransportModeEnum] = Query(
         None,
         description=(
-            "Filter by transport mode: 'train' or 'plane'. "
+            "Filter by location transport mode: 'train' or 'plane'. "
             "If not provided, returns both types."
         ),
     ),
@@ -50,7 +50,7 @@ async def search_locations(
     Args:
         query: Search query string (minimum 2 characters)
         limit: Maximum number of results (default: 5, max: 20)
-        transport_mode: Filter by transport mode ('train' or 'plane').
+        transport_mode: Filter by location transport mode ('train' or 'plane').
             If None, returns both types.
         db: Database session
         current_user: Authenticated user
@@ -69,7 +69,7 @@ async def search_locations(
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="transport_mode must be either 'train' or 'plane'",
+            detail="location transport_mode must be either 'train' or 'plane'",
         )
     service = LocationService(db)
     locations = await service.search_locations(
@@ -109,7 +109,7 @@ async def calculate_distance(
     current_user: User = Depends(get_current_active_user),
 ):
     """
-    Calculate distance between two locations based on transport mode.
+    Calculate distance between two locations based on location transport mode.
 
     For flights: Haversine distance + 95 km (airport approaches, routing, taxiing)
     For trains: Haversine distance × 1.2 (track routing, curves, detours)
@@ -119,7 +119,7 @@ async def calculate_distance(
     Args:
         origin_location_id: Origin location ID
         destination_location_id: Destination location ID
-        transport_mode: 'plane' or 'train'
+        transport_mode: Location transport mode ('plane' or 'train')
         number_of_trips: Number of trips (default: 1)
         db: Database session
         current_user: Authenticated user
@@ -129,7 +129,8 @@ async def calculate_distance(
 
     Raises:
         HTTPException 404: If location not found
-        HTTPException 400: If transport_mode is invalid or coordinates are invalid
+        HTTPException 400: If location transport_mode is invalid
+            or coordinates are invalid
     """
     service = LocationService(db)
     result = await service.calculate_distance(

--- a/backend/app/models/data_entry.py
+++ b/backend/app/models/data_entry.py
@@ -21,7 +21,8 @@ class DataEntryTypeEnum(int, Enum):
     it = 10
     other = 11
     # travel
-    trips = 20
+    plane = 20
+    train = 21
     #
     building = 30
     # external clouds and ai

--- a/backend/app/models/location.py
+++ b/backend/app/models/location.py
@@ -13,8 +13,8 @@ from sqlmodel import Field, SQLModel
 # enum - used in other files
 class TransportModeEnum(str, Enum):
     """
-    Module types for travel data entries.
-    Used to differentiate between plane and train data entries.
+    Location classification for transport networks.
+    Used to distinguish airport locations from train station locations.
     """
 
     plane = "plane"
@@ -30,7 +30,7 @@ class LocationBase(SQLModel):
     transport_mode: TransportModeEnum = Field(
         nullable=False,
         index=True,
-        description="Transport mode: 'plane' or 'train'",
+        description="Location transport mode: 'plane' (airport) or 'train' (station)",
     )
     name: str = Field(
         max_length=255,

--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -48,9 +48,8 @@ MODULE_TYPE_TO_DATA_ENTRY_TYPES = {
         DataEntryTypeEnum.other,
     ],
     ModuleTypeEnum.professional_travel: [
-        # DataEntryTypeEnum.flight,
-        # DataEntryTypeEnum.train,
-        DataEntryTypeEnum.trips,
+        DataEntryTypeEnum.plane,
+        DataEntryTypeEnum.train,
     ],
     ModuleTypeEnum.infrastructure: [
         DataEntryTypeEnum.building,

--- a/backend/app/modules/professional_travel/__init__.py
+++ b/backend/app/modules/professional_travel/__init__.py
@@ -1,3 +1,3 @@
-# This ensures the handlers are registered
-from . import emissions as emissions
+# This ensures the handlers are registered.
+# Travel formulas are registered in data_entry_emission_service.
 from . import schemas as schemas

--- a/backend/app/modules/professional_travel/emissions.py
+++ b/backend/app/modules/professional_travel/emissions.py
@@ -17,7 +17,8 @@ settings = get_settings()
 logger = get_logger(__name__)
 
 
-@DataEntryEmissionService.register_formula(DataEntryTypeEnum.trips)
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.plane)
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.train)
 async def compute_trips(
     self, data_entry: DataEntry | DataEntryResponse, factors: list[Factor]
 ) -> dict:
@@ -62,6 +63,8 @@ async def compute_trips(
     OriginLoc = aliased(Location, name="origin")
     DestLoc = aliased(Location, name="dest")
 
+    selected_type = DataEntryTypeEnum(data_entry.data_entry_type)
+
     stmt = (
         select(OriginLoc, DestLoc, Factor)
         .select_from(OriginLoc)
@@ -69,7 +72,7 @@ async def compute_trips(
         .outerjoin(
             Factor,
             and_(
-                col(Factor.data_entry_type_id) == DataEntryTypeEnum.trips.value,
+                col(Factor.data_entry_type_id) == selected_type.value,
                 Factor.classification["kind"].as_string() == transport_mode.value,
             ),
         )

--- a/backend/app/modules/professional_travel/schemas.py
+++ b/backend/app/modules/professional_travel/schemas.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, field_validator
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.data_entry_emission import DataEntryEmission
-from app.models.location import TransportModeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.schemas.data_entry import (
     BaseModuleHandler,
@@ -24,7 +23,6 @@ class DepartureDateMixin(BaseModel):
     @field_validator("departure_date", mode="before", check_fields=False)
     @classmethod
     def parse_departure_date(cls, v: Any) -> Optional[date]:
-        """Parse departure_date from various formats (date, datetime, string)."""
         if v is None:
             return None
         if isinstance(v, date) and not isinstance(v, datetime):
@@ -42,53 +40,80 @@ class DepartureDateMixin(BaseModel):
         return v
 
 
-class ProfessionalTravelHandlerResponse(DepartureDateMixin, DataEntryResponseGen):
+class ProfessionalTravelPlaneHandlerResponse(DepartureDateMixin, DataEntryResponseGen):
     traveler_name: str
     traveler_id: Optional[int] = None
     origin_location_id: int
     destination_location_id: int
-    transport_mode: TransportModeEnum
-    cabin_class: Optional[str] = None  # eco, business, first, class_1, class_2
+    cabin_class: Optional[str] = None
     departure_date: Optional[date] = None
     number_of_trips: int = 1
-    is_round_trip: bool = False
-    trip_direction: Optional[str] = None  # "outbound" or "return"
     origin: Optional[str] = None
     destination: Optional[str] = None
     distance_km: Optional[float] = None
     kg_co2eq: Optional[float] = None
 
 
-class ProfessionalTravelHandlerCreate(DepartureDateMixin, DataEntryCreate):
+class ProfessionalTravelTrainHandlerResponse(DepartureDateMixin, DataEntryResponseGen):
     traveler_name: str
     traveler_id: Optional[int] = None
     origin_location_id: int
     destination_location_id: int
-    transport_mode: TransportModeEnum
-    cabin_class: Optional[str] = None  # eco, business, first, class_1, class_2
+    cabin_class: Optional[str] = None
     departure_date: Optional[date] = None
     number_of_trips: int = 1
-    is_round_trip: bool = False
-    trip_direction: Optional[str] = None  # "outbound" or "return"
+    origin: Optional[str] = None
+    destination: Optional[str] = None
+    distance_km: Optional[float] = None
+    kg_co2eq: Optional[float] = None
 
 
-class ProfessionalTravelHandlerUpdate(DataEntryUpdate):
+class ProfessionalTravelPlaneHandlerCreate(DepartureDateMixin, DataEntryCreate):
+    traveler_name: str
+    traveler_id: Optional[int] = None
+    origin_location_id: int
+    destination_location_id: int
+    cabin_class: Optional[str] = None
+    departure_date: Optional[date] = None
+    number_of_trips: int = 1
+
+
+class ProfessionalTravelTrainHandlerCreate(DepartureDateMixin, DataEntryCreate):
+    traveler_name: str
+    traveler_id: Optional[int] = None
+    origin_location_id: int
+    destination_location_id: int
+    cabin_class: Optional[str] = None
+    departure_date: Optional[date] = None
+    number_of_trips: int = 1
+
+
+class ProfessionalTravelPlaneHandlerUpdate(DataEntryUpdate):
     traveler_name: Optional[str] = None
     traveler_id: Optional[int] = None
     origin_location_id: Optional[int] = None
     destination_location_id: Optional[int] = None
-    transport_mode: Optional[TransportModeEnum] = None
     cabin_class: Optional[str] = None
     departure_date: Optional[date] = None
     number_of_trips: Optional[int] = None
 
 
-class ProfessionalTravelModuleHandler(BaseModuleHandler):
+class ProfessionalTravelTrainHandlerUpdate(DataEntryUpdate):
+    traveler_name: Optional[str] = None
+    traveler_id: Optional[int] = None
+    origin_location_id: Optional[int] = None
+    destination_location_id: Optional[int] = None
+    cabin_class: Optional[str] = None
+    departure_date: Optional[date] = None
+    number_of_trips: Optional[int] = None
+
+
+class ProfessionalTravelBaseModuleHandler(BaseModuleHandler):
     module_type: ModuleTypeEnum = ModuleTypeEnum.professional_travel
-    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.trips
-    create_dto = ProfessionalTravelHandlerCreate
-    update_dto = ProfessionalTravelHandlerUpdate
-    response_dto = ProfessionalTravelHandlerResponse
+    data_entry_type: DataEntryTypeEnum
+    create_dto: type[DataEntryCreate]
+    update_dto: type[DataEntryUpdate]
+    response_dto: type[DataEntryResponseGen]
 
     kind_field = None
     subkind_field = None
@@ -99,88 +124,12 @@ class ProfessionalTravelModuleHandler(BaseModuleHandler):
         "id": DataEntry.id,
         "traveler_name": DataEntry.data["traveler_name"].as_string(),
         "departure_date": DataEntry.data["departure_date"].as_string(),
-        "transport_mode": DataEntry.data["transport_mode"].as_string(),
         "cabin_class": DataEntry.data["cabin_class"].as_string(),
         "number_of_trips": DataEntry.data["number_of_trips"].as_float(),
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
-    # async def resolve_primary_factor_id(
-    #     self,
-    #     payload: dict,
-    #     data_entry_type_id: DataEntryTypeEnum,
-    #     db: AsyncSession,
-    #     existing_data: Optional[dict] = None,
-    # ) -> dict:
-    #     """
-    #     Resolve factor ID if kind/or subkind change
-    #     Sets primary_factor_id
-
-    #     distance is computed in emission_service
-    #     """
-    # # Merge payload with existing data
-    # origin_id = payload.get("origin_location_id")
-    # dest_id = payload.get("destination_location_id")
-    # transport_mode = payload.get("transport_mode")
-
-    # if existing_data:
-    #     if origin_id is None:
-    #         origin_id = existing_data.get("origin_location_id")
-    #     if dest_id is None:
-    #         dest_id = existing_data.get("destination_location_id")
-    #     if transport_mode is None:
-    #         transport_mode = existing_data.get("transport_mode")
-
-    # if not origin_id or not dest_id:
-    #     logger.warning("Missing origin or destination location for trip")
-    #     return payload
-
-    # if not transport_mode or transport_mode not in
-    #   (TransportModeEnum.plane, TransportModeEnum.train):
-    #     logger.warning(f"Unknown transport_mode: {transport_mode}")
-    #     return payload
-
-    # OriginLoc = aliased(Location, name="origin")
-    # DestLoc = aliased(Location, name="dest")
-
-    # stmt = (
-    #     sa_select(OriginLoc, DestLoc, Factor)
-    #     .select_from(OriginLoc)
-    #     .join(DestLoc, col(DestLoc.id) == dest_id)
-    #     .outerjoin(
-    #         Factor,
-    #         and_(
-    #             col(Factor.data_entry_type_id) == DataEntryTypeEnum.trips.value,
-    #             Factor.classification["kind"].as_string() == transport_mode,
-    #         ),
-    #     )
-    #     .where(col(OriginLoc.id) == origin_id)
-    # )
-
-    # result = await db.execute(stmt)
-    # rows = result.all()
-
-    # if not rows:
-    #     logger.warning("Missing origin or destination location for trip")
-    #     return payload
-
-    # origin_loc, dest_loc = rows[0][0], rows[0][1]
-    # factors = [row[2] for row in rows if row[2] is not None]
-
-    # payload["origin"] = origin_loc.name
-    # payload["destination"] = dest_loc.name
-
-    # if transport_mode == "plane":
-    #     distance_km, factor = resolve_flight_factor(origin_loc, dest_loc, factors)
-    # else:  # train
-    #     distance_km, factor = resolve_train_factor(origin_loc, dest_loc, factors)
-
-    # payload["distance_km"] = distance_km
-    # payload["primary_factor_id"] = factor.id if factor else None
-
-    # return payload
-
-    def to_response(self, data_entry: DataEntry) -> ProfessionalTravelHandlerResponse:
+    def to_response(self, data_entry: DataEntry) -> DataEntryResponseGen:
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
@@ -190,8 +139,22 @@ class ProfessionalTravelModuleHandler(BaseModuleHandler):
             }
         )
 
-    def validate_create(self, payload: dict) -> ProfessionalTravelHandlerCreate:
+    def validate_create(self, payload: dict) -> DataEntryCreate:
         return self.create_dto.model_validate(payload)
 
-    def validate_update(self, payload: dict) -> ProfessionalTravelHandlerUpdate:
+    def validate_update(self, payload: dict) -> DataEntryUpdate:
         return self.update_dto.model_validate(payload)
+
+
+class ProfessionalTravelPlaneModuleHandler(ProfessionalTravelBaseModuleHandler):
+    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.plane
+    create_dto = ProfessionalTravelPlaneHandlerCreate
+    update_dto = ProfessionalTravelPlaneHandlerUpdate
+    response_dto = ProfessionalTravelPlaneHandlerResponse
+
+
+class ProfessionalTravelTrainModuleHandler(ProfessionalTravelBaseModuleHandler):
+    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.train
+    create_dto = ProfessionalTravelTrainHandlerCreate
+    update_dto = ProfessionalTravelTrainHandlerUpdate
+    response_dto = ProfessionalTravelTrainHandlerResponse

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -257,13 +257,12 @@ class DataEntryEmissionRepository:
         carbon_report_module_id: int,
     ) -> List[Dict[str, Any]]:
         """
-        Aggregate trip emissions by transport_mode and cabin_class.
+        Aggregate travel emissions by data entry type and cabin_class.
         """
-        # Define expressions once so SELECT and GROUP BY use the same objects
-        category_expr = DataEntry.data["transport_mode"].as_string()
+        category_expr = col(DataEntry.data_entry_type_id)
         class_expr = DataEntry.data["cabin_class"].as_string()
 
-        query = (
+        query: Select[Any] = (
             select(
                 category_expr.label("category"),
                 class_expr.label("class_key"),
@@ -275,7 +274,9 @@ class DataEntryEmissionRepository:
             )
             .where(
                 DataEntry.carbon_report_module_id == carbon_report_module_id,
-                DataEntry.data_entry_type_id == DataEntryTypeEnum.trips.value,
+                col(DataEntry.data_entry_type_id).in_(
+                    [DataEntryTypeEnum.plane.value, DataEntryTypeEnum.train.value]
+                ),
                 col(DataEntryEmission.kg_co2eq).isnot(None),
                 col(DataEntryEmission.kg_co2eq) > 0,
             )
@@ -285,10 +286,15 @@ class DataEntryEmissionRepository:
         result = await self.session.execute(query)
         rows = result.all()
 
-        # Group by category (transport_mode), aggregate by class
+        # Group by category, aggregate by class
         data_dict: Dict[str, Dict[str, float]] = {}
         for row in rows:
-            category = row.category or "unknown"
+            if row.category == DataEntryTypeEnum.plane.value:
+                category = "plane"
+            elif row.category == DataEntryTypeEnum.train.value:
+                category = "train"
+            else:
+                continue
             class_key = row.class_key
             kg_co2eq = float(row.kg_co2eq or 0.0)
 
@@ -302,10 +308,8 @@ class DataEntryEmissionRepository:
             if class_key is None:
                 if category == "plane":
                     class_key = "eco"
-                elif category == "train":
-                    class_key = "class_2"
                 else:
-                    class_key = "unknown"
+                    class_key = "class_2"
 
             data_dict[category][class_key] = (
                 data_dict[category].get(class_key, 0.0) + kg_co2eq
@@ -345,23 +349,23 @@ class DataEntryEmissionRepository:
         unit_id: int,
     ) -> List[Dict[str, Any]]:
         """
-        Aggregate trip emissions by year and transport_mode across all years
+        Aggregate travel emissions by year and category across all years
         for a given unit.
 
         Returns:
         [
-            {"year": 2023, "transport_mode": "plane", "kg_co2eq": 15000.0},
-            {"year": 2023, "transport_mode": "train", "kg_co2eq": 8000.0},
+            {"year": 2023, "category": "plane", "kg_co2eq": 15000.0},
+            {"year": 2023, "category": "train", "kg_co2eq": 8000.0},
             ...
         ]
         """
         year_expr = col(CarbonReport.year)
-        transport_mode_expr = DataEntry.data["transport_mode"].as_string()
+        category_expr = col(DataEntry.data_entry_type_id)
 
         query: Select[Any] = (
             select(
                 year_expr.label("year"),
-                transport_mode_expr.label("transport_mode"),
+                category_expr.label("category"),
                 func.sum(col(DataEntryEmission.kg_co2eq)).label("kg_co2eq"),
             )
             .join(
@@ -380,22 +384,32 @@ class DataEntryEmissionRepository:
                 CarbonReport.unit_id == unit_id,
                 CarbonReportModule.module_type_id
                 == ModuleTypeEnum.professional_travel.value,
-                DataEntry.data_entry_type_id == DataEntryTypeEnum.trips.value,
+                col(DataEntry.data_entry_type_id).in_(
+                    [DataEntryTypeEnum.plane.value, DataEntryTypeEnum.train.value]
+                ),
                 col(DataEntryEmission.kg_co2eq).isnot(None),
                 col(DataEntryEmission.kg_co2eq) > 0,
             )
-            .group_by(year_expr, transport_mode_expr)
-            .order_by(year_expr.asc(), transport_mode_expr.asc())
+            .group_by(year_expr, category_expr)
+            .order_by(year_expr.asc(), category_expr.asc())
         )
 
         result = await self.session.execute(query)
         rows = result.all()
 
-        return [
-            {
-                "year": row.year,
-                "transport_mode": row.transport_mode or "unknown",
-                "kg_co2eq": row.kg_co2eq or None,
-            }
-            for row in rows
-        ]
+        result_list: List[Dict[str, Any]] = []
+        for row in rows:
+            if row.category == DataEntryTypeEnum.plane.value:
+                category = "plane"
+            elif row.category == DataEntryTypeEnum.train.value:
+                category = "train"
+            else:
+                continue
+            result_list.append(
+                {
+                    "year": row.year,
+                    "category": category,
+                    "kg_co2eq": row.kg_co2eq or None,
+                }
+            )
+        return result_list

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -241,14 +241,17 @@ class DataEntryRepository:
         sort_order: str,
         filter: Optional[str] = None,
     ) -> SubmoduleResponse:
-        is_trips = data_entry_type_id == DataEntryTypeEnum.trips.value
+        is_travel_entry = data_entry_type_id in (
+            DataEntryTypeEnum.plane.value,
+            DataEntryTypeEnum.train.value,
+        )
 
         # Build query based on entry type
         entities: list[Any] = [DataEntry, DataEntryEmission, Factor]
         OriginLocation = aliased(Location)
         DestLocation = aliased(Location)
 
-        if is_trips:
+        if is_travel_entry:
             entities.extend([OriginLocation, DestLocation])
         statement: Select[Any] = (
             sa_select(*entities)
@@ -264,7 +267,7 @@ class DataEntryRepository:
             )
         )
 
-        if is_trips:
+        if is_travel_entry:
             statement = statement.join(
                 OriginLocation,
                 DataEntry.data["origin_location_id"].as_integer() == OriginLocation.id,
@@ -312,7 +315,7 @@ class DataEntryRepository:
 
         for row in rows:
             # Unpack based on query shape
-            if is_trips:
+            if is_travel_entry:
                 (
                     data_entry,
                     data_entry_emission,

--- a/backend/app/repositories/location_repo.py
+++ b/backend/app/repositories/location_repo.py
@@ -38,7 +38,7 @@ class LocationRepository:
 
         Results are prioritized by:
         1. Switzerland (country_code == "CH") first
-        2. For flights (transport_mode='plane'): large_airport first
+        2. For airports (location transport_mode='plane'): large_airport first
         3. Then by relevance (exact match, starts with, contains)
 
         Results are ordered by relevance:
@@ -49,11 +49,11 @@ class LocationRepository:
         Args:
             query: Search query string
             limit: Maximum number of results to return (default: 20)
-            transport_mode: Filter by transport mode ('train' or 'plane').
+            transport_mode: Filter by location transport mode ('train' or 'plane').
 
         Returns:
             List of Location objects ordered by country (Switzerland first),
-            relevance, and airport_size (for flights)
+            relevance, and airport_size (for airport searches)
         """
 
         query = query.strip()
@@ -97,7 +97,7 @@ class LocationRepository:
 
         statement = statement.where(search_condition)
 
-        # Filter by transport_mode if provided
+        # Filter by location transport_mode
         if transport_mode:
             statement = statement.where(col(Location.transport_mode) == transport_mode)
 
@@ -149,7 +149,7 @@ class LocationRepository:
             else_=2,
         )
 
-        # For flights, prioritize large_airport first
+        # For airport searches, prioritize large_airport first
         if transport_mode == TransportModeEnum.plane.value:
             airport_priority = case(
                 (col(Location.airport_size) == "large_airport", 1),
@@ -162,7 +162,7 @@ class LocationRepository:
                 col(Location.name).asc(),
             )
         else:
-            # For trains or mixed results, order by Switzerland first
+            # For train searches, order by Switzerland first
             statement = statement.order_by(
                 switzerland_priority.asc(),
                 relevance.asc(),

--- a/backend/app/schemas/factor.py
+++ b/backend/app/schemas/factor.py
@@ -247,15 +247,15 @@ class ExternalAIFactorResponse(FactorResponseGen):
 
 class TravelPlaneFactorResponse(FactorResponseGen):
     category: str
-    impact_score: float
-    rfi_adjustment: Optional[float] = None
+    ef_kg_co2eq_per_km: float
+    rfi_adjustement: Optional[float] = None
     min_distance: Optional[float] = None
     max_distance: Optional[float] = None
 
 
 class TravelTrainFactorResponse(FactorResponseGen):
     country_code: str
-    impact_score: float
+    ef_kg_co2eq_per_km: float
 
 
 class EquipmentFactorCreate(FactorCreate):
@@ -375,15 +375,15 @@ class ExternalAIFactorUpdate(FactorUpdate):
 
 class TravelPlaneFactorCreate(FactorCreate):
     category: str
-    impact_score: float
-    rfi_adjustment: Optional[float] = None
+    ef_kg_co2eq_per_km: float
+    rfi_adjustement: Optional[float] = None
     min_distance: Optional[float] = None
     max_distance: Optional[float] = None
 
     classification_field_map: dict[str, str] = {"category": "category"}
     value_field_map: dict[str, str] = {
-        "impact_score": "impact_score",
-        "rfi_adjustment": "rfi_adjustment",
+        "ef_kg_co2eq_per_km": "ef_kg_co2eq_per_km",
+        "rfi_adjustement": "rfi_adjustement",
         "min_distance": "min_distance",
         "max_distance": "max_distance",
     }
@@ -398,15 +398,15 @@ class TravelPlaneFactorCreate(FactorCreate):
 
 class TravelPlaneFactorUpdate(FactorUpdate):
     category: Optional[str] = None
-    impact_score: Optional[float] = None
-    rfi_adjustment: Optional[float] = None
+    ef_kg_co2eq_per_km: Optional[float] = None
+    rfi_adjustement: Optional[float] = None
     min_distance: Optional[float] = None
     max_distance: Optional[float] = None
 
     classification_field_map: dict[str, str] = {"category": "category"}
     value_field_map: dict[str, str] = {
-        "impact_score": "impact_score",
-        "rfi_adjustment": "rfi_adjustment",
+        "ef_kg_co2eq_per_km": "ef_kg_co2eq_per_km",
+        "rfi_adjustement": "rfi_adjustement",
         "min_distance": "min_distance",
         "max_distance": "max_distance",
     }
@@ -418,10 +418,10 @@ class TravelPlaneFactorUpdate(FactorUpdate):
 
 class TravelTrainFactorCreate(FactorCreate):
     country_code: str
-    impact_score: float
+    ef_kg_co2eq_per_km: float
 
     classification_field_map: dict[str, str] = {"country_code": "country_code"}
-    value_field_map: dict[str, str] = {"impact_score": "impact_score"}
+    value_field_map: dict[str, str] = {"ef_kg_co2eq_per_km": "ef_kg_co2eq_per_km"}
 
     @classmethod
     def computed_classification(cls, payload: dict) -> dict:
@@ -433,10 +433,10 @@ class TravelTrainFactorCreate(FactorCreate):
 
 class TravelTrainFactorUpdate(FactorUpdate):
     country_code: Optional[str] = None
-    impact_score: Optional[float] = None
+    ef_kg_co2eq_per_km: Optional[float] = None
 
     classification_field_map: dict[str, str] = {"country_code": "country_code"}
-    value_field_map: dict[str, str] = {"impact_score": "impact_score"}
+    value_field_map: dict[str, str] = {"ef_kg_co2eq_per_km": "ef_kg_co2eq_per_km"}
 
     @classmethod
     def computed_classification(cls, payload: dict) -> dict:
@@ -498,11 +498,11 @@ class ExternalAIFactorHandler(BaseFactorHandler):
 
 
 class TravelPlaneFactorHandler(BaseFactorHandler):
-    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.trips
+    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.plane
     factor_variant: str = "plane"
     emission_type: EmissionTypeEnum = EmissionTypeEnum.plane
 
-    registration_keys = [(DataEntryTypeEnum.trips, "plane")]
+    registration_keys = [(DataEntryTypeEnum.plane, "plane")]
 
     create_dto = TravelPlaneFactorCreate
     update_dto = TravelPlaneFactorUpdate
@@ -510,11 +510,11 @@ class TravelPlaneFactorHandler(BaseFactorHandler):
 
 
 class TravelTrainFactorHandler(BaseFactorHandler):
-    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.trips
+    data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.train
     factor_variant: str = "train"
     emission_type: EmissionTypeEnum = EmissionTypeEnum.train
 
-    registration_keys = [(DataEntryTypeEnum.trips, "train")]
+    registration_keys = [(DataEntryTypeEnum.train, "train")]
 
     create_dto = TravelTrainFactorCreate
     update_dto = TravelTrainFactorUpdate

--- a/backend/app/seed/seed_emission_factors.py
+++ b/backend/app/seed/seed_emission_factors.py
@@ -58,14 +58,17 @@ async def seed_emission_factors(session: AsyncSession) -> None:
             "description": "Swiss electricity consumption mix",
             "methodology": "Life cycle analysis",
         },
-        values={"kg_co2eq_per_kwh": settings.EMISSION_FACTOR_SWISS_MIX},
+        values={"kgco2eq_per_kwh": settings.EMISSION_FACTOR_SWISS_MIX},
     )
 
     session.add(factor)
     await session.commit()
+    factor_value = factor.values.get("kgco2eq_per_kwh") or factor.values.get(
+        "kg_co2eq_per_kwh"
+    )
     logger.info(
         f"Created emission factor: {factor.classification['description']}"
-        f" = {factor.values['kgco2eq_per_kwh']} kgCO2eq/kWh"
+        f" = {factor_value} kgCO2eq/kWh"
     )
 
 

--- a/backend/app/seed/seed_locations.py
+++ b/backend/app/seed/seed_locations.py
@@ -36,7 +36,7 @@ async def seed_locations(session: AsyncSession) -> None:
         logger.error(f"CSV file not found: {csv_path}")
         return
 
-    # Load existing locations into a dict keyed by (name, transport_mode)
+    # Load existing locations into a dict keyed by (name, location transport_mode)
     result = await session.exec(select(Location))
     existing_locations = {
         (loc.name.lower(), loc.transport_mode): loc for loc in result.all()
@@ -54,14 +54,14 @@ async def seed_locations(session: AsyncSession) -> None:
         reader = csv.DictReader(f)
         for row_num, row in enumerate(reader, start=2):  # Start at 2 (row 1 is header)
             try:
-                # Parse transport mode
+                # Parse location transport_mode
                 transport_mode_raw = row.get("transport_mode", "").strip().lower()
                 if transport_mode_raw not in (
                     TransportModeEnum.plane.name,
                     TransportModeEnum.train.name,
                 ):
                     logger.warning(
-                        f"Row {row_num}: Invalid transport mode "
+                        f"Row {row_num}: Invalid location transport_mode "
                         f"'{transport_mode_raw}', skipping"
                     )
                     skipped += 1

--- a/backend/app/seed/seed_plane_factors.py
+++ b/backend/app/seed/seed_plane_factors.py
@@ -28,7 +28,7 @@ async def seed_plane_factors() -> None:
         service = FactorService(session)
 
         # Delete existing flight factors
-        existing = await service.list_by_data_entry_type(DataEntryTypeEnum.trips)
+        existing = await service.list_by_data_entry_type(DataEntryTypeEnum.plane)
         ids = [
             f.id
             for f in existing
@@ -42,19 +42,34 @@ async def seed_plane_factors() -> None:
         with open(CSV_PATH, encoding="utf-8") as f:
             for row in csv.DictReader(f):
                 category = row["category"]
+                impact_score_raw = row.get("impact_score") or row.get(
+                    "ef_kg_co2eq_per_km"
+                )
+                rfi_adjustment_raw = row.get("rfi_adjustment") or row.get(
+                    "rfi_adjustement"
+                )
                 factor = await service.prepare_create(
                     emission_type_id=EmissionTypeEnum.plane.value,
                     is_conversion=False,
-                    data_entry_type_id=DataEntryTypeEnum.trips.value,
+                    data_entry_type_id=DataEntryTypeEnum.plane.value,
                     classification={
                         "kind": TransportModeEnum.plane.value,
                         "subkind": category,
                         "category": category,
                     },
                     values={
-                        "impact_score": float(row["impact_score"]),
-                        "rfi_adjustment": float(row["rfi_adjustment"])
-                        if row.get("rfi_adjustment")
+                        # Keep both key variants for backward compatibility.
+                        "impact_score": float(impact_score_raw)
+                        if impact_score_raw
+                        else None,
+                        "ef_kg_co2eq_per_km": float(impact_score_raw)
+                        if impact_score_raw
+                        else None,
+                        "rfi_adjustment": float(rfi_adjustment_raw)
+                        if rfi_adjustment_raw
+                        else None,
+                        "rfi_adjustement": float(rfi_adjustment_raw)
+                        if rfi_adjustment_raw
                         else None,
                         "min_distance": float(row["min_distance"])
                         if row.get("min_distance")

--- a/backend/app/seed/seed_train_factors.py
+++ b/backend/app/seed/seed_train_factors.py
@@ -28,7 +28,7 @@ async def seed_train_factors() -> None:
         service = FactorService(session)
 
         # Delete existing train factors
-        existing = await service.list_by_data_entry_type(DataEntryTypeEnum.trips)
+        existing = await service.list_by_data_entry_type(DataEntryTypeEnum.train)
         ids = [
             f.id
             for f in existing
@@ -42,16 +42,27 @@ async def seed_train_factors() -> None:
         with open(CSV_PATH, encoding="utf-8") as f:
             for row in csv.DictReader(f):
                 country_code = row["country_code"]
+                impact_score_raw = row.get("impact_score") or row.get(
+                    "ef_kg_co2eq_per_km"
+                )
                 factor = await service.prepare_create(
                     emission_type_id=EmissionTypeEnum.train.value,
                     is_conversion=False,
-                    data_entry_type_id=DataEntryTypeEnum.trips.value,
+                    data_entry_type_id=DataEntryTypeEnum.train.value,
                     classification={
                         "kind": TransportModeEnum.train.value,
                         "subkind": country_code,
                         "country_code": country_code,
                     },
-                    values={"impact_score": float(row["impact_score"])},
+                    values={
+                        # Keep both key variants for backward compatibility.
+                        "impact_score": float(impact_score_raw)
+                        if impact_score_raw
+                        else None,
+                        "ef_kg_co2eq_per_km": float(impact_score_raw)
+                        if impact_score_raw
+                        else None,
+                    },
                 )
                 factors.append(factor)
 

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -1,5 +1,7 @@
 from typing import Callable
 
+from sqlalchemy.orm import aliased
+from sqlmodel import and_, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
@@ -7,11 +9,13 @@ from app.core.logging import get_logger
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.data_entry_emission import DataEntryEmission, EmissionTypeEnum
 from app.models.factor import Factor
+from app.models.location import Location
 from app.repositories.data_entry_emission_repo import (
     DataEntryEmissionRepository,
 )
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.factor_service import FactorService
+from app.utils.distance_geography import resolve_flight_factor, resolve_train_factor
 
 settings = get_settings()
 logger = get_logger(__name__)
@@ -58,11 +62,10 @@ class DataEntryEmissionService:
             or data_entry.data_entry_type == DataEntryTypeEnum.additional_purchases
         ):
             emission_type = EmissionTypeEnum.purchase
-        elif data_entry.data_entry_type == DataEntryTypeEnum.trips:
-            transport_mode = data_entry.data.get("transport_mode")
-            if transport_mode is None:
-                raise ValueError("transport_mode is required for trips")
-            emission_type = EmissionTypeEnum[str(transport_mode)]
+        elif data_entry.data_entry_type == DataEntryTypeEnum.plane:
+            emission_type = EmissionTypeEnum.plane
+        elif data_entry.data_entry_type == DataEntryTypeEnum.train:
+            emission_type = EmissionTypeEnum.train
         elif data_entry.data_entry_type == DataEntryTypeEnum.process_emissions:
             emission_type = EmissionTypeEnum.process_emissions
         # for equipment?
@@ -117,8 +120,11 @@ class DataEntryEmissionService:
             )
             return None
         subcategory = None  # TODO: should be an enum somwhere
-        if data_entry.data_entry_type == DataEntryTypeEnum.trips:
-            subcategory = data_entry.data.get("transport_mode")
+        if data_entry.data_entry_type in (
+            DataEntryTypeEnum.plane,
+            DataEntryTypeEnum.train,
+        ):
+            subcategory = DataEntryTypeEnum(data_entry.data_entry_type).name
         elif data_entry.data_entry_type == DataEntryTypeEnum.process_emissions:
             sub_cat = data_entry.data.get("sub_category")
             subcategory = sub_cat if sub_cat else data_entry.data.get("emitted_gas")
@@ -213,7 +219,7 @@ class DataEntryEmissionService:
         self,
         carbon_report_module_id: int,
     ) -> list[dict]:
-        """Get travel emissions aggregated by transport_mode and cabin_class."""
+        """Get travel emissions aggregated by category and cabin_class."""
         return await self.repo.get_travel_stats_by_class(
             carbon_report_module_id,
         )
@@ -222,7 +228,7 @@ class DataEntryEmissionService:
         self,
         unit_id: int,
     ) -> list[dict]:
-        """Get travel emissions aggregated by year and transport_mode."""
+        """Get travel emissions aggregated by year and category."""
         return await self.repo.get_travel_evolution_over_time(unit_id)
 
     # Dict of dataEntryTypeEnum , func to calculation formulas
@@ -249,3 +255,245 @@ class DataEntryEmissionService:
             return await formula_func(self, data_entry, factors)
         else:
             raise ValueError(f"No formula registered for: {data_entry.data_entry_type}")
+
+
+# Register formulas for different DataEntryTypeEnum
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.external_clouds)
+async def compute_external_clouds(
+    self, data_entry: DataEntry | DataEntryResponse, factors: list[Factor]
+) -> dict:
+    """Compute emissions for external clouds."""
+
+    kg_co2eq = None
+    # e.g {"electricity_mix_intensity_kgco2_per_eur": 0.1,
+    # "cloud_provider_adjustment": 0.2, "service_type_adjustment": 0.2
+    #  "factor_kgco2_per_eur": 0.144}
+    total_spending_eur = data_entry.data.get("spending", 0)
+    if not factors or len(factors) == 0:
+        return {"kg_co2eq": kg_co2eq}
+    factor = factors[0]
+    if total_spending_eur is not None and factor.values is not None:
+        kg_co2eq = factor.values.get("factor_kgco2_per_eur", 0) * total_spending_eur
+    return {"kg_co2eq": kg_co2eq}
+
+
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.external_ai)
+async def compute_external_ai(
+    self, data_entry: DataEntry | DataEntryResponse, factors: list[Factor]
+) -> dict:
+    """Compute emissions for external AI."""
+    # Implement actual calculation based on data_entry data
+    kg_co2eq = None
+    frequency = data_entry.data.get("frequency_use_per_day", 0)
+    number_of_users = data_entry.data.get("user_count", 0)
+    if not factors or len(factors) == 0:
+        return {"kg_co2eq": kg_co2eq}
+
+    factor = factors[0]
+    if frequency and number_of_users and factor.values:
+        kg_co2eq = (
+            (frequency * 5 * 46 * number_of_users)
+            * factor.values.get("factor_gCO2eq", 0)
+        ) / 1000
+    # return intermediary dict with calculation details alway kg_co2eq at least
+    return {"kg_co2eq": kg_co2eq}
+
+
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.scientific)
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.it)
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.other)
+async def compute_scientific_it_other(
+    self, data_entry: DataEntry | DataEntryResponse, factors: list[Factor]
+) -> dict:
+    """Compute emissions for scientific, it, other."""
+    # Implement actual calculation based on data_entry data
+    kg_co2eq = None
+    response = {"kg_co2eq": kg_co2eq}
+    if not factors or len(factors) == 0:
+        return response
+
+    factor = factors[0]
+    active_usage_hours = data_entry.data.get("active_usage_hours", None)
+    if active_usage_hours is None:
+        logger.warning("active_usage_hours is missing in data entry data")
+        return response
+    passive_usage_hours = data_entry.data.get("passive_usage_hours", None)
+    if passive_usage_hours is None:
+        logger.warning("passive_usage_hours is missing in data entry data")
+        return response
+
+    active_power_w = factor.values.get("active_power_w", None)
+    if active_power_w is None:
+        logger.warning("active_power_w is missing in factor values")
+        return response
+    standby_power_w = factor.values.get("standby_power_w", None)
+    if standby_power_w is None:
+        logger.warning("standby_power_w is missing in factor values")
+        return response
+    # Calculate weekly energy consumption in Watt-hours
+    weekly_wh = (active_usage_hours * active_power_w) + (
+        passive_usage_hours * standby_power_w
+    )
+    # Convert to annual kWh: (Wh/week * 52 weeks) / 1000
+    annual_kwh = (weekly_wh * settings.WEEKS_PER_YEAR) / 1000
+
+    emission_electric_factor = factors[1].values.get("kgco2eq_per_kwh", None)
+    if emission_electric_factor is None:
+        raise ValueError("factor_kgco2_per_kwh is required for emissions calculation")
+    # Calculate CO2 emissions
+    kg_co2eq = annual_kwh * emission_electric_factor
+
+    logger.debug(
+        f"CO2 calculation: {active_usage_hours}hrs*{active_power_w}W + "
+        f"{passive_usage_hours}hrs*{standby_power_w}W = {annual_kwh:.2f} kWh/year * "
+        f"{emission_electric_factor} = {kg_co2eq:.2f} kgCO2eq"
+    )
+
+    return {"kg_co2eq": kg_co2eq, "weekly_wh": weekly_wh, "annual_kwh": annual_kwh}
+
+
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.plane)
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.train)
+async def compute_travel(
+    self, data_entry: DataEntry | DataEntryResponse, factors: list[Factor]
+) -> dict:
+    """Compute emissions for professional travel (plane/train)."""
+    selected_type = DataEntryTypeEnum(data_entry.data_entry_type)
+    cabin_class = data_entry.data.get("cabin_class")
+    number_of_trips = data_entry.data.get("number_of_trips", 1)
+    distance_km = None
+
+    origin_id = data_entry.data.get("origin_location_id")
+    dest_id = data_entry.data.get("destination_location_id")
+
+    ## define response
+
+    response = {
+        "kg_co2eq": None,
+        "distance_km": distance_km,
+        "cabin_class": cabin_class,
+        "number_of_trips": number_of_trips,
+        "origin_location_id": data_entry.data.get("origin_location_id"),
+        "destination_location_id": data_entry.data.get("destination_location_id"),
+    }
+
+    if not origin_id or not dest_id:
+        logger.warning("Missing origin or destination location for trip")
+        return response
+
+    OriginLoc = aliased(Location, name="origin")
+    DestLoc = aliased(Location, name="dest")
+
+    stmt = (
+        select(OriginLoc, DestLoc, Factor)
+        .select_from(OriginLoc)
+        .join(DestLoc, col(DestLoc.id) == dest_id)
+        .outerjoin(
+            Factor,
+            and_(
+                col(Factor.data_entry_type_id) == selected_type.value,
+            ),
+        )
+        .where(col(OriginLoc.id) == origin_id)
+    )
+
+    result = await self.session.execute(stmt)
+    rows = result.all()
+
+    if not rows:
+        logger.warning("Missing origin or destination location for trip")
+        return response
+
+    origin_loc, dest_loc = rows[0][0], rows[0][1]
+    factors = [row[2] for row in rows if row[2] is not None]
+
+    if not factors:
+        logger.warning("No factor provided for trip emission calculation")
+        return response
+
+    if selected_type == DataEntryTypeEnum.plane:
+        distance_km, matched_factor = resolve_flight_factor(
+            origin_loc, dest_loc, factors
+        )
+        if not distance_km or not matched_factor:
+            logger.warning("Could not resolve flight distance or factor")
+            return response
+        distance_km = distance_km * number_of_trips
+        factor_values = matched_factor.values or {}
+        result = compute_travel_plane(distance_km, factor_values)
+    elif selected_type == DataEntryTypeEnum.train:
+        distance_km, matched_factor = resolve_train_factor(
+            origin_loc, dest_loc, factors
+        )
+        if not distance_km or not matched_factor:
+            logger.warning("Could not resolve train distance or factor")
+            return response
+        distance_km = distance_km * number_of_trips
+        factor_values = matched_factor.values or {}
+        result = compute_travel_train(distance_km, factor_values)
+    else:
+        logger.warning("Unknown travel data_entry_type: %s", selected_type)
+        return response
+
+    response["distance_km"] = distance_km
+    response["kg_co2eq"] = result.get("kg_co2eq")
+    return response
+
+
+def compute_travel_plane(
+    distance_km: float,
+    factor_values: dict,
+) -> dict:
+    """Compute emissions for plane travel.
+
+    Args:
+        distance_km: Total distance.
+        factor_values: Factor values containing impact_score and rfi_adjustment.
+    """
+    impact_score = factor_values.get("ef_kg_co2eq_per_km", 0)
+    rfi_adjustment = factor_values.get("rfi_adjustement", 1)
+    kg_co2eq = distance_km * impact_score * rfi_adjustment
+
+    logger.debug(
+        f"Flight: {distance_km}km × {impact_score} × {rfi_adjustment} "
+        f"= {kg_co2eq:.2f} kg CO2eq"
+    )
+
+    return {"kg_co2eq": kg_co2eq}
+
+
+def compute_travel_train(
+    distance_km: float,
+    factor_values: dict,
+) -> dict:
+    """Compute emissions for train travel.
+
+    Args:
+        distance_km: Total distance.
+        factor_values: Factor values containing impact_score.
+    """
+    impact_score = factor_values.get("ef_kg_co2eq_per_km", 0)
+    kg_co2eq = distance_km * impact_score
+
+    logger.debug(f"Train: {distance_km}km × {impact_score} = {kg_co2eq:.2f} kg CO2eq")
+
+    return {"kg_co2eq": kg_co2eq}
+
+
+@DataEntryEmissionService.register_formula(DataEntryTypeEnum.process_emissions)
+async def compute_process_emissions(
+    self, data_entry: DataEntry | DataEntryResponse, factors: list[Factor]
+) -> dict:
+    """Emissions_CO2eq = Quantity (kg) × GWP_factor"""
+    quantity_kg = data_entry.data.get("quantity_kg", 0)
+    if not factors:
+        return {"kg_co2eq": None}
+    factor = factors[0]
+
+    gwp = factor.values.get("gwp_kg_co2eq_per_kg", 0)
+    # Defensive check for legacy or corrupted data: quantity must not be negative.
+    if quantity_kg < 0:
+        return {"kg_co2eq": None}
+
+    kg_co2eq = quantity_kg * gwp
+    return {"kg_co2eq": kg_co2eq, "quantity_kg": quantity_kg, "gwp_factor": gwp}

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -410,11 +410,12 @@ class DataEntryService:
             and (request_context is not None)
             and (response is not None)
             and (
-                data_entry_type_id == DataEntryTypeEnum.trips.value
+                data_entry_type_id == DataEntryTypeEnum.plane.value
+                or data_entry_type_id == DataEntryTypeEnum.train.value
                 or data_entry_type_id == DataEntryTypeEnum.member.value
             )
         ):
-            # for headcount and trips we need for OPDO to have a record of READ
+            # for headcount and travel (plane/train), keep a READ audit record
             # Create version record for read
             extracted_handled_ids = extract_handled_ids_from_list(
                 list(response.items), DataEntryTypeEnum(data_entry_type_id)

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -174,7 +174,6 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
                     "provider": self.config["provider"],
                     "origin_location_id": origin_location_id,
                     "destination_location_id": destination_location_id,
-                    "transport_mode": record.get("TRANSPORT_TYPE"),
                     "year": self.config["year"],
                 }
                 transformed.append(entry)
@@ -192,14 +191,27 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
             raise
 
     async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        def resolve_data_entry_type_id(item: Dict[str, Any]) -> int:
+            raw_transport_type = (item.get("transport_type") or "").strip().lower()
+            if "train" in raw_transport_type:
+                return DataEntryTypeEnum.train.value
+            if "plane" in raw_transport_type:
+                return DataEntryTypeEnum.plane.value
+
+            logger.warning(
+                "Unknown transport_type '%s'; defaulting to plane",
+                item.get("transport_type"),
+            )
+            return DataEntryTypeEnum.plane.value
+
         result = []
         async with SessionLocal() as db:
             service = DataEntryService(db)
             entries = [
                 DataEntry(
                     carbon_report_module_id=item.get("carbon_report_module_id"),
-                    data_entry_type_id=DataEntryTypeEnum.trips.value,
-                    data=item,
+                    data_entry_type_id=resolve_data_entry_type_id(item),
+                    data={k: v for k, v in item.items() if k != "transport_type"},
                 )
                 for item in data
             ]

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -351,7 +351,10 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                 return None, "Missing data_entry_type"
 
             variant = factor_variant
-            if data_entry_type == DataEntryTypeEnum.trips:
+            if data_entry_type in (
+                DataEntryTypeEnum.plane,
+                DataEntryTypeEnum.train,
+            ):
                 variant = variant or row.get("factor_variant")
                 if not variant:
                     error_msg = "Missing factor_variant for travel factors"

--- a/backend/app/services/data_ingestion/csv_providers/professional_travel_csv_provider.py
+++ b/backend/app/services/data_ingestion/csv_providers/professional_travel_csv_provider.py
@@ -26,7 +26,7 @@ from app.services.data_ingestion.base_csv_provider import (
 logger = get_logger(__name__)
 
 # Columns the user provides in the travel CSV
-TRAVEL_CSV_REQUIRED_COLUMNS = {"transport_mode", "from", "to", "traveler_name"}
+TRAVEL_CSV_REQUIRED_COLUMNS = {"from", "to", "traveler_name", "cabin_class"}
 TRAVEL_CSV_OPTIONAL_COLUMNS = {
     "departure_date",
     "sciper",
@@ -45,8 +45,6 @@ class ProfessionalTravelCSVProvider(BaseCSVProvider):
        via in-memory caches
     3. Transform rows into the format expected by ProfessionalTravelHandlerCreate
     """
-
-    SUPPORTED_TRANSPORT_MODES = {mode.value for mode in TransportModeEnum}
 
     def __init__(
         self,
@@ -154,6 +152,13 @@ class ProfessionalTravelCSVProvider(BaseCSVProvider):
         if configured_data_entry_type_id is None:
             raise ValueError("data_entry_type_id is required for travel CSV ingestion")
         configured_data_entry_type = DataEntryTypeEnum(configured_data_entry_type_id)
+        if configured_data_entry_type not in (
+            DataEntryTypeEnum.plane,
+            DataEntryTypeEnum.train,
+        ):
+            raise ValueError(
+                "travel CSV ingestion only supports data_entry_type_id plane/train"
+            )
         handler = BaseModuleHandler.get_by_type(configured_data_entry_type)
         expected_columns = set(handler.create_dto.model_fields.keys())
 
@@ -179,8 +184,10 @@ class ProfessionalTravelCSVProvider(BaseCSVProvider):
             raise
 
         # --- Build location caches ---
-        self._iata_cache = await self._build_iata_cache()
-        self._train_name_cache = await self._build_train_name_cache()
+        if configured_data_entry_type == DataEntryTypeEnum.plane:
+            self._iata_cache = await self._build_iata_cache()
+        else:
+            self._train_name_cache = await self._build_train_name_cache()
 
         return {
             "csv_text": csv_text,
@@ -209,29 +216,27 @@ class ProfessionalTravelCSVProvider(BaseCSVProvider):
         """
         origin_raw = (row.get("from") or "").strip()
         destination_raw = (row.get("to") or "").strip()
-        transport_mode = (row.get("transport_mode") or "").strip().lower()
+        data_entry_type = DataEntryTypeEnum(int(self.config["data_entry_type_id"]))
 
-        # Validate transport_mode
-        if transport_mode not in self.SUPPORTED_TRANSPORT_MODES:
-            error_msg = (
-                f"Unsupported transport_mode '{transport_mode}': "
-                f"only {sorted(self.SUPPORTED_TRANSPORT_MODES)} are supported"
-            )
-            self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-            return None, error_msg, None
-
-        # Resolve origin and destination based on transport mode
-        if transport_mode == TransportModeEnum.plane:
+        # Resolve origin and destination based on configured data_entry_type
+        # (location transport_mode is only used internally by location caches)
+        if data_entry_type == DataEntryTypeEnum.plane:
             origin_location_id = self._iata_cache.get(origin_raw.upper())
             destination_location_id = self._iata_cache.get(destination_raw.upper())
             origin_label, destination_label = (
                 origin_raw.upper(),
                 destination_raw.upper(),
             )
-        elif transport_mode == TransportModeEnum.train:
+        elif data_entry_type == DataEntryTypeEnum.train:
             origin_location_id = self._train_name_cache.get(origin_raw)
             destination_location_id = self._train_name_cache.get(destination_raw)
             origin_label, destination_label = origin_raw, destination_raw
+        else:
+            error_msg = (
+                f"Unsupported travel data_entry_type_id '{data_entry_type.value}'"
+            )
+            self._record_row_error(stats, row_idx, error_msg, max_row_errors)
+            return None, error_msg, None
 
         if not origin_location_id:
             error_msg = f"Origin '{origin_label}' not found in locations"
@@ -245,7 +250,6 @@ class ProfessionalTravelCSVProvider(BaseCSVProvider):
 
         # Build transformed row with schema field names
         transformed_row: Dict[str, str] = {
-            "transport_mode": transport_mode,
             "origin_location_id": str(origin_location_id),
             "destination_location_id": str(destination_location_id),
         }
@@ -257,6 +261,14 @@ class ProfessionalTravelCSVProvider(BaseCSVProvider):
             self._record_row_error(stats, row_idx, error_msg, max_row_errors)
             return None, error_msg, None
         transformed_row["traveler_name"] = traveler_name
+
+        # Map cabin_class (required)
+        cabin_class = (row.get("cabin_class") or "").strip()
+        if not cabin_class:
+            error_msg = "Missing required value for 'cabin_class'"
+            self._record_row_error(stats, row_idx, error_msg, max_row_errors)
+            return None, error_msg, None
+        transformed_row["cabin_class"] = cabin_class
 
         # Map sciper (optional → traveler_id)
         sciper = (row.get("sciper") or "").strip()

--- a/backend/app/services/location_service.py
+++ b/backend/app/services/location_service.py
@@ -35,19 +35,20 @@ class LocationService:
         Args:
             query: Search query string
             limit: Maximum number of results
-            transport_mode: Filter by transport mode ('train' or 'plane')
+            transport_mode: Filter by location transport mode ('train' or 'plane')
 
         Returns:
             List of LocationRead DTOs ordered by relevance
 
         Raises:
-            HTTPException 400: If transport_mode is invalid or query is too short
+            HTTPException 400: If location transport_mode is invalid
+                or query is too short
         """
-        # Validate transport_mode if provided
+        # Validate location transport_mode
         if transport_mode is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="transport_mode must be either 'train' or 'plane'",
+                detail="location transport_mode must be either 'train' or 'plane'",
             )
 
         # Normalize and validate query
@@ -88,7 +89,7 @@ class LocationService:
         number_of_trips: int = 1,
     ) -> dict[str, float]:
         """
-        Calculate distance between two locations based on transport mode.
+        Calculate distance between two locations based on location transport mode.
 
         For flights: Haversine distance + 95 km (airport approaches, routing, taxiing)
         For trains: Haversine distance × 1.2 (track routing, curves, detours)
@@ -98,14 +99,15 @@ class LocationService:
         Args:
             origin_location_id: Origin location ID
             destination_location_id: Destination location ID
-            transport_mode: 'plane' or 'train'
+            transport_mode: Location transport mode ('plane' or 'train')
             number_of_trips: Number of trips (default: 1)
 
         Returns:
             Dict with distance_km in kilometers
 
         Raises:
-            HTTPException 400: If transport_mode is invalid or coordinates are invalid
+            HTTPException 400: If location transport_mode is invalid
+                or coordinates are invalid
             HTTPException 404: If location not found
         """
         # Fetch locations

--- a/backend/app/utils/audit_helpers.py
+++ b/backend/app/utils/audit_helpers.py
@@ -19,7 +19,7 @@ def extract_handled_ids(
     Extract list of user provider codes affected by this data entry.
 
     Different data entry types store user identifiers in different fields:
-    - Professional travel (trips): traveler_id or sciper
+    - Professional travel (plane/train): traveler_id or sciper
     - Headcount (member/student): sciper or user_provider_code
     - Equipment/Cloud/AI: No user-specific data (returns empty list)
 
@@ -50,7 +50,10 @@ def extract_handled_ids(
         handled_ids = []
 
         # Professional travel - extract traveler identifier
-        if data_entry_type_id == DataEntryTypeEnum.trips:
+        if data_entry_type_id in (
+            DataEntryTypeEnum.plane,
+            DataEntryTypeEnum.train,
+        ):
             # Try multiple field names that might contain the traveler's sciper
             traveler_id = (
                 data.get("traveler_id")

--- a/backend/tests/unit/repositories/test_data_entry_emission_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_emission_repo.py
@@ -32,7 +32,7 @@ async def test_create_emission(db_session: AsyncSession):
 
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -71,7 +71,7 @@ async def test_update_emission(db_session: AsyncSession):
 
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -108,7 +108,7 @@ async def test_get_by_data_entry_id(db_session: AsyncSession):
 
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -155,7 +155,7 @@ async def test_delete_by_data_entry_id(db_session: AsyncSession):
 
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -203,7 +203,7 @@ async def test_bulk_create_emissions(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -252,9 +252,9 @@ async def test_get_stats_by_emission_type(db_session: AsyncSession):
     plane_entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
-            data={"name": f"Plane {i}", "transport_mode": "plane"},
+            data={"name": f"Plane {i}"},
         )
         for i in range(2)
     ]
@@ -262,9 +262,9 @@ async def test_get_stats_by_emission_type(db_session: AsyncSession):
     train_entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.train,
             status=DataEntryStatusEnum.PENDING,
-            data={"name": f"Train {i}", "transport_mode": "train"},
+            data={"name": f"Train {i}"},
         )
         for i in range(3)
     ]
@@ -355,9 +355,9 @@ async def test_get_emission_breakdown_basic(db_session: AsyncSession):
     # Travel entry
     plane_entry = DataEntry(
         carbon_report_module_id=module_travel.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane"},
+        data={},
     )
     db_session.add_all([sci_entry, it_entry, plane_entry])
     await db_session.flush()
@@ -425,7 +425,7 @@ async def test_get_emission_breakdown_validated_only(db_session: AsyncSession):
     )
     entry_ip = DataEntry(
         carbon_report_module_id=in_progress_module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "In progress item"},
     )
@@ -533,16 +533,16 @@ async def test_get_travel_stats_by_class_basic(db_session: AsyncSession):
     # Create plane trips with different cabin classes
     eco_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane", "cabin_class": "eco"},
+        data={"cabin_class": "eco"},
     )
 
     business_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane", "cabin_class": "business"},
+        data={"cabin_class": "business"},
     )
 
     db_session.add_all([eco_entry, business_entry])
@@ -603,17 +603,17 @@ async def test_get_travel_stats_by_class_null_cabin(db_session: AsyncSession):
     # Create plane trip with NULL cabin_class
     plane_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane"},  # No cabin_class
+        data={},  # No cabin_class
     )
 
     # Create train trip with NULL cabin_class
     train_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.train,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "train"},  # No cabin_class
+        data={},  # No cabin_class
     )
 
     db_session.add_all([plane_entry, train_entry])
@@ -668,16 +668,16 @@ async def test_get_travel_stats_by_class_filters_zero_emissions(
     # Create entries
     valid_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane", "cabin_class": "eco"},
+        data={"cabin_class": "eco"},
     )
 
     zero_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane", "cabin_class": "business"},
+        data={"cabin_class": "business"},
     )
 
     db_session.add_all([valid_entry, zero_entry])
@@ -756,24 +756,24 @@ async def test_get_travel_evolution_over_time(db_session: AsyncSession):
     # Create entries for 2023
     plane_2023 = DataEntry(
         carbon_report_module_id=module_2023.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane"},
+        data={},
     )
 
     # Create entries for 2024
     plane_2024 = DataEntry(
         carbon_report_module_id=module_2024.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "plane"},
+        data={},
     )
 
     train_2024 = DataEntry(
         carbon_report_module_id=module_2024.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.train,
         status=DataEntryStatusEnum.PENDING,
-        data={"transport_mode": "train"},
+        data={},
     )
 
     db_session.add_all([plane_2023, plane_2024, train_2024])
@@ -808,13 +808,13 @@ async def test_get_travel_evolution_over_time(db_session: AsyncSession):
 
     # Find specific records
     plane_2023_record = next(
-        r for r in result if r["year"] == 2023 and r["transport_mode"] == "plane"
+        r for r in result if r["year"] == 2023 and r["category"] == "plane"
     )
     plane_2024_record = next(
-        r for r in result if r["year"] == 2024 and r["transport_mode"] == "plane"
+        r for r in result if r["year"] == 2024 and r["category"] == "plane"
     )
     train_2024_record = next(
-        r for r in result if r["year"] == 2024 and r["transport_mode"] == "train"
+        r for r in result if r["year"] == 2024 and r["category"] == "train"
     )
 
     assert plane_2023_record["kg_co2eq"] == pytest.approx(500.0, rel=0.01)

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -33,16 +33,16 @@ async def test_create_data_entry(db_session: AsyncSession):
     # Create data entry
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"name": "Test Trip", "transport_mode": "plane"},
+        data={"name": "Test Trip", "cabin_class": "eco"},
     )
 
     result = await repo.create(data_entry)
 
     assert result.id is not None
     assert result.carbon_report_module_id == module.id
-    assert result.data_entry_type_id == DataEntryTypeEnum.trips
+    assert result.data_entry_type_id == DataEntryTypeEnum.plane
     assert result.data["name"] == "Test Trip"
 
 
@@ -63,7 +63,7 @@ async def test_get_data_entry(db_session: AsyncSession):
     # Create data entry
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -104,25 +104,25 @@ async def test_update_data_entry(db_session: AsyncSession):
     # Create data entry
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"name": "Test Trip", "transport_mode": "plane"},
+        data={"name": "Test Trip", "cabin_class": "eco"},
     )
     db_session.add(data_entry)
     await db_session.flush()
 
     # Update data entry
     update_data = DataEntryUpdate(
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         carbon_report_module_id=module.id,
-        data={"transport_mode": "train", "new_field": "value"},
+        data={"cabin_class": "business", "new_field": "value"},
     )
 
     result = await repo.update(data_entry.id, update_data, user_id=1)
 
     assert result is not None
     assert result.data["name"] == "Test Trip"  # Original field preserved
-    assert result.data["transport_mode"] == "train"  # Updated field
+    assert result.data["cabin_class"] == "business"  # Updated field
     assert result.data["new_field"] == "value"  # New field added
 
 
@@ -132,7 +132,7 @@ async def test_update_data_entry_not_found(db_session: AsyncSession):
     repo = DataEntryRepository(db_session)
 
     update_data = DataEntryUpdate(
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         carbon_report_module_id=1,
         data={"name": "Updated"},
     )
@@ -158,7 +158,7 @@ async def test_delete_data_entry(db_session: AsyncSession):
     # Create data entry
     data_entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -207,7 +207,7 @@ async def test_bulk_create_data_entries(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -237,10 +237,10 @@ async def test_bulk_delete_data_entries(db_session: AsyncSession):
     await db_session.flush()
 
     # Create entries of different types
-    trips_entries = [
+    plane_entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -254,23 +254,23 @@ async def test_bulk_delete_data_entries(db_session: AsyncSession):
         data={"name": "Cloud"},
     )
 
-    db_session.add_all(trips_entries + [other_entry])
+    db_session.add_all(plane_entries + [other_entry])
     await db_session.flush()
 
-    # Bulk delete only trips
-    await repo.bulk_delete(module.id, DataEntryTypeEnum.trips)
+    # Bulk delete only plane entries
+    await repo.bulk_delete(module.id, DataEntryTypeEnum.plane)
     await db_session.flush()
 
-    # Verify trips are deleted
+    # Verify plane entries are deleted
     from sqlmodel import select
 
     stmt = select(DataEntry).where(
         DataEntry.carbon_report_module_id == module.id,
-        DataEntry.data_entry_type_id == DataEntryTypeEnum.trips.value,
+        DataEntry.data_entry_type_id == DataEntryTypeEnum.plane.value,
     )
     result = await db_session.exec(stmt)
-    remaining_trips = list(result.all())
-    assert len(remaining_trips) == 0
+    remaining_plane = list(result.all())
+    assert len(remaining_plane) == 0
 
     # Verify other entry still exists
     stmt = select(DataEntry).where(
@@ -305,7 +305,7 @@ async def test_get_total_count_by_submodule(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -317,8 +317,8 @@ async def test_get_total_count_by_submodule(db_session: AsyncSession):
 
     result = await repo.get_total_count_by_submodule(module.id)
 
-    assert DataEntryTypeEnum.trips.value in result
-    assert result[DataEntryTypeEnum.trips.value] == 5
+    assert DataEntryTypeEnum.plane.value in result
+    assert result[DataEntryTypeEnum.plane.value] == 5
 
 
 @pytest.mark.asyncio
@@ -373,7 +373,7 @@ async def test_get_total_per_field_kg_co2eq(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}", "kg_co2eq": 100.0 * (i + 1)},
         )
@@ -404,24 +404,24 @@ async def test_get_total_per_field_with_type_filter(db_session: AsyncSession):
     await db_session.flush()
 
     # Create mixed entries
-    trips = [
+    plane_entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}", "kg_co2eq": 100.0},
         )
         for i in range(3)
     ]
 
-    db_session.add_all(trips)
+    db_session.add_all(plane_entries)
     await db_session.flush()
 
     result = await repo.get_total_per_field(
-        "kg_co2eq", module.id, DataEntryTypeEnum.trips.value
+        "kg_co2eq", module.id, DataEntryTypeEnum.plane.value
     )
 
-    # Only trips counted: 100 * 3 = 300
+    # Only plane entries counted: 100 * 3 = 300
     assert result == pytest.approx(300.0, rel=0.01)
 
 
@@ -453,7 +453,7 @@ async def test_get_stats_by_data_entry_type(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}", "fte": 1.0},
         )
@@ -467,8 +467,8 @@ async def test_get_stats_by_data_entry_type(db_session: AsyncSession):
         module.id, aggregate_by="data_entry_type_id", aggregate_field="fte"
     )
 
-    assert str(DataEntryTypeEnum.trips.value) in result
-    assert result[str(DataEntryTypeEnum.trips.value)] == pytest.approx(3.0, rel=0.01)
+    assert str(DataEntryTypeEnum.plane.value) in result
+    assert result[str(DataEntryTypeEnum.plane.value)] == pytest.approx(3.0, rel=0.01)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/repositories/test_factor_repo.py
+++ b/backend/tests/unit/repositories/test_factor_repo.py
@@ -198,7 +198,7 @@ async def test_get_factor_with_fallback(repo):
     repo.session.exec = AsyncMock(side_effect=[result_mock_none, result_mock_factor])
 
     result = await repo.get_factor(
-        DataEntryTypeEnum.trips,
+        DataEntryTypeEnum.train,
         fallbacks={"country_code": "RoW"},
         kind="train",
         country_code="FR",

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -137,7 +137,7 @@ def test_resolve_data_entry_type_missing_multi():
 
 
 @pytest.mark.asyncio
-async def test_process_row_missing_factor_variant_for_trips():
+async def test_process_row_missing_factor_variant_for_travel():
     provider = ConcreteFactorProvider(
         {"file_path": "tmp/test.csv"}, data_session=MagicMock()
     )
@@ -145,12 +145,12 @@ async def test_process_row_missing_factor_variant_for_trips():
 
     setup_result = {
         "expected_columns": {"data_entry_type_id"},
-        "valid_entry_types": [DataEntryTypeEnum.trips],
+        "valid_entry_types": [DataEntryTypeEnum.plane],
         "factor_variant": None,
     }
 
     factor, error_msg = await provider._process_row(
-        row={"data_entry_type_id": str(DataEntryTypeEnum.trips.value)},
+        row={"data_entry_type_id": str(DataEntryTypeEnum.plane.value)},
         row_idx=1,
         setup_result=setup_result,
         stats=stats,

--- a/backend/tests/unit/services/data_ingestion/test_professional_travel_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_professional_travel_csv_provider.py
@@ -28,12 +28,14 @@ def _make_stats() -> StatsDict:
 
 def _make_setup_result(
     csv_text: str = "",
-    configured_data_entry_type_id: int = DataEntryTypeEnum.trips.value,
+    configured_data_entry_type_id: int = DataEntryTypeEnum.plane.value,
 ) -> dict:
     """Minimal setup_result dict expected by _process_row."""
     from app.schemas.data_entry import BaseModuleHandler
 
-    handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum.trips)
+    handler = BaseModuleHandler.get_by_type(
+        DataEntryTypeEnum(configured_data_entry_type_id)
+    )
     expected_columns = set(handler.create_dto.model_fields.keys())
     return {
         "csv_text": csv_text,
@@ -54,7 +56,7 @@ def base_config():
         "job_id": 1,
         "file_path": "tmp/travel.csv",
         "carbon_report_module_id": 10,
-        "data_entry_type_id": DataEntryTypeEnum.trips.value,
+        "data_entry_type_id": DataEntryTypeEnum.plane.value,
     }
 
 
@@ -138,10 +140,10 @@ class TestProcessRow:
     async def test_valid_row_creates_data_entry(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "GVA",
             "to": "SFO",
             "traveler_name": "Alice",
+            "cabin_class": "eco",
         }
         stats = _make_stats()
         setup = _make_setup_result()
@@ -153,16 +155,17 @@ class TestProcessRow:
         assert entry.data["origin_location_id"] == 100
         assert entry.data["destination_location_id"] == 200
         assert entry.data["traveler_name"] == "Alice"
+        assert entry.data["cabin_class"] == "eco"
         assert stats["rows_skipped"] == 0
 
     @pytest.mark.asyncio
     async def test_sciper_mapped_to_traveler_id(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "GVA",
             "to": "SFO",
             "traveler_name": "Bob",
+            "cabin_class": "eco",
             "sciper": "123456",
         }
         stats = _make_stats()
@@ -177,10 +180,10 @@ class TestProcessRow:
     async def test_number_of_trips_passed_through(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "GVA",
             "to": "SFO",
             "traveler_name": "Charlie",
+            "cabin_class": "eco",
             "number_of_trips": "3",
         }
         stats = _make_stats()
@@ -195,10 +198,10 @@ class TestProcessRow:
     async def test_departure_date_passed_through(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "GVA",
             "to": "SFO",
             "traveler_name": "Dave",
+            "cabin_class": "eco",
             "departure_date": "2024-06-15",
         }
         stats = _make_stats()
@@ -210,13 +213,14 @@ class TestProcessRow:
         assert entry is not None
 
     @pytest.mark.asyncio
-    async def test_unsupported_transport_mode_skips_row(self, provider):
+    async def test_unsupported_data_entry_type_skips_row(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
+        provider.config["data_entry_type_id"] = DataEntryTypeEnum.external_ai.value
         row = {
-            "transport_mode": "bus",
             "from": "GVA",
             "to": "SFO",
             "traveler_name": "Eve",
+            "cabin_class": "eco",
         }
         stats = _make_stats()
         setup = _make_setup_result()
@@ -224,20 +228,21 @@ class TestProcessRow:
         entry, err, _ = await provider._process_row(row, 1, setup, stats, 100)
 
         assert entry is None
-        assert "Unsupported transport_mode" in err
+        assert "Unsupported travel data_entry_type_id" in err
         assert stats["rows_skipped"] == 1
 
     @pytest.mark.asyncio
     async def test_valid_train_row_creates_data_entry(self, provider):
         provider._train_name_cache = {"Lausanne": 300, "Zürich HB": 400}
+        provider.config["data_entry_type_id"] = DataEntryTypeEnum.train.value
         row = {
-            "transport_mode": "train",
             "from": "Lausanne",
             "to": "Zürich HB",
             "traveler_name": "Fiona",
+            "cabin_class": "class_2",
         }
         stats = _make_stats()
-        setup = _make_setup_result()
+        setup = _make_setup_result(DataEntryTypeEnum.train.value)
 
         entry, err, factor = await provider._process_row(row, 1, setup, stats, 100)
 
@@ -251,14 +256,15 @@ class TestProcessRow:
     @pytest.mark.asyncio
     async def test_unknown_train_origin_skips_row(self, provider):
         provider._train_name_cache = {"Zürich HB": 400}
+        provider.config["data_entry_type_id"] = DataEntryTypeEnum.train.value
         row = {
-            "transport_mode": "train",
             "from": "Unknown Station",
             "to": "Zürich HB",
             "traveler_name": "George",
+            "cabin_class": "class_2",
         }
         stats = _make_stats()
-        setup = _make_setup_result()
+        setup = _make_setup_result(DataEntryTypeEnum.train.value)
 
         entry, err, _ = await provider._process_row(row, 1, setup, stats, 100)
 
@@ -269,14 +275,15 @@ class TestProcessRow:
     @pytest.mark.asyncio
     async def test_unknown_train_destination_skips_row(self, provider):
         provider._train_name_cache = {"Lausanne": 300}
+        provider.config["data_entry_type_id"] = DataEntryTypeEnum.train.value
         row = {
-            "transport_mode": "train",
             "from": "Lausanne",
             "to": "Nowhere",
             "traveler_name": "Hannah",
+            "cabin_class": "class_2",
         }
         stats = _make_stats()
-        setup = _make_setup_result()
+        setup = _make_setup_result(DataEntryTypeEnum.train.value)
 
         entry, err, _ = await provider._process_row(row, 1, setup, stats, 100)
 
@@ -288,10 +295,10 @@ class TestProcessRow:
     async def test_unknown_origin_iata_skips_row(self, provider):
         provider._iata_cache = {"SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "XXX",
             "to": "SFO",
             "traveler_name": "Frank",
+            "cabin_class": "eco",
         }
         stats = _make_stats()
         setup = _make_setup_result()
@@ -306,10 +313,10 @@ class TestProcessRow:
     async def test_unknown_destination_iata_skips_row(self, provider):
         provider._iata_cache = {"GVA": 100}
         row = {
-            "transport_mode": "plane",
             "from": "GVA",
             "to": "YYY",
             "traveler_name": "Grace",
+            "cabin_class": "eco",
         }
         stats = _make_stats()
         setup = _make_setup_result()
@@ -324,10 +331,10 @@ class TestProcessRow:
     async def test_iata_codes_are_case_insensitive(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "gva",
             "to": "sfo",
             "traveler_name": "Henry",
+            "cabin_class": "eco",
         }
         stats = _make_stats()
         setup = _make_setup_result()
@@ -339,13 +346,13 @@ class TestProcessRow:
         assert entry.data["destination_location_id"] == 200
 
     @pytest.mark.asyncio
-    async def test_empty_transport_mode_skips_row(self, provider):
+    async def test_empty_traveler_name_skips_row(self, provider):
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "",
             "from": "GVA",
             "to": "SFO",
-            "traveler_name": "Ivy",
+            "traveler_name": "",
+            "cabin_class": "eco",
         }
         stats = _make_stats()
         setup = _make_setup_result()
@@ -353,17 +360,17 @@ class TestProcessRow:
         entry, err, _ = await provider._process_row(row, 1, setup, stats, 100)
 
         assert entry is None
-        assert "Unsupported transport_mode" in err
+        assert "Missing required value for 'traveler_name'" in err
 
     @pytest.mark.asyncio
     async def test_float_ids_are_coerced_to_int(self, provider):
         """Ensure float values from CSV parsing are coerced to int."""
         provider._iata_cache = {"GVA": 100, "SFO": 200}
         row = {
-            "transport_mode": "plane",
             "from": "GVA",
             "to": "SFO",
             "traveler_name": "Jack",
+            "cabin_class": "eco",
             "number_of_trips": "2",
         }
         stats = _make_stats()
@@ -386,7 +393,7 @@ class TestSetupAndValidate:
         config = {
             "job_id": 1,
             "carbon_report_module_id": 10,
-            "data_entry_type_id": DataEntryTypeEnum.trips.value,
+            "data_entry_type_id": DataEntryTypeEnum.plane.value,
         }
         mock_session = AsyncMock()
         prov = ProfessionalTravelCSVProvider(
@@ -401,7 +408,7 @@ class TestSetupAndValidate:
 
     @pytest.mark.asyncio
     async def test_successful_setup(self, provider):
-        csv_content = "transport_mode,from,to,traveler_name\nplane,GVA,SFO,Alice\n"
+        csv_content = "from,to,traveler_name,cabin_class\nGVA,SFO,Alice,eco\n"
         provider._files_store.move_file = AsyncMock(return_value=True)
         provider._files_store.get_file = AsyncMock(
             return_value=(csv_content.encode("utf-8"), "text/csv")
@@ -424,7 +431,7 @@ class TestSetupAndValidate:
     @pytest.mark.asyncio
     async def test_missing_required_csv_column_raises(self, provider):
         # CSV missing "from" column
-        csv_content = "transport_mode,to,traveler_name\nplane,SFO,Alice\n"
+        csv_content = "to,traveler_name\nSFO,Alice\n"
         provider._files_store.move_file = AsyncMock(return_value=True)
         provider._files_store.get_file = AsyncMock(
             return_value=(csv_content.encode("utf-8"), "text/csv")

--- a/backend/tests/unit/services/test_data_entry_emission_service.py
+++ b/backend/tests/unit/services/test_data_entry_emission_service.py
@@ -14,9 +14,11 @@ from app.modules.external_cloud_and_ai.emissions import (
     compute_external_clouds,
 )
 from app.modules.process_emissions.emissions import compute_process_emissions
-from app.modules.professional_travel.emissions import compute_trips
 from app.modules.purchase.emissions import compute_additional_purchase, compute_purchase
-from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.services.data_entry_emission_service import (
+    DataEntryEmissionService,
+    compute_travel,
+)
 
 # ======================================================================
 # External Clouds Emission Calculation Tests
@@ -401,61 +403,60 @@ async def test_compute_scientific_it_other_zero_usage():
 
 
 # ======================================================================
-# Trips Emission Calculation Tests (Simplified - without DB queries)
+# Travel Emission Calculation Tests (Simplified - without DB queries)
 # ======================================================================
 
 
 @pytest.mark.asyncio
-async def test_compute_trips_missing_origin_destination():
-    """Test trips calculation with missing origin or destination."""
+async def test_compute_travel_missing_origin_destination():
+    """Test travel calculation with missing origin or destination."""
     mock_session = MagicMock()
     service = DataEntryEmissionService(mock_session)
 
     data_entry = MagicMock()
-    data_entry.data_entry_type = DataEntryTypeEnum.trips
+    data_entry.data_entry_type = DataEntryTypeEnum.plane
     data_entry.data = {
-        "transport_mode": "plane",
         "number_of_trips": 1,
         # Missing origin_location_id and destination_location_id
     }
 
-    result = await compute_trips(service, data_entry, [])
+    result = await compute_travel(service, data_entry, [])
 
     assert result["kg_co2eq"] is None
-    assert result["transport_mode"] == "plane"
+    assert result["number_of_trips"] == 1
 
 
 @pytest.mark.asyncio
-async def test_compute_trips_invalid_transport_mode():
-    """Test trips calculation with invalid transport mode."""
+async def test_compute_travel_invalid_data_entry_type():
+    """Test travel calculation with unsupported travel data entry type."""
     mock_session = MagicMock()
     service = DataEntryEmissionService(mock_session)
+    service.session.execute = AsyncMock(
+        return_value=MagicMock(all=MagicMock(return_value=[]))
+    )
 
     data_entry = MagicMock()
-    data_entry.data_entry_type = DataEntryTypeEnum.trips
+    data_entry.data_entry_type = DataEntryTypeEnum.other
     data_entry.data = {
-        "transport_mode": "teleportation",  # Invalid mode
         "origin_location_id": 1,
         "destination_location_id": 2,
         "number_of_trips": 1,
     }
 
-    result = await compute_trips(service, data_entry, [])
+    result = await compute_travel(service, data_entry, [])
 
     assert result["kg_co2eq"] is None
-    assert result["transport_mode"] is None
 
 
 @pytest.mark.asyncio
-async def test_compute_trips_response_structure():
-    """Test that trips calculation returns proper response structure."""
+async def test_compute_travel_response_structure():
+    """Test that travel calculation returns proper response structure."""
     mock_session = MagicMock()
     service = DataEntryEmissionService(mock_session)
 
     data_entry = MagicMock()
-    data_entry.data_entry_type = DataEntryTypeEnum.trips
+    data_entry.data_entry_type = DataEntryTypeEnum.train
     data_entry.data = {
-        "transport_mode": "train",
         "cabin_class": "second",
         "origin_location_id": 1,
         "destination_location_id": 2,
@@ -466,17 +467,15 @@ async def test_compute_trips_response_structure():
         return_value=MagicMock(all=MagicMock(return_value=[]))
     )
 
-    result = await compute_trips(service, data_entry, [])
+    result = await compute_travel(service, data_entry, [])
 
     # Verify response structure (DB query would fail, but structure should be correct)
     assert "kg_co2eq" in result
     assert "distance_km" in result
-    assert "transport_mode" in result
     assert "cabin_class" in result
     assert "number_of_trips" in result
     assert "origin_location_id" in result
     assert "destination_location_id" in result
-    assert result["transport_mode"] == "train"
     assert result["cabin_class"] == "second"
     assert result["number_of_trips"] == 5
 
@@ -681,7 +680,8 @@ def test_formula_registration():
     assert DataEntryTypeEnum.scientific in formulas
     assert DataEntryTypeEnum.it in formulas
     assert DataEntryTypeEnum.other in formulas
-    assert DataEntryTypeEnum.trips in formulas
+    assert DataEntryTypeEnum.plane in formulas
+    assert DataEntryTypeEnum.train in formulas
     assert DataEntryTypeEnum.process_emissions in formulas
 
     # Verify they point to the correct functions
@@ -690,7 +690,8 @@ def test_formula_registration():
     assert formulas[DataEntryTypeEnum.scientific] == compute_scientific_it_other
     assert formulas[DataEntryTypeEnum.it] == compute_scientific_it_other
     assert formulas[DataEntryTypeEnum.other] == compute_scientific_it_other
-    assert formulas[DataEntryTypeEnum.trips] == compute_trips
+    assert formulas[DataEntryTypeEnum.plane] == compute_travel
+    assert formulas[DataEntryTypeEnum.train] == compute_travel
     assert formulas[DataEntryTypeEnum.process_emissions] == compute_process_emissions
 
 

--- a/backend/tests/unit/services/test_data_entry_service.py
+++ b/backend/tests/unit/services/test_data_entry_service.py
@@ -39,23 +39,23 @@ async def test_create_data_entry_success(db_session: AsyncSession):
 
     # Create data
     data = DataEntryCreate(
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         carbon_report_module_id=module.id,
-        data={"name": "Test Trip", "transport_mode": "plane"},
+        data={"name": "Test Trip", "cabin_class": "eco"},
     )
 
     result = await service.create(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         user=user,
         data=data,
     )
 
     assert result.id is not None
     assert result.carbon_report_module_id == module.id
-    assert result.data_entry_type_id == DataEntryTypeEnum.trips
+    assert result.data_entry_type_id == DataEntryTypeEnum.plane
     assert result.data["name"] == "Test Trip"
-    assert result.data["transport_mode"] == "plane"
+    assert result.data["cabin_class"] == "eco"
 
 
 # ======================================================================
@@ -80,9 +80,9 @@ async def test_update_data_entry_success(db_session: AsyncSession):
     # Create existing entry
     entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
-        data={"name": "Original Trip", "transport_mode": "plane"},
+        data={"name": "Original Trip", "cabin_class": "eco"},
     )
     db_session.add(entry)
     await db_session.flush()
@@ -97,16 +97,16 @@ async def test_update_data_entry_success(db_session: AsyncSession):
 
     # Update data
     update_data = DataEntryUpdate(
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         carbon_report_module_id=module.id,
-        data={"transport_mode": "train"},
+        data={"cabin_class": "business"},
     )
 
     result = await service.update(id=entry.id, data=update_data, user=user)
 
     assert result.id == entry.id
     assert result.data["name"] == "Original Trip"  # Preserved
-    assert result.data["transport_mode"] == "train"  # Updated
+    assert result.data["cabin_class"] == "business"  # Updated
 
 
 @pytest.mark.asyncio
@@ -115,7 +115,7 @@ async def test_update_data_entry_without_user_raises_error(db_session: AsyncSess
     service = DataEntryService(db_session)
 
     update_data = DataEntryUpdate(
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         carbon_report_module_id=1,
         data={"name": "Updated"},
     )
@@ -140,7 +140,7 @@ async def test_update_data_entry_not_found_raises_error(db_session: AsyncSession
         provider_code="default-1441",
     )
     update_data = DataEntryUpdate(
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         carbon_report_module_id=1,
         data={"name": "Updated"},
     )
@@ -171,7 +171,7 @@ async def test_delete_data_entry_success(db_session: AsyncSession):
     # Create entry
     entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -233,7 +233,7 @@ async def test_get_data_entry_success(db_session: AsyncSession):
     # Create entry
     entry = DataEntry(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips,
+        data_entry_type_id=DataEntryTypeEnum.plane,
         status=DataEntryStatusEnum.PENDING,
         data={"name": "Test Trip"},
     )
@@ -286,7 +286,7 @@ async def test_bulk_create_data_entries(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -324,10 +324,10 @@ async def test_bulk_delete_data_entries(db_session: AsyncSession):
     )
 
     # Create entries of different types
-    trips = [
+    plane_entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -341,22 +341,22 @@ async def test_bulk_delete_data_entries(db_session: AsyncSession):
         data={"name": "Cloud"},
     )
 
-    db_session.add_all(trips + [other_entry])
+    db_session.add_all(plane_entries + [other_entry])
     await db_session.flush()
 
-    # Bulk delete only trips
-    await service.bulk_delete(module.id, DataEntryTypeEnum.trips, user)
+    # Bulk delete only plane entries
+    await service.bulk_delete(module.id, DataEntryTypeEnum.plane, user)
 
-    # Verify trips are deleted
+    # Verify plane entries are deleted
     from sqlmodel import select
 
     stmt = select(DataEntry).where(
         DataEntry.carbon_report_module_id == module.id,
-        DataEntry.data_entry_type_id == DataEntryTypeEnum.trips.value,
+        DataEntry.data_entry_type_id == DataEntryTypeEnum.plane.value,
     )
     result = await db_session.exec(stmt)
-    remaining_trips = list(result.all())
-    assert len(remaining_trips) == 0
+    remaining_plane = list(result.all())
+    assert len(remaining_plane) == 0
 
     # Verify other entry still exists
     stmt = select(DataEntry).where(
@@ -391,7 +391,7 @@ async def test_get_list_data_entries(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -436,7 +436,7 @@ async def test_get_module_data(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={"name": f"Trip {i}"},
         )
@@ -449,8 +449,8 @@ async def test_get_module_data(db_session: AsyncSession):
 
     assert result.carbon_report_module_id == module.id
     assert result.data_entry_types_total_items is not None
-    assert DataEntryTypeEnum.trips.value in result.data_entry_types_total_items
-    assert result.data_entry_types_total_items[DataEntryTypeEnum.trips.value] == 5
+    assert DataEntryTypeEnum.plane.value in result.data_entry_types_total_items
+    assert result.data_entry_types_total_items[DataEntryTypeEnum.plane.value] == 5
     assert result.retrieved_at is not None
 
 
@@ -477,13 +477,12 @@ async def test_get_submodule_data(db_session: AsyncSession):
     entries = [
         DataEntry(
             carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.trips,
+            data_entry_type_id=DataEntryTypeEnum.plane,
             status=DataEntryStatusEnum.PENDING,
             data={
                 "traveler_name": f"Traveler {i}",
                 "origin_location_id": 1,
                 "destination_location_id": 2,
-                "transport_mode": "plane",
                 "number_of_trips": 1,
                 "unit_id": 1,
             },
@@ -495,14 +494,14 @@ async def test_get_submodule_data(db_session: AsyncSession):
 
     result = await service.get_submodule_data(
         carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.trips.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
         limit=10,
         offset=0,
         sort_by="id",
         sort_order="asc",
     )
 
-    assert result.id == DataEntryTypeEnum.trips.value
+    assert result.id == DataEntryTypeEnum.plane.value
     assert result.count == 3
     assert result.summary.total_items == 3
 

--- a/frontend/src/components/charts/EvolutionOverTimeChart.vue
+++ b/frontend/src/components/charts/EvolutionOverTimeChart.vue
@@ -59,7 +59,7 @@ onMounted(() => {
 const chartData = computed(() => {
   const rawData = moduleStore.state.travelEvolutionOverTime as Array<{
     year: number;
-    transport_mode: string;
+    category: string;
     kg_co2eq: number;
   }>;
 
@@ -80,14 +80,14 @@ const chartData = computed(() => {
   });
   const years = Array.from(yearsSet).sort((a, b) => a - b);
 
-  // Group data by transport mode and year
+  // Group data by category and year
   const dataByMode: Record<string, Record<number, number>> = {
     plane: {},
     train: {},
   };
 
   rawData.forEach((item) => {
-    const mode = item.transport_mode === 'plane' ? 'plane' : 'train';
+    const mode = item.category === 'plane' ? 'plane' : 'train';
     const year = item.year;
     const value = item.kg_co2eq || 0;
 

--- a/frontend/src/components/charts/TreeMapModuleChart.vue
+++ b/frontend/src/components/charts/TreeMapModuleChart.vue
@@ -281,7 +281,7 @@ const showEvolutionDialogRef = ref(false);
 const hasMultipleYears = computed(() => {
   const evolutionData = moduleStore.state.travelEvolutionOverTime as Array<{
     year: number;
-    transport_mode: string;
+    category: string;
     kg_co2eq: number;
   }>;
 

--- a/frontend/src/components/organisms/data-management/AnnualDataImport.vue
+++ b/frontend/src/components/organisms/data-management/AnnualDataImport.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { ref, onUnmounted } from 'vue';
+import { computed, ref, onUnmounted } from 'vue';
 import { MODULES_LIST } from 'src/constant/modules';
-import { enumSubmodule } from 'src/constant/modules';
 import FilesUploadDialog from './FilesUploadDialog.vue';
 import { useFilesStore } from 'src/stores/files';
 import { useBackofficeDataManagement } from 'src/stores/backofficeDataManagement';
@@ -24,6 +23,23 @@ defineProps<Props>();
 const showUploadDialog = ref<boolean>(false);
 const uploadTargetType = ref<'data_entries' | 'factors'>('data_entries');
 const uploadFactorVariant = ref<string | null>(null);
+const uploadDataEntryTypeId = ref<number | null>(null);
+
+type ImportRow = {
+  key: string;
+  labelKey: string;
+  moduleTypeId: number;
+  dataEntryTypeId?: number;
+  factorVariant?: 'plane' | 'train';
+};
+
+const importRows = computed<ImportRow[]>(() => {
+  return MODULES_LIST.map((module, index) => ({
+    key: module,
+    labelKey: module,
+    moduleTypeId: index + 1,
+  }));
+});
 
 /**
  * Initiate CSV upload sync for a module (MODULE_PER_YEAR bulk import).
@@ -88,10 +104,14 @@ const onFilesUploaded = async (filePaths: string[]) => {
       file_path: filePath,
     };
 
-    // Add data_entry_type_id for headcount (members only)
-    // probably should be done in backend, but doing here for now to avoid changing existing backend endpoint signature
-    if (uploadTargetType.value === 'data_entries' && module_type_id === 1) {
-      syncParams.data_entry_type_id = enumSubmodule.member; // value: 1
+    if (uploadDataEntryTypeId.value !== null) {
+      syncParams.data_entry_type_id = uploadDataEntryTypeId.value;
+    } else if (
+      uploadTargetType.value === 'data_entries' &&
+      module_type_id === 1
+    ) {
+      // Keep existing headcount default behavior
+      syncParams.data_entry_type_id = 1;
     }
 
     if (uploadTargetType.value === 'factors' && uploadFactorVariant.value) {
@@ -149,50 +169,23 @@ const dataEntrySync = async (moduleTypeId: number, year: number) => {
   });
 };
 
-const openUploadCsvDialog = (moduleTypeId: number, year: number) => {
+const openUploadCsvDialog = (row: ImportRow, year: number) => {
   // store moduleTypeId in filesStore to retrieve later when files are uploaded
   // TODO: FORBID USER to CHANGE
-  filesStore.currentUploadModuleTypeId = moduleTypeId;
+  filesStore.currentUploadModuleTypeId = row.moduleTypeId;
   filesStore.currentUploadYear = year;
   uploadTargetType.value = 'data_entries';
   uploadFactorVariant.value = null;
+  uploadDataEntryTypeId.value = row.dataEntryTypeId ?? null;
   showUploadDialog.value = true;
 };
 
-const openUploadFactorsDialog = async (moduleTypeId: number, year: number) => {
-  filesStore.currentUploadModuleTypeId = moduleTypeId;
+const openUploadFactorsDialog = (row: ImportRow, year: number) => {
+  filesStore.currentUploadModuleTypeId = row.moduleTypeId;
   filesStore.currentUploadYear = year;
   uploadTargetType.value = 'factors';
-  uploadFactorVariant.value = null;
-
-  if (moduleTypeId === 2) {
-    const result = await new Promise<string | null>((resolve) => {
-      $q.dialog({
-        title: 'Select travel factor type',
-        message: 'Which travel factor CSV are you uploading?',
-        options: {
-          type: 'radio',
-          model: 'plane',
-          items: [
-            { label: 'Plane factors', value: 'plane' },
-            { label: 'Train factors', value: 'train' },
-          ],
-        },
-        cancel: true,
-        persistent: true,
-      })
-        .onOk((value: string) => resolve(value))
-        .onCancel(() => resolve(null))
-        .onDismiss(() => resolve(null));
-    });
-
-    if (!result) {
-      return;
-    }
-
-    uploadFactorVariant.value = result;
-  }
-
+  uploadDataEntryTypeId.value = row.dataEntryTypeId ?? null;
+  uploadFactorVariant.value = row.factorVariant ?? null;
   showUploadDialog.value = true;
 };
 
@@ -286,8 +279,10 @@ onUnmounted(() => {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="module in MODULES_LIST" :key="module">
-            <td class="text-weight-medium" align="left">{{ $t(module) }}</td>
+          <tr v-for="row in importRows" :key="row.key">
+            <td class="text-weight-medium" align="left">
+              {{ $t(row.labelKey) }}
+            </td>
             <td align="left"></td>
             <td align="left">
               <div class="q-mb-sm">
@@ -305,9 +300,7 @@ onUnmounted(() => {
                   size="sm"
                   :label="$t('data_management_upload_csv_files')"
                   class="text-weight-medium"
-                  @click="
-                    openUploadCsvDialog(MODULES_LIST.indexOf(module) + 1, year)
-                  "
+                  @click="openUploadCsvDialog(row, year)"
                 />
                 <!-- TODO: use enum for data_module_type_id -->
                 <q-btn
@@ -317,7 +310,7 @@ onUnmounted(() => {
                   size="sm"
                   :label="$t('data_management_connect_api')"
                   class="text-weight-medium on-right"
-                  @click="dataEntrySync(MODULES_LIST.indexOf(module) + 1, year)"
+                  @click="dataEntrySync(row.moduleTypeId, year)"
                 />
                 <q-btn
                   no-caps
@@ -345,12 +338,7 @@ onUnmounted(() => {
                   size="sm"
                   :label="$t('data_management_upload_csv_files')"
                   class="text-weight-medium"
-                  @click="
-                    openUploadFactorsDialog(
-                      MODULES_LIST.indexOf(module) + 1,
-                      year,
-                    )
-                  "
+                  @click="openUploadFactorsDialog(row, year)"
                 />
                 <q-btn
                   no-caps

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -64,17 +64,11 @@
           <div class="form-grid">
             <div
               v-for="inp in visibleFieldsWithConditional"
-              :key="inp.optionsId || inp.id"
+              :key="inp.id"
               :class="['form-field', getGridClass(getDynamicRatio(inp))]"
             >
               <template
-                v-if="
-                  inp.optionsId === 'subkind' &&
-                  !loadingSubclasses &&
-                  (!dynamicOptions['subkind'] ||
-                    dynamicOptions['subkind'].length === 0) &&
-                  !form['subkind']
-                "
+                v-if="inp.disableUntilField && !form[inp.disableUntilField]"
               >
                 <div class="subclass-placeholder" />
               </template>
@@ -163,11 +157,7 @@
                   :to="String(form.destination ?? '')"
                   :error="!!errors.origin || !!errors.destination"
                   :error-message="errors.origin || errors.destination || ''"
-                  :transport-mode="
-                    !rowData && form.transport_mode
-                      ? (form.transport_mode as 'plane' | 'train')
-                      : undefined
-                  "
+                  :transport-mode="getTravelMode()"
                   :disable="inp.disable"
                   @update:from="
                     (val) => {
@@ -197,8 +187,11 @@
                 :type="inp.type === 'number' ? 'number' : undefined"
                 :options="getFilteredOptions(inp)"
                 :loading="
-                  (inp.optionsId === 'kind' && loadingClasses) ||
-                  (inp.optionsId === 'subkind' && loadingSubclasses)
+                  inp.optionsId === 'kind'
+                    ? loadingClasses
+                    : inp.optionsId === 'subkind'
+                      ? loadingSubclasses
+                      : false
                 "
                 :error="!!errors[inp.id]"
                 :error-message="errors[inp.id]"
@@ -286,7 +279,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, watch, computed, toRef, ref } from 'vue';
+import { reactive, watch, computed, ref, toRef } from 'vue';
 
 import type { ModuleField } from 'src/constant/moduleConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
@@ -301,13 +294,16 @@ import {
 } from 'quasar';
 import type { Component } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useEquipmentClassOptions } from 'src/composables/useEquipmentClassOptions';
 import StudentFTECalculator from './StudentFTECalculator.vue';
 import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import DirectionInput from 'src/components/atoms/CO2DestinationInput.vue';
 import NoteDialog from 'src/components/molecules/NoteDialog.vue';
 import { calculateDistance } from 'src/api/locations';
-import { MODULES } from 'src/constant/modules';
+import { useEquipmentClassOptions } from 'src/composables/useEquipmentClassOptions';
+import {
+  MODULES,
+  SUBMODULE_PROFESSIONAL_TRAVEL_TYPES,
+} from 'src/constant/modules';
 
 const { t: $t } = useI18n();
 const workspaceStore = useWorkspaceStore();
@@ -416,7 +412,7 @@ const filteredOptionsMap = computed(() => {
       dynamicOpts && dynamicOpts.length > 0
         ? dynamicOpts
         : (inp.options?.map((o) => ({
-            label: o.label,
+            label: $t(o.label) !== o.label ? $t(o.label) : o.label,
             value: o.value,
           })) ?? []);
 
@@ -491,13 +487,17 @@ const subkindFieldId = computed(() => {
 
 const { dynamicOptions, loadingClasses, loadingSubclasses } =
   useEquipmentClassOptions(form, toRef(props, 'submoduleType'), {
-    // classFieldId: 'equipment_class',
-    // subClassFieldId: 'sub_class',
-    classFieldId: kindFieldId.value,
-    subClassFieldId: subkindFieldId.value,
+    classFieldId: kindFieldId.value ?? undefined,
+    subClassFieldId: subkindFieldId.value ?? undefined,
   });
-
-// Use equipment options directly as dynamic options
+function getTravelMode(): 'plane' | 'train' | undefined {
+  if (props.moduleType !== MODULES.ProfessionalTravel) return undefined;
+  if (props.submoduleType === SUBMODULE_PROFESSIONAL_TRAVEL_TYPES.Plane)
+    return 'plane';
+  if (props.submoduleType === SUBMODULE_PROFESSIONAL_TRAVEL_TYPES.Train)
+    return 'train';
+  return undefined;
+}
 
 function validateUsage(value: unknown) {
   if (value === null || value === undefined || value === '') {
@@ -510,10 +510,6 @@ function validateUsage(value: unknown) {
   if (n > 168) return { valid: false, parsed: null, error: 'Max 168 hrs/wk' };
   return { valid: true, parsed: n, error: null };
 }
-
-// legacy helpers kept only for typing compatibility; logic lives
-// entirely in the useEquipmentClassOptions composable.
-// They are intentionally not used here.
 
 function init() {
   if (props.rowData) {
@@ -543,12 +539,10 @@ function init() {
           case 'radio-group':
             form[i.id] = (() => {
               const options =
-                dynamicOptions[i.optionsId] ??
                 i.options?.map((o) => ({
                   label: o.label,
                   value: o.value,
-                })) ??
-                [];
+                })) ?? [];
               return options.length > 0 ? options[0].value : '';
             })();
             break;
@@ -605,36 +599,29 @@ watch(
   },
 );
 
-// Clear location data when transport mode changes (specific to professional travel)
-watch(
-  () => form.transport_mode,
-  (newMode, oldMode) => {
-    // Only clear if transport mode actually changed (not on initial mount)
-    if (oldMode !== undefined && newMode !== oldMode && !props.rowData) {
-      // Clear origin and destination field values
-      form.origin = '';
-      form.destination = '';
-      // Clear location IDs when switching transport modes
-      form.origin_location_id = undefined;
-      form.destination_location_id = undefined;
-      // Clear distance when transport mode changes
-      form.distance_km = null;
-    }
-  },
-);
-// Watch for changes to location IDs, transport mode, and number of trips to calculate distance
+// Watch for changes to location IDs and number of trips to calculate distance.
 watch(
   () => [
     form.origin_location_id,
     form.destination_location_id,
-    form.transport_mode,
     form.number_of_trips,
   ],
   async () => {
+    const travelMode = getTravelMode();
+    if (!travelMode) return;
+    if (
+      form.origin_location_id === undefined ||
+      form.origin_location_id === null ||
+      form.destination_location_id === undefined ||
+      form.destination_location_id === null
+    ) {
+      form.distance_km = null;
+      return;
+    }
     form.distance_km = await calculateDistance(
       form.origin_location_id as number,
       form.destination_location_id as number,
-      form.transport_mode as 'plane' | 'train',
+      travelMode,
       (form.number_of_trips as number) || 1,
     );
   },
@@ -795,12 +782,10 @@ function reset() {
     else if (effectiveType === 'radio-group') {
       // Set first option as default
       const options =
-        dynamicOptions[i.optionsId] ??
         i.options?.map((o) => ({
           label: o.label,
           value: o.value,
-        })) ??
-        [];
+        })) ?? [];
       form[i.id] = options.length > 0 ? options[0].value : '';
     } else if (effectiveType === 'direction-input') {
       // Clear origin and destination fields
@@ -837,11 +822,20 @@ async function handleFromLocationSelected(location: {
   latitude: number;
   longitude: number;
 }) {
+  const travelMode = getTravelMode();
+  if (!travelMode) return;
   form.origin_location_id = location.id;
+  if (
+    form.destination_location_id === undefined ||
+    form.destination_location_id === null
+  ) {
+    form.distance_km = null;
+    return;
+  }
   form.distance_km = await calculateDistance(
     form.origin_location_id as number,
     form.destination_location_id as number,
-    form.transport_mode as 'plane' | 'train',
+    travelMode,
     (form.number_of_trips as number) || 1,
   );
 }
@@ -852,26 +846,46 @@ async function handleToLocationSelected(location: {
   latitude: number;
   longitude: number;
 }) {
+  const travelMode = getTravelMode();
+  if (!travelMode) return;
   form.destination_location_id = location.id;
+  if (
+    form.origin_location_id === undefined ||
+    form.origin_location_id === null
+  ) {
+    form.distance_km = null;
+    return;
+  }
   form.distance_km = await calculateDistance(
     form.origin_location_id as number,
     form.destination_location_id as number,
-    form.transport_mode as 'plane' | 'train',
+    travelMode,
     (form.number_of_trips as number) || 1,
   );
 }
 
 async function handleSwapLocations() {
+  const travelMode = getTravelMode();
+  if (!travelMode) return;
   // Swap location IDs when user swaps from/to
   const oldOriginId = form.origin_location_id;
   const oldDestinationId = form.destination_location_id;
 
   form.origin_location_id = oldDestinationId;
   form.destination_location_id = oldOriginId;
+  if (
+    form.origin_location_id === undefined ||
+    form.origin_location_id === null ||
+    form.destination_location_id === undefined ||
+    form.destination_location_id === null
+  ) {
+    form.distance_km = null;
+    return;
+  }
   form.distance_km = await calculateDistance(
     form.origin_location_id as number,
     form.destination_location_id as number,
-    form.transport_mode as 'plane' | 'train',
+    travelMode,
     (form.number_of_trips as number) || 1,
   );
 }

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -981,6 +981,16 @@ function isNew(row: ModuleRow) {
   return Boolean(row.is_new);
 }
 
+function hasValue(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim() !== '';
+  return true;
+}
+
+function hasRequiredValues(row: ModuleRow, fields: string[]) {
+  return fields.every((fieldId) => hasValue(row[fieldId]));
+}
+
 function isCompleteEquipement(row: ModuleRow) {
   const required = [
     'name',
@@ -991,9 +1001,7 @@ function isCompleteEquipement(row: ModuleRow) {
     'standby_power_w',
   ];
 
-  return required.every(
-    (k) => row[k] !== null && row[k] !== undefined && row[k] !== '',
-  );
+  return hasRequiredValues(row, required);
 }
 
 function isCompleteHeadcount(row: ModuleRow) {
@@ -1001,23 +1009,17 @@ function isCompleteHeadcount(row: ModuleRow) {
   const requiredStudent = ['fte'];
   // implicit behavior: if sciper is set, it's a member
   // todo: sciper field should not exist: maybe user_id to be agnostic
-  if (row.sciper !== '') {
-    return requiredMember.every(
-      (k) => row[k] !== null && row[k] !== undefined && row[k] !== '',
-    );
+  if (hasValue(row.sciper)) {
+    return hasRequiredValues(row, requiredMember);
   }
 
-  return requiredStudent.every(
-    (k) => row[k] !== null && row[k] !== undefined && row[k] !== '',
-  );
+  return hasRequiredValues(row, requiredStudent);
 }
 
 //  dependence on the submodule type
 function isCompleteExternalCloud(row: ModuleRow) {
   const required = ['service_type', 'cloud_provider', 'spending'];
-  return required.every(
-    (k) => row[k] !== null && row[k] !== undefined && row[k] !== '',
-  );
+  return hasRequiredValues(row, required);
 }
 
 function isCompleteExternalAI(row: ModuleRow) {
@@ -1027,9 +1029,7 @@ function isCompleteExternalAI(row: ModuleRow) {
     'frequency_use_per_day',
     'user_count',
   ];
-  return required.every(
-    (k) => row[k] !== null && row[k] !== undefined && row[k] !== '',
-  );
+  return hasRequiredValues(row, required);
 }
 
 function isCompletePurchase(row: ModuleRow) {
@@ -1052,7 +1052,10 @@ function isCompletePurchaseAdditional(row: ModuleRow) {
 }
 
 function isComplete(row: ModuleRow) {
-  // # TODO : move isComplete to module definition
+  const requiredFieldIds = props.submoduleConfig?.requiredFieldIds ?? [];
+  if (requiredFieldIds.length > 0) {
+    return hasRequiredValues(row, requiredFieldIds);
+  }
 
   if (props.moduleType === MODULES.Headcount) {
     // For Headcount, consider complete if name and status are set
@@ -1092,9 +1095,7 @@ function isComplete(row: ModuleRow) {
   }
   if (props.moduleType === MODULES.ProcessEmissions) {
     const baseRequired = ['emitted_gas', 'quantity_kg'];
-    const hasBaseRequired = baseRequired.every(
-      (k) => row[k] !== null && row[k] !== undefined && row[k] !== '',
-    );
+    const hasBaseRequired = hasRequiredValues(row, baseRequired);
     if (!hasBaseRequired) {
       return false;
     }
@@ -1175,21 +1176,18 @@ function onUploadCsv() {
 }
 
 function onDownloadTemplate() {
-  //
-  const csvEquipmentContent = `name,equipment_class,sub_class,active_usage_hours,passive_usage_hours`;
-
-  const csvHeadcountContent = `name,function,fte`;
-
-  const csvProfessionalTravelContent = `Type, From, To, Start Date, Number of trips, Traveler Name, Class, Purpose, Notes`;
-
-  const csvExternalCloudContent = `service_type,cloud_provider,spending`;
-  const csvExternalAIContent = `ai_provider,ai_use,frequency_use_per_day,user_count`;
-
-  const csvPurchaseContent = `name,purchase_institutional_code,quantity,total_spent_amount`;
-
-  const csvProcessesContent = `emitted_gas,sub_category,quantity_kg`;
-
-  const csvDefaultContent = `not_implemented_yet`;
+  const csvEquipmentContent =
+    'name,equipment_class,sub_class,active_usage_hours,passive_usage_hours';
+  const csvHeadcountContent = 'name,function,fte';
+  const csvProfessionalTravelContent =
+    'Type, From, To, Start Date, Number of trips, Traveler Name, Class, Purpose, Notes';
+  const csvExternalCloudContent = 'service_type,cloud_provider,spending';
+  const csvExternalAIContent =
+    'ai_provider,ai_use,frequency_use_per_day,user_count';
+  const csvPurchaseContent =
+    'name,purchase_institutional_code,quantity,total_spent_amount';
+  const csvProcessesContent = 'emitted_gas,sub_category,quantity_kg';
+  const csvDefaultContent = 'not_implemented_yet';
 
   let csvContent: string;
   switch (props.moduleType) {
@@ -1231,16 +1229,15 @@ function onDownloadTemplate() {
 
   const a = document.createElement('a');
   a.href = csvUrl;
-  a.download = `${props.moduleType}-template.csv`; // filename for the user
+  a.download = `${props.moduleType}-template.csv`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
+  URL.revokeObjectURL(csvUrl);
 
   $q.notify({
     color: 'info',
-    message:
-      $t('common_download_csv_template_mock') ||
-      'CSV template download (mocked)',
+    message: $t('common_download_csv_template_mock') || 'CSV template download',
     position: 'top',
   });
 }

--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -3,20 +3,7 @@ import { MODULES, MODULES_THRESHOLD_TYPES } from 'src/constant/modules';
 import { formatTonnesCO2 } from 'src/utils/number';
 import type { ProfessionalTravelSubType } from 'src/constant/modules';
 
-const moduleFields: ModuleField[] = [
-  {
-    id: 'transport_mode',
-    labelKey: `${MODULES.ProfessionalTravel}-field-type`,
-    type: 'radio-group',
-    required: true,
-    sortable: true,
-    ratio: '2/12',
-    options: [
-      { value: 'train', label: 'Train' },
-      { value: 'plane', label: 'Flight' },
-    ],
-    editableInline: false,
-  },
+const commonTravelFields: ModuleField[] = [
   {
     id: 'round_trip',
     labelKey: [
@@ -121,6 +108,10 @@ const moduleFields: ModuleField[] = [
       form: true,
     },
   },
+];
+
+const planeFields: ModuleField[] = [
+  ...commonTravelFields,
   {
     id: 'cabin_class',
     labelKey: `${MODULES.ProfessionalTravel}-field-class`,
@@ -133,26 +124,30 @@ const moduleFields: ModuleField[] = [
       table: true,
     },
     options: [
-      // Train classes
-      { value: 'class_1', label: 'Class 1' },
-      { value: 'class_2', label: 'Class 2' },
-      // Plane classes
       { value: 'first', label: 'First' },
       { value: 'business', label: 'Business' },
       { value: 'eco', label: 'Eco' },
       { value: 'eco_plus', label: 'Eco+' },
     ],
-    conditionalOptions: [
-      // Show train classes when transport_mode is 'train'
-      {
-        when: { fieldId: 'transport_mode', value: 'train' },
-        showOptions: ['class_2', 'class_1'],
-      },
-      // Show plane classes when transport_mode is 'plane'
-      {
-        when: { fieldId: 'transport_mode', value: 'plane' },
-        showOptions: ['eco', 'eco_plus', 'business', 'first'],
-      },
+  },
+];
+
+const trainFields: ModuleField[] = [
+  ...commonTravelFields,
+  {
+    id: 'cabin_class',
+    labelKey: `${MODULES.ProfessionalTravel}-field-class`,
+    type: 'select',
+    required: true,
+    sortable: true,
+    ratio: '1/1',
+    editableInline: false,
+    hideIn: {
+      table: true,
+    },
+    options: [
+      { value: 'class_1', label: 'Class 1' },
+      { value: 'class_2', label: 'Class 2' },
     ],
   },
 ];
@@ -163,7 +158,7 @@ export const professionalTravel: ModuleConfig = {
   hasDescription: true,
   hasDescriptionSubtext: true,
   hasTooltip: true,
-  hasSubmodules: false,
+  hasSubmodules: true,
   formStructure: 'perSubmodule',
   numberFormatOptions: {
     minimumFractionDigits: 0,
@@ -177,14 +172,56 @@ export const professionalTravel: ModuleConfig = {
   },
   submodules: [
     {
-      id: 'trips',
-      type: 'trips' as ProfessionalTravelSubType,
-      tableNameKey: `${MODULES.ProfessionalTravel}-table-title`,
-      moduleFields,
+      id: 'plane',
+      type: 'plane' as ProfessionalTravelSubType,
+      tableNameKey: `${MODULES.ProfessionalTravel}-plane-table-title`,
+      moduleFields: planeFields,
+      requiredFieldIds: [
+        'origin',
+        'destination',
+        'traveler_name',
+        'cabin_class',
+      ],
+      csvTemplateHeaders: [
+        'from',
+        'to',
+        'departure_date',
+        'number_of_trips',
+        'traveler_name',
+        'cabin_class',
+        'sciper',
+      ],
       hasTableTopBar: true,
       hasTablePagination: true,
       hasTableAction: true,
       hasFormTooltip: `${MODULES.ProfessionalTravel}-form-tooltip`,
+      addButtonLabelKey: `${MODULES.ProfessionalTravel}-add-plane-button`,
+    },
+    {
+      id: 'train',
+      type: 'train' as ProfessionalTravelSubType,
+      tableNameKey: `${MODULES.ProfessionalTravel}-train-table-title`,
+      moduleFields: trainFields,
+      requiredFieldIds: [
+        'origin',
+        'destination',
+        'traveler_name',
+        'cabin_class',
+      ],
+      csvTemplateHeaders: [
+        'from',
+        'to',
+        'departure_date',
+        'number_of_trips',
+        'traveler_name',
+        'cabin_class',
+        'sciper',
+      ],
+      hasTableTopBar: true,
+      hasTablePagination: true,
+      hasTableAction: true,
+      hasFormTooltip: `${MODULES.ProfessionalTravel}-form-tooltip`,
+      addButtonLabelKey: `${MODULES.ProfessionalTravel}-add-train-button`,
     },
   ],
 } as ModuleConfig & { unit?: string };

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -56,6 +56,9 @@ export interface ModuleField {
   default?: string | number | boolean;
   options?: Array<{ value: string; label: string }>;
   optionsId?: string; // ID to fetch options from store (kind or subkind)
+  treeLevel?: number;
+  disableUntilField?: string;
+  appendFromFieldId?: string;
   // Flat configuration (preferred): used by both table and form where relevant
   unit?: string;
   tooltip?: string;
@@ -98,6 +101,8 @@ export interface Submodule {
   hasTableAction?: boolean;
   addButtonLabelKey?: string;
   tooltipKey?: string;
+  requiredFieldIds?: string[];
+  csvTemplateHeaders?: string[];
 }
 
 export interface ResultBigNumberConfig {

--- a/frontend/src/constant/modules.ts
+++ b/frontend/src/constant/modules.ts
@@ -93,7 +93,8 @@ export const enumSubmodule = {
   [SUBMODULE_EQUIPMENT_TYPES.Scientific]: 9,
   [SUBMODULE_EQUIPMENT_TYPES.IT]: 10,
   [SUBMODULE_EQUIPMENT_TYPES.Other]: 11,
-  trips: 20,
+  plane: 20,
+  train: 21,
   building: 30,
   [SUBMODULE_EXTERNAL_CLOUD_TYPES.external_clouds]: 40,
   [SUBMODULE_EXTERNAL_CLOUD_TYPES.external_ai]: 41,
@@ -147,10 +148,8 @@ export type HeadcountProps = {
 };
 
 export const SUBMODULE_PROFESSIONAL_TRAVEL_TYPES = {
-  Conference: 'conference',
-  Fieldwork: 'fieldwork',
-  Training: 'training',
-  Other: 'other',
+  Plane: 'plane',
+  Train: 'train',
 } as const;
 
 export type ProfessionalTravelSubType =

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -6,6 +6,14 @@ export default {
     en: 'Trips',
     fr: 'Voyages',
   },
+  [`${MODULES.ProfessionalTravel}-plane-table-title`]: {
+    en: 'Plane Trip ({count}) | Plane Trips ({count})',
+    fr: 'Avion ({count}) | Avions ({count})',
+  },
+  [`${MODULES.ProfessionalTravel}-train-table-title`]: {
+    en: 'Train Trip ({count}) | Train Trips ({count})',
+    fr: 'Train ({count}) | Trains ({count})',
+  },
   [`${MODULES.ProfessionalTravel}-field-type`]: {
     en: 'Type',
     fr: 'Type',
@@ -43,6 +51,14 @@ export default {
     en: 'Add a trip',
     fr: 'Ajouter un voyage',
   },
+  [`${MODULES.ProfessionalTravel}-plane-form-title`]: {
+    en: 'Add a plane trip',
+    fr: 'Ajouter un trajet en avion',
+  },
+  [`${MODULES.ProfessionalTravel}-train-form-title`]: {
+    en: 'Add a train trip',
+    fr: 'Ajouter un trajet en train',
+  },
   [`${MODULES.ProfessionalTravel}-form-tooltip`]: {
     en: 'Please enter the details of your trip by train of flight in Switzerland or abroad. Every leg of the journey needs to be entered a new trip (e.g. Lausanne to New York would be 1. a train from Lausanne to Geneva Airport, then 2. a flight from Geneva Airport to Paris-Charles de Gaulle and 3. A flight from Paris-Charles de Gaulle to John F. Kennedy International Airport). The return can be selected by checking the box provided for this purpose.',
     fr: 'Veuillez saisir les détails de votre voyage en train ou en avion, en Suisse ou à l’étranger. Chaque étape du trajet doit être saisie comme un nouveau voyage (par ex. : Lausanne–New York correspondrait à 1. un trajet en train de Lausanne à l’aéroport de Genève, puis 2. un vol de l’aéroport de Genève à Paris–Charles-de-Gaulle et 3. un vol de Paris–Charles-de-Gaulle à l’aéroport international John-F.-Kennedy). Le retour peut être sélectionné en cochant la case prévue à cet effet.',
@@ -75,6 +91,22 @@ export default {
   [`${MODULES.ProfessionalTravel}-trips`]: {
     en: 'trip',
     fr: 'voyage',
+  },
+  [`${MODULES.ProfessionalTravel}-plane`]: {
+    en: 'plane',
+    fr: 'avion',
+  },
+  [`${MODULES.ProfessionalTravel}-train`]: {
+    en: 'train',
+    fr: 'train',
+  },
+  [`${MODULES.ProfessionalTravel}-add-plane-button`]: {
+    en: 'Add a plane trip',
+    fr: 'Ajouter un trajet en avion',
+  },
+  [`${MODULES.ProfessionalTravel}-add-train-button`]: {
+    en: 'Add a train trip',
+    fr: 'Ajouter un trajet en train',
   },
   // Legacy keys (keeping for backward compatibility)
   [MODULES.ProfessionalTravel]: {
@@ -166,8 +198,8 @@ export default {
     fr: 'Train',
   },
   plane: {
-    en: 'Flight',
-    fr: 'Vol',
+    en: 'Plane',
+    fr: 'Avion',
   },
   [`${MODULES.ProfessionalTravel}-error-same-destination`]: {
     en: 'Origin and destination cannot be the same',

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -428,15 +428,18 @@ export const useModuleStore = defineStore('modules', () => {
       if (moduleType === MODULES.EquipmentElectricConsumption) {
         // Fallback category if not provided by the form // for equipment
         normalized.category = (normalized.class as string) || 'Uncategorized';
-      } else if (moduleType === MODULES.ProfessionalTravel) {
-        // Add unit_id for professional travel (required by backend)
-        normalized.unit_id = unitId;
       }
-
-      const body = normalized;
 
       const isRoundTrip =
         moduleType === MODULES.ProfessionalTravel && !!normalized.is_round_trip;
+      const body =
+        moduleType === MODULES.ProfessionalTravel
+          ? (() => {
+              const rest = { ...normalized };
+              delete rest.is_round_trip;
+              return rest;
+            })()
+          : normalized;
 
       try {
         await api.post(path, { json: body }).json();
@@ -458,10 +461,9 @@ export const useModuleStore = defineStore('modules', () => {
 
       if (isRoundTrip) {
         const returnBody = {
-          ...normalized,
+          ...body,
           origin_location_id: normalized.destination_location_id,
           destination_location_id: normalized.origin_location_id,
-          is_round_trip: false,
         };
         try {
           await api.post(path, { json: returnBody }).json();
@@ -536,32 +538,6 @@ export const useModuleStore = defineStore('modules', () => {
             ? null
             : (value as string | number | boolean | null);
       });
-
-      // Module-specific payload adjustments
-      if (moduleType === MODULES.ProfessionalTravel) {
-        // Ensure number_of_trips is an integer if present and prevent negative values
-        if (
-          'number_of_trips' in normalized &&
-          normalized.number_of_trips !== null
-        ) {
-          const tripsValue = normalized.number_of_trips;
-          let parsed: number;
-          if (typeof tripsValue === 'string') {
-            parsed = parseInt(tripsValue, 10);
-            if (isNaN(parsed)) {
-              throw new Error('number_of_trips must be a valid integer');
-            }
-          } else if (typeof tripsValue === 'number') {
-            parsed = Math.floor(tripsValue);
-          } else {
-            throw new Error('number_of_trips must be a number');
-          }
-          if (parsed < 1) {
-            throw new Error('number_of_trips must be at least 1');
-          }
-          normalized.number_of_trips = parsed;
-        }
-      }
 
       await api.patch(path, { json: normalized }).json();
 


### PR DESCRIPTION
## What does this change?
Split the generic `trips` data entry type into two distinct `plane` and `train` types across the full stack — backend models, repositories, emission services, CSV ingestion, frontend module config, stores, charts, and i18n.

## Why is this needed?
The single `trips` type with a `transport_mode` field was brittle and required runtime checks throughout the codebase. Separating plane and train into first-class types simplifies logic, removes conditional branching on `transport_mode`, and enables cleaner submodule configuration (separate fields, CSV templates, and factor variants per travel type).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues

- Closes #483 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
