### PR TITLE
fix/528 default 0

### DIFF
--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -122,11 +122,14 @@ onMounted(() => {
 });
 
 const formDefaults = computed<Record<string, unknown> | undefined>(() => {
-  const fte = moduleStore.state.validatedTotals?.total_fte;
+  const validatedTotals = moduleStore.state.validatedTotals;
+  if (!validatedTotals) return undefined;
 
   const defaults: Record<string, unknown> = {};
   for (const field of props.submodule.moduleFields ?? []) {
-    if (field.defaultFrom === 'total_fte') defaults[field.id] = Math.round(fte);
+    if (field.defaultFrom === 'total_fte') {
+      defaults[field.id] = Math.round(validatedTotals.total_fte);
+    }
   }
   return Object.keys(defaults).length > 0 ? defaults : undefined;
 });


### PR DESCRIPTION
## What does this change?
Guards the `formDefaults` computed property against a `undefined` `validatedTotals` before accessing `total_fte`, and early-returns `undefined` when the store value is not yet available.

## Why is this needed?
Previously, `Math.round(fte)` could be called with `undefined` when `validatedTotals` had not yet been populated, resulting in `NaN` being written as the default field value. This caused fields with `defaultFrom: 'total_fte'` to render with `NaN` instead of 0 or no value.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues
- Closes #528
- Related to #