### PR TITLE
feat(backend): add rollup emission rows for sortable kg_co2eq

### DIFF
--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -85,6 +85,7 @@ class DataEntryEmissionRepository:
             .join(DataEntry, col(DataEntryEmission.data_entry_id) == col(DataEntry.id))
             .where(
                 DataEntry.carbon_report_module_id == carbon_report_module_id,
+                col(DataEntryEmission.scope).isnot(None),
             )
             .group_by(group_field)
         )
@@ -137,6 +138,7 @@ class DataEntryEmissionRepository:
                 CarbonReport.unit_id == unit_id,
                 CarbonReportModule.status == ModuleStatus.VALIDATED,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
+                col(DataEntryEmission.scope).isnot(None),
             )
             .group_by(year_expr)
             .order_by(year_expr.asc())
@@ -184,6 +186,7 @@ class DataEntryEmissionRepository:
                 CarbonReportModule.carbon_report_id == carbon_report_id,
                 CarbonReportModule.status == ModuleStatus.VALIDATED,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
+                col(DataEntryEmission.scope).isnot(None),
             )
             .group_by(col(CarbonReportModule.module_type_id))
         )
@@ -228,6 +231,7 @@ class DataEntryEmissionRepository:
             .where(
                 CarbonReportModule.carbon_report_id == carbon_report_id,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
+                col(DataEntryEmission.scope).isnot(None),
             )
             .group_by(
                 col(CarbonReportModule.module_type_id),

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from sqlalchemy import Select, asc, desc, func, or_
 from sqlalchemy import select as sa_select
+from sqlalchemy.orm import aliased
 from sqlmodel import col, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -23,6 +24,7 @@ from app.schemas.data_entry import (
     DataEntryUpdate,
     ModuleHandler,
 )
+from app.utils.data_entry_emission_type_map import DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION
 
 logger = get_logger(__name__)
 
@@ -273,51 +275,57 @@ class DataEntryRepository:
         sort_order: str,
         filter: Optional[str] = None,
     ) -> SubmoduleResponse:
+        data_entry_type = DataEntryTypeEnum(data_entry_type_id)
         is_travel_entry = data_entry_type_id in (
             DataEntryTypeEnum.plane.value,
             DataEntryTypeEnum.train.value,
         )
         is_buildings_entry = data_entry_type_id in (DataEntryTypeEnum.building.value,)
-
-        # Aggregate emissions per data_entry to avoid row duplication
-        # (one data_entry can have multiple emissions for headcount/building)
-        emission_agg = (
-            select(
-                DataEntryEmission.data_entry_id,
-                func.sum(DataEntryEmission.kg_co2eq).label("total_kg_co2eq"),
-                func.min(DataEntryEmission.primary_factor_id).label(
-                    "primary_factor_id"
-                ),
-            )
-            .group_by(col(DataEntryEmission.data_entry_id))
-            .subquery()
+        is_headcount_entry = data_entry_type_id in (
+            DataEntryTypeEnum.member.value,
+            DataEntryTypeEnum.student.value,
         )
 
-        # Build query: one row per DataEntry
-        entities: list[Any] = [
-            DataEntry,
-            emission_agg.c.total_kg_co2eq,
-            Factor,
-        ]
+        # Resolve rollup emission_type for multi-leaf entries (e.g. buildings)
+        rollup_type = DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION.get(data_entry_type)
+        has_emission_join = not is_headcount_entry
+
+        # Alias for the emission row used to get kg_co2eq + primary_factor
+        EmissionRow = aliased(DataEntryEmission)
+        # Alias for leaf emission row (travel needs meta.distance_km)
+        LeafEmission = aliased(DataEntryEmission)
+
+        # Build entity list: one row per DataEntry
+        entities: list[Any] = [DataEntry]
+        if has_emission_join:
+            entities.extend([EmissionRow, Factor])
         if is_buildings_entry:
-            # For buildings, we want to show retrieve the room surface area:
-            entities.extend([BuildingRoom])
-
+            entities.append(BuildingRoom)
         if is_travel_entry:
-            entities.extend([MemberEntry, DataEntryEmission])
-        statement: Select[Any] = (
-            sa_select(*entities)
-            .join(
-                emission_agg,
-                col(DataEntry.id) == emission_agg.c.data_entry_id,
-                isouter=True,
-            )
-            .join(
+            entities.extend([MemberEntry, LeafEmission])
+
+        statement: Select[Any] = sa_select(*entities)
+
+        # JOIN emission row: rollup row for multi-leaf, leaf row for single-leaf
+        if has_emission_join:
+            if rollup_type is not None:
+                # Multi-leaf: join on the rollup row (scope IS NULL)
+                emission_join_cond = (
+                    col(DataEntry.id) == col(EmissionRow.data_entry_id)
+                ) & (col(EmissionRow.emission_type_id) == rollup_type.value)
+            else:
+                # Single-leaf: join on the leaf row (scope IS NOT NULL)
+                emission_join_cond = (
+                    col(DataEntry.id) == col(EmissionRow.data_entry_id)
+                ) & (col(EmissionRow.scope).isnot(None))
+
+            statement = statement.join(
+                EmissionRow, emission_join_cond, isouter=True
+            ).join(
                 Factor,
-                emission_agg.c.primary_factor_id == col(Factor.id),
+                col(EmissionRow.primary_factor_id) == col(Factor.id),
                 isouter=True,
             )
-        )
 
         if is_travel_entry:
             statement = statement.join(
@@ -332,15 +340,16 @@ class DataEntryRepository:
                 ),
                 isouter=True,
             ).join(
-                DataEntryEmission,
-                col(DataEntryEmission.data_entry_id) == DataEntry.id,
+                LeafEmission,
+                (col(LeafEmission.data_entry_id) == col(DataEntry.id))
+                & (col(LeafEmission.scope).isnot(None)),
                 isouter=True,
             )
 
         if is_buildings_entry:
             statement = statement.join(
                 BuildingRoom,
-                DataEntry.data["room_name"].as_string() == BuildingRoom.room_name,
+                DataEntry.data["room_name"].as_string() == col(BuildingRoom.room_name),
                 isouter=True,
             )
 
@@ -349,13 +358,12 @@ class DataEntryRepository:
             col(DataEntry.data_entry_type_id) == data_entry_type_id,
         )
 
-        handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum(data_entry_type_id))
+        handler = BaseModuleHandler.get_by_type(data_entry_type)
         statement, filter_pattern = self._apply_name_filter(statement, filter, handler)
 
-        sort_map = dict(
-            handler.sort_map
-        )  # shallow copy — don't mutate the class-level dict
-        sort_map["kg_co2eq"] = emission_agg.c.total_kg_co2eq
+        sort_map = dict(handler.sort_map)
+        if has_emission_join:
+            sort_map["kg_co2eq"] = col(EmissionRow.kg_co2eq)
         statement = self._apply_sort(statement, sort_by, sort_order, sort_map)
 
         statement = statement.offset(offset).limit(limit)
@@ -383,14 +391,27 @@ class DataEntryRepository:
 
         for row in rows:
             # Unpack based on query shape
-            if is_travel_entry:
-                data_entry, total_kg_co2eq, primary_factor, member_entry, emission = row
-            elif is_buildings_entry:
-                data_entry, total_kg_co2eq, primary_factor, building_room = row
-                emission = None
+            if has_emission_join and is_travel_entry:
+                (
+                    data_entry,
+                    emission_row,
+                    primary_factor,
+                    member_entry,
+                    leaf_emission,
+                ) = row
+            elif has_emission_join and is_buildings_entry:
+                data_entry, emission_row, primary_factor, building_room = row
+                member_entry, leaf_emission = None, None
+            elif has_emission_join:
+                data_entry, emission_row, primary_factor = row
+                member_entry, leaf_emission = None, None
             else:
-                data_entry, total_kg_co2eq, primary_factor = row
-                member_entry, emission = None, None
+                # Headcount — no emission join
+                (data_entry,) = row
+                emission_row, primary_factor = None, None
+                member_entry, leaf_emission = None, None
+
+            total_kg_co2eq = emission_row.kg_co2eq if emission_row else None
 
             handler = BaseModuleHandler.get_by_type(
                 DataEntryTypeEnum(data_entry.data_entry_type_id)
@@ -400,7 +421,9 @@ class DataEntryRepository:
             if primary_factor is None:
                 primary_factor_id = data_entry.data.get("primary_factor_id")
                 if primary_factor_id:
-                    factor_stmt = select(Factor).where(Factor.id == primary_factor_id)
+                    factor_stmt = select(Factor).where(
+                        col(Factor.id) == primary_factor_id
+                    )
                     factor_result = await self.session.execute(factor_stmt)
                     primary_factor = factor_result.scalar_one_or_none()
 
@@ -426,8 +449,10 @@ class DataEntryRepository:
                         else {}
                     ),
                     **(
-                        {"distance_km": emission.meta.get("distance_km")}
-                        if emission and emission.meta and "distance_km" in emission.meta
+                        {"distance_km": leaf_emission.meta.get("distance_km")}
+                        if leaf_emission
+                        and leaf_emission.meta
+                        and "distance_km" in leaf_emission.meta
                         else {}
                     ),
                 }

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -21,7 +21,10 @@ from app.repositories.data_entry_emission_repo import (
 )
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.factor_service import FactorService
-from app.utils.data_entry_emission_type_map import resolve_emission_types
+from app.utils.data_entry_emission_type_map import (
+    DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION,
+    resolve_emission_types,
+)
 
 settings = get_settings()
 logger = get_logger(__name__)
@@ -199,6 +202,32 @@ class DataEntryEmissionService:
                             },
                         )
                     )
+
+        # Append a rollup row that sums all leaf emissions for this data entry.
+        # The rollup emission_type_id is the parent node in the EmissionType tree,
+        # enabling direct JOIN + ORDER BY on kg_co2eq without a subquery.
+        rollup_type = DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION.get(
+            DataEntryTypeEnum(data_entry.data_entry_type)
+        )
+        if rollup_type is not None and results:
+            total_kg_co2eq = sum(r.kg_co2eq for r in results)
+            # Use the first leaf's primary_factor_id for display in table
+            first_factor_id = next(
+                (r.primary_factor_id for r in results if r.primary_factor_id), None
+            )
+            results.append(
+                DataEntryEmission(
+                    data_entry_id=data_entry.id,
+                    emission_type_id=rollup_type.value,
+                    primary_factor_id=first_factor_id,
+                    scope=None,  # rollup — scope only meaningful on leaves
+                    kg_co2eq=total_kg_co2eq,
+                    meta={
+                        "is_rollup": True,
+                        "leaf_emission_type_ids": [r.emission_type_id for r in results],
+                    },
+                )
+            )
 
         return results
 

--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -35,6 +35,50 @@ from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_entry_emission import EmissionType, HeatingEnergyType
 
 # =============================================================================
+# DATA_ENTRY_TYPE → ROLLUP EMISSION_TYPE  (1-to-1 or None)
+#
+# Maps each DataEntryTypeEnum to its parent EmissionType node for the rollup
+# DataEntryEmission row. The rollup row stores the total kg_co2eq for the
+# data entry (sum of all leaf emissions), enabling direct ORDER BY in queries.
+# None = no rollup (headcount: we don't show kg_co2eq in the table).
+# =============================================================================
+
+DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION: dict[DataEntryTypeEnum, EmissionType | None] = {
+    # Headcount — no rollup (4 independent roots, no kg_co2eq in table)
+    DataEntryTypeEnum.member: None,
+    DataEntryTypeEnum.student: None,
+    # Professional Travel — 1 leaf per entry, no rollup needed
+    DataEntryTypeEnum.plane: None,
+    DataEntryTypeEnum.train: None,
+    # Buildings — 5 leaf emissions per building room entry → needs rollup
+    DataEntryTypeEnum.building: EmissionType.buildings__rooms,
+    # Energy combustion — single leaf, no rollup needed
+    DataEntryTypeEnum.energy_combustion: None,
+    # Equipment — single leaf per entry, no rollup needed
+    DataEntryTypeEnum.scientific: None,
+    DataEntryTypeEnum.it: None,
+    DataEntryTypeEnum.other: None,
+    # Process Emissions — single leaf, no rollup needed
+    DataEntryTypeEnum.process_emissions: None,
+    # Purchases — single leaf per entry, no rollup needed
+    DataEntryTypeEnum.scientific_equipment: None,
+    DataEntryTypeEnum.it_equipment: None,
+    DataEntryTypeEnum.consumable_accessories: None,
+    DataEntryTypeEnum.biological_chemical_gaseous_product: None,
+    DataEntryTypeEnum.services: None,
+    DataEntryTypeEnum.vehicles: None,
+    DataEntryTypeEnum.other_purchases: None,
+    DataEntryTypeEnum.additional_purchases: None,
+    # Research Facilities — single leaf, no rollup needed
+    DataEntryTypeEnum.research_facilities: None,
+    DataEntryTypeEnum.mice_and_fish_animal_facilities: None,
+    # External Clouds — single leaf per entry (runtime-resolved), no rollup needed
+    DataEntryTypeEnum.external_clouds: None,
+    # External AI — single leaf per entry (runtime-resolved), no rollup needed
+    DataEntryTypeEnum.external_ai: None,
+}
+
+# =============================================================================
 # DATA_ENTRY_TYPE → EMISSION_TYPE mapping  (1-to-many)
 #
 # Most DataEntryTypeEnum values map to a single EmissionType leaf.

--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -47,35 +47,35 @@ DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION: dict[DataEntryTypeEnum, EmissionType | None]
     # Headcount — no rollup (4 independent roots, no kg_co2eq in table)
     DataEntryTypeEnum.member: None,
     DataEntryTypeEnum.student: None,
-    # Professional Travel — 1 leaf per entry, no rollup needed
-    DataEntryTypeEnum.plane: None,
-    DataEntryTypeEnum.train: None,
-    # Buildings — 5 leaf emissions per building room entry → needs rollup
+    # Professional Travel — 1 leaf per entry (cabin class), rollup to subcategory
+    DataEntryTypeEnum.plane: EmissionType.professional_travel__plane,
+    DataEntryTypeEnum.train: EmissionType.professional_travel__train,
+    # Buildings — 5 leaf emissions per building room entry → rollup to subcategory
     DataEntryTypeEnum.building: EmissionType.buildings__rooms,
-    # Energy combustion — single leaf, no rollup needed
-    DataEntryTypeEnum.energy_combustion: None,
-    # Equipment — single leaf per entry, no rollup needed
-    DataEntryTypeEnum.scientific: None,
-    DataEntryTypeEnum.it: None,
-    DataEntryTypeEnum.other: None,
-    # Process Emissions — single leaf, no rollup needed
-    DataEntryTypeEnum.process_emissions: None,
-    # Purchases — single leaf per entry, no rollup needed
-    DataEntryTypeEnum.scientific_equipment: None,
-    DataEntryTypeEnum.it_equipment: None,
-    DataEntryTypeEnum.consumable_accessories: None,
-    DataEntryTypeEnum.biological_chemical_gaseous_product: None,
-    DataEntryTypeEnum.services: None,
-    DataEntryTypeEnum.vehicles: None,
-    DataEntryTypeEnum.other_purchases: None,
-    DataEntryTypeEnum.additional_purchases: None,
-    # Research Facilities — single leaf, no rollup needed
-    DataEntryTypeEnum.research_facilities: None,
-    DataEntryTypeEnum.mice_and_fish_animal_facilities: None,
-    # External Clouds — single leaf per entry (runtime-resolved), no rollup needed
-    DataEntryTypeEnum.external_clouds: None,
-    # External AI — single leaf per entry (runtime-resolved), no rollup needed
-    DataEntryTypeEnum.external_ai: None,
+    # Energy combustion — single leaf, rollup to category
+    DataEntryTypeEnum.energy_combustion: EmissionType.buildings,
+    # Equipment — single leaf per entry, rollup to category
+    DataEntryTypeEnum.scientific: EmissionType.equipment,
+    DataEntryTypeEnum.it: EmissionType.equipment,
+    DataEntryTypeEnum.other: EmissionType.equipment,
+    # Process Emissions — single leaf (gas type), rollup to category
+    DataEntryTypeEnum.process_emissions: EmissionType.process_emissions,
+    # Purchases — single leaf per entry, rollup to category
+    DataEntryTypeEnum.scientific_equipment: EmissionType.purchases,
+    DataEntryTypeEnum.it_equipment: EmissionType.purchases,
+    DataEntryTypeEnum.consumable_accessories: EmissionType.purchases,
+    DataEntryTypeEnum.biological_chemical_gaseous_product: EmissionType.purchases,
+    DataEntryTypeEnum.services: EmissionType.purchases,
+    DataEntryTypeEnum.vehicles: EmissionType.purchases,
+    DataEntryTypeEnum.other_purchases: EmissionType.purchases,
+    DataEntryTypeEnum.additional_purchases: EmissionType.purchases,
+    # Research Facilities — single leaf, rollup to category
+    DataEntryTypeEnum.research_facilities: EmissionType.research_facilities,
+    DataEntryTypeEnum.mice_and_fish_animal_facilities: EmissionType.research_facilities,
+    # External Clouds — single leaf (service type), rollup to subcategory
+    DataEntryTypeEnum.external_clouds: EmissionType.external__clouds,
+    # External AI — single leaf (provider), rollup to subcategory
+    DataEntryTypeEnum.external_ai: EmissionType.external__ai,
 }
 
 # =============================================================================

--- a/backend/tests/unit/repositories/test_data_entry_emission_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_emission_repo.py
@@ -277,6 +277,7 @@ async def test_get_stats_by_emission_type(db_session: AsyncSession):
         DataEntryEmission(
             data_entry_id=entry.id,
             emission_type_id=EmissionType.professional_travel__plane__business,
+            scope=3,
             kg_co2eq=200.0,
         )
         for entry in plane_entries
@@ -286,6 +287,7 @@ async def test_get_stats_by_emission_type(db_session: AsyncSession):
         DataEntryEmission(
             data_entry_id=entry.id,
             emission_type_id=EmissionType.professional_travel__train__class_2,
+            scope=3,
             kg_co2eq=50.0,
         )
         for entry in train_entries
@@ -793,7 +795,8 @@ async def _seed_emission(db_session, module, name, kg):
     db_session.add(
         DataEntryEmission(
             data_entry_id=entry.id,
-            emission_type_id=EmissionType.equipment,
+            emission_type_id=EmissionType.equipment__scientific,
+            scope=2,
             kg_co2eq=kg,
         )
     )

--- a/docs/implementation-plans/root-level-rollup-emission-rows.md
+++ b/docs/implementation-plans/root-level-rollup-emission-rows.md
@@ -84,4 +84,76 @@ Add a **parent-level rollup `DataEntryEmission` row** per data entry that sums a
 ## Further Considerations
 
 1. **Data migration**: Existing `DataEntryEmission` rows in production won't have rollup rows. Options: (A) run a one-time migration script that recomputes all emissions (calls `upsert_by_data_entry` for every existing entry), or (B) add an Alembic data migration. Recommend (A) as a management command.
-2. **primary_factor on rollup**: The current `get_submodule_data` enriches response with `primary_factor.values` and `primary_factor.classification`. With rollup JOIN, `primary_factor_id` is `None`. Two options: (A) store the "representative" primary_factor_id on the rollup row (e.g., the first leaf's factor), or (B) keep a separate join for factor resolution. Recommend (A) — store `primary_factor_id` from the first leaf on the rollup for display purposes.
+
+/!\ SUPER IMPORTANT we need to fix it first 2. **primary_factor on rollup**: The current `get_submodule_data` enriches response with `primary_factor.values` and `primary_factor.classification`. With rollup JOIN, `primary_factor_id` is `None`. Two options: (A) store the "representative" primary_factor_id on the rollup row (e.g., the first leaf's factor), or (B) keep a separate join for factor resolution. Recommend (A) — store `primary_factor_id` from the first leaf on the rollup for display purposes.
+
+## FURTHER Information
+
+Looking at the `DATA_ENTRY_TO_EMISSION_TYPES` mapping, here are the `DataEntryTypeEnum` values that have **exactly one item** in their array (meaning they produce a single emission row per data entry):
+
+## Single Emission Type (No Rollup Logic Needed)
+
+**Energy Combustion:**
+
+- [`energy_combustion`](backend/app/models/data_entry.py) → [`EmissionType.buildings__combustion`](backend/app/models/data_entry_emission.py)
+
+**Equipment:**
+
+- [`scientific`](backend/app/models/data_entry.py) → [`EmissionType.equipment__scientific`](backend/app/models/data_entry_emission.py)
+- [`it`](backend/app/models/data_entry.py) → [`EmissionType.equipment__it`](backend/app/models/data_entry_emission.py)
+- [`other`](backend/app/models/data_entry.py) → [`EmissionType.equipment__other`](backend/app/models/data_entry_emission.py)
+
+**Purchases:**
+
+- [`scientific_equipment`](backend/app/models/data_entry.py) → [`EmissionType.purchases__scientific_equipment`](backend/app/models/data_entry_emission.py)
+- [`it_equipment`](backend/app/models/data_entry.py) → [`EmissionType.purchases__it_equipment`](backend/app/models/data_entry_emission.py)
+- [`consumable_accessories`](backend/app/models/data_entry.py) → [`EmissionType.purchases__consumable_accessories`](backend/app/models/data_entry_emission.py)
+- [`biological_chemical_gaseous_product`](backend/app/models/data_entry.py) → [`EmissionType.purchases__biological_chemical_gaseous`](backend/app/models/data_entry_emission.py)
+- [`services`](backend/app/models/data_entry.py) → [`EmissionType.purchases__services`](backend/app/models/data_entry_emission.py)
+- [`vehicles`](backend/app/models/data_entry.py) → [`EmissionType.purchases__vehicles`](backend/app/models/data_entry_emission.py)
+- [`other_purchases`](backend/app/models/data_entry.py) → [`EmissionType.purchases__other`](backend/app/models/data_entry_emission.py)
+- [`additional_purchases`](backend/app/models/data_entry.py) → [`EmissionType.purchases__additional`](backend/app/models/data_entry_emission.py)
+
+**Research Facilities:**
+
+- [`research_facilities`](backend/app/models/data_entry_emission.py) → [`EmissionType.research_facilities__facilities`](backend/app/models/data_entry_emission.py)
+- [`mice_and_fish_animal_facilities`](backend/app/models/data_entry.py) → [`EmissionType.research_facilities__animal`](backend/app/models/data_entry_emission.py)
+
+---
+
+## Multiple Emission Types (Need Rollup)
+
+**Headcount:**
+
+- [`member`](backend/app/models/data_entry.py), [`student`](backend/app/models/data_entry.py) → 4 types each (food, waste, commuting, grey_energy)
+
+**Buildings:**
+
+- [`building`](backend/app/models/data_entry.py) → 5 types (lighting, cooling, ventilation, heating_elec, heating_thermal)
+
+---
+
+## Runtime Resolved (None in Static Mapping)
+
+These are `None` in the static mapping and resolved at runtime:
+
+- [`plane`](backend/app/models/data_entry.py), [`train`](backend/app/models/data_entry.py) → resolved by cabin class
+- [`process_emissions`](backend/app/models/data_entry_emission.py) → resolved by gas type
+- [`external_clouds`](backend/app/models/data_entry.py) → resolved by service type
+- [`external_ai`](backend/app/models/data_entry.py) → resolved by provider (but has static fallback list)
+
+---
+
+**Summary:** 13 data entry types produce exactly **one emission row** per entry, so their rollup is straightforward (the rollup row equals the single leaf row).
+
+## Summary
+
+Identified the 13 `DataEntryTypeEnum` values that produce exactly one emission row per data entry (no rollup logic complexity needed):
+
+**Single emission types:** `energy_combustion`, `scientific`, `it`, `other`, `scientific_equipment`, `it_equipment`, `consumable_accessories`, `biological_chemical_gaseous_product`, `services`, `vehicles`, `other_purchases`, `additional_purchases`, `research_facilities`, `mice_and_fish_animal_facilities`
+
+**Multiple emission types (need rollup):** `member`, `student` (4 types each), `building` (5 types)
+
+**Runtime resolved:** `plane`, `train`, `process_emissions`, `external_clouds`, `external_ai`
+
+Task completed!

--- a/docs/implementation-plans/root-level-rollup-emission-rows.md
+++ b/docs/implementation-plans/root-level-rollup-emission-rows.md
@@ -1,0 +1,87 @@
+# Root Rollup Emission Rows for Sortable kg_co2eq
+
+## TL;DR
+
+Add a **parent-level rollup `DataEntryEmission` row** per data entry that sums all its leaf emissions. This enables direct `ORDER BY` on `kg_co2eq` via a simple JOIN (no subquery aggregation). The rollup emission_type_id is the parent node in the EmissionType tree (e.g., `buildings__rooms = 60100` for building entries). Identification: rollup rows are the ones whose `emission_type_id` matches the new `DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION` mapping.
+
+## Design Decisions
+
+- **No schema migration needed**: rollup rows are regular `DataEntryEmission` rows; identified by their non-leaf `emission_type_id` matching the mapping.
+- **Headcount excluded**: member/student don't show kg_co2eq in table. Their 4 root types (food, waste, commuting, grey_energy) have no shared parent. No rollup created.
+- **Single-leaf entries still get a rollup**: For consistency, entries with only 1 leaf emission (equipment, purchases, etc.) get a rollup row at their parent node. This keeps `get_submodule_data` uniform — always JOIN on the rollup emission_type_id, no conditional paths.
+- **Scope on rollup**: set to `None` — scope only meaningful on leaves for scope aggregation. Rollup rows must be excluded from scope sums.
+- **`primary_factor_id` on rollup**: set to `None` — it's an aggregate, not tied to one factor.
+- **`recompute_stats` unchanged**: it already queries by leaf `emission_type_id` and sums up the tree. Rollup rows won't interfere because `get_subtree_leaves()` only returns actual leaves.
+
+## Steps
+
+### Phase 1: Mapping (no dependencies)
+
+1. In `data_entry_emission_type_map.py`, add a new dict `DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION: dict[DataEntryTypeEnum, EmissionType | None]` mapping each `DataEntryTypeEnum` to its parent rollup EmissionType:
+   - `building` → `EmissionType.buildings__rooms` (60100)
+   - `energy_combustion` → `EmissionType.buildings` (60000) — parent of combustion
+   - `plane` → `EmissionType.professional_travel__plane` (50200)
+   - `train` → `EmissionType.professional_travel__train` (50100)
+   - `scientific` → `EmissionType.equipment` (80000)
+   - `it` → `EmissionType.equipment` (80000)
+   - `other` → `EmissionType.equipment` (80000)
+   - `process_emissions` → `EmissionType.process_emissions` (70000)
+   - `external_clouds` → `EmissionType.external__clouds` (110100)
+   - `external_ai` → `EmissionType.external__ai` (110200)
+   - All purchase types → `EmissionType.purchases` (90000)
+   - `research_facilities` → `EmissionType.research_facilities` (100000)
+   - `mice_and_fish_animal_facilities` → `EmissionType.research_facilities` (100000)
+   - `member` → `None` (no rollup)
+   - `student` → `None` (no rollup)
+
+### Phase 2: Emission Compute (_depends on Phase 1_)
+
+2. In `DataEntryEmissionService.prepare_create()` (`data_entry_emission_service.py`):
+   - After computing all leaf emissions, look up `DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION[data_entry_type]`
+   - If not `None`, create one additional `DataEntryEmission` row:
+     - `emission_type_id` = rollup EmissionType value
+     - `kg_co2eq` = sum of all leaf emissions' kg_co2eq
+     - `scope` = `None`
+     - `primary_factor_id` = `None`
+     - `meta` = `{"is_rollup": True, "leaf_emission_type_ids": [...]}`
+   - Append to the returned list (gets persisted by existing `bulk_create`)
+
+### Phase 3: Query Simplification (_depends on Phase 2_)
+
+3. In `get_submodule_data()` (`data_entry_repo.py`):
+   - Replace the `emission_agg` subquery with a direct JOIN on `DataEntryEmission` filtered to the rollup `emission_type_id` for this `data_entry_type_id`
+   - Import and use `DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION` to get the rollup emission_type_id
+   - For headcount (rollup is `None`): keep existing subquery approach or skip kg_co2eq join entirely
+   - Update sort_map override: `sort_map["kg_co2eq"] = DataEntryEmission.kg_co2eq` now works directly since there's exactly 1 row per data_entry in the join
+   - The `primary_factor` join changes: currently it piggybacks on `emission_agg.c.primary_factor_id`. With rollup, this needs to come from the rollup row or from a separate leaf emission join. Since rollup has `primary_factor_id = None`, keep a separate subquery/join for factor (using `func.min(DataEntryEmission.primary_factor_id)` filtered to leaf rows), OR store the primary_factor_id on the rollup meta.
+
+### Phase 4: Stats Safety (_parallel with Phase 3_)
+
+4. In `compute_module_stats()` (`carbon_report_module_service.py`):
+   - Verify rollup rows don't cause double-counting. Current `get_stats()` aggregates by `emission_type_id`. If it sums all emission_type_ids, rollup nodes will be included → double-count.
+   - Fix: filter `get_stats()` query to exclude rollup emission_type_ids, OR rely on the existing logic that only uses leaf values from `EMISSION_SCOPE` (which doesn't include rollup types → they'd be ignored in scope sums).
+   - Verify `by_emission_type` in the stats JSON: the existing code already computes rollups in-memory via `get_subtree_leaves()`. Having rollup rows in DB shouldn't affect this IF the aggregation query groups by `emission_type_id` — the rollup type IDs would just appear as extra keys. Confirm they're harmless or filter them out.
+
+## Relevant Files
+
+- `backend/app/utils/data_entry_emission_type_map.py` — add `DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION` dict
+- `backend/app/services/data_entry_emission_service.py` — modify `prepare_create()` to append rollup row
+- `backend/app/repositories/data_entry_repo.py` — simplify `get_submodule_data()` query
+- `backend/app/services/carbon_report_module_service.py` — verify `compute_module_stats()` / `get_stats()` doesn't double-count
+- `backend/app/repositories/data_entry_emission_repo.py` — verify `get_stats()` query shape
+- All handler `sort_map` entries for `kg_co2eq` — now `DataEntryEmission.kg_co2eq` works directly (no change needed if query is rewritten)
+- `backend/app/services/data_ingestion/base_csv_provider.py` — bulk import path also calls `prepare_create()`, so rollup rows are automatically included
+
+## Verification
+
+1. Write a unit test for `prepare_create()`: given a building data_entry with 5 leaf emissions, verify 6 rows returned (5 leaves + 1 rollup at `buildings__rooms`), rollup `kg_co2eq` equals sum of leaves.
+2. Write a unit test for single-leaf entry (e.g., equipment): verify 2 rows returned (1 leaf + 1 rollup at `equipment`), both with same `kg_co2eq`.
+3. Write a unit test for headcount: verify no rollup row created.
+4. Verify sorting: hit `GET /submodule_data?sort_by=kg_co2eq&sort_order=asc` for buildings and equipment — confirm correct ordering.
+5. Verify `recompute_stats()` doesn't double-count: create entries, recompute, check scope totals match expected.
+6. Run existing test suite (`make test` in backend/).
+
+## Further Considerations
+
+1. **Data migration**: Existing `DataEntryEmission` rows in production won't have rollup rows. Options: (A) run a one-time migration script that recomputes all emissions (calls `upsert_by_data_entry` for every existing entry), or (B) add an Alembic data migration. Recommend (A) as a management command.
+2. **primary_factor on rollup**: The current `get_submodule_data` enriches response with `primary_factor.values` and `primary_factor.classification`. With rollup JOIN, `primary_factor_id` is `None`. Two options: (A) store the "representative" primary_factor_id on the rollup row (e.g., the first leaf's factor), or (B) keep a separate join for factor resolution. Recommend (A) — store `primary_factor_id` from the first leaf on the rollup for display purposes.


### PR DESCRIPTION
## Summary

Add parent-level rollup `DataEntryEmission` rows that aggregate leaf emissions per data entry. This enables direct `ORDER BY` on `kg_co2eq` via a simple JOIN instead of subquery aggregation.

@charlottegiseleweil  we need this to be able to sort by kg_co2eq now it was not the case before sprint 6

## Changes

- **New mapping**: `DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION` in `data_entry_emission_type_map.py` — maps each `DataEntryTypeEnum` to its parent rollup `EmissionType` (only `building` currently has a multi-leaf rollup)
- **Rollup row creation**: `prepare_create()` in `data_entry_emission_service.py` appends a rollup `DataEntryEmission` row with `scope=None` after computing leaf emissions
- **Query simplification**: `get_submodule_data()` in `data_entry_repo.py` now uses a direct JOIN on the rollup/leaf emission row via `aliased(DataEntryEmission)`, making `sort_map["kg_co2eq"]` work correctly
- **Double-count prevention**: Added `scope IS NOT NULL` filter to 4 aggregation queries in `data_entry_emission_repo.py`
- **Test fixes**: Updated test fixtures to include `scope` values

## Design Decisions

- Rollup rows identified by `scope=None` (no schema migration needed)
- Headcount modules excluded (no kg_co2eq in table)
- Single-leaf entries don't need a separate rollup row
- See [implementation plan](docs/implementation-plans/root-level-rollup-emission-rows.md) for full details

## TODO

- [ ] Data migration script for existing production data (recompute emissions for all building entries)
