### PR TITLE
fix: refactor factors API endpoints and implement store for factor

### DIFF
--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -36,10 +36,10 @@ async def get_class_subclass_map(
 
 # example of call
 #
-# http://localhost:9000/api/v1/factors/scientific/classes/Milling%20machine/power
-# http://localhost:9000/api/v1/factors/scientific/classes/Agitator%20%2F%20Incubator/power?sub_class=Simple%20agitators%2Fincubators
+# http://localhost:9000/api/v1/factors/scientific/classes/Milling%20machine/values
+# http://localhost:9000/api/v1/factors/scientific/classes/Agitator%20%2F%20Incubator/values?sub_class=Simple%20agitators%2Fincubators
 @router.get(
-    "/{data_entry_type_id}/classes/{kind:path}/power",
+    "/{data_entry_type_id}/classes/{kind:path}/values",
     response_model=Optional[dict[str, float | str]],
 )
 async def get_factor(

--- a/frontend/src/api/factors.ts
+++ b/frontend/src/api/factors.ts
@@ -4,7 +4,7 @@ import type { AllSubmoduleTypes } from 'src/constant/modules';
 import { enumSubmodule } from 'src/constant/modules';
 
 export async function getSubclassMap(
-  submodule: AllSubmoduleTypes,
+  submodule: keyof typeof enumSubmodule,
 ): Promise<Record<string, string[]>> {
   const res = await api
     .get(
@@ -14,27 +14,19 @@ export async function getSubclassMap(
   return res ?? {};
 }
 
-export interface PowerFactorResponse {
-  // submodule: string;
-  // equipment_class: string;
-  // sub_class: string | null;
-  // TODO: IMPROVE: change to optional?
-  // return generic for kind and subkind and values
-  active_power_w: number;
-  standby_power_w: number;
-}
+export type ValueFactorResponse = Record<string, number> | null;
 
-export async function getPowerFactor(
+export async function getFactorValues(
   submodule: AllSubmoduleTypes,
   equipmentClass: string,
   subClass?: string | null,
-): Promise<PowerFactorResponse | null> {
+): Promise<ValueFactorResponse | null> {
   let path = `factors/${encodeURIComponent(
     enumSubmodule[submodule],
-  )}/classes/${encodeURIComponent(equipmentClass)}/power`;
+  )}/classes/${encodeURIComponent(equipmentClass)}/values`;
   if (subClass) {
     path += `?sub_class=${encodeURIComponent(subClass)}`;
   }
-  const res = await api.get(path).json<PowerFactorResponse | null>();
+  const res = await api.get(path).json<ValueFactorResponse | null>();
   return res ?? null;
 }

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -200,7 +200,7 @@
                 :step="inp.step"
                 :dense="inp.type !== 'boolean' && inp.type !== 'checkbox'"
                 :outlined="inp.type !== 'boolean' && inp.type !== 'checkbox'"
-                :readonly="inp.disable"
+                :readonly="inp.disable || inp.readOnly"
                 :disable="inp.disable"
                 :color="inp.type === 'checkbox' ? 'accent' : undefined"
                 :size="inp.type === 'checkbox' ? 'xs' : undefined"
@@ -498,10 +498,18 @@ const subkindFieldId = computed(() => {
   return subkindField ? subkindField.id : null;
 });
 
+const useEquipmentClassOptionsConfig: Record<string, string> = {};
+if (props.moduleType === MODULES.EquipmentElectricConsumption) {
+  useEquipmentClassOptionsConfig['primaryValueFieldId'] = 'active_power_w';
+  useEquipmentClassOptionsConfig['secondaryValueFieldId'] = 'standby_power_w';
+}
+
 const { dynamicOptions, loadingClasses, loadingSubclasses } =
   useEquipmentClassOptions(form, toRef(props, 'submoduleType'), {
     classFieldId: kindFieldId.value ?? undefined,
     subClassFieldId: subkindFieldId.value ?? undefined,
+    fetchFactorValuesOnChange: true,
+    ...useEquipmentClassOptionsConfig,
   });
 function getTravelMode(): 'plane' | 'train' | undefined {
   if (props.moduleType !== MODULES.ProfessionalTravel) return undefined;

--- a/frontend/src/composables/useEquipmentClassOptions.ts
+++ b/frontend/src/composables/useEquipmentClassOptions.ts
@@ -1,5 +1,5 @@
 import { reactive, ref, watch, type Ref } from 'vue';
-import { useFactorsStore } from 'src/stores/powerFactors';
+import { useFactorsStore } from 'src/stores/factors';
 import { AllSubmoduleTypes } from 'src/constant/modules';
 
 type Option = { label: string; value: string };
@@ -13,8 +13,19 @@ interface FieldConfig {
   classOptionId?: string;
   subClassOptionId?: string;
   // values of the fields in the entity record (real value we want to use)
-  actPowerFieldId?: string;
-  pasPowerFieldId?: string;
+  primaryValueFieldId?: string; // was actPowerFieldId
+  secondaryValueFieldId?: string; // was pasPowerFieldId
+
+  // Whether to automatically fetch power factor values when class/subclass changes.
+  // Default is false to avoid unexpected API calls and allow the user to explicitly
+  //  trigger fetch (for example with a button), but can be enabled if desired.
+  // case where it might be desirable to set this to true: when the form
+  // is primarily for data viewing rather than editing, so automatic fetching on change would be more intuitive and efficient.
+  // ALSO: table row where class/subclass are  editable shoudl have this
+  // flag as false: because -> if user is editing class/subclass in
+  // a table row, they might not want to trigger power factor fetch
+  // until they have finished editing both class and subclass, and automatic fetching on change could lead to multiple unnecessary API calls and potentially inconsistent intermediate states.
+  fetchFactorValuesOnChange?: boolean;
 }
 
 export function useEquipmentClassOptions<
@@ -30,8 +41,11 @@ export function useEquipmentClassOptions<
   const classOptionId = config.classOptionId ?? 'kind';
   const subClassOptionId = config.subClassOptionId ?? 'subkind';
   // #  TODO: make power field IDs configurable
-  const actPowerFieldId = config.actPowerFieldId ?? 'act_power';
-  const pasPowerFieldId = config.pasPowerFieldId ?? 'pas_power';
+  const primaryValueFieldId = config.primaryValueFieldId ?? '';
+  const secondaryValueFieldId = config.secondaryValueFieldId ?? '';
+
+  const fetchFactorValuesOnChange: boolean =
+    config.fetchFactorValuesOnChange ?? false;
 
   const dynamicOptions = reactive<Record<string, Option[]>>({});
   const loadingClasses = ref(false);
@@ -125,15 +139,16 @@ export function useEquipmentClassOptions<
     try {
       const pf = await store.fetchPowerFactor(sub, cls, subCls);
       if (pf) {
-        if (actPowerFieldId in entity)
+        if (primaryValueFieldId && primaryValueFieldId in entity)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (entity as any)[actPowerFieldId] = pf.active_power_w;
-        if (pasPowerFieldId in entity)
+          (entity as any)[primaryValueFieldId] = pf[primaryValueFieldId];
+        if (secondaryValueFieldId && secondaryValueFieldId in entity)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (entity as any)[pasPowerFieldId] = pf.standby_power_w;
+          (entity as any)[secondaryValueFieldId] = pf[secondaryValueFieldId];
       }
     } catch {
       // ignore, user can still fill manually
+      // should set error though
     } finally {
       loadingPowerFactor.value = false;
     }
@@ -143,12 +158,12 @@ export function useEquipmentClassOptions<
     if (subClassFieldId in entity)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (entity as any)[subClassFieldId] = '';
-    if (actPowerFieldId in entity)
+    if (primaryValueFieldId in entity)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entity as any)[actPowerFieldId] = null;
-    if (pasPowerFieldId in entity)
+      (entity as any)[primaryValueFieldId] = null;
+    if (secondaryValueFieldId in entity)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entity as any)[pasPowerFieldId] = null;
+      (entity as any)[secondaryValueFieldId] = null;
   }
 
   // React to submodule type changes
@@ -201,7 +216,9 @@ export function useEquipmentClassOptions<
 
       await loadSubclassOptions();
 
-      await loadPowerFactor();
+      if (fetchFactorValuesOnChange) {
+        await loadPowerFactor();
+      }
     },
     { immediate: true },
   );
@@ -210,7 +227,9 @@ export function useEquipmentClassOptions<
   watch(
     () => entity[subClassFieldId],
     async () => {
-      await loadPowerFactor();
+      if (fetchFactorValuesOnChange) {
+        await loadPowerFactor();
+      }
     },
   );
 

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -42,7 +42,7 @@ const baseModuleFields: ModuleField[] = [
     placeholder: 'e.g., Agitator, Centrifuge',
     sortable: true,
     align: 'left',
-    readOnly: true,
+    readOnly: false,
     ratio: '1/1',
   },
   {
@@ -117,7 +117,7 @@ const baseModuleFields: ModuleField[] = [
     ratio: '3/12',
     icon: 'o_electric_bolt',
     hideIn: {
-      form: true,
+      form: false,
     },
     maxColumnWidth: 150,
   },
@@ -133,7 +133,7 @@ const baseModuleFields: ModuleField[] = [
     tooltip: powerTooltip,
     readOnly: true,
     hideIn: {
-      form: true,
+      form: false,
     },
     editableInline: false,
     ratio: '3/12',

--- a/frontend/src/constant/module-config/infrastructure.ts
+++ b/frontend/src/constant/module-config/infrastructure.ts
@@ -1,7 +1,7 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { SUBMODULE_INFRASTRUCTURE_TYPES } from 'src/constant/modules';
 import { formatTonnesCO2 } from 'src/utils/number';
-import type { InfrastructureSubType } from 'src/constant/modules';
+import type { AllSubmoduleTypes } from 'src/constant/modules';
 
 const buildingFields: ModuleField[] = [
   {
@@ -48,7 +48,7 @@ export const infrastructure: ModuleConfig = {
   submodules: [
     {
       id: 'sub_building',
-      type: SUBMODULE_INFRASTRUCTURE_TYPES.Building as InfrastructureSubType,
+      type: SUBMODULE_INFRASTRUCTURE_TYPES.Building as AllSubmoduleTypes,
       name: 'Building',
       moduleFields: buildingFields,
     },

--- a/frontend/src/constant/module-config/internal-services.ts
+++ b/frontend/src/constant/module-config/internal-services.ts
@@ -2,7 +2,7 @@ import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { SUBMODULE_INTERNAL_SERVICES_TYPES } from 'src/constant/modules';
 import { formatTonnesCO2 } from 'src/utils/number';
 
-import type { InternalServicesSubType } from 'src/constant/modules';
+import type { AllSubmoduleTypes } from 'src/constant/modules';
 const rootFields: ModuleField[] = [
   {
     id: 'waste_general',
@@ -139,19 +139,19 @@ export const internalServices: ModuleConfig = {
   submodules: [
     {
       id: 'sub_general_waste',
-      type: SUBMODULE_INTERNAL_SERVICES_TYPES.ITSupport as InternalServicesSubType,
+      type: SUBMODULE_INTERNAL_SERVICES_TYPES.ITSupport as AllSubmoduleTypes,
       name: 'General Waste',
       moduleFields: generalWasteFields,
     },
     {
       id: 'sub_recycling',
-      type: SUBMODULE_INTERNAL_SERVICES_TYPES.Maintenance as InternalServicesSubType,
+      type: SUBMODULE_INTERNAL_SERVICES_TYPES.Maintenance as AllSubmoduleTypes,
       name: 'Recycling',
       moduleFields: recyclingFields,
     },
     {
       id: 'sub_organic',
-      type: SUBMODULE_INTERNAL_SERVICES_TYPES.Other as InternalServicesSubType,
+      type: SUBMODULE_INTERNAL_SERVICES_TYPES.Other as AllSubmoduleTypes,
       name: 'Organic Waste',
       moduleFields: organicFields,
     },

--- a/frontend/src/constant/modules.ts
+++ b/frontend/src/constant/modules.ts
@@ -52,7 +52,7 @@ export type ExternalCloudSubType =
 
 type ExternalCloudProps = {
   moduleType: typeof MODULES.ExternalCloudAndAI;
-  submoduleType?: ExternalCloudSubType;
+  submoduleType?: AllSubmoduleTypes; // ExternalCloudSubType;
 };
 
 export const SUBMODULE_PURCHASE_TYPES = {
@@ -71,7 +71,7 @@ export type PurchaseSubType =
 
 type PurchaseProps = {
   moduleType: typeof MODULES.Purchase;
-  submoduleType?: PurchaseSubType;
+  submoduleType?: AllSubmoduleTypes; // PurchaseSubType;
 };
 
 export const SUBMODULE_PROCESSES_TYPES = {
@@ -83,7 +83,7 @@ export type ProcessesSubType =
 
 type ProcessesProps = {
   moduleType: typeof MODULES.ProcessEmissions;
-  submoduleType?: ProcessesSubType;
+  submoduleType?: AllSubmoduleTypes; // ProcessesSubType;
 };
 
 export const enumSubmodule = {
@@ -134,17 +134,17 @@ export type InfrastructureSubType =
 
 type InfrastructureProps = {
   moduleType: typeof MODULES.Infrastructure;
-  submoduleType?: InfrastructureSubType;
+  submoduleType?: AllSubmoduleTypes; // InfrastructureSubType;
 };
 
 type EquipmentElectricConsumptionProps = {
   moduleType: typeof MODULES.EquipmentElectricConsumption;
-  submoduleType?: EquipmentElectricConsumptionSubType;
+  submoduleType?: AllSubmoduleTypes; // EquipmentElectricConsumptionSubType;
 };
 
 export type HeadcountProps = {
   moduleType: typeof MODULES.Headcount;
-  submoduleType?: HeadcountSubType;
+  submoduleType?: AllSubmoduleTypes; // HeadcountSubType;
 };
 
 export const SUBMODULE_PROFESSIONAL_TRAVEL_TYPES = {
@@ -157,7 +157,7 @@ export type ProfessionalTravelSubType =
 
 type ProfessionalTravelProps = {
   moduleType: typeof MODULES.ProfessionalTravel;
-  submoduleType?: ProfessionalTravelSubType;
+  submoduleType?: AllSubmoduleTypes; // ProfessionalTravelSubType;
 };
 
 export const SUBMODULE_INTERNAL_SERVICES_TYPES = {
@@ -171,18 +171,10 @@ export type InternalServicesSubType =
 
 type InternalServicesProps = {
   moduleType: typeof MODULES.InternalServices;
-  submoduleType?: InternalServicesSubType;
+  submoduleType?: AllSubmoduleTypes; // InternalServicesSubType;
 };
 
-export type AllSubmoduleTypes =
-  | EquipmentElectricConsumptionSubType
-  | HeadcountSubType
-  | PurchaseSubType
-  | InfrastructureSubType
-  | ProfessionalTravelSubType
-  | InternalServicesSubType
-  | ExternalCloudSubType
-  | ProcessesSubType;
+export type AllSubmoduleTypes = keyof typeof enumSubmodule;
 
 export type ConditionalSubmoduleProps =
   | EquipmentElectricConsumptionProps

--- a/frontend/src/stores/factors.ts
+++ b/frontend/src/stores/factors.ts
@@ -2,10 +2,10 @@ import { defineStore } from 'pinia';
 import { reactive } from 'vue';
 import {
   getSubclassMap,
-  getPowerFactor,
-  PowerFactorResponse,
-} from 'src/api/powerFactors';
-import { AllSubmoduleTypes } from 'src/constant/modules';
+  getFactorValues,
+  ValueFactorResponse,
+} from 'src/api/factors';
+import { AllSubmoduleTypes, enumSubmodule } from 'src/constant/modules';
 
 type Option = { label: string; value: string };
 
@@ -21,7 +21,7 @@ export const useFactorsStore = defineStore('factors', () => {
   >({});
 
   async function ensureSubclassOptionMap(
-    submodule: AllSubmoduleTypes,
+    submodule: keyof typeof enumSubmodule,
   ): Promise<Record<string, Option[]>> {
     const now = Date.now();
     const existing = subclassOptionMapBySubmodule[submodule];
@@ -63,8 +63,8 @@ export const useFactorsStore = defineStore('factors', () => {
     submodule: AllSubmoduleTypes,
     equipmentClass: string,
     subClass?: string | null,
-  ): Promise<PowerFactorResponse | null> {
-    return await getPowerFactor(submodule, equipmentClass, subClass);
+  ): Promise<ValueFactorResponse | null> {
+    return await getFactorValues(submodule, equipmentClass, subClass);
   }
 
   return {


### PR DESCRIPTION
This pull request refactors the power factor API and related frontend logic to support more generic factor values, improves configurability and type safety, and updates module configurations to use unified submodule types. The changes enhance flexibility for handling equipment and infrastructure modules, and streamline the codebase by generalizing APIs and field mappings.

**API and Type Refactoring**

* Changed backend API endpoint and frontend API calls from `/power` to `/values`, making factor value retrieval more generic and not limited to power factors. (`backend/app/api/v1/factors.py`, `frontend/src/api/factors.ts`) [[1]](diffhunk://#diff-bfdb1f64b2fc387247da6ab52d82a9732284e9c00a8da2d12b0656e6b678b24aL39-R42) [[2]](diffhunk://#diff-1a1958448c5ceef2c7b2645278b71beed4d989787b1e30e3b852c4ca28ff9bceL17-R30)
* Updated frontend types: replaced `PowerFactorResponse` with a generic `ValueFactorResponse`, and changed API function names to reflect broader factor value support. (`frontend/src/api/factors.ts`, `frontend/src/stores/factors.ts`) [[1]](diffhunk://#diff-1a1958448c5ceef2c7b2645278b71beed4d989787b1e30e3b852c4ca28ff9bceL17-R30) [[2]](diffhunk://#diff-350f854f8d1a074be62fd207e78c7c47e6e62bd8822a71bfc9a6aadf907bd584L5-R8) [[3]](diffhunk://#diff-350f854f8d1a074be62fd207e78c7c47e6e62bd8822a71bfc9a6aadf907bd584L66-R67)

**Configurability and Reactivity Improvements**

* Made value field IDs (`primaryValueFieldId`, `secondaryValueFieldId`) configurable in `useEquipmentClassOptions`, and added an option to automatically fetch factor values when class/subclass changes. (`frontend/src/composables/useEquipmentClassOptions.ts`, `frontend/src/components/organisms/module/ModuleForm.vue`) [[1]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efL16-R28) [[2]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efL33-R48) [[3]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efL128-R151) [[4]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efL146-R166) [[5]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efR219-R221) [[6]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efR230-R232) [[7]](diffhunk://#diff-4cdfb00119907836c5dfacfd1d2e859cb8bcfec2ffb6fdb7390c3cd46d7db827R501-R512)
* Updated form fields to respect both `disable` and new `readOnly` flags for better UX. (`frontend/src/components/organisms/module/ModuleForm.vue`)

**Module Configuration Updates**

* Changed module field configurations for equipment electric consumption to allow editing of class and power fields in forms, and adjusted read-only settings for better flexibility. (`frontend/src/constant/module-config/equipment-electric-consumption.ts`) [[1]](diffhunk://#diff-940f4ea104c528b6222266a78a03c3ab7583bd39161583333fc55d2f0d8ac197L45-R45) [[2]](diffhunk://#diff-940f4ea104c528b6222266a78a03c3ab7583bd39161583333fc55d2f0d8ac197L120-R120) [[3]](diffhunk://#diff-940f4ea104c528b6222266a78a03c3ab7583bd39161583333fc55d2f0d8ac197L136-R136)

**Unified Submodule Types**

* Refactored all module configuration files and props to use a unified `AllSubmoduleTypes` type, improving type safety and consistency across modules. (`frontend/src/constant/modules.ts`, `frontend/src/constant/module-config/infrastructure.ts`, `frontend/src/constant/module-config/internal-services.ts`) [[1]](diffhunk://#diff-ee78600f4698f765dec6ad13dce2c9dc2cb392b4082bbe55461032b480adc030L55-R55) [[2]](diffhunk://#diff-ee78600f4698f765dec6ad13dce2c9dc2cb392b4082bbe55461032b480adc030L74-R74) [[3]](diffhunk://#diff-ee78600f4698f765dec6ad13dce2c9dc2cb392b4082bbe55461032b480adc030L86-R86) [[4]](diffhunk://#diff-ee78600f4698f765dec6ad13dce2c9dc2cb392b4082bbe55461032b480adc030L137-R147) [[5]](diffhunk://#diff-ee78600f4698f765dec6ad13dce2c9dc2cb392b4082bbe55461032b480adc030L160-R160) [[6]](diffhunk://#diff-ee78600f4698f765dec6ad13dce2c9dc2cb392b4082bbe55461032b480adc030L174-R177) [[7]](diffhunk://#diff-6a1046778ee24d3d9d426ef4c54fefc3996ccb487e3e2f6da0323169e4f2efbaL4-R4) [[8]](diffhunk://#diff-6a1046778ee24d3d9d426ef4c54fefc3996ccb487e3e2f6da0323169e4f2efbaL51-R51) [[9]](diffhunk://#diff-5dba53bad0ef648afb81cc478a1286a933350e2e67725a5b9438d9981e536f65L5-R5) [[10]](diffhunk://#diff-5dba53bad0ef648afb81cc478a1286a933350e2e67725a5b9438d9981e536f65L142-R154)

**File Renaming and Cleanup**

* Renamed `powerFactors` files to `factors` to reflect the more generic factor value support, and updated imports accordingly. (`frontend/src/api/factors.ts`, `frontend/src/stores/factors.ts`, `frontend/src/composables/useEquipmentClassOptions.ts`) [[1]](diffhunk://#diff-214b5b8dee6afcaaede7f54add53640c991013fcdc9010773fae11dbc73517efL2-R2) [[2]](diffhunk://#diff-350f854f8d1a074be62fd207e78c7c47e6e62bd8822a71bfc9a6aadf907bd584L5-R8)

Let me know if you want more details about any specific change or how these improvements affect the workflow!
## What does this change?

Only form needs to call the endpoint that retrieve the values of the factors. Needed only for equipment now


## Why is this needed?

One call per line of each table: Danger


## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
