### PR TITLE
feat/460 reporting aggregated results box

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -123,7 +123,6 @@ seed-data: ## Seed the database with initial data
 	$(UV) run -m app.seed.seed_locations
 	$(UV) run -m app.seed.seed_building_rooms
 	$(UV) run -m app.seed.seed_generic_factors
-# 	$(UV) run -m app.seed.seed_generic_data_entries
 
 .PHONY: seed-units
 seed-units: ## Seed units from accred

--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from sqlmodel import select
+from sqlmodel import desc, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_db
@@ -560,6 +560,7 @@ async def list_backoffice_units(
     return PaginatedUnitReportingData(
         data=unit_reporting_data,
         pagination=PaginationMeta(**result),
+        emission_breakdown=result.get("emission_breakdown"),
     )
 
 
@@ -872,20 +873,16 @@ async def get_backoffice_unit(
 @router.get("/years")
 async def get_available_years(
     current_user: User = Depends(require_permission("backoffice.users", "view")),
+    db: AsyncSession = Depends(get_db),
 ):
     """
-    Get all available years from all units combined.
-    Returns all unique years found across all units' completion data,
+    Get all available years from CarbonReport records in the database,
     sorted in descending order (latest first).
     """
-    all_years: set[str] = set(
-        "2025".split()
-    )  # Mocked for demo, replace with real data extraction
-
-    # Sort years in descending order (latest first)
-    sorted_years = sorted(
-        all_years, key=lambda y: int(y) if y.isdigit() else 0, reverse=True
+    result = await db.exec(
+        select(CarbonReport.year).distinct().order_by(desc(CarbonReport.year))
     )
-    latest_year = sorted_years[0]
-
-    return {"years": sorted_years, "latest": latest_year}
+    years = [str(y) for y in result.all()]
+    if not years:
+        return {"years": [], "latest": ""}
+    return {"years": years, "latest": years[0]}

--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -561,6 +561,8 @@ async def list_backoffice_units(
         data=unit_reporting_data,
         pagination=PaginationMeta(**result),
         emission_breakdown=result.get("emission_breakdown"),
+        validated_units_count=result.get("validated_units_count", 0),
+        total_units_count=result.get("total_units_count", 0),
     )
 
 

--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -136,5 +136,6 @@ async def update_carbon_report_module_status(
             ),
         )
 
+    await report_service.recompute_report_progress(carbon_report_id)
     await db.commit()
     return result

--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -295,7 +295,7 @@ async def get_submodule(
     request: Request,
     background_tasks: BackgroundTasks,
     page: int = Query(default=1, ge=1, description="Page number"),
-    limit: int = Query(default=50, le=1000, description="Items per page"),
+    limit: int = Query(default=100, le=1000, description="Items per page"),
     sort_by: str = Query(default="id", description="Field to sort by"),
     sort_order: str = Query(default="asc", description="Sort order: 'asc' or 'desc'"),
     filter: Optional[str] = Query(

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -3,7 +3,7 @@
 from math import ceil
 from typing import Any, List, Optional
 
-from sqlmodel import and_, case, col, desc, func, select
+from sqlmodel import and_, case, col, desc, func, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
@@ -13,6 +13,7 @@ from app.models.data_entry_emission import DataEntryEmission
 from app.models.module_type import ModuleTypeEnum
 from app.models.unit import Unit
 from app.models.user import User
+from app.utils.emission_category import build_chart_breakdown
 
 logger = get_logger(__name__)
 
@@ -173,6 +174,130 @@ class CarbonReportModuleRepository:
         await self.session.flush()
         return count
 
+    @staticmethod
+    def _split_filter_values(
+        values: Optional[List[str]],
+    ) -> tuple[List[int], List[str]]:
+        """Split mixed query values into integer IDs and string names."""
+        ids: List[int] = []
+        names: List[str] = []
+        for raw in values or []:
+            value = str(raw).strip()
+            if not value:
+                continue
+            if value.isdigit():
+                ids.append(int(value))
+            else:
+                names.append(value)
+        return ids, names
+
+    async def _get_selected_units(
+        self, values: Optional[List[str]]
+    ) -> List[tuple[int, Optional[str]]]:
+        """Resolve selected units from mixed ID/name values to id/code tuples."""
+        ids, names = self._split_filter_values(values)
+        if not ids and not names:
+            return []
+
+        filters = []
+        if ids:
+            filters.append(col(Unit.id).in_(ids))
+        if names:
+            filters.append(col(Unit.name).in_(names))
+
+        statement = select(Unit.id, Unit.institutional_code).where(or_(*filters))
+        rows = (await self.session.exec(statement)).all()
+        # Unit.id is expected to be present, but SQL typing can expose Optional.
+        return [(unit_id, code) for unit_id, code in rows if unit_id is not None]
+
+    async def _get_descendant_unit_ids(self, values: Optional[List[str]]) -> set[int]:
+        """Resolve hierarchy nodes to descendant unit IDs, including self."""
+        selected_units = await self._get_selected_units(values)
+        if not selected_units:
+            return set()
+
+        selected_ids = {unit_id for unit_id, _ in selected_units}
+        selected_codes = {code for _, code in selected_units if code}
+
+        path_conditions = []
+        for code in selected_codes:
+            # Token-boundary matching for ancestor code in path string.
+            path_conditions.extend(
+                [
+                    col(Unit.path_institutional_code) == code,
+                    col(Unit.path_institutional_code).like(f"{code} %"),
+                    col(Unit.path_institutional_code).like(f"% {code}"),
+                    col(Unit.path_institutional_code).like(f"% {code} %"),
+                ]
+            )
+
+        descendants_stmt = select(Unit.id)
+        if path_conditions:
+            descendants_stmt = descendants_stmt.where(or_(*path_conditions))
+        descendant_ids = {
+            unit_id
+            for unit_id in (await self.session.exec(descendants_stmt)).all()
+            if unit_id is not None
+        }
+
+        # Ensure selected units are included even if path is null or non-standard.
+        return selected_ids.union(descendant_ids)
+
+    async def _get_direct_unit_ids(self, values: Optional[List[str]]) -> set[int]:
+        """Resolve direct unit filter values (ID/name) to unit IDs."""
+        selected_units = await self._get_selected_units(values)
+        return {unit_id for unit_id, _ in selected_units}
+
+    async def _resolve_hierarchy_unit_ids(
+        self,
+        path_lvl2: Optional[List[str]] = None,
+        path_lvl3: Optional[List[str]] = None,
+        path_lvl4: Optional[List[str]] = None,
+    ) -> Optional[set[int]]:
+        """
+        Build the effective unit ID filter with intersection semantics across levels.
+
+        Returns:
+            - None when no hierarchy filters were provided (no-op)
+            - set of unit IDs when at least one hierarchy filter is provided
+        """
+        filter_sets: List[set[int]] = []
+
+        if path_lvl2:
+            filter_sets.append(await self._get_descendant_unit_ids(path_lvl2))
+        if path_lvl3:
+            filter_sets.append(await self._get_descendant_unit_ids(path_lvl3))
+        if path_lvl4:
+            filter_sets.append(await self._get_direct_unit_ids(path_lvl4))
+
+        if not filter_sets:
+            return None
+
+        effective_ids = filter_sets[0]
+        for ids in filter_sets[1:]:
+            effective_ids = effective_ids.intersection(ids)
+        return effective_ids
+
+    @staticmethod
+    def _get_completion_status_from_progress(
+        completion_progress: Optional[str],
+    ) -> ModuleStatus:
+        """Map completion progress string (e.g. '5/7') to ModuleStatus."""
+        if not completion_progress:
+            return ModuleStatus.NOT_STARTED
+
+        completed_raw, _, total_raw = completion_progress.partition("/")
+        if not completed_raw.isdigit() or not total_raw.isdigit():
+            return ModuleStatus.NOT_STARTED
+
+        completed = int(completed_raw)
+        total = int(total_raw)
+        if total <= 0 or completed <= 0:
+            return ModuleStatus.NOT_STARTED
+        if completed >= total:
+            return ModuleStatus.VALIDATED
+        return ModuleStatus.IN_PROGRESS
+
     async def get_reporting_overview(
         self,
         path_lvl2: Optional[List[str]] = None,
@@ -193,14 +318,39 @@ class CarbonReportModuleRepository:
             raise ValueError(
                 "At least one year must be specified for the reporting overview."
             )
+
+        hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
+            path_lvl2=path_lvl2,
+            path_lvl3=path_lvl3,
+            path_lvl4=path_lvl4,
+        )
+
+        # If filters were provided but resolve to no units, short-circuit early.
+        if hierarchy_unit_ids is not None and len(hierarchy_unit_ids) == 0:
+            return {
+                "data": [],
+                "total": 0,
+                "page": page,
+                "page_size": page_size,
+                "total_pages": 0,
+            }
+
         # --- STEP 1: The Cheap Count ---
         count_statement = (
             select(func.count(col(Unit.id)))
             .join(CarbonReport, col(CarbonReport.unit_id) == Unit.id)
             .where(col(CarbonReport.year).in_(years))
         )
-        # if unit_ids:
-        #     count_statement = count_statement.where(col(Unit.id).in_(unit_ids))
+
+        if completion_status is not None:
+            count_statement = count_statement.where(
+                col(CarbonReport.overall_status) == int(completion_status)
+            )
+
+        if hierarchy_unit_ids is not None:
+            count_statement = count_statement.where(
+                col(Unit.id).in_(hierarchy_unit_ids)
+            )
 
         total = (await self.session.exec(count_statement)).one()
 
@@ -222,6 +372,7 @@ class CarbonReportModuleRepository:
             col(Unit.path_name).label("path_name"),
             col(User.display_name).label("principal_user_name"),
             col(CarbonReport.id).label("carbon_report_id"),
+            col(CarbonReport.completion_progress).label("completion_progress"),
         ]
 
         # 2. Unpack them into the select statement
@@ -233,6 +384,34 @@ class CarbonReportModuleRepository:
             )
             .where(col(CarbonReport.year).in_(years))
         )
+        if hierarchy_unit_ids is not None:
+            units_stmt = units_stmt.where(col(Unit.id).in_(hierarchy_unit_ids))
+
+        if completion_status is not None:
+            units_stmt = units_stmt.where(
+                col(CarbonReport.overall_status) == int(completion_status)
+            )
+
+        filtered_report_ids_stmt = (
+            select(col(CarbonReport.id))
+            .join(Unit, col(CarbonReport.unit_id) == col(Unit.id))
+            .where(col(CarbonReport.year).in_(years))
+        )
+        if hierarchy_unit_ids is not None:
+            filtered_report_ids_stmt = filtered_report_ids_stmt.where(
+                col(Unit.id).in_(hierarchy_unit_ids)
+            )
+
+        if completion_status is not None:
+            filtered_report_ids_stmt = filtered_report_ids_stmt.where(
+                col(CarbonReport.overall_status) == int(completion_status)
+            )
+
+        filtered_report_ids = [
+            report_id
+            for report_id in (await self.session.exec(filtered_report_ids_stmt)).all()
+            if report_id is not None
+        ]
 
         # if unit_ids:
         #     units_stmt = units_stmt.where(col(Unit.id).in_(unit_ids))
@@ -246,6 +425,76 @@ class CarbonReportModuleRepository:
 
         paginated_units = (await self.session.exec(units_stmt)).all()
         page_report_ids = [u.carbon_report_id for u in paginated_units]
+
+        # Build an aggregated emission breakdown from module stats by_emission_type
+        # so frontend can reuse result-page charts with reporting filters.
+        module_stats_rows: list[tuple[int, int, Optional[dict[str, Any]]]] = []
+        if filtered_report_ids:
+            module_stats_stmt = select(
+                CarbonReportModule.module_type_id,
+                CarbonReportModule.status,
+                CarbonReportModule.stats,
+            ).where(col(CarbonReportModule.carbon_report_id).in_(filtered_report_ids))
+            raw_module_stats_rows = (await self.session.exec(module_stats_stmt)).all()
+            module_stats_rows = [
+                (
+                    int(module_type_id),
+                    int(status),
+                    stats if isinstance(stats, dict) else None,
+                )
+                for module_type_id, status, stats in raw_module_stats_rows
+            ]
+
+        global_fte_stmt = (
+            select(func.sum(func.coalesce(DataEntry.data["fte"].as_float(), 0.0)))
+            .join(
+                CarbonReportModule,
+                col(CarbonReportModule.id) == col(DataEntry.carbon_report_module_id),
+            )
+            .where(
+                col(CarbonReportModule.carbon_report_id).in_(filtered_report_ids),
+                col(CarbonReportModule.module_type_id) == ModuleTypeEnum.headcount,
+            )
+        )
+        global_fte_result = (await self.session.exec(global_fte_stmt)).one()
+        global_fte = float(global_fte_result or 0.0)
+
+        chart_rows: list[tuple[int, int, float]] = []
+        validated_module_type_ids: set[int] = set()
+        headcount_validated = False
+
+        for module_type_id, status, stats in module_stats_rows:
+            if status == ModuleStatus.VALIDATED:
+                validated_module_type_ids.add(int(module_type_id))
+                if int(module_type_id) == int(ModuleTypeEnum.headcount):
+                    headcount_validated = True
+
+            if not isinstance(stats, dict):
+                continue
+
+            by_emission_type = stats.get("by_emission_type", {})
+            if not isinstance(by_emission_type, dict):
+                continue
+
+            for emission_type_id_raw, kg_value in by_emission_type.items():
+                try:
+                    emission_type_id = int(emission_type_id_raw)
+                except (TypeError, ValueError):
+                    continue
+
+                if not isinstance(kg_value, (int, float)):
+                    continue
+
+                chart_rows.append(
+                    (int(module_type_id), emission_type_id, float(kg_value))
+                )
+
+        emission_breakdown = build_chart_breakdown(
+            rows=chart_rows,
+            total_fte=global_fte,
+            headcount_validated=headcount_validated,
+            validated_module_type_ids=validated_module_type_ids,
+        )
 
         # --- STEP 3: The Heavy Math (Restricted to max 50 reports) ---
         # We no longer need to join CarbonReport here,
@@ -344,25 +593,16 @@ class CarbonReportModuleRepository:
             # or default empty values
             aggs = agg_map.get(u.carbon_report_id)
 
-            agg_value = (
-                f"{aggs.val_count if aggs else 0}/{aggs.total_count if aggs else 0}"
-            )
-            # TODO: fix logic should be coming from carbon_report module directly
-            # via aggregated stats, not re-deriving it here
-            #  This is just a temporary solution to unblock the frontend.
-            completion_status = (
-                ModuleStatus.VALIDATED
-                if aggs and aggs.val_count == aggs.total_count and aggs.total_count > 0
-                else ModuleStatus.IN_PROGRESS
-                if aggs and aggs.val_count > 0
-                else ModuleStatus.NOT_STARTED
+            completion_progress = u.completion_progress or "0/7"
+            completion_status_value = self._get_completion_status_from_progress(
+                completion_progress
             )
             reporting_data.append(
                 {
                     "id": u.unit_id,
                     "unit_name": u.unit_name,
                     "affiliation": aff,
-                    "validation_status": agg_value,
+                    "validation_status": completion_progress,
                     "principal_user": u.principal_user_name or "Unknown",
                     "last_update": aggs.last_update if aggs else None,
                     "highest_result_category": self._map_module_id_to_name(
@@ -372,7 +612,8 @@ class CarbonReportModuleRepository:
                     if aggs
                     else 0.0,
                     "view_url": f"/backoffice/unit/{u.unit_id}",
-                    "completion": completion_status,
+                    "completion": completion_status_value,
+                    "completion_progress": completion_progress,
                 }
             )
 
@@ -382,6 +623,7 @@ class CarbonReportModuleRepository:
             "page": page,
             "page_size": page_size,
             "total_pages": ceil(total / page_size),
+            "emission_breakdown": emission_breakdown,
         }
 
     def _map_module_id_to_name(self, module_type_id: Optional[int]) -> str:

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -219,6 +219,11 @@ class CarbonReportModuleRepository:
         selected_ids = {unit_id for unit_id, _ in selected_units}
         selected_codes = {code for _, code in selected_units if code}
 
+        # No institutional codes — descendants can only be looked up by path,
+        # so return the directly resolved IDs to avoid a full-table scan.
+        if not selected_codes:
+            return selected_ids
+
         path_conditions = []
         for code in selected_codes:
             # Token-boundary matching for ancestor code in path string.
@@ -231,9 +236,7 @@ class CarbonReportModuleRepository:
                 ]
             )
 
-        descendants_stmt = select(Unit.id)
-        if path_conditions:
-            descendants_stmt = descendants_stmt.where(or_(*path_conditions))
+        descendants_stmt = select(Unit.id).where(or_(*path_conditions))
         descendant_ids = {
             unit_id
             for unit_id in (await self.session.exec(descendants_stmt)).all()
@@ -277,6 +280,21 @@ class CarbonReportModuleRepository:
         for ids in filter_sets[1:]:
             effective_ids = effective_ids.intersection(ids)
         return effective_ids
+
+    @staticmethod
+    def _apply_report_filters(
+        stmt: Any,
+        hierarchy_unit_ids: Optional[set[int]],
+        completion_status: Optional["ModuleStatus"],
+    ) -> Any:
+        """Apply hierarchy and completion-status filters to a statement."""
+        if hierarchy_unit_ids is not None:
+            stmt = stmt.where(col(Unit.id).in_(hierarchy_unit_ids))
+        if completion_status is not None:
+            stmt = stmt.where(
+                col(CarbonReport.overall_status) == int(completion_status)
+            )
+        return stmt
 
     @staticmethod
     def _get_completion_status_from_progress(
@@ -333,23 +351,36 @@ class CarbonReportModuleRepository:
                 "page": page,
                 "page_size": page_size,
                 "total_pages": 0,
+                "validated_units_count": 0,
+                "total_units_count": 0,
             }
 
         # --- STEP 1: The Cheap Count ---
-        count_statement = (
+        # Base count (hierarchy + year only — used for the completion bar).
+        base_count_stmt = (
             select(func.count(col(Unit.id)))
             .join(CarbonReport, col(CarbonReport.unit_id) == Unit.id)
             .where(col(CarbonReport.year).in_(years))
         )
+        if hierarchy_unit_ids is not None:
+            base_count_stmt = base_count_stmt.where(
+                col(Unit.id).in_(hierarchy_unit_ids)
+            )
 
+        total_units_count = (await self.session.exec(base_count_stmt)).one()
+        validated_units_count = (
+            await self.session.exec(
+                base_count_stmt.where(
+                    col(CarbonReport.overall_status) == int(ModuleStatus.VALIDATED)
+                )
+            )
+        ).one()
+
+        # Filtered count (adds optional completion_status filter for the table).
+        count_statement = base_count_stmt
         if completion_status is not None:
             count_statement = count_statement.where(
                 col(CarbonReport.overall_status) == int(completion_status)
-            )
-
-        if hierarchy_unit_ids is not None:
-            count_statement = count_statement.where(
-                col(Unit.id).in_(hierarchy_unit_ids)
             )
 
         total = (await self.session.exec(count_statement)).one()
@@ -384,34 +415,22 @@ class CarbonReportModuleRepository:
             )
             .where(col(CarbonReport.year).in_(years))
         )
-        if hierarchy_unit_ids is not None:
-            units_stmt = units_stmt.where(col(Unit.id).in_(hierarchy_unit_ids))
+        units_stmt = self._apply_report_filters(
+            units_stmt, hierarchy_unit_ids, completion_status
+        )
 
-        if completion_status is not None:
-            units_stmt = units_stmt.where(
-                col(CarbonReport.overall_status) == int(completion_status)
-            )
-
-        filtered_report_ids_stmt = (
+        filtered_report_ids_stmt = self._apply_report_filters(
             select(col(CarbonReport.id))
             .join(Unit, col(CarbonReport.unit_id) == col(Unit.id))
-            .where(col(CarbonReport.year).in_(years))
+            .where(col(CarbonReport.year).in_(years)),
+            hierarchy_unit_ids,
+            completion_status,
         )
-        if hierarchy_unit_ids is not None:
-            filtered_report_ids_stmt = filtered_report_ids_stmt.where(
-                col(Unit.id).in_(hierarchy_unit_ids)
-            )
 
-        if completion_status is not None:
-            filtered_report_ids_stmt = filtered_report_ids_stmt.where(
-                col(CarbonReport.overall_status) == int(completion_status)
-            )
-
-        filtered_report_ids = [
-            report_id
-            for report_id in (await self.session.exec(filtered_report_ids_stmt)).all()
-            if report_id is not None
-        ]
+        # Use a subquery instead of materializing the full list of report IDs
+        # to avoid large IN (...) parameter lists for big datasets.
+        filtered_report_ids_subq = filtered_report_ids_stmt.subquery()
+        filtered_report_ids_in = select(filtered_report_ids_subq.c.id)
 
         # if unit_ids:
         #     units_stmt = units_stmt.where(col(Unit.id).in_(unit_ids))
@@ -428,22 +447,20 @@ class CarbonReportModuleRepository:
 
         # Build an aggregated emission breakdown from module stats by_emission_type
         # so frontend can reuse result-page charts with reporting filters.
-        module_stats_rows: list[tuple[int, int, Optional[dict[str, Any]]]] = []
-        if filtered_report_ids:
-            module_stats_stmt = select(
-                CarbonReportModule.module_type_id,
-                CarbonReportModule.status,
-                CarbonReportModule.stats,
-            ).where(col(CarbonReportModule.carbon_report_id).in_(filtered_report_ids))
-            raw_module_stats_rows = (await self.session.exec(module_stats_stmt)).all()
-            module_stats_rows = [
-                (
-                    int(module_type_id),
-                    int(status),
-                    stats if isinstance(stats, dict) else None,
-                )
-                for module_type_id, status, stats in raw_module_stats_rows
-            ]
+        module_stats_stmt = select(
+            CarbonReportModule.module_type_id,
+            CarbonReportModule.status,
+            CarbonReportModule.stats,
+        ).where(col(CarbonReportModule.carbon_report_id).in_(filtered_report_ids_in))
+        raw_module_stats_rows = (await self.session.exec(module_stats_stmt)).all()
+        module_stats_rows: list[tuple[int, int, Optional[dict[str, Any]]]] = [
+            (
+                int(module_type_id),
+                int(status),
+                stats if isinstance(stats, dict) else None,
+            )
+            for module_type_id, status, stats in raw_module_stats_rows
+        ]
 
         global_fte_stmt = (
             select(func.sum(func.coalesce(DataEntry.data["fte"].as_float(), 0.0)))
@@ -452,7 +469,7 @@ class CarbonReportModuleRepository:
                 col(CarbonReportModule.id) == col(DataEntry.carbon_report_module_id),
             )
             .where(
-                col(CarbonReportModule.carbon_report_id).in_(filtered_report_ids),
+                col(CarbonReportModule.carbon_report_id).in_(filtered_report_ids_in),
                 col(CarbonReportModule.module_type_id) == ModuleTypeEnum.headcount,
             )
         )
@@ -624,6 +641,8 @@ class CarbonReportModuleRepository:
             "page_size": page_size,
             "total_pages": ceil(total / page_size),
             "emission_breakdown": emission_breakdown,
+            "validated_units_count": validated_units_count,
+            "total_units_count": total_units_count,
         }
 
     def _map_module_id_to_name(self, module_type_id: Optional[int]) -> str:

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -201,7 +201,7 @@ class DataEntryEmissionRepository:
     async def get_emission_breakdown(
         self,
         carbon_report_id: int,
-    ) -> list[tuple[int, int, float | None]]:
+    ) -> list[tuple[int, int, float]]:
         """Aggregate emissions by module_type_id and emission_type_id.
 
         Returns:

--- a/backend/app/schemas/backoffice.py
+++ b/backend/app/schemas/backoffice.py
@@ -62,3 +62,5 @@ class PaginatedUnitReportingData(BaseModel):
     data: List[UnitReportingData]
     pagination: PaginationMeta
     emission_breakdown: Optional[Dict[str, Any]] = None
+    validated_units_count: int = 0
+    total_units_count: int = 0

--- a/backend/app/schemas/backoffice.py
+++ b/backend/app/schemas/backoffice.py
@@ -1,7 +1,7 @@
 """Backoffice reporting schemas for API request/response validation."""
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -30,11 +30,17 @@ class UnitReportingData(BaseModel):
     # Numeric value for the sum of emissions
     total_carbon_footprint: float = Field(..., description="Total tCO2-eq")
 
+    # Aggregated FTE from headcount module data entries
+    total_fte: Optional[float] = Field(None, description="Total FTE")
+
     # URL or ID for the eye icon action
     view_url: Optional[str] = None
 
     # Completion data for whole report
     completion: Optional[ModuleStatus] = None
+
+    # Progress string from carbon_reports.completion_progress (e.g. "5/7")
+    completion_progress: Optional[str] = None
 
     class Config:
         # Allows using the field names or the original aliases
@@ -55,3 +61,4 @@ class PaginatedUnitReportingData(BaseModel):
 
     data: List[UnitReportingData]
     pagination: PaginationMeta
+    emission_breakdown: Optional[Dict[str, Any]] = None

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -435,7 +435,7 @@ class DataEntryEmissionService:
     async def get_emission_breakdown(
         self,
         carbon_report_id: int,
-    ) -> list[tuple[int, int, float | None]]:
+    ) -> list[tuple[int, int, float]]:
         """Get emission breakdown by module and emission type.
 
         Returns list of (module_type_id, emission_type_id, sum_kg_co2eq).

--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -486,7 +486,7 @@ def _build_category_row(
 
 
 def build_chart_breakdown(
-    rows: list[tuple[int, int, float | None]],
+    rows: list[tuple[int, int, float]],
     total_fte: float = 0.0,
     headcount_validated: bool = False,
     validated_module_type_ids: set[int] | None = None,
@@ -529,7 +529,8 @@ def build_chart_breakdown(
     module_totals_kg: dict[int, float] = {}
     real_kg = 0.0
 
-    for module_type_id, emission_type_id, kg_co2eq in rows:
+    for row in rows:
+        module_type_id, emission_type_id, kg_co2eq = row
         if kg_co2eq is None:
             continue
         emission_type = _resolve_emission_type(emission_type_id)

--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -531,8 +531,6 @@ def build_chart_breakdown(
 
     for row in rows:
         module_type_id, emission_type_id, kg_co2eq = row
-        if kg_co2eq is None:
-            continue
         emission_type = _resolve_emission_type(emission_type_id)
         if emission_type is None:
             continue
@@ -598,6 +596,7 @@ def build_chart_breakdown(
         "additional_breakdown": additional_breakdown,
         "per_person_breakdown": per_person,
         "validated_categories": validated_categories,
+        "headcount_validated": headcount_validated,
         "total_tonnes_co2eq": total_tonnes,
         "total_fte": total_fte,
     }

--- a/docs/code-review/460-reporting-aggregated-results-box.md
+++ b/docs/code-review/460-reporting-aggregated-results-box.md
@@ -1,0 +1,180 @@
+# Code Review: Commit `b9c1b83b` — Aggregated Results Box (#460)
+
+**Reviewer:** Claude (automated)
+**Date:** 2026-03-24
+**Commit:** `b9c1b83b1cbd9d9c11870826f3617ac826a89516`
+**Message:** feat: implement Aggregated box section in backend's reporting tab
+**Scope:** 27 files changed, ~1226 insertions, ~363 deletions
+
+---
+
+## Summary
+
+This commit replaces the static placeholder image in the reporting page with functional aggregated results: a completion rate bar, carbon footprint charts (bar + per-FTE), and an emission breakdown treemap. It also implements real hierarchy filtering (lvl2/lvl3/lvl4) in the backend, replaces the mocked `get_available_years` with a real DB query, and extracts treemap logic into a shared composable.
+
+---
+
+## Critical Issues
+
+### C1. `_get_descendant_unit_ids` — potential full table scan
+
+**File:** `backend/app/repositories/carbon_report_module_repo.py`
+
+When `path_conditions` is empty (selected units have no `institutional_code`), the query becomes `select(Unit.id)` with **no WHERE clause** — scanning the entire `units` table:
+
+```python
+descendants_stmt = select(Unit.id)
+if path_conditions:
+    descendants_stmt = descendants_stmt.where(or_(*path_conditions))
+```
+
+**Fix:** Return `selected_ids` directly when `selected_codes` is empty (no path-based lookup needed).
+
+### C2. `headcountValidated` uses wrong proxy in ReportingPage
+
+**File:** `frontend/src/pages/back-office/ReportingPage.vue:293-296`
+
+```vue
+:headcount-validated="
+reportingEmissionBreakdown?.validated_categories?.includes('commuting') ?? false
+"
+```
+
+This checks whether `commuting` is validated as a proxy for headcount validation. The backend already computes and returns `headcount_validated` — the field should be used directly instead of this fragile heuristic.
+
+### C3. Completion rate counts only current page, not full filtered set
+
+**File:** `frontend/src/pages/back-office/ReportingPage.vue:96-102`
+
+```typescript
+const tableRows = computed(() => units.value?.data ?? []);
+const validatedCount = computed(
+  () =>
+    tableRows.value.filter((row) =>
+      isFullyValidatedProgress(row.completion_progress),
+    ).length,
+);
+const tableTotal = computed(() => tableRows.value.length);
+```
+
+`units.value.data` only contains the current page (max 50 rows). The `CompletionRateBar` therefore shows "X out of Y validated" scoped to the visible page, not the full filtered dataset. The backend should return aggregated counts for the full result set.
+
+### C4. `filtered_report_ids` loaded into memory without limit
+
+**File:** `backend/app/repositories/carbon_report_module_repo.py`
+
+```python
+filtered_report_ids = [
+    report_id
+    for report_id in (await self.session.exec(filtered_report_ids_stmt)).all()
+    if report_id is not None
+]
+```
+
+This loads **all** matching report IDs into a Python list, then passes them in `WHERE ... IN (...)`. For large deployments, this could be thousands of IDs. Consider using a subquery instead of materializing the list:
+
+```python
+# Use subquery instead of list
+filtered_report_ids_subq = filtered_report_ids_stmt.subquery()
+# Then: .where(col(CarbonReportModule.carbon_report_id).in_(select(filtered_report_ids_subq)))
+```
+
+---
+
+## Warnings
+
+### W1. `emission_category.py` — `kg_co2eq is None` still checked despite `float` type
+
+**File:** `backend/app/utils/emission_category.py`
+
+The type signature was changed from `float | None` to `float`, but the loop body still checks `if kg_co2eq is None: continue`. This is dead code now — either remove the check or keep `float | None` if `None` values are still possible in practice.
+
+### W2. Duplicate filter construction between `count_statement` and `units_stmt`
+
+**File:** `backend/app/repositories/carbon_report_module_repo.py`
+
+The `hierarchy_unit_ids` and `completion_status` WHERE clauses are applied identically to `count_statement`, `units_stmt`, and `filtered_report_ids_stmt`. This triplication is error-prone — if one changes, the others may diverge. Consider extracting a shared filter-builder.
+
+### W3. `build_chart_breakdown` called with module stats rows, not emission rows
+
+**File:** `backend/app/repositories/carbon_report_module_repo.py`
+
+The reporting endpoint aggregates from `CarbonReportModule.stats['by_emission_type']` (pre-computed JSON), while the results page aggregates from live `DataEntryEmission` rows. If stats are stale (e.g., not recomputed after data edits), the reporting charts will show outdated data.
+
+### W4. `GenericEmissionTreeMapChart` — i18n labels removed
+
+**File:** `frontend/src/components/charts/GenericEmissionTreeMapChart.vue`
+
+The entire `TREEMAP_LABEL_KEY_MAP` was removed. Labels now use raw keys like `scientific`, `it`, `co2` via `node.name.replace(/_/g, ' ')`. This means the treemap will show English-only machine keys instead of translated labels, breaking FR i18n for the results page treemap.
+
+### W5. `Promise.resolve().then()` instead of `nextTick`
+
+**File:** `frontend/src/stores/unitFilters.ts`
+
+The comment says "Use nextTick to ensure data is reset before fetching", but `Promise.resolve().then()` is used instead of Vue's `nextTick()`. While both are microtask-based, `nextTick` is the idiomatic Vue approach and ensures the DOM/reactivity flush has completed. This pattern is also duplicated 3 times — should be a shared helper.
+
+### W6. `recompute_report_progress` called before `db.commit()`
+
+**File:** `backend/app/api/v1/carbon_report.py:139`
+
+```python
+await report_service.recompute_report_progress(carbon_report_id)
+await db.commit()
+```
+
+If `recompute_report_progress` reads data that was just written in the same transaction, it may not see the uncommitted changes depending on the isolation level. Verify that this ordering is intentional.
+
+---
+
+## Notes
+
+### N1. `CompletionRateBar` — `loading` prop declared but never used
+
+**File:** `frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue:452`
+
+The `loading` prop is defined with a default of `false` but is not referenced in the template or script.
+
+### N2. `ResultsPage.vue` — `viewUncertainties` props removed
+
+**File:** `frontend/src/pages/app/ResultsPage.vue`
+
+The `:view-uncertainties` prop was removed from `ModuleCarbonFootprintChart` and `CarbonFootPrintPerPersonChart`. Verify these components no longer use this prop (or that it's optional) to avoid a silent regression.
+
+### N3. `UnitReportingData.ts` — duplicate interface
+
+**File:** `frontend/src/constant/UnitReportingData.ts`
+
+This new file defines `UnitReportingData` interface, but `BackofficeUnitData` in `frontend/src/stores/backoffice.ts` defines the same shape. Having two sources of truth for the same data shape will cause drift.
+
+### N4. `Makefile` — seed commands uncommented
+
+**File:** `backend/Makefile`
+
+`seed_locations` and `seed_building_rooms` were uncommented. Ensure these seeds are idempotent, as they will now run on every `make seed-data` invocation.
+
+### N5. Color prop always `'primary'` in `EmissionBreakdownChart`
+
+**File:** `frontend/src/components/charts/EmissionBreakdownChart.vue:114`
+
+```vue
+:color="activeTab === mod ? 'primary' : 'primary'"
+```
+
+Both branches of the ternary are identical — the outline/unelevated distinction handles the visual difference, but this should likely be cleaned up.
+
+### N6. `ReportingYear.vue` — guard removed
+
+**File:** `frontend/src/components/organisms/backoffice/reporting/ReportingYear.vue`
+
+The `if (newYears.length === 0) return {}` guard was removed from the watcher. Now an empty selection will emit `update:years` with `[]`, which the parent handles by clearing state. This is fine but is a behavior change worth noting.
+
+---
+
+## Overall Assessment
+
+The commit delivers the core #460 feature successfully — the reporting page now shows real aggregated charts. The main concerns are:
+
+1. **Performance**: Full table scan risk in `_get_descendant_unit_ids` and in-memory materialization of all filtered report IDs (C1, C4)
+2. **Data accuracy**: Completion rate scoped to current page only (C3), stale stats risk (W3)
+3. **i18n regression**: Treemap labels lost translations (W4), FR text missing diacritics (W5)
+4. **Fragile proxy**: `headcountValidated` derived from `commuting` presence instead of using the backend field (C2)

--- a/docs/implementation-plans/460-charts.md
+++ b/docs/implementation-plans/460-charts.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Reporting Aggregated Charts (#460)
+
+## Objective
+
+Implement two charts in the reporting page using already aggregated unit data:
+
+1. Unit Carbon Footprint (`tCO2-eq`)
+2. Carbon Footprint per FTE (`tCO2-eq/FTE`)
+
+Both charts must react to the same filter state as the units table.
+
+## Final Architecture
+
+- Data source: existing `GET /backoffice/units` endpoint
+- Backend extension: expose `emission_breakdown` aggregated from module `stats.by_emission_type`
+- Frontend integration: reuse existing result-page chart components
+  (`ModuleCarbonFootprintChart` and `CarbonFootPrintPerPersonChart`)
+  using `emission_breakdown`
+- No new endpoint introduced
+
+## API Contract
+
+- Endpoint: `GET /backoffice/units`
+- Request filters (unchanged):
+  - `years`
+  - `path_lvl2`
+  - `path_lvl3`
+  - `path_lvl4`
+  - `completion_status`
+  - `search`, `modules`, `page`, `page_size`
+- Response fields used by charts:
+  - `emission_breakdown.module_breakdown`
+  - `emission_breakdown.additional_breakdown`
+  - `emission_breakdown.per_person_breakdown`
+  - `emission_breakdown.validated_categories`
+  - `emission_breakdown.total_tonnes_co2eq`
+  - `emission_breakdown.total_fte`
+
+## Implementation Status
+
+### Backend
+
+- [x] Build aggregated chart rows from `CarbonReportModule.stats.by_emission_type`
+      for current reporting result set
+- [x] Derive chart payload with backend helper `build_chart_breakdown`
+- [x] Expose `emission_breakdown` in `/backoffice/units` response schema
+
+### Frontend
+
+- [x] Extend backoffice units response typing with `emission_breakdown`
+- [x] Reuse result-page components in reporting page:
+  - `ModuleCarbonFootprintChart`
+  - `CarbonFootPrintPerPersonChart`
+- [x] Bind reused charts to `units.emission_breakdown`
+
+## Validation Checklist
+
+- [ ] Compare chart values against aggregated emission type totals from module stats
+- [ ] Verify per-person chart behavior for headcount validated/non-validated cases
+- [ ] Verify year and hierarchy filters update table + charts together
+- [ ] Verify completion filter updates table + charts together
+- [ ] Verify chart rendering when filtered result set is empty
+
+## Non-Goals
+
+- No dedicated charts endpoint
+- No additional pagination strategy for charts in this iteration
+
+## Risks / Follow-ups
+
+- Aggregation currently uses current page report IDs (page-scoped charts); if full filtered
+  aggregation is required across all pages, add a dedicated aggregate query in follow-up
+- Missing or stale module stats would directly impact chart accuracy

--- a/docs/implementation-plans/460-percentage-bar.md
+++ b/docs/implementation-plans/460-percentage-bar.md
@@ -1,0 +1,71 @@
+Implementation plan aggregation box
+
+# Percentagle bar
+
+## Objective
+
+Implement a completion-percentage bar for Backoffice reporting using the existing completion-status pipeline, without introducing a new endpoint.
+
+## Decision
+
+Reuse the existing Backoffice units endpoint and extend server-side filtering so hierarchy filters are applied before completion aggregation.
+
+## API Contract
+
+- Endpoint: GET /backoffice/units
+- Query params:
+  - years: required list of reporting years
+  - path_lvl2: optional list of VP/Faculty filters
+  - path_lvl3: optional list of Institute filters
+  - path_lvl4: optional list of Unit filters
+  - page, page_size, search, completion_status: unchanged
+- Response fields consumed by percentage bar:
+  - data
+  - completion
+  - validation_status
+  - pagination.total
+
+## Backend Tasks
+
+- Repository/query layer:
+  - apply path_lvl2, path_lvl3, and path_lvl4 filters in both:
+    - count query used for pagination.total
+    - paginated units query used for data rows
+  - apply hierarchy filters before completion-status grouping/derivation
+  - keep intersection semantics when multiple hierarchy filters are present
+- API layer:
+  - keep endpoint contract unchanged: GET /backoffice/units
+  - keep response schema backward-compatible (no required field additions)
+  - preserve current behavior of page, page_size, search, completion_status
+- Validation and quality checks:
+  - add/update tests for count and data consistency under filters
+  - verify unfiltered behavior remains unchanged
+  - verify empty-result filters return total = 0 and empty data
+
+## Frontend Tasks
+
+- Reuse existing hierarchy selectors already present in Backoffice reporting:
+  - VP/Faculty
+  - Institute
+  - Unit (optional)
+  - Year (required)
+- Ensure selected values are mapped to API query params:
+  - path_lvl2 from VP/Faculty selector
+  - path_lvl3 from Institute selector
+  - path_lvl4 from Unit selector
+  - years from Year selector
+- Call GET /backoffice/units with selected filters.
+- Compute values:
+  - complete_count: units with completion = validated
+  - incomplete_count: total - complete_count
+  - complete_percentage: complete_count / total_filtered_units
+- Ensure percentage bar and table use the same API response cycle.
+- Verify reset/clear behavior keeps table and percentage bar in sync.
+
+## Success Criteria
+
+1. VP/Faculty filtering updates table and percentage bar consistently.
+2. Institute filtering narrows both table and percentage bar consistently.
+3. Combined VP/Faculty + Institute filtering uses intersection behavior.
+4. Percentage values match filtered table totals exactly.
+5. No new aggregation endpoint is introduced.

--- a/docs/implementation-plans/460-treemap-charts.md
+++ b/docs/implementation-plans/460-treemap-charts.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Reporting Aggregated Treemap Chart (#460)
+
+## Objective
+
+Add an **Emission Breakdown** treemap chart to the backoffice reporting page, visualising
+aggregated emission data across the currently filtered unit set, with module-level tabs for
+drill-down (e.g. Professional Travel, Equipment, …).
+
+The chart must react to the same filter state as the units table, using the
+`emission_breakdown` already returned by `GET /backoffice/units`.
+
+## Final Architecture
+
+- Data source: existing `GET /backoffice/units` endpoint (unchanged)
+- Treemap hierarchy: built entirely on the frontend from
+  `emission_breakdown.module_breakdown` using `useEmissionTreemap.ts` composable
+- Chart component: reuse existing `GenericEmissionTreeMapChart.vue`
+- No new endpoint introduced
+
+## API Contract
+
+- Endpoint: `GET /backoffice/units` (unchanged)
+- Request filters (unchanged): `years`, `path_lvl2`, `path_lvl3`, `path_lvl4`,
+  `completion_status`, `search`, `modules`, `page`, `page_size`
+- Response fields consumed by the treemap:
+  - `emission_breakdown.module_breakdown` — flat per-category rows used as treemap input
+  - `emission_breakdown.validated_categories` — used to filter out unvalidated categories
+
+## Composable Contract
+
+`useEmissionTreemap.ts` exposes:
+
+```typescript
+export interface EmissionTreemapChild {
+  name: string;
+  value: number;
+  percentage: number;
+}
+
+export interface EmissionTreemapCategory {
+  name: string;
+  value: number;
+  percentage: number;
+  children: EmissionTreemapChild[];
+}
+
+// Builds treemap hierarchy from flat module_breakdown rows.
+// Uses categoryChartKeys to determine which keys are children of each category.
+export function buildModuleTreemapData(
+  rows: Array<{ category: string; [key: string]: number | string }>,
+  categoryChartKeys: Record<string, string[]>,
+): EmissionTreemapCategory[];
+
+// Builds treemap for the results summary from module_breakdown totals.
+export function buildResultsTreemapData(
+  moduleBreakdown: Array<{ category: string; [key: string]: number | string }>,
+): EmissionTreemapCategory[];
+```
+
+`categoryChartKeys` mirrors the backend constant:
+
+```typescript
+const CATEGORY_CHART_KEYS: Record<string, string[]> = {
+  Processes: [],
+  "Buildings energy consumption": ["energy"],
+  "Buildings room": ["grey_energy"],
+  Equipment: ["scientific", "it", "other"],
+  "External cloud & AI": [
+    "stockage",
+    "virtualisation",
+    "calcul",
+    "ai_provider",
+  ],
+  Purchases: [],
+  "Research facilities": [],
+  "Professional travel": ["plane", "train"],
+};
+```
+
+## Implementation Status
+
+### Backend
+
+- [x] `emission_breakdown.module_breakdown` already exposed by `/backoffice/units`
+- [ ] No additional backend changes required
+
+### Frontend
+
+- [x] Create `frontend/src/composables/useEmissionTreemap.ts`
+  - Export `EmissionTreemapChild` and `EmissionTreemapCategory` interfaces
+  - Implement `buildModuleTreemapData()` — builds hierarchy from flat `module_breakdown` rows
+  - Implement `buildResultsTreemapData()` — top-level category totals for summary treemap
+- [x] Update `GenericEmissionTreeMapChart.vue`
+  - Import `EmissionTreemapChild` / `EmissionTreemapCategory` from composable instead of
+    defining them inline
+  - Remove `TREEMAP_LABEL_KEY_MAP`, `resolveLabel`, `getCategoryScale`, `levelColor`,
+    `getFixedSubcategoryColor` — replace with simple colour assignment from category color map
+- [x] Add treemap to `ReportingPage.vue`
+  - Derive `treemapData` from `reportingEmissionBreakdown.module_breakdown` via
+    `buildResultsTreemapData()`
+  - Render `<GenericEmissionTreeMapChart :data="treemapData" />` below the existing
+    `ModuleCarbonFootprintChart` / `CarbonFootPrintPerPersonChart` pair
+  - Gate rendering on `treemapData.length > 0`
+- [x] Update `ModuleCharts.vue`
+  - Replace inline `buildTreemapFromRows()` and `buildModuleTreemapData()` with
+    `buildModuleTreemapData()` imported from `useEmissionTreemap.ts`
+  - Remove local `BackendTreemapCategory` type; align to composable types
+
+## Validation Checklist
+
+- [ ] Treemap categories match `module_breakdown` category totals exactly
+- [ ] Children (subcategories) sum to their parent category value
+- [ ] Year and hierarchy filters update table + treemap together
+- [ ] Completion filter updates table + treemap together
+- [ ] Treemap hides / shows correctly when filtered result set is empty
+- [ ] Module-level tab selection renders correct subcategory breakdown
+- [ ] Colour assignment is consistent with `ModuleCarbonFootprintChart`
+
+## Non-Goals
+
+- No backend treemap hierarchy construction (`module_treemap`, `module_breakdown_parents`)
+- No new aggregation endpoint
+- No multi-level colour scales (`CHART_CATEGORY_COLOR_SCALES`, `CHART_SUBCATEGORY_COLOR_SCHEMES`)
+- No YY subcategory keys (`co2`, `ch4`, `n2o`, `refrigerants`, …)
+
+## Risks / Follow-ups
+
+- `module_breakdown` is currently page-scoped (current page units only); full filtered
+  aggregation across all pages requires a dedicated aggregate query in a follow-up
+- `GenericEmissionTreeMapChart.vue` inline type definitions must be removed before the
+  composable types can be shared with `ModuleCharts.vue` without duplication

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
+import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTreeMapChart.vue';
+import { MODULE_TO_CATEGORIES } from 'src/constant/charts';
+import { MODULES } from 'src/constant/modules';
+import {
+  buildModuleTreemapData,
+  CATEGORY_CHART_KEYS,
+  type EmissionTreemapCategory,
+} from 'src/composables/useEmissionTreemap';
+
+interface BreakdownData {
+  module_breakdown: Array<Record<string, unknown>>;
+}
+
+const props = defineProps<{
+  breakdownData: BreakdownData | null;
+  height?: string;
+}>();
+
+const { t } = useI18n();
+
+// Modules that can appear as tabs (exclude headcount — no treemap chart)
+// Same left-to-right order as the bar chart (mirrors backend MODULE_BREAKDOWN_ORDER)
+const TREEMAP_MODULES = [
+  MODULES.ProcessEmissions,
+  MODULES.Buildings,
+  MODULES.EquipmentElectricConsumption,
+  MODULES.ExternalCloudAndAI,
+  MODULES.Purchase,
+  MODULES.ResearchFacilities,
+  MODULES.ProfessionalTravel,
+] as const;
+
+/** Modules that actually have non-zero data in the current breakdown */
+const availableModules = computed(() => {
+  if (!props.breakdownData) return [];
+  const rows = props.breakdownData.module_breakdown;
+  return TREEMAP_MODULES.filter((mod) => {
+    const categories = MODULE_TO_CATEGORIES.value[mod] ?? [];
+    return categories.some((cat) => {
+      const row = rows.find((r) => r.category === cat);
+      if (!row) return false;
+      return Object.entries(row).some(
+        ([k, v]) => k !== 'category' && !k.endsWith('StdDev') && Number(v) > 0,
+      );
+    });
+  });
+});
+
+type TabKey = (typeof TREEMAP_MODULES)[number];
+
+const selectedTab = ref<TabKey | null>(null);
+
+const activeTab = computed<TabKey | null>(() => {
+  if (selectedTab.value && availableModules.value.includes(selectedTab.value)) {
+    return selectedTab.value;
+  }
+  return availableModules.value[0] ?? null;
+});
+
+function selectTab(tab: TabKey) {
+  selectedTab.value = tab;
+}
+
+type BreakdownRow = { category: string; [key: string]: number | string };
+
+function toRow(r: Record<string, unknown>): BreakdownRow {
+  const row: BreakdownRow = { category: String(r.category ?? '') };
+  for (const [k, v] of Object.entries(r)) {
+    if (k === 'category') continue;
+    if (typeof v === 'number' || typeof v === 'string') row[k] = v;
+  }
+  return row;
+}
+
+const treemapData = computed<EmissionTreemapCategory[]>(() => {
+  if (!props.breakdownData || !activeTab.value) return [];
+
+  const categories = MODULE_TO_CATEGORIES.value[activeTab.value] ?? [];
+  const filteredKeys = Object.fromEntries(
+    Object.entries(CATEGORY_CHART_KEYS).filter(([k]) => categories.includes(k)),
+  );
+  const rows = props.breakdownData.module_breakdown.map(toRow);
+  return buildModuleTreemapData(rows, filteredKeys);
+});
+</script>
+
+<template>
+  <q-card flat bordered class="q-pa-xl">
+    <div class="flex justify-between items-center q-mb-md">
+      <span class="text-h5 text-weight-medium">{{
+        $t('results_treemap_title')
+      }}</span>
+    </div>
+
+    <!-- Module tab buttons -->
+    <div class="flex flex-wrap q-gutter-sm q-mb-md">
+      <q-btn
+        v-for="mod in availableModules"
+        :key="mod"
+        :outline="activeTab !== mod"
+        :unelevated="activeTab === mod"
+        no-caps
+        size="sm"
+        :color="activeTab === mod ? 'primary' : 'primary'"
+        class="tab-btn text-weight-medium"
+        @click="selectTab(mod)"
+      >
+        <ModuleIcon
+          :name="mod"
+          size="sm"
+          :color="activeTab === mod ? 'white' : 'accent'"
+          class="q-mr-xs"
+        />
+        {{ t(mod) }}
+      </q-btn>
+    </div>
+
+    <GenericEmissionTreeMapChart
+      v-if="treemapData.length > 0"
+      :data="treemapData"
+      :height="height ?? '250px'"
+    />
+    <span v-else class="text-body2 text-secondary">
+      {{ $t('backoffice_reporting_chart_no_data') }}
+    </span>
+  </q-card>
+</template>
+
+<style scoped>
+.tab-btn {
+  border-radius: 3px;
+}
+</style>

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -105,7 +105,7 @@ const treemapData = computed<EmissionTreemapCategory[]>(() => {
         :unelevated="activeTab === mod"
         no-caps
         size="sm"
-        :color="activeTab === mod ? 'primary' : 'primary'"
+        color="primary"
         class="tab-btn text-weight-medium"
         @click="selectTab(mod)"
       >

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { TreemapChart } from 'echarts/charts';
@@ -15,27 +14,11 @@ import EvolutionOverTimeChart from './EvolutionOverTimeChart.vue';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { formatTonnesForChart } from 'src/utils/number';
-import {
-  CHART_CATEGORY_COLOR_SCALES,
-  getChartSubcategoryColor,
-} from 'src/constant/charts';
+import type {
+  EmissionTreemapCategory,
+  EmissionTreemapChild,
+} from 'src/composables/useEmissionTreemap';
 
-interface EmissionTreemapChild {
-  name: string;
-  value: number;
-  percentage?: number;
-  color?: string;
-  children?: EmissionTreemapChild[];
-}
-
-interface EmissionTreemapCategory {
-  name: string;
-  value: number;
-  color: string;
-  children: EmissionTreemapChild[];
-}
-
-const { t } = useI18n();
 const moduleStore = useModuleStore();
 const workspaceStore = useWorkspaceStore();
 
@@ -53,103 +36,6 @@ const props = defineProps<{
   showEvolutionDialog?: boolean;
 }>();
 
-const TREEMAP_LABEL_KEY_MAP: Record<string, string> = {
-  // Core subcategories
-  scientific: 'charts-scientific-subcategory',
-  it: 'charts-equipment-it',
-  other: 'charts-other-purchases-subcategory',
-  plane: 'charts-plane-subcategory',
-  train: 'charts-train-subcategory',
-  clouds: 'charts-clouds-subcategory',
-  ai: 'charts-ai-subcategory',
-  // Process emissions gases
-  co2: 'charts-co2-subcategory',
-  ch4: 'charts-ch4-subcategory',
-  n2o: 'charts-n2o-subcategory',
-  refrigerants: 'charts-refrigerants-subcategory',
-  // Purchases
-  scientific_equipment: 'charts-scientific-subcategory',
-  it_equipment: 'charts-equipment-it',
-  consumable_accessories: 'charts-consumables-subcategory',
-  biological_chemical_gaseous: 'charts-bio-chemicals-subcategory',
-  services: 'charts-services-subcategory',
-  vehicles: 'charts-other-purchases-subcategory',
-  additional: 'charts-other-purchases-subcategory',
-  // External cloud & AI leaves
-  stockage: 'charts-stockage-subcategory',
-  virtualisation: 'charts-virtualisation-subcategory',
-  calcul: 'charts-calcul-subcategory',
-  ai_provider: 'charts-ai-provider-subcategory',
-  // Research facilities
-  facilities: 'charts-research-facilities-subcategory',
-  animal: 'charts-research-animal-subcategory',
-};
-
-function resolveLabel(raw: string): string {
-  const key = TREEMAP_LABEL_KEY_MAP[raw];
-  return key ? t(key) : raw.replace(/_/g, ' ');
-}
-
-type ColorScale = {
-  darker: string;
-  dark: string;
-  default: string;
-  light: string;
-  lighter: string;
-};
-
-function getCategoryScale(
-  categoryName: string,
-  fallbackColor: string,
-): ColorScale {
-  const byCategory =
-    CHART_CATEGORY_COLOR_SCALES.value[
-      categoryName as keyof typeof CHART_CATEGORY_COLOR_SCALES.value
-    ];
-  if (byCategory) return byCategory;
-  return {
-    darker: fallbackColor,
-    dark: fallbackColor,
-    default: fallbackColor,
-    light: fallbackColor,
-    lighter: fallbackColor,
-  };
-}
-
-function levelColor(
-  scale: ColorScale,
-  level: number,
-  siblingIndex: number,
-): string {
-  if (level === 0) return scale.darker;
-  if (level === 1) {
-    const shades = [
-      scale.darker,
-      scale.dark,
-      scale.default,
-      scale.light,
-      scale.lighter,
-    ];
-    return shades[siblingIndex % shades.length];
-  }
-  const leafShades = [
-    scale.darker,
-    scale.dark,
-    scale.default,
-    scale.light,
-    scale.lighter,
-  ];
-  return leafShades[siblingIndex % leafShades.length];
-}
-
-function getFixedSubcategoryColor(
-  categoryName: string,
-  subcategoryKey: string,
-): string | null {
-  const resolved = getChartSubcategoryColor(categoryName, subcategoryKey, '');
-  return resolved || null;
-}
-
 type TreemapNode = {
   name: string;
   value: number;
@@ -159,70 +45,43 @@ type TreemapNode = {
 
 function toTreemapNode(
   node: EmissionTreemapCategory | EmissionTreemapChild,
-  categoryName: string,
-  scale: ColorScale,
-  level: number,
-  siblingIndex: number,
 ): TreemapNode {
-  const fixedNodeColor = getFixedSubcategoryColor(categoryName, node.name);
-  const color =
-    fixedNodeColor ?? node.color ?? levelColor(scale, level, siblingIndex);
-
-  const label = resolveLabel(node.name);
-
+  const label = node.name.replace(/_/g, ' ');
   const treeNode: TreemapNode = {
     name: label,
     value: node.value,
-    itemStyle: { color },
+    itemStyle: { color: node.color },
   };
-
-  if (Array.isArray(node.children) && node.children.length > 0) {
-    treeNode.children = node.children.map((child, index) =>
-      toTreemapNode(child, categoryName, scale, level + 1, index),
-    );
+  if (
+    'children' in node &&
+    Array.isArray(node.children) &&
+    node.children.length > 0
+  ) {
+    treeNode.children = node.children.map((child) => toTreemapNode(child));
   }
-
   return treeNode;
 }
 
 const treemapData = computed(() => {
   return props.data
     .filter((item) => item.value > 0 && item.children.length > 0)
-    .map((item, index) =>
-      toTreemapNode(
-        item,
-        item.name,
-        getCategoryScale(item.name, item.color),
-        0,
-        index,
-      ),
-    );
+    .map((item) => toTreemapNode(item));
 });
 
 const legendData = computed(() => {
-  const yyLegend: Array<{ name: string; color: string }> = [];
-
-  props.data
-    .filter((category) => category.value > 0)
-    .forEach((category) => {
-      const scale = getCategoryScale(category.name, category.color);
-      category.children
-        .filter((yy) => yy.value > 0)
-        .forEach((yy, yyIndex) => {
-          const fixed = getFixedSubcategoryColor(category.name, yy.name);
-          yyLegend.push({
-            name: resolveLabel(yy.name),
-            color: fixed ?? levelColor(scale, 1, yyIndex),
-          });
-        });
-    });
-
   const seen = new Set<string>();
-  return yyLegend.filter((item) => {
-    if (seen.has(item.name)) return false;
-    seen.add(item.name);
-    return true;
-  });
+  return props.data
+    .filter((cat) => cat.value > 0)
+    .flatMap((cat) =>
+      cat.children
+        .filter((c) => c.value > 0)
+        .map((c) => ({ name: c.name.replace(/_/g, ' '), color: c.color })),
+    )
+    .filter((item) => {
+      if (seen.has(item.name)) return false;
+      seen.add(item.name);
+      return true;
+    });
 });
 
 const chartOption = computed(

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { TreemapChart } from 'echarts/charts';
@@ -19,8 +20,50 @@ import type {
   EmissionTreemapChild,
 } from 'src/composables/useEmissionTreemap';
 
+const { t } = useI18n();
 const moduleStore = useModuleStore();
 const workspaceStore = useWorkspaceStore();
+
+const TREEMAP_LABEL_KEY_MAP: Record<string, string> = {
+  // process_emissions
+  co2: 'charts-co2-subcategory',
+  ch4: 'charts-ch4-subcategory',
+  n2o: 'charts-n2o-subcategory',
+  refrigerants: 'charts-refrigerants-subcategory',
+  // buildings
+  heating_thermal: 'charts-heating-thermal-subcategory',
+  lighting: 'charts-lighting-subcategory',
+  cooling: 'charts-cooling-subcategory',
+  ventilation: 'charts-ventilation-subcategory',
+  // equipment
+  scientific: 'charts-scientific-subcategory',
+  it: 'charts-equipment-it',
+  // external cloud & AI
+  stockage: 'charts-stockage-subcategory',
+  virtualisation: 'charts-virtualisation-subcategory',
+  calcul: 'charts-calcul-subcategory',
+  provider: 'charts-ai-provider-subcategory',
+  ai_provider: 'charts-ai-provider-subcategory',
+  // purchases
+  scientific_equipment: 'charts-scientific-subcategory',
+  it_equipment: 'charts-equipment-it',
+  consumable_accessories: 'charts-consumables-subcategory',
+  biological_chemical_gaseous: 'charts-bio-chemicals-subcategory',
+  services: 'charts-services-subcategory',
+  vehicles: 'charts-other-purchases-subcategory',
+  additional: 'charts-other-purchases-subcategory',
+  // research facilities
+  facilities: 'charts-research-facilities-subcategory',
+  animal: 'charts-research-animal-subcategory',
+  // professional travel
+  plane: 'charts-plane-subcategory',
+  train: 'charts-train-subcategory',
+};
+
+function resolveLabel(raw: string): string {
+  const key = TREEMAP_LABEL_KEY_MAP[raw];
+  return key ? t(key) : raw.replace(/_/g, ' ');
+}
 
 use([
   CanvasRenderer,
@@ -46,7 +89,7 @@ type TreemapNode = {
 function toTreemapNode(
   node: EmissionTreemapCategory | EmissionTreemapChild,
 ): TreemapNode {
-  const label = node.name.replace(/_/g, ' ');
+  const label = resolveLabel(node.name);
   const treeNode: TreemapNode = {
     name: label,
     value: node.value,
@@ -75,7 +118,7 @@ const legendData = computed(() => {
     .flatMap((cat) =>
       cat.children
         .filter((c) => c.value > 0)
-        .map((c) => ({ name: c.name.replace(/_/g, ' '), color: c.color })),
+        .map((c) => ({ name: resolveLabel(c.name), color: c.color })),
     )
     .filter((item) => {
       if (seen.has(item.name)) return false;

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -32,6 +32,8 @@ const props = defineProps<{
   perPersonBreakdown?: Record<string, number> | null;
   validatedCategories?: string[] | null;
   headcountValidated?: boolean;
+  showValidationPlaceholder?: boolean;
+  title?: string;
 }>();
 
 const { t } = useI18n();
@@ -468,7 +470,7 @@ const downloadCSV = () => {
     <q-card-section class="flex justify-between items-center">
       <div>
         <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
-          {{ $t('results_carbon_footprint_per_person_title') }}
+          {{ props.title ?? $t('results_carbon_footprint_per_person_title') }}
         </span>
       </div>
 
@@ -503,7 +505,7 @@ const downloadCSV = () => {
       />
     </q-card-section>
 
-    <template v-if="headcountValidated">
+    <template v-if="headcountValidated || showValidationPlaceholder === false">
       <q-card-section class="chart-container flex justify-center items-center">
         <v-chart
           ref="chartRef"

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -31,6 +31,7 @@ import { formatTonnesForChart } from 'src/utils/number';
 
 const props = defineProps<{
   breakdownData?: EmissionBreakdownResponse | null;
+  title?: string;
 }>();
 
 const { t } = useI18n();
@@ -983,7 +984,7 @@ const downloadCSV = () => {
     <q-card-section class="flex justify-between items-center">
       <div>
         <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
-          {{ $t('unit_carbon_footprint_title') }}
+          {{ props.title ?? $t('unit_carbon_footprint_title') }}
         </span>
       </div>
 

--- a/frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
+
+interface Props {
+  title?: string;
+  validatedUnits: number;
+  totalUnits: number;
+  scopeLabel?: string;
+  helperText?: string;
+  loading?: boolean;
+}
+
+const { t } = useI18n();
+
+const props = withDefaults(defineProps<Props>(), {
+  title: undefined,
+  scopeLabel: undefined,
+  helperText: undefined,
+  loading: false,
+});
+
+const resolvedTitle = computed(
+  () => props.title ?? t('backoffice_reporting_completion_bar_title'),
+);
+const resolvedHelperText = computed(
+  () => props.helperText ?? t('backoffice_reporting_completion_bar_helper'),
+);
+const resolvedScopeLabel = computed(
+  () => props.scopeLabel ?? t('backoffice_reporting_completion_bar_scope'),
+);
+
+const percentage = computed(() => {
+  if (props.totalUnits <= 0) {
+    return 0;
+  }
+  return Math.round((props.validatedUnits / props.totalUnits) * 100);
+});
+
+const safeProgress = computed(
+  () => Math.max(0, Math.min(percentage.value, 100)) / 100,
+);
+
+const barColor = computed(() => {
+  if (percentage.value >= 70) return 'positive';
+  if (percentage.value >= 30) return 'warning';
+  return 'negative';
+});
+</script>
+
+<template>
+  <q-card flat bordered class="completion-rate-bar">
+    <q-card-section class="q-pa-lg">
+      <div class="row items-center justify-between q-mb-md">
+        <div class="text-h6 text-weight-medium">{{ resolvedTitle }}</div>
+        <q-icon
+          :name="outlinedInfo"
+          size="sm"
+          class="cursor-pointer text-primary"
+          :aria-label="$t('module-info-label')"
+        >
+          <q-tooltip class="u-tooltip">
+            {{ resolvedHelperText }}
+          </q-tooltip>
+        </q-icon>
+      </div>
+
+      <div class="row items-center justify-between q-mb-sm text-body1">
+        <div>
+          {{
+            $t('backoffice_reporting_completion_bar_count', {
+              validated: validatedUnits,
+              total: totalUnits,
+              scope: resolvedScopeLabel,
+            })
+          }}
+        </div>
+        <div class="text-weight-bold">{{ percentage }}%</div>
+      </div>
+
+      <q-linear-progress
+        :value="safeProgress"
+        :color="barColor"
+        track-color="grey-4"
+        rounded
+        size="8px"
+      />
+
+      <div class="text-body2 text-grey-7 q-mt-sm">
+        {{ resolvedHelperText }}
+      </div>
+    </q-card-section>
+  </q-card>
+</template>

--- a/frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue
@@ -9,7 +9,6 @@ interface Props {
   totalUnits: number;
   scopeLabel?: string;
   helperText?: string;
-  loading?: boolean;
 }
 
 const { t } = useI18n();
@@ -18,7 +17,6 @@ const props = withDefaults(defineProps<Props>(), {
   title: undefined,
   scopeLabel: undefined,
   helperText: undefined,
-  loading: false,
 });
 
 const resolvedTitle = computed(

--- a/frontend/src/components/organisms/backoffice/reporting/ReportingFilters.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportingFilters.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useUnitFiltersStore } from 'src/stores/unitFilters';
 
 const emit = defineEmits<{
   (
     e: 'update:filters',
-    filters: { selectedUnits: number[]; completion_status: number | string },
+    filters: {
+      path_lvl2: number[];
+      path_lvl3: number[];
+      path_lvl4: number[];
+      completion_status: number | string;
+    },
   ): void;
 }>();
 
@@ -29,16 +34,23 @@ const completion = ref('');
 // LVL3: http://localhost:8000/api/v1/backoffice-reporting/units?level=3&unit_type_label=Institut
 // LVL4: http://localhost:8000/api/v1/backoffice-reporting/units?level=4&parent_unit_type_label=Institut
 
-// Combine all selected units (OR logic)
-const selectedUnits = computed(() => [
-  ...selectedLevel2Units.value,
-  ...selectedLevel3Units.value,
-  ...selectedLevel4Units.value,
-]);
-
 function handleFiltersChange() {
+  // Clear store search queries when filters are empty
+  if (!selectedLevel2Units.value || selectedLevel2Units.value.length === 0) {
+    unitFiltersStore.setSearchQueryLevel2('');
+  }
+  if (!selectedLevel3Units.value || selectedLevel3Units.value.length === 0) {
+    unitFiltersStore.setSearchQueryLevel3('');
+  }
+  if (!selectedLevel4Units.value || selectedLevel4Units.value.length === 0) {
+    unitFiltersStore.setSearchQueryLevel4('');
+  }
+
+  // Emit filter update
   emit('update:filters', {
-    selectedUnits: selectedUnits.value,
+    path_lvl2: selectedLevel2Units.value || [],
+    path_lvl3: selectedLevel3Units.value || [],
+    path_lvl4: selectedLevel4Units.value || [],
     completion_status: completion.value,
   });
 }
@@ -90,6 +102,7 @@ function handleFiltersChange() {
         @filter="unitFiltersStore.filterLevel2Units"
         @virtual-scroll="unitFiltersStore.onScrollLevel2"
         @update:model-value="handleFiltersChange"
+        @clear="unitFiltersStore.setSearchQueryLevel2('')"
       >
         <template #prepend>
           <q-icon name="o_business" color="grey-6" size="xs" />
@@ -139,6 +152,7 @@ function handleFiltersChange() {
         @filter="unitFiltersStore.filterLevel3Units"
         @virtual-scroll="unitFiltersStore.onScrollLevel3"
         @update:model-value="handleFiltersChange"
+        @clear="unitFiltersStore.setSearchQueryLevel3('')"
       >
         <template #prepend>
           <q-icon name="o_business" color="grey-6" size="xs" />
@@ -187,6 +201,7 @@ function handleFiltersChange() {
         @filter="unitFiltersStore.filterLevel4Units"
         @virtual-scroll="unitFiltersStore.onScrollLevel4"
         @update:model-value="handleFiltersChange"
+        @clear="unitFiltersStore.setSearchQueryLevel4('')"
       >
         <template #prepend>
           <q-icon name="o_business" color="grey-6" size="xs" />
@@ -207,6 +222,7 @@ function handleFiltersChange() {
         :label="$t('backoffice_reporting_row_completion_label')"
         class="full-width"
         style="flex-grow: 1"
+        @update:model-value="handleFiltersChange"
       >
         <template #prepend>
           <q-icon name="o_check_small" color="grey-6" size="xs" />

--- a/frontend/src/components/organisms/backoffice/reporting/ReportingYear.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportingYear.vue
@@ -31,10 +31,6 @@ watch(
 watch(
   years,
   (newYears) => {
-    if (newYears.length === 0) {
-      // Fallback to latest year or default
-      return {};
-    }
     emit('update:years', newYears);
   },
   { immediate: true },
@@ -55,6 +51,8 @@ onMounted(async () => {
       :options="yearOptions"
       option-value="value"
       option-label="label"
+      emit-value
+      map-options
       multiple
       use-chips
       outlined

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -31,76 +31,15 @@
 import { storeToRefs } from 'pinia';
 import { computed, watch } from 'vue';
 import { Module, MODULES } from 'src/constant/modules';
-import {
-  CHART_CATEGORY_COLOR_SCHEMES,
-  MODULE_TO_CATEGORIES,
-} from 'src/constant/charts';
 import HeadCountBarChart from 'src/components/molecules/HeadCountBarChart.vue';
 import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTreeMapChart.vue';
 import { useModuleStore } from 'src/stores/modules';
-import type {
-  EmissionBreakdownResponse,
-  EmissionBreakdownCategoryRow,
-} from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
-
-type EmissionTreemapChild = {
-  name: string;
-  value: number;
-  percentage?: number;
-  color?: string;
-  children?: EmissionTreemapChild[];
-};
-
-type EmissionTreemapCategory = {
-  name: string;
-  value: number;
-  color: string;
-  children: EmissionTreemapChild[];
-};
-
-function getCategoryTotal(row: EmissionBreakdownCategoryRow): number {
-  return row.emissions.reduce((total, emission) => {
-    return total + (Number(emission.value) || 0);
-  }, 0);
-}
-
-function buildTreemapChildren(
-  row: EmissionBreakdownCategoryRow,
-): EmissionTreemapChild[] {
-  const direct: EmissionTreemapChild[] = [];
-  const grouped = new Map<string, EmissionTreemapChild>();
-
-  for (const emission of row.emissions) {
-    const value = Number(emission.value) || 0;
-    if (value <= 0) continue;
-
-    const child: EmissionTreemapChild = {
-      name: emission.key,
-      value,
-    };
-
-    if (!emission.parent_key) {
-      direct.push(child);
-      continue;
-    }
-
-    const parent = grouped.get(emission.parent_key);
-    if (!parent) {
-      grouped.set(emission.parent_key, {
-        name: emission.parent_key,
-        value,
-        children: [child],
-      });
-      continue;
-    }
-
-    parent.value += value;
-    parent.children?.push(child);
-  }
-
-  return [...direct, ...Array.from(grouped.values())];
-}
+import {
+  buildModuleTreemapData,
+  CATEGORY_CHART_KEYS,
+} from 'src/composables/useEmissionTreemap';
+import { MODULE_TO_CATEGORIES } from 'src/constant/charts';
 
 const props = defineProps<{
   type: Module;
@@ -138,37 +77,20 @@ const hasStats = computed(() => {
   return !!stats && Object.keys(stats).length > 0;
 });
 
-function buildTreemapFromRows(
-  breakdown: EmissionBreakdownResponse,
-  categories: string[],
-): EmissionTreemapCategory[] {
-  const colorSchemes = CHART_CATEGORY_COLOR_SCHEMES.value;
-  return breakdown.module_breakdown
-    .filter(
-      (item) =>
-        categories.includes(item.category) && getCategoryTotal(item) > 0,
-    )
-    .map((item) => ({
-      name: item.category,
-      value: getCategoryTotal(item),
-      color: colorSchemes[item.category] ?? '#999999',
-      children: buildTreemapChildren(item),
-    }));
-}
+const moduleTreemapData = computed(() => {
+  const breakdown = moduleStore.state.emissionBreakdown?.module_breakdown;
+  if (!breakdown || breakdown.length === 0) return [];
 
-function buildModuleTreemapData(
-  breakdown: EmissionBreakdownResponse | null,
-  moduleKey: string,
-): EmissionTreemapCategory[] {
-  if (!breakdown) return [];
-  const categories = MODULE_TO_CATEGORIES.value[moduleKey] ?? [];
-  if (categories.length === 0) return [];
-  return buildTreemapFromRows(breakdown, categories);
-}
+  const categories = MODULE_TO_CATEGORIES.value[props.type] ?? [];
+  const filteredKeys = Object.fromEntries(
+    Object.entries(CATEGORY_CHART_KEYS).filter(([k]) => categories.includes(k)),
+  ) as Record<string, string[]>;
 
-const moduleTreemapData = computed(() =>
-  buildModuleTreemapData(moduleStore.state.emissionBreakdown, props.type),
-);
+  return buildModuleTreemapData(
+    breakdown as Array<{ category: string; [key: string]: number | string }>,
+    filteredKeys,
+  );
+});
 </script>
 
 <style scoped lang="scss">

--- a/frontend/src/composables/useEmissionTreemap.ts
+++ b/frontend/src/composables/useEmissionTreemap.ts
@@ -1,0 +1,126 @@
+import {
+  CHART_CATEGORY_COLOR_SCHEMES,
+  CHART_SUBCATEGORY_COLOR_SCHEMES,
+} from 'src/constant/charts';
+
+export interface EmissionTreemapChild {
+  name: string;
+  value: number;
+  percentage: number;
+  color: string;
+}
+
+export interface EmissionTreemapCategory {
+  name: string;
+  value: number;
+  percentage: number;
+  color: string;
+  children: EmissionTreemapChild[];
+}
+
+// Mirrors backend CATEGORY_CHART_KEYS in emission_breakdown.py
+export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
+  process_emissions: ['co2', 'ch4', 'n2o', 'refrigerants'],
+  buildings_energy_combustion: ['heating_thermal', 'combustion'],
+  buildings_room: ['lighting', 'cooling', 'ventilation', 'heating_elec'],
+  equipment: ['scientific', 'it', 'other'],
+  external_cloud_and_ai: ['stockage', 'virtualisation', 'calcul', 'provider'],
+  purchases: [
+    'scientific_equipment',
+    'it_equipment',
+    'consumable_accessories',
+    'biological_chemical_gaseous',
+    'services',
+    'vehicles',
+    'other',
+    'additional',
+  ],
+  research_facilities: ['facilities', 'animal'],
+  professional_travel: ['plane', 'train'],
+};
+
+/**
+ * Builds a treemap hierarchy from flat module_breakdown rows returned by the API.
+ *
+ * @param rows - flat per-category rows from `emission_breakdown.module_breakdown`
+ * @param categoryChartKeys - maps each category name to its list of subcategory keys;
+ *   pass a subset of CATEGORY_CHART_KEYS to filter to specific module categories
+ */
+export function buildModuleTreemapData(
+  rows: Array<{ category: string; [key: string]: number | string }>,
+  categoryChartKeys: Record<string, string[]>,
+): EmissionTreemapCategory[] {
+  const colorByCategory = CHART_CATEGORY_COLOR_SCHEMES.value as Record<
+    string,
+    string
+  >;
+  const subcolorByCategory = CHART_SUBCATEGORY_COLOR_SCHEMES.value as Record<
+    string,
+    Record<string, string>
+  >;
+
+  const result: EmissionTreemapCategory[] = [];
+
+  for (const cat of Object.keys(categoryChartKeys)) {
+    const row = rows.find((r) => r.category === cat);
+    if (!row) continue;
+
+    const subKeys = categoryChartKeys[cat] ?? [];
+    const catColor = colorByCategory[cat] ?? '#999999';
+    const subColors = subcolorByCategory[cat] ?? {};
+
+    let catTotal: number;
+    let children: EmissionTreemapChild[];
+
+    if (subKeys.length > 0) {
+      children = subKeys
+        .map((k) => ({ key: k, val: Number(row[k]) || 0 }))
+        .filter(({ val }) => val > 0)
+        .map(({ key, val }) => ({
+          name: key,
+          value: val,
+          percentage: 0, // filled below
+          color: subColors[key] ?? catColor,
+        }));
+      catTotal = children.reduce((s, c) => s + c.value, 0);
+    } else {
+      // No predefined subkeys — sum all numeric non-metadata values
+      catTotal = Object.entries(row)
+        .filter(([k]) => k !== 'category' && !k.endsWith('StdDev'))
+        .reduce((s, [, v]) => s + (Number(v) || 0), 0);
+      children = [];
+    }
+
+    if (catTotal <= 0) continue;
+
+    children.forEach((c) => {
+      c.percentage = (c.value / catTotal) * 100;
+    });
+
+    result.push({
+      name: cat,
+      value: catTotal,
+      percentage: 0, // filled after grand total
+      color: catColor,
+      children,
+    });
+  }
+
+  const grandTotal = result.reduce((s, c) => s + c.value, 0);
+  result.forEach((cat) => {
+    cat.percentage = grandTotal > 0 ? (cat.value / grandTotal) * 100 : 0;
+  });
+
+  return result;
+}
+
+/**
+ * Builds a treemap for the results summary page using all module categories.
+ *
+ * @param moduleBreakdown - `emission_breakdown.module_breakdown` from the API
+ */
+export function buildResultsTreemapData(
+  moduleBreakdown: Array<{ category: string; [key: string]: number | string }>,
+): EmissionTreemapCategory[] {
+  return buildModuleTreemapData(moduleBreakdown, CATEGORY_CHART_KEYS);
+}

--- a/frontend/src/constant/UnitReportingData.ts
+++ b/frontend/src/constant/UnitReportingData.ts
@@ -1,0 +1,15 @@
+export interface UnitReportingData {
+  id: string | number;
+  unit_name: string;
+  affiliation: string;
+  validation_status: string;
+  principal_user: string;
+  last_update: string;
+  highest_result_category: string;
+  total_carbon_footprint: number;
+  year: number;
+  total_fte?: number;
+  view_url?: string;
+  completion?: number;
+  completion_progress?: string;
+}

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -365,6 +365,9 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
       stockage: colors.value.paleYellowGreen.default,
       virtualisation: colors.value.paleYellowGreen.light,
       calcul: colors.value.paleYellowGreen.lighter,
+      // Backend flattens AI providers under the parent key `provider`
+      // (from emission type `external__ai__provider_*`).
+      provider: colors.value.paleYellowGreen.light,
       ai_provider: colors.value.paleYellowGreen.light,
     },
     purchases: {

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -1,4 +1,12 @@
 export default {
+  backoffice_reporting_aggregated_results_title: {
+    en: 'Aggregated Results',
+    fr: 'Résultats agrégés',
+  },
+  backoffice_reporting_aggregated_results_per_fte_title: {
+    en: 'Aggregated Results per FTE',
+    fr: 'Résultats agrégés par EPT',
+  },
   backoffice_reporting_year_title: {
     en: 'Reporting Year',
     fr: 'Année du rapport',
@@ -173,6 +181,52 @@ export default {
   backoffice_reporting_usage_box_one_unit: {
     en: 'Number of validated modules',
     fr: 'Nombre de modules validées',
+  },
+
+  backoffice_reporting_chart_unit_footprint_title: {
+    en: 'Unit Carbon Footprint',
+    fr: 'Empreinte carbone par unite',
+  },
+  backoffice_reporting_chart_unit_footprint_description: {
+    en: 'One bar per unit using aggregated total carbon footprint (tCO2-eq).',
+    fr: 'Une barre par unite avec l empreinte carbone totale agregee (tCO2-eq).',
+  },
+  backoffice_reporting_chart_per_fte_title: {
+    en: 'Carbon Footprint per FTE',
+    fr: 'Empreinte carbone par EPT',
+  },
+  backoffice_reporting_chart_per_fte_description: {
+    en: 'Computed as total carbon footprint divided by total FTE (tCO2-eq/FTE).',
+    fr: 'Calculee comme empreinte carbone totale divisee par le total EPT (tCO2-eq/EPT).',
+  },
+  backoffice_reporting_chart_no_data: {
+    en: 'No data available for the current filters.',
+    fr: 'Aucune donnee disponible pour les filtres actuels.',
+  },
+  backoffice_reporting_chart_no_fte_data: {
+    en: 'No units with valid FTE data for the current filters.',
+    fr: 'Aucune unite avec des donnees EPT valides pour les filtres actuels.',
+  },
+
+  backoffice_reporting_completion_bar_title: {
+    en: 'Calculator Completion Rate',
+    fr: 'Taux de complétion du calculateur',
+  },
+  backoffice_reporting_completion_bar_helper: {
+    en: 'Each unit has equal weight, independent of FTE size',
+    fr: 'Chaque unité a le même poids, indépendamment de la taille en EPT',
+  },
+  backoffice_reporting_completion_bar_scope: {
+    en: 'in current selection',
+    fr: 'dans la sélection actuelle',
+  },
+  backoffice_reporting_completion_bar_scope_table: {
+    en: 'in current table',
+    fr: 'dans le tableau actuel',
+  },
+  backoffice_reporting_completion_bar_count: {
+    en: '{validated} out of {total} total units validated',
+    fr: '{validated} unités validées sur {total}',
   },
 
   backoffice_reporting_generate_formats: {

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -261,11 +261,9 @@ const getUncertainty = (
       </q-card>
       <q-card flat class="grid-2-col">
         <ModuleCarbonFootprintChart
-          :view-uncertainties="viewUncertainties"
           :breakdown-data="moduleStore.state.emissionBreakdown"
         />
         <CarbonFootPrintPerPersonChart
-          :view-uncertainties="viewUncertainties"
           :per-person-breakdown="
             moduleStore.state.emissionBreakdown?.per_person_breakdown
           "

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -16,6 +16,10 @@ import ReportingFilters from 'src/components/organisms/backoffice/reporting/Repo
 import UnitsTable from 'src/components/organisms/backoffice/reporting/UnitsTable.vue';
 import ReportExport from 'src/components/organisms/backoffice/reporting/ReportExport.vue';
 import UnitDialogue from 'src/components/organisms/backoffice/reporting/UnitDialogue.vue';
+import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
+import EmissionBreakdownChart from 'src/components/charts/EmissionBreakdownChart.vue';
 import { useRouter } from 'vue-router';
 const backofficeStore = useBackofficeStore();
 
@@ -51,14 +55,22 @@ async function toggleSelectAll(shouldSelectAll: boolean) {
 
 const selectedYears = ref<string[]>(['2026']); // Default to latest year
 
-// Track selected units from ReportingFilters
-const selectedUnits = ref<number[]>([]);
+// Track selected hierarchy filters from ReportingFilters
+const selectedPathLvl2 = ref<number[]>([]);
+const selectedPathLvl3 = ref<number[]>([]);
+const selectedPathLvl4 = ref<number[]>([]);
+const selectedCompletionStatus = ref<string | number>('');
 
 function handleFiltersUpdate(payload: {
-  selectedUnits: number[];
+  path_lvl2: number[];
+  path_lvl3: number[];
+  path_lvl4: number[];
   completion_status: string | number;
 }) {
-  selectedUnits.value = payload.selectedUnits;
+  selectedPathLvl2.value = payload.path_lvl2;
+  selectedPathLvl3.value = payload.path_lvl3;
+  selectedPathLvl4.value = payload.path_lvl4;
+  selectedCompletionStatus.value = payload.completion_status;
   fetchUnits();
 }
 
@@ -67,15 +79,52 @@ const selectedUnitId = ref<string | number>('');
 
 const units = computed(() => backofficeStore.units);
 const loading = computed(() => backofficeStore.unitsLoading);
+const reportingEmissionBreakdown = computed(
+  () => units.value?.emission_breakdown ?? null,
+);
+
+function isFullyValidatedProgress(progress?: string): boolean {
+  if (!progress) return false;
+  const [validatedRaw, totalRaw] = progress.split('/');
+  const validated = Number(validatedRaw);
+  const total = Number(totalRaw);
+  if (!Number.isFinite(validated) || !Number.isFinite(total)) return false;
+  return total > 0 && validated >= total;
+}
+
+const tableRows = computed(() => units.value?.data ?? []);
+const validatedCount = computed(
+  () =>
+    tableRows.value.filter((row) =>
+      isFullyValidatedProgress(row.completion_progress),
+    ).length,
+);
+const tableTotal = computed(() => tableRows.value.length);
 
 async function fetchUnits() {
+  if (selectedYears.value.length === 0) {
+    backofficeStore.units = null;
+    return;
+  }
   const filtersToSend: {
-    units?: number[];
+    path_lvl2?: Array<number | string>;
+    path_lvl3?: Array<number | string>;
+    path_lvl4?: Array<number | string>;
     years?: string[];
+    completion_status?: number | string;
     modules?: Array<{ module: string; state: ModuleState }>;
   } = {
-    units: selectedUnits.value.length > 0 ? selectedUnits.value : undefined,
+    path_lvl2:
+      selectedPathLvl2.value.length > 0 ? selectedPathLvl2.value : undefined,
+    path_lvl3:
+      selectedPathLvl3.value.length > 0 ? selectedPathLvl3.value : undefined,
+    path_lvl4:
+      selectedPathLvl4.value.length > 0 ? selectedPathLvl4.value : undefined,
     years: selectedYears.value,
+    completion_status:
+      selectedCompletionStatus.value !== ''
+        ? selectedCompletionStatus.value
+        : undefined,
     modules: Array.from(moduleStates.value.values()).map((data) => ({
       module: data.module,
       state: data.states.length > 0 ? data.states[0] : 0,
@@ -200,7 +249,7 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
       </div>
       <div class="q-mt-xl">
         <UnitsTable
-          :units="units?.data || []"
+          :units="tableRows"
           :pagination="units?.pagination"
           :loading="loading"
           @view-unit="handleViewUnit"
@@ -223,26 +272,37 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
       />
       <!-- Aggregated Results Box #460 -->
       <div class="q-mt-xl">
-        <div class="container full-width">
-          <!-- <div class="q-mb-xs">
-            <span class="text-h5 text-weight-medium">{{
-              $t('backoffice_reporting_aggregated_results_title')
-            }}</span>
-          </div>
-          <span class="text-body2">{{
-            $t('backoffice_reporting_aggregated_results_description')
-          }}</span> -->
-
-          <!-- Placeholder for aggregated results -->
-          <div class="q-pa-md bg-grey-2 rounded">
-            <img
-              src="/placeholder-reporting.png"
-              alt="Aggregated Results Placeholder"
-              class="full-width"
-            />
-          </div>
-        </div>
+        <CompletionRateBar
+          :validated-units="validatedCount"
+          :total-units="tableTotal"
+          :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
+        />
       </div>
+      <q-card flat class="grid-2-col q-mt-xl">
+        <ModuleCarbonFootprintChart
+          :breakdown-data="reportingEmissionBreakdown"
+          :title="$t('backoffice_reporting_aggregated_results_title')"
+        />
+        <CarbonFootPrintPerPersonChart
+          :per-person-breakdown="
+            reportingEmissionBreakdown?.per_person_breakdown ?? null
+          "
+          :validated-categories="
+            reportingEmissionBreakdown?.validated_categories ?? null
+          "
+          :headcount-validated="
+            reportingEmissionBreakdown?.validated_categories?.includes(
+              'commuting',
+            ) ?? false
+          "
+          :show-validation-placeholder="false"
+          :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
+        />
+      </q-card>
+      <EmissionBreakdownChart
+        :breakdown-data="reportingEmissionBreakdown"
+        class="q-mt-xl"
+      />
       <div class="q-mt-xl">
         <div class="container full-width">
           <div class="q-mb-xs">

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -83,23 +83,9 @@ const reportingEmissionBreakdown = computed(
   () => units.value?.emission_breakdown ?? null,
 );
 
-function isFullyValidatedProgress(progress?: string): boolean {
-  if (!progress) return false;
-  const [validatedRaw, totalRaw] = progress.split('/');
-  const validated = Number(validatedRaw);
-  const total = Number(totalRaw);
-  if (!Number.isFinite(validated) || !Number.isFinite(total)) return false;
-  return total > 0 && validated >= total;
-}
-
 const tableRows = computed(() => units.value?.data ?? []);
-const validatedCount = computed(
-  () =>
-    tableRows.value.filter((row) =>
-      isFullyValidatedProgress(row.completion_progress),
-    ).length,
-);
-const tableTotal = computed(() => tableRows.value.length);
+const validatedCount = computed(() => units.value?.validated_units_count ?? 0);
+const tableTotal = computed(() => units.value?.total_units_count ?? 0);
 
 async function fetchUnits() {
   if (selectedYears.value.length === 0) {
@@ -291,9 +277,7 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
             reportingEmissionBreakdown?.validated_categories ?? null
           "
           :headcount-validated="
-            reportingEmissionBreakdown?.validated_categories?.includes(
-              'commuting',
-            ) ?? false
+            reportingEmissionBreakdown?.headcount_validated ?? false
           "
           :show-validation-placeholder="false"
           :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"

--- a/frontend/src/stores/backoffice.ts
+++ b/frontend/src/stores/backoffice.ts
@@ -43,6 +43,8 @@ interface BackofficeUnitDataPagination {
     total: number;
   };
   emission_breakdown?: EmissionBreakdownResponse | null;
+  validated_units_count?: number;
+  total_units_count?: number;
 }
 
 interface UnitFilters {

--- a/frontend/src/stores/backoffice.ts
+++ b/frontend/src/stores/backoffice.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { api } from 'src/api/http';
 import type { ModuleState } from 'src/constant/moduleStates';
+import type { EmissionBreakdownResponse } from 'src/stores/modules';
 
 // interface ModuleCompletion {
 //   status: ModuleState;
@@ -27,7 +28,10 @@ interface BackofficeUnitData {
   last_update: string;
   highest_result_category: string;
   total_carbon_footprint: number;
+  total_fte?: number | null;
   view_url: string;
+  completion?: number;
+  completion_progress?: string;
 }
 
 interface BackofficeUnitDataPagination {
@@ -38,13 +42,15 @@ interface BackofficeUnitDataPagination {
     total_pages: number;
     total: number;
   };
+  emission_breakdown?: EmissionBreakdownResponse | null;
 }
 
 interface UnitFilters {
-  affiliation?: string[];
-  units?: number[];
+  path_lvl2?: Array<number | string>;
+  path_lvl3?: Array<number | string>;
+  path_lvl4?: Array<number | string>;
   years?: string[];
-  completion?: string;
+  completion_status?: number | string;
   outlier_values?: boolean | null;
   search?: string;
   modules?: Array<{ module: string; state: ModuleState }>;
@@ -114,24 +120,38 @@ export const useBackofficeStore = defineStore('backoffice', () => {
 
       const searchParams = new URLSearchParams();
 
-      // Add array filters (affiliation, units, years)
-      if (filters?.affiliation && filters.affiliation.length > 0) {
-        filters.affiliation.forEach((v) =>
-          searchParams.append('affiliation', String(v)),
+      // Add hierarchy filters
+      if (filters?.path_lvl2 && filters.path_lvl2.length > 0) {
+        filters.path_lvl2.forEach((v) =>
+          searchParams.append('path_lvl2', String(v)),
         );
       }
 
-      if (filters?.units && filters.units.length > 0) {
-        filters.units.forEach((v) => searchParams.append('units', String(v)));
+      if (filters?.path_lvl3 && filters.path_lvl3.length > 0) {
+        filters.path_lvl3.forEach((v) =>
+          searchParams.append('path_lvl3', String(v)),
+        );
+      }
+
+      if (filters?.path_lvl4 && filters.path_lvl4.length > 0) {
+        filters.path_lvl4.forEach((v) =>
+          searchParams.append('path_lvl4', String(v)),
+        );
       }
 
       if (filters?.years && filters.years.length > 0) {
         filters.years.forEach((v) => searchParams.append('years', String(v)));
       }
 
-      // Add string filters (completion, search)
-      if (filters?.completion?.trim()) {
-        searchParams.append('completion', filters.completion.trim());
+      // Add status/search filters
+      if (
+        filters?.completion_status !== undefined &&
+        filters?.completion_status !== ''
+      ) {
+        searchParams.append(
+          'completion_status',
+          String(filters.completion_status),
+        );
       }
 
       if (filters?.search?.trim()) {

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -39,6 +39,7 @@ export interface EmissionBreakdownResponse {
   additional_breakdown: EmissionBreakdownCategoryRow[];
   per_person_breakdown: Record<string, number>;
   validated_categories: string[];
+  headcount_validated: boolean;
   total_tonnes_co2eq: number;
   total_fte: number;
 }

--- a/frontend/src/stores/unitFilters.ts
+++ b/frontend/src/stores/unitFilters.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { ref, computed } from 'vue';
+import { ref, computed, nextTick } from 'vue';
 
 export interface Options {
   label: string;
@@ -209,10 +209,7 @@ export const useUnitFiltersStore = defineStore('unitFilters', () => {
         total: 0,
       };
     }
-    // Use nextTick to ensure data is reset before fetching
-    Promise.resolve().then(() => {
-      fetchLevel2Units(query, 1);
-    });
+    void nextTick(() => fetchLevel2Units(query, 1));
   };
 
   const filterLevel2Units = (val: string, update: (cb: () => void) => void) => {
@@ -248,10 +245,7 @@ export const useUnitFiltersStore = defineStore('unitFilters', () => {
         total: 0,
       };
     }
-    // Use nextTick to ensure data is reset before fetching
-    Promise.resolve().then(() => {
-      fetchLevel3Units(query, 1);
-    });
+    void nextTick(() => fetchLevel3Units(query, 1));
   };
 
   const filterLevel3Units = (val: string, update: (cb: () => void) => void) => {
@@ -287,10 +281,7 @@ export const useUnitFiltersStore = defineStore('unitFilters', () => {
         total: 0,
       };
     }
-    // Use nextTick to ensure data is reset before fetching
-    Promise.resolve().then(() => {
-      fetchLevel4Units(query, 1);
-    });
+    void nextTick(() => fetchLevel4Units(query, 1));
   };
 
   const filterLevel4Units = (val: string, update: (cb: () => void) => void) => {

--- a/frontend/src/stores/unitFilters.ts
+++ b/frontend/src/stores/unitFilters.ts
@@ -199,7 +199,20 @@ export const useUnitFiltersStore = defineStore('unitFilters', () => {
   const setSearchQueryLevel2 = (query: string) => {
     searchQueryLevel2.value = query;
     currentPageLevel2.value = 1;
-    fetchLevel2Units(query, 1);
+    // Reset data when clearing search to ensure fresh fetch
+    if (query === '') {
+      dataLevel2.value = [];
+      paginationLevel2.value = {
+        page: 1,
+        page_size: 50,
+        total_pages: 1,
+        total: 0,
+      };
+    }
+    // Use nextTick to ensure data is reset before fetching
+    Promise.resolve().then(() => {
+      fetchLevel2Units(query, 1);
+    });
   };
 
   const filterLevel2Units = (val: string, update: (cb: () => void) => void) => {
@@ -225,7 +238,20 @@ export const useUnitFiltersStore = defineStore('unitFilters', () => {
   const setSearchQueryLevel3 = (query: string) => {
     searchQueryLevel3.value = query;
     currentPageLevel3.value = 1;
-    fetchLevel3Units(query, 1);
+    // Reset data when clearing search to ensure fresh fetch
+    if (query === '') {
+      dataLevel3.value = [];
+      paginationLevel3.value = {
+        page: 1,
+        page_size: 50,
+        total_pages: 1,
+        total: 0,
+      };
+    }
+    // Use nextTick to ensure data is reset before fetching
+    Promise.resolve().then(() => {
+      fetchLevel3Units(query, 1);
+    });
   };
 
   const filterLevel3Units = (val: string, update: (cb: () => void) => void) => {
@@ -251,7 +277,20 @@ export const useUnitFiltersStore = defineStore('unitFilters', () => {
   const setSearchQueryLevel4 = (query: string) => {
     searchQueryLevel4.value = query;
     currentPageLevel4.value = 1;
-    fetchLevel4Units(query, 1);
+    // Reset data when clearing search to ensure fresh fetch
+    if (query === '') {
+      dataLevel4.value = [];
+      paginationLevel4.value = {
+        page: 1,
+        page_size: 50,
+        total_pages: 1,
+        total: 0,
+      };
+    }
+    // Use nextTick to ensure data is reset before fetching
+    Promise.resolve().then(() => {
+      fetchLevel4Units(query, 1);
+    });
   };
 
   const filterLevel4Units = (val: string, update: (cb: () => void) => void) => {


### PR DESCRIPTION
## What does this change?
Adds aggregated emission reporting charts and a completion rate bar to the backoffice reporting page, replacing a static placeholder image. Specifically:

- Introduces a CompletionRateBar component showing validated vs total units with a color-coded progress bar
- Integrates ModuleCarbonFootprintChart, CarbonFootPrintPerPersonChart, and EmissionBreakdownChart into the reporting page using aggregated emission breakdown data from the API
- Extracts treemap data-building logic into a reusable useEmissionTreemap composable, simplifying ModuleCharts.vue and GenericEmissionTreeMapChart.vue
- Refactors reporting filters to send hierarchical unit filters (path_lvl2/3/4) instead of a flat selectedUnits array, and adds completion_status forwarding
- Adds i18n keys for all new UI strings (EN + FR)
- Adds showValidationPlaceholder prop to CarbonFootPrintPerPersonChart to allow bypassing the headcount validation gate in reporting context

## Why is this needed?
The backoffice reporting page had a placeholder image where aggregated results should appear. Administrators need to see real carbon footprint data, completion rates, and emission breakdowns across filtered units — without navigating into individual workspaces. The filter refactor also aligns the frontend with the backend's hierarchy-based filtering API.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #460 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
