### PR TITLE
feat: add usage statistics title to reporting page and update styles

### DIFF
--- a/frontend/src/components/organisms/backoffice/reporting/ReportingStatCardUnit.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportingStatCardUnit.vue
@@ -36,8 +36,6 @@ defineProps<Props>();
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-
-  margin-top: 24px;
   gap: 12px;
 }
 </style>

--- a/frontend/src/components/organisms/backoffice/reporting/ReportingStatCards.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportingStatCards.vue
@@ -70,7 +70,7 @@ const cards = computed(() => [
 
 .stat-card {
   flex: 1;
-  margin-top: 24px;
+
   border-radius: 3px;
   padding: 24px;
   height: 131px;

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -11,6 +11,10 @@ export default {
     en: 'Reporting Year',
     fr: 'Année du rapport',
   },
+  backoffice_reporting_usage_statistic: {
+    en: 'Usage statistics',
+    fr: 'Statistiques d’usage',
+  },
   backoffice_reporting_year_description: {
     en: 'Select the year to view module completion data for that reporting period.',
     fr: "Sélectionnez l'année pour afficher les données d'achèvement des modules pour cette période de rapport.",

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -293,6 +293,11 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
         :breakdown-data="reportingEmissionBreakdown"
         class="q-mt-xl"
       />
+      <div class="flex justify-between items-center q-pt-xl q-pb-md">
+        <span class="text-body1 text-weight-medium">{{
+          $t('backoffice_reporting_usage_statistic')
+        }}</span>
+      </div>
       <ReportingStatCards
         v-if="tableRows.length > 1"
         :stats="usageStats"


### PR DESCRIPTION
## What does this change?
This PR improves the visual hierarchy and layout of the Backoffice Reporting page by:

Adding a section title: Introduced the backoffice_reporting_usage_statistic translation key and displayed it above the usage statistics cards.

Refining Layout: Removed hardcoded margin-top: 24px from ReportingStatCardUnit.vue and ReportingStatCards.vue.

Spacing Adjustments: Replaced manual margins with Quasar utility classes (q-pt-xl, q-pb-md) in the parent page to ensure consistent spacing between the emission breakdown and the usage statistics section.

## Why is this needed?
Previously, the usage statistics cards lacked a clear label, making the data feel disconnected from the rest of the report. Additionally, the hardcoded CSS margins caused layout rigidity; moving the spacing responsibility to the parent page (ReportingPage.vue) allows for better component reusability and more predictable spacing.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #461 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
