### PR TITLE
feat(mkdocs): remove site_url for env-agnostic /docs deployment

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,4 @@
 site_name: EPFL Project Technical Docs
-site_url: ""
 repo_url: https://github.com/epfl-enac/co2-calculator
 theme:
   name: material
@@ -97,7 +96,7 @@ nav:
 
   - Infrastructure:
       - Overview: infra/01-overview.md
-  
+
   - User Documentation:
       - Overview: user-docs/01-overview.md
       - Module Equipment: user-docs/02-equipment.md


### PR DESCRIPTION
MkDocs was configured with `site_url: ""`, causing inconsistent URL generation in built HTML (e.g. meta tags and canonical links with unexpected prefixes).

Docs are served under the same `/docs` path across environments (dev, stage, prod) but with different domains. Keeping `site_url` introduces build-time coupling to a specific environment.

Remove `site_url` to force relative URLs and ensure the same build artifact works across all environments.

Consequences:

* canonical URLs and OpenGraph metadata are no longer absolute
* sitemap may be incomplete or invalid for SEO

Rationale:
Prioritize a single portable build over environment-specific SEO correctness, as this documentation is not SEO-critical.

## What does this change?

<!-- Briefly describe what you're adding, fixing, or improving -->

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
