### PR TITLE
fix(process-emissions): correct typo in refrigerants category value

### DIFF
--- a/frontend/src/constant/module-config/process_emissions.ts
+++ b/frontend/src/constant/module-config/process_emissions.ts
@@ -32,7 +32,7 @@ const processEmissionsFields: ModuleField[] = [
     conditionalVisibility: {
       showWhen: {
         fieldId: 'category',
-        value: 'Refrigerants',
+        value: 'Refrigerant',
       },
     },
     icon: 'o_category',


### PR DESCRIPTION
## What does this change?
Fixes a typo in the processing emissions modules config: 'Refrigerants' → 'Refrigerant' to match the actual category value.

## Why is this needed?
The misspelled value 'Refrigerants' broke the connection between the category and subcategory fields in the module form. As a result, the subcategory field would never appear when selecting the Refrigerant category, making it impossible to use subcategory selection for that module.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Related to #621 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
