### PR TITLE
feat(175): added emissions formulas for research facilities commons and animals

### DIFF
--- a/backend/app/modules/__init__.py
+++ b/backend/app/modules/__init__.py
@@ -21,9 +21,15 @@ from app.modules.professional_travel.schemas import (
     ProfessionalTravelTrainHandlerCreate,
 )
 from app.modules.purchase.schemas import (
+    PurchaseAdditionalHandlerCreate,
     PurchaseHandlerCreate,
 )
-from app.modules.research_facilities.schemas import ResearchFacilitiesHandlerCreate
+from app.modules.research_facilities.animals_schemas import (
+    ResearchFacilitiesAnimalHandlerCreate,
+)
+from app.modules.research_facilities.common_schemas import (
+    ResearchFacilitiesCommonHandlerCreate,
+)
 
 __all__ = [
     "BuildingRoomHandlerCreate",
@@ -39,5 +45,7 @@ __all__ = [
     "ProfessionalTravelPlaneHandlerCreate",
     "ProfessionalTravelTrainHandlerCreate",
     "PurchaseHandlerCreate",
-    "ResearchFacilitiesHandlerCreate",
+    "PurchaseAdditionalHandlerCreate",
+    "ResearchFacilitiesCommonHandlerCreate",
+    "ResearchFacilitiesAnimalHandlerCreate",
 ]

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -22,6 +22,7 @@ from app.schemas.factor import (
     FactorResponseGen,
     FactorUpdate,
 )
+from app.services.exchange_rates_service import ExchangeRatesService
 
 logger = get_logger(__name__)
 
@@ -224,12 +225,43 @@ class ExternalCloudModuleHandler(BaseModuleHandler):
         factor_id = ctx.get("primary_factor_id")
         if factor_id is None:
             return []
+
+        # Get the year from the carbon report associated with the module,
+        # to ensure we get the correct exchange rate for the year
+        # of the purchase
+        year = ctx.get("_year")
+
+        def _cloud_formula(ctx: dict, factor_values: dict) -> Optional[float]:
+            if year is None:
+                return None
+
+            spent_amount = ctx.get("spent_amount")
+            entry_currency = (ctx.get("currency", "") or "eur").lower()
+            ef = factor_values.get("ef_kg_co2eq_per_currency")
+            ef_currency = (factor_values.get("currency", "eur") or "eur").lower()
+            if spent_amount is None or ef is None:
+                return None
+
+            spent_amount_eur = spent_amount
+            if entry_currency != "eur":
+                exchange_rate = ExchangeRatesService().get_exchange_rate_to_eur(
+                    year, entry_currency
+                )
+                spent_amount_eur = spent_amount * exchange_rate
+            ef_eur = ef
+            if ef_currency != "eur":
+                exchange_rate = ExchangeRatesService().get_exchange_rate_to_eur(
+                    year, ef_currency
+                )
+                ef_eur = ef * exchange_rate
+
+            return spent_amount_eur * ef_eur
+
         return [
             EmissionComputation(
                 emission_type=emission_type,
                 factor_id=int(factor_id),
-                formula_key="ef_kg_co2eq_per_currency",
-                quantity_key="spent_amount",
+                formula_func=_cloud_formula,
             )
         ]
 

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -226,12 +226,10 @@ class ExternalCloudModuleHandler(BaseModuleHandler):
         if factor_id is None:
             return []
 
-        # Get the year from the carbon report associated with the module,
-        # to ensure we get the correct exchange rate for the year
-        # of the purchase
-        year = ctx.get("_year")
-
         def _cloud_formula(ctx: dict, factor_values: dict) -> Optional[float]:
+            # Get the year to ensure we get the correct exchange rate for the year
+            # of the purchase
+            year = ctx.get("_year")
             if year is None:
                 return None
 

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -22,6 +22,7 @@ from app.schemas.factor import (
     FactorResponseGen,
     FactorUpdate,
 )
+from app.services.exchange_rates_service import ExchangeRatesService
 
 logger = get_logger(__name__)
 
@@ -222,12 +223,48 @@ class PurchaseModuleHandler(BaseModuleHandler):
         factor_id = ctx.get("primary_factor_id")
         if factor_id is None:
             return []
+
+        # Get the year from the carbon report associated with the module,
+        # to ensure we get the correct exchange rate for the year
+        # of the purchase
+        year = ctx.get("_year")
+
+        def _purchase_formula(ctx: dict, factor_values: dict) -> Optional[float]:
+            if year is None:
+                return None
+
+            total_spent_amount = ctx.get("total_spent_amount", 0)
+            entry_currency = (ctx.get("currency", "chf") or "chf").lower()
+            ef = factor_values.get("ef_kg_co2eq_per_currency", 0)
+            ef_currency = (factor_values.get("currency", "eur") or "eur").lower()
+            if total_spent_amount is None or ef is None:
+                return None
+
+            # Use the exchange rate service to convert the total
+            # spent amount to the eur currency
+            total_spent_amount_eur = total_spent_amount
+            if entry_currency != "eur":
+                exchange_rate = ExchangeRatesService().get_exchange_rate_to_eur(
+                    year, entry_currency
+                )
+                total_spent_amount_eur = total_spent_amount * exchange_rate
+            # Similarly, convert the emission factor to eur if it's in a different
+            # currency, so that the final kg_co2eq is correctly computed in relation
+            # to the total spent amount in eur
+            ef_eur = ef
+            if ef_currency != "eur":
+                exchange_rate = ExchangeRatesService().get_exchange_rate_to_eur(
+                    year, ef_currency
+                )
+                ef_eur = ef * exchange_rate
+
+            return total_spent_amount_eur * ef_eur
+
         return [
             EmissionComputation(
                 emission_type=emission_type,
                 factor_id=int(factor_id),
-                formula_key="ef_kg_co2eq_per_currency",
-                quantity_key="total_spent_amount",
+                formula_func=_purchase_formula,
             )
         ]
 

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -224,12 +224,10 @@ class PurchaseModuleHandler(BaseModuleHandler):
         if factor_id is None:
             return []
 
-        # Get the year from the carbon report associated with the module,
-        # to ensure we get the correct exchange rate for the year
-        # of the purchase
-        year = ctx.get("_year")
-
         def _purchase_formula(ctx: dict, factor_values: dict) -> Optional[float]:
+            # Get the year to ensure we get the correct exchange rate for the year
+            # of the purchase
+            year = ctx.get("_year")
             if year is None:
                 return None
 

--- a/backend/app/modules/research_facilities/__init__.py
+++ b/backend/app/modules/research_facilities/__init__.py
@@ -1,2 +1,3 @@
 # This ensures the handlers are registered.
-from . import schemas as schemas
+from . import animals_schemas as animals_schemas
+from . import common_schemas as common_schemas

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -29,7 +29,7 @@ logger = get_logger(__name__)
 
 
 class ResearchFacilitiesAnimalHandlerResponse(DataEntryResponseGen):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use: Optional[float] = None
     use_unit: Optional[str] = None
@@ -38,7 +38,7 @@ class ResearchFacilitiesAnimalHandlerResponse(DataEntryResponseGen):
 
 
 class ResearchFacilitiesAnimalHandlerCreate(DataEntryCreate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use: Optional[float] = None
     use_unit: Optional[str] = None
@@ -46,7 +46,7 @@ class ResearchFacilitiesAnimalHandlerCreate(DataEntryCreate):
 
 
 class ResearchFacilitiesAnimalHandlerUpdate(DataEntryUpdate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use: Optional[float] = None
     use_unit: Optional[str] = None
@@ -184,10 +184,10 @@ research_facilities_animal_value_fields: list[str] = [
 
 
 class ResearchFacilitiesAnimalFactorCreate(FactorCreate):
-    researchfacility_id: Optional[int] = None
-    researchfacility_name: str
-    researchfacility_type: str
-    use_unit: str
+    researchfacility_id: Optional[str] = None
+    researchfacility_name: Optional[str] = None
+    researchfacility_type: Optional[str] = None
+    use_unit: Optional[str] = None
     processemissions_share: Optional[float] = None
     building_energycombustions_share: Optional[float] = None
     building_rooms_share: Optional[float] = None
@@ -200,7 +200,14 @@ class ResearchFacilitiesAnimalFactorCreate(FactorCreate):
     kg_co2eq_sum_purchases_common: Optional[float] = None
     kg_co2eq_sum_purchases_additional: Optional[float] = None
     kg_co2eq_sum_equipments: Optional[float] = None
-    total_use: float
+    total_use: Optional[float] = None
+
+    @field_validator("researchfacility_id", mode="before")
+    @classmethod
+    def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
 
     @field_validator("total_use", mode="after")
     @classmethod
@@ -228,7 +235,7 @@ class ResearchFacilitiesAnimalFactorCreate(FactorCreate):
 
 
 class ResearchFacilitiesAnimalFactorUpdate(FactorUpdate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     researchfacility_type: Optional[str] = None
     use_unit: Optional[str] = None
@@ -246,9 +253,16 @@ class ResearchFacilitiesAnimalFactorUpdate(FactorUpdate):
     kg_co2eq_sum_equipments: Optional[float] = None
     total_use: Optional[float] = None
 
+    @field_validator("researchfacility_id", mode="before")
+    @classmethod
+    def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
+
 
 class ResearchFacilitiesAnimalFactorResponse(FactorResponseGen):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: str
     researchfacility_type: Optional[str] = None
     use_unit: str
@@ -265,6 +279,13 @@ class ResearchFacilitiesAnimalFactorResponse(FactorResponseGen):
     kg_co2eq_sum_purchases_additional: Optional[float] = None
     kg_co2eq_sum_equipments: Optional[float] = None
     total_use: Optional[float] = None
+
+    @field_validator("researchfacility_id", mode="before")
+    @classmethod
+    def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
 
 
 class ResearchFacilitiesAnimalFactorHandler(BaseFactorHandler):

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -164,7 +164,6 @@ research_facilities_animal_classification_fields: list[str] = [
     "researchfacility_id",
     "researchfacility_name",
     "researchfacility_type",
-    "use_unit",
 ]
 research_facilities_animal_value_fields: list[str] = [
     "processemissions_share",
@@ -179,6 +178,7 @@ research_facilities_animal_value_fields: list[str] = [
     "kg_co2eq_sum_purchases_common",
     "kg_co2eq_sum_purchases_additional",
     "kg_co2eq_sum_equipments",
+    "use_unit",
     "total_use",
 ]
 

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -28,41 +28,48 @@ from app.schemas.factor import (
 logger = get_logger(__name__)
 
 
-class ResearchFacilitiesHandlerResponse(DataEntryResponseGen):
-    name: Optional[str] = None
+class ResearchFacilitiesAnimalHandlerResponse(DataEntryResponseGen):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use: Optional[float] = None
+    use_unit: Optional[str] = None
     note: Optional[str] = None
     kg_co2eq: Optional[float] = None
 
 
-class ResearchFacilitiesHandlerCreate(DataEntryCreate):
-    name: Optional[str] = None
+class ResearchFacilitiesAnimalHandlerCreate(DataEntryCreate):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use: Optional[float] = None
+    use_unit: Optional[str] = None
     note: Optional[str] = None
 
 
-class ResearchFacilitiesHandlerUpdate(DataEntryUpdate):
-    name: Optional[str] = None
+class ResearchFacilitiesAnimalHandlerUpdate(DataEntryUpdate):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use: Optional[float] = None
+    use_unit: Optional[str] = None
     note: Optional[str] = None
 
 
-class ResearchFacilitiesModuleHandler(BaseModuleHandler):
-    """Handler for research facilities data entries (Strategy A — primary_factor_id).
-
-    Formula: TBD (returns None until factors and a formula are defined).
+class ResearchFacilitiesAnimalModuleHandler(BaseModuleHandler):
+    """Handler for research facilities data entries related
+    to mice and fish animal facilities.
     """
 
     module_type: ModuleTypeEnum = ModuleTypeEnum.research_facilities
     data_entry_type: DataEntryTypeEnum | None = None
     registration_keys = [
-        DataEntryTypeEnum.research_facilities,
         DataEntryTypeEnum.mice_and_fish_animal_facilities,
     ]
 
-    create_dto = ResearchFacilitiesHandlerCreate
-    update_dto = ResearchFacilitiesHandlerUpdate
-    response_dto = ResearchFacilitiesHandlerResponse
+    create_dto = ResearchFacilitiesAnimalHandlerCreate
+    update_dto = ResearchFacilitiesAnimalHandlerUpdate
+    response_dto = ResearchFacilitiesAnimalHandlerResponse
 
-    kind_field: Optional[str] = None
-    subkind_field: Optional[str] = None
+    kind_field: str = "researchfacility_id"
+    subkind_field: str = "researchfacility_type"
     require_subkind_for_factor = False
 
     sort_map = {
@@ -72,7 +79,9 @@ class ResearchFacilitiesModuleHandler(BaseModuleHandler):
 
     filter_map: dict = {}
 
-    def to_response(self, data_entry: DataEntry) -> ResearchFacilitiesHandlerResponse:
+    def to_response(
+        self, data_entry: DataEntry
+    ) -> ResearchFacilitiesAnimalHandlerResponse:
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
@@ -82,85 +91,72 @@ class ResearchFacilitiesModuleHandler(BaseModuleHandler):
             }
         )
 
-    def validate_create(self, payload: dict) -> ResearchFacilitiesHandlerCreate:
+    def validate_create(self, payload: dict) -> ResearchFacilitiesAnimalHandlerCreate:
         return self.create_dto.model_validate(payload)
 
-    def validate_update(self, payload: dict) -> ResearchFacilitiesHandlerUpdate:
+    def validate_update(self, payload: dict) -> ResearchFacilitiesAnimalHandlerUpdate:
         return self.update_dto.model_validate(payload)
 
     def resolve_computations(self, data_entry, emission_type, ctx: dict) -> list:
-        """Strategy A — primary_factor_id. Formula TBD; returns empty until defined."""
+        """Strategy A — primary_factor_id."""
 
         factor_id = ctx.get("primary_factor_id")
         if factor_id is None:
             return []
+
+        def _research_facilities_formula(
+            ctx: dict, factor_values: dict
+        ) -> Optional[float]:
+            """
+            Compute emissions based on share of use of the facility compared
+            to total use.
+            Formula: (use / total_use) * kg_co2eq_sum, for each sources,
+            with unit check on use_unit.
+            """
+            use = ctx.get("use")
+            use_unit = ctx.get("use_unit")
+            if use is None or use_unit is None:
+                return None
+            # Must be same unit for the factor and the data entry to apply the formula
+            use_unit_factor = factor_values.get("use_unit")
+            if use_unit != use_unit_factor:
+                return None
+            # Compute share of use and apply to each source emissions
+            # and sum them up.
+            total_use = factor_values.get("total_use")
+            if total_use is None:
+                return None
+            sources = [
+                "processemissions",
+                "building_energycombustions",
+                "building_rooms",
+                "purchases_common",
+                "purchases_additional",
+                "equipments",
+            ]
+            kg_co2eq_sum = None
+            for source in sources:
+                source_share = factor_values.get(f"{source}_share")
+                kg_co2eq_sum_source = factor_values.get(f"kg_co2eq_sum_{source}")
+                if source_share is None or kg_co2eq_sum_source is None:
+                    continue
+                if kg_co2eq_sum is None:
+                    kg_co2eq_sum = 0
+                kg_co2eq_sum += (
+                    use * source_share / total_use if total_use > 0 else 0
+                ) * kg_co2eq_sum_source
+            return kg_co2eq_sum
+
         return [
             EmissionComputation(
                 emission_type=emission_type,
                 factor_id=int(factor_id),
-                # Formula TBD — no emission rows until factors are defined
+                formula_func=_research_facilities_formula,
             )
         ]
 
 
 ## RESEARCH FACILITIES FACTOR HANDLERS
-
-# --- Common (research_facilities) ---
-
-research_facilities_common_classification_fields: list[str] = [
-    "researchfacility_id",
-    "researchfacility_name",
-    "use_unit",
-]
-research_facilities_common_value_fields: list[str] = [
-    "kg_co2eq_sum",
-    "total_use",
-]
-
-
-class ResearchFacilitiesCommonFactorCreate(FactorCreate):
-    researchfacility_id: Optional[int] = None
-    researchfacility_name: str
-    use_unit: str
-    kg_co2eq_sum: Optional[float] = None
-    total_use: float
-
-    @field_validator("total_use", mode="after")
-    @classmethod
-    def validate_total_use(cls, v: float) -> float:
-        if v < 0:
-            raise ValueError("total_use must be non-negative")
-        return v
-
-
-class ResearchFacilitiesCommonFactorUpdate(FactorUpdate):
-    researchfacility_id: Optional[int] = None
-    researchfacility_name: Optional[str] = None
-    use_unit: Optional[str] = None
-    kg_co2eq_sum: Optional[float] = None
-    total_use: Optional[float] = None
-
-
-class ResearchFacilitiesCommonFactorResponse(FactorResponseGen):
-    researchfacility_id: Optional[int] = None
-    researchfacility_name: str
-    use_unit: str
-    kg_co2eq_sum: Optional[float] = None
-    total_use: Optional[float] = None
-
-
-class ResearchFacilitiesCommonFactorHandler(BaseFactorHandler):
-    data_entry_type: DataEntryTypeEnum | None = None
-    registration_keys = [DataEntryTypeEnum.research_facilities]
-    emission_type = EmissionType.research_facilities__facilities
-
-    create_dto = ResearchFacilitiesCommonFactorCreate
-    update_dto = ResearchFacilitiesCommonFactorUpdate
-    response_dto = ResearchFacilitiesCommonFactorResponse
-
-    classification_fields: list[str] = research_facilities_common_classification_fields
-    value_fields: list[str] = research_facilities_common_value_fields
-
 
 # --- Animal (mice_and_fish_animal_facilities) ---
 
@@ -177,7 +173,12 @@ research_facilities_animal_value_fields: list[str] = [
     "purchases_common_share",
     "purchases_additional_share",
     "equipments_share",
-    "kg_co2eq_sum",
+    "kg_co2eq_sum_processemissions",
+    "kg_co2eq_sum_building_energycombustions",
+    "kg_co2eq_sum_building_rooms",
+    "kg_co2eq_sum_purchases_common",
+    "kg_co2eq_sum_purchases_additional",
+    "kg_co2eq_sum_equipments",
     "total_use",
 ]
 
@@ -193,7 +194,12 @@ class ResearchFacilitiesAnimalFactorCreate(FactorCreate):
     purchases_common_share: Optional[float] = None
     purchases_additional_share: Optional[float] = None
     equipments_share: Optional[float] = None
-    kg_co2eq_sum: Optional[float] = None
+    kg_co2eq_sum_processemissions: Optional[float] = None
+    kg_co2eq_sum_building_energycombustions: Optional[float] = None
+    kg_co2eq_sum_building_rooms: Optional[float] = None
+    kg_co2eq_sum_purchases_common: Optional[float] = None
+    kg_co2eq_sum_purchases_additional: Optional[float] = None
+    kg_co2eq_sum_equipments: Optional[float] = None
     total_use: float
 
     @field_validator("total_use", mode="after")
@@ -232,7 +238,12 @@ class ResearchFacilitiesAnimalFactorUpdate(FactorUpdate):
     purchases_common_share: Optional[float] = None
     purchases_additional_share: Optional[float] = None
     equipments_share: Optional[float] = None
-    kg_co2eq_sum: Optional[float] = None
+    kg_co2eq_sum_processemissions: Optional[float] = None
+    kg_co2eq_sum_building_energycombustions: Optional[float] = None
+    kg_co2eq_sum_building_rooms: Optional[float] = None
+    kg_co2eq_sum_purchases_common: Optional[float] = None
+    kg_co2eq_sum_purchases_additional: Optional[float] = None
+    kg_co2eq_sum_equipments: Optional[float] = None
     total_use: Optional[float] = None
 
 
@@ -247,7 +258,12 @@ class ResearchFacilitiesAnimalFactorResponse(FactorResponseGen):
     purchases_common_share: Optional[float] = None
     purchases_additional_share: Optional[float] = None
     equipments_share: Optional[float] = None
-    kg_co2eq_sum: Optional[float] = None
+    kg_co2eq_sum_processemissions: Optional[float] = None
+    kg_co2eq_sum_building_energycombustions: Optional[float] = None
+    kg_co2eq_sum_building_rooms: Optional[float] = None
+    kg_co2eq_sum_purchases_common: Optional[float] = None
+    kg_co2eq_sum_purchases_additional: Optional[float] = None
+    kg_co2eq_sum_equipments: Optional[float] = None
     total_use: Optional[float] = None
 
 

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -29,28 +29,49 @@ logger = get_logger(__name__)
 
 
 class ResearchFacilitiesCommonHandlerResponse(DataEntryResponseGen):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use: Optional[float] = None
     use_unit: Optional[str] = None
     note: Optional[str] = None
     kg_co2eq: Optional[float] = None
 
+    @field_validator("researchfacility_id", mode="before")
+    @classmethod
+    def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
+
 
 class ResearchFacilitiesCommonHandlerCreate(DataEntryCreate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use: Optional[float] = None
     use_unit: Optional[str] = None
     note: Optional[str] = None
+
+    @field_validator("researchfacility_id", mode="before")
+    @classmethod
+    def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
 
 
 class ResearchFacilitiesCommonHandlerUpdate(DataEntryUpdate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use: Optional[float] = None
     use_unit: Optional[str] = None
     note: Optional[str] = None
+
+    @field_validator("researchfacility_id", mode="before")
+    @classmethod
+    def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
 
 
 class ResearchFacilitiesCommonModuleHandler(BaseModuleHandler):
@@ -149,7 +170,7 @@ research_facilities_common_value_fields: list[str] = [
 
 
 class ResearchFacilitiesCommonFactorCreate(FactorCreate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: str
     use_unit: str
     kg_co2eq_sum: Optional[float] = None
@@ -164,7 +185,7 @@ class ResearchFacilitiesCommonFactorCreate(FactorCreate):
 
 
 class ResearchFacilitiesCommonFactorUpdate(FactorUpdate):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: Optional[str] = None
     use_unit: Optional[str] = None
     kg_co2eq_sum: Optional[float] = None
@@ -181,7 +202,7 @@ class ResearchFacilitiesCommonFactorUpdate(FactorUpdate):
 
 
 class ResearchFacilitiesCommonFactorResponse(FactorResponseGen):
-    researchfacility_id: Optional[int] = None
+    researchfacility_id: Optional[str] = None
     researchfacility_name: str
     use_unit: str
     kg_co2eq_sum: Optional[float] = None

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -1,0 +1,192 @@
+"""Research Facilities module handler."""
+
+from typing import Optional
+
+from pydantic import field_validator
+
+from app.core.logging import get_logger
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import (
+    DataEntryEmission,
+    EmissionComputation,
+    EmissionType,
+)
+from app.models.module_type import ModuleTypeEnum
+from app.schemas.data_entry import (
+    BaseModuleHandler,
+    DataEntryCreate,
+    DataEntryResponseGen,
+    DataEntryUpdate,
+)
+from app.schemas.factor import (
+    BaseFactorHandler,
+    FactorCreate,
+    FactorResponseGen,
+    FactorUpdate,
+)
+
+logger = get_logger(__name__)
+
+
+class ResearchFacilitiesCommonHandlerResponse(DataEntryResponseGen):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use: Optional[float] = None
+    use_unit: Optional[str] = None
+    note: Optional[str] = None
+    kg_co2eq: Optional[float] = None
+
+
+class ResearchFacilitiesCommonHandlerCreate(DataEntryCreate):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use: Optional[float] = None
+    use_unit: Optional[str] = None
+    note: Optional[str] = None
+
+
+class ResearchFacilitiesCommonHandlerUpdate(DataEntryUpdate):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use: Optional[float] = None
+    use_unit: Optional[str] = None
+    note: Optional[str] = None
+
+
+class ResearchFacilitiesCommonModuleHandler(BaseModuleHandler):
+    """Handler for common research facilities data entries."""
+
+    module_type: ModuleTypeEnum = ModuleTypeEnum.research_facilities
+    data_entry_type: DataEntryTypeEnum | None = None
+    registration_keys = [
+        DataEntryTypeEnum.research_facilities,
+    ]
+
+    create_dto = ResearchFacilitiesCommonHandlerCreate
+    update_dto = ResearchFacilitiesCommonHandlerUpdate
+    response_dto = ResearchFacilitiesCommonHandlerResponse
+
+    kind_field: str = "researchfacility_id"
+    subkind_field: Optional[str] = None
+    require_subkind_for_factor = False
+
+    sort_map = {
+        "id": DataEntry.id,
+        "kg_co2eq": DataEntryEmission.kg_co2eq,
+    }
+
+    filter_map: dict = {}
+
+    def to_response(
+        self, data_entry: DataEntry
+    ) -> ResearchFacilitiesCommonHandlerResponse:
+        return self.response_dto.model_validate(
+            {
+                "id": data_entry.id,
+                "data_entry_type_id": data_entry.data_entry_type_id,
+                "carbon_report_module_id": data_entry.carbon_report_module_id,
+                **data_entry.data,
+            }
+        )
+
+    def validate_create(self, payload: dict) -> ResearchFacilitiesCommonHandlerCreate:
+        return self.create_dto.model_validate(payload)
+
+    def validate_update(self, payload: dict) -> ResearchFacilitiesCommonHandlerUpdate:
+        return self.update_dto.model_validate(payload)
+
+    def resolve_computations(self, data_entry, emission_type, ctx: dict) -> list:
+        """Strategy A — primary_factor_id."""
+
+        factor_id = ctx.get("primary_factor_id")
+        if factor_id is None:
+            return []
+
+        def _research_facilities_formula(
+            ctx: dict, factor_values: dict
+        ) -> Optional[float]:
+            """
+            Formula: (use / total_use) * kg_co2eq_sum, with unit check on use_unit.
+            """
+            use = ctx.get("use")
+            use_unit = ctx.get("use_unit")
+            if use is None or use_unit is None:
+                return None
+            # Must be same unit for the factor and the data entry to apply the formula
+            use_unit_factor = factor_values.get("use_unit")
+            if use_unit != use_unit_factor:
+                return None
+            # Compute share of use and apply to total emissions
+            total_use = factor_values.get("total_use")
+            kg_co2eq_sum = factor_values.get("kg_co2eq_sum")
+            if total_use is None or kg_co2eq_sum is None:
+                return None
+            use_share = use / total_use if total_use > 0 else 0
+            return use_share * kg_co2eq_sum
+
+        return [
+            EmissionComputation(
+                emission_type=emission_type,
+                factor_id=int(factor_id),
+                formula_func=_research_facilities_formula,
+            )
+        ]
+
+
+## RESEARCH FACILITIES FACTOR HANDLERS
+
+# --- Common (research_facilities) ---
+
+research_facilities_common_classification_fields: list[str] = [
+    "researchfacility_id",
+    "researchfacility_name",
+    "use_unit",
+]
+research_facilities_common_value_fields: list[str] = [
+    "kg_co2eq_sum",
+    "total_use",
+]
+
+
+class ResearchFacilitiesCommonFactorCreate(FactorCreate):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: str
+    use_unit: str
+    kg_co2eq_sum: Optional[float] = None
+    total_use: float
+
+    @field_validator("total_use", mode="after")
+    @classmethod
+    def validate_total_use(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("total_use must be non-negative")
+        return v
+
+
+class ResearchFacilitiesCommonFactorUpdate(FactorUpdate):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: Optional[str] = None
+    use_unit: Optional[str] = None
+    kg_co2eq_sum: Optional[float] = None
+    total_use: Optional[float] = None
+
+
+class ResearchFacilitiesCommonFactorResponse(FactorResponseGen):
+    researchfacility_id: Optional[int] = None
+    researchfacility_name: str
+    use_unit: str
+    kg_co2eq_sum: Optional[float] = None
+    total_use: Optional[float] = None
+
+
+class ResearchFacilitiesCommonFactorHandler(BaseFactorHandler):
+    data_entry_type: DataEntryTypeEnum | None = None
+    registration_keys = [DataEntryTypeEnum.research_facilities]
+    emission_type = EmissionType.research_facilities__facilities
+
+    create_dto = ResearchFacilitiesCommonFactorCreate
+    update_dto = ResearchFacilitiesCommonFactorUpdate
+    response_dto = ResearchFacilitiesCommonFactorResponse
+
+    classification_fields: list[str] = research_facilities_common_classification_fields
+    value_fields: list[str] = research_facilities_common_value_fields

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -140,9 +140,9 @@ class ResearchFacilitiesCommonModuleHandler(BaseModuleHandler):
 research_facilities_common_classification_fields: list[str] = [
     "researchfacility_id",
     "researchfacility_name",
-    "use_unit",
 ]
 research_facilities_common_value_fields: list[str] = [
+    "use_unit",
     "kg_co2eq_sum",
     "total_use",
 ]
@@ -169,6 +169,15 @@ class ResearchFacilitiesCommonFactorUpdate(FactorUpdate):
     use_unit: Optional[str] = None
     kg_co2eq_sum: Optional[float] = None
     total_use: Optional[float] = None
+
+    @field_validator("total_use", mode="after")
+    @classmethod
+    def validate_total_use(cls, v: Optional[float]) -> Optional[float]:
+        if v is None:
+            return v
+        if v < 0:
+            raise ValueError("total_use must be non-negative")
+        return v
 
 
 class ResearchFacilitiesCommonFactorResponse(FactorResponseGen):

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -410,3 +410,36 @@ class DataEntryEmissionRepository:
                 }
             )
         return result_list
+
+    async def get_total_emissions_per_type(
+        self, emission_type_id: int, unit_id: int, year: int
+    ) -> float | None:
+        """Get total emissions for a given emission type, unit and year."""
+        query: Select[Any] = (
+            select(
+                func.sum(col(DataEntryEmission.kg_co2eq)).label("kg_co2eq"),
+            )
+            .join(
+                DataEntry,
+                col(DataEntryEmission.data_entry_id) == col(DataEntry.id),
+            )
+            .join(
+                CarbonReportModule,
+                col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
+            )
+            .join(
+                CarbonReport,
+                col(CarbonReportModule.carbon_report_id) == col(CarbonReport.id),
+            )
+            .where(
+                CarbonReport.unit_id == unit_id,
+                CarbonReport.year == year,
+                DataEntryEmission.emission_type_id == emission_type_id,
+                col(DataEntryEmission.kg_co2eq).isnot(None),
+                col(DataEntryEmission.kg_co2eq) > 0,
+            )
+        )
+
+        result = await self.session.execute(query)
+        rval = result.scalar_one_or_none()
+        return rval

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -410,36 +410,3 @@ class DataEntryEmissionRepository:
                 }
             )
         return result_list
-
-    async def get_total_emissions_per_type(
-        self, emission_type_id: int, unit_id: int, year: int
-    ) -> float | None:
-        """Get total emissions for a given emission type, unit and year."""
-        query: Select[Any] = (
-            select(
-                func.sum(col(DataEntryEmission.kg_co2eq)).label("kg_co2eq"),
-            )
-            .join(
-                DataEntry,
-                col(DataEntryEmission.data_entry_id) == col(DataEntry.id),
-            )
-            .join(
-                CarbonReportModule,
-                col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
-            )
-            .join(
-                CarbonReport,
-                col(CarbonReportModule.carbon_report_id) == col(CarbonReport.id),
-            )
-            .where(
-                CarbonReport.unit_id == unit_id,
-                CarbonReport.year == year,
-                DataEntryEmission.emission_type_id == emission_type_id,
-                col(DataEntryEmission.kg_co2eq).isnot(None),
-                col(DataEntryEmission.kg_co2eq) > 0,
-            )
-        )
-
-        result = await self.session.execute(query)
-        rval = result.scalar_one_or_none()
-        return rval

--- a/backend/app/seed/seed_generic_factors.py
+++ b/backend/app/seed/seed_generic_factors.py
@@ -166,11 +166,14 @@ FACTOR_SEEDS: list[FactorSeedConfig] = [
 ]
 
 
-def get_float_or_none(value: str | None) -> float | None:
+def get_float_str_or_none(value: str | None) -> float | str | None:
     """Convert string to float or return None if empty."""
     if value is None or value == "":
         return None
-    return float(value)
+    try:
+        return float(value)
+    except ValueError:
+        return value
 
 
 async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
@@ -224,7 +227,7 @@ async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
                         f"Missing required value field '{field_name}'"
                         f" for {data_entry_type.name} factor: {row}"
                     )
-                values[field_name] = get_float_or_none(row.get(field_name))
+                values[field_name] = get_float_str_or_none(row.get(field_name))
 
             factor = await service.prepare_create(
                 emission_type_id=emission_type_id,

--- a/backend/app/seed/seed_generic_factors.py
+++ b/backend/app/seed/seed_generic_factors.py
@@ -19,7 +19,10 @@ from app.modules.purchase import (
     schemas as _purchase_schemas,  # noqa: F401 — registers handlers
 )
 from app.modules.research_facilities import (
-    schemas as _rf_schemas,  # noqa: F401 — registers handlers
+    animals_schemas as _rf_animals_schemas,  # noqa: F401 — registers handlers
+)
+from app.modules.research_facilities import (
+    common_schemas as _rf_common_schemas,  # noqa: F401 — registers handlers
 )
 from app.schemas.factor import BaseFactorHandler
 from app.seed.seed_helper import (

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -5,7 +5,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
 from app.core.logging import get_logger
-from app.models.carbon_report import CarbonReport
+from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.data_entry_emission import (
     DataEntryEmission,
@@ -121,9 +121,10 @@ class DataEntryEmissionService:
 
         # Build context: data_entry.data enriched with pre-computed values
         ctx: dict = {**data_entry.data}
-        # TBD Add year to context for time-sensitive factors
-        # Relates to #697
-        ctx["_year"] = 2025
+        # Add year to context for time-sensitive factors, derived from CarbonReport
+        year = await self._get_carbon_report_year(data_entry)
+        if year is not None:
+            ctx["_year"] = year
         ctx.update(await handler.pre_compute(data_entry, self.session))
 
         # Get year from CarbonReport for year-aware factor lookup
@@ -452,6 +453,34 @@ class DataEntryEmissionService:
     ) -> list[dict]:
         """Get travel emissions aggregated by year and category."""
         return await self.repo.get_travel_evolution_over_time(unit_id)
+
+    async def _get_carbon_report_year(
+        self, data_entry: DataEntry | DataEntryResponse
+    ) -> Optional[int]:
+        """Resolve the carbon report year for the given data entry."""
+        carbon_report_module_id = getattr(data_entry, "carbon_report_module_id", None)
+        if carbon_report_module_id is None:
+            return None
+        carbon_report_module = await self.session.get(
+            CarbonReportModule, carbon_report_module_id
+        )
+        if carbon_report_module is None:
+            logger.warning(
+                "CarbonReportModule not found for id=%s", carbon_report_module_id
+            )
+            return None
+        carbon_report_id = getattr(carbon_report_module, "carbon_report_id", None)
+        if carbon_report_id is None:
+            logger.warning(
+                "CarbonReportModule id=%s has no carbon_report_id",
+                carbon_report_module_id,
+            )
+            return None
+        carbon_report = await self.session.get(CarbonReport, carbon_report_id)
+        if carbon_report is None:
+            logger.warning("CarbonReport not found for id=%s", carbon_report_id)
+            return None
+        return getattr(carbon_report, "year", None)
 
     # # Dict of dataEntryTypeEnum , func to calculation formulas
     # FORMULAS: dict[EmissionType, Callable] = {}

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -33,8 +33,6 @@ class DataEntryEmissionService:
     def __init__(self, session: AsyncSession):
         self.session = session
         self.repo = DataEntryEmissionRepository(session)
-        self._year_by_carbon_report_module_id: dict[int, int] = {}
-        self._year_by_carbon_report_id: dict[int, int] = {}
 
     async def _get_year_from_data_entry(
         self, data_entry: DataEntry | DataEntryResponse
@@ -52,7 +50,6 @@ class DataEntryEmissionService:
             return None
 
         # Fetch the CarbonReportModule to get carbon_report_id
-        from app.models.carbon_report import CarbonReportModule
 
         stmt = select(CarbonReportModule).where(
             col(CarbonReportModule.id) == data_entry.carbon_report_module_id
@@ -123,10 +120,6 @@ class DataEntryEmissionService:
 
         # Build context: data_entry.data enriched with pre-computed values
         ctx: dict = {**data_entry.data}
-        # Add year to context for time-sensitive factors, derived from CarbonReport
-        year = await self._get_carbon_report_module_year(data_entry)
-        if year is not None:
-            ctx["_year"] = year
         ctx.update(await handler.pre_compute(data_entry, self.session))
 
         # Get year from CarbonReport for year-aware factor lookup
@@ -135,6 +128,8 @@ class DataEntryEmissionService:
             logger.warning(
                 "Could not determine year for data entry, factors may not match"
             )
+        # Add factor year to context for year-specific formulas
+        ctx["_year"] = year
 
         results: list[DataEntryEmission] = []
 
@@ -455,55 +450,6 @@ class DataEntryEmissionService:
     ) -> list[dict]:
         """Get travel emissions aggregated by year and category."""
         return await self.repo.get_travel_evolution_over_time(unit_id)
-
-    async def _get_carbon_report_module_year(
-        self, data_entry: DataEntry | DataEntryResponse
-    ) -> Optional[int]:
-        """Resolve the carbon report year for a data entry, with caching."""
-        carbon_report_module_id = getattr(data_entry, "carbon_report_module_id", None)
-        if carbon_report_module_id is not None:
-            cached = self._year_by_carbon_report_module_id.get(carbon_report_module_id)
-            if cached is not None:
-                return cached
-        year = await self._get_carbon_report_year(data_entry)
-        if year is None:
-            return None
-        if carbon_report_module_id is not None:
-            self._year_by_carbon_report_module_id[carbon_report_module_id] = year
-        return year
-
-    async def _get_carbon_report_year(
-        self, data_entry: DataEntry | DataEntryResponse
-    ) -> Optional[int]:
-        """Resolve the carbon report year for the given data entry, with caching."""
-        carbon_report_module_id = getattr(data_entry, "carbon_report_module_id", None)
-        if carbon_report_module_id is None:
-            return None
-        carbon_report_module = await self.session.get(
-            CarbonReportModule, carbon_report_module_id
-        )
-        if carbon_report_module is None:
-            logger.warning(
-                "CarbonReportModule not found for id=%s", carbon_report_module_id
-            )
-            return None
-        carbon_report_id = getattr(carbon_report_module, "carbon_report_id", None)
-        if carbon_report_id is None:
-            logger.warning(
-                "CarbonReportModule id=%s has no carbon_report_id",
-                carbon_report_module_id,
-            )
-            return None
-        if carbon_report_id in self._year_by_carbon_report_id:
-            return self._year_by_carbon_report_id[carbon_report_id]
-        carbon_report = await self.session.get(CarbonReport, carbon_report_id)
-        if carbon_report is None:
-            logger.warning("CarbonReport not found for id=%s", carbon_report_id)
-            return None
-        year = getattr(carbon_report, "year", None)
-        if year is not None:
-            self._year_by_carbon_report_id[carbon_report_id] = year
-        return year
 
     # # Dict of dataEntryTypeEnum , func to calculation formulas
     # FORMULAS: dict[EmissionType, Callable] = {}

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -121,6 +121,9 @@ class DataEntryEmissionService:
 
         # Build context: data_entry.data enriched with pre-computed values
         ctx: dict = {**data_entry.data}
+        # TBD Add year to context for time-sensitive factors
+        # Relates to #697
+        ctx["_year"] = 2025
         ctx.update(await handler.pre_compute(data_entry, self.session))
 
         # Get year from CarbonReport for year-aware factor lookup

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -33,6 +33,8 @@ class DataEntryEmissionService:
     def __init__(self, session: AsyncSession):
         self.session = session
         self.repo = DataEntryEmissionRepository(session)
+        self._year_by_carbon_report_module_id: dict[int, int] = {}
+        self._year_by_carbon_report_id: dict[int, int] = {}
 
     async def _get_year_from_data_entry(
         self, data_entry: DataEntry | DataEntryResponse
@@ -122,7 +124,7 @@ class DataEntryEmissionService:
         # Build context: data_entry.data enriched with pre-computed values
         ctx: dict = {**data_entry.data}
         # Add year to context for time-sensitive factors, derived from CarbonReport
-        year = await self._get_carbon_report_year(data_entry)
+        year = await self._get_carbon_report_module_year(data_entry)
         if year is not None:
             ctx["_year"] = year
         ctx.update(await handler.pre_compute(data_entry, self.session))
@@ -454,10 +456,26 @@ class DataEntryEmissionService:
         """Get travel emissions aggregated by year and category."""
         return await self.repo.get_travel_evolution_over_time(unit_id)
 
+    async def _get_carbon_report_module_year(
+        self, data_entry: DataEntry | DataEntryResponse
+    ) -> Optional[int]:
+        """Resolve the carbon report year for a data entry, with caching."""
+        carbon_report_module_id = getattr(data_entry, "carbon_report_module_id", None)
+        if carbon_report_module_id is not None:
+            cached = self._year_by_carbon_report_module_id.get(carbon_report_module_id)
+            if cached is not None:
+                return cached
+        year = await self._get_carbon_report_year(data_entry)
+        if year is None:
+            return None
+        if carbon_report_module_id is not None:
+            self._year_by_carbon_report_module_id[carbon_report_module_id] = year
+        return year
+
     async def _get_carbon_report_year(
         self, data_entry: DataEntry | DataEntryResponse
     ) -> Optional[int]:
-        """Resolve the carbon report year for the given data entry."""
+        """Resolve the carbon report year for the given data entry, with caching."""
         carbon_report_module_id = getattr(data_entry, "carbon_report_module_id", None)
         if carbon_report_module_id is None:
             return None
@@ -476,11 +494,16 @@ class DataEntryEmissionService:
                 carbon_report_module_id,
             )
             return None
+        if carbon_report_id in self._year_by_carbon_report_id:
+            return self._year_by_carbon_report_id[carbon_report_id]
         carbon_report = await self.session.get(CarbonReport, carbon_report_id)
         if carbon_report is None:
             logger.warning("CarbonReport not found for id=%s", carbon_report_id)
             return None
-        return getattr(carbon_report, "year", None)
+        year = getattr(carbon_report, "year", None)
+        if year is not None:
+            self._year_by_carbon_report_id[carbon_report_id] = year
+        return year
 
     # # Dict of dataEntryTypeEnum , func to calculation formulas
     # FORMULAS: dict[EmissionType, Callable] = {}

--- a/backend/app/services/exchange_rates_service.py
+++ b/backend/app/services/exchange_rates_service.py
@@ -19,6 +19,22 @@ class ExchangeRatesService:
     def __init__(self):
         pass
 
+    def get_exchange_rate_to_eur(self, year: int, currency: str) -> float:
+        """Get the exchange rate from the specified currency to EUR.
+
+        Args:
+            year (int): The year for which to fetch the exchange rate.
+            currency (str): The currency code to fetch the exchange rate for.
+
+        Raises:
+            ValueError: If no exchange rate data is found for the specified year
+              and currency or if there is an error fetching the data.
+
+        Returns:
+            float: The exchange rate from the specified currency to EUR.
+        """
+        return self.get_exchange_rate(year, currency, invert=True)
+
     def get_exchange_rate(
         self, year: int, currency: str, invert: bool = False
     ) -> float:
@@ -41,7 +57,7 @@ class ExchangeRatesService:
               optionally inverted.
         """
         rates = self.get_exchange_rates(year)
-        filtered_rates = rates[rates["CURRENCY"] == currency]
+        filtered_rates = rates[rates["CURRENCY"] == self._normalize_currency(currency)]
         if filtered_rates.empty:
             raise ValueError(
                 f"No exchange rate data found for year {year} and currency {currency}"
@@ -49,7 +65,7 @@ class ExchangeRatesService:
         rate = float(filtered_rates["OBS_VALUE"].iloc[0])
         if invert:
             return 1 / rate
-        return rate
+        return float(rate)
 
     def get_exchange_rates(self, year: int) -> pd.DataFrame:
         """Get exchange rates for a specific year, using caching to avoid
@@ -112,7 +128,8 @@ class ExchangeRatesService:
             start_period = str(year)
             end_period = str(year)
 
-        url = f"{ECB_EXR_URL}{frequency}.{currency if currency else ''}.EUR.SP00.A"
+        currency_n = self._normalize_currency(currency) if currency else ""
+        url = f"{ECB_EXR_URL}{frequency}.{currency_n}.EUR.SP00.A"
         params = {
             "startPeriod": start_period,
             "endPeriod": end_period,
@@ -147,6 +164,10 @@ class ExchangeRatesService:
             df["OBS_VALUE"] = 1 / df["OBS_VALUE"]
 
         return df[["TIME_PERIOD", "CURRENCY", "OBS_VALUE"]]
+
+    def _normalize_currency(self, currency: str) -> str:
+        """Normalize the currency code to uppercase and strip whitespace."""
+        return currency.strip().upper()
 
     @staticmethod
     def clear_cache():


### PR DESCRIPTION
## What does this change?

This PR introduces emission computation logic for two research facility sub-types, splits the existing `research_facilities` schemas module into dedicated files, and adds a supporting repository query.

### Changes

#### New: common_schemas.py

Adds module and factor handlers for the `research_facilities` data entry type (general/common facilities).

- **`ResearchFacilitiesCommonModuleHandler`** — resolves emissions using the formula:
  ```
  kg_co2eq = (use / total_use) * kg_co2eq_sum
  ```
  A unit check ensures `use_unit` matches the factor's `use_unit` before applying the formula.
- **`ResearchFacilitiesCommonFactorHandler`** — registered for `EmissionType.research_facilities__facilities`. Factor fields: `researchfacility_id`, `researchfacility_name`, `use_unit`, `kg_co2eq_sum`, `total_use`.
- Pydantic validators ensure `total_use >= 0`.

#### New: animals_schemas.py

Renamed from the previous `schemas.py` and extended with full emission computation logic for the `mice_and_fish_animal_facilities` data entry type.

- **`ResearchFacilitiesAnimalModuleHandler`** — resolves emissions by distributing the facility's usage share across 6 emission source types:
  - `processemissions`, `building_energycombustions`, `building_rooms`, `purchases_common`, `purchases_additional`, `equipments`
  - Formula per source: `(use / total_use) * kg_co2eq_sum_<source> * <source>_share`
  - Results are summed; sources with missing share or sum values are skipped.
- **`ResearchFacilitiesAnimalFactorHandler`** — registered for `EmissionType.research_facilities__animal`. Factor fields include per-source `_share` and `kg_co2eq_sum_*` values.
- Pydantic validators ensure share values are in `[0, 1]` and `total_use >= 0`.

#### Modified: __init__.py

Updated to import from the new `animals_schemas` module instead of the old `schemas` module.

#### Modified: __init__.py

- Replaced `ResearchFacilitiesHandlerCreate` with:
  - `ResearchFacilitiesCommonHandlerCreate`
  - `ResearchFacilitiesAnimalHandlerCreate`
- Added missing `PurchaseAdditionalHandlerCreate` to the module's public exports.

#### Modified: data_entry_emission_service.py

Injected `_year` into the emission computation context from associated factor.

### Notes

- `_year` in the computation context is temporary — tracked in #697.
- The two research facilities handler types (`common` and `animal`) follow the same handler pattern as other modules but differ in their emission formula complexity.

## Why is this needed?

Research facilities emissions computation.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Related to #175 #402

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
