### PR TITLE
Fix/reporting

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -26,6 +26,7 @@ from app.models.user import User
 from app.repositories.carbon_report_module_repo import (
     CarbonReportModuleRepository,
 )
+from app.repositories.carbon_report_repo import CarbonReportRepository
 from app.repositories.unit_repo import UnitRepository
 from app.schemas.backoffice import (
     PaginatedUnitReportingData,
@@ -256,10 +257,22 @@ async def list_backoffice_units(
     """
     List units with their reporting completion status and outlier values,
     """
-    carbon_report_repo = CarbonReportModuleRepository(db)
+    carbon_report_module_repo = CarbonReportModuleRepository(db)
+    carbon_report_repo = CarbonReportRepository(db)
     if years is None or len(years) == 0:
         raise ValueError("At least one year must be specified for reporting overview")
-    result = await carbon_report_repo.get_reporting_overview(
+    data = await carbon_report_repo.get_reporting_overview(
+        path_lvl2=path_lvl2,
+        path_lvl3=path_lvl3,
+        path_lvl4=path_lvl4,
+        completion_status=completion_status,
+        search=search,
+        modules=modules,
+        years=years,
+        page=page,
+        page_size=page_size,
+    )
+    result = await carbon_report_module_repo.get_reporting_overview(
         path_lvl2=path_lvl2,
         path_lvl3=path_lvl3,
         path_lvl4=path_lvl4,
@@ -276,9 +289,33 @@ async def list_backoffice_units(
 
     # Convert the data to UnitReportingData instances
     unit_reporting_data = []
-    for item in result.get("data", []):
+    for item in data:
         if isinstance(item, dict):
-            unit_reporting_data.append(UnitReportingData(**item))
+            completion = item.get("completion_progress", "0/8")
+            completion_status = ModuleStatus.NOT_STARTED
+            left, right = completion.split("/")
+            if left == right and left != "0":
+                completion_status = ModuleStatus.VALIDATED
+            elif left != "0":
+                completion_status = ModuleStatus.IN_PROGRESS
+            unit_reporting_data.append(
+                UnitReportingData(
+                    id=item.get("id", -1),
+                    unit_name=item.get("unit_name", "Unknown Unit"),
+                    affiliation=item.get("affiliation", "Unknown Affiliation"),
+                    validation_status=item.get("validation_status", "unknown"),
+                    principal_user=item.get("principal_user", "Unknown User"),
+                    last_update=item.get("last_update"),
+                    highest_result_category=item.get("highest_result_category"),
+                    total_carbon_footprint=item.get("total_carbon_footprint", 0.0),
+                    total_fte=item.get("total_fte"),
+                    view_url=item.get("view_url"),
+                    completion=completion_status,
+                    completion_progress=item.get("completion_progress"),
+                )
+            )
+        elif isinstance(item, CarbonReport):
+            unit_reporting_data.append(UnitReportingData.model_validate(item))
         else:
             unit_reporting_data.append(item)
 
@@ -292,6 +329,59 @@ async def list_backoffice_units(
         total_units_count=result.get("total_units_count", 0),
         module_status_counts=result.get("module_status_counts"),
     )
+
+
+# usage !?
+# SELECT
+#     cr.id AS report_id,
+#     cr.year,
+#     cr.unit_id,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 1) AS headcount_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 2) AS
+#   professional_travel_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 3) AS buildings_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 4) AS
+#   equipment_electric_consumption_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 5) AS purchase_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 6) AS
+#   research_facilities_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 7) AS
+#   external_cloud_and_ai_status,
+#     MAX(crm.status) FILTER (WHERE crm.module_type_id = 8) AS process_emissions_status,
+#     cr.last_updated,
+#     cr.completion_progress,
+#     cr.overall_status
+# FROM carbon_reports cr
+# LEFT JOIN carbon_report_modules crm
+#     ON crm.carbon_report_id = cr.id
+# GROUP BY cr.id, cr.year, cr.unit_id, cr.last_updated, cr.completion_progress,
+#   cr.overall_status
+# ORDER BY cr.id;
+
+# or different usage
+# SELECT
+#     cr.id AS report_id,
+#     cr.year,
+#     cr.unit_id,
+#     CASE crm.module_type_id
+#         WHEN 1 THEN 'headcount'
+#         WHEN 2 THEN 'professional_travel'
+#         WHEN 3 THEN 'buildings'
+#         WHEN 4 THEN 'equipment_electric_consumption'
+#         WHEN 5 THEN 'purchase'
+#         WHEN 6 THEN 'research_facilities'
+#         WHEN 7 THEN 'external_cloud_and_ai'
+#         WHEN 8 THEN 'process_emissions'
+#     END AS module_name,
+#     crm.status AS module_status,
+#     cr.last_updated,
+#     cr.stats,
+#     cr.completion_progress,
+#     cr.overall_status
+# FROM carbon_reports cr
+# JOIN carbon_report_modules crm
+#     ON crm.carbon_report_id = cr.id
+# ORDER BY cr.id, crm.module_type_id;
 
 
 @router.get("/export-detailed")
@@ -309,10 +399,59 @@ async def export_detailed_reporting(
     current_user: User = Depends(require_permission("backoffice.users", "export")),
 ):
     """
-    Export detailed reporting data for all units, including module-level details.
-    Creates one CSV per unit/year/module combination using response
-      DTOs and packages them in a ZIP file.
-    File naming format: {AFFILIATION}_{UNIT_NAME}_{YEAR}_module_{MODULE_TYPE}.csv
+        Export detailed reporting data for all units, including module-level details.
+        Creates one CSV per unit/year/module combination using response
+          DTOs and packages them in a ZIP file.
+        File naming format: {AFFILIATION}_{UNIT_NAME}_{YEAR}_module_{MODULE_TYPE}.csv
+
+        We can do it faster if we skip the DTO validation and just dump the
+        raw data from the database,
+        like so
+
+    SELECT
+        cr.year,
+        de.data_entry_type_id,
+        u.institutional_id,
+        de.id,
+
+        j.name,
+        j.equipment_class,
+        j.sub_class,
+
+        SUM(dee.kg_co2eq) AS total_kg_co2eq
+
+    FROM data_entries de
+
+    JOIN carbon_report_modules crm ON crm.id = de.carbon_report_module_id
+    JOIN carbon_reports cr ON cr.id = crm.carbon_report_id
+    JOIN units u ON u.id = cr.unit_id
+
+    LEFT JOIN data_entry_emissions dee ON dee.data_entry_id = de.id
+
+    -- JSON → columns
+    LEFT JOIN LATERAL jsonb_to_record(de.data::jsonb) AS j(
+
+            name TEXT,
+            equipment_class TEXT,
+            sub_class TEXT,
+            active_usage_hours_per_week INT,
+            standby_usage_hours_per_week INT,
+            note TEXT
+    ) ON TRUE
+
+    WHERE de.data_entry_type_id = 10
+
+    GROUP BY
+        cr.year,
+        de.data_entry_type_id,
+        u.institutional_id,
+        de.id,
+        j.name,
+        j.equipment_class,
+        j.sub_class;
+
+
+
     """
     # Get units based on filters
     unit_repo = UnitRepository(db)

--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -14,13 +14,13 @@ from sqlmodel import desc, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_db
+from app.core.constants import ModuleStatus
 from app.core.logging import get_logger
 from app.core.security import require_permission
 from app.models.carbon_report import (
     CarbonReport,
     CarbonReportModule,
     CarbonReportModuleRead,
-    ModuleStatus,
 )
 from app.models.user import User
 from app.repositories.carbon_report_module_repo import (

--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -6,10 +6,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.core.config import get_settings
+from app.core.constants import ModuleStatus
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import check_module_permission as _check_module_permission
-from app.models.carbon_report import CarbonReportModule, ModuleStatus
+from app.models.carbon_report import CarbonReportModule
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
 from app.schemas.carbon_report import CarbonReportModuleRead

--- a/backend/app/models/carbon_report.py
+++ b/backend/app/models/carbon_report.py
@@ -1,23 +1,9 @@
-from enum import IntEnum
 from typing import Optional
 
 from sqlalchemy import Index, UniqueConstraint
 from sqlmodel import JSON, Column, Field, SQLModel
 
-
-class ModuleStatus(IntEnum):
-    """
-    Status values for inventory modules.
-
-    These map to the frontend MODULE_STATES constant:
-    - NOT_STARTED (0) = Default
-    - IN_PROGRESS (1) = InProgress
-    - VALIDATED (2) = Validated
-    """
-
-    NOT_STARTED = 0
-    IN_PROGRESS = 1
-    VALIDATED = 2
+from app.core.constants import ModuleStatus
 
 
 class CarbonReportBase(SQLModel):

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -6,8 +6,9 @@ from typing import Any, List, Optional
 from sqlmodel import and_, case, col, desc, func, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.constants import ModuleStatus
 from app.core.logging import get_logger
-from app.models.carbon_report import CarbonReport, CarbonReportModule, ModuleStatus
+from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import DataEntry
 from app.models.data_entry_emission import DataEntryEmission
 from app.models.module_type import ModuleTypeEnum

--- a/backend/app/repositories/carbon_report_repo.py
+++ b/backend/app/repositories/carbon_report_repo.py
@@ -1,10 +1,11 @@
 """Carbon report repository for database operations."""
 
-from typing import Optional
+from typing import List, Optional
 
-from sqlmodel import select
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.constants import ModuleStatus
 from app.core.logging import get_logger
 from app.models.carbon_report import CarbonReport
 from app.schemas.carbon_report import CarbonReportCreate, CarbonReportUpdate
@@ -75,3 +76,27 @@ class CarbonReportRepository:
         await self.session.delete(db_obj)
         await self.session.flush()
         return True
+
+    async def get_reporting_overview(
+        self,
+        path_lvl2: Optional[List[str]] = None,
+        path_lvl3: Optional[List[str]] = None,
+        path_lvl4: Optional[List[str]] = None,
+        completion_status: Optional[ModuleStatus] = None,
+        search: Optional[str] = None,
+        modules: Optional[List[str]] = None,  # complex TBD
+        years: Optional[List[int]] = None,  # Default to first year for overview for now
+        page: int = 1,
+        page_size: int = 50,
+    ) -> list[CarbonReport]:
+        """
+        Retrieves the aggregated reporting data using a Deferred Join strategy.
+        First paginates the Units, then calculates footprints ONLY for those 50 units.
+        """
+        statement = select(CarbonReport).where(
+            (col(CarbonReport.year).in_(years)) if years else True
+        )
+
+        statement = statement.offset((page - 1) * page_size).limit(page_size)
+        result = await self.session.execute(statement)
+        return list(result.scalars().all())

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -6,8 +6,9 @@ from sqlalchemy import Select, case, literal
 from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.constants import ModuleStatus
 from app.core.logging import get_logger
-from app.models.carbon_report import CarbonReport, CarbonReportModule, ModuleStatus
+from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.data_entry_emission import DataEntryEmission
 from app.models.module_type import ModuleTypeEnum

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -8,9 +8,10 @@ from sqlalchemy import select as sa_select
 from sqlmodel import col, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.constants import ModuleStatus
 from app.core.logging import get_logger
 from app.models.building_room import BuildingRoom
-from app.models.carbon_report import CarbonReportModule, ModuleStatus
+from app.models.carbon_report import CarbonReportModule
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.data_entry_emission import DataEntryEmission
 from app.models.factor import Factor

--- a/backend/app/schemas/carbon_report.py
+++ b/backend/app/schemas/carbon_report.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from app.models.carbon_report import ModuleStatus
+from app.core.constants import ModuleStatus
 
 
 class CarbonReportBase(BaseModel):

--- a/backend/app/seed/random_generator/seed_carbon_reports.py
+++ b/backend/app/seed/random_generator/seed_carbon_reports.py
@@ -18,7 +18,7 @@ import random
 import asyncpg
 
 from app.core.config import get_settings
-from app.models.carbon_report import ModuleStatus
+from app.core.constants import ModuleStatus
 from app.models.module_type import ALL_MODULE_TYPE_IDS
 
 YEARS = [2023, 2024, 2025]

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -5,9 +5,9 @@ from typing import List, Optional
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.constants import ModuleStatus
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
-from app.models.carbon_report import ModuleStatus
 from app.models.data_entry_emission import (
     EmissionType,
     get_all_nodes,

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -5,9 +5,9 @@ from typing import List, Optional
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.constants import ModuleStatus
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
-from app.models.carbon_report import ModuleStatus
 from app.repositories.carbon_report_repo import CarbonReportRepository
 from app.schemas.carbon_report import (
     CarbonReportCreate,

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -47,6 +47,10 @@ class CarbonReportService:
             return None
         return CarbonReportRead.model_validate(carbon_report)
 
+    async def get_reporting_overview(self, args) -> list[CarbonReportRead]:
+        results = await self.repo.get_reporting_overview(*args)
+        return [CarbonReportRead.model_validate(cr) for cr in results]
+
     async def list_by_unit(self, unit_id: int) -> List[CarbonReportRead]:
         """List all carbon reports for a unit."""
         carbon_reports = await self.repo.list_by_unit(unit_id)

--- a/docs/implementation-plans/504-backoffice-reporting-results-csv.md
+++ b/docs/implementation-plans/504-backoffice-reporting-results-csv.md
@@ -1,0 +1,409 @@
+This is already solid — let’s turn it into something a dev can **execute step-by-step without ambiguity**, and make a few key improvements (performance, correctness, extensibility).
+
+---
+
+# 📄 PRD 2 — Results CSV (`results.csv`)
+
+## 🚀 0. Implementation Plan (READ FIRST)
+
+Follow these steps **in order**:
+
+### Step 1 — Ensure mapping table is correct
+
+- Table: `emission_type_mapping`
+- Must contain:
+  - `id`, `name`
+  - `category_id`, `subcategory_id`
+  - `category_name`, `subcategory_name`
+
+👉 If not populated, run:
+
+```sql
+UPDATE emission_type_mapping
+SET
+    category_id = (id / 10000) * 10000,
+    subcategory_id = CASE
+        WHEN id % 10000 >= 100 THEN (id / 100) * 100
+        ELSE NULL
+    END;
+```
+
+---
+
+### Step 2 — Validate JSON structure
+
+Ensure `carbon_reports.stats` contains:
+
+```json
+{
+  "scope1": ...,
+  "scope2": ...,
+  "scope3": ...,
+  "total": ...,
+  "by_emission_type": {
+    "10000": 123.4,
+    "20000": 456.7
+  }
+}
+```
+
+👉 If `by_emission_type` is missing → STOP (data issue)
+
+---
+
+### Step 3 — Run base query (below)
+
+👉 This generates the dataset
+
+---
+
+### Step 4 — Export
+
+In pgAdmin:
+
+- Run query
+- Right-click → **Save as CSV**
+- File name: `results.csv`
+
+---
+
+### Step 5 (optional, recommended)
+
+Create a **materialized view** for performance:
+
+```sql
+CREATE MATERIALIZED VIEW carbon_report_results AS
+<query below>;
+```
+
+---
+
+# 🎯 1. Objective
+
+Provide a dataset of **emissions per report × emission_type**, enriched with hierarchy:
+
+- category
+- subcategory
+- emission type
+
+Used for:
+
+- analytics
+- dashboards
+- exports
+
+---
+
+# 📦 2. Scope
+
+- One row per **(report_id × emission_type_id)**
+- Source: `carbon_reports.stats`
+- Enrichment: `emission_type_mapping`
+- No recomputation from raw emissions
+
+---
+
+# 🧩 3. Data Sources
+
+| Table                   | Role                        |
+| ----------------------- | --------------------------- |
+| `carbon_reports`        | aggregated emissions (JSON) |
+| `emission_type_mapping` | hierarchy + labels          |
+
+---
+
+# 🧠 4. Data Model
+
+### Granularity
+
+```
+1 row = 1 report × 1 emission_type
+```
+
+---
+
+### Columns
+
+| Column             | Type    | Description         |
+| ------------------ | ------- | ------------------- |
+| report_id          | integer | report identifier   |
+| year               | integer | reporting year      |
+| unit_id            | integer | unit identifier     |
+| category_id        | integer | derived category    |
+| subcategory_id     | integer | derived subcategory |
+| category_name      | text    | category label      |
+| subcategory_name   | text    | subcategory label   |
+| emission_type_id   | integer | emission type       |
+| emission_type_name | text    | emission label      |
+| kg_co2eq           | float   | emissions           |
+
+---
+
+# 🧮 5. SQL Specification (FINAL)
+
+## ✅ Recommended version (robust + explicit)
+
+```sql
+SELECT
+    cr.id AS report_id,
+    cr.year,
+    cr.unit_id,
+
+    etm.category_id,
+    etm.subcategory_id,
+    etm.category_name,
+    etm.subcategory_name,
+
+    etm.id AS emission_type_id,
+    etm.name AS emission_type_name,
+
+    (kv.value)::float AS kg_co2eq
+
+FROM carbon_reports cr
+
+-- 🔥 explode JSON (safer + faster than ? operator)
+CROSS JOIN LATERAL jsonb_each(cr.stats->'by_emission_type') kv(key, value)
+
+-- join mapping
+JOIN emission_type_mapping etm
+    ON etm.id = kv.key::int
+
+ORDER BY
+    cr.id,
+    etm.category_id,
+    etm.subcategory_id,
+    etm.id;
+```
+
+---
+
+## ⚠️ Why this version is better than original
+
+| Change                      | Reason                      |
+| --------------------------- | --------------------------- |
+| `jsonb_each` instead of `?` | avoids repeated JSON lookup |
+| `CROSS JOIN LATERAL`        | explicit row expansion      |
+| direct join on `kv.key`     | faster + cleaner            |
+
+---
+
+# 📊 6. Output
+
+- File: `results.csv`
+- Format: CSV
+- Sorted by:
+  - report
+  - category
+  - subcategory
+  - emission type
+
+---
+
+# ⚙️ 7. Constraints
+
+| Constraint            | Behavior                     |
+| --------------------- | ---------------------------- |
+| Missing emission type | Not included                 |
+| Missing mapping       | Row dropped (JOIN)           |
+| JSON malformed        | Query fails                  |
+| No aggregation        | Raw report-level values only |
+
+---
+
+# ⚡ 8. Performance Notes
+
+- Query is **O(number of emission types × reports)**
+- Typically fast (JSON already aggregated)
+- Add index:
+
+```sql
+CREATE INDEX idx_carbon_reports_stats_gin
+ON carbon_reports USING GIN (stats);
+```
+
+---
+
+# 🔄 9. Optional Improvements
+
+## Add scopes
+
+```sql
+(cr.stats->>'scope1')::float AS scope1,
+(cr.stats->>'scope2')::float AS scope2,
+(cr.stats->>'scope3')::float AS scope3,
+(cr.stats->>'total')::float AS total,
+```
+
+---
+
+## Add institutional_id
+
+```sql
+JOIN units u ON u.id = cr.unit_id
+```
+
+---
+
+## Zero-fill missing emission types
+
+👉 requires LEFT JOIN + full mapping scan (not current design)
+
+---
+
+## Materialized view (recommended)
+
+```sql
+CREATE MATERIALIZED VIEW carbon_report_results AS
+SELECT ...
+```
+
+Refresh:
+
+```sql
+REFRESH MATERIALIZED VIEW carbon_report_results;
+```
+
+---
+
+# 🧠 10. Design Decisions
+
+| Decision          | Reason               |
+| ----------------- | -------------------- |
+| Use JSON stats    | already aggregated   |
+| Use mapping table | decouples enum       |
+| No pivot          | keeps flexibility    |
+| LATERAL join      | proper JSON handling |
+| No zero-fill      | smaller dataset      |
+
+---
+
+# 💬 TL;DR for the dev
+
+1. Ensure `emission_type_mapping` is correct
+2. Use `jsonb_each` to explode `stats.by_emission_type`
+3. Join mapping
+4. Export
+5. (Optional) materialize
+
+---
+
+Example not completed (missing category/subcategory depends on what we want to display in the csv) (can import direct in DB)
+
+"id" "name" "category_id" "subcategory_id" "category_name" "subcategory_name"
+10000 "food" 10000 10000
+10001 "food**vegetarian" 10000 10000
+10002 "food**non_vegetarian" 10000 10000
+20000 "waste" 20000 20000
+20001 "waste**incineration" 20000 20000
+20002 "waste**composting" 20000 20000
+20003 "waste**biogas" 20000 20000
+20004 "waste**recycling" 20000 20000
+30000 "commuting" 30000 30000
+30001 "commuting**walking" 30000 30000
+30002 "commuting**cycling" 30000 30000
+30003 "commuting**powered_two_wheeler" 30000 30000
+30004 "commuting**public_transport" 30000 30000
+30005 "commuting**car" 30000 30000
+50000 "professional_travel" 50000 50000
+50100 "professional_travel**train" 50000 50100
+50101 "professional_travel**train**class_1" 50000 50100
+50102 "professional_travel**train**class_2" 50000 50100
+50200 "professional_travel**plane" 50000 50200
+50201 "professional_travel**plane**first" 50000 50200
+50202 "professional_travel**plane**business" 50000 50200
+50203 "professional_travel**plane**eco" 50000 50200
+60000 "buildings" 60000 60000
+60100 "buildings**rooms" 60000 60100
+60101 "buildings**rooms**lighting" 60000 60100
+60102 "buildings**rooms**cooling" 60000 60100
+60103 "buildings**rooms**ventilation" 60000 60100
+60104 "buildings**rooms**heating_elec" 60000 60100
+60105 "buildings**rooms**heating_thermal" 60000 60100
+60200 "buildings**combustion" 60000 60200
+60201 "buildings**combustion**natural_gas" 60000 60200
+60202 "buildings**combustion**heating_oil" 60000 60200
+60203 "buildings**combustion**biomethane" 60000 60200
+60204 "buildings**combustion**pellets" 60000 60200
+60205 "buildings**combustion**forest_chips" 60000 60200
+60206 "buildings**combustion**wood_logs" 60000 60200
+60300 "buildings**embodied_energy" 60000 60300
+70000 "process_emissions" 70000 70000
+70100 "process_emissions**ch4" 70000 70100
+70200 "process_emissions**co2" 70000 70200
+70300 "process_emissions**n2o" 70000 70300
+70400 "process_emissions**refrigerants" 70000 70400
+80000 "equipment" 80000 80000
+80100 "equipment**scientific" 80000 80100
+80200 "equipment**it" 80000 80200
+80300 "equipment**other" 80000 80300
+90000 "purchases" 90000 90000
+90100 "purchases**goods_and_services" 90000 90100
+90200 "purchases**scientific_equipment" 90000 90200
+90300 "purchases**it_equipment" 90000 90300
+90400 "purchases**consumable_accessories" 90000 90400
+90500 "purchases**biological_chemical_gaseous" 90000 90500
+90600 "purchases**services" 90000 90600
+90700 "purchases**vehicles" 90000 90700
+90800 "purchases**other" 90000 90800
+90900 "purchases**additional" 90000 90900
+90901 "purchases**additional**ln2" 90000 90900
+100000 "research_facilities" 100000 100000
+100100 "research_facilities**facilities" 100000 100100
+100200 "research_facilities**animal" 100000 100200
+110000 "external" 110000 110000
+110100 "external**clouds" 110000 110100
+110101 "external**clouds**virtualisation" 110000 110100
+110102 "external**clouds**calcul" 110000 110100
+110103 "external**clouds**stockage" 110000 110100
+110200 "external**ai" 110000 110200
+110201 "external**ai**provider_google" 110000 110200
+110202 "external**ai**provider_mistral_ai" 110000 110200
+110203 "external**ai**provider_anthropic" 110000 110200
+110204 "external**ai**provider_openai" 110000 110200
+110205 "external**ai**provider_cohere" 110000 110200
+110206 "external**ai**provider_others" 110000 110200
+2000301 "waste**biogas**organic_waste_food_leftovers" 2000000 2000300
+2000302 "waste**biogas**cooking_vegetable_oil" 2000000 2000300
+2000401 "waste**recycling**paper" 2000000 2000400
+2000402 "waste**recycling**cardboard" 2000000 2000400
+2000403 "waste**recycling**plastics" 2000000 2000400
+2000404 "waste**recycling**glass" 2000000 2000400
+2000405 "waste**recycling**ferrous_metals" 2000000 2000400
+2000406 "waste**recycling**non_ferrous_metals" 2000000 2000400
+2000407 "waste**recycling**electronics" 2000000 2000400
+2000408 "waste**recycling**wood" 2000000 2000400
+2000409 "waste**recycling**pet" 2000000 2000400
+2000410 "waste**recycling**aluminum" 2000000 2000400
+2000411 "waste**recycling**textile" 2000000 2000400
+2000412 "waste**recycling**toner_and_ink_cartridges" 2000000 2000400
+2000413 "waste**recycling**inert_waste" 2000000 2000400
+6010101 "buildings**rooms**lighting**office" 6010000 6010100
+6010102 "buildings**rooms**lighting**laboratories" 6010000 6010100
+6010103 "buildings**rooms**lighting**archives" 6010000 6010100
+6010104 "buildings**rooms**lighting**libraries" 6010000 6010100
+6010105 "buildings**rooms**lighting**auditoriums" 6010000 6010100
+6010106 "buildings**rooms**lighting**miscellaneous" 6010000 6010100
+6010201 "buildings**rooms**cooling**office" 6010000 6010200
+6010202 "buildings**rooms**cooling**laboratories" 6010000 6010200
+6010203 "buildings**rooms**cooling**archives" 6010000 6010200
+6010204 "buildings**rooms**cooling**libraries" 6010000 6010200
+6010205 "buildings**rooms**cooling**auditoriums" 6010000 6010200
+6010206 "buildings**rooms**cooling**miscellaneous" 6010000 6010200
+6010301 "buildings**rooms**ventilation**office" 6010000 6010300
+6010302 "buildings**rooms**ventilation**laboratories" 6010000 6010300
+6010303 "buildings**rooms**ventilation**archives" 6010000 6010300
+6010304 "buildings**rooms**ventilation**libraries" 6010000 6010300
+6010305 "buildings**rooms**ventilation**auditoriums" 6010000 6010300
+6010306 "buildings**rooms**ventilation**miscellaneous" 6010000 6010300
+6010401 "buildings**rooms**heating_elec**office" 6010000 6010400
+6010402 "buildings**rooms**heating_elec**laboratories" 6010000 6010400
+6010403 "buildings**rooms**heating_elec**archives" 6010000 6010400
+6010404 "buildings**rooms**heating_elec**libraries" 6010000 6010400
+6010405 "buildings**rooms**heating_elec**auditoriums" 6010000 6010400
+6010406 "buildings**rooms**heating_elec**miscellaneous" 6010000 6010400
+6010501 "buildings**rooms**heating_thermal**office" 6010000 6010500
+6010502 "buildings**rooms**heating_thermal**laboratories" 6010000 6010500
+6010503 "buildings**rooms**heating_thermal**archives" 6010000 6010500
+6010504 "buildings**rooms**heating_thermal**libraries" 6010000 6010500
+6010505 "buildings**rooms**heating_thermal**auditoriums" 6010000 6010500
+6010506 "buildings**rooms**heating_thermal**miscellaneous" 6010000 6010500

--- a/docs/implementation-plans/589-backoffice-reporting-detailed-csv.md
+++ b/docs/implementation-plans/589-backoffice-reporting-detailed-csv.md
@@ -1,0 +1,163 @@
+# 📄 PRD 3 — Detailed CSVs (`*_data.csv`)
+
+## 1. Objective
+
+Provide **raw, traceable, and schema-specific data** for each data entry type.
+
+This dataset is intended for:
+
+- auditing
+- debugging
+- detailed analysis
+
+---
+
+## 2. Scope
+
+- One CSV per `data_entry_type_id`
+- One row per `data_entry`
+- JSON data flattened into columns
+
+---
+
+## 3. Data Sources
+
+- `data_entries`
+- `data_entry_emissions`
+- `carbon_report_modules`
+- `carbon_reports`
+- `units`
+
+---
+
+## 4. Data Model
+
+### Granularity
+
+- 1 row = 1 data_entry
+
+---
+
+## 5. Common Columns
+
+| Column                | Description          |
+| --------------------- | -------------------- |
+| unit_institutional_id | unit identifier      |
+| year                  | reporting year       |
+| data_entry_id         | entry identifier     |
+| kg_co2eq              | aggregated emissions |
+| note                  | optional note        |
+
+---
+
+## 6. Key Rule
+
+Each CSV:
+
+- corresponds to one `data_entry_type_id`
+- has its own schema
+- flattens `data_entries.data` JSON
+
+---
+
+## 7. Base SQL Template
+
+```sql
+SELECT
+    cr.year,
+    u.institutional_id AS unit_institutional_id,
+    de.id AS data_entry_id,
+    de.data,
+    SUM(dee.kg_co2eq) AS kg_co2eq
+
+FROM data_entries de
+
+JOIN carbon_report_modules crm
+    ON crm.id = de.carbon_report_module_id
+
+JOIN carbon_reports cr
+    ON cr.id = crm.carbon_report_id
+
+JOIN units u
+    ON u.id = cr.unit_id
+
+LEFT JOIN data_entry_emissions dee
+    ON dee.data_entry_id = de.id
+
+WHERE de.data_entry_type_id = <TYPE_ID>
+
+GROUP BY
+    cr.year,
+    u.institutional_id,
+    de.id,
+    de.data;
+```
+
+---
+
+## 8. Transformation
+
+- Extract JSON fields using `->>` operator
+- Cast values when needed
+- Rename columns to match CSV contract
+
+---
+
+## 9. Example — Plane Travel
+
+```sql
+SELECT
+    u.institutional_id,
+    de.data->>'origin_iata' AS origin_iata,
+    de.data->>'destination_iata' AS destination_iata,
+    de.data->>'user_institutional_id' AS user_institutional_id,
+    de.data->>'departure_date' AS departure_date,
+    (de.data->>'number_of_trips')::int AS number_of_trips,
+    de.data->>'cabin_class' AS cabin_class,
+    de.data->>'note' AS note,
+
+    SUM(dee.kg_co2eq) AS kg_co2eq
+
+FROM data_entries de
+JOIN carbon_report_modules crm ON crm.id = de.carbon_report_module_id
+JOIN carbon_reports cr ON cr.id = crm.carbon_report_id
+JOIN units u ON u.id = cr.unit_id
+LEFT JOIN data_entry_emissions dee ON dee.data_entry_id = de.id
+
+WHERE de.data_entry_type_id = 20
+
+GROUP BY
+    u.institutional_id,
+    origin_iata,
+    destination_iata,
+    user_institutional_id,
+    departure_date,
+    number_of_trips,
+    cabin_class,
+    note;
+```
+
+---
+
+## 10. Output
+
+- Files: `<type_name>_data.csv`
+- One file per `data_entry_type_id`
+
+---
+
+## 11. Constraints
+
+- No mixing of types
+- JSON schema must be stable per type
+- Aggregation only at data_entry level
+
+---
+
+## 12. Future Improvements
+
+- Automate SQL generation per type
+- Add validation layer for schema consistency
+- Build unified export pipeline (Python/dbt)
+
+---

--- a/docs/implementation-plans/760-backoffice-reporting-export-usage-csv.md
+++ b/docs/implementation-plans/760-backoffice-reporting-export-usage-csv.md
@@ -1,0 +1,143 @@
+# 📄 PRD 1 — Usage CSV (`usage.csv`)
+
+## 1. Objective
+
+Provide a dataset that tracks the **status and progress of each module** for every carbon report.
+
+This dataset is intended for:
+
+- monitoring completion
+- identifying gaps in data collection
+- operational dashboards
+
+THE CSV results should look like this
+
+report_id
+year
+unit_id
+module_name
+module_stat last_updated
+
+---
+
+## 2. Scope
+
+- One row per **(report_id × module_type_id)**
+- Covers all modules defined in `ModuleTypeEnum`
+- Includes status and last update timestamp
+
+---
+
+## 3. Data Sources
+
+- `carbon_reports`
+- `carbon_report_modules`
+
+---
+
+## 4. Data Model
+
+### Granularity
+
+- 1 row = 1 report × 1 module
+
+### Columns
+
+| db column     | csv Column            | Type      | Description                        |
+| ------------- | --------------------- | --------- | ---------------------------------- |
+| id            | report_id             | integer   | `carbon_reports.id`                |
+| year          | year                  | string    | reporting year (2026)              |
+| unit_id       | unit_institutional_id | string    | unit identifier (cost center)      |
+| module_name   | module_name           | text      | mapped from `module_type_id`       |
+| module_status | module_status         | text      | status of the module (cf \*A)      |
+| last_updated  | last_updated          | timestamp | last update of the module (cf \*B) |
+
+- (\*A) status of module is 0,1,2 but _MUST_ display Not Started In Progress, Completed --> create an enum in DB or map to facilitate SQL)
+- (\*B) date is "2026-03-25T16:23:54.601649+00:00" in stats.computed_at, so that's a problem we should have a 'last_updated' field as Date not null (currently it's null), and in the csv we should have a csv/excell compatible date format like: 2026-03-25
+
+- example of carbon_reports table
+
+```csv
+"year"	"unit_id"	"id"	"last_updated"	"stats"	"completion_progress"	"overall_status"
+2025	2011	1		"{""scope1"": 0.0, ""scope2"": 0.0, ""scope3"": 96982.92000000001, ""total"": 96982.92000000001, ""by_emission_type"": {""10000"": 27750.0, ""20000"": 827.3199999999999, ""30000"": 68405.6}, ""computed_at"": ""2026-03-30T07:53:04.029432+00:00"", ""entry_count"": 8}"	"0/8"	0
+```
+
+- example of carbon_report_modules table
+
+```csv
+"module_type_id"	"status"	"carbon_report_id"	"id"	"last_updated"	"stats"
+1	0	125	993		"{""scope1"": 0.0, ""scope2"": 0.0, ""scope3"": 81255.95999999999, ""total"": 81255.95999999999, ""by_emission_type"": {""10000"": 23250.0, ""20000"": 693.16, ""30000"": 57312.79999999999}, ""computed_at"": ""2026-03-25T16:23:54.601649+00:00"", ""entry_count"": 8}"
+```
+
+---
+
+## 5. Mapping Logic
+
+### module_type_id → module_name
+
+| ID  | Name                           |
+| --- | ------------------------------ |
+| 1   | headcount                      |
+| 2   | professional_travel            |
+| 3   | buildings                      |
+| 4   | equipment_electric_consumption |
+| 5   | purchase                       |
+| 6   | research_facilities            |
+| 7   | external_cloud_and_ai          |
+| 8   | process_emissions              |
+
+---
+
+## 6. SQL Specification
+
+```sql
+SELECT
+    cr.id AS report_id,
+    cr.year,
+    cr.unit_id,
+
+    CASE crm.module_type_id
+        WHEN 1 THEN 'headcount'
+        WHEN 2 THEN 'professional_travel'
+        WHEN 3 THEN 'buildings'
+        WHEN 4 THEN 'equipment_electric_consumption'
+        WHEN 5 THEN 'purchase'
+        WHEN 6 THEN 'research_facilities'
+        WHEN 7 THEN 'external_cloud_and_ai'
+        WHEN 8 THEN 'process_emissions'
+    END AS module_name,
+
+    crm.status AS module_status,
+    crm.last_updated
+
+FROM carbon_reports cr
+JOIN carbon_report_modules crm
+    ON crm.carbon_report_id = cr.id
+
+ORDER BY cr.id, crm.module_type_id;
+```
+
+---
+
+## 7. Output
+
+- File: `usage.csv`
+- Format: CSV
+- Sorted by `(report_id, module_type_id)`
+
+---
+
+## 8. Constraints
+
+- All modules must be included, even if status is NULL
+- No aggregation
+- No filtering by year unless specified externally
+
+---
+
+## Improvements
+
+- Replace `CASE` with a `module_type_mapping` table
+- don't forget about completion_progress, overall_status
+  - Add completion percentage per report
+  - Add derived status (e.g. completed / incomplete)

--- a/docs/implementation-plans/detailed-view-reporting.md
+++ b/docs/implementation-plans/detailed-view-reporting.md
@@ -1,0 +1,211 @@
+CREATE TABLE emission_type_mapping (
+id INT PRIMARY KEY,
+name TEXT NOT NULL
+);
+
+INSERT INTO emission_type_mapping (id, name) VALUES
+-- food
+(10000, 'food'),
+(10001, 'food**vegetarian'),
+(10002, 'food**non_vegetarian'),
+
+-- waste
+(20000, 'waste'),
+(20001, 'waste**incineration'),
+(20002, 'waste**composting'),
+(20003, 'waste**biogas'),
+(2000301, 'waste**biogas**organic_waste_food_leftovers'),
+(2000302, 'waste**biogas**cooking_vegetable_oil'),
+(20004, 'waste**recycling'),
+(2000401, 'waste**recycling**paper'),
+(2000402, 'waste**recycling**cardboard'),
+(2000403, 'waste**recycling**plastics'),q
+(2000404, 'waste**recycling**glass'),
+(2000405, 'waste**recycling**ferrous_metals'),
+(2000406, 'waste**recycling**non_ferrous_metals'),
+(2000407, 'waste**recycling**electronics'),
+(2000408, 'waste**recycling**wood'),
+(2000409, 'waste**recycling**pet'),
+(2000410, 'waste**recycling**aluminum'),
+(2000411, 'waste**recycling**textile'),
+(2000412, 'waste**recycling**toner_and_ink_cartridges'),
+(2000413, 'waste**recycling**inert_waste'),
+
+-- commuting
+(30000, 'commuting'),
+(30001, 'commuting**walking'),
+(30002, 'commuting**cycling'),
+(30003, 'commuting**powered_two_wheeler'),
+(30004, 'commuting**public_transport'),
+(30005, 'commuting\_\_car'),
+
+-- professional travel
+(50000, 'professional_travel'),
+(50100, 'professional_travel**train'),
+(50101, 'professional_travel**train**class_1'),
+(50102, 'professional_travel**train**class_2'),
+(50200, 'professional_travel**plane'),
+(50201, 'professional_travel**plane**first'),
+(50202, 'professional_travel**plane**business'),
+(50203, 'professional_travel**plane**eco'),
+
+-- buildings
+(60000, 'buildings'),
+(60100, 'buildings\_\_rooms'),
+
+(60101, 'buildings**rooms**lighting'),
+(6010101, 'buildings**rooms**lighting**office'),
+(6010102, 'buildings**rooms**lighting**laboratories'),
+(6010103, 'buildings**rooms**lighting**archives'),
+(6010104, 'buildings**rooms**lighting**libraries'),
+(6010105, 'buildings**rooms**lighting**auditoriums'),
+(6010106, 'buildings**rooms**lighting**miscellaneous'),
+
+(60102, 'buildings**rooms**cooling'),
+(6010201, 'buildings**rooms**cooling**office'),
+(6010202, 'buildings**rooms**cooling**laboratories'),
+(6010203, 'buildings**rooms**cooling**archives'),
+(6010204, 'buildings**rooms**cooling**libraries'),
+(6010205, 'buildings**rooms**cooling**auditoriums'),
+(6010206, 'buildings**rooms**cooling**miscellaneous'),
+
+(60103, 'buildings**rooms**ventilation'),
+(6010301, 'buildings**rooms**ventilation**office'),
+(6010302, 'buildings**rooms**ventilation**laboratories'),
+(6010303, 'buildings**rooms**ventilation**archives'),
+(6010304, 'buildings**rooms**ventilation**libraries'),
+(6010305, 'buildings**rooms**ventilation**auditoriums'),
+(6010306, 'buildings**rooms**ventilation**miscellaneous'),
+
+(60104, 'buildings**rooms**heating_elec'),
+(6010401, 'buildings**rooms**heating_elec**office'),
+(6010402, 'buildings**rooms**heating_elec**laboratories'),
+(6010403, 'buildings**rooms**heating_elec**archives'),
+(6010404, 'buildings**rooms**heating_elec**libraries'),
+(6010405, 'buildings**rooms**heating_elec**auditoriums'),
+(6010406, 'buildings**rooms**heating_elec**miscellaneous'),
+
+(60105, 'buildings**rooms**heating_thermal'),
+(6010501, 'buildings**rooms**heating_thermal**office'),
+(6010502, 'buildings**rooms**heating_thermal**laboratories'),
+(6010503, 'buildings**rooms**heating_thermal**archives'),
+(6010504, 'buildings**rooms**heating_thermal**libraries'),
+(6010505, 'buildings**rooms**heating_thermal**auditoriums'),
+(6010506, 'buildings**rooms**heating_thermal**miscellaneous'),
+
+(60200, 'buildings**combustion'),
+(60201, 'buildings**combustion**natural_gas'),
+(60202, 'buildings**combustion**heating_oil'),
+(60203, 'buildings**combustion**biomethane'),
+(60204, 'buildings**combustion**pellets'),
+(60205, 'buildings**combustion**forest_chips'),
+(60206, 'buildings**combustion**wood_logs'),
+(60300, 'buildings**embodied_energy'),
+
+-- process emissions
+(70000, 'process_emissions'),
+(70100, 'process_emissions**ch4'),
+(70200, 'process_emissions**co2'),
+(70300, 'process_emissions**n2o'),
+(70400, 'process_emissions**refrigerants'),
+
+-- equipment
+(80000, 'equipment'),
+(80100, 'equipment**scientific'),
+(80200, 'equipment**it'),
+(80300, 'equipment\_\_other'),
+
+-- purchases
+(90000, 'purchases'),
+(90100, 'purchases**goods_and_services'),
+(90200, 'purchases**scientific_equipment'),
+(90300, 'purchases**it_equipment'),
+(90400, 'purchases**consumable_accessories'),
+(90500, 'purchases**biological_chemical_gaseous'),
+(90600, 'purchases**services'),
+(90700, 'purchases**vehicles'),
+(90800, 'purchases**other'),
+(90900, 'purchases**additional'),
+(90901, 'purchases**additional\_\_ln2'),
+
+-- research facilities
+(100000, 'research_facilities'),
+(100100, 'research_facilities**facilities'),
+(100200, 'research_facilities**animal'),
+
+-- external
+(110000, 'external'),
+(110100, 'external**clouds'),
+(110101, 'external**clouds**virtualisation'),
+(110102, 'external**clouds**calcul'),
+(110103, 'external**clouds**stockage'),
+(110200, 'external**ai'),
+(110201, 'external**ai**provider_google'),
+(110202, 'external**ai**provider_mistral_ai'),
+(110203, 'external**ai**provider_anthropic'),
+(110204, 'external**ai**provider_openai'),
+(110205, 'external**ai**provider_cohere'),
+(110206, 'external**ai**provider_others');
+
+pivot that generate the sql
+
+WITH keys AS (
+SELECT DISTINCT
+(jsonb_object_keys(cr.stats::jsonb -> 'by_emission_type'))::int AS id
+FROM carbon_reports cr
+),
+cols AS (
+SELECT
+k.id,
+m.name
+FROM keys k
+LEFT JOIN emission_type_mapping m ON m.id = k.id
+)
+SELECT
+'SELECT
+cr.year,
+u.institutional_id,
+
+        (cr.stats->>''scope1'')::float AS scope1,
+        (cr.stats->>''scope2'')::float AS scope2,
+        (cr.stats->>''scope3'')::float AS scope3,
+        (cr.stats->>''total'')::float AS total,' ||
+
+    string_agg(
+        format(
+            'COALESCE((cr.stats->''by_emission_type''->>''%s'')::float, 0) AS "%s"',
+            id,
+            COALESCE(name, id::text)
+        ),
+        ',\n        '
+        ORDER BY id
+    ) ||
+
+    '
+
+    FROM carbon_reports cr
+    JOIN units u ON u.id = cr.unit_id
+
+    ORDER BY cr.year, u.institutional_id;
+    '
+
+FROM cols;
+
+-->
+here it is
+
+SELECT
+cr.year,
+u.institutional_id,
+
+        (cr.stats->>'scope1')::float AS scope1,
+        (cr.stats->>'scope2')::float AS scope2,
+        (cr.stats->>'scope3')::float AS scope3,
+        (cr.stats->>'total')::float AS total,COALESCE((cr.stats->'by_emission_type'->>'10000')::float, 0) AS "food",
+    	COALESCE((cr.stats->'by_emission_type'->>'20000')::float, 0) AS "waste",
+    	COALESCE((cr.stats->'by_emission_type'->>'30000')::float, 0) AS "commuting"
+
+    FROM carbon_reports cr
+    JOIN units u ON u.id = cr.unit_id
+
+    ORDER BY cr.year, u.institutional_id;


### PR DESCRIPTION
## What does this change?

This pull request refactors how the `ModuleStatus` enum is imported and used throughout the backend, centralizing its definition in `app.core.constants` instead of duplicating it in `app.models.carbon_report`. It also introduces a new method for efficiently retrieving reporting overviews in the `CarbonReportRepository`, updates the logic for processing reporting data in the backoffice API, and adds documentation for detailed CSV exports. These changes improve maintainability, performance, and documentation clarity.

**Centralization and Refactoring of ModuleStatus:**

- The `ModuleStatus` enum is removed from `app.models.carbon_report` and is now exclusively imported from `app.core.constants` throughout the codebase, including repositories, services, schemas, seed scripts, and API modules. This reduces duplication and ensures consistency. [[1]](diffhunk://#diff-ed41bfd83f25d68327489eb3e0a34069f6a266c39943cad0596411b731b87f0eL1-R6) [[2]](diffhunk://#diff-36cfa41b6b70f2f0ed3b0038cac20549ef2ca530b4b3954dbd032c329fe82950R17-R29) [[3]](diffhunk://#diff-7e58421ff5e86e728762231f1e6bab2e6109e2128b8e68f5ac472636ab293267R9-R13) [[4]](diffhunk://#diff-82181a6374778aa53e4ae2d0f021574e136f72c15c4c1312ed90957c5794e855R9-R11) [[5]](diffhunk://#diff-ff498bb7382bec6e91ab0fd3f8ef13134845abb41a54cf1acd107851aab8af56R11-R14) [[6]](diffhunk://#diff-9ea7e137fb2b7b150616a4d7f1e629839669a2f15597efb2bcaa2be5726765a3R9-R11) [[7]](diffhunk://#diff-31c03d9c77b0d1a8c2aaf6a86b6b33bc6f4282cfbae216ae6bef7943c75f4b3cL7-R7) [[8]](diffhunk://#diff-2088b1b8bfe7221b2cb4f20f2a9db16599f4e3571dc2cd3de2b14a0ff48030b1L21-R21) [[9]](diffhunk://#diff-62a8ef1310ee7090786731bf6b5419fa5a8bced0781bde3be35dcb408f441231R8-L10) [[10]](diffhunk://#diff-e11765d4e2d2085a7e210ff51eb7e96f9b03b7d101e4689948ed7bd87b3f87f2R8-L10)

**Repository and Service Enhancements:**

- A new `get_reporting_overview` method is added to `CarbonReportRepository` to fetch paginated, aggregated reporting data efficiently using a deferred join strategy, improving the performance of reporting endpoints. [[1]](diffhunk://#diff-b74ff330d051065f6057b7a01f17eabd8288b56de212f5e40af7bfb84c0d8224L3-R8) [[2]](diffhunk://#diff-b74ff330d051065f6057b7a01f17eabd8288b56de212f5e40af7bfb84c0d8224R79-R102)
- The `CarbonReportService` is updated with a `get_reporting_overview` method that uses the repository's new method and returns validated results.

**Backoffice API Improvements:**

- The `/backoffice/units` endpoint now uses both `CarbonReportRepository` and `CarbonReportModuleRepository` to retrieve and process reporting data, with updated logic for determining completion status and constructing `UnitReportingData` objects. [[1]](diffhunk://#diff-36cfa41b6b70f2f0ed3b0038cac20549ef2ca530b4b3954dbd032c329fe82950L259-R275) [[2]](diffhunk://#diff-36cfa41b6b70f2f0ed3b0038cac20549ef2ca530b4b3954dbd032c329fe82950L279-R318)
- Adds SQL query examples and comments for future reporting enhancements and raw data exports in the API code, improving developer guidance. [[1]](diffhunk://#diff-36cfa41b6b70f2f0ed3b0038cac20549ef2ca530b4b3954dbd032c329fe82950R334-R386) [[2]](diffhunk://#diff-36cfa41b6b70f2f0ed3b0038cac20549ef2ca530b4b3954dbd032c329fe82950R406-R454)

**Documentation:**

- Adds a new implementation plan document (`docs/implementation-plans/589-backoffice-reporting-detailed-csv.md`) detailing requirements, SQL templates, and output formats for exporting detailed CSVs per data entry type, supporting future auditing and analysis needs.
## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
