### PR TITLE
feat: change module order

### DIFF
--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -70,18 +70,18 @@ const scopeConfig = computed(() => {
 });
 
 const CATEGORY_LABEL_MAP: Record<string, string> = {
+  commuting: 'charts-commuting-category', // Headcount
+  food: 'charts-food-category',
+  waste: 'charts-waste-category',
   process_emissions: 'charts-process-emissions-category',
   buildings_room: 'charts-buildings-room-category',
   buildings_energy_combustion: 'charts-buildings-energy-combustion-category',
+  embodied_energy: 'charts-embodied-energy-category',
   equipment: 'equipment-electric-consumption',
   external_cloud_and_ai: 'external-cloud-and-ai',
   purchases: 'purchase',
-  research_facilities: 'charts-research-facilities-category',
   professional_travel: 'professional-travel',
-  commuting: 'charts-commuting-category',
-  food: 'charts-food-category',
-  waste: 'charts-waste-category',
-  embodied_energy: 'charts-embodied-energy-category',
+  research_facilities: 'charts-research-facilities-category',
 };
 
 function translateCategory(
@@ -138,6 +138,24 @@ function collapseByCategory(
   return Array.from(merged.values());
 }
 
+const ADDITIONAL_CATEGORY_KEYS = [
+  t('charts-commuting-category'),
+  t('charts-food-category'),
+  t('charts-waste-category'),
+  t('charts-embodied-energy-category'),
+];
+
+const MAIN_CATEGORY_ORDER = [
+  t('charts-process-emissions-category'),
+  t('charts-buildings-room-category'),
+  t('charts-buildings-energy-combustion-category'),
+  t('equipment-electric-consumption'),
+  t('external-cloud-and-ai'),
+  t('purchase'),
+  t('professional-travel'),
+  t('charts-research-facilities-category'),
+];
+
 const datasetSource = computed(() => {
   if (!props.breakdownData) return [];
 
@@ -150,6 +168,7 @@ const datasetSource = computed(() => {
       .map(translateCategory),
   );
 
+  let allData = baseData;
   if (toggleAdditionalData.value) {
     const additionalData = collapseByCategory(
       props.breakdownData.additional_breakdown
@@ -161,9 +180,39 @@ const datasetSource = computed(() => {
         })
         .map(translateCategory),
     );
-    return [...baseData, ...additionalData];
+    allData = [...baseData, ...additionalData];
   }
-  return baseData;
+
+  // Partition into additional and main categories
+  const additional = [];
+  const main = [];
+  for (const item of allData) {
+    if (ADDITIONAL_CATEGORY_KEYS.includes(String(item.category))) {
+      additional.push(item);
+    } else {
+      main.push(item);
+    }
+  }
+
+  // Sort main and additional separately
+  main.sort((a, b) => {
+    const aIdx = MAIN_CATEGORY_ORDER.indexOf(String(a.category));
+    const bIdx = MAIN_CATEGORY_ORDER.indexOf(String(b.category));
+    if (aIdx === -1 && bIdx === -1) return 0;
+    if (aIdx === -1) return 1;
+    if (bIdx === -1) return -1;
+    return aIdx - bIdx;
+  });
+  additional.sort((a, b) => {
+    const aIdx = ADDITIONAL_CATEGORY_KEYS.indexOf(String(a.category));
+    const bIdx = ADDITIONAL_CATEGORY_KEYS.indexOf(String(b.category));
+    if (aIdx === -1 && bIdx === -1) return 0;
+    if (aIdx === -1) return 1;
+    if (bIdx === -1) return -1;
+    return aIdx - bIdx;
+  });
+
+  return [...main, ...additional];
 });
 
 const additionalSeriesData = computed(() => {
@@ -573,37 +622,6 @@ const chartOption = computed((): EChartsOption => {
       },
       label: { show: false },
     },
-    // Professional Travel — subcategories: plane, train
-    {
-      name: t('charts-plane-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'plane' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'professional_travel',
-          'plane',
-          colors.value.babyBlue.darker,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-train-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'train' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'professional_travel',
-          'train',
-          colors.value.babyBlue.dark,
-        ),
-      },
-      label: { show: false },
-    },
     // External cloud & AI — YY subcategories
     {
       name: t('charts-clouds-subcategory'),
@@ -635,6 +653,38 @@ const chartOption = computed((): EChartsOption => {
       },
       label: { show: false },
     },
+    // Professional Travel — subcategories: plane, train
+    {
+      name: t('charts-plane-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'plane' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'professional_travel',
+          'plane',
+          colors.value.babyBlue.darker,
+        ),
+      },
+      label: { show: false },
+    },
+    {
+      name: t('charts-train-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'train' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'professional_travel',
+          'train',
+          colors.value.babyBlue.dark,
+        ),
+      },
+      label: { show: false },
+    },
+
     ...additionalSeriesData.value,
   ];
 

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -398,13 +398,14 @@ export function getChartSubcategoryColor(
 // Maps Module enum value → category names present in module_breakdown
 export const MODULE_TO_CATEGORIES = computed(
   (): Record<string, string[]> => ({
+    [MODULES.Headcount]: ['headcount'],
     [MODULES.ProcessEmissions]: ['process_emissions'],
     [MODULES.Buildings]: ['buildings_room', 'buildings_energy_combustion'],
     [MODULES.EquipmentElectricConsumption]: ['equipment'],
-    [MODULES.Purchase]: ['purchases'],
-    [MODULES.ResearchFacilities]: ['research_facilities'],
     [MODULES.ExternalCloudAndAI]: ['external_cloud_and_ai'],
+    [MODULES.Purchase]: ['purchases'],
     [MODULES.ProfessionalTravel]: ['professional_travel'],
+    [MODULES.ResearchFacilities]: ['research_facilities'],
   }),
 );
 

--- a/frontend/src/constant/moduleCards.ts
+++ b/frontend/src/constant/moduleCards.ts
@@ -24,15 +24,6 @@ export const MODULE_CARDS: ModuleCard[] = [
     },
   },
   {
-    module: MODULES.ProfessionalTravel,
-    active: true,
-    badge: {
-      label: 'New',
-      color: 'primary',
-      textColor: 'white',
-    },
-  },
-  {
     module: MODULES.ProcessEmissions,
     active: true,
   },
@@ -45,15 +36,24 @@ export const MODULE_CARDS: ModuleCard[] = [
     active: true,
   },
   {
+    module: MODULES.ExternalCloudAndAI,
+    active: true,
+  },
+  {
     module: MODULES.Purchase,
     active: true,
   },
   {
-    module: MODULES.ResearchFacilities,
+    module: MODULES.ProfessionalTravel,
     active: true,
+    badge: {
+      label: 'New',
+      color: 'primary',
+      textColor: 'white',
+    },
   },
   {
-    module: MODULES.ExternalCloudAndAI,
+    module: MODULES.ResearchFacilities,
     active: true,
   },
 ];

--- a/frontend/src/constant/modules.ts
+++ b/frontend/src/constant/modules.ts
@@ -193,7 +193,16 @@ export type ConditionalSubmoduleProps =
 
 // Exclude the 4 modules that should be removed
 // TODO: refactor the codebase to remove these 4 modules and then remove this exclusion
-export const MODULES_LIST: Module[] = Object.values(MODULES).slice(0, -4);
+export const MODULES_LIST: Module[] = [
+  MODULES.Headcount,
+  MODULES.ProcessEmissions,
+  MODULES.Buildings,
+  MODULES.EquipmentElectricConsumption,
+  MODULES.ExternalCloudAndAI,
+  MODULES.Purchase,
+  MODULES.ProfessionalTravel,
+  MODULES.ResearchFacilities,
+];
 
 export const MODULES_PATTERN = MODULES_LIST.join('|');
 

--- a/frontend/src/constant/timelineItems.ts
+++ b/frontend/src/constant/timelineItems.ts
@@ -5,10 +5,7 @@ export const timelineItems = [
     icon: 'o_diversity_2',
     link: MODULES.Headcount,
   },
-  {
-    icon: 'o_flight',
-    link: MODULES.ProfessionalTravel,
-  },
+
   {
     icon: 'o_science',
     link: MODULES.ProcessEmissions,
@@ -22,16 +19,21 @@ export const timelineItems = [
     link: MODULES.EquipmentElectricConsumption,
   },
   {
+    icon: 'o_filter_drama',
+    link: MODULES.ExternalCloudAndAI,
+  },
+  {
     icon: 'o_sell',
     link: MODULES.Purchase,
+  },
+
+  {
+    icon: 'o_flight',
+    link: MODULES.ProfessionalTravel,
   },
   {
     icon: 'o_apps',
     link: MODULES.ResearchFacilities,
-  },
-  {
-    icon: 'o_filter_drama',
-    link: MODULES.ExternalCloudAndAI,
   },
 ];
 


### PR DESCRIPTION
## What does this change?
Reorders the modules displayed throughout the application — in the sidebar timeline, module cards, chart legend, and results breakdown — to follow a new canonical sequence:
Headcount → Process Emissions → Buildings → Equipment → External Cloud & AI → Purchases → Professional Travel → Research Facilities
Also refactors ModuleCarbonFootprintChart.vue to unify base and additional data into a single sorted array (using an explicit CATEGORY_ORDER constant), removing the separate additionalSeriesData computed property.

## Why is this needed?
The previous module order was inconsistent and partially historical. This change enforces a single, explicit ordering across all surfaces (timeline, cards, chart axes, legend) so that the UI is coherent and easier to navigate. Replacing Object.values(MODULES).slice(0, -4) with an explicit array also makes the intended module list clear and less fragile.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #774 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
