### PR TITLE
feat(#384): Merge sync jobs into year-config & wire backoffice UI controls

### DIFF
--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -26,10 +26,12 @@ from app.models.data_entry import DataEntryTypeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
 from app.models.year_configuration import YearConfiguration
+from app.repositories.data_ingestion import DataIngestionRepository
 from app.schemas.year_configuration import (
     FileCategory,
     FileMetadata,
     FileUploadResponse,
+    SyncJobSummary,
     YearConfigurationCreate,
     YearConfigurationResponse,
     YearConfigurationUpdate,
@@ -45,9 +47,129 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
+def _build_job_lookup(
+    jobs: list,
+) -> dict[tuple[int | None, int | None], "SyncJobSummary"]:
+    """Build a lookup dict from latest jobs keyed by (module, data_entry) IDs.
+
+    Args:
+        jobs: List of DataIngestionJob objects.
+
+    Returns:
+        Dict mapping (module_type_id, data_entry_type_id) to SyncJobSummary.
+    """
+    lookup: dict[tuple[int | None, int | None], SyncJobSummary] = {}
+    for job in jobs:
+        if job.id is None:
+            continue
+        key = (job.module_type_id, job.data_entry_type_id)
+        lookup[key] = SyncJobSummary(
+            job_id=job.id,
+            module_type_id=job.module_type_id,
+            data_entry_type_id=job.data_entry_type_id,
+            year=job.year,
+            ingestion_method=job.ingestion_method.value
+            if job.ingestion_method is not None
+            else 0,
+            target_type=job.target_type.value if job.target_type is not None else None,
+            state=job.state.value if job.state is not None else None,
+            result=job.result.value if job.result is not None else None,
+            status_message=job.status_message,
+            meta=job.meta,
+        )
+    return lookup
+
+
+def _build_jobs_list(jobs: list) -> list["SyncJobSummary"]:
+    """Build a flat list of SyncJobSummary from DataIngestionJob objects.
+
+    Args:
+        jobs: List of DataIngestionJob objects.
+
+    Returns:
+        List of SyncJobSummary (all current jobs for the year).
+    """
+    result: list[SyncJobSummary] = []
+    for job in jobs:
+        if job.id is None:
+            continue
+        result.append(
+            SyncJobSummary(
+                job_id=job.id,
+                module_type_id=job.module_type_id,
+                data_entry_type_id=job.data_entry_type_id,
+                year=job.year,
+                ingestion_method=job.ingestion_method.value
+                if job.ingestion_method is not None
+                else 0,
+                target_type=job.target_type.value
+                if job.target_type is not None
+                else None,
+                state=job.state.value if job.state is not None else None,
+                result=job.result.value if job.result is not None else None,
+                status_message=job.status_message,
+                meta=job.meta,
+            )
+        )
+    return result
+
+
+def _enrich_config_with_jobs(
+    config: dict, job_lookup: dict[tuple[int | None, int | None], SyncJobSummary]
+) -> dict:
+    """Inject latest_job into each submodule of the config dict.
+
+    Args:
+        config: Year configuration dict (modules → submodules).
+        job_lookup: Mapping from (module_type_id, data_entry_type_id) to job summary.
+
+    Returns:
+        Enriched config dict (mutated in-place for efficiency).
+    """
+    modules = config.get("modules", {})
+    for module_key, module_val in modules.items():
+        if not isinstance(module_val, dict):
+            continue
+        submodules = module_val.get("submodules", {})
+        for sub_key, sub_val in submodules.items():
+            if not isinstance(sub_val, dict):
+                continue
+            try:
+                m_id = int(module_key)
+                s_id = int(sub_key)
+            except (ValueError, TypeError):
+                continue
+            job = job_lookup.get((m_id, s_id))
+            sub_val["latest_job"] = job.model_dump() if job else None
+    return config
+
+
 def get_files_storage_path() -> str:
     """Get the files storage path from environment or default."""
     return os.environ.get("FILES_STORAGE_PATH", "./files_storage")
+
+
+def _deep_merge(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge patch into base (returns a new dict).
+
+    For each key in patch:
+    - If both base[key] and patch[key] are dicts, recurse.
+    - Otherwise, patch[key] overwrites base[key].
+
+    Args:
+        base: Original dict.
+        patch: Partial dict to merge in.
+
+    Returns:
+        New merged dict (base is not mutated).
+    """
+    merged = base.copy()
+    for key, value in patch.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
 
 
 def generate_unique_filename(original_filename: str) -> str:
@@ -186,7 +308,11 @@ async def get_year_configuration(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Fetch year configuration for the given year.
+    """Fetch year configuration for the given year, enriched with latest sync jobs.
+
+    Each submodule in the response includes a `latest_job` field with the most
+    recent ingestion job summary. This eliminates the need for a separate
+    call to `/sync/jobs/year/{year}/latest`.
 
     Returns 404 if no configuration has been created yet.
     Backoffice users can then create it via POST /{year}.
@@ -197,7 +323,7 @@ async def get_year_configuration(
         current_user: Current authenticated user.
 
     Returns:
-        Year configuration.
+        Year configuration enriched with latest sync job per submodule.
     """
     stmt = select(YearConfiguration).where(col(YearConfiguration.year) == year)
     result = (await db.exec(stmt)).first()
@@ -208,7 +334,23 @@ async def get_year_configuration(
             detail=f"No configuration found for year {year}",
         )
 
-    return YearConfigurationResponse.model_validate(result)
+    # Fetch latest jobs and enrich config
+    repo = DataIngestionRepository(db)
+    latest_jobs = await repo.get_latest_jobs_by_year(year)
+    job_lookup = _build_job_lookup(latest_jobs)
+    jobs_list = _build_jobs_list(latest_jobs)
+
+    enriched_config = copy.deepcopy(result.config)
+    _enrich_config_with_jobs(enriched_config, job_lookup)
+
+    return YearConfigurationResponse(
+        year=result.year,
+        is_started=result.is_started,
+        is_reports_synced=result.is_reports_synced,
+        config=enriched_config,
+        latest_jobs=jobs_list,
+        updated_at=result.updated_at,
+    )
 
 
 @router.post(
@@ -367,7 +509,7 @@ async def update_year_configuration(
     if payload.is_reports_synced is not None:
         result.is_reports_synced = payload.is_reports_synced
     if payload.config is not None:
-        result.config = payload.config
+        result.config = _deep_merge(result.config, payload.config)
 
     new_snapshot = {
         "is_started": result.is_started,
@@ -397,7 +539,23 @@ async def update_year_configuration(
         extra={"user_id": current_user.id, "year": year},
     )
 
-    return YearConfigurationResponse.model_validate(result)
+    # Fetch latest jobs so the response includes them
+    repo = DataIngestionRepository(db)
+    latest_jobs = await repo.get_latest_jobs_by_year(year)
+    jobs_list = _build_jobs_list(latest_jobs)
+    job_lookup = _build_job_lookup(latest_jobs)
+
+    enriched_config = copy.deepcopy(result.config)
+    _enrich_config_with_jobs(enriched_config, job_lookup)
+
+    return YearConfigurationResponse(
+        year=result.year,
+        is_started=result.is_started,
+        is_reports_synced=result.is_reports_synced,
+        config=enriched_config,
+        latest_jobs=jobs_list,
+        updated_at=result.updated_at,
+    )
 
 
 @router.post(

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Type definitions
 UncertaintyTag = Literal["low", "medium", "high", "none"]
@@ -60,6 +60,21 @@ class ReductionObjectives(BaseModel):
     )
 
 
+class SyncJobSummary(BaseModel):
+    """Summary of the latest sync job for a submodule (read-only, not stored in DB)."""
+
+    job_id: int = Field(..., description="Ingestion job ID")
+    module_type_id: Optional[int] = Field(None, description="Module type ID")
+    data_entry_type_id: Optional[int] = Field(None, description="Data entry type ID")
+    year: Optional[int] = Field(None, description="Reference year")
+    ingestion_method: int = Field(..., description="0=api, 1=csv, 2=manual")
+    target_type: Optional[int] = Field(None, description="0=data_entries, 1=factors")
+    state: Optional[int] = Field(None, description="0=NOT_STARTED..3=FINISHED")
+    result: Optional[int] = Field(None, description="0=SUCCESS, 1=WARNING, 2=ERROR")
+    status_message: Optional[str] = Field(None, description="Human-readable status")
+    meta: Optional[Dict[str, Any]] = Field(None, description="Job metadata")
+
+
 class SubmoduleConfig(BaseModel):
     """Configuration for a single data entry type (submodule)."""
 
@@ -68,6 +83,14 @@ class SubmoduleConfig(BaseModel):
         default=None,
         description="Fixed threshold in kgCO2eq (null if not set)",
     )
+
+    @field_validator("threshold")
+    @classmethod
+    def validate_threshold(cls, v: Optional[float]) -> Optional[float]:
+        """Threshold must be >= 0 when set."""
+        if v is not None and v < 0:
+            raise ValueError("threshold must be >= 0")
+        return v
 
 
 class ModuleConfig(BaseModel):
@@ -81,6 +104,23 @@ class ModuleConfig(BaseModel):
         default_factory=dict,
         description="Configuration for each data entry type under this module",
     )
+
+
+class SubmoduleConfigResponse(SubmoduleConfig):
+    """Submodule config enriched with latest sync job info (read-only)."""
+
+    latest_job: Optional[SyncJobSummary] = Field(
+        default=None,
+        description="Latest sync job for this submodule (computed, not stored)",
+    )
+
+
+class ModuleConfigResponse(BaseModel):
+    """Module config enriched with submodule job info (read-only)."""
+
+    enabled: bool = Field(default=True)
+    uncertainty_tag: UncertaintyTag = Field(default="medium")
+    submodules: Dict[str, SubmoduleConfigResponse] = Field(default_factory=dict)
 
 
 class YearConfigJSON(BaseModel):
@@ -126,14 +166,43 @@ class YearConfigurationUpdate(BaseModel):
     is_reports_synced: Optional[bool] = None
     config: Optional[Dict[str, Any]] = None
 
+    @model_validator(mode="after")
+    def validate_thresholds(self) -> "YearConfigurationUpdate":
+        """Validate threshold values in modules config if provided."""
+        if not self.config or "modules" not in self.config:
+            return self
+        modules = self.config["modules"]
+        for module_key, module_val in modules.items():
+            if not isinstance(module_val, dict):
+                continue
+            submodules = module_val.get("submodules", {})
+            if not isinstance(submodules, dict):
+                continue
+            for sub_key, sub_val in submodules.items():
+                if not isinstance(sub_val, dict):
+                    continue
+                threshold = sub_val.get("threshold")
+                if threshold is not None and (
+                    not isinstance(threshold, (int, float)) or threshold < 0
+                ):
+                    raise ValueError(
+                        f"threshold for module {module_key} / submodule {sub_key} "
+                        f"must be a number >= 0 or null, got {threshold}"
+                    )
+        return self
+
 
 class YearConfigurationResponse(BaseModel):
-    """Schema for year configuration response."""
+    """Schema for year configuration response with enriched submodule data."""
 
     year: int
     is_started: bool
     is_reports_synced: bool
     config: Dict[str, Any]
+    latest_jobs: List[SyncJobSummary] = Field(
+        default_factory=list,
+        description="All current ingestion jobs for this year",
+    )
     updated_at: datetime
 
     class Config:

--- a/backend/tests/integration/data_ingestion/fixtures/valid_module_per_year.csv
+++ b/backend/tests/integration/data_ingestion/fixtures/valid_module_per_year.csv
@@ -1,0 +1,3 @@
+unit_institutional_id,name,position_title,position_category,user_institutional_id,fte,note
+UNIT001,John Doe,Professor,professor,UID001,1.0,
+UNIT002,Jane Smith,Post-doctoral researcher,postdoctoral_assistant,UID002,0.5,

--- a/backend/tests/integration/data_ingestion/test_csv_upload_e2e.py
+++ b/backend/tests/integration/data_ingestion/test_csv_upload_e2e.py
@@ -46,12 +46,13 @@ async def test_user(db_session: AsyncSession):
 
 
 @pytest.fixture
-def get_test_client(test_user, monkeypatch):
+def get_test_client(test_user, db_session, monkeypatch):
     """Create test client with mocked authentication and permissions."""
 
     def _get_client():
         from app.api import deps
         from app.api.v1 import data_sync, files
+        from app.db import get_db
 
         # Override get_current_user to return test user
         async def mock_get_current_user():
@@ -61,11 +62,16 @@ def get_test_client(test_user, monkeypatch):
         async def mock_is_permitted(user, path, action):
             return True
 
+        # Override get_db to use the test session (tables already created)
+        async def mock_get_db():
+            yield db_session
+
         app.dependency_overrides[deps.get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_db] = mock_get_db
         monkeypatch.setattr(files, "is_permitted", mock_is_permitted)
         monkeypatch.setattr(data_sync, "is_permitted", mock_is_permitted)
 
-        client = TestClient(app, raise_server_exceptions=True)
+        client = TestClient(app, raise_server_exceptions=False)
         return client
 
     yield _get_client

--- a/docs/implementation-plans/384-backoffice-data-management-thresholds.md
+++ b/docs/implementation-plans/384-backoffice-data-management-thresholds.md
@@ -1,0 +1,23 @@
+## 🎯 Feature Overview (Why?)
+
+In the calculator a carbon footprint appears in red if crossing a certain threshold, as defined in Data mgt.
+
+## 🧩 Solution
+
+In Data Management possibility to set the threshold for each module/sub-module
+
+-> KEEP ONLY OPTION FIXED Threshold (deicison 19.03)
+
+## 🎨 Design
+
+ONLY FIXED THRESHOLD
+
+## 📋 Implementation Plan
+
+- be filled by dev
+
+## ✅ Success Criteria
+
+- [ ] Possibility to enter a threshold is _mandatory_ in the backoffice
+- [ ] When entered erase the last value threshold
+- [ ] In the correpsonding module for all unit, the values above the threshold appears in red

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
 
   - Frontend:
       - Overview: frontend/01-overview.md
+      - Design Tokens: frontend/02-design-tokens.md
 
   - Backend:
       - Overview: backend/01-overview.md

--- a/docs/src/frontend/02-design-tokens.md
+++ b/docs/src/frontend/02-design-tokens.md
@@ -14,9 +14,10 @@ Your ITCSS-like structure already aligns with design token architecture:
 Quasar provides extensive SCSS variables (as you've shown). Here's how to approach it:
 
 **Option A: Override Quasar Variables with Your Tokens**
+
 ```scss
 // 02-tokens/_quasar-overrides.scss
-@use 'design-tokens' as tokens;
+@use "design-tokens" as tokens;
 
 // Map your design tokens to Quasar variables
 $primary: tokens.$color-brand-primary;
@@ -25,20 +26,21 @@ $space-base: tokens.$spacing-base;
 $breakpoint-xs: tokens.$breakpoint-mobile;
 
 // Import Quasar with your overrides
-@import 'quasar/src/css/variables.sass';
+@import "quasar/src/css/variables.sass";
 ```
 
 **Option B: Create a Token Mapping Layer**
+
 ```scss
 // 02-tokens/_design-tokens.scss
 // Your source of truth
-$color-brand-primary: #1976D2;
-$color-brand-secondary: #26A69A;
+$color-brand-primary: #1976d2;
+$color-brand-secondary: #26a69a;
 $spacing-base: 16px;
 
 // 02-tokens/_quasar-bridge.scss
 // Bridge layer that maps tokens to Quasar
-@use 'design-tokens' as tokens;
+@use "design-tokens" as tokens;
 
 $primary: tokens.$color-brand-primary;
 $secondary: tokens.$color-brand-secondary;
@@ -65,27 +67,28 @@ Since your designer uses Atomic Design, organize your components layer:
 ```
 
 **BEM with Component Tokens:**
+
 ```scss
 // 05-components/_atoms/_button.scss
-@use '../../02-tokens/decisions' as decisions;
+@use "../../02-tokens/decisions" as decisions;
 
 .button {
   // Base button using decision tokens
   padding: decisions.$button-padding;
   border-radius: decisions.$button-border-radius;
   font-size: decisions.$button-font-size;
-  
+
   &--primary {
     // Component token: button-primary
     background: decisions.$button-primary-background;
     color: decisions.$button-primary-text;
   }
-  
+
   &--secondary {
     background: decisions.$button-secondary-background;
     color: decisions.$button-secondary-text;
   }
-  
+
   &__icon {
     // Element within button
     margin-right: decisions.$button-icon-spacing;
@@ -96,6 +99,7 @@ Since your designer uses Atomic Design, organize your components layer:
 ### 4. **Three-Layer Token Architecture**
 
 **Layer 1: Options (Primitives)**
+
 ```scss
 // 02-tokens/_options.scss
 // What's available (the palette)
@@ -107,9 +111,10 @@ $spacing-16: 16px;
 ```
 
 **Layer 2: Decisions (Semantic)**
+
 ```scss
 // 02-tokens/_decisions.scss
-@use 'options' as opt;
+@use "options" as opt;
 
 // How they're applied
 $color-primary: opt.$color-blue-900;
@@ -122,9 +127,10 @@ $button-border-radius: 4px;
 ```
 
 **Layer 3: Component Tokens**
+
 ```scss
 // 02-tokens/_components.scss
-@use 'decisions' as dec;
+@use "decisions" as dec;
 
 // Where they're applied
 $button-primary-background: dec.$color-primary;
@@ -165,27 +171,27 @@ styles/
 @layer reset, tokens, layout, utils, components;
 
 @layer reset {
-  @import '01-reset/normalize';
+  @import "01-reset/normalize";
 }
 
 @layer tokens {
   // Tokens generate CSS custom properties
-  @import '02-tokens/index';
+  @import "02-tokens/index";
 }
 
 @layer layout {
-  @import '03-layout/grid';
-  @import '03-layout/container';
+  @import "03-layout/grid";
+  @import "03-layout/container";
 }
 
 @layer utils {
-  @import '04-utils/spacing';
-  @import '04-utils/text';
+  @import "04-utils/spacing";
+  @import "04-utils/text";
 }
 
 @layer components {
-  @import '05-components/atoms/button';
-  @import '05-components/molecules/search-bar';
+  @import "05-components/atoms/button";
+  @import "05-components/molecules/search-bar";
 }
 ```
 
@@ -210,17 +216,17 @@ $button-radius: 4px;
   // Use decision tokens
   padding: $button-padding-y $button-padding-x;
   border-radius: $button-radius;
-  
+
   &--primary {
     background: $color-primary;
     color: $color-text-on-primary;
   }
-  
+
   &--outline {
     border: 2px solid $color-primary;
     color: $color-primary;
   }
-  
+
   &__icon {
     margin-right: $spacing-small;
   }
@@ -237,6 +243,7 @@ $button-radius: 4px;
 6. **Document which tokens are public** in your `02-tokens/_index.scss`
 
 This approach gives you:
+
 - ✅ Design token architecture (flexibility + automation potential)
 - ✅ ITCSS organization (scalability)
 - ✅ Atomic Design (designer alignment)
@@ -244,6 +251,7 @@ This approach gives you:
 - ✅ Quasar integration (framework leverage)
 
 # Complete break down
+
 ```scss
 // ============================================================================
 // 02-TOKENS LAYER - DESIGN TOKEN ARCHITECTURE
@@ -253,7 +261,7 @@ This approach gives you:
 // -----------------------------
 // This is NOT SCSS-specific - it's a design token architecture pattern
 // from the "Design Token-Based UI Architecture" methodology.
-// 
+//
 // Think of it as THREE LEVELS OF DECISION-MAKING:
 //
 // ┌─────────────────────────────────────────────────────────────────┐
@@ -277,7 +285,7 @@ This approach gives you:
 //
 // WHY THREE LAYERS?
 // -----------------
-// 1. FLEXIBILITY: Change "primary" from blue to green without touching 
+// 1. FLEXIBILITY: Change "primary" from blue to green without touching
 //    every component
 // 2. CONSISTENCY: All "primary" colors update together
 // 3. SCALABILITY: Add new components easily by referencing decisions
@@ -364,15 +372,23 @@ $color-grey-700: #616161 !default;
 $color-white: #ffffff !default;
 
 // Shadow primitives (from Quasar's system)
-$shadow-1: 0 1px 3px rgba(0,0,0,.2), 0 1px 1px rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12) !default;
-$shadow-2: 0 1px 5px rgba(0,0,0,.2), 0 2px 2px rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.12) !default;
-$shadow-5: 0 3px 5px -1px rgba(0,0,0,.2), 0 5px 8px rgba(0,0,0,.14), 0 1px 14px rgba(0,0,0,.12) !default;
+$shadow-1:
+  0 1px 3px rgba(0, 0, 0, 0.2),
+  0 1px 1px rgba(0, 0, 0, 0.14),
+  0 2px 1px -1px rgba(0, 0, 0, 0.12) !default;
+$shadow-2:
+  0 1px 5px rgba(0, 0, 0, 0.2),
+  0 2px 2px rgba(0, 0, 0, 0.14),
+  0 3px 1px -2px rgba(0, 0, 0, 0.12) !default;
+$shadow-5:
+  0 3px 5px -1px rgba(0, 0, 0, 0.2),
+  0 5px 8px rgba(0, 0, 0, 0.14),
+  0 1px 14px rgba(0, 0, 0, 0.12) !default;
 
 // Transition options
-$transition-fast: .15s !default;
-$transition-normal: .3s !default;
-$transition-easing: cubic-bezier(.25, .8, .5, 1) !default;
-
+$transition-fast: 0.15s !default;
+$transition-normal: 0.3s !default;
+$transition-easing: cubic-bezier(0.25, 0.8, 0.5, 1) !default;
 
 // ----------------------------------------------------------------------------
 // 02-tokens/_decisions.scss (PUBLIC - Semantic/Contextual)
@@ -398,14 +414,14 @@ $transition-easing: cubic-bezier(.25, .8, .5, 1) !default;
 // Without decisions: Designer says "change brand color"
 //   → You search codebase for all "blue-600" (200+ files)
 //   → Miss some, inconsistent results
-// With decisions: 
+// With decisions:
 //   → Change $color-primary: blue-600 to $color-primary: green-600
 //   → Done! Everything updates
 //
 // REFERENCE PATTERN:
 // Notice how we reference options using: opt.$option-name
 // This is SCSS modules syntax - it imports from _options.scss
-@use 'options' as opt;
+@use "options" as opt;
 
 // Brand colors (semantic naming)
 $color-primary: opt.$color-blue-600 !default;
@@ -437,7 +453,6 @@ $text-body-size: opt.$font-size-sm !default;
 $text-body-line-height: opt.$line-height-relaxed !default;
 $text-weight-emphasis: opt.$font-weight-medium !default;
 
-
 // ----------------------------------------------------------------------------
 // 02-tokens/_components.scss (PUBLIC - Component-specific)
 // ----------------------------------------------------------------------------
@@ -460,7 +475,7 @@ $text-weight-emphasis: opt.$font-weight-medium !default;
 // 4. Component Isolation: Change button styles without affecting cards
 //
 // WHEN TO USE COMPONENT TOKENS VS DECISIONS?
-// 
+//
 // Use DECISIONS directly when:
 //   → Simple, one-off usage
 //   → No component-specific variations needed
@@ -480,14 +495,14 @@ $text-weight-emphasis: opt.$font-weight-medium !default;
 //   → Change $button-primary-bg = $color-primary-dark
 //   → Only buttons affected!
 //
-@use 'decisions' as dec;
+@use "decisions" as dec;
 
 // Button component tokens
 // Notice: We're creating a "namespace" for all button-related tokens
 $button-padding-y: dec.$spacing-sm !default;
 $button-padding-x: dec.$spacing-md !default;
 $button-padding: $button-padding-y $button-padding-x !default;
-$button-padding-dense: .285em !default;
+$button-padding-dense: 0.285em !default;
 
 $button-radius: dec.$interactive-radius !default;
 $button-radius-rounded: dec.$interactive-radius-round !default;
@@ -528,7 +543,6 @@ $card-shadow: dec.$interactive-shadow !default;
 $card-header-padding: dec.$spacing-md dec.$spacing-lg !default;
 $card-body-padding: dec.$spacing-lg !default;
 $card-footer-padding: dec.$spacing-md dec.$spacing-lg !default;
-
 
 // ----------------------------------------------------------------------------
 // 02-tokens/_quasar-bridge.scss
@@ -578,8 +592,8 @@ $card-footer-padding: dec.$spacing-md dec.$spacing-lg !default;
 //
 // Bridge layer: Maps your tokens to Quasar's variable names
 // This file overrides Quasar defaults with your design tokens
-@use 'components' as comp;
-@use 'decisions' as dec;
+@use "components" as comp;
+@use "decisions" as dec;
 
 // Override Quasar's button variables with your component tokens
 // Pattern: $quasar-var-name: comp.$your-token-name
@@ -612,7 +626,6 @@ $space-base: dec.$spacing-md !default;
 //   → NO → Use Quasar's default
 //
 // RESULT: All Quasar buttons automatically use your design tokens!
-
 
 // ----------------------------------------------------------------------------
 // 02-tokens/_index.scss (Public API)
@@ -648,10 +661,9 @@ $space-base: dec.$spacing-md !default;
 // @forward 'file';       → Re-export for others who import THIS file
 // @import 'file';        → Old way (global namespace, avoid in new code)
 
-@forward 'decisions';
-@forward 'components';
+@forward "decisions";
+@forward "components";
 // Note: 'options' is NOT forwarded - it's private/internal only
-
 
 // ============================================================================
 // 05-COMPONENTS LAYER (Atomic Design Structure)
@@ -662,7 +674,7 @@ $space-base: dec.$spacing-md !default;
 // ----------------------------------------------------------------------------
 // Custom button using BEM + Design Tokens
 // This demonstrates building components alongside Quasar
-@use '../../02-tokens' as tokens;
+@use "../../02-tokens" as tokens;
 
 .btn {
   // Base button styles using component tokens
@@ -679,58 +691,58 @@ $space-base: dec.$spacing-md !default;
   border: none;
   text-decoration: none;
   user-select: none;
-  
+
   // Variants (BEM modifiers)
   &--primary {
     background-color: tokens.$button-primary-bg;
     color: tokens.$button-primary-text;
     box-shadow: tokens.$button-shadow;
-    
+
     &:hover {
       background-color: tokens.$button-primary-bg-hover;
       box-shadow: tokens.$button-shadow-active;
     }
-    
+
     &:active {
       box-shadow: tokens.$button-shadow;
     }
   }
-  
+
   &--secondary {
     background-color: tokens.$button-secondary-bg;
     color: tokens.$button-secondary-text;
     box-shadow: tokens.$button-shadow;
-    
+
     &:hover {
       opacity: 0.9;
       box-shadow: tokens.$button-shadow-active;
     }
   }
-  
+
   &--outline {
     background-color: transparent;
     color: tokens.$button-outline-text;
     border: 2px solid tokens.$button-outline-border;
     box-shadow: none;
-    
+
     &:hover {
       background-color: tokens.$button-outline-bg-hover;
     }
   }
-  
+
   &--rounded {
     border-radius: tokens.$button-radius-rounded;
   }
-  
+
   &--dense {
     padding: tokens.$button-padding-dense;
   }
-  
+
   &--block {
     display: flex;
     width: 100%;
   }
-  
+
   // States
   &:disabled,
   &--disabled {
@@ -738,53 +750,52 @@ $space-base: dec.$spacing-md !default;
     cursor: not-allowed;
     pointer-events: none;
   }
-  
+
   // Elements (BEM elements)
   &__icon {
     &--left {
       margin-right: tokens.$spacing-sm;
     }
-    
+
     &--right {
       margin-left: tokens.$spacing-sm;
     }
   }
-  
+
   &__label {
     flex: 1;
   }
 }
 
-
 // ----------------------------------------------------------------------------
 // 05-components/_molecules/_card.scss
 // ----------------------------------------------------------------------------
 // Custom card component using BEM + Design Tokens
-@use '../../02-tokens' as tokens;
+@use "../../02-tokens" as tokens;
 
 .card {
   background-color: tokens.$card-bg;
   border-radius: tokens.$card-radius;
   box-shadow: tokens.$card-shadow;
   overflow: hidden;
-  
+
   // Elements
   &__header {
     padding: tokens.$card-header-padding;
     border-bottom: 1px solid tokens.$color-surface-variant;
   }
-  
+
   &__title {
     margin: 0;
     font-size: tokens.$text-body-size;
     font-weight: tokens.$text-weight-emphasis;
     color: tokens.$color-on-surface;
   }
-  
+
   &__body {
     padding: tokens.$card-body-padding;
   }
-  
+
   &__footer {
     padding: tokens.$card-footer-padding;
     border-top: 1px solid tokens.$color-surface-variant;
@@ -792,25 +803,24 @@ $space-base: dec.$spacing-md !default;
     justify-content: flex-end;
     gap: tokens.$spacing-sm;
   }
-  
+
   // Modifiers
   &--flat {
     box-shadow: none;
     border: 1px solid tokens.$color-surface-variant;
   }
-  
+
   &--bordered {
     border: 1px solid tokens.$color-surface-variant;
   }
 }
-
 
 // ----------------------------------------------------------------------------
 // 05-components/_quasar-overrides/_q-btn-custom.scss
 // ----------------------------------------------------------------------------
 // Additional customization for Quasar's q-btn component
 // This goes beyond variable overrides for specific use cases
-@use '../../02-tokens' as tokens;
+@use "../../02-tokens" as tokens;
 
 .q-btn {
   // Add custom variant that Quasar doesn't have
@@ -822,13 +832,13 @@ $space-base: dec.$spacing-md !default;
     );
     color: tokens.$button-primary-text;
   }
-  
+
   // Custom size variant
   &.q-btn--xs {
     font-size: 12px;
     padding: tokens.$spacing-xs tokens.$spacing-sm;
   }
-  
+
   // Industry-specific variant (e.g., for your domain)
   &.q-btn--action {
     text-transform: none;
@@ -836,7 +846,6 @@ $space-base: dec.$spacing-md !default;
     font-weight: tokens.$font-weight-bold;
   }
 }
-
 
 // ============================================================================
 // MAIN.SCSS - Putting it all together
@@ -853,16 +862,16 @@ $space-base: dec.$spacing-md !default;
 //
 // Step 1: Import Quasar bridge BEFORE Quasar itself
 // ↓
-@use '02-tokens/quasar-bridge';
+@use "02-tokens/quasar-bridge";
 //   ↑ This defines variables like $button-padding
 //
 // Step 2: Import Quasar (it will use your overridden variables)
 // ↓
-@import 'quasar/src/css/index.sass';
+@import "quasar/src/css/index.sass";
 //   ↑ Quasar reads $button-padding and uses YOUR value
 //   ↑ Why @import here? Quasar uses old syntax, we must too
 //
-// 💡 KEY INSIGHT: 
+// 💡 KEY INSIGHT:
 // The ORDER matters because SCSS processes files sequentially
 // If you import Quasar BEFORE bridge, it uses defaults (bridge is too late!)
 //
@@ -919,36 +928,36 @@ $space-base: dec.$spacing-md !default;
 // → Gives you surgical control over Quasar without !important
 
 @layer reset {
-  @import '01-reset/normalize';
+  @import "01-reset/normalize";
 }
 
 @layer tokens {
   // Generate CSS custom properties from tokens if needed
   // Example: :root { --color-primary: #1976d2; }
   // This is optional - useful for runtime theme switching
-  @import '02-tokens/css-properties'; // Optional
+  @import "02-tokens/css-properties"; // Optional
 }
 
 @layer layout {
-  @import '03-layout/grid';
-  @import '03-layout/container';
+  @import "03-layout/grid";
+  @import "03-layout/container";
 }
 
 @layer quasar-overrides {
   // Additional Quasar customizations beyond variable overrides
-  @import '05-components/quasar-overrides/q-btn-custom';
+  @import "05-components/quasar-overrides/q-btn-custom";
 }
 
 @layer components {
   // Your custom components (Atomic Design structure)
-  @import '05-components/atoms/button';
-  @import '05-components/molecules/card';
+  @import "05-components/atoms/button";
+  @import "05-components/molecules/card";
   // ... more components
 }
 
 @layer utilities {
-  @import '04-utils/spacing';
-  @import '04-utils/text';
+  @import "04-utils/spacing";
+  @import "04-utils/text";
 }
 
 //
@@ -974,7 +983,6 @@ $space-base: dec.$spacing-md !default;
 // ✓ Your custom components stay consistent
 // ✓ Predictable cascade (no specificity wars!)
 //
-
 
 // ============================================================================
 // USAGE EXAMPLES

--- a/frontend/src/components/organisms/data-management/AnnualDataImport.vue
+++ b/frontend/src/components/organisms/data-management/AnnualDataImport.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { useFilesStore } from 'src/stores/files';
-import { useBackofficeDataManagement } from 'src/stores/backofficeDataManagement';
 import type {
   SyncJobResponse,
-  DataIngestionJob,
   ImportRow,
 } from 'src/stores/backofficeDataManagement';
 import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
@@ -14,11 +12,15 @@ import {
   IngestionMethod,
   TargetType,
 } from 'src/stores/backofficeDataManagement';
+import {
+  useYearConfigStore,
+  type SyncJobSummary,
+} from 'src/stores/yearConfig';
 import { useI18n } from 'vue-i18n';
 import DataEntryDialog from './DataEntryDialog.vue';
 
 const filesStore = useFilesStore();
-const dataManagementStore = useBackofficeDataManagement();
+const yearConfigStore = useYearConfigStore();
 const { t: $t } = useI18n();
 
 interface Props {
@@ -206,12 +208,12 @@ const BASE_IMPORT_ROWS: Omit<
 // ── Pure helpers (no reactive side-effects) ───────────────────────────────────
 
 function findJob(
-  jobs: DataIngestionJob[],
+  jobs: SyncJobSummary[],
   moduleTypeId: number,
   targetType: TargetType | null,
   dataEntryTypeId?: number,
   ingestionMethod?: IngestionMethod,
-): DataIngestionJob | undefined {
+): SyncJobSummary | undefined {
   const candidates = jobs.filter(
     (j) => j.module_type_id === moduleTypeId && j.target_type === targetType,
   );
@@ -219,17 +221,18 @@ function findJob(
   if (dataEntryTypeId !== undefined) {
     return candidates.find(
       (j) =>
-        (j.meta?.config as Record<string, unknown>)?.data_entry_type_id ===
-          dataEntryTypeId && j.ingestion_method === ingestionMethod?.valueOf(),
+        j.data_entry_type_id === dataEntryTypeId &&
+        j.ingestion_method === ingestionMethod?.valueOf(),
     );
   }
   return candidates[0];
 }
 
-function toSyncJobResponse(job: DataIngestionJob): SyncJobResponse {
+function toSyncJobResponse(job: SyncJobSummary): SyncJobResponse {
   return {
     job_id: job.job_id,
     module_type_id: job.module_type_id,
+    data_entry_type_id: job.data_entry_type_id,
     year: job.year,
     target_type: job.target_type as TargetType,
     state: job.state as IngestionState,
@@ -252,9 +255,7 @@ function importInfo(job: SyncJobResponse | undefined) {
 // ── Computed: reads from store cache, parent owns the fetch ───────────────────
 
 const importRows = computed<ImportRow[]>(() => {
-  const jobs: DataIngestionJob[] = dataManagementStore.getLatestJobsByYear(
-    props.year,
-  );
+  const jobs = yearConfigStore.latestJobs;
   return BASE_IMPORT_ROWS.map((row) => {
     const dataJob = findJob(
       jobs,
@@ -356,13 +357,13 @@ function openDataEntryDialog(row: ImportRow, targetType: TargetType | null) {
 
 // Re-fetch after upload so the store cache (and this view) updates
 async function handleJobCompleted() {
-  await dataManagementStore.fetchLatestSyncJobsByYear(props.year);
+  await yearConfigStore.fetchConfig(props.year);
 }
 
 async function handleJobProgressing(job: SyncJobResponse) {
   console.log('Job progressing:', job);
 
-  await dataManagementStore.fetchLatestSyncJobsByYear(props.year);
+  await yearConfigStore.fetchConfig(props.year);
 }
 </script>
 

--- a/frontend/src/components/organisms/data-management/AnnualDataImport.vue
+++ b/frontend/src/components/organisms/data-management/AnnualDataImport.vue
@@ -12,10 +12,7 @@ import {
   IngestionMethod,
   TargetType,
 } from 'src/stores/backofficeDataManagement';
-import {
-  useYearConfigStore,
-  type SyncJobSummary,
-} from 'src/stores/yearConfig';
+import { useYearConfigStore, type SyncJobSummary } from 'src/stores/yearConfig';
 import { useI18n } from 'vue-i18n';
 import DataEntryDialog from './DataEntryDialog.vue';
 

--- a/frontend/src/components/organisms/data-management/ModuleConfigItem.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfigItem.vue
@@ -146,6 +146,7 @@ const handleSave = () => {
                       type="number"
                       dense
                       outlined
+                      :debounce="600"
                       :placeholder="$t('no_threshold')"
                       @update:model-value="handleSave"
                     >

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -532,4 +532,32 @@ export default {
     en: 'Mice and Fish Animal Facilities',
     fr: 'Animaleries rongeurs et poissons',
   },
+  year_config_saved: {
+    en: 'Configuration saved',
+    fr: 'Configuration enregistrée',
+  },
+  year_config_save_error: {
+    en: 'Failed to save configuration',
+    fr: "Échec de l'enregistrement de la configuration",
+  },
+  year_config_target_year_error: {
+    en: 'Target year must be after the configuration year',
+    fr: "L'année cible doit être postérieure à l'année de configuration",
+  },
+  year_config_percentage_error: {
+    en: 'Reduction percentage must be between 0 and 1',
+    fr: 'Le pourcentage de réduction doit être compris entre 0 et 1',
+  },
+  uploading_file: {
+    en: 'Uploading file…',
+    fr: 'Téléversement du fichier…',
+  },
+  file_upload_success: {
+    en: 'File uploaded successfully',
+    fr: 'Fichier téléversé avec succès',
+  },
+  file_upload_error: {
+    en: 'File upload failed',
+    fr: 'Échec du téléversement du fichier',
+  },
 } as const;

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -545,8 +545,8 @@ export default {
     fr: "L'année cible doit être postérieure à l'année de configuration",
   },
   year_config_percentage_error: {
-    en: 'Reduction percentage must be between 0 and 1',
-    fr: 'Le pourcentage de réduction doit être compris entre 0 et 1',
+    en: 'Reduction percentage must be between 0 and 100',
+    fr: 'Le pourcentage de réduction doit être compris entre 0 et 100',
   },
   year_config_reference_year_error: {
     en: 'Reference year must be a valid year',

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -548,6 +548,10 @@ export default {
     en: 'Reduction percentage must be between 0 and 1',
     fr: 'Le pourcentage de réduction doit être compris entre 0 et 1',
   },
+  year_config_reference_year_error: {
+    en: 'Reference year must be a valid year',
+    fr: "L'année de référence doit être une année valide",
+  },
   uploading_file: {
     en: 'Uploading file…',
     fr: 'Téléversement du fichier…',

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -152,6 +152,10 @@ export default {
     en: 'Incomplete',
     fr: 'Incomplet',
   },
+  common_disabled: {
+    en: 'Disabled',
+    fr: 'Désactivé',
+  },
   common_filters_search_label: {
     en: 'Search',
     fr: 'Rechercher',

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -15,9 +15,11 @@ import {
   TargetType,
   type ImportRow,
   type SyncJobResponse,
-  type DataIngestionJob,
 } from 'src/stores/backofficeDataManagement';
-import { useYearConfigStore } from 'src/stores/yearConfig';
+import {
+  useYearConfigStore,
+  type SyncJobSummary,
+} from 'src/stores/yearConfig';
 
 import { Notify, Loading } from 'quasar';
 import { useI18n } from 'vue-i18n';
@@ -39,10 +41,6 @@ const backofficeDataManagement = useBackofficeDataManagement();
 const yearConfigStore = useYearConfigStore();
 const { t: $t } = useI18n();
 
-const fetchSyncJobs = async () => {
-  await backofficeDataManagement.fetchLatestSyncJobsByYear(selectedYear.value);
-};
-
 const fetchYearConfig = async () => {
   await yearConfigStore.fetchConfig(selectedYear.value);
 };
@@ -51,7 +49,6 @@ watch(
   selectedYear,
   async () => {
     try {
-      await fetchSyncJobs();
       await fetchYearConfig();
     } catch (err: unknown) {
       const msg =
@@ -288,29 +285,30 @@ const MODULE_SUBMODULES: Partial<
 // ── Helpers mirroring AnnualDataImport ───────────────────────────────────────
 
 function findJob(
-  jobs: DataIngestionJob[],
+  jobs: SyncJobSummary[],
   moduleTypeId: number,
   targetType: TargetType | null,
   dataEntryTypeId?: number,
   ingestionMethod?: IngestionMethod,
-): DataIngestionJob | undefined {
+): SyncJobSummary | undefined {
   const candidates = jobs.filter(
     (j) => j.module_type_id === moduleTypeId && j.target_type === targetType,
   );
   if (dataEntryTypeId !== undefined) {
     return candidates.find(
       (j) =>
-        (j.meta?.config as Record<string, unknown>)?.data_entry_type_id ===
-          dataEntryTypeId && j.ingestion_method === ingestionMethod?.valueOf(),
+        j.data_entry_type_id === dataEntryTypeId &&
+        j.ingestion_method === ingestionMethod?.valueOf(),
     );
   }
   return candidates[0];
 }
 
-function toSyncJobResponse(job: DataIngestionJob): SyncJobResponse {
+function toSyncJobResponse(job: SyncJobSummary): SyncJobResponse {
   return {
     job_id: job.job_id,
     module_type_id: job.module_type_id,
+    data_entry_type_id: job.data_entry_type_id,
     year: job.year,
     target_type: job.target_type as TargetType,
     state: job.state as IngestionState,
@@ -321,9 +319,7 @@ function toSyncJobResponse(job: DataIngestionJob): SyncJobResponse {
 }
 
 function getImportRow(sub: SubmoduleConfig): ImportRow {
-  const jobs: DataIngestionJob[] = backofficeDataManagement.getLatestJobsByYear(
-    selectedYear.value,
-  );
+  const jobs = yearConfigStore.latestJobs;
   const dataJob = findJob(
     jobs,
     sub.moduleTypeId,
@@ -451,55 +447,234 @@ function safeFileName(meta: unknown): string | undefined {
 const jobsRefreshKey = ref(0);
 
 async function handleJobCompleted() {
-  await backofficeDataManagement.fetchLatestSyncJobsByYear(selectedYear.value);
-  jobsRefreshKey.value += 1; // Force re-render of food/commuting/waste section
+  await yearConfigStore.fetchConfig(selectedYear.value);
+  jobsRefreshKey.value += 1;
 }
 
 async function handleJobProgressing() {
-  await backofficeDataManagement.fetchLatestSyncJobsByYear(selectedYear.value);
-  jobsRefreshKey.value += 1; // Force re-render
+  await yearConfigStore.fetchConfig(selectedYear.value);
+  jobsRefreshKey.value += 1;
 }
 
 function isModuleIncomplete(module: string): boolean {
+  if (!isModuleEnabled(module)) return false;
+
   const submodules =
     MODULE_SUBMODULES[module as keyof typeof MODULE_SUBMODULES] ?? [];
   if (submodules.length === 0) return false;
 
   return submodules.some((sub) => {
+    if (!isSubmoduleEnabled(sub)) return false;
     const row = getImportRow(sub);
-    // Check if ANY required component (data, factors, references) is missing or unsuccessful
     const dataIncomplete =
       row.hasData && (!row.lastDataJob || row.lastDataJob.result !== 0);
     const factorsIncomplete =
       row.hasFactors && (!row.lastFactorJob || row.lastFactorJob.result !== 0);
     const referencesIncomplete =
-      row.hasOtherUpload && (!row.lastDataJob || row.lastDataJob.result !== 0); // References use same job as data
+      row.hasOtherUpload && (!row.lastDataJob || row.lastDataJob.result !== 0);
     return dataIncomplete || factorsIncomplete || referencesIncomplete;
   });
 }
 
-const toggleModule = ref(false);
-const submoduleThreshold = ref<string>('');
-const uncertainty = ref<'none' | 'low' | 'medium' | 'high'>('none');
+/**
+ * Get the module-level enabled flag from the year config store.
+ */
+function isModuleEnabled(module: string): boolean {
+  const moduleTypeId = getModuleTypeIdFromName(module);
+  if (!moduleTypeId) return true;
+  const moduleConfig =
+    yearConfigStore.config?.config?.modules?.[String(moduleTypeId)];
+  return moduleConfig?.enabled ?? true;
+}
+
+/**
+ * Toggle module enabled state and persist via PATCH.
+ */
+async function updateModuleEnabled(
+  module: string,
+  value: boolean,
+): Promise<void> {
+  const moduleTypeId = getModuleTypeIdFromName(module);
+  if (!moduleTypeId) return;
+  const moduleKey = String(moduleTypeId);
+
+  try {
+    await yearConfigStore.updateConfig(selectedYear.value, {
+      config: { modules: { [moduleKey]: { enabled: value } } },
+    });
+    Notify.create({ type: 'positive', message: $t('year_config_saved') });
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: $t('year_config_save_error'),
+    });
+  }
+}
+
+/**
+ * Get the submodule-level enabled flag from the year config store.
+ */
+function isSubmoduleEnabled(sub: SubmoduleConfig): boolean {
+  const moduleKey = String(sub.moduleTypeId);
+  const subKey =
+    sub.dataEntryTypeId !== undefined
+      ? String(sub.dataEntryTypeId)
+      : undefined;
+  if (!subKey) return true;
+  const moduleConfig =
+    yearConfigStore.config?.config?.modules?.[moduleKey];
+  return moduleConfig?.submodules?.[subKey]?.enabled ?? true;
+}
+
+/**
+ * Toggle submodule enabled state and persist via PATCH.
+ */
+async function updateSubmoduleEnabled(
+  sub: SubmoduleConfig,
+  value: boolean,
+): Promise<void> {
+  const moduleKey = String(sub.moduleTypeId);
+  const subKey =
+    sub.dataEntryTypeId !== undefined
+      ? String(sub.dataEntryTypeId)
+      : undefined;
+  if (!subKey) return;
+
+  try {
+    await yearConfigStore.updateConfig(selectedYear.value, {
+      config: {
+        modules: {
+          [moduleKey]: {
+            submodules: { [subKey]: { enabled: value } },
+          },
+        },
+      },
+    });
+    Notify.create({ type: 'positive', message: $t('year_config_saved') });
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: $t('year_config_save_error'),
+    });
+  }
+}
+
+type UncertaintyTag = 'none' | 'low' | 'medium' | 'high';
+
+/**
+ * Resolve the module type ID from its name via MODULE_SUBMODULES.
+ */
+function getModuleTypeIdFromName(module: string): number {
+  const subs =
+    MODULE_SUBMODULES[module as keyof typeof MODULE_SUBMODULES] ?? [];
+  return subs.length > 0 ? subs[0].moduleTypeId : 0;
+}
+
+/**
+ * Get the current uncertainty tag for a module from the year config store.
+ */
+function getModuleUncertainty(module: string): UncertaintyTag {
+  const moduleTypeId = getModuleTypeIdFromName(module);
+  if (!moduleTypeId) return 'medium';
+  const moduleConfig =
+    yearConfigStore.config?.config?.modules?.[String(moduleTypeId)];
+  return moduleConfig?.uncertainty_tag ?? 'medium';
+}
+
+/**
+ * Update uncertainty tag for a module and persist via PATCH.
+ */
+async function updateModuleUncertainty(
+  module: string,
+  value: UncertaintyTag,
+): Promise<void> {
+  const moduleTypeId = getModuleTypeIdFromName(module);
+  if (!moduleTypeId) return;
+  const moduleKey = String(moduleTypeId);
+
+  try {
+    await yearConfigStore.updateConfig(selectedYear.value, {
+      config: {
+        modules: {
+          [moduleKey]: {
+            uncertainty_tag: value,
+          },
+        },
+      },
+    });
+    Notify.create({ type: 'positive', message: $t('year_config_saved') });
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: $t('year_config_save_error'),
+    });
+  }
+}
+
+/**
+ * Get the current threshold value for a submodule from the year config store.
+ */
+function getSubmoduleThreshold(sub: SubmoduleConfig): number | null {
+  const moduleKey = String(sub.moduleTypeId);
+  const subKey = sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
+  if (!subKey) return null;
+  const moduleConfig = yearConfigStore.config?.config?.modules?.[moduleKey];
+  if (!moduleConfig) return null;
+  return moduleConfig.submodules?.[subKey]?.threshold ?? null;
+}
+
+/**
+ * Update threshold for a submodule and persist via PATCH.
+ */
+async function updateSubmoduleThreshold(
+  sub: SubmoduleConfig,
+  value: number | null,
+): Promise<void> {
+  const moduleKey = String(sub.moduleTypeId);
+  const subKey = sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
+  if (!subKey) return;
+  const existingModule = yearConfigStore.config?.config?.modules?.[moduleKey];
+  if (!existingModule) return;
+  const existingSub = existingModule.submodules?.[subKey];
+  if (!existingSub) return;
+
+  try {
+    await yearConfigStore.updateConfig(selectedYear.value, {
+      config: {
+        modules: {
+          [moduleKey]: {
+            ...existingModule,
+            submodules: {
+              ...existingModule.submodules,
+              [subKey]: {
+                ...existingSub,
+                threshold: value,
+              },
+            },
+          },
+        },
+      },
+    });
+    Notify.create({
+      type: 'positive',
+      message: $t('year_config_saved'),
+    });
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: $t('year_config_save_error'),
+    });
+  }
+}
 
 watch(
-  () => backofficeDataManagement.loading,
+  () => yearConfigStore.loading,
   (newValue) => {
     if (newValue) {
       Loading.show({ message: $t('data_management_loading') });
     } else {
       Loading.hide();
     }
-  },
-);
-
-// Re-render when year changes to refresh all job states
-watch(
-  () => selectedYear.value,
-  async () => {
-    await backofficeDataManagement.fetchLatestSyncJobsByYear(
-      selectedYear.value,
-    );
   },
 );
 
@@ -649,7 +824,15 @@ onMounted(() => {
                     $t(module)
                   }}</span>
                   <q-badge
-                    v-if="isModuleIncomplete(module)"
+                    v-if="!isModuleEnabled(module)"
+                    outline
+                    rounded
+                    color="grey"
+                    class="text-weight-medium"
+                    :label="$t('common_disabled')"
+                  />
+                  <q-badge
+                    v-else-if="isModuleIncomplete(module)"
                     outline
                     rounded
                     color="accent"
@@ -677,11 +860,13 @@ onMounted(() => {
                   {{ $t('data_management_module_activation_description') }}
                 </div>
                 <q-toggle
-                  v-model="toggleModule"
+                  :model-value="isModuleEnabled(module)"
                   color="accent"
                   keep-color
-                  readonly
                   size="lg"
+                  @update:model-value="
+                    (val: boolean) => updateModuleEnabled(module, val)
+                  "
                 />
               </q-card>
             </q-card>
@@ -704,28 +889,40 @@ onMounted(() => {
                   {{ $t('data_management_uncertainty_description') }}
                 </div>
                 <q-radio
-                  v-model="uncertainty"
+                  :model-value="getModuleUncertainty(module)"
                   val="none"
                   :label="$t('data_management_uncertainty_none')"
                   color="accent"
+                  @update:model-value="
+                    updateModuleUncertainty(module, 'none')
+                  "
                 />
                 <q-radio
-                  v-model="uncertainty"
+                  :model-value="getModuleUncertainty(module)"
                   val="low"
                   :label="$t('data_management_uncertainty_low')"
                   color="accent"
+                  @update:model-value="
+                    updateModuleUncertainty(module, 'low')
+                  "
                 />
                 <q-radio
-                  v-model="uncertainty"
+                  :model-value="getModuleUncertainty(module)"
                   val="medium"
                   :label="$t('data_management_uncertainty_medium')"
                   color="accent"
+                  @update:model-value="
+                    updateModuleUncertainty(module, 'medium')
+                  "
                 />
                 <q-radio
-                  v-model="uncertainty"
+                  :model-value="getModuleUncertainty(module)"
                   val="high"
                   :label="$t('data_management_uncertainty_high')"
                   color="accent"
+                  @update:model-value="
+                    updateModuleUncertainty(module, 'high')
+                  "
                 />
               </q-card>
             </q-card>
@@ -783,11 +980,14 @@ onMounted(() => {
                       }}
                     </div>
                     <q-toggle
-                      v-model="toggleModule"
+                      :model-value="isSubmoduleEnabled(submodule)"
                       color="accent"
                       keep-color
-                      readonly
                       size="md"
+                      @update:model-value="
+                        (val: boolean) =>
+                          updateSubmoduleEnabled(submodule, val)
+                      "
                     />
                   </q-card>
                   <q-separator class="q-my-xs" />
@@ -807,12 +1007,24 @@ onMounted(() => {
                       {{ $t('data_management_threshold_description') }}
                     </div>
                     <q-input
-                      v-model="submoduleThreshold"
+                      :model-value="getSubmoduleThreshold(submodule)"
+                      type="number"
                       dense
                       outlined
                       size="md"
+                      :debounce="600"
                       :suffix="$t('tco2eq')"
+                      :placeholder="$t('no_threshold')"
                       style="max-width: 500px"
+                      @update:model-value="
+                        (val: string | number | null) =>
+                          updateSubmoduleThreshold(
+                            submodule,
+                            val === '' || val === null
+                              ? null
+                              : Number(val),
+                          )
+                      "
                     />
                   </q-card>
                   <q-separator class="q-my-xs" />

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -141,15 +141,20 @@ const localGoals = ref<ReductionObjectiveGoal[]>([
 
 const isSavingGoals = ref(false);
 
-/** Sync store → local when config is fetched. */
+/** Sync store → local when config is fetched. Percentage is converted to 0–100 for display. */
 watch(
   () => yearConfigStore.config?.config?.reduction_objectives?.goals,
   (storeGoals) => {
     if (!storeGoals) return;
     for (let i = 0; i < 3; i++) {
-      localGoals.value[i] = storeGoals[i]
-        ? { ...storeGoals[i] }
-        : emptyGoal();
+      if (storeGoals[i]) {
+        localGoals.value[i] = {
+          ...storeGoals[i],
+          reduction_percentage: storeGoals[i].reduction_percentage * 100,
+        };
+      } else {
+        localGoals.value[i] = emptyGoal();
+      }
     }
   },
   { immediate: true },
@@ -162,7 +167,7 @@ const hasReductionGoals = computed(() =>
   ),
 );
 
-/** True when all filled-in goals pass validation. */
+/** True when all filled-in goals pass validation (percentage displayed as 0–100). */
 const goalsAreValid = computed(() =>
   localGoals.value.every((g) => {
     const isEmpty = !g.target_year && !g.reference_year && !g.reduction_percentage;
@@ -170,17 +175,20 @@ const goalsAreValid = computed(() =>
     return (
       g.target_year > selectedYear.value &&
       g.reduction_percentage >= 0 &&
-      g.reduction_percentage <= 1 &&
+      g.reduction_percentage <= 100 &&
       g.reference_year > 0
     );
   }),
 );
 
-/** Persist all non-empty goals to the store. */
+/** Persist all non-empty goals to the store. Converts percentage from 0–100 display to 0–1 storage. */
 async function saveReductionGoals(): Promise<void> {
-  const goalsToSave = localGoals.value.filter(
-    (g) => g.target_year > 0 && g.reference_year > 0,
-  );
+  const goalsToSave = localGoals.value
+    .filter((g) => g.target_year > 0 && g.reference_year > 0)
+    .map((g) => ({
+      ...g,
+      reduction_percentage: g.reduction_percentage / 100,
+    }));
 
   isSavingGoals.value = true;
   try {
@@ -1635,12 +1643,12 @@ onMounted(() => {
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  placeholder="0.4"
-                  hint="0 – 1"
+                  placeholder="40"
+                  hint="0 – 100"
                   :rules="[
                     (v: number) =>
                       (!v && v !== undefined) ||
-                      (v >= 0 && v <= 1) ||
+                      (v >= 0 && v <= 100) ||
                       $t('year_config_percentage_error'),
                   ]"
                 />
@@ -1695,12 +1703,12 @@ onMounted(() => {
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  placeholder="0.4"
-                  hint="0 – 1"
+                  placeholder="40"
+                  hint="0 – 100"
                   :rules="[
                     (v: number) =>
                       (!v && v !== undefined) ||
-                      (v >= 0 && v <= 1) ||
+                      (v >= 0 && v <= 100) ||
                       $t('year_config_percentage_error'),
                   ]"
                 />
@@ -1755,12 +1763,12 @@ onMounted(() => {
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  placeholder="0.4"
-                  hint="0 – 1"
+                  placeholder="40"
+                  hint="0 – 100"
                   :rules="[
                     (v: number) =>
                       (!v && v !== undefined) ||
-                      (v >= 0 && v <= 1) ||
+                      (v >= 0 && v <= 100) ||
                       $t('year_config_percentage_error'),
                   ]"
                 />

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
 import DataEntryDialog from 'src/components/organisms/data-management/DataEntryDialog.vue';
@@ -19,6 +19,7 @@ import {
 import {
   useYearConfigStore,
   type SyncJobSummary,
+  type ReductionObjectiveGoal,
 } from 'src/stores/yearConfig';
 
 import { Notify, Loading } from 'quasar';
@@ -121,6 +122,105 @@ const handleUnitSync = async () => {
 
 const expandedModules = ref<Record<string, boolean>>({});
 const reductionObjectivesExpanded = ref(false);
+
+/** Default empty goal for a slot. */
+function emptyGoal(): ReductionObjectiveGoal {
+  return {
+    target_year: 0,
+    reduction_percentage: 0,
+    reference_year: 0,
+  };
+}
+
+/** Local goals (3 fixed slots). Updated from store on config change. */
+const localGoals = ref<ReductionObjectiveGoal[]>([
+  emptyGoal(),
+  emptyGoal(),
+  emptyGoal(),
+]);
+
+const isSavingGoals = ref(false);
+
+/** Sync store → local when config is fetched. */
+watch(
+  () => yearConfigStore.config?.config?.reduction_objectives?.goals,
+  (storeGoals) => {
+    if (!storeGoals) return;
+    for (let i = 0; i < 3; i++) {
+      localGoals.value[i] = storeGoals[i]
+        ? { ...storeGoals[i] }
+        : emptyGoal();
+    }
+  },
+  { immediate: true },
+);
+
+/** True when at least one goal has meaningful data filled. */
+const hasReductionGoals = computed(() =>
+  localGoals.value.some(
+    (g) => g.target_year > 0 && g.reference_year > 0,
+  ),
+);
+
+/** Persist all non-empty goals to the store. */
+async function saveReductionGoals(): Promise<void> {
+  const goalsToSave = localGoals.value.filter(
+    (g) => g.target_year > 0 && g.reference_year > 0,
+  );
+
+  isSavingGoals.value = true;
+  try {
+    await yearConfigStore.updateConfig(selectedYear.value, {
+      config: {
+        reduction_objectives: { goals: goalsToSave },
+      },
+    });
+    Notify.create({ type: 'positive', message: $t('year_config_saved') });
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: $t('year_config_save_error'),
+    });
+  } finally {
+    isSavingGoals.value = false;
+  }
+}
+
+/** File refs for reduction objective CSV uploads. */
+const footprintFile = ref<File | null>(null);
+const populationFile = ref<File | null>(null);
+const scenariosFile = ref<File | null>(null);
+
+/** Uploaded file names derived from the store. */
+const uploadedFileNames = computed(() => {
+  const files =
+    yearConfigStore.config?.config?.reduction_objectives?.files;
+  return {
+    footprint: files?.institutional_footprint?.filename ?? null,
+    population: files?.population_projections?.filename ?? null,
+    scenarios: files?.unit_scenarios?.filename ?? null,
+  };
+});
+
+/** Handle a reduction-objective file upload. */
+async function handleReductionFileUpload(
+  category: 'footprint' | 'population' | 'scenarios',
+  file: File | null,
+): Promise<void> {
+  if (!file) return;
+  Loading.show({ message: $t('uploading_file') });
+  try {
+    await yearConfigStore.uploadFile(selectedYear.value, category, file);
+    if (category === 'footprint') footprintFile.value = null;
+    if (category === 'population') populationFile.value = null;
+    if (category === 'scenarios') scenariosFile.value = null;
+    Notify.create({ type: 'positive', message: $t('file_upload_success') });
+  } catch {
+    Notify.create({ type: 'negative', message: $t('file_upload_error') });
+  } finally {
+    Loading.hide();
+  }
+}
 
 type SubmoduleConfig = {
   key: string;
@@ -1324,6 +1424,7 @@ onMounted(() => {
                   {{ $t('data_management_reduction_objectives') }}</span
                 >
                 <q-badge
+                  v-if="!hasReductionGoals"
                   outline
                   rounded
                   color="accent"
@@ -1336,6 +1437,7 @@ onMounted(() => {
             </q-item-section>
           </template>
           <q-separator />
+          <!-- File Upload Section -->
           <q-card flat class="q-pa-none row">
             <q-card
               flat
@@ -1358,22 +1460,28 @@ onMounted(() => {
                   $t('data_management_institution_carbon_footprint_description')
                 }}
               </div>
+              <div
+                v-if="uploadedFileNames.footprint"
+                class="text-caption text-positive q-mt-sm"
+              >
+                <q-icon name="check" /> {{ uploadedFileNames.footprint }}
+              </div>
               <div class="row q-gutter-md q-mt-lg">
-                <q-btn
-                  icon="o_upload"
-                  color="primary"
-                  outline
-                  size="sm"
+                <q-file
+                  v-model="footprintFile"
+                  outlined
+                  dense
+                  accept=".csv"
                   :label="$t('common_upload_csv')"
-                  class="q-mt-md text-weight-medium text-capitalize"
-                />
-                <q-btn
-                  icon="o_table_view"
-                  color="accent"
-                  size="sm"
-                  :label="$t('common_download_csv_template')"
-                  class="q-mt-md text-weight-medium text-capitalize"
-                />
+                  class="col"
+                  @update:model-value="
+                    handleReductionFileUpload('footprint', $event)
+                  "
+                >
+                  <template #prepend>
+                    <q-icon name="o_upload" />
+                  </template>
+                </q-file>
               </div>
             </q-card>
             <q-card
@@ -1395,22 +1503,28 @@ onMounted(() => {
               <div class="text-body2 text-secondary">
                 {{ $t('data_management_population_projections_description') }}
               </div>
+              <div
+                v-if="uploadedFileNames.population"
+                class="text-caption text-positive q-mt-sm"
+              >
+                <q-icon name="check" /> {{ uploadedFileNames.population }}
+              </div>
               <div class="row q-gutter-md q-mt-lg">
-                <q-btn
-                  icon="o_upload"
-                  color="primary"
-                  outline
-                  size="sm"
+                <q-file
+                  v-model="populationFile"
+                  outlined
+                  dense
+                  accept=".csv"
                   :label="$t('common_upload_csv')"
-                  class="q-mt-md text-weight-medium text-capitalize"
-                />
-                <q-btn
-                  icon="o_table_view"
-                  color="accent"
-                  size="sm"
-                  :label="$t('common_download_csv_template')"
-                  class="q-mt-md text-weight-medium text-capitalize"
-                />
+                  class="col"
+                  @update:model-value="
+                    handleReductionFileUpload('population', $event)
+                  "
+                >
+                  <template #prepend>
+                    <q-icon name="o_upload" />
+                  </template>
+                </q-file>
               </div>
             </q-card>
             <q-card flat class="col q-px-lg q-py-xl border-right">
@@ -1428,26 +1542,33 @@ onMounted(() => {
               <div class="text-body2 text-secondary">
                 {{ $t('data_management_unit_reduction_scenarios_description') }}
               </div>
+              <div
+                v-if="uploadedFileNames.scenarios"
+                class="text-caption text-positive q-mt-sm"
+              >
+                <q-icon name="check" /> {{ uploadedFileNames.scenarios }}
+              </div>
               <div class="row q-gutter-md q-mt-lg">
-                <q-btn
-                  icon="o_upload"
-                  color="primary"
-                  outline
-                  size="sm"
+                <q-file
+                  v-model="scenariosFile"
+                  outlined
+                  dense
+                  accept=".csv"
                   :label="$t('common_upload_csv')"
-                  class="q-mt-md text-weight-medium text-capitalize"
-                />
-                <q-btn
-                  icon="o_table_view"
-                  color="accent"
-                  size="sm"
-                  :label="$t('common_download_csv_template')"
-                  class="q-mt-md text-weight-medium text-capitalize"
-                />
+                  class="col"
+                  @update:model-value="
+                    handleReductionFileUpload('scenarios', $event)
+                  "
+                >
+                  <template #prepend>
+                    <q-icon name="o_upload" />
+                  </template>
+                </q-file>
               </div>
             </q-card>
           </q-card>
           <q-separator />
+          <!-- Goals Section -->
           <q-item-section class="q-pt-xl q-pb-sm q-px-md">
             <div class="row items-start align-center q-mb-xs">
               <q-icon name="adjust" color="accent" size="xs" class="q-mr-sm" />
@@ -1462,6 +1583,7 @@ onMounted(() => {
             </div>
           </q-item-section>
           <div class="row q-my-sm">
+            <!-- First Goal (mandatory) -->
             <q-card flat bordered class="q-pa-md q-ma-md col">
               <div class="row justify-between items-center">
                 <div class="text-body2 text-weight-medium">
@@ -1474,107 +1596,118 @@ onMounted(() => {
               </div>
               <div class="col full-width q-mt-lg q-gutter-md">
                 <q-input
+                  v-model.number="localGoals[0].target_year"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_first_reduction_objectives_target_year')
                   "
-                  :model-value="''"
                   placeholder="2030"
                 />
                 <q-input
+                  v-model.number="localGoals[0].reduction_percentage"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  :model-value="''"
                   placeholder="30"
                 />
                 <q-input
+                  v-model.number="localGoals[0].reference_year"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_reduction_objectives_reference_year')
                   "
-                  :model-value="''"
                   placeholder="2019"
                 />
               </div>
             </q-card>
+            <!-- Second Goal -->
             <q-card flat bordered class="q-pa-md q-ma-md col">
               <div class="text-body2 text-weight-medium">
                 {{ $t('data_management_second_reduction_objectives') }}
               </div>
               <div class="col full-width q-mt-lg q-gutter-md">
                 <q-input
+                  v-model.number="localGoals[1].target_year"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_first_reduction_objectives_target_year')
                   "
-                  :model-value="''"
                   placeholder="2030"
                 />
                 <q-input
+                  v-model.number="localGoals[1].reduction_percentage"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  :model-value="''"
                   placeholder="30"
                 />
                 <q-input
+                  v-model.number="localGoals[1].reference_year"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_reduction_objectives_reference_year')
                   "
-                  :model-value="''"
                   placeholder="2019"
                 />
               </div>
             </q-card>
+            <!-- Third Goal -->
             <q-card flat bordered class="q-pa-md q-ma-md col">
               <div class="text-body2 text-weight-medium">
                 {{ $t('data_management_third_reduction_objectives') }}
               </div>
               <div class="col full-width q-mt-lg q-gutter-md">
                 <q-input
+                  v-model.number="localGoals[2].target_year"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_first_reduction_objectives_target_year')
                   "
-                  :model-value="''"
                   placeholder="2030"
                 />
                 <q-input
+                  v-model.number="localGoals[2].reduction_percentage"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  :model-value="''"
                   placeholder="30"
                 />
                 <q-input
+                  v-model.number="localGoals[2].reference_year"
                   outlined
                   dense
+                  type="number"
                   class="full-width"
                   :label="
                     $t('data_management_reduction_objectives_reference_year')
                   "
-                  :model-value="''"
                   placeholder="2019"
                 />
               </div>
@@ -1584,7 +1717,9 @@ onMounted(() => {
             color="accent"
             size="md"
             :label="$t('common_save')"
+            :loading="isSavingGoals"
             class="q-mb-md q-ml-md text-weight-medium text-capitalize"
+            @click="saveReductionGoals"
           />
         </q-expansion-item>
       </q-card>

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -162,15 +162,14 @@ watch(
 
 /** True when at least one goal has meaningful data filled. */
 const hasReductionGoals = computed(() =>
-  localGoals.value.some(
-    (g) => g.target_year > 0 && g.reference_year > 0,
-  ),
+  localGoals.value.some((g) => g.target_year > 0 && g.reference_year > 0),
 );
 
 /** True when all filled-in goals pass validation (percentage displayed as 0–100). */
 const goalsAreValid = computed(() =>
   localGoals.value.every((g) => {
-    const isEmpty = !g.target_year && !g.reference_year && !g.reduction_percentage;
+    const isEmpty =
+      !g.target_year && !g.reference_year && !g.reduction_percentage;
     if (isEmpty) return true;
     return (
       g.target_year > selectedYear.value &&
@@ -215,8 +214,7 @@ const scenariosFile = ref<File | null>(null);
 
 /** Uploaded file names derived from the store. */
 const uploadedFileNames = computed(() => {
-  const files =
-    yearConfigStore.config?.config?.reduction_objectives?.files;
+  const files = yearConfigStore.config?.config?.reduction_objectives?.files;
   return {
     footprint: files?.institutional_footprint?.filename ?? null,
     population: files?.population_projections?.filename ?? null,
@@ -639,12 +637,9 @@ async function updateModuleEnabled(
 function isSubmoduleEnabled(sub: SubmoduleConfig): boolean {
   const moduleKey = String(sub.moduleTypeId);
   const subKey =
-    sub.dataEntryTypeId !== undefined
-      ? String(sub.dataEntryTypeId)
-      : undefined;
+    sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
   if (!subKey) return true;
-  const moduleConfig =
-    yearConfigStore.config?.config?.modules?.[moduleKey];
+  const moduleConfig = yearConfigStore.config?.config?.modules?.[moduleKey];
   return moduleConfig?.submodules?.[subKey]?.enabled ?? true;
 }
 
@@ -657,9 +652,7 @@ async function updateSubmoduleEnabled(
 ): Promise<void> {
   const moduleKey = String(sub.moduleTypeId);
   const subKey =
-    sub.dataEntryTypeId !== undefined
-      ? String(sub.dataEntryTypeId)
-      : undefined;
+    sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
   if (!subKey) return;
 
   try {
@@ -738,7 +731,8 @@ async function updateModuleUncertainty(
  */
 function getSubmoduleThreshold(sub: SubmoduleConfig): number | null {
   const moduleKey = String(sub.moduleTypeId);
-  const subKey = sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
+  const subKey =
+    sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
   if (!subKey) return null;
   const moduleConfig = yearConfigStore.config?.config?.modules?.[moduleKey];
   if (!moduleConfig) return null;
@@ -753,7 +747,8 @@ async function updateSubmoduleThreshold(
   value: number | null,
 ): Promise<void> {
   const moduleKey = String(sub.moduleTypeId);
-  const subKey = sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
+  const subKey =
+    sub.dataEntryTypeId !== undefined ? String(sub.dataEntryTypeId) : undefined;
   if (!subKey) return;
   const existingModule = yearConfigStore.config?.config?.modules?.[moduleKey];
   if (!existingModule) return;
@@ -1015,18 +1010,14 @@ onMounted(() => {
                   val="none"
                   :label="$t('data_management_uncertainty_none')"
                   color="accent"
-                  @update:model-value="
-                    updateModuleUncertainty(module, 'none')
-                  "
+                  @update:model-value="updateModuleUncertainty(module, 'none')"
                 />
                 <q-radio
                   :model-value="getModuleUncertainty(module)"
                   val="low"
                   :label="$t('data_management_uncertainty_low')"
                   color="accent"
-                  @update:model-value="
-                    updateModuleUncertainty(module, 'low')
-                  "
+                  @update:model-value="updateModuleUncertainty(module, 'low')"
                 />
                 <q-radio
                   :model-value="getModuleUncertainty(module)"
@@ -1042,9 +1033,7 @@ onMounted(() => {
                   val="high"
                   :label="$t('data_management_uncertainty_high')"
                   color="accent"
-                  @update:model-value="
-                    updateModuleUncertainty(module, 'high')
-                  "
+                  @update:model-value="updateModuleUncertainty(module, 'high')"
                 />
               </q-card>
             </q-card>
@@ -1107,8 +1096,7 @@ onMounted(() => {
                       keep-color
                       size="md"
                       @update:model-value="
-                        (val: boolean) =>
-                          updateSubmoduleEnabled(submodule, val)
+                        (val: boolean) => updateSubmoduleEnabled(submodule, val)
                       "
                     />
                   </q-card>
@@ -1142,9 +1130,7 @@ onMounted(() => {
                         (val: string | number | null) =>
                           updateSubmoduleThreshold(
                             submodule,
-                            val === '' || val === null
-                              ? null
-                              : Number(val),
+                            val === '' || val === null ? null : Number(val),
                           )
                       "
                     />
@@ -1664,9 +1650,7 @@ onMounted(() => {
                   placeholder="2019"
                   :rules="[
                     (v: number) =>
-                      !v ||
-                      v > 0 ||
-                      $t('year_config_reference_year_error'),
+                      !v || v > 0 || $t('year_config_reference_year_error'),
                   ]"
                 />
               </div>
@@ -1724,9 +1708,7 @@ onMounted(() => {
                   placeholder="2019"
                   :rules="[
                     (v: number) =>
-                      !v ||
-                      v > 0 ||
-                      $t('year_config_reference_year_error'),
+                      !v || v > 0 || $t('year_config_reference_year_error'),
                   ]"
                 />
               </div>
@@ -1784,9 +1766,7 @@ onMounted(() => {
                   placeholder="2019"
                   :rules="[
                     (v: number) =>
-                      !v ||
-                      v > 0 ||
-                      $t('year_config_reference_year_error'),
+                      !v || v > 0 || $t('year_config_reference_year_error'),
                   ]"
                 />
               </div>

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -162,6 +162,20 @@ const hasReductionGoals = computed(() =>
   ),
 );
 
+/** True when all filled-in goals pass validation. */
+const goalsAreValid = computed(() =>
+  localGoals.value.every((g) => {
+    const isEmpty = !g.target_year && !g.reference_year && !g.reduction_percentage;
+    if (isEmpty) return true;
+    return (
+      g.target_year > selectedYear.value &&
+      g.reduction_percentage >= 0 &&
+      g.reduction_percentage <= 1 &&
+      g.reference_year > 0
+    );
+  }),
+);
+
 /** Persist all non-empty goals to the store. */
 async function saveReductionGoals(): Promise<void> {
   const goalsToSave = localGoals.value.filter(
@@ -1605,6 +1619,12 @@ onMounted(() => {
                     $t('data_management_first_reduction_objectives_target_year')
                   "
                   placeholder="2030"
+                  :rules="[
+                    (v: number) =>
+                      !v ||
+                      v > selectedYear ||
+                      $t('year_config_target_year_error'),
+                  ]"
                 />
                 <q-input
                   v-model.number="localGoals[0].reduction_percentage"
@@ -1615,7 +1635,14 @@ onMounted(() => {
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  placeholder="30"
+                  placeholder="0.4"
+                  hint="0 – 1"
+                  :rules="[
+                    (v: number) =>
+                      (!v && v !== undefined) ||
+                      (v >= 0 && v <= 1) ||
+                      $t('year_config_percentage_error'),
+                  ]"
                 />
                 <q-input
                   v-model.number="localGoals[0].reference_year"
@@ -1627,6 +1654,12 @@ onMounted(() => {
                     $t('data_management_reduction_objectives_reference_year')
                   "
                   placeholder="2019"
+                  :rules="[
+                    (v: number) =>
+                      !v ||
+                      v > 0 ||
+                      $t('year_config_reference_year_error'),
+                  ]"
                 />
               </div>
             </q-card>
@@ -1646,6 +1679,12 @@ onMounted(() => {
                     $t('data_management_first_reduction_objectives_target_year')
                   "
                   placeholder="2030"
+                  :rules="[
+                    (v: number) =>
+                      !v ||
+                      v > selectedYear ||
+                      $t('year_config_target_year_error'),
+                  ]"
                 />
                 <q-input
                   v-model.number="localGoals[1].reduction_percentage"
@@ -1656,7 +1695,14 @@ onMounted(() => {
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  placeholder="30"
+                  placeholder="0.4"
+                  hint="0 – 1"
+                  :rules="[
+                    (v: number) =>
+                      (!v && v !== undefined) ||
+                      (v >= 0 && v <= 1) ||
+                      $t('year_config_percentage_error'),
+                  ]"
                 />
                 <q-input
                   v-model.number="localGoals[1].reference_year"
@@ -1668,6 +1714,12 @@ onMounted(() => {
                     $t('data_management_reduction_objectives_reference_year')
                   "
                   placeholder="2019"
+                  :rules="[
+                    (v: number) =>
+                      !v ||
+                      v > 0 ||
+                      $t('year_config_reference_year_error'),
+                  ]"
                 />
               </div>
             </q-card>
@@ -1687,6 +1739,12 @@ onMounted(() => {
                     $t('data_management_first_reduction_objectives_target_year')
                   "
                   placeholder="2030"
+                  :rules="[
+                    (v: number) =>
+                      !v ||
+                      v > selectedYear ||
+                      $t('year_config_target_year_error'),
+                  ]"
                 />
                 <q-input
                   v-model.number="localGoals[2].reduction_percentage"
@@ -1697,7 +1755,14 @@ onMounted(() => {
                   :label="
                     $t('data_management_reduction_objectives_reduction_goal')
                   "
-                  placeholder="30"
+                  placeholder="0.4"
+                  hint="0 – 1"
+                  :rules="[
+                    (v: number) =>
+                      (!v && v !== undefined) ||
+                      (v >= 0 && v <= 1) ||
+                      $t('year_config_percentage_error'),
+                  ]"
                 />
                 <q-input
                   v-model.number="localGoals[2].reference_year"
@@ -1709,6 +1774,12 @@ onMounted(() => {
                     $t('data_management_reduction_objectives_reference_year')
                   "
                   placeholder="2019"
+                  :rules="[
+                    (v: number) =>
+                      !v ||
+                      v > 0 ||
+                      $t('year_config_reference_year_error'),
+                  ]"
                 />
               </div>
             </q-card>
@@ -1718,6 +1789,7 @@ onMounted(() => {
             size="md"
             :label="$t('common_save')"
             :loading="isSavingGoals"
+            :disable="!goalsAreValid"
             class="q-mb-md q-ml-md text-weight-medium text-capitalize"
             @click="saveReductionGoals"
           />

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -7,6 +7,7 @@ import { getModuleTypeId } from 'src/constant/moduleStates';
 export interface DataIngestionJob {
   job_id: number;
   module_type_id: number;
+  data_entry_type_id?: number;
   year: number;
   provider_type: string;
   target_type: number;
@@ -70,6 +71,7 @@ export interface SyncJobStatus {
 export interface SyncJobResponse {
   job_id: number;
   module_type_id?: number;
+  data_entry_type_id?: number;
   year?: number;
   ingestion_method?: IngestionMethod;
   target_type?: TargetType;

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { api } from 'src/api/http';
 
 export interface FileMetadata {
@@ -26,6 +26,20 @@ export interface ReductionObjectives {
 export interface SubmoduleConfig {
   enabled: boolean;
   threshold: number | null;
+  latest_job?: SyncJobSummary | null;
+}
+
+export interface SyncJobSummary {
+  job_id: number;
+  module_type_id?: number;
+  data_entry_type_id?: number;
+  year?: number;
+  ingestion_method: number;
+  target_type?: number;
+  state?: number;
+  result?: number;
+  status_message?: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface ModuleConfig {
@@ -44,6 +58,7 @@ export interface YearConfigurationResponse {
   is_started: boolean;
   is_reports_synced: boolean;
   config: YearConfig;
+  latest_jobs: SyncJobSummary[];
   updated_at: string;
 }
 
@@ -53,11 +68,18 @@ export interface YearConfigurationCreate {
   config?: Partial<YearConfig>;
 }
 
+/** Partial module config allowing nested partial submodule updates. */
+export interface ModuleConfigUpdate {
+  enabled?: boolean;
+  uncertainty_tag?: ModuleConfig['uncertainty_tag'];
+  submodules?: Record<string, Partial<SubmoduleConfig>>;
+}
+
 export interface YearConfigurationUpdate {
   is_started?: boolean;
   is_reports_synced?: boolean;
   config?: {
-    modules?: Record<string, ModuleConfig>;
+    modules?: Record<string, ModuleConfigUpdate>;
     reduction_objectives?: Partial<ReductionObjectives>;
   };
 }
@@ -233,6 +255,11 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     notFound.value = false;
   }
 
+  /** All current ingestion jobs for the loaded year. */
+  const latestJobs = computed<SyncJobSummary[]>(
+    () => config.value?.latest_jobs ?? [],
+  );
+
   return {
     // State
     config,
@@ -240,6 +267,8 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     error,
     currentYear,
     notFound,
+    // Computed
+    latestJobs,
     // Methods
     fetchConfig,
     createConfig,


### PR DESCRIPTION
## Summary

Closes #384

Merges `GET /api/v1/sync/jobs/year/{year}/latest` into `GET /api/v1/year-configuration/{year}` so the frontend makes **1 call instead of 2**. Also wires up all disconnected backoffice Data Management UI controls.

## Changes

### Backend
- **Embed `latest_jobs[]`** in year-config GET response — each job includes `module_type_id`, `data_entry_type_id`, `year`
- **Fix PATCH deep merge** — added `_deep_merge()` so partial config updates (e.g. one module's uncertainty) don't destroy sibling modules/submodules

### Frontend
- **Single API call** — removed separate `fetchSyncJobs()`; job data now comes from `yearConfigStore.latestJobs`
- **Threshold inputs** — wired to store with 600ms Quasar debounce
- **Uncertainty radios** — per-module store-backed getters/setters
- **Module Activation toggle** — live toggle persisted via PATCH
- **Submodule Activation toggle** — same pattern, nested under module
- **Badge improvements** — disabled modules show grey "Disabled" badge; disabled modules/submodules excluded from incomplete checks
- **Type safety** — `ModuleConfigUpdate` interface for nested partial submodule updates
- **i18n** — added `common_disabled` key (en/fr)

## Files changed (8)
| File | What |
|------|------|
| `backend/app/api/v1/year_configuration.py` | `_build_jobs_list()`, `_deep_merge()`, enriched GET/PATCH |
| `backend/app/schemas/year_configuration.py` | `SyncJobSummary` fields, `latest_jobs` in response |
| `frontend/src/stores/yearConfig.ts` | `SyncJobSummary` type, `latestJobs` computed, `ModuleConfigUpdate` |
| `frontend/src/stores/backofficeDataManagement.ts` | `data_entry_type_id` on job interfaces |
| `frontend/src/pages/back-office/DataManagementPage.vue` | All UI control wiring, badge logic, helpers |
| `frontend/src/components/.../AnnualDataImport.vue` | Switched to yearConfig store for jobs |
| `frontend/src/components/.../ModuleConfigItem.vue` | Debounce on threshold input |
| `frontend/src/i18n/common.ts` | `common_disabled` key |

## Checks
- `vue-tsc` ✅ | `eslint` ✅ | `ruff` ✅ | `mypy` ✅