### PR TITLE
fix(building): update texts

### DIFF
--- a/frontend/src/constant/module-config/buildings.ts
+++ b/frontend/src/constant/module-config/buildings.ts
@@ -206,6 +206,7 @@ export const buildings: ModuleConfig = {
       tableNameKey: `${MODULES.Buildings}.combustion_table_title`,
       moduleFields: energyCombustionFields,
       hasTableAction: true,
+      hasFormTooltip: `${MODULES.Buildings}-energy_combustion-form-title-info-tooltip`,
       addButtonLabelKey: `${MODULES.Buildings}.add_combustion_button`,
     },
   ],

--- a/frontend/src/i18n/buildings.ts
+++ b/frontend/src/i18n/buildings.ts
@@ -24,8 +24,8 @@ export default {
     fr: 'Local ({count}) | Locaux ({count})',
   },
   [`${MODULES.Buildings}.add_room_button`]: {
-    en: 'Add a room',
-    fr: 'Ajouter un local',
+    en: 'Add',
+    fr: 'Ajouter',
   },
   [`${MODULES.Buildings}.rooms-form-title`]: {
     en: 'Add a room',
@@ -35,9 +35,14 @@ export default {
     en: 'Add a room',
     fr: 'Ajouter un local',
   },
+
+  [`${MODULES.Buildings}-building-table-title-info-tooltip`]: {
+    en: 'Rooms surfaces are extracted from Archibus and energy consumption data per type of surface are provided by the VPO based on building-specific measurements.',
+    fr: 'Les surfaces des locaux sont extraites d’Archibus et les données de consommation énergétique par type de surface sont fournies par la VPO sur la base de mesures spécifiques aux bâtiments EPFL.',
+  },
   [`${MODULES.Buildings}-energy_combustion-form-title`]: {
-    en: 'Add an energy source',
-    fr: "Ajouter une source d'énergie",
+    en: 'Add a heating type',
+    fr: 'Ajouter un type de chauffage',
   },
 
   // Rooms fields
@@ -113,6 +118,10 @@ export default {
     en: 'Lighting (kWh)',
     fr: 'Éclairage (kWh)',
   },
+  [`${MODULES.Buildings}-energy_combustion-form-title-info-tooltip`]: {
+    en: 'Enter the sources of fossil or non-fossil energy combustion if they are not taken into account in the main module.',
+    fr: "Entrez les sources de combustion d'énergie fossiles ou non-fossiles si celles-ci ne sont pas prises en compte dans le module principal.",
+  },
 
   // Rooms tooltips
   [`${MODULES.Buildings}.tooltips.heating`]: {
@@ -134,16 +143,16 @@ export default {
 
   // Energy combustion submodule
   [`${MODULES.Buildings}.combustion_table_title`]: {
-    en: 'Energy combustion ({count}) | Energy combustions ({count})',
-    fr: "Combustion d'énergie ({count}) | Combustions d'énergie ({count})",
+    en: 'Energy Combustion Emissions ({count}) | Energy Combustions Emissions ({count})',
+    fr: "Émissions de combustion d'énergie ({count}) | Émissions de combustion d'énergie ({count})",
   },
   [`${MODULES.Buildings}.add_combustion_button`]: {
-    en: 'Add an energy source',
-    fr: "Ajouter une source d'énergie",
+    en: 'Add',
+    fr: 'Ajouter ',
   },
   [`${MODULES.Buildings}.combustion-form-title`]: {
-    en: 'Add an energy source',
-    fr: "Ajouter une source d'énergie",
+    en: 'Add a heating type',
+    fr: 'Ajouter un type de chauffage',
   },
 
   // Combustion fields


### PR DESCRIPTION
## What does this change?
Updates labels, button text, and tooltips in the Buildings module for the rooms and energy combustion submodules. Specifically:

Shortens "Add a room" / "Add an energy source" buttons to simply "Add" / "Ajouter"
Renames "Add an energy source" form titles to "Add a heating type" / "Ajouter un type de chauffage"
Adds informational tooltips (hasFormTooltip) to both the rooms and energy combustion submodule forms
Updates the combustion table title to include "Emissions" for clarity
Adds missing i18n keys for the new tooltip labels (EN + FR)

## Why is this needed?
The previous labels were inconsistent or unclear for end users. Renaming energy-related entries to "heating type" better reflects the actual data being entered. The new tooltips provide contextual guidance, clarifying that users should enter combustion sources not already covered by the main module. The table title update makes it clearer that the entries represent emission data.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues

- Closes #173 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
