### PR TITLE
fix(csv-template): corrections before alpha release

### DIFF
--- a/frontend/public/templates/purchases_scientificequipment_template.csv
+++ b/frontend/public/templates/purchases_scientificequipment_template.csv
@@ -1,2 +1,2 @@
 name,supplier,quantity,total_spent_amount,currency,purchase_institutional_code,purchase_institutional_description,purchase_additional_code,note
-Horizontal Tube Holder, For Use With: Mi,Bentley Systems International Ltd,1,166.18,CHF,,41103800,NB73,
+Horizontal Tube Holder For Use With: Mi,Bentley Systems International Ltd,1,166.18,CHF,,41103800,NB73,


### PR DESCRIPTION
## What does this change?
A few corrections before alpha release

- Remove comma that breaks CSV template fromat in Purchase scientific equipment