### PR TITLE
feat528/ add formDefaults support and defaultFrom field for total_fte in module configuration

### DIFF
--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -325,6 +325,7 @@ const props = withDefaults(
     addButtonLabelKey?: string;
     unitId?: number;
     year?: string | number;
+    formDefaults?: Record<string, unknown>;
   }>(),
   {
     fields: null,
@@ -335,6 +336,7 @@ const props = withDefaults(
     addButtonLabelKey: 'common_add_button',
     unitId: undefined,
     year: undefined,
+    formDefaults: undefined,
   },
 );
 
@@ -576,9 +578,11 @@ function init() {
     if (props.rowData && props.rowData[i.id] !== undefined) {
       form[i.id] = props.rowData[i.id];
     } else {
-      // Check if field has a default value
+      // Check if field has a default value (static config or dynamic formDefaults)
       if (i.default !== undefined) {
         form[i.id] = i.default;
+      } else if (props.formDefaults?.[i.id] !== undefined) {
+        form[i.id] = props.formDefaults[i.id] as FieldValue;
       } else {
         switch (effectiveType) {
           case 'checkbox':
@@ -627,9 +631,9 @@ function init() {
   });
 }
 
-// re-init when inputs or rowData change (e.g. dynamic config or edit mode)
+// re-init when inputs, rowData, or external defaults change
 watch(
-  () => [props.fields, props.rowData],
+  () => [props.fields, props.rowData, props.formDefaults],
   () => init(),
   { deep: true, immediate: true },
 );
@@ -843,9 +847,11 @@ function onSubmit() {
 function reset() {
   visibleFields.value.forEach((i) => {
     const effectiveType = i.type;
-    // Check if field has a default value
+    // Check if field has a default value (static config or dynamic formDefaults)
     if (i.default !== undefined) {
       form[i.id] = i.default;
+    } else if (props.formDefaults?.[i.id] !== undefined) {
+      form[i.id] = props.formDefaults[i.id] as FieldValue;
     } else if (effectiveType === 'checkbox' || effectiveType === 'boolean')
       form[i.id] = false;
     else if (effectiveType === 'number') form[i.id] = null;

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -61,6 +61,7 @@
           :has-tooltip="submodule.hasFormTooltip"
           :unit-id="unitId"
           :year="year"
+          :form-defaults="formDefaults"
           @submit="submitForm"
         />
       </div>
@@ -83,7 +84,7 @@ import {
 } from 'src/constant/moduleConfig';
 import ModuleTable from 'src/components/organisms/module/ModuleTable.vue';
 import ModuleForm from 'src/components/organisms/module/ModuleForm.vue';
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useAuthStore } from 'src/stores/auth';
@@ -96,7 +97,7 @@ import type {
   EnumSubmoduleType,
 } from 'src/constant/modules';
 import { enumSubmodule } from 'src/constant/modules';
-import { useModuleStore } from 'src/stores/modules';
+import { useModuleStore, useTimelineStore } from 'src/stores/modules';
 import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
 interface Option {
   label: string;
@@ -104,6 +105,31 @@ interface Option {
 }
 type FieldValue = string | number | boolean | null | Option;
 const moduleStore = useModuleStore();
+const timelineStore = useTimelineStore();
+
+onMounted(() => {
+  const needsFte = props.submodule.moduleFields?.some(
+    (f) => f.defaultFrom === 'total_fte',
+  );
+  const carbonReportId = timelineStore.currentCarbonReportId;
+  if (
+    needsFte &&
+    carbonReportId &&
+    carbonReportId !== moduleStore.validatedTotalsCarbonReportId
+  ) {
+    moduleStore.getValidatedTotals(carbonReportId);
+  }
+});
+
+const formDefaults = computed<Record<string, unknown> | undefined>(() => {
+  const fte = moduleStore.state.validatedTotals?.total_fte;
+
+  const defaults: Record<string, unknown> = {};
+  for (const field of props.submodule.moduleFields ?? []) {
+    if (field.defaultFrom === 'total_fte') defaults[field.id] = Math.round(fte);
+  }
+  return Object.keys(defaults).length > 0 ? defaults : undefined;
+});
 
 type CommonProps = {
   submodule: ConfigSubmodule;

--- a/frontend/src/constant/module-config/external-cloud-and-ai.ts
+++ b/frontend/src/constant/module-config/external-cloud-and-ai.ts
@@ -129,6 +129,7 @@ const externalAIFields: ModuleField[] = [
     ratio: '4/12',
     sortable: true,
     hideIn: { table: false },
+    defaultFrom: 'total_fte',
   },
   {
     id: 'requests_per_user_per_day',

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -56,6 +56,7 @@ export interface ModuleField {
   max?: number;
   step?: number;
   default?: string | number | boolean;
+  defaultFrom?: 'total_fte';
   options?: Array<{ value: string; label: string }>;
   optionsId?: string; // ID to fetch options from store (kind or subkind)
   appendFromFieldId?: string;

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -98,7 +98,7 @@ export default {
     fr: '>100 fois/jour',
   },
   [`${MODULES.ExternalCloudAndAI}.inputs.user_count`]: {
-    en: 'Number of users',
-    fr: "Nombre d'utilisateurs",
+    en: 'Number of users (fte)',
+    fr: "Nombre d'utilisateurs (EPT)",
   },
 } as const;


### PR DESCRIPTION
## What does this change?
This PR introduces the ability to pre-fill module forms using dynamic external data. 
* **Dynamic Defaults:** Added a `formDefaults` prop to `ModuleForm.vue` and updated the initialization/reset logic to prioritize these values over static config defaults.
* **FTE Integration:** Updated `SubModuleSection.vue` to automatically fetch `total_fte` from the `moduleStore` (via `getValidatedTotals`) if a field in the submodule configuration requires it.
* **Schema Update:** Added `defaultFrom: 'total_fte'` to the `ConfigField` interface and applied it to the `external-cloud-and-ai` configuration.
* **Reactive Re-init:** Updated the watcher in `ModuleForm` to ensure the form re-initializes correctly when `formDefaults` are loaded asynchronously.

## Why is this needed?
To improve UX and data consistency. Users should not have to manually input institutional data (like Total FTE) that the system already knows. This change automates the pre-filling of these fields, reducing manual entry errors and saving time.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally (verified FTE auto-populates in Cloud/AI forms)
- [x] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues
- Closes #528 