### PR TITLE
feat(504): added carbon results report endpoint and download ui

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -952,3 +952,82 @@ async def report_detailed(
             f'filename="detailed_report_{timestamp}.zip"'
         },
     )
+
+
+@router.get("/report/results")
+async def report_results(
+    path_lvl2: Optional[List[str]] = Query(
+        None, description="Filter by VP and Faculties"
+    ),
+    path_lvl3: Optional[List[str]] = Query(None, description="Filter by Institutes"),
+    path_lvl4: Optional[List[str]] = Query(
+        None, description="Filter by unit name(s) - can specify multiple"
+    ),
+    completion_status: Optional[ModuleStatus] = Query(
+        None,
+        description=(
+            "Filter by completion status: NOT_STARTED (0), IN_PROGRESS (1), "
+            "VALIDATED (2)"
+        ),
+    ),
+    search: Optional[str] = Query(
+        None, description="Search in unit name or institutional code"
+    ),
+    years: Optional[List[int]] = Query(
+        None, description="Filter by years (e.g., [2024, 2025])"
+    ),
+    format: str = Query("csv", description="Export format: csv or json"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("backoffice.users", "export")),
+) -> StreamingResponse:
+    if format not in {"csv", "json"}:
+        raise HTTPException(status_code=400, detail="Invalid format specified")
+
+    try:
+        data = await CarbonReportModuleRepository(db).get_results_report(
+            path_lvl2=path_lvl2,
+            path_lvl3=path_lvl3,
+            path_lvl4=path_lvl4,
+            completion_status=completion_status,
+            search=search,
+            years=years,
+        )
+    except ValueError as exc:
+        # Invalid filter values or other issues in query parameters
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    if format == "json":
+        content = json.dumps(data, indent=2, default=str)
+        return StreamingResponse(
+            iter([content]),
+            media_type="application/json",
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="results_report_{timestamp}.json"'
+                ),
+            },
+        )
+    else:
+        output = io.StringIO()
+        writer = csv.writer(output)
+        if data:
+            # Build a stable header list across all rows to avoid misalignment
+            headers: list[str] = []
+            for row in data:
+                for key in row.keys():
+                    if key not in headers:
+                        headers.append(key)
+            writer.writerow(headers)
+            for row in data:
+                writer.writerow([row.get(h, "") for h in headers])
+        content = output.getvalue()
+        return StreamingResponse(
+            iter([content]),
+            media_type="text/csv",
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="results_report_{timestamp}.csv"'
+                ),
+            },
+        )

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -1046,14 +1046,16 @@ class CarbonReportModuleRepository:
                 stats = row.stats if isinstance(row.stats, dict) else {}
                 by_emission_type = stats.get("by_emission_type") or {}
                 # Convert emission type keys to names if possible
-                by_emission_type = {
-                    (
-                        EmissionType(int(k)).name.replace("__", "_")
-                        if k.isdigit() and int(k) in EmissionType._value2member_map_
-                        else k
-                    ): v
-                    for k, v in by_emission_type.items()
-                }
+                converted_by_emission_type: dict[str, Any] = {}
+                for k, v in by_emission_type.items():
+                    k_str = str(k)
+                    try:
+                        emission_type = EmissionType(int(k_str))
+                        key = emission_type.name.replace("__", "_")
+                    except (ValueError, TypeError):
+                        key = k_str
+                    converted_by_emission_type[key] = v
+                by_emission_type = converted_by_emission_type
                 report.append(
                     {
                         "year": row.year,

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -10,7 +10,7 @@ from app.core.constants import ModuleStatus
 from app.core.logging import get_logger
 from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
-from app.models.data_entry_emission import DataEntryEmission
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
 from app.models.module_type import ModuleTypeEnum
 from app.models.unit import Unit
 from app.models.user import User
@@ -722,8 +722,9 @@ class CarbonReportModuleRepository:
               and statuses (e.g., ["headcount:2", "professional_travel:1"])
             years: Optional filter for specific years (e.g., [2024, 2025])
         Returns:
-            A list of dictionaries containing year, unit_id, module_name,
-              module_status, and last_updated.
+            A list of dictionaries containing year, unit information, module type,
+            module status, and last updated timestamp for each module matching
+            the filters.
         """
         hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
             path_lvl2=path_lvl2,
@@ -738,7 +739,8 @@ class CarbonReportModuleRepository:
 
         columns: List[Any] = [
             col(CarbonReport.year),
-            col(CarbonReport.unit_id),
+            col(Unit.institutional_id).label("unit_institutional_id"),
+            col(Unit.path_name).label("unit_path_name"),
             col(CarbonReportModule.module_type_id),
             col(CarbonReportModule.status),
             col(CarbonReportModule.last_updated),
@@ -749,6 +751,7 @@ class CarbonReportModuleRepository:
                 CarbonReportModule,
                 CarbonReportModule.carbon_report_id == CarbonReport.id,
             )
+            .join(Unit, Unit.id == CarbonReport.unit_id)
             .order_by(CarbonReport.id, CarbonReportModule.module_type_id)
         )
         if years:
@@ -759,7 +762,7 @@ class CarbonReportModuleRepository:
             )
         if search:
             search_term = f"%{search.strip().lower()}%"
-            statement = statement.join(Unit, Unit.id == CarbonReport.unit_id).where(
+            statement = statement.where(
                 or_(
                     func.lower(Unit.name).like(search_term),
                     func.lower(Unit.institutional_code).like(search_term),
@@ -797,18 +800,17 @@ class CarbonReportModuleRepository:
                         col(CarbonReportModule.module_type_id) == module_type
                     )
             statement = statement.where(or_(*module_conditions))
-
         if hierarchy_unit_ids is not None:
-            statement = statement.where(
-                col(CarbonReport.unit_id).in_(hierarchy_unit_ids)
-            )
+            statement = statement.where(col(Unit.id).in_(hierarchy_unit_ids))
+
         cursor = await self.session.stream(statement)
         async for partition in cursor.partitions(500):
             for row in partition:
                 report.append(
                     {
                         "year": row.year,
-                        "unit_id": row.unit_id,
+                        "unit_institutional_id": row.unit_institutional_id,
+                        "unit_path_name": row.unit_path_name,
                         "module_name": ModuleTypeEnum(row.module_type_id).name,
                         "module_status": row.status,
                         "last_updated": row.last_updated,
@@ -848,6 +850,7 @@ class CarbonReportModuleRepository:
             - ``data_entry_type``: The name of the data entry type.
             - ``year``: The reporting year.
             - ``unit_institutional_id``: The institutional identifier of the unit.
+            - ``unit_path_name``: The full hierarchy path of the unit.
             - ``data_entry_id``: The ID of the data entry record.
             - ``kg_co2eq``: The summed emissions in kilograms of CO2 equivalent
               associated with the data entry.
@@ -869,6 +872,7 @@ class CarbonReportModuleRepository:
             col(DataEntry.data_entry_type_id),
             col(CarbonReport.year),
             col(Unit.institutional_id).label("unit_institutional_id"),
+            col(Unit.path_name).label("unit_path_name"),
             col(DataEntry.id).label("data_entry_id"),
             col(DataEntry.data),
             func.coalesce(
@@ -894,7 +898,10 @@ class CarbonReportModuleRepository:
             )
             .where(DataEntry.data_entry_type_id == data_entry_type.value)
             .group_by(
-                col(CarbonReport.year), col(Unit.institutional_id), col(DataEntry.id)
+                col(CarbonReport.year),
+                col(Unit.institutional_id),
+                col(Unit.path_name),
+                col(DataEntry.id),
             )
         )
 
@@ -945,11 +952,9 @@ class CarbonReportModuleRepository:
                         col(CarbonReportModule.module_type_id) == module_type
                     )
             statement = statement.where(or_(*module_conditions))
-
         if hierarchy_unit_ids is not None:
-            statement = statement.where(
-                col(CarbonReport.unit_id).in_(hierarchy_unit_ids)
-            )
+            statement = statement.where(col(Unit.id).in_(hierarchy_unit_ids))
+
         cursor = await self.session.stream(statement)
         async for partition in cursor.partitions(500):
             for row in partition:
@@ -963,9 +968,103 @@ class CarbonReportModuleRepository:
                         ).name,
                         "year": row.year,
                         "unit_institutional_id": row.unit_institutional_id,
+                        "unit_path_name": row.unit_path_name,
                         "data_entry_id": row.data_entry_id,
                         **data,
                         "kg_co2eq": row.kg_co2eq,
+                    }
+                )
+
+        return report
+
+    async def get_results_report(
+        self,
+        path_lvl2: Optional[List[str]] = None,
+        path_lvl3: Optional[List[str]] = None,
+        path_lvl4: Optional[List[str]] = None,
+        completion_status: Optional[ModuleStatus] = None,
+        search: Optional[str] = None,
+        years: Optional[List[int]] = None,
+    ) -> list[dict]:
+        """
+        Get a report of carbon report results aggregated at the unit-year level,
+        including scope totals and breakdowns by emission type.
+
+        Args:
+            path_lvl2: Optional list of hierarchy level 2 filters (unit names or IDs)
+            path_lvl3: Optional list of hierarchy level 3 filters (unit names or IDs)
+            path_lvl4: Optional list of hierarchy level 4 filters (unit names or IDs)
+            completion_status: Optional filter for report-level completion status.
+            search: Optional search term to filter results.
+            years: Optional filter for specific years (e.g., [2024, 2025])
+        Returns:
+            A list of dictionaries containing year, unit info, scope1/2/3 totals,
+            and breakdown by emission type.
+        """
+        hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
+            path_lvl2=path_lvl2,
+            path_lvl3=path_lvl3,
+            path_lvl4=path_lvl4,
+        )
+        # If hierarchy filters were provided but matched no units, return no results.
+        if hierarchy_unit_ids is not None and not hierarchy_unit_ids:
+            return []
+
+        report: list[dict] = []
+
+        columns: List[Any] = [
+            col(CarbonReport.year),
+            col(Unit.institutional_id).label("unit_institutional_id"),
+            col(Unit.path_name).label("unit_path_name"),
+            col(CarbonReport.stats),
+        ]
+        statement = (
+            select(*columns)
+            .join(Unit, Unit.id == CarbonReport.unit_id)
+            .order_by(CarbonReport.id)
+        )
+        if years:
+            statement = statement.where(col(CarbonReport.year).in_(years))
+        if completion_status:
+            statement = statement.where(
+                col(CarbonReport.overall_status) == int(completion_status)
+            )
+        if search:
+            search_term = f"%{search.strip().lower()}%"
+            statement = statement.where(
+                or_(
+                    func.lower(Unit.name).like(search_term),
+                    func.lower(Unit.institutional_code).like(search_term),
+                )
+            )
+        if hierarchy_unit_ids is not None:
+            statement = statement.where(col(Unit.id).in_(hierarchy_unit_ids))
+
+        cursor = await self.session.stream(statement)
+        async for partition in cursor.partitions(500):
+            for row in partition:
+                stats = row.stats if isinstance(row.stats, dict) else {}
+                by_emission_type = stats.get("by_emission_type") or {}
+                # Convert emission type keys to names if possible
+                by_emission_type = {
+                    (
+                        EmissionType(int(k)).name.replace("__", "_")
+                        if k.isdigit() and int(k) in EmissionType._value2member_map_
+                        else k
+                    ): v
+                    for k, v in by_emission_type.items()
+                }
+                report.append(
+                    {
+                        "year": row.year,
+                        "unit_institutional_id": row.unit_institutional_id,
+                        "unit_path_name": row.unit_path_name,
+                        "scope1": stats.get("scope1"),
+                        "scope2": stats.get("scope2"),
+                        "scope3": stats.get("scope3"),
+                        "total": stats.get("total"),
+                        # Flatten by_emission_type into top-level keys
+                        **by_emission_type,
                     }
                 )
 

--- a/frontend/src/api/reporting.ts
+++ b/frontend/src/api/reporting.ts
@@ -35,6 +35,7 @@ export async function exportReport(
 function _applyReportFilters(
   searchParams: URLSearchParams,
   unitFilters: UnitFilters,
+  withModules: boolean = true,
 ): void {
   if (unitFilters.path_lvl2) {
     unitFilters.path_lvl2.forEach((v) =>
@@ -63,7 +64,7 @@ function _applyReportFilters(
   if (unitFilters.search) {
     searchParams.append('search', unitFilters.search);
   }
-  if (unitFilters.modules && unitFilters.modules.length > 0) {
+  if (withModules && unitFilters.modules && unitFilters.modules.length > 0) {
     unitFilters.modules.forEach((v) =>
       searchParams.append(
         'modules',
@@ -106,4 +107,19 @@ export async function downloadDetailedReportFile(
   _applyReportFilters(searchParams, unitFilters);
 
   return api.get('backoffice/report/detailed', { searchParams }).blob();
+}
+
+export async function downloadResultsReportFile(
+  unitFilters: UnitFilters,
+  format: ReportFormat,
+): Promise<Blob> {
+  if (format === 'pdf') {
+    throw new Error('PDF format is not supported for results report');
+  }
+  const searchParams = new URLSearchParams({
+    format,
+  });
+  _applyReportFilters(searchParams, unitFilters, false);
+
+  return api.get('backoffice/report/results', { searchParams }).blob();
 }

--- a/frontend/src/components/organisms/backoffice/reporting/ReportExport.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportExport.vue
@@ -8,6 +8,7 @@ import {
   exportReport,
   downloadUsageReportFile,
   downloadDetailedReportFile,
+  downloadResultsReportFile,
 } from 'src/api/reporting';
 import type { ReportFormat, ReportType } from 'src/api/reporting';
 import { type UnitFilters } from 'src/stores/backoffice';
@@ -55,6 +56,15 @@ const downloading = ref(false);
 //   return stringValue;
 // }
 
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 async function downloadReport(format: 'csv' | 'json') {
   if (!selectedReport.value) return;
   downloading.value = true;
@@ -64,13 +74,10 @@ async function downloadReport(format: 'csv' | 'json') {
         props.unitFilters || {},
         format as ReportFormat,
       );
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const today = new Date().toISOString().slice(0, 10);
-      a.download = `usage_report_${today}.${format}`;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(
+        blob,
+        `usage_report_${new Date().toISOString().slice(0, 10)}.${format}`,
+      );
       Notify.create({
         color: 'positive',
         message: t('backoffice_reporting_usage_downloaded'),
@@ -93,13 +100,10 @@ async function downloadReport(format: 'csv' | 'json') {
         props.unitFilters || {},
         format as ReportFormat,
       );
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const today = new Date().toISOString().slice(0, 10);
-      a.download = `detailed_report_${today}.zip`;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(
+        blob,
+        `detailed_report_${new Date().toISOString().slice(0, 10)}.zip`,
+      );
       Notify.create({
         color: 'positive',
         message: t('backoffice_reporting_detailed_downloaded'),
@@ -110,6 +114,32 @@ async function downloadReport(format: 'csv' | 'json') {
       Notify.create({
         color: 'negative',
         message: t('backoffice_reporting_detailed_download_failed'),
+        position: 'top',
+        timeout: 3000,
+      });
+    } finally {
+      downloading.value = false;
+    }
+  } else if (selectedReport.value === 'results') {
+    try {
+      const blob = await downloadResultsReportFile(
+        props.unitFilters || {},
+        format as ReportFormat,
+      );
+      downloadBlob(
+        blob,
+        `results_report_${new Date().toISOString().slice(0, 10)}.${format}`,
+      );
+      Notify.create({
+        color: 'positive',
+        message: t('backoffice_reporting_results_downloaded'),
+        position: 'top',
+        timeout: 2000,
+      });
+    } catch {
+      Notify.create({
+        color: 'negative',
+        message: t('backoffice_reporting_results_download_failed'),
         position: 'top',
         timeout: 3000,
       });

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -202,6 +202,14 @@ export default {
     en: 'Failed to download detailed report',
     fr: 'Échec du téléchargement du rapport détaillé',
   },
+  backoffice_reporting_results_downloaded: {
+    en: 'Results report downloaded',
+    fr: 'Rapport de résultats téléchargé',
+  },
+  backoffice_reporting_results_download_failed: {
+    en: 'Failed to download results report',
+    fr: 'Échec du téléchargement du rapport de résultats',
+  },
 
   backoffice_reporting_chart_unit_footprint_title: {
     en: 'Unit Carbon Footprint',


### PR DESCRIPTION
## What does this change?

Get a report of carbon report results aggregated at the unit-year level, including scope totals and breakdowns by emission type.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #504

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
