### PR TITLE
fix(factors): merge classification and values for combustion factors in get_factor function

### DIFF
--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -54,5 +54,8 @@ async def get_factor(
         subkind=subkind,
     )
     if factor:
-        return factor.values
+        # For combustion factors, `unit` lives in `classification` rather than `values`.
+        # Merge both so callers receive a single flat dict; values win on key collision.
+        # This mght be a hack with unintended consequences.
+        return {**(factor.classification or {}), **(factor.values or {})}
     return None

--- a/frontend/src/api/factors.ts
+++ b/frontend/src/api/factors.ts
@@ -14,7 +14,7 @@ export async function getSubclassMap(
   return res ?? {};
 }
 
-export type ValueFactorResponse = Record<string, number> | null;
+export type ValueFactorResponse = Record<string, number | string | null> | null;
 
 export async function getFactorValues(
   submodule: AllSubmoduleTypes,

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -866,6 +866,7 @@ defineExpose({ setFieldError });
 function onSubmit() {
   if (!validateForm()) return;
   emit('submit', buildPayload());
+  reset();
 }
 
 function reset() {


### PR DESCRIPTION
## What does this change?
Merges classification and values dicts in the get_factor endpoint so combustion factors expose their unit field to callers. Updates the frontend ValueFactorResponse type to reflect the wider return type (number | string | null). Adds a reset() call after form submission in ModuleForm so the form clears correctly after the user submits.

## Why is this needed?
Combustion factors store unit in classification rather than values. Previously only values was returned, so the unit field was silently dropped and the frontend had no way to display or use it. Additionally, the form was not resetting after submission, leaving stale data visible to the user (issue #621).

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
