### PR TITLE
chore(CICD): test trivy image scan cron

### DIFF
--- a/.github/workflows/image-vulnerability-scan.yml
+++ b/.github/workflows/image-vulnerability-scan.yml
@@ -1,0 +1,112 @@
+name: Registry Vulnerability Scan
+
+on:
+  # push:
+  #   branches:
+  #     - chore/456-scan-image-cron # Test action
+  schedule:
+    - cron: "0 3 * * 0" # Every Sunday at 3:00 AM
+
+  workflow_dispatch:
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  PACKAGE: epfl-enac/epfl/co2-calculator
+
+jobs:
+  scan-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+      issues: write
+
+    strategy:
+      matrix:
+        image: [frontend, backend]
+
+    steps:
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq wget
+
+          wget -qO- https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo "deb https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
+
+          curl -sL https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz \
+          | tar xz crane
+          sudo mv crane /usr/local/bin/
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Get tags from GHCR
+        run: |
+          crane ls ghcr.io/${{ env.PACKAGE }}/${{ matrix.image }} | grep -E 'stage|^v' > tags.txt
+
+      - name: List tags without issues
+        run: |
+          while read tag; do
+
+            digest=$(crane digest ghcr.io/${{ env.PACKAGE }}/${{ matrix.image }}:$tag)
+
+            if gh issue list \
+                --repo ${{ github.repository }} \
+                --search "in:title '🚨 Vulnerabilities in ghcr image ${{ matrix.image }}:$tag $digest'" | grep -q "$tag"; then
+              echo "Issue already exists for ${{ matrix.image }}:$tag  $digest, skipping"
+            else
+              echo "$tag@$digest" >> tags-to-scan.txt
+            fi
+          done < tags.txt
+
+      - name: Scan images
+        run: |
+          IMAGE="ghcr.io/${{ env.PACKAGE }}/${{ matrix.image }}"
+          mkdir -p reports
+
+          if [ ! -f tags-to-scan.txt ]; then
+            echo "No tags to scan"
+            exit 0
+          fi
+
+          echo "Tags to scan:"
+          cat tags-to-scan.txt
+
+          while read tagdigest; do
+            tag=$(echo $tagdigest | cut -d'@' -f1)
+            digest=$(echo $tagdigest | cut -d'@' -f2)
+            if ! trivy image \
+              --severity HIGH,CRITICAL \
+              --exit-code 1 \
+              --format table \
+              $IMAGE@$digest > reports/$tagdigest.txt
+            then
+              echo "$tagdigest" >> vulnerable-tags.txt
+            fi
+          done < tags-to-scan.txt
+
+      - name: Create issues
+        if: always()
+        run: |
+          if [ ! -f vulnerable-tags.txt ]; then
+            echo "No vulnerabilities"
+            exit 0
+          fi
+
+          while read tagdigest; do
+            tag=$(echo $tagdigest | cut -d'@' -f1)
+            digest=$(echo $tagdigest | cut -d'@' -f2)
+            echo "🚨 Vulnerabilities in ghcr image ${{ matrix.image }}:$tag $digest" > issue.txt
+            echo "\`\`\`txt" >> issue.txt
+            cat reports/$tagdigest.txt >> issue.txt
+            echo "\`\`\`" >> issue.txt
+
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "🚨 Vulnerabilities in ghcr image ${{ matrix.image }}:$tag $digest" \
+              --body-file issue.txt
+
+          done < vulnerable-tags.txt


### PR DESCRIPTION
## What does this change?

Add cron github action to scan image vulnerabilities and create issues in case of problem

## Why is this needed?

Do not keep vulnerable images

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #456

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
