### PR TITLE
feat(docs): add documentation deployment to Kubernetes

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -1,20 +1,22 @@
 name: deploy-mkdocs
 
 # =============================================================================
-# IMPORTANT: DEPRECATED - FOR MAIN BRANCH FALLBACK ONLY
+# IMPORTANT: DEPRECATED - FOR MAIN BRANCH FALLBACK ONLY (GITHUB PAGES)
 # =============================================================================
-# This workflow is ONLY for deploying docs to GitHub Pages on the main branch.
 # 
-# For development, staging, and release documentation:
-# - dev branch docs: Deployed via deploy.yml (GitHub Pages alternative)
-# - stage branch docs: Deployed via deploy.yml (GitHub Pages alternative)  
-# - release docs (tags): Deployed via deploy.yml (GitHub Pages alternative)
+# ⚠️  THIS WORKFLOW IS DEPRECATED AND ONLY USED FOR MAIN BRANCH FALLBACK
+# 
+# For ALL other branches (dev, stage, ci-test/*, tags):
+#   Documentation is deployed via deploy.yml and deploy-quay.yml
+#   Access docs at: https://co2-calculator-*.epfl.ch/docs
 #
-# All dev/stage/release documentation is served at:
-#   https://co2-calculator-*.epfl.ch/docs
+# Branch-to-URL mapping:
+#   - dev branch    → https://co2-calculator-dev.epfl.ch/docs
+#   - stage branch  → https://co2-calculator-stage.epfl.ch/docs
+#   - tags (v*)     → https://co2-calculator.epfl.ch/docs
 #
-# DO NOT use this workflow for testing branch-specific documentation.
-# Use the helm chart deployment instead for all non-main branches.
+# This workflow ONLY deploys to GitHub Pages for the main branch.
+# Consider removing this workflow once GitHub Pages is no longer needed.
 # =============================================================================
 
 on:

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -1,5 +1,22 @@
 name: deploy-mkdocs
 
+# =============================================================================
+# IMPORTANT: DEPRECATED - FOR MAIN BRANCH FALLBACK ONLY
+# =============================================================================
+# This workflow is ONLY for deploying docs to GitHub Pages on the main branch.
+# 
+# For development, staging, and release documentation:
+# - dev branch docs: Deployed via deploy.yml (GitHub Pages alternative)
+# - stage branch docs: Deployed via deploy.yml (GitHub Pages alternative)  
+# - release docs (tags): Deployed via deploy.yml (GitHub Pages alternative)
+#
+# All dev/stage/release documentation is served at:
+#   https://co2-calculator-*.epfl.ch/docs
+#
+# DO NOT use this workflow for testing branch-specific documentation.
+# Use the helm chart deployment instead for all non-main branches.
+# =============================================================================
+
 on:
   push:
     branches:

--- a/.github/workflows/deploy-quay.yml
+++ b/.github/workflows/deploy-quay.yml
@@ -15,73 +15,9 @@ jobs:
     with:
       name: "co2-calculator"
       registry: "epfl-enac/co2-calculator"
-
-  build-docs:
-    name: Build and Push Docs Image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Quay Registry
-        uses: docker/login-action@v3
-        with:
-          registry: quay-its.epfl.ch
-          username: svc1751+ghaction
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install documentation dependencies
-        working-directory: ./docs
-        run: uv sync --locked --all-extras --dev
-
-      - name: Build documentation
-        working-directory: ./docs
-        run: uv run mkdocs build --strict --site-dir ../docs-site
-
-      - name: Determine docs image tag
-        id: tag
-        run: |
-          if [[ "${{github.ref}}" == refs/tags/v* ]]; then
-            # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
-            TAG=${{github.ref}}#refs/tags/
-            echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          elif [[ "${{github.ref}}" == refs/heads/dev ]]; then
-            echo "tag=dev" >> $GITHUB_OUTPUT
-          elif [[ "${{github.ref}}" == refs/heads/stage ]]; then
-            echo "tag=stage" >> $GITHUB_OUTPUT
-          elif [[ "${{github.ref}}" == refs/heads/ci-test/* ]]; then
-            echo "tag=dev" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push docs image to Quay
-        uses: docker/build-push-action@v5
-        with:
-          context: ./docs-site
-          file: ./docs/Dockerfile
-          push: true
-          tags: |
-            quay-its.epfl.ch/svc1751/co2-calculator/docs:${{ steps.tag.outputs.tag }}
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   deploy:
     needs:
       - publish-chart
-      - build-docs
     permissions:
       contents: read
       packages: write
@@ -93,7 +29,7 @@ jobs:
       # Optional inputs can be passed here
       ORG: epfl
       REPO: co2-calculator
-      build_context: '[ "./frontend", "./backend" ]' # context paths to build
+      build_context: '[ "./frontend", "./backend", "./docs" ]' # context paths to build
       argo_repository: "['EPFL-ENAC/openshift-app-config']"
       registry: quay-its.epfl.ch
       registry_path: svc1751

--- a/.github/workflows/deploy-quay.yml
+++ b/.github/workflows/deploy-quay.yml
@@ -15,9 +15,73 @@ jobs:
     with:
       name: "co2-calculator"
       registry: "epfl-enac/co2-calculator"
+
+  build-docs:
+    name: Build and Push Docs Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay Registry
+        uses: docker/login-action@v3
+        with:
+          registry: quay-its.epfl.ch
+          username: svc1751+ghaction
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install documentation dependencies
+        working-directory: ./docs
+        run: uv sync --locked --all-extras --dev
+
+      - name: Build documentation
+        working-directory: ./docs
+        run: uv run mkdocs build --strict --site-dir ../docs-site
+
+      - name: Determine docs image tag
+        id: tag
+        run: |
+          if [[ "${{github.ref}}" == refs/tags/v* ]]; then
+            # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
+            TAG=${{github.ref}}#refs/tags/
+            echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/heads/dev ]]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/heads/stage ]]; then
+            echo "tag=stage" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/heads/ci-test/* ]]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push docs image to Quay
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docs-site
+          file: ./docs/Dockerfile
+          push: true
+          tags: |
+            quay-its.epfl.ch/svc1751/co2-calculator/docs:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy:
     needs:
       - publish-chart
+      - build-docs
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,73 +15,9 @@ jobs:
     with:
       name: "co2-calculator"
       registry: "epfl-enac/co2-calculator"
-
-  build-docs:
-    name: Build and Push Docs Image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install documentation dependencies
-        working-directory: ./docs
-        run: uv sync --locked --all-extras --dev
-
-      - name: Build documentation
-        working-directory: ./docs
-        run: uv run mkdocs build --strict --site-dir ../docs-site
-
-      - name: Determine docs image tag
-        id: tag
-        run: |
-          if [[ "${{github.ref}}" == refs/tags/v* ]]; then
-            # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
-            TAG=${{github.ref}}#refs/tags/
-            echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          elif [[ "${{github.ref}}" == refs/heads/dev ]]; then
-            echo "tag=dev" >> $GITHUB_OUTPUT
-          elif [[ "${{github.ref}}" == refs/heads/stage ]]; then
-            echo "tag=stage" >> $GITHUB_OUTPUT
-          elif [[ "${{github.ref}}" == refs/heads/ci-test/* ]]; then
-            echo "tag=dev" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push docs image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./docs-site
-          file: ./docs/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/epfl-enac/epfl/co2-calculator/docs:${{ steps.tag.outputs.tag }}
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   deploy:
     needs:
       - publish-chart
-      - build-docs
     permissions:
       contents: read
       packages: write
@@ -93,6 +29,6 @@ jobs:
       # Optional inputs can be passed here
       ORG: epfl
       REPO: co2-calculator
-      build_context: '[ "./frontend", "./backend" ]' # context paths to build
+      build_context: '[ "./frontend", "./backend", "./docs" ]' # context paths to build
       helm_chart_name: co2-calculator
       helm_chart_version: ${{ needs.publish-chart.outputs.chart_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,73 @@ jobs:
     with:
       name: "co2-calculator"
       registry: "epfl-enac/co2-calculator"
+
+  build-docs:
+    name: Build and Push Docs Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install documentation dependencies
+        working-directory: ./docs
+        run: uv sync --locked --all-extras --dev
+
+      - name: Build documentation
+        working-directory: ./docs
+        run: uv run mkdocs build --strict --site-dir ../docs-site
+
+      - name: Determine docs image tag
+        id: tag
+        run: |
+          if [[ "${{github.ref}}" == refs/tags/v* ]]; then
+            # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
+            TAG=${{github.ref}}#refs/tags/
+            echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/heads/dev ]]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/heads/stage ]]; then
+            echo "tag=stage" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/heads/ci-test/* ]]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push docs image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docs-site
+          file: ./docs/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/epfl-enac/epfl/co2-calculator/docs:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy:
     needs:
       - publish-chart
+      - build-docs
     permissions:
       contents: read
       packages: write

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,7 +1,39 @@
+# Stage 1: Build MkDocs site
+FROM ghcr.io/astral-sh/uv:python3.12-alpine AS builder
+
+# Install build dependencies and git
+RUN apk add --no-cache gcc g++ musl-dev libffi-dev openssl-dev git
+
+# Set working directory
+WORKDIR /app
+
+# Create virtual environment
+RUN uv venv /app/.venv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies (production only)
+RUN uv sync --frozen --no-dev
+
+# Copy documentation source
+COPY src/ ./src/
+COPY mkdocs.yml ./
+
+# Initialize git repo for mkdocs-git-authors-plugin (required even if not using real git history)
+RUN git init . && git config user.email "build@localhost" && git config user.name "Build" && git add . && git commit -m "Build commit"
+
+# Set GitPython to quiet mode
+ENV GIT_PYTHON_REFRESH=quiet
+
+# Build documentation site
+RUN uv run mkdocs build --strict --site-dir /dist
+
+# Stage 2: Serve with nginx
 FROM nginx:alpine
 
-# Copy built documentation to nginx html directory
-COPY . /usr/share/nginx/html
+# Copy built documentation from builder stage
+COPY --from=builder /dist /usr/share/nginx/html
 
 # Expose nginx port
 EXPOSE 8080

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:alpine
+
+# Copy built documentation to nginx html directory
+COPY . /usr/share/nginx/html
+
+# Expose nginx port
+EXPOSE 8080
+
+# Use nginx default startup command
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -30,12 +30,12 @@ ENV GIT_PYTHON_REFRESH=quiet
 RUN uv run mkdocs build --strict --site-dir /dist
 
 # Stage 2: Serve with nginx
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:stable
 
 # Copy built documentation from builder stage
 COPY --from=builder /dist /usr/share/nginx/html
 
-# Expose nginx port
+# Expose nginx port (unprivileged nginx uses 8080 by default)
 EXPOSE 8080
 
 # Use nginx default startup command

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,12 +22,16 @@ install: ## Install documentation dependencies
 	@echo "Installing documentation dependencies..."
 	UV_NO_ISOLATION=1 uv sync --locked --all-extras --dev
 	@echo "Documentation dependencies installed!"
-	
+
 
 .PHONY: pdf
 pdf: ## Build documentation with PDF export enabled
 	cd docs && $(MAKE) pdf
 	UV_NO_ISOLATION=1 ENABLE_PDF_EXPORT=1 uv run mkdocs build
+
+.PHONY: docker-build-run
+docker-build-run: ## Build and run documentation in Docker (convenience target)
+	docker build -t docs:test . && docker run --rm -p 8080:8080 docs:test
 
 .PHONY: build-docs
 build-docs: ## Build documentation
@@ -40,3 +44,7 @@ serve-docs: ## Serve documentation with live reload
 .PHONY: clean-docs
 clean-docs: ## Clean built documentation
 	rm -rf site/
+
+.PHONY: clean-docker
+clean-docker: ## Remove Docker images
+	docker rmi -f co2-docs docs:test 2>/dev/null || true

--- a/docs/implementation-plans/95-docs-deploy-dev-branches.md
+++ b/docs/implementation-plans/95-docs-deploy-dev-branches.md
@@ -1,0 +1,221 @@
+# Issue #95: Deploy Documentation to Kubernetes
+
+## Overview
+
+Implement deployment of technical documentation (MkDocs) to Kubernetes alongside the main application, enabling branch-specific documentation accessible at `/docs` sub-path.
+
+## Problem Statement
+
+Currently, documentation is only deployed to GitHub Pages for the main branch via `deploy-mkdocs.yml`. This doesn't support:
+
+- Development branch documentation
+- Stage/testing branch documentation
+- Release-specific documentation
+- Branch-based documentation testing (as requested in issue #95)
+
+## Solution
+
+Add documentation as a third component (alongside frontend and backend) in the existing Helm chart, deployed via the same CI/CD pipelines (`deploy.yml` and `deploy-quay.yml`).
+
+## Implementation Details
+
+### 1. Docker Image for Documentation
+
+**File**: `docs/Dockerfile`
+
+Created a simple nginx-based Docker image to serve static MkDocs site:
+
+```dockerfile
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+### 2. Helm Chart Updates
+
+#### A. Values Configuration (`helm/values.yaml`)
+
+Added `docs` section with:
+
+- `enabled`: true (default)
+- `replicaCount`: 1
+- `image.repository`: ghcr.io/epfl-enac/epfl/co2-calculator/docs
+- `image.tag`: latest (overridden by CI/CD)
+- Service, resources, probes, and scaling configuration
+- OpenShift routes configuration
+
+#### B. Deployment Template (`helm/templates/docs-deployment.yaml`)
+
+- Nginx deployment serving static documentation
+- Configurable via `docs.image.repository` and `docs.image.tag`
+- Health checks, security context, and resource limits
+- Conditional rendering based on `docs.enabled`
+
+#### C. Service Template (`helm/templates/docs-service.yaml`)
+
+- ClusterIP service on port 80 → targetPort 8080
+- Standard component labels and selectors
+
+#### D. Ingress Updates (`helm/templates/ingress.yaml`)
+
+Added `/docs` path routing:
+
+```yaml
+- path: /docs(/|$)(.*)
+  pathType: ImplementationSpecific
+  backend: docs service
+```
+
+Routing order:
+
+1. `/api` → backend
+2. `/docs` → docs (NEW)
+3. `/` → frontend
+
+#### E. OpenShift Routes (`helm/templates/routes.yaml`)
+
+Added docs route when `routes.enabled` is true:
+
+- Path: `/docs`
+- Host: Same as main application
+- TLS termination: edge
+
+#### F. Helper Templates (`helm/templates/_helpers.tpl`)
+
+Added `co2-calculator.docs.image` helper for image tag resolution.
+
+### 3. CI/CD Pipeline Updates
+
+#### A. `deploy.yml` (GitHub Registry)
+
+Added `build-docs` job that:
+
+1. Checks out code
+2. Installs documentation dependencies via uv
+3. Builds MkDocs site to `docs-site/`
+4. Determines tag based on git ref:
+   - `dev` branch → `:dev`
+   - `stage` branch → `:stage`
+   - `tags (v*)` → `:vX.Y.Z`
+   - `ci-test/*` → `:dev`
+5. Builds and pushes Docker image to `ghcr.io/epfl-enac/epfl/co2-calculator/docs:<tag>`
+6. Depends on `build-docs` before running deploy job
+
+#### B. `deploy-quay.yml` (Quay Registry)
+
+Same as `deploy.yml` but:
+
+- Pushes to `quay-its.epfl.ch/svc1751/co2-calculator/docs:<tag>`
+- Uses Quay credentials
+
+#### C. `deploy-mkdocs.yml` (GitHub Pages - Deprecated)
+
+- Added prominent deprecation notice
+- Keeps functionality for main branch fallback only
+- Clear documentation that dev/stage/release use `/docs` path instead
+
+### 4. Helm Chart Version
+
+Updated `helm/Chart.yaml`:
+
+- Version: `0.2.0` → `0.3.0`
+- Description: Added "and documentation"
+- Keywords: Added "documentation"
+
+## Branch-to-Environment Mapping
+
+| Git Ref        | Docs Image Tag | Access URL                        |
+| -------------- | -------------- | --------------------------------- |
+| `dev` branch   | `:dev`         | co2-calculator-dev.epfl.ch/docs   |
+| `stage` branch | `:stage`       | co2-calculator-stage.epfl.ch/docs |
+| `tags (v*)`    | `:vX.Y.Z`      | co2-calculator.epfl.ch/docs       |
+| `ci-test/*`    | `:dev`         | co2-calculator-dev.epfl.ch/docs   |
+
+## Files Modified
+
+### New Files
+
+- `docs/Dockerfile`
+- `helm/templates/docs-deployment.yaml`
+- `helm/templates/docs-service.yaml`
+
+### Modified Files
+
+- `helm/values.yaml` - Added docs configuration
+- `helm/templates/ingress.yaml` - Added /docs path routing
+- `helm/templates/routes.yaml` - Added docs route
+- `helm/templates/_helpers.tpl` - Added docs.image helper
+- `helm/templates/backend-deployment.yaml` - Added enabled conditional
+- `helm/templates/frontend-deployment.yaml` - Added enabled conditional
+- `helm/Chart.yaml` - Bumped version to 0.3.0
+- `.github/workflows/deploy.yml` - Added build-docs job
+- `.github/workflows/deploy-quay.yml` - Added build-docs job
+- `.github/workflows/deploy-mkdocs.yml` - Added deprecation notice
+
+## Usage
+
+### Accessing Documentation
+
+- **Dev**: Navigate to `https://co2-calculator-dev.epfl.ch/docs`
+- **Stage**: Navigate to `https://co2-calculator-stage.epfl.ch/docs`
+- **Release**: Navigate to `https://co2-calculator.epfl.ch/docs`
+
+### Disabling Documentation Deployment
+
+Set `docs.enabled: false` in Helm values if documentation deployment is not needed.
+
+### Manual Documentation Build (Local)
+
+```bash
+cd docs
+uv sync --locked --all-extras --dev
+uv run mkdocs build --strict --site-dir ../docs-site
+```
+
+### Testing Documentation Locally
+
+```bash
+cd docs
+uv run mkdocs serve
+```
+
+## Benefits
+
+1. **Branch-based Documentation**: Each branch has its own documentation
+2. **Version Consistency**: Docs version matches app version
+3. **Single Deployment Unit**: Documentation deployed with main application
+4. **Consistent Access**: All documentation at `/docs` sub-path
+5. **OpenShift Compatible**: Works with both nginx ingress and OpenShift routes
+6. **Fallback Available**: GitHub Pages deployment kept for main branch
+
+## Testing Checklist
+
+- [ ] Helm chart lint passes: `helm lint ./helm`
+- [ ] Helm template renders correctly: `helm template test ./helm`
+- [ ] Docs build successfully: `cd docs && make build-docs`
+- [ ] Docker image builds: `docker build -t docs:test docs/`
+- [ ] CI/CD pipelines build and push docs image
+- [ ] Documentation accessible at `/docs` path
+- [ ] Branch-specific tags deployed correctly
+- [ ] OpenShift routes work when enabled
+
+## Future Enhancements
+
+1. **Documentation Search**: Enable mkdocs search plugin
+2. **Version Picker**: Add version selector for multiple releases
+3. **PDF Export**: Enable PDF generation via mkdocs-with-pdf plugin
+4. **Analytics**: Add documentation usage tracking
+5. **Multi-language**: Support for documentation in multiple languages
+
+## Related Issues
+
+- Issue #95: "Docs of each branch available for testing"
+
+## Notes
+
+- The documentation is served via nginx in a lightweight container
+- Image tag is dynamically set by CI/CD based on git ref
+- Helm chart uses `latest` as default tag, overridden by ArgoCD
+- Documentation build uses the same MkDocs configuration as before
+- No changes to documentation content or structure

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
 name: co2-calculator
-description: Helm chart for the CO2 Calculator frontend and backend
+description: Helm chart for the CO2 Calculator frontend, backend, and documentation
 kubeVersion: ">=1.24.0-0"
 icon: https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - co2
   - fastapi
   - quasar
   - postgres
+  - documentation
 maintainers:
   - name: EPFL-ENAC

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -41,6 +41,24 @@ lint: lint-helm ## Run all lint checks (format + helm)
 
 
 ## -------------------------------
+## 🧪 Testing
+## -------------------------------
+.PHONY: template
+template: ## Render Helm templates with default values
+	@echo "🧪 Rendering Helm templates..."
+	@helm template . --values values.yaml
+
+.PHONY: template-docs-disabled
+template-docs-disabled: ## Render Helm templates with docs disabled
+	@echo "🧪 Rendering Helm templates with docs.enabled=false..."
+	@helm template . --values values.yaml --set docs.enabled=false | grep -i "kind:.*\(Deployment\|Service\)" || echo "No docs resources rendered"
+
+.PHONY: template-frontend-disabled
+template-frontend-disabled: ## Render Helm templates with frontend disabled
+	@echo "🧪 Rendering Helm templates with frontend.enabled=false..."
+	@helm template . --values values.yaml --set frontend.enabled=false | grep -i "kind:.*\(Deployment\|Service\)" || echo "No frontend resources rendered"
+
+## -------------------------------
 ## Skaffold
 ## -------------------------------
 .PHONY: skaffold-dev

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -53,6 +53,11 @@ app.kubernetes.io/component: {{ .component }}
 {{- printf "%s:%s" .Values.frontend.image.repository $tag -}}
 {{- end -}}
 
+{{- define "co2-calculator.docs.image" -}}
+{{- $tag := .Values.docs.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.docs.image.repository $tag -}}
+{{- end -}}
+
 {{- define "co2-calculator.backendSecretName" -}}
 {{- if and .Values.backend.existingSecret.enabled .Values.backend.existingSecret.name -}}
 {{- .Values.backend.existingSecret.name -}}

--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.backend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -287,3 +288,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/docs-deployment.yaml
+++ b/helm/templates/docs-deployment.yaml
@@ -1,10 +1,9 @@
-{{- if .Values.frontend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "co2-calculator.fullname" . }}-frontend
+  name: {{ include "co2-calculator.fullname" . }}-docs
   labels:
-    {{- include "co2-calculator.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
+    {{- include "co2-calculator.componentLabels" (dict "ctx" . "component" "docs") | nindent 4 }}
 spec:
   revisionHistoryLimit: 2
 
@@ -14,18 +13,18 @@ spec:
       maxSurge: 0
       maxUnavailable: 1
 
-  {{- if not .Values.frontend.autoscaling.enabled }}
-  replicas: {{ .Values.frontend.replicaCount }}
+  {{- if not .Values.docs.autoscaling.enabled }}
+  replicas: {{ .Values.docs.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "frontend") | nindent 6 }}
+      {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "docs") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "frontend") | nindent 8 }}
+        {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "docs") | nindent 8 }}
       annotations:
-        {{- with .Values.frontend.podAnnotations }}
+        {{- with .Values.docs.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -34,33 +33,30 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.frontend.podSecurityContext }}
+      {{- with .Values.docs.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: frontend
-          image: {{ include "co2-calculator.frontend.image" . }}
-          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+        - name: docs
+          image: {{ include "co2-calculator.docs.image" . }}
+          imagePullPolicy: {{ .Values.docs.image.pullPolicy }}
           securityContext:
-            {{- toYaml .Values.frontend.securityContext | nindent 12 }}
+            {{- toYaml .Values.docs.securityContext | nindent 12 }}
           ports:
             - name: http
-              containerPort: {{ .Values.frontend.service.targetPort }}
+              containerPort: {{ .Values.docs.service.targetPort }}
               protocol: TCP
-          env:
-            - name: API_BASE_URL
-              value: {{ .Values.frontend.env.API_BASE_URL | quote }}
-          {{- with .Values.frontend.livenessProbe }}
+          {{- with .Values.docs.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.frontend.readinessProbe }}
+          {{- with .Values.docs.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.frontend.resources | nindent 12 }}
+            {{- toYaml .Values.docs.resources | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
@@ -75,16 +71,15 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
-      {{- with .Values.frontend.nodeSelector }}
+      {{- with .Values.docs.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.frontend.affinity }}
+      {{- with .Values.docs.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.frontend.tolerations }}
+      {{- with .Values.docs.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}

--- a/helm/templates/docs-deployment.yaml
+++ b/helm/templates/docs-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.docs.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -83,3 +84,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/docs-service.yaml
+++ b/helm/templates/docs-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "co2-calculator.fullname" . }}-docs
+  labels:
+    {{- include "co2-calculator.componentLabels" (dict "ctx" . "component" "docs") | nindent 4 }}
+  {{- with .Values.docs.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.docs.service.type }}
+  selector:
+    {{- include "co2-calculator.componentSelectorLabels" (dict "ctx" . "component" "docs") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.docs.service.port }}
+      targetPort: {{ .Values.docs.service.targetPort }}
+      protocol: TCP

--- a/helm/templates/docs-service.yaml
+++ b/helm/templates/docs-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.docs.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
       port: {{ .Values.docs.service.port }}
       targetPort: {{ .Values.docs.service.targetPort }}
       protocol: TCP
+{{- end }}

--- a/helm/templates/frontend-service.yaml
+++ b/helm/templates/frontend-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
       port: {{ .Values.frontend.service.port }}
       targetPort: {{ .Values.frontend.service.targetPort }}
       protocol: TCP
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -43,6 +43,15 @@ spec:
                 name: {{ include "co2-calculator.fullname" $ }}-backend
                 port:
                   number: {{ $.Values.backend.service.port }}
+          {{- if $.Values.docs.enabled }}
+          - path: /docs(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "co2-calculator.fullname" $ }}-docs
+                port:
+                  number: {{ $.Values.docs.service.port }}
+          {{- end }}
           - path: /()(.*)
             pathType: ImplementationSpecific
             backend:

--- a/helm/templates/routes.yaml
+++ b/helm/templates/routes.yaml
@@ -66,10 +66,13 @@ metadata:
     {{- with .Values.routes.docs.extraLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.routes.docs.annotations }}
   annotations:
+    {{- with .Values.routes.docs.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    {{- if not (hasKey .Values.routes.docs.annotations "haproxy.router.openshift.io/rewrite-target") }}
+    haproxy.router.openshift.io/rewrite-target: /
+    {{- end }}
 spec:
   to:
     name: {{ include "co2-calculator.fullname" $ }}-docs

--- a/helm/templates/routes.yaml
+++ b/helm/templates/routes.yaml
@@ -55,4 +55,33 @@ spec:
   {{- end }}
   port:
     targetPort: http
+{{- if .Values.docs.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "co2-calculator.fullname" . }}-docs
+  labels:
+    {{- include "co2-calculator.labels" . | nindent 4 }}
+    {{- with .Values.routes.docs.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.routes.docs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  to:
+    name: {{ include "co2-calculator.fullname" $ }}-docs
+    weight: {{ .Values.routes.docs.weight }}
+    kind: Service
+  host: {{ .Values.routes.host | quote }}
+  path: '/docs'
+  {{- with .Values.routes.docs.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  port:
+    targetPort: http
+{{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -311,6 +311,13 @@ routes:
     tls:
       termination: edge
 
+  docs:
+    extraLabels: {}
+    annotations: {}
+    weight: 100
+    tls:
+      termination: edge
+
 serviceAccount:
   create: true
   annotations: {}
@@ -328,3 +335,72 @@ podDisruptionBudget:
 networkPolicy:
   enabled: false
   ingress: []
+
+# -----------------------------------------------------------------------------
+# Documentation deployment
+# Static documentation served via nginx, built from docs/ directory
+# -----------------------------------------------------------------------------
+docs:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/epfl-enac/epfl/co2-calculator/docs
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+    annotations: {}
+
+  podAnnotations: {}
+
+  podSecurityContext:
+    # runAsNonRoot: true
+    # runAsUser: 101
+    # fsGroup: 101
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 8080
+    initialDelaySeconds: 10
+    periodSeconds: 10
+
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 8080
+    initialDelaySeconds: 5
+    periodSeconds: 5
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -339,6 +339,11 @@ networkPolicy:
 # -----------------------------------------------------------------------------
 # Documentation deployment
 # Static documentation served via nginx, built from docs/ directory
+# Built automatically by CI/CD via deploy.yml and deploy-quay.yml
+# Image tag is set by ArgoCD based on branch:
+#   - dev branch → commit SHA
+#   - stage branch → commit SHA
+#   - tags (v*) → version tag (e.g., v1.2.3)
 # -----------------------------------------------------------------------------
 docs:
   enabled: true
@@ -346,7 +351,7 @@ docs:
 
   image:
     repository: ghcr.io/epfl-enac/epfl/co2-calculator/docs
-    tag: "latest"
+    tag: "latest" # Overridden by ArgoCD with actual tag from CI/CD
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
## Summary
- Fixed Helm template guards for docs and frontend resources
- Added rewrite-target annotation for OpenShift docs route
- Added Helm template test targets to Makefile

## Changes
- **docs-deployment.yaml**: Added  guard
- **docs-service.yaml**: Added  guard  
- **frontend-service.yaml**: Added  guard
- **routes.yaml**: Added conditional rewrite-target annotation for docs route
- **Makefile**: Added template test targets

## Testing
All Copilot feedback addressed. Helm lint passes. Template rendering verified with components disabled.

## Resolves
Copilot PR feedback on conditional resource rendering and route rewrite-target configuration.