### PR TITLE
feat/518 featheadcount add unit institutional id to module headcount

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -12,13 +12,14 @@ from fastapi import (
     Response,
     status,
 )
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import check_module_permission as _check_module_permission
-from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
 from app.modules.headcount.schemas import HeadcountItemResponse
@@ -314,6 +315,62 @@ async def get_submodule(
     return submodule_data
 
 
+@router.get(
+    "/{unit_id}/{year}/{module_id}/{submodule_id}/check-unique",
+)
+async def check_unique(
+    unit_id: int,
+    year: int,
+    module_id: str,
+    submodule_id: str,
+    field: str = Query(..., description="JSON data field to check uniqueness for"),
+    value: str = Query(..., description="Value to check"),
+    exclude_id: Optional[int] = Query(
+        default=None, description="Entry ID to exclude (for PATCH pre-validation)"
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Check whether a data field value is unique within a submodule.
+
+    Intended to be called from the form before submitting a PATCH (or POST)
+    so the UI can surface a duplicate error before the round-trip.
+
+    Args:
+        unit_id: Unit ID.
+        year: Report year.
+        module_id: Module identifier.
+        submodule_id: Submodule identifier.
+        field: JSON key inside ``data`` to check (e.g. ``user_institutional_id``).
+        value: The value that must be unique.
+        exclude_id: ID of the entry being edited — excluded from the duplicate scan.
+
+    Returns:
+        ``{"unique": true}`` when the value is available,
+        ``{"unique": false}`` when a conflict exists.
+    """
+    await _check_module_permission(current_user, module_id, "view")
+
+    module_key = module_id.replace("-", "_")
+    submodule_key = submodule_id.replace("-", "_")
+    data_entry_type_id = DataEntryTypeEnum[submodule_key].value
+    carbon_report_module_id = await get_carbon_report_id(
+        unit_id=unit_id,
+        year=year,
+        module_type_id=ModuleTypeEnum[module_key],
+        db=db,
+    )
+
+    is_unique = await DataEntryService(db).check_json_field_unique(
+        carbon_report_module_id=carbon_report_module_id,
+        data_entry_type_id=data_entry_type_id,
+        field=field,
+        value=value,
+        exclude_id=exclude_id,
+    )
+    return {"unique": is_unique}
+
+
 @router.post(
     "/{unit_id}/{year}/{module_id}/{submodule_id}",
     response_model=DataEntryResponse,
@@ -406,10 +463,35 @@ async def create(
 
         validated_data = handler.validate_create(create_payload)
 
+        # For member entries with institutional ID, check for duplicates before creating
+        if (
+            data_entry_type == DataEntryTypeEnum.member
+            and validated_data.model_dump().get("user_institutional_id")
+        ):
+            uid = validated_data.model_dump()["user_institutional_id"]
+            duplicate = (
+                await db.execute(
+                    select(DataEntry)
+                    .where(
+                        DataEntry.carbon_report_module_id == carbon_report_module_id,
+                        DataEntry.data_entry_type_id == DataEntryTypeEnum.member.value,
+                        DataEntry.data["user_institutional_id"].as_string() == uid,
+                    )
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if duplicate:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="This user institutional id already exists.",
+                )
+
         data_entry_create = DataEntryCreate(
             **validated_data.model_dump(exclude_unset=True)
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(
             "Error validating item_data for data entry creation",

--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -12,14 +12,13 @@ from fastapi import (
     Response,
     status,
 )
-from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import check_module_permission as _check_module_permission
-from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry import DataEntryTypeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
 from app.modules.headcount.schemas import HeadcountItemResponse
@@ -469,18 +468,13 @@ async def create(
             and validated_data.model_dump().get("user_institutional_id")
         ):
             uid = validated_data.model_dump()["user_institutional_id"]
-            duplicate = (
-                await db.execute(
-                    select(DataEntry)
-                    .where(
-                        DataEntry.carbon_report_module_id == carbon_report_module_id,
-                        DataEntry.data_entry_type_id == DataEntryTypeEnum.member.value,
-                        DataEntry.data["user_institutional_id"].as_string() == uid,
-                    )
-                    .limit(1)
-                )
-            ).scalar_one_or_none()
-            if duplicate:
+            is_unique = await DataEntryService(db).check_json_field_unique(
+                carbon_report_module_id=carbon_report_module_id,
+                data_entry_type_id=DataEntryTypeEnum.member.value,
+                field="user_institutional_id",
+                value=uid,
+            )
+            if not is_unique:
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail="This user institutional id already exists.",

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -108,6 +108,40 @@ class DataEntryRepository:
         await self.session.flush()
         return bool(deleted)
 
+    async def check_json_field_unique(
+        self,
+        carbon_report_module_id: int,
+        data_entry_type_id: int,
+        field: str,
+        value: str,
+        exclude_id: Optional[int] = None,
+    ) -> bool:
+        """Check whether a JSON data field value is unique within a submodule.
+
+        Args:
+            carbon_report_module_id: The module to scope the check to.
+            data_entry_type_id: The submodule type.
+            field: The JSON key inside ``DataEntry.data`` to check.
+            value: The value that must be unique.
+            exclude_id: Optional entry ID to exclude (for PATCH uniqueness checks).
+
+        Returns:
+            True if the value is unique (no conflicting row found), False otherwise.
+        """
+        statement = (
+            select(DataEntry)
+            .where(
+                col(DataEntry.carbon_report_module_id) == carbon_report_module_id,
+                col(DataEntry.data_entry_type_id) == data_entry_type_id,
+                DataEntry.data[field].as_string() == value,
+            )
+            .limit(1)
+        )
+        if exclude_id is not None:
+            statement = statement.where(col(DataEntry.id) != exclude_id)
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none() is None
+
     async def get_list(
         self,
         carbon_report_module_id: int,

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -72,6 +72,34 @@ class DataEntryService:
             aggregate_field=aggregate_field,
         )
 
+    async def check_json_field_unique(
+        self,
+        carbon_report_module_id: int,
+        data_entry_type_id: int,
+        field: str,
+        value: str,
+        exclude_id: Optional[int] = None,
+    ) -> bool:
+        """Check whether a JSON data field value is unique within a submodule.
+
+        Args:
+            carbon_report_module_id: The module to scope the check to.
+            data_entry_type_id: The submodule type.
+            field: The JSON key inside the entry data to check.
+            value: The value that must be unique.
+            exclude_id: Optional entry ID to exclude (for PATCH uniqueness checks).
+
+        Returns:
+            True if the value is unique, False otherwise.
+        """
+        return await self.repo.check_json_field_unique(
+            carbon_report_module_id=carbon_report_module_id,
+            data_entry_type_id=data_entry_type_id,
+            field=field,
+            value=value,
+            exclude_id=exclude_id,
+        )
+
     async def create(
         self,
         carbon_report_module_id: int,

--- a/docs/implementation-plans/518-headcount-uniqueness-validation.md
+++ b/docs/implementation-plans/518-headcount-uniqueness-validation.md
@@ -1,0 +1,109 @@
+# Plan: Headcount `user_institutional_id` — Uniqueness Validation + Institution Label
+
+## Context
+
+The headcount module stores a `user_institutional_id` (SCIPER at EPFL) per member entry.
+Two issues exist:
+
+1. **No uniqueness check**: the same SCIPER can be entered twice in the same unit's carbon report, causing duplicate data.
+2. **Generic label**: the field shows "Institutional ID" but EPFL calls it "SCIPER". The label should be institution-configurable by a dev.
+
+Scope: uniqueness is **per `carbon_report_module_id`** (same unit + year). The same SCIPER across different units/years is allowed (by design).
+
+---
+
+## Part 1 — Backend: Uniqueness Validation on Create
+
+### Files to modify
+
+**`backend/app/api/v1/carbon_report_module.py`** — `create()` endpoint (lines ~407–434)
+
+After `validated_data = handler.validate_create(create_payload)` and before `DataEntryService(db).create(...)`, insert a uniqueness check for headcount members:
+
+```python
+from sqlmodel import select, col
+
+# After validated_data is built:
+if (
+    data_entry_type == DataEntryTypeEnum.member
+    and validated_data.model_dump().get("user_institutional_id")
+):
+    uid = validated_data.model_dump()["user_institutional_id"]
+    duplicate = (await db.execute(
+        select(DataEntry).where(
+            DataEntry.carbon_report_module_id == carbon_report_module_id,
+            DataEntry.data_entry_type_id == DataEntryTypeEnum.member.value,
+            DataEntry.data["user_institutional_id"].as_string() == uid,
+        ).limit(1)
+    )).scalar_one_or_none()
+    if duplicate:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="This user's institutional ID (Sciper) already exists.",
+        )
+```
+
+This reuses the existing `DataEntry.data["field"].as_string()` JSON query pattern already used in filter/sort maps (e.g., `schemas.py:150`).
+
+### Why here, not in the schema/service
+
+The check requires a DB query and `carbon_report_module_id` context. The API endpoint is the right layer — it already owns both. No new service method needed.
+
+---
+
+## Part 2 — Frontend: Institution-Configurable Label
+
+### New file: `frontend/src/constant/institution.ts`
+
+```typescript
+/**
+ * Institution-specific display configuration.
+ *
+ * Configuring for your institution:
+ *   - Set USER_INSTITUTIONAL_ID_LABEL to the term your institution uses
+ *     for the internal user identifier stored in headcount.
+ *
+ * Examples:
+ *   EPFL  → 'SCIPER'
+ *   Other → 'Institutional ID'
+ *
+ * This value is used in headcount form labels, table column headers,
+ * and error messages across the application.
+ */
+export const USER_INSTITUTIONAL_ID_LABEL = "SCIPER"; // EPFL default
+```
+
+### Modify: `frontend/src/i18n/headcount.ts`
+
+Import the constant and replace the static string:
+
+```typescript
+import { USER_INSTITUTIONAL_ID_LABEL } from 'src/constant/institution';
+
+// Replace the existing label (line 92-95):
+[`${MODULES.Headcount}-member-form-field-user-institutional-id-label`]: {
+  en: USER_INSTITUTIONAL_ID_LABEL,
+  fr: USER_INSTITUTIONAL_ID_LABEL,
+},
+```
+
+Since "SCIPER" is an acronym with no translation, both `en` and `fr` use the same constant.
+
+---
+
+## Critical Files
+
+| File                                         | Change                                       |
+| -------------------------------------------- | -------------------------------------------- |
+| `backend/app/api/v1/carbon_report_module.py` | Add SCIPER uniqueness check in `create()`    |
+| `frontend/src/constant/institution.ts`       | **New** — institution config constant        |
+| `frontend/src/i18n/headcount.ts`             | Import and use `USER_INSTITUTIONAL_ID_LABEL` |
+
+---
+
+## Verification
+
+1. **Backend**: POST to `POST /modules/{unit_id}/{year}/headcount/member` twice with the same `user_institutional_id` → second call returns HTTP 422 with `"This user's  **unit_instituional_ID_display_text** already exists."`.
+2. **Backend**: Same `user_institutional_id` in a different unit → succeeds (different `carbon_report_module_id`).
+3. **Frontend**: Headcount member form field label shows "SCIPER" instead of "Institutional ID".
+4. **Label change**: Change `USER_INSTITUTIONAL_ID_LABEL` in `institution.ts` to `'Institutional ID'` → label updates everywhere without touching i18n or components.

--- a/docs/implementation-plans/518-headcount-uniqueness-validation.md
+++ b/docs/implementation-plans/518-headcount-uniqueness-validation.md
@@ -60,7 +60,7 @@ The check requires a DB query and `carbon_report_module_id` context. The API end
  * Institution-specific display configuration.
  *
  * Configuring for your institution:
- *   - Set USER_INSTITUTIONAL_ID_LABEL to the term your institution uses
+ *   - Set INSTITUTIONAL_ID_LABEL to the term your institution uses
  *     for the internal user identifier stored in headcount.
  *
  * Examples:
@@ -70,7 +70,108 @@ The check requires a DB query and `carbon_report_module_id` context. The API end
  * This value is used in headcount form labels, table column headers,
  * and error messages across the application.
  */
-export const USER_INSTITUTIONAL_ID_LABEL = "SCIPER"; // EPFL default
+export const INSTITUTIONAL_ID_LABEL = "SCIPER"; // EPFL default
+```
+
+### Modify: `frontend/src/i18n/headcount.ts`
+
+Import the constant and replace the static string:
+
+### Why here, and how it is wired through the service/repository
+
+### Modify: `frontend/src/i18n/headcount.ts`
+
+Import the constant and replace the static string:
+
+```typescript
+import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
+
+// Replace the existing label (line 92-95):
+[`${MODULES.Headcount}-member-form-field-user-institutional-id-label`]: {
+en: INSTITUTIONAL_ID_LABEL,
+fr: INSTITUTIONAL_ID_LABEL,
+},
+```
+
+## Verification
+
+1. **Backend**: POST to `POST /modules/{unit_id}/{year}/headcount/member` twice with the same `user_institutional_id` → second call returns HTTP 422 with `"This user's institutional ID (Sciper) already exists."`.
+2. **Backend**: Same `user_institutional_id` in a different unit → succeeds (different `carbon_report_module_id`).
+3. **Frontend**: Headcount member form field label shows "SCIPER" instead of "Institutional ID".
+
+# Plan: Headcount `user_institutional_id` — Uniqueness Validation + Institution Label
+
+## Context
+
+The headcount module stores a `user_institutional_id` (SCIPER at EPFL) per member entry.
+Two issues exist:
+
+1. **No uniqueness check**: the same SCIPER can be entered twice in the same unit's carbon report, causing duplicate data.
+2. **Generic label**: the field shows "Institutional ID" but EPFL calls it "SCIPER". The label should be institution-configurable by a dev.
+
+Scope: uniqueness is **per `carbon_report_module_id`** (same unit + year). The same SCIPER across different units/years is allowed (by design).
+
+---
+
+## Part 1 — Backend: Uniqueness Validation on Create
+
+### Files to modify
+
+**`backend/app/api/v1/carbon_report_module.py`** — `create()` endpoint (lines ~407–434)
+
+After `validated_data = handler.validate_create(create_payload)` and before `DataEntryService(db).create(...)`, insert a uniqueness check for headcount members:
+
+```python
+from sqlmodel import select, col
+
+# After validated_data is built:
+if (
+    data_entry_type == DataEntryTypeEnum.member
+    and validated_data.model_dump().get("user_institutional_id")
+):
+    uid = validated_data.model_dump()["user_institutional_id"]
+    duplicate = (await db.execute(
+        select(DataEntry).where(
+            DataEntry.carbon_report_module_id == carbon_report_module_id,
+            DataEntry.data_entry_type_id == DataEntryTypeEnum.member.value,
+            DataEntry.data["user_institutional_id"].as_string() == uid,
+        ).limit(1)
+    )).scalar_one_or_none()
+    if duplicate:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="This user's institutional ID already exists.",
+        )
+```
+
+This reuses the existing `DataEntry.data["field"].as_string()` JSON query pattern already used in filter/sort maps (e.g., `schemas.py:150`).
+
+### Why here, not in the schema/service
+
+The check requires a DB query and `carbon_report_module_id` context. The API endpoint is the right layer — it already owns both. No new service method needed.
+
+---
+
+## Part 2 — Frontend: Institution-Configurable Label
+
+### New file: `frontend/src/constant/institution.ts`
+
+```typescript
+/**
+ * Institution-specific display configuration.
+ *
+ * Configuring for your institution:
+ *   - Set INSTITUTIONAL_ID_LABEL to the term your institution uses
+ *     for the internal user identifier stored in headcount.
+ *
+ * Examples:
+ *   EPFL  → 'SCIPER'
+ *   Other → 'Institutional ID'
+ *
+ * This value is used in headcount form labels, table column headers,
+ * and error messages across the application.
+ */
+export const INSTITUTIONAL_ID_LABEL = "SCIPER"; // EPFL default
 ```
 
 ### Modify: `frontend/src/i18n/headcount.ts`
@@ -78,12 +179,12 @@ export const USER_INSTITUTIONAL_ID_LABEL = "SCIPER"; // EPFL default
 Import the constant and replace the static string:
 
 ```typescript
-import { USER_INSTITUTIONAL_ID_LABEL } from 'src/constant/institution';
+import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institution';
 
 // Replace the existing label (line 92-95):
 [`${MODULES.Headcount}-member-form-field-user-institutional-id-label`]: {
-  en: USER_INSTITUTIONAL_ID_LABEL,
-  fr: USER_INSTITUTIONAL_ID_LABEL,
+en: INSTITUTIONAL_ID_LABEL,
+fr: INSTITUTIONAL_ID_LABEL,
 },
 ```
 
@@ -93,11 +194,41 @@ Since "SCIPER" is an acronym with no translation, both `en` and `fr` use the sam
 
 ## Critical Files
 
-| File                                         | Change                                       |
-| -------------------------------------------- | -------------------------------------------- |
-| `backend/app/api/v1/carbon_report_module.py` | Add SCIPER uniqueness check in `create()`    |
-| `frontend/src/constant/institution.ts`       | **New** — institution config constant        |
-| `frontend/src/i18n/headcount.ts`             | Import and use `USER_INSTITUTIONAL_ID_LABEL` |
+| File                                         | Change                                    |
+| -------------------------------------------- | ----------------------------------------- |
+| `backend/app/api/v1/carbon_report_module.py` | Add SCIPER uniqueness check in `create()` |
+| `frontend/src/constant/institution.ts`       | **New** — institution config constant     |
+| `frontend/src/i18n/headcount.ts`             | Import and use `INSTITUTIONAL_ID_LABEL`   |
+
+---
+
+## Verification
+
+1. **Backend**: POST to `/modules/{unit_id}/{year}/headcount/member` twice with the same `user_institutional_id` → second call returns HTTP 422 with `"This user's institutional ID already exists."`.
+2. **Backend**: Same `user_institutional_id` in a different unit → succeeds (different `carbon_report_module_id`).
+3. **Frontend**: Headcount member form field label shows "SCIPER" instead of "Institutional ID".
+4. **Label change**: Change `INSTITUTIONAL_ID_LABEL` in `institution.ts` to `'Institutional ID'` → label updates everywhere without touching i18n or components.
+   import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institution';
+
+// Replace the existing label (line 92-95):
+[`${MODULES.Headcount}-member-form-field-user-institutional-id-label`]: {
+en: INSTITUTIONAL_ID_LABEL,
+fr: INSTITUTIONAL_ID_LABEL,
+},
+
+```
+
+Since "SCIPER" is an acronym with no translation, both `en` and `fr` use the same constant.
+
+---
+
+## Critical Files
+
+| File                                         | Change                                    |
+| -------------------------------------------- | ----------------------------------------- |
+| `backend/app/api/v1/carbon_report_module.py` | Add SCIPER uniqueness check in `create()` |
+| `frontend/src/constant/institution.ts`       | **New** — institution config constant     |
+| `frontend/src/i18n/headcount.ts`             | Import and use `INSTITUTIONAL_ID_LABEL`   |
 
 ---
 
@@ -106,4 +237,5 @@ Since "SCIPER" is an acronym with no translation, both `en` and `fr` use the sam
 1. **Backend**: POST to `POST /modules/{unit_id}/{year}/headcount/member` twice with the same `user_institutional_id` → second call returns HTTP 422 with `"This user's  **unit_instituional_ID_display_text** already exists."`.
 2. **Backend**: Same `user_institutional_id` in a different unit → succeeds (different `carbon_report_module_id`).
 3. **Frontend**: Headcount member form field label shows "SCIPER" instead of "Institutional ID".
-4. **Label change**: Change `USER_INSTITUTIONAL_ID_LABEL` in `institution.ts` to `'Institutional ID'` → label updates everywhere without touching i18n or components.
+4. **Label change**: Change `INSTITUTIONAL_ID_LABEL` in `institution.ts` to `'Institutional ID'` → label updates everywhere without touching i18n or components.
+```

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -815,10 +815,15 @@ function buildPayload(): Record<
   return payload;
 }
 
+function setFieldError(fieldId: string, error: string | null) {
+  errors[fieldId] = error;
+}
+
+defineExpose({ setFieldError });
+
 function onSubmit() {
   if (!validateForm()) return;
   emit('submit', buildPayload());
-  reset();
 }
 
 function reset() {

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -50,6 +50,7 @@
       <q-separator />
       <div v-if="hasModuleForm && !disable && canEdit" class="q-mx-lg">
         <module-form
+          ref="formRef"
           :fields="submodule.moduleFields"
           :submodule-type="submodule.type"
           :module-type="moduleType"
@@ -83,7 +84,7 @@ import {
 } from 'src/constant/moduleConfig';
 import ModuleTable from 'src/components/organisms/module/ModuleTable.vue';
 import ModuleForm from 'src/components/organisms/module/ModuleForm.vue';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useAuthStore } from 'src/stores/auth';
@@ -97,6 +98,7 @@ import type {
 } from 'src/constant/modules';
 import { enumSubmodule } from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
+import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
 interface Option {
   label: string;
   value: string;
@@ -167,7 +169,9 @@ const hasTableTooltip = computed(() => {
 
 // actions
 
-function submitForm(payload: Record<string, FieldValue>) {
+const formRef = ref<InstanceType<typeof ModuleForm> | null>(null);
+
+async function submitForm(payload: Record<string, FieldValue>) {
   // if update! (for headcount student for instance)
   if (item.value && item.value.id) {
     return moduleStore.patchItem(
@@ -179,13 +183,21 @@ function submitForm(payload: Record<string, FieldValue>) {
       payload,
     );
   } else {
-    moduleStore.postItem(
-      props.moduleType,
-      props.unitId,
-      props.year,
-      props.submoduleType,
-      payload,
-    );
+    try {
+      await moduleStore.postItem(
+        props.moduleType,
+        props.unitId,
+        props.year,
+        props.submoduleType,
+        payload,
+      );
+    } catch (err: unknown) {
+      const raw = err instanceof Error ? err.message : 'Unexpected error';
+      formRef.value?.setFieldError(
+        'user_institutional_id',
+        raw.replace(/user institutional id/gi, INSTITUTIONAL_ID_LABEL),
+      );
+    }
   }
 }
 </script>

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -193,6 +193,8 @@ async function submitForm(payload: Record<string, FieldValue>) {
       );
     } catch (err: unknown) {
       const raw = err instanceof Error ? err.message : 'Unexpected error';
+      // Replace generic "user institutional id" in server error messages with
+      // the institution-specific label (SCIPER for EPFL).
       formRef.value?.setFieldError(
         'user_institutional_id',
         raw.replace(/user institutional id/gi, INSTITUTIONAL_ID_LABEL),

--- a/frontend/src/constant/institutionalId.ts
+++ b/frontend/src/constant/institutionalId.ts
@@ -1,0 +1,15 @@
+/**
+ * Institution-specific display configuration.
+ *
+ * Configuring for your institution:
+ *   - Set INSTITUTIONAL_ID_LABEL to the term your institution uses
+ *     for the internal user identifier stored in headcount.
+ *
+ * Examples:
+ *   EPFL  → 'SCIPER'
+ *   Other → 'Institutional ID'
+ *
+ * This value is used in headcount form labels, table column headers,
+ * and error messages across the application.
+ */
+export const INSTITUTIONAL_ID_LABEL = 'SCIPER';

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -1,4 +1,5 @@
 import { MODULES, MODULES_DESCRIPTIONS } from 'src/constant/modules';
+import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
 
 export default {
   [MODULES.Headcount]: {
@@ -90,8 +91,8 @@ export default {
     fr: 'Nom',
   },
   [`${MODULES.Headcount}-member-form-field-user-institutional-id-label`]: {
-    en: 'Institutional ID',
-    fr: 'ID institutionnel',
+    en: INSTITUTIONAL_ID_LABEL,
+    fr: INSTITUTIONAL_ID_LABEL,
   },
   // module_mylab_student_form_field_fte_label
   [`${MODULES.Headcount}-student_form_field_fte_label`]: {

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -511,13 +511,10 @@ export const useModuleStore = defineStore('modules', () => {
           error &&
           typeof error === 'object' &&
           'response' in error &&
-          error.response &&
-          typeof error.response === 'object' &&
-          'json' in error.response &&
-          typeof error.response.json === 'function'
+          error.response
         ) {
-          const errorBody = await error.response.json();
-          console.error('[ModuleStore] Backend error response:', errorBody);
+          const { detail } = await (error.response as Response).json();
+          throw new Error(detail, { cause: error });
         }
         throw error;
       }
@@ -540,11 +537,13 @@ export const useModuleStore = defineStore('modules', () => {
             'json' in error.response &&
             typeof error.response.json === 'function'
           ) {
-            const errorBody = await error.response.json();
-            console.error(
-              '[ModuleStore] Backend error response (return leg):',
-              errorBody,
-            );
+            const errorBody = await (
+              error.response as { json: () => Promise<unknown> }
+            ).json();
+            const detail = (errorBody as { detail?: unknown })?.detail;
+            const message =
+              typeof detail === 'string' ? detail : JSON.stringify(errorBody);
+            throw new Error(message, { cause: error });
           }
           throw error;
         }


### PR DESCRIPTION
## What does this change?
Adds uniqueness validation for `user_institutional_id` (SCIPER) in the headcount module, and makes the institutional ID label institution-configurable.

- **Backend**: prevents duplicate member entries with the same SCIPER within the same carbon report module (same unit + year). Returns HTTP 422 with a clear error message if a duplicate is detected.
- **Frontend**: surfaces the backend error inline on the `user_institutional_id` field without resetting the form. Introduces a new `institution.ts` constant so the field label (e.g. "SCIPER" at EPFL) can be changed in one place without touching i18n files or components.

## Why is this needed?
The same SCIPER could previously be submitted twice for the same unit/year, silently creating duplicate headcount entries and corrupting report data. The field label was also hardcoded as "Institutional ID" / "ID institutionnel", making it harder to adapt the app for other institutions.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

## Related issues

- Closes #518 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
