### PR TITLE
ci: test lighthouse workflow fix

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,6 @@
 name: Lighthouse CI
 
+
 on:
   pull_request:
     branches: [main, dev, stage, 'ci-test/**']


### PR DESCRIPTION
Test PR to validate the ecoindex plugin fix — installs at repo root instead of frontend/.