### PR TITLE
feat/772 toggle research facilities

### DIFF
--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -1,6 +1,6 @@
 """Module stats API endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -116,6 +116,7 @@ async def get_module_stats(
 @router.get("/{carbon_report_id}/results-summary", response_model=dict)
 async def get_results_summary(
     carbon_report_id: int,
+    exclude_modules: list[int] = Query(default_factory=list),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -142,12 +143,14 @@ async def get_results_summary(
         raw["prev_emissions"],
         get_settings().CO2_PER_KM_KG,
         str(ModuleTypeEnum.headcount.value),
+        exclude_module_type_ids=set(exclude_modules),
     )
 
 
 @router.get("/{carbon_report_id}/emission-breakdown")
 async def get_emission_breakdown(
     carbon_report_id: int,
+    exclude_modules: list[int] = Query(default_factory=list),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -194,4 +197,5 @@ async def get_emission_breakdown(
         total_fte=total_fte,
         headcount_validated=headcount_validated,
         validated_module_type_ids=validated_module_type_ids,
+        exclude_module_type_ids=set(exclude_modules),
     )

--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -495,6 +495,7 @@ def build_chart_breakdown(
     total_fte: float = 0.0,
     headcount_validated: bool = False,
     validated_module_type_ids: set[int] | None = None,
+    exclude_module_type_ids: set[int] | frozenset[int] = frozenset(),
 ) -> dict:
     """Build chart payload sections from raw aggregated emission rows.
 
@@ -536,6 +537,8 @@ def build_chart_breakdown(
 
     for row in rows:
         module_type_id, emission_type_id, kg_co2eq = row
+        if module_type_id in exclude_module_type_ids:
+            continue
         emission_type = _resolve_emission_type(emission_type_id)
         if emission_type is None:
             continue
@@ -555,6 +558,7 @@ def build_chart_breakdown(
     module_breakdown = [
         _build_category_row(category, category_data.get(category, {}))
         for category in MODULE_BREAKDOWN_ORDER
+        if CATEGORY_TO_MODULE_PER_UNIT.get(category) not in exclude_module_type_ids
     ]
 
     headcount_data: dict[EmissionType, float] = (

--- a/backend/app/utils/report_computations.py
+++ b/backend/app/utils/report_computations.py
@@ -48,6 +48,7 @@ def compute_results_summary(
     prev_emissions: dict[str, float],
     co2_per_km_kg: float,
     headcount_key: str,
+    exclude_module_type_ids: set[int] | frozenset[int] = frozenset(),
 ) -> dict:
     """Build the results-summary response from raw emission/FTE data.
 
@@ -60,6 +61,8 @@ def compute_results_summary(
         prev_emissions: ``{module_type_id_str: kg_co2eq}`` (empty if no prev year)
         co2_per_km_kg: conversion factor for equivalent car km (must be > 0)
         headcount_key: string form of ``ModuleTypeEnum.headcount.value``
+        exclude_module_type_ids: set of integer module_type_ids to omit from
+            both per-module results and unit totals.
 
     Raises:
         ValueError: If *co2_per_km_kg* is zero or negative.
@@ -72,6 +75,8 @@ def compute_results_summary(
     # --- Per-module results ---
     module_results: list[dict] = []
     for module_key, kg_co2eq in current_emissions.items():
+        if int(module_key) in exclude_module_type_ids:
+            continue
         if kg_co2eq is None:
             continue
         total_tonnes = kg_co2eq / 1000
@@ -99,8 +104,16 @@ def compute_results_summary(
         )
 
     # --- Unit totals ---
-    non_none_emissions = [v for v in current_emissions.values() if v is not None]
-    non_none_prev = [v for v in prev_emissions.values() if v is not None]
+    non_none_emissions = [
+        v
+        for k, v in current_emissions.items()
+        if v is not None and int(k) not in exclude_module_type_ids
+    ]
+    non_none_prev = [
+        v
+        for k, v in prev_emissions.items()
+        if v is not None and int(k) not in exclude_module_type_ids
+    ]
     total_kg: float | None = sum(non_none_emissions) if non_none_emissions else None
     total_prev_kg: float | None = sum(non_none_prev) if non_none_prev else None
     total_tonnes_all = total_kg / 1000 if total_kg is not None else None

--- a/backend/tests/unit/utils/test_emission_category.py
+++ b/backend/tests/unit/utils/test_emission_category.py
@@ -136,6 +136,70 @@ def test_build_chart_breakdown_validated_categories_follow_module_validation():
     assert "professional_travel" not in result["validated_categories"]
 
 
+def test_build_chart_breakdown_excludes_single_module():
+    rows = [
+        (
+            ModuleTypeEnum.research_facilities.value,
+            EmissionType.research_facilities__facilities.value,
+            5_000.0,
+        ),
+        (
+            ModuleTypeEnum.equipment_electric_consumption.value,
+            EmissionType.equipment__scientific.value,
+            10_000.0,
+        ),
+    ]
+
+    result_full = build_chart_breakdown(rows, total_fte=10.0)
+    result_excluded = build_chart_breakdown(
+        rows,
+        total_fte=10.0,
+        exclude_module_type_ids={ModuleTypeEnum.research_facilities.value},
+    )
+
+    categories = [r["category"] for r in result_excluded["module_breakdown"]]
+    assert "research_facilities" not in categories
+    assert result_excluded["per_person_breakdown"][
+        "research_facilities"
+    ] == pytest.approx(0.0)
+    assert result_excluded["total_tonnes_co2eq"] < result_full["total_tonnes_co2eq"]
+
+
+def test_build_chart_breakdown_excludes_multiple_modules():
+    rows = [
+        (
+            ModuleTypeEnum.research_facilities.value,
+            EmissionType.research_facilities__facilities.value,
+            5_000.0,
+        ),
+        (
+            ModuleTypeEnum.professional_travel.value,
+            EmissionType.professional_travel__plane__eco.value,
+            3_000.0,
+        ),
+        (
+            ModuleTypeEnum.equipment_electric_consumption.value,
+            EmissionType.equipment__scientific.value,
+            10_000.0,
+        ),
+    ]
+
+    result = build_chart_breakdown(
+        rows,
+        exclude_module_type_ids={
+            ModuleTypeEnum.research_facilities.value,
+            ModuleTypeEnum.professional_travel.value,
+        },
+    )
+
+    categories = [r["category"] for r in result["module_breakdown"]]
+    assert "research_facilities" not in categories
+    assert "professional_travel" not in categories
+    equipment_row = _row_by_category(result["module_breakdown"], "equipment")
+    assert equipment_row["scientific"] == pytest.approx(10.0)
+    assert result["total_tonnes_co2eq"] == pytest.approx(10.0)
+
+
 def test_build_treemap_basic():
     rows = [("eco", 200.0), ("business", 600.0), ("first", 200.0)]
     result = build_treemap(rows)

--- a/docs/implementation-plans/772-toggle-research-facilities.md
+++ b/docs/implementation-plans/772-toggle-research-facilities.md
@@ -1,0 +1,367 @@
+# Toggle Research Facilities
+
+## Overview
+
+Add a "Show Research Facilities" checkbox to the results page header (below "View Uncertainties") that shows/hides research facilities data in the carbon footprint charts and summary totals.
+
+Filtering is done **backend-side** via a generic `exclude_modules` query param (a list of `module_type_id` integers). The research facilities toggle passes `ModuleTypeEnum.research_facilities = 6` into that list when off.
+
+---
+
+## Tasks
+
+### 1. Backend — add `exclude_modules` query param to the endpoint
+
+**File**: `backend/app/api/v1/carbon_report_module_stats.py`
+
+```python
+from fastapi import Query
+
+@router.get("/{carbon_report_id}/emission-breakdown")
+async def get_emission_breakdown(
+    carbon_report_id: int,
+    exclude_modules: list[int] = Query(default=[]),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    ...
+    return build_chart_breakdown(
+        rows=emission_rows,
+        total_fte=total_fte,
+        headcount_validated=headcount_validated,
+        validated_module_type_ids=validated_module_type_ids,
+        exclude_module_type_ids=set(exclude_modules),
+    )
+```
+
+FastAPI serialises repeated query params automatically: `?exclude_modules=6&exclude_modules=2`.
+
+---
+
+### 2. Backend — filter in `build_chart_breakdown`
+
+**File**: `backend/app/utils/emission_category.py`
+
+**2a.** Add `exclude_module_type_ids: set[int] = frozenset()` parameter to `build_chart_breakdown` (line 493).
+
+**2b.** Skip rows whose `module_type_id` is in the exclusion set in the row-processing loop (lines 537–553):
+
+```python
+for row in rows:
+    module_type_id, emission_type_id, kg_co2eq = row
+    if module_type_id in exclude_module_type_ids:   # <-- new guard
+        continue
+    emission_type = _resolve_emission_type(emission_type_id)
+    ...
+```
+
+Filtering by `module_type_id` directly (rather than by derived category) is simpler and guarantees all emission types belonging to that module are excluded. The exclusion cascades automatically through `module_breakdown`, `per_person_breakdown` (via `module_totals_kg`), `validated_categories`, and `total_tonnes_co2eq`.
+
+---
+
+### 3. Backend — add unit test
+
+**File**: `backend/tests/unit/utils/test_emission_category.py`
+
+Add a test that calls `build_chart_breakdown` with `exclude_module_type_ids={6}` (research facilities) and asserts:
+
+- No row in `module_breakdown` has `category_key == 'research_facilities'`
+- `per_person_breakdown['research_facilities'] == 0.0`
+- `total_tonnes_co2eq` is lower than the same call without exclusions
+
+Also add a test for excluding multiple modules to verify the generic behaviour.
+
+---
+
+### 4. Frontend — update the store action
+
+**File**: `frontend/src/stores/modules.ts`
+
+Update `getEmissionBreakdown` to accept an optional set of module type IDs to exclude and serialise them as repeated query params:
+
+```ts
+async getEmissionBreakdown(carbonReportId: number, excludeModules: number[] = []) {
+  const params = new URLSearchParams()
+  excludeModules.forEach((id) => params.append('exclude_modules', String(id)))
+  const qs = params.toString() ? `?${params.toString()}` : ''
+  // fetch from `modules-stats/${carbonReportId}/emission-breakdown${qs}`
+}
+```
+
+Invalidate the cache (`invalidateEmissionBreakdown()`) before re-fetching when the excluded set changes.
+
+---
+
+### 5. Frontend — add i18n key
+
+**File**: `frontend/src/i18n/en.ts` (and other locale files)
+
+```ts
+results_show_research_facilities: "Show Research Facilities";
+```
+
+---
+
+### 6. Frontend — add toggle checkbox to ResultsPage
+
+**File**: `frontend/src/pages/app/ResultsPage.vue`
+
+**6a.** Add reactive ref near `viewUncertainties` (around line 110):
+
+```ts
+const showResearchFacilities = ref(true);
+```
+
+**6b.** Derive the excluded modules list from all toggles:
+
+```ts
+const excludedModules = computed(() => {
+  const ids: number[] = [];
+  if (!showResearchFacilities.value) ids.push(6); // ModuleTypeEnum.research_facilities
+  return ids;
+});
+```
+
+**6c.** Watch and re-fetch when the excluded set changes:
+
+```ts
+watch(
+  excludedModules,
+  async (ids) => {
+    moduleStore.invalidateEmissionBreakdown();
+    await moduleStore.getEmissionBreakdown(carbonReportId, ids);
+  },
+  { deep: true },
+);
+```
+
+**6d.** Add checkbox in the template directly below the `viewUncertainties` checkbox (around line 177):
+
+```vue
+<q-checkbox
+  v-model="showResearchFacilities"
+  :label="$t('results_show_research_facilities')"
+  color="accent"
+  class="text-weight-medium"
+  size="xs"
+/>
+```
+
+The `excludedModules` computed means future module toggles only need to push their `module_type_id` into the array — no other changes required.
+
+---
+
+### 7. Frontend — recalculate scope rects in `ModuleCarbonFootprintChart`
+
+**File**: `frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue`
+
+The chart overlays three `graphic` rects that mark GHG scope boundaries. Their pixel positions and widths are hardcoded in the `scopeConfig` computed (line 48) based on the assumption of **8 main-category bars**:
+
+| Scope | Bars covered                                                                   | Current width |
+| ----- | ------------------------------------------------------------------------------ | ------------- |
+| 1     | process_emissions, buildings_room                                              | 108 px        |
+| 2     | buildings_energy_combustion, equipment                                         | 108 px        |
+| 3     | external_cloud_and_ai, purchases, professional_travel, **research_facilities** | 330 px        |
+
+When `research_facilities` is hidden the dataset shrinks to **7 bars**. Because ECharts distributes bar width evenly across the plot area, every bar becomes wider and the scope 3 rect must cover only 3 bars instead of 4. Neither of these adjustments happen automatically.
+
+**Why hardcoded values break**: the existing `scopeConfig` bakes in pixel positions for exactly 8 or 12 bars. Every change in visible category count (research_facilities toggle, additional-data toggle, future new modules) requires new hardcoded values. Instead, use ECharts' `convertToPixel` API to derive positions from the actual rendered bar centers, making the rects self-adjusting for any combination of toggles.
+
+**7a.** Add a `showResearchFacilities` prop:
+
+```ts
+const props = defineProps<{
+  breakdownData?: EmissionBreakdownResponse | null;
+  title?: string;
+  showResearchFacilities?: boolean;
+}>();
+```
+
+**7b.** Declare the static scope membership map (raw category keys → GHG scope):
+
+```ts
+const CATEGORY_SCOPE: Record<string, 1 | 2 | 3 | "additional"> = {
+  process_emissions: 1,
+  buildings_room: 1,
+  buildings_energy_combustion: 2,
+  equipment: 2,
+  external_cloud_and_ai: 3,
+  purchases: 3,
+  professional_travel: 3,
+  research_facilities: 3,
+  commuting: "additional",
+  food: "additional",
+  waste: "additional",
+  embodied_energy: "additional",
+};
+```
+
+**7c.** Build a reverse map from translated label → raw category key so `datasetSource` entries (which carry translated labels) can be looked up in `CATEGORY_SCOPE`:
+
+```ts
+const labelToKey = computed<Record<string, string>>(() => {
+  const map: Record<string, string> = {};
+  for (const [key, i18nKey] of Object.entries(CATEGORY_LABEL_MAP)) {
+    map[t(i18nKey)] = key;
+  }
+  return map;
+});
+```
+
+**7d.** Replace `scopeConfig` with a reactive `scopeRects` ref and a `recalculateScopeRects()` function that runs after every chart render:
+
+```ts
+interface ScopeRect {
+  left: number;
+  width: number;
+}
+interface ScopeRects {
+  scope1: ScopeRect | null;
+  scope2: ScopeRect | null;
+  scope3: ScopeRect | null;
+  dividerX: number | null; // x pixel of main/additional divider line
+}
+
+const scopeRects = ref<ScopeRects>({
+  scope1: null,
+  scope2: null,
+  scope3: null,
+  dividerX: null,
+});
+
+function recalculateScopeRects() {
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+
+  const items = datasetSource.value;
+  if (items.length < 2) return;
+
+  // convertToPixel returns x-pixel of the category center relative to the chart canvas
+  const getX = (label: string): number =>
+    chart.convertToPixel({ xAxisIndex: 0 }, label) as number;
+
+  // Half a bar-slot width = half the distance between adjacent bar centers
+  const step =
+    getX(String(items[1].category)) - getX(String(items[0].category));
+  const halfStep = step / 2;
+
+  // Group translated labels by scope using the reverse map
+  const groups: Record<string, string[]> = {
+    "1": [],
+    "2": [],
+    "3": [],
+    additional: [],
+  };
+  for (const item of items) {
+    const label = String(item.category);
+    const key = labelToKey.value[label] ?? "";
+    const scope = String(CATEGORY_SCOPE[key] ?? "additional");
+    groups[scope].push(label);
+  }
+
+  const toRect = (labels: string[]): ScopeRect | null => {
+    if (!labels.length) return null;
+    const left = getX(labels[0]) - halfStep;
+    const right = getX(labels[labels.length - 1]) + halfStep;
+    return { left, width: right - left };
+  };
+
+  scopeRects.value = {
+    scope1: toRect(groups["1"]),
+    scope2: toRect(groups["2"]),
+    scope3: toRect(groups["3"]),
+    dividerX: groups["additional"].length
+      ? getX(groups["additional"][0]) - halfStep
+      : null,
+  };
+}
+```
+
+Register it on the chart's `finished` event (fires after every render including resize, because the component already uses `autoresize`):
+
+```ts
+watch(
+  chartRef,
+  (chart) => {
+    chart?.chart?.on("finished", recalculateScopeRects);
+  },
+  { immediate: true },
+);
+```
+
+The recalculation trigger chain on toggle:
+
+1. `breakdownData` changes (research_facilities absent) → `datasetSource` computed drops that category → `chartOption` computed re-runs → ECharts re-renders the bars
+2. ECharts fires `finished` → `recalculateScopeRects()` calls `convertToPixel` on the new bar layout → `scopeRects` ref updates
+3. `scopeRects` change → `chartOption` re-runs (graphic array now has correct positions) → ECharts updates the overlays
+4. ECharts fires `finished` again → `recalculateScopeRects()` runs but `scopeRects` values are identical → no further updates (stable)
+
+The same chain fires on container resize (step 1 is replaced by the resize event, rest is identical).
+
+**7e.** Rewrite the `graphic` array in `chartOption` to consume `scopeRects` instead of the old `scopeConfig` numbers. Each scope rect maps directly to an overlay element:
+
+```ts
+graphic: [
+  // Scope 1
+  ...(scopeRects.value.scope1 ? [{
+    type: 'rect',
+    left: scopeRects.value.scope1.left,
+    top: '15px',
+    shape: { width: scopeRects.value.scope1.width, height: 300 },
+    style: { fill: new graphic.LinearGradient(...) },
+  }, {
+    type: 'text',
+    left: scopeRects.value.scope1.left + 10,
+    top: '30px',
+    style: { text: t('charts-scope') + ' 1', ... },
+  }] : []),
+  // Scope 2 — same pattern
+  // Scope 3 — same pattern
+  // Additional-data divider line
+  ...(scopeRects.value.dividerX !== null && toggleAdditionalData.value ? [{
+    type: 'rect', // vertical divider
+    left: scopeRects.value.dividerX,
+    ...
+  }] : []),
+],
+```
+
+This eliminates all four hardcoded branches. Adding or removing any visible category — research_facilities toggle, additional-data toggle, or any future module toggle — automatically repositions the rects without any code changes to the chart component.
+
+**7f.** No prop threading needed from `ResultsPage` for this task — the chart already reacts to `breakdownData` changing (research_facilities absent from data → absent from `datasetSource` → `recalculateScopeRects` fires on next `finished` event). The `showResearchFacilities` prop added in 7a is only needed if the chart must render a placeholder or style differently when the module is hidden; if not, it can be omitted.
+
+> **Note on `CarbonFootPrintPerPersonChart`**: that chart has a single horizontal bar row ("My unit"), so its background rect spans the full bar group and requires no adjustment.
+
+---
+
+## Data Flow
+
+```
+User toggles "Show Research Facilities" checkbox
+  ↓
+showResearchFacilities ref changes → excludedModules computed = [6]
+  ↓
+watcher invalidates store cache + calls getEmissionBreakdown(id, [6])
+  ↓
+GET /modules-stats/{id}/emission-breakdown?exclude_modules=6
+  ↓
+build_chart_breakdown() skips all rows where module_type_id == 6
+  ↓
+Response has no research_facilities in module_breakdown / per_person / totals
+  ↓
+Store updates → charts re-render automatically
+```
+
+---
+
+## Affected Files
+
+| File                                                                    | Change                                                                                             |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `backend/app/api/v1/carbon_report_module_stats.py`                      | Add `exclude_modules` query param, forward as `exclude_module_type_ids`                            |
+| `backend/app/utils/emission_category.py`                                | Add `exclude_module_type_ids` param to `build_chart_breakdown`, skip rows                          |
+| `backend/tests/unit/utils/test_emission_category.py`                    | Add tests for single and multiple module exclusions                                                |
+| `frontend/src/stores/modules.ts`                                        | Accept `excludeModules: number[]`, serialise as repeated query params                              |
+| `frontend/src/i18n/en.ts` (+ other locales)                             | Add `results_show_research_facilities` key                                                         |
+| `frontend/src/pages/app/ResultsPage.vue`                                | Add ref, `excludedModules` computed, watcher, checkbox; pass prop to chart                         |
+| `frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue` | Replace hardcoded `scopeConfig` with `convertToPixel`-based `scopeRects`; add scope membership map |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -101,6 +101,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -534,7 +535,6 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -636,6 +636,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -701,6 +702,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -749,6 +751,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -824,14 +827,14 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
@@ -844,9 +847,9 @@
       "optional": true
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -863,9 +866,9 @@
       "optional": true
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1353,13 +1356,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.4.tgz",
+      "integrity": "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.4",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -1368,22 +1371,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.4.tgz",
+      "integrity": "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.2.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1415,9 +1418,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.4.tgz",
+      "integrity": "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1425,13 +1428,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.0.tgz",
+      "integrity": "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1545,9 +1548,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
-      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1555,16 +1558,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
-      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
+      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1579,14 +1582,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
-      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
+      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1601,15 +1604,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
-      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
+      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -1628,15 +1631,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
-      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.0.tgz",
+      "integrity": "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/external-editor": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1651,14 +1654,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
-      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.12.tgz",
+      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1673,9 +1676,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1695,9 +1698,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
-      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1705,14 +1708,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
-      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
+      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1727,14 +1730,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
-      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.11.tgz",
+      "integrity": "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1749,15 +1752,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
-      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.11.tgz",
+      "integrity": "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1772,22 +1775,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
-      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.1.tgz",
+      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.2",
-        "@inquirer/confirm": "^6.0.10",
-        "@inquirer/editor": "^5.0.10",
-        "@inquirer/expand": "^5.0.10",
-        "@inquirer/input": "^5.0.10",
-        "@inquirer/number": "^4.0.10",
-        "@inquirer/password": "^5.0.10",
-        "@inquirer/rawlist": "^5.2.6",
-        "@inquirer/search": "^4.1.6",
-        "@inquirer/select": "^5.1.2"
+        "@inquirer/checkbox": "^5.1.3",
+        "@inquirer/confirm": "^6.0.11",
+        "@inquirer/editor": "^5.1.0",
+        "@inquirer/expand": "^5.0.12",
+        "@inquirer/input": "^5.0.11",
+        "@inquirer/number": "^4.0.11",
+        "@inquirer/password": "^5.0.11",
+        "@inquirer/rawlist": "^5.2.7",
+        "@inquirer/search": "^4.1.7",
+        "@inquirer/select": "^5.1.3"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1802,14 +1805,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
-      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.7.tgz",
+      "integrity": "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1824,15 +1827,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
-      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.7.tgz",
+      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1847,16 +1850,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
-      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.3.tgz",
+      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1871,9 +1874,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
-      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1934,6 +1937,34 @@
         "url": "https://github.com/sponsors/kazupon"
       }
     },
+    "node_modules/@intlify/core-base/node_modules/@intlify/message-compiler": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.3.0.tgz",
+      "integrity": "sha512-RAJp3TMsqohg/Wa7bVF3cChRhecSYBLrTCQSj7j0UtWVFLP+6iEJoE2zb7GU5fp+fmG5kCbUdzhmlAUCWXiUJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.3.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/core-base/node_modules/@intlify/shared": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@intlify/devtools-types": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.3.0.tgz",
@@ -1950,13 +1981,26 @@
         "url": "https://github.com/sponsors/kazupon"
       }
     },
-    "node_modules/@intlify/message-compiler": {
+    "node_modules/@intlify/devtools-types/node_modules/@intlify/shared": {
       "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.3.0.tgz",
-      "integrity": "sha512-RAJp3TMsqohg/Wa7bVF3cChRhecSYBLrTCQSj7j0UtWVFLP+6iEJoE2zb7GU5fp+fmG5kCbUdzhmlAUCWXiUJw==",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.3.1.tgz",
+      "integrity": "sha512-uIa4YurbphU+4Cl5CoL6nq/c7uQhVNRowEelgboNmXNs+UEcyFLQBESwaUjMvdtYxzA2qh+vGim080KZ84ruDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "11.3.0",
+        "@intlify/shared": "11.3.1",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -1967,9 +2011,10 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
-      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.1.tgz",
+      "integrity": "sha512-9GWc5PKuRdeWkT7FJN43c/+rD6xpSB3WtizewkfFCK/0XzYqCk4gQBWWcTdfKo8ylEcHwqYsR2Z3HRE3XhEHrQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -2732,9 +2777,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2870,9 +2915,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2894,9 +2936,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2957,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2942,9 +2978,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2966,9 +2999,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2990,9 +3020,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3345,9 +3372,9 @@
       }
     },
     "node_modules/@playwright/experimental-ct-core/node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3451,9 +3478,9 @@
       }
     },
     "node_modules/@playwright/experimental-ct-vue/node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3631,9 +3658,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
-      "integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -3648,9 +3675,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
-      "integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -3665,9 +3692,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
-      "integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -3682,9 +3709,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
-      "integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -3699,9 +3726,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
-      "integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -3716,9 +3743,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
-      "integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -3733,9 +3760,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
-      "integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -3750,9 +3777,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
-      "integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -3767,9 +3794,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
-      "integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -3784,9 +3811,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
-      "integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -3801,9 +3828,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
-      "integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -3818,9 +3845,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
-      "integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -3835,9 +3862,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
-      "integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -3852,9 +3879,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
-      "integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3869,9 +3896,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
-      "integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3886,9 +3913,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
-      "integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -3903,9 +3930,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
-      "integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -3920,9 +3947,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
-      "integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -3937,9 +3964,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
-      "integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -3954,9 +3981,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
-      "integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -3971,9 +3998,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
-      "integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -3988,9 +4015,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
-      "integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -4005,9 +4032,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
-      "integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -4022,9 +4049,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
-      "integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -4039,9 +4066,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
-      "integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -4056,9 +4083,9 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
-      "integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -4089,12 +4116,13 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/esbuild": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
-      "integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4102,32 +4130,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.5",
-        "@esbuild/android-arm": "0.27.5",
-        "@esbuild/android-arm64": "0.27.5",
-        "@esbuild/android-x64": "0.27.5",
-        "@esbuild/darwin-arm64": "0.27.5",
-        "@esbuild/darwin-x64": "0.27.5",
-        "@esbuild/freebsd-arm64": "0.27.5",
-        "@esbuild/freebsd-x64": "0.27.5",
-        "@esbuild/linux-arm": "0.27.5",
-        "@esbuild/linux-arm64": "0.27.5",
-        "@esbuild/linux-ia32": "0.27.5",
-        "@esbuild/linux-loong64": "0.27.5",
-        "@esbuild/linux-mips64el": "0.27.5",
-        "@esbuild/linux-ppc64": "0.27.5",
-        "@esbuild/linux-riscv64": "0.27.5",
-        "@esbuild/linux-s390x": "0.27.5",
-        "@esbuild/linux-x64": "0.27.5",
-        "@esbuild/netbsd-arm64": "0.27.5",
-        "@esbuild/netbsd-x64": "0.27.5",
-        "@esbuild/openbsd-arm64": "0.27.5",
-        "@esbuild/openbsd-x64": "0.27.5",
-        "@esbuild/openharmony-arm64": "0.27.5",
-        "@esbuild/sunos-x64": "0.27.5",
-        "@esbuild/win32-arm64": "0.27.5",
-        "@esbuild/win32-ia32": "0.27.5",
-        "@esbuild/win32-x64": "0.27.5"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/@quasar/app-vite/node_modules/readdirp": {
@@ -4145,16 +4173,16 @@
       }
     },
     "node_modules/@quasar/app-vite/node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
+      "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.13",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -4172,7 +4200,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -4288,9 +4316,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
       ],
@@ -4305,9 +4333,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
       ],
@@ -4322,9 +4350,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
       ],
@@ -4339,9 +4367,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
       ],
@@ -4356,9 +4384,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
       ],
@@ -4373,16 +4401,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4393,16 +4418,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4413,16 +4435,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4433,16 +4452,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4453,16 +4469,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4473,16 +4486,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4493,9 +4503,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
       ],
@@ -4510,9 +4520,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
       ],
@@ -4520,10 +4530,48 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -4545,10 +4593,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
       ],
@@ -4563,9 +4619,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
       ],
@@ -4701,9 +4757,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4718,9 +4771,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4735,9 +4785,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4752,9 +4799,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4769,9 +4813,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4786,9 +4827,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4803,9 +4841,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4820,9 +4855,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4837,9 +4869,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4854,9 +4883,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4871,9 +4897,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4888,9 +4911,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4905,9 +4925,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5323,15 +5340,16 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.21.tgz",
-      "integrity": "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.24.tgz",
+      "integrity": "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.25"
+        "@swc/types": "^0.1.26"
       },
       "engines": {
         "node": ">=10"
@@ -5341,18 +5359,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.21",
-        "@swc/core-darwin-x64": "1.15.21",
-        "@swc/core-linux-arm-gnueabihf": "1.15.21",
-        "@swc/core-linux-arm64-gnu": "1.15.21",
-        "@swc/core-linux-arm64-musl": "1.15.21",
-        "@swc/core-linux-ppc64-gnu": "1.15.21",
-        "@swc/core-linux-s390x-gnu": "1.15.21",
-        "@swc/core-linux-x64-gnu": "1.15.21",
-        "@swc/core-linux-x64-musl": "1.15.21",
-        "@swc/core-win32-arm64-msvc": "1.15.21",
-        "@swc/core-win32-ia32-msvc": "1.15.21",
-        "@swc/core-win32-x64-msvc": "1.15.21"
+        "@swc/core-darwin-arm64": "1.15.24",
+        "@swc/core-darwin-x64": "1.15.24",
+        "@swc/core-linux-arm-gnueabihf": "1.15.24",
+        "@swc/core-linux-arm64-gnu": "1.15.24",
+        "@swc/core-linux-arm64-musl": "1.15.24",
+        "@swc/core-linux-ppc64-gnu": "1.15.24",
+        "@swc/core-linux-s390x-gnu": "1.15.24",
+        "@swc/core-linux-x64-gnu": "1.15.24",
+        "@swc/core-linux-x64-musl": "1.15.24",
+        "@swc/core-win32-arm64-msvc": "1.15.24",
+        "@swc/core-win32-ia32-msvc": "1.15.24",
+        "@swc/core-win32-x64-msvc": "1.15.24"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -5364,9 +5382,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.21.tgz",
-      "integrity": "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.24.tgz",
+      "integrity": "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g==",
       "cpu": [
         "arm64"
       ],
@@ -5381,9 +5399,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.21.tgz",
-      "integrity": "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.24.tgz",
+      "integrity": "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg==",
       "cpu": [
         "x64"
       ],
@@ -5398,9 +5416,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.21.tgz",
-      "integrity": "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.24.tgz",
+      "integrity": "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw==",
       "cpu": [
         "arm"
       ],
@@ -5415,16 +5433,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.21.tgz",
-      "integrity": "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.24.tgz",
+      "integrity": "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5435,16 +5450,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.21.tgz",
-      "integrity": "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.24.tgz",
+      "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5455,16 +5467,13 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.21.tgz",
-      "integrity": "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.24.tgz",
+      "integrity": "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5475,16 +5484,13 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.21.tgz",
-      "integrity": "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.24.tgz",
+      "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5495,16 +5501,13 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.21.tgz",
-      "integrity": "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.24.tgz",
+      "integrity": "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5515,16 +5518,13 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.21.tgz",
-      "integrity": "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.24.tgz",
+      "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5535,9 +5535,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.21.tgz",
-      "integrity": "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.24.tgz",
+      "integrity": "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA==",
       "cpu": [
         "arm64"
       ],
@@ -5552,9 +5552,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.21.tgz",
-      "integrity": "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.24.tgz",
+      "integrity": "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ==",
       "cpu": [
         "ia32"
       ],
@@ -5569,9 +5569,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.21.tgz",
-      "integrity": "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.24.tgz",
+      "integrity": "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ==",
       "cpu": [
         "x64"
       ],
@@ -5626,7 +5626,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5647,7 +5646,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5658,7 +5656,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5672,7 +5669,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5687,8 +5683,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -5755,8 +5750,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5826,9 +5820,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.38.tgz",
-      "integrity": "sha512-5aK4m9wZqoWAoB98aElESLm/5pXpqJnFWMNoiCs/XdPsXR6wNdVkJFSdQ9Wr4PnTuUrxD0SuNuDHh3EG5QeBzA==",
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.39.tgz",
+      "integrity": "sha512-AttzlXiLx2TSqmuJy8baP7YrOb8yyIM6V02dePrK/n1wRlhnu7Obd7GqUUVhje0hhkU7BaJuQmoFXRd5hWqdjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5988,6 +5982,7 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6073,17 +6068,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/type-utils": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6096,22 +6091,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6127,14 +6123,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.0",
-        "@typescript-eslint/types": "^8.58.0",
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6149,14 +6145,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6167,9 +6163,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6184,15 +6180,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6209,9 +6205,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6223,16 +6219,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.0",
-        "@typescript-eslint/tsconfig-utils": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6251,16 +6247,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0"
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6275,13 +6271,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.58.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6418,9 +6414,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6435,9 +6428,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6452,9 +6442,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6469,9 +6456,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6486,9 +6470,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6503,9 +6484,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6520,9 +6498,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6537,9 +6512,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6611,6 +6583,7 @@
       "integrity": "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rolldown/pluginutils": "1.0.0-rc.2"
       },
@@ -6710,28 +6683,28 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.31.tgz",
-      "integrity": "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.31",
+        "@vue/shared": "3.5.32",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.31.tgz",
-      "integrity": "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.31",
-        "@vue/shared": "3.5.31"
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/compiler-sfc": {
@@ -6983,9 +6956,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.31.tgz",
-      "integrity": "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7032,6 +7005,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7535,6 +7509,7 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -7545,9 +7520,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
-      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.6.0.tgz",
+      "integrity": "sha512-2YkS7NuiJceSEbyEOdSNLE9tsGd+f4+f7C+Nik/MCk27SYdwIMPT/yRKvg++FZhQXgk0KWJKJyXX9RhVV0RGqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7570,9 +7545,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.6.tgz",
-      "integrity": "sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7648,9 +7623,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7747,6 +7722,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7998,9 +7974,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {
@@ -8475,9 +8451,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8652,6 +8628,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -8837,9 +8814,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
-      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -8914,8 +8891,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "0.2.2",
@@ -9023,9 +8999,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-      "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -9091,6 +9067,7 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
@@ -9104,9 +9081,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.333",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.333.tgz",
+      "integrity": "sha512-skNh4FsE+IpCJV7xAQGbQ4eyOGvcEctVBAk7a5KPzxC3alES9rLrT+2IsPRPgeQr8LVxdJr8BHQ9481+TOr0xg==",
       "dev": true,
       "license": "ISC"
     },
@@ -9349,18 +9326,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.3",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -9440,6 +9418,7 @@
       "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -10995,16 +10974,16 @@
       "license": "ISC"
     },
     "node_modules/inquirer": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.3.2.tgz",
-      "integrity": "sha512-bh/OjBGxNR9qvfQj1n5bxtIF58mbOTp2InN5dKuwUK03dXcDGFsjlDinQRuXMZ4EGiJaFieUWHCAaxH2p7iUBw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.1.tgz",
+      "integrity": "sha512-IUopujY77lFiSaLz0fx6FHEOEANz0nAsqv+vQJddnVshi6wdos984qwjb42mZbH3zCJS4f9ioIGDqSPqMMMXjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/prompts": "^8.3.2",
-        "@inquirer/type": "^4.0.4",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/prompts": "^8.4.1",
+        "@inquirer/type": "^4.0.5",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6",
         "rxjs": "^7.8.2"
@@ -11447,6 +11426,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -12535,6 +12515,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -12672,9 +12653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12696,9 +12674,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12720,9 +12695,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12744,9 +12716,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12893,7 +12862,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14033,6 +14001,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -14245,9 +14214,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "funding": [
         {
           "type": "opencollective",
@@ -14263,6 +14232,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14467,6 +14437,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14511,6 +14482,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14858,6 +14830,7 @@
       "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.18.5.tgz",
       "integrity": "sha512-5ItDSsNjqBVRrC7SqcdvT1F5mghVyJ/KmaWNwnaT5mM91a7gWpT/d7wTCIFxxDbWLZdkHKI+cpdudEqnfcSw9A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.18.1",
         "npm": ">= 6.13.4",
@@ -14921,6 +14894,7 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14931,6 +14905,7 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15189,14 +15164,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -15205,27 +15180,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
@@ -15235,6 +15210,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15536,11 +15512,12 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
-      "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -15557,11 +15534,12 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.98.0.tgz",
-      "integrity": "sha512-Do7u6iRb6K+lrllcTkB1BXcHwOxcKe3rEfOF/GcCLE2w3WpddakRAosJOHFUR37DpsvimQXEt5abs3NzUjEIqg==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.99.0.tgz",
+      "integrity": "sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "colorjs.io": "^0.5.0",
@@ -15578,30 +15556,30 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-all-unknown": "1.98.0",
-        "sass-embedded-android-arm": "1.98.0",
-        "sass-embedded-android-arm64": "1.98.0",
-        "sass-embedded-android-riscv64": "1.98.0",
-        "sass-embedded-android-x64": "1.98.0",
-        "sass-embedded-darwin-arm64": "1.98.0",
-        "sass-embedded-darwin-x64": "1.98.0",
-        "sass-embedded-linux-arm": "1.98.0",
-        "sass-embedded-linux-arm64": "1.98.0",
-        "sass-embedded-linux-musl-arm": "1.98.0",
-        "sass-embedded-linux-musl-arm64": "1.98.0",
-        "sass-embedded-linux-musl-riscv64": "1.98.0",
-        "sass-embedded-linux-musl-x64": "1.98.0",
-        "sass-embedded-linux-riscv64": "1.98.0",
-        "sass-embedded-linux-x64": "1.98.0",
-        "sass-embedded-unknown-all": "1.98.0",
-        "sass-embedded-win32-arm64": "1.98.0",
-        "sass-embedded-win32-x64": "1.98.0"
+        "sass-embedded-all-unknown": "1.99.0",
+        "sass-embedded-android-arm": "1.99.0",
+        "sass-embedded-android-arm64": "1.99.0",
+        "sass-embedded-android-riscv64": "1.99.0",
+        "sass-embedded-android-x64": "1.99.0",
+        "sass-embedded-darwin-arm64": "1.99.0",
+        "sass-embedded-darwin-x64": "1.99.0",
+        "sass-embedded-linux-arm": "1.99.0",
+        "sass-embedded-linux-arm64": "1.99.0",
+        "sass-embedded-linux-musl-arm": "1.99.0",
+        "sass-embedded-linux-musl-arm64": "1.99.0",
+        "sass-embedded-linux-musl-riscv64": "1.99.0",
+        "sass-embedded-linux-musl-x64": "1.99.0",
+        "sass-embedded-linux-riscv64": "1.99.0",
+        "sass-embedded-linux-x64": "1.99.0",
+        "sass-embedded-unknown-all": "1.99.0",
+        "sass-embedded-win32-arm64": "1.99.0",
+        "sass-embedded-win32-x64": "1.99.0"
       }
     },
     "node_modules/sass-embedded-all-unknown": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.98.0.tgz",
-      "integrity": "sha512-6n4RyK7/1mhdfYvpP3CClS3fGoYqDvRmLClCESS6I7+SAzqjxvGG6u5Fo+cb1nrPNbbilgbM4QKdgcgWHO9NCA==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.99.0.tgz",
+      "integrity": "sha512-qPIRG8Uhjo6/OKyAKixTnwMliTz+t9K6Duk0mx5z+K7n0Ts38NSJz2sjDnc7cA/8V9Lb3q09H38dZ1CLwD+ssw==",
       "cpu": [
         "!arm",
         "!arm64",
@@ -15612,13 +15590,13 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "sass": "1.98.0"
+        "sass": "1.99.0"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.98.0.tgz",
-      "integrity": "sha512-LjGiMhHgu7VL1n7EJxTCre1x14bUsWd9d3dnkS2rku003IWOI/fxc7OXgaKagoVzok1kv09rzO3vFXJR5ZeONQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.99.0.tgz",
+      "integrity": "sha512-EHvJ0C7/VuP78Qr6f8gIUVUmCqIorEQpw2yp3cs3SMg02ZuumlhjXvkTcFBxHmFdFR23vTNk1WnhY6QSeV1nFQ==",
       "cpu": [
         "arm"
       ],
@@ -15633,9 +15611,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.98.0.tgz",
-      "integrity": "sha512-M9Ra98A6vYJHpwhoC/5EuH1eOshQ9ZyNwC8XifUDSbRl/cGeQceT1NReR9wFj3L7s1pIbmes1vMmaY2np0uAKQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.99.0.tgz",
+      "integrity": "sha512-fNHhdnP23yqqieCbAdym4N47AleSwjbNt6OYIYx4DdACGdtERjQB4iOX/TaKsW034MupfF7SjnAAK8w7Ptldtg==",
       "cpu": [
         "arm64"
       ],
@@ -15650,9 +15628,9 @@
       }
     },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.98.0.tgz",
-      "integrity": "sha512-WPe+0NbaJIZE1fq/RfCZANMeIgmy83x4f+SvFOG7LhUthHpZWcOcrPTsCKKmN3xMT3iw+4DXvqTYOCYGRL3hcQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.99.0.tgz",
+      "integrity": "sha512-4zqDFRvgGDTL5vTHuIhRxUpXFoh0Cy7Gm5Ywk19ASd8Settmd14YdPRZPmMxfgS1GH292PofV1fq1ifiSEJWBw==",
       "cpu": [
         "riscv64"
       ],
@@ -15667,9 +15645,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.98.0.tgz",
-      "integrity": "sha512-zrD25dT7OHPEgLWuPEByybnIfx4rnCtfge4clBgjZdZ3lF6E7qNLRBtSBmoFflh6Vg0RlEjJo5VlpnTMBM5MQQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.99.0.tgz",
+      "integrity": "sha512-Uk53k/dGYt04RjOL4gFjZ0Z9DH9DKh8IA8WsXUkNqsxerAygoy3zqRBS2zngfE9K2jiOM87q+1R1p87ory9oQQ==",
       "cpu": [
         "x64"
       ],
@@ -15684,9 +15662,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.98.0.tgz",
-      "integrity": "sha512-cgr1z9rBnCdMf8K+JabIaYd9Rag2OJi5mjq08XJfbJGMZV/TA6hFJCLGkr5/+ZOn4/geTM5/3aSfQ8z5EIJAOg==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.99.0.tgz",
+      "integrity": "sha512-u61/7U3IGLqoO6gL+AHeiAtlTPFwJK1+964U8gp45ZN0hzh1yrARf5O1mivXv8NnNgJvbG2wWJbiNZP0lG/lTg==",
       "cpu": [
         "arm64"
       ],
@@ -15701,9 +15679,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.98.0.tgz",
-      "integrity": "sha512-OLBOCs/NPeiMqTdOrMFbVHBQFj19GS3bSVSxIhcCq16ZyhouUkYJEZjxQgzv9SWA2q6Ki8GCqp4k6jMeUY9dcA==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.99.0.tgz",
+      "integrity": "sha512-j/kkk/NcXdIameLezSfXjgCiBkVcA+G60AXrX768/3g0miK1g7M9dj7xOhCb1i7/wQeiEI3rw2LLuO63xRIn4A==",
       "cpu": [
         "x64"
       ],
@@ -15718,14 +15696,13 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.98.0.tgz",
-      "integrity": "sha512-03baQZCxVyEp8v1NWBRlzGYrmVT/LK7ZrHlF1piscGiGxwfdxoLXVuxsylx3qn/dD/4i/rh7Bzk7reK1br9jvQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.99.0.tgz",
+      "integrity": "sha512-d4IjJZrX2+AwB2YCy1JySwdptJECNP/WfAQLUl8txI3ka8/d3TUI155GtelnoZUkio211PwIeFvvAeZ9RXPQnw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15736,14 +15713,13 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.98.0.tgz",
-      "integrity": "sha512-axOE3t2MTBwCtkUCbrdM++Gj0gC0fdHJPrgzQ+q1WUmY9NoNMGqflBtk5mBZaWUeha2qYO3FawxCB8lctFwCtw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.99.0.tgz",
+      "integrity": "sha512-btNcFpItcB56L40n8hDeL7sRSMLDXQ56nB5h2deddJx1n60rpKSElJmkaDGHtpkrY+CTtDRV0FZDjHeTJddYew==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15754,14 +15730,13 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.98.0.tgz",
-      "integrity": "sha512-OBkjTDPYR4hSaueOGIM6FDpl9nt/VZwbSRpbNu9/eEJcxE8G/vynRugW8KRZmCFjPy8j/jkGBvvS+k9iOqKV3g==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.99.0.tgz",
+      "integrity": "sha512-2gvHOupgIw3ytatXT4nFUow71LFbuOZPEwG+HUzcNQDH8ue4Ez8cr03vsv5MDv3lIjOKcXwDvWD980t18MwkoQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15772,14 +15747,13 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.98.0.tgz",
-      "integrity": "sha512-LeqNxQA8y4opjhe68CcFvMzCSrBuJqYVFbwElEj9bagHXQHTp9xVPJRn6VcrC+0VLEDq13HVXMv7RslIuU0zmA==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.99.0.tgz",
+      "integrity": "sha512-Hi2bt/IrM5P4FBKz6EcHAlniwfpoz9mnTdvSd58y+avA3SANM76upIkAdSayA8ZGwyL3gZokru1AKDPF9lJDNw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15790,14 +15764,13 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.98.0.tgz",
-      "integrity": "sha512-7w6hSuOHKt8FZsmjRb3iGSxEzM87fO9+M8nt5JIQYMhHTj5C+JY/vcske0v715HCVj5e1xyTnbGXf8FcASeAIw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.99.0.tgz",
+      "integrity": "sha512-mKqGvVaJ9rHMqyZsF0kikQe4NO0f4osb67+X6nLhBiVDKvyazQHJ3zJQreNefIE36yL2sjHIclSB//MprzaQDg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15808,14 +15781,13 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.98.0.tgz",
-      "integrity": "sha512-QikNyDEJOVqPmxyCFkci8ZdCwEssdItfjQFJB+D+Uy5HFqcS5Lv3d3GxWNX/h1dSb23RPyQdQc267ok5SbEyJw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.99.0.tgz",
+      "integrity": "sha512-huhgOMmOc30r7CH7qbRbT9LerSEGSnWuS4CYNOskr9BvNeQp4dIneFufNRGZ7hkOAxUM8DglxIZJN/cyAT95Ew==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15826,14 +15798,13 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.98.0.tgz",
-      "integrity": "sha512-E7fNytc/v4xFBQKzgzBddV/jretA4ULAPO6XmtBiQu4zZBdBozuSxsQLe2+XXeb0X4S2GIl72V7IPABdqke/vA==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.99.0.tgz",
+      "integrity": "sha512-mevFPIFAVhrH90THifxLfOntFmHtcEKOcdWnep2gJ0X4DVva4AiVIRlQe/7w9JFx5+gnDRE1oaJJkzuFUuYZsA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15844,14 +15815,13 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.98.0.tgz",
-      "integrity": "sha512-VsvP0t/uw00mMNPv3vwyYKUrFbqzxQHnRMO+bHdAMjvLw4NFf6mscpym9Bzf+NXwi1ZNKnB6DtXjmcpcvqFqYg==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.99.0.tgz",
+      "integrity": "sha512-9k7IkULqIZdCIVt4Mboryt6vN8Mjmm3EhI1P3mClU5y5i3wLK5ExC3cbVWk047KsID/fvB1RLslqghXJx5BoxA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15862,9 +15832,9 @@
       }
     },
     "node_modules/sass-embedded-unknown-all": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.98.0.tgz",
-      "integrity": "sha512-C4MMzcAo3oEDQnW7L8SBgB9F2Fq5qHPnaYTZRMOH3Mp/7kM4OooBInXpCiiFjLnjY95hzP4KyctVx0uYR6MYlQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.99.0.tgz",
+      "integrity": "sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -15875,13 +15845,13 @@
         "!win32"
       ],
       "dependencies": {
-        "sass": "1.98.0"
+        "sass": "1.99.0"
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.98.0.tgz",
-      "integrity": "sha512-nP/10xbAiPbhQkMr3zQfXE4TuOxPzWRQe1Hgbi90jv2R4TbzbqQTuZVOaJf7KOAN4L2Bo6XCTRjK5XkVnwZuwQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.99.0.tgz",
+      "integrity": "sha512-8whpsW7S+uO8QApKfQuc36m3P9EISzbVZOgC79goob4qGy09u8Gz/rYvw8h1prJDSjltpHGhOzBE6LDz7WvzVw==",
       "cpu": [
         "arm64"
       ],
@@ -15896,9 +15866,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.98.0.tgz",
-      "integrity": "sha512-/lbrVsfbcbdZQ5SJCWcV0NVPd6YRs+FtAnfedp4WbCkO/ZO7Zt/58MvI4X2BVpRY/Nt5ZBo1/7v2gYcQ+J4svQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.99.0.tgz",
+      "integrity": "sha512-ipuOv1R2K4MHeuCEAZGpuUbAgma4gb0sdacyrTjJtMOy/OY9UvWfVlwErdB09KIkp4fPDpQJDJfvYN6bC8jeNg==",
       "cpu": [
         "x64"
       ],
@@ -16403,6 +16373,7 @@
       "integrity": "sha512-UUm5eGSm6BLhkcFP0WbxkmAHJZfVN2ViLpIZOqiIPS++q32VYn+CLFC0lrTYTDqYvaG7i4BK4uowXYujzE4NdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -16693,6 +16664,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -17270,6 +17242,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -17356,14 +17329,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -17577,6 +17550,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17586,16 +17560,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.0",
-        "@typescript-eslint/parser": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0"
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -17822,9 +17796,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -17898,9 +17872,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
-      "integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -17910,15 +17884,14 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
-      "integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -17928,15 +17901,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
-      "integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -17946,15 +17918,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
-      "integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -17964,15 +17935,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
-      "integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -17982,15 +17952,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
-      "integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -18000,15 +17969,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
-      "integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -18018,15 +17986,14 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
-      "integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -18036,15 +18003,14 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
-      "integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -18054,15 +18020,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
-      "integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -18072,15 +18037,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
-      "integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -18090,15 +18054,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
-      "integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -18108,15 +18071,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
-      "integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -18126,15 +18088,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
-      "integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -18144,15 +18105,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
-      "integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -18162,15 +18122,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
-      "integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -18180,15 +18139,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
-      "integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -18198,15 +18156,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
-      "integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -18216,15 +18173,14 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
-      "integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -18234,15 +18190,14 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
-      "integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -18252,15 +18207,14 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
-      "integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -18270,15 +18224,14 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
-      "integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -18288,15 +18241,14 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
-      "integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -18306,15 +18258,14 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
-      "integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -18324,15 +18275,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
-      "integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -18342,15 +18292,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
-      "integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -18360,19 +18309,17 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
-      "integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -18380,32 +18327,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.5",
-        "@esbuild/android-arm": "0.27.5",
-        "@esbuild/android-arm64": "0.27.5",
-        "@esbuild/android-x64": "0.27.5",
-        "@esbuild/darwin-arm64": "0.27.5",
-        "@esbuild/darwin-x64": "0.27.5",
-        "@esbuild/freebsd-arm64": "0.27.5",
-        "@esbuild/freebsd-x64": "0.27.5",
-        "@esbuild/linux-arm": "0.27.5",
-        "@esbuild/linux-arm64": "0.27.5",
-        "@esbuild/linux-ia32": "0.27.5",
-        "@esbuild/linux-loong64": "0.27.5",
-        "@esbuild/linux-mips64el": "0.27.5",
-        "@esbuild/linux-ppc64": "0.27.5",
-        "@esbuild/linux-riscv64": "0.27.5",
-        "@esbuild/linux-s390x": "0.27.5",
-        "@esbuild/linux-x64": "0.27.5",
-        "@esbuild/netbsd-arm64": "0.27.5",
-        "@esbuild/netbsd-x64": "0.27.5",
-        "@esbuild/openbsd-arm64": "0.27.5",
-        "@esbuild/openbsd-x64": "0.27.5",
-        "@esbuild/openharmony-arm64": "0.27.5",
-        "@esbuild/sunos-x64": "0.27.5",
-        "@esbuild/win32-arm64": "0.27.5",
-        "@esbuild/win32-ia32": "0.27.5",
-        "@esbuild/win32-x64": "0.27.5"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/void-elements": {
@@ -18430,6 +18377,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",
@@ -18531,6 +18479,7 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -18581,6 +18530,18 @@
       },
       "peerDependencies": {
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-i18n/node_modules/@intlify/shared": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/vue-i18n/node_modules/@vue/devtools-api": {

--- a/frontend/src/api/modules.ts
+++ b/frontend/src/api/modules.ts
@@ -89,11 +89,18 @@ export async function getHeadcountMembers(
  * Fetch the results summary for a carbon report.
  *
  * @param carbonReportId - Carbon report ID
+ * @param excludeModules - Optional list of module_type_ids to exclude from totals
  * @returns Unit-wide totals and per-module breakdowns
  */
 export async function getResultsSummary(
   carbonReportId: number,
+  excludeModules: number[] = [],
 ): Promise<ResultsSummary> {
   const path = `modules-stats/${encodeURIComponent(carbonReportId)}/results-summary`;
-  return api.get(path).json<ResultsSummary>();
+  const searchParams = new URLSearchParams();
+  for (const id of excludeModules) {
+    searchParams.append('exclude_modules', String(id));
+  }
+  const query = searchParams.toString();
+  return api.get(query ? `${path}?${query}` : path).json<ResultsSummary>();
 }

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -228,7 +228,7 @@ const chartOption = computed((): EChartsOption => {
         y: 'research_facilities',
       },
       itemStyle: {
-        color: colors.value.lavender.darker,
+        color: colors.value.paleYellowGreen.darker,
       },
       label: {
         show: false,

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -45,29 +45,272 @@ function getSubcategoryColor(
   return getChartSubcategoryColor(category, key, fallback);
 }
 
-const scopeConfig = computed(() => {
-  if (toggleAdditionalData.value) {
-    return {
-      scope1RectWidth: 72,
-      scope2RectLeft: 118,
-      scope2RectWidth: 72,
-      scope3RectLeft: 190,
-      scope3RectWidth: 144,
-      estimatedRectLeft: 334,
-      estimatedText: t('charts-additional-category'),
-    };
+// Static map: raw category key → GHG scope
+const CATEGORY_SCOPE: Record<string, 1 | 2 | 3 | 'additional'> = {
+  process_emissions: 1,
+  buildings_room: 1,
+  buildings_energy_combustion: 2,
+  equipment: 2,
+  external_cloud_and_ai: 3,
+  purchases: 3,
+  professional_travel: 3,
+  research_facilities: 3,
+  commuting: 'additional',
+  food: 'additional',
+  waste: 'additional',
+  embodied_energy: 'additional',
+};
+
+// Reverse map: translated label → raw category key (rebuilt when locale changes)
+const labelToKey = computed<Record<string, string>>(() => {
+  const map: Record<string, string> = {};
+  for (const [key, i18nKey] of Object.entries(CATEGORY_LABEL_MAP)) {
+    map[t(i18nKey)] = key;
+  }
+  return map;
+});
+
+// Key of the last graphic option pushed to ECharts — used to break the
+// finished → setOption → finished loop.
+let lastGraphicKey = '';
+
+function recalculateScopeRects() {
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+
+  const items = datasetSource.value;
+  if (items.length < 2) return;
+
+  const getX = (label: string): number =>
+    chart.convertToPixel({ xAxisIndex: 0 }, label) as number;
+
+  const step =
+    getX(String(items[1].category)) - getX(String(items[0].category));
+  if (!step) return;
+  const halfStep = step / 2;
+
+  const groups: Record<string, string[]> = {
+    '1': [],
+    '2': [],
+    '3': [],
+    additional: [],
+  };
+  for (const item of items) {
+    const label = String(item.category);
+    const key = labelToKey.value[label] ?? '';
+    const scope = String(CATEGORY_SCOPE[key] ?? 'additional');
+    groups[scope].push(label);
   }
 
-  return {
-    scope1RectWidth: 108,
-    scope2RectLeft: 154,
-    scope2RectWidth: 108,
-    scope3RectLeft: 262,
-    scope3RectWidth: 330,
-    estimatedRectLeft: 0,
-    estimatedText: '',
+  const toRect = (labels: string[]) => {
+    if (!labels.length) return null;
+    const left = getX(labels[0]) - halfStep;
+    const right = getX(labels[labels.length - 1]) + halfStep;
+    return { left, width: right - left };
   };
-});
+
+  const s1 = toRect(groups['1']);
+  const s2 = toRect(groups['2']);
+  const s3 = toRect(groups['3']);
+  const additionalRect = toRect(groups['additional']);
+  const dividerX = groups['additional'].length
+    ? getX(groups['additional'][0]) - halfStep
+    : null;
+
+  const key = JSON.stringify({
+    s1,
+    s2,
+    s3,
+    dividerX,
+    aw: additionalRect?.width,
+  });
+  if (key === lastGraphicKey) return; // nothing changed — stop the loop
+  lastGraphicKey = key;
+
+  const showAdditional = toggleAdditionalData.value && dividerX !== null;
+  const elements: object[] = [
+    ...(s1
+      ? [
+          {
+            type: 'rect',
+            id: 'sr1',
+            left: s1.left,
+            top: '15px',
+            shape: { width: s1.width, height: 300 },
+            style: {
+              fill: new graphic.LinearGradient(0, 0, 0, 1, [
+                { offset: 0, color: 'rgba(248,248,248,0.9)' },
+                { offset: 1, color: 'rgba(248,248,248,0.1)' },
+              ]),
+            },
+            silent: true,
+          },
+          {
+            type: 'text',
+            id: 'st1',
+            left: s1.left + 10,
+            top: '30px',
+            style: {
+              fill: '#000000',
+              text: t('charts-scope') + ' 1',
+              font: '11px SuisseIntl',
+            },
+            silent: true,
+          },
+        ]
+      : []),
+    ...(s2
+      ? [
+          {
+            type: 'rect',
+            id: 'sr2',
+            left: s2.left,
+            top: '15px',
+            shape: { width: s2.width, height: 300 },
+            style: {
+              fill: new graphic.LinearGradient(0, 0, 0, 1, [
+                { offset: 0, color: 'rgba(240,240,240,0.9)' },
+                { offset: 1, color: 'rgba(240,240,240,0.1)' },
+              ]),
+            },
+            silent: true,
+          },
+          {
+            type: 'text',
+            id: 'st2',
+            left: s2.left + 10,
+            top: '30px',
+            style: {
+              fill: '#000000',
+              text: t('charts-scope') + ' 2',
+              font: '11px SuisseIntl',
+            },
+            silent: true,
+          },
+        ]
+      : []),
+    ...(s3
+      ? [
+          {
+            type: 'rect',
+            id: 'sr3',
+            left: s3.left,
+            top: '15px',
+            shape: { width: s3.width, height: 300 },
+            style: {
+              fill: new graphic.LinearGradient(0, 0, 0, 1, [
+                { offset: 0, color: 'rgba(229,229,229,0.9)' },
+                { offset: 1, color: 'rgba(229,229,229,0.1)' },
+              ]),
+            },
+            silent: true,
+          },
+          {
+            type: 'text',
+            id: 'st3',
+            left: s3.left + 10,
+            top: '30px',
+            style: {
+              fill: '#000000',
+              text: t('charts-scope') + ' 3',
+              font: '11px SuisseIntl',
+            },
+            silent: true,
+          },
+        ]
+      : []),
+    {
+      type: 'text',
+      id: 'smain',
+      left: s1 ? s1.left + 10 : 56,
+      top: '0px',
+      style: {
+        fill: '#000000',
+        text: t('charts-main-category'),
+        font: '11px SuisseIntl',
+      },
+      silent: true,
+    },
+    ...(showAdditional
+      ? [
+          {
+            type: 'rect',
+            id: 'sadd',
+            left: dividerX,
+            top: '15px',
+            shape: { width: additionalRect?.width ?? 200, height: 300 },
+            style: {
+              fill: new graphic.LinearGradient(0, 0, 0, 1, [
+                { offset: 0, color: 'rgba(215,215,215,0.9)' },
+                { offset: 1, color: 'rgba(215,215,215,0.1)' },
+              ]),
+            },
+            silent: true,
+          },
+          {
+            type: 'text',
+            id: 'stadd',
+            left: dividerX + 10,
+            top: '0px',
+            style: {
+              fill: '#000000',
+              text: t('charts-additional-category'),
+              font: '11px SuisseIntl',
+            },
+            silent: true,
+          },
+          {
+            type: 'rect',
+            id: 'sdiv',
+            left: dividerX,
+            top: '0px',
+            shape: { width: 1, height: 420 },
+            style: {
+              fill: new graphic.LinearGradient(0, 0, 0, 1, [
+                { offset: 0, color: 'rgba(0,0,0,1)' },
+                { offset: 1, color: 'rgba(240,240,240,0.1)' },
+              ]),
+            },
+            z: 100,
+            silent: true,
+          },
+        ]
+      : [
+          {
+            type: 'rect',
+            id: 'sadd',
+            left: 0,
+            top: 0,
+            shape: { width: 0, height: 0 },
+            style: { opacity: 0 },
+            silent: true,
+          },
+          {
+            type: 'text',
+            id: 'stadd',
+            left: 0,
+            top: 0,
+            style: { opacity: 0, text: '' },
+            silent: true,
+          },
+          {
+            type: 'rect',
+            id: 'sdiv',
+            left: 0,
+            top: 0,
+            shape: { width: 0, height: 0 },
+            style: { opacity: 0 },
+            silent: true,
+          },
+        ]),
+  ];
+
+  requestAnimationFrame(() => {
+    chart.setOption({ graphic: elements }, {
+      replaceMerge: ['graphic'],
+    } as Parameters<typeof chart.setOption>[1]);
+  });
+}
 
 const CATEGORY_LABEL_MAP: Record<string, string> = {
   commuting: 'charts-commuting-category', // Headcount
@@ -684,6 +927,37 @@ const chartOption = computed((): EChartsOption => {
       },
       label: { show: false },
     },
+    // Research Facilities — subcategories: facilities, animal
+    {
+      name: t('charts-research-facilities-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'facilities' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'research_facilities',
+          'facilities',
+          colors.value.paleYellowGreen.darker,
+        ),
+      },
+      label: { show: false },
+    },
+    {
+      name: t('charts-research-animal-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'animal' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'research_facilities',
+          'animal',
+          colors.value.paleYellowGreen.dark,
+        ),
+      },
+      label: { show: false },
+    },
 
     ...additionalSeriesData.value,
   ];
@@ -796,146 +1070,7 @@ const chartOption = computed((): EChartsOption => {
         formatter: '{value}',
       },
     },
-    graphic: [
-      // Scope 1 overlay (Processes, Buildings energy consumption)
-      {
-        type: 'rect',
-        left: '46px',
-        top: '15px',
-        shape: {
-          width: scopeConfig.value.scope1RectWidth,
-          height: 300,
-        },
-        style: {
-          fill: new graphic.LinearGradient(0, 0, 0, 1, [
-            { offset: 0, color: 'rgba(248,248,248,0.9)' },
-            { offset: 1, color: 'rgba(248,248,248,0.1)' },
-          ]),
-        },
-      },
-      {
-        type: 'text',
-        left: '56px',
-        top: '30px',
-        style: {
-          fill: '#000000',
-          text: t('charts-scope') + ' 1',
-          font: '11px SuisseIntl',
-        },
-      },
-      // Scope 2 overlay (Energy combustion, Equipment)
-      {
-        type: 'rect',
-        left: scopeConfig.value.scope2RectLeft,
-        top: '15px',
-        shape: {
-          width: scopeConfig.value.scope2RectWidth,
-          height: 300,
-        },
-        style: {
-          fill: new graphic.LinearGradient(0, 0, 0, 1, [
-            { offset: 0, color: 'rgba(240,240,240,0.9)' },
-            { offset: 1, color: 'rgba(240,240,240,0.1)' },
-          ]),
-        },
-      },
-      {
-        type: 'text',
-        left: scopeConfig.value.scope2RectLeft + 10,
-        top: '30px',
-        style: {
-          fill: '#000000',
-          text: t('charts-scope') + ' 2',
-          font: '11px SuisseIntl',
-        },
-      },
-      // Scope 3 overlay (External cloud & AI, Purchases, Research facilities, Professional travel)
-      {
-        type: 'rect',
-        left: scopeConfig.value.scope3RectLeft,
-        top: '15px',
-        shape: {
-          width: scopeConfig.value.scope3RectWidth,
-          height: 300,
-        },
-        style: {
-          fill: new graphic.LinearGradient(0, 0, 0, 1, [
-            { offset: 0, color: 'rgba(229,229,229,0.9)' },
-            { offset: 1, color: 'rgba(229,229,229,0.1)' },
-          ]),
-        },
-      },
-      {
-        type: 'text',
-        left: scopeConfig.value.scope3RectLeft + 10,
-        top: '30px',
-        style: {
-          fill: '#000000',
-          text: t('charts-scope') + ' 3',
-          font: '11px SuisseIntl',
-        },
-      },
-      {
-        type: 'text',
-        left: '56px',
-        top: '00px',
-        style: {
-          fill: '#000000',
-          text: t('charts-main-category'),
-          font: '11px SuisseIntl',
-        },
-      },
-      ...(() => {
-        if (toggleAdditionalData.value) {
-          return [
-            // Additional categories background (darker grey)
-            {
-              type: 'rect',
-              left: scopeConfig.value.estimatedRectLeft,
-              top: '15px',
-              shape: {
-                width: 200,
-                height: 300,
-              },
-              style: {
-                fill: new graphic.LinearGradient(0, 0, 0, 1, [
-                  { offset: 0, color: 'rgba(215,215,215,0.9)' },
-                  { offset: 1, color: 'rgba(215,215,215,0.1)' },
-                ]),
-              },
-            },
-            {
-              type: 'text',
-              left: scopeConfig.value.estimatedRectLeft + 10,
-              top: '0px',
-              style: {
-                fill: '#000000',
-                text: scopeConfig.value.estimatedText,
-                font: '11px SuisseIntl',
-              },
-            },
-            // Divider line
-            {
-              type: 'rect',
-              left: scopeConfig.value.estimatedRectLeft,
-              top: '0px',
-              shape: {
-                width: 1,
-                height: 420,
-              },
-              style: {
-                fill: new graphic.LinearGradient(0, 0, 0, 1, [
-                  { offset: 0, color: 'rgba(0,0,0)' },
-                  { offset: 1, color: 'rgba(240,240,240,0.1)' },
-                ]),
-              },
-              z: 100,
-            },
-          ];
-        }
-        return [];
-      })(),
-    ],
+    graphic: [],
     dataset: {
       dimensions: [
         'category',
@@ -968,6 +1103,8 @@ const chartOption = computed((): EChartsOption => {
         'virtualisation',
         'calcul',
         'ai_provider',
+        'facilities',
+        'animal',
         'commuting',
         'food',
         'waste',
@@ -1082,7 +1219,13 @@ const downloadCSV = () => {
       />
     </q-card-section>
     <q-card-section class="chart-container flex justify-center items-center">
-      <v-chart ref="chartRef" class="chart" autoresize :option="chartOption" />
+      <v-chart
+        ref="chartRef"
+        class="chart"
+        autoresize
+        :option="chartOption"
+        @rendered="recalculateScopeRects"
+      />
     </q-card-section>
   </q-card>
 </template>

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -70,9 +70,14 @@ const labelToKey = computed<Record<string, string>>(() => {
   return map;
 });
 
-// Key of the last graphic option pushed to ECharts — used to break the
-// finished → setOption → finished loop.
-let lastGraphicKey = '';
+// Memoize the last scope rects to avoid redundant updates
+let lastScopeState: {
+  s1Left?: number;
+  s2Left?: number;
+  s3Left?: number;
+  dividerX?: number | null;
+  showAdditional: boolean;
+} | null = null;
 
 function recalculateScopeRects() {
   const chart = chartRef.value?.chart;
@@ -116,18 +121,27 @@ function recalculateScopeRects() {
   const dividerX = groups['additional'].length
     ? getX(groups['additional'][0]) - halfStep
     : null;
-
-  const key = JSON.stringify({
-    s1,
-    s2,
-    s3,
-    dividerX,
-    aw: additionalRect?.width,
-  });
-  if (key === lastGraphicKey) return; // nothing changed — stop the loop
-  lastGraphicKey = key;
-
   const showAdditional = toggleAdditionalData.value && dividerX !== null;
+
+  // Check if state has changed
+  const newState = {
+    s1Left: s1?.left,
+    s2Left: s2?.left,
+    s3Left: s3?.left,
+    dividerX,
+    showAdditional,
+  };
+  if (
+    lastScopeState?.s1Left === newState.s1Left &&
+    lastScopeState?.s2Left === newState.s2Left &&
+    lastScopeState?.s3Left === newState.s3Left &&
+    lastScopeState?.dividerX === newState.dividerX &&
+    lastScopeState?.showAdditional === newState.showAdditional
+  ) {
+    return; // nothing changed — stop the loop
+  }
+  lastScopeState = newState;
+
   const elements: object[] = [
     ...(s1
       ? [
@@ -381,23 +395,44 @@ function collapseByCategory(
   return Array.from(merged.values());
 }
 
-const ADDITIONAL_CATEGORY_KEYS = [
-  t('charts-commuting-category'),
-  t('charts-food-category'),
-  t('charts-waste-category'),
-  t('charts-embodied-energy-category'),
+// Keys not translated here — moved to computed properties below
+const ADDITIONAL_CATEGORY_KEY_IDS = [
+  'charts-commuting-category',
+  'charts-food-category',
+  'charts-waste-category',
+  'charts-embodied-energy-category',
 ];
 
-const MAIN_CATEGORY_ORDER = [
-  t('charts-process-emissions-category'),
-  t('charts-buildings-room-category'),
-  t('charts-buildings-energy-combustion-category'),
-  t('equipment-electric-consumption'),
-  t('external-cloud-and-ai'),
-  t('purchase'),
-  t('professional-travel'),
-  t('charts-research-facilities-category'),
+const MAIN_CATEGORY_ORDER_IDS = [
+  'charts-process-emissions-category',
+  'charts-buildings-room-category',
+  'charts-buildings-energy-combustion-category',
+  'equipment-electric-consumption',
+  'external-cloud-and-ai',
+  'purchase',
+  'professional-travel',
+  'charts-research-facilities-category',
 ];
+
+const additionalCategoryKeysSet = computed(
+  () => new Set(ADDITIONAL_CATEGORY_KEY_IDS.map((id) => t(id))),
+);
+
+const mainCategoryOrderMap = computed(() => {
+  const map = new Map<string, number>();
+  MAIN_CATEGORY_ORDER_IDS.forEach((id, idx) => {
+    map.set(t(id), idx);
+  });
+  return map;
+});
+
+const additionalCategoryOrderMap = computed(() => {
+  const map = new Map<string, number>();
+  ADDITIONAL_CATEGORY_KEY_IDS.forEach((id, idx) => {
+    map.set(t(id), idx);
+  });
+  return map;
+});
 
 const datasetSource = computed(() => {
   if (!props.breakdownData) return [];
@@ -429,8 +464,9 @@ const datasetSource = computed(() => {
   // Partition into additional and main categories
   const additional = [];
   const main = [];
+  const addSet = additionalCategoryKeysSet.value;
   for (const item of allData) {
-    if (ADDITIONAL_CATEGORY_KEYS.includes(String(item.category))) {
+    if (addSet.has(String(item.category))) {
       additional.push(item);
     } else {
       main.push(item);
@@ -438,20 +474,16 @@ const datasetSource = computed(() => {
   }
 
   // Sort main and additional separately
+  const mainMap = mainCategoryOrderMap.value;
   main.sort((a, b) => {
-    const aIdx = MAIN_CATEGORY_ORDER.indexOf(String(a.category));
-    const bIdx = MAIN_CATEGORY_ORDER.indexOf(String(b.category));
-    if (aIdx === -1 && bIdx === -1) return 0;
-    if (aIdx === -1) return 1;
-    if (bIdx === -1) return -1;
+    const aIdx = mainMap.get(String(a.category)) ?? 999;
+    const bIdx = mainMap.get(String(b.category)) ?? 999;
     return aIdx - bIdx;
   });
+  const addMap = additionalCategoryOrderMap.value;
   additional.sort((a, b) => {
-    const aIdx = ADDITIONAL_CATEGORY_KEYS.indexOf(String(a.category));
-    const bIdx = ADDITIONAL_CATEGORY_KEYS.indexOf(String(b.category));
-    if (aIdx === -1 && bIdx === -1) return 0;
-    if (aIdx === -1) return 1;
-    if (bIdx === -1) return -1;
+    const aIdx = addMap.get(String(a.category)) ?? 999;
+    const bIdx = addMap.get(String(b.category)) ?? 999;
     return aIdx - bIdx;
   });
 

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -295,7 +295,7 @@ export const CHART_CATEGORY_COLOR_SCHEMES = computed(() => ({
   equipment: colors.value.mauve.darker,
   external_cloud_and_ai: colors.value.paleYellowGreen.darker,
   purchases: colors.value.lavender.darker,
-  research_facilities: colors.value.peach.darker,
+  research_facilities: colors.value.paleYellowGreen.darker,
   professional_travel: colors.value.babyBlue.darker,
   commuting: colors.value.aqua.darker,
   food: colors.value.mint.darker,
@@ -311,7 +311,7 @@ export const CHART_CATEGORY_COLOR_SCALES = computed(() => ({
   equipment: colors.value.lilac,
   external_cloud_and_ai: colors.value.paleYellowGreen,
   purchases: colors.value.lightGreen,
-  research_facilities: colors.value.peach,
+  research_facilities: colors.value.paleYellowGreen,
   professional_travel: colors.value.babyBlue,
   commuting: colors.value.aqua,
   food: colors.value.mint,
@@ -370,6 +370,10 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
       // (from emission type `external__ai__provider_*`).
       provider: colors.value.paleYellowGreen.light,
       ai_provider: colors.value.paleYellowGreen.light,
+    },
+    research_facilities: {
+      facilities: colors.value.paleYellowGreen.darker,
+      animal: colors.value.paleYellowGreen.dark,
     },
     purchases: {
       scientific_equipment: colors.value.lightGreen.darker,

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -143,6 +143,10 @@ export default {
     en: 'Show additional estimated categories',
     fr: 'Afficher les catégories supplémentaires',
   },
+  results_hide_research_facilities: {
+    en: 'Hide Research Facilities',
+    fr: 'Masquer les infrastructures de recherche',
+  },
   results_carbon_footprint_per_person: {
     en: 'Carbon Footprint Per Person',
     fr: 'Empreinte carbone par personne',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -2,6 +2,7 @@
 import { computed, ref, onMounted, watch } from 'vue';
 import { MODULES_LIST } from 'src/constant/modules';
 import { MODULES_CONFIG } from 'src/constant/module-config';
+
 import { colorblindMode } from 'src/constant/charts';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
@@ -49,13 +50,27 @@ const currentYear = computed(() => {
 const resultsSummary = ref<ResultsSummary | null>(null);
 const resultsSummaryLoading = ref(false);
 
+const hideResearchFacilities = ref(false);
+
+const excludedModules = computed(() => {
+  const ids: number[] = [];
+  if (hideResearchFacilities.value) {
+    const id = getModuleTypeId(MODULES.ResearchFacilities);
+    if (id !== undefined) ids.push(id);
+  }
+  return ids;
+});
+
 async function fetchResultsSummary() {
   const carbonReportId = workspaceStore.selectedCarbonReport?.id;
   if (!carbonReportId) return;
 
   try {
     resultsSummaryLoading.value = true;
-    resultsSummary.value = await getResultsSummary(carbonReportId);
+    resultsSummary.value = await getResultsSummary(
+      carbonReportId,
+      excludedModules.value,
+    );
   } catch (error) {
     console.error('Error fetching results summary:', error);
     resultsSummary.value = null;
@@ -67,7 +82,7 @@ async function fetchResultsSummary() {
 async function fetchEmissionBreakdown() {
   const carbonReportId = workspaceStore.selectedCarbonReport?.id;
   if (!carbonReportId) return;
-  await moduleStore.getEmissionBreakdown(carbonReportId);
+  await moduleStore.getEmissionBreakdown(carbonReportId, excludedModules.value);
 }
 
 onMounted(() => {
@@ -83,6 +98,11 @@ watch(
     fetchEmissionBreakdown();
   },
 );
+
+async function onHideResearchFacilitiesChange() {
+  moduleStore.invalidateEmissionBreakdown();
+  await Promise.all([fetchResultsSummary(), fetchEmissionBreakdown()]);
+}
 
 const isModuleValidated = (module: string) => {
   return timelineStore.itemStates[module as Module] === MODULE_STATES.Validated;
@@ -174,6 +194,14 @@ const getUncertainty = (
                 color="accent"
                 class="text-weight-medium"
                 size="xs"
+              />
+              <q-checkbox
+                v-model="hideResearchFacilities"
+                :label="$t('results_hide_research_facilities')"
+                color="accent"
+                class="text-weight-medium"
+                size="xs"
+                @update:model-value="onHideResearchFacilitiesChange"
               />
               <q-separator class="q-my-sm" />
               <q-checkbox
@@ -321,7 +349,10 @@ const getUncertainty = (
         </q-card>
         <template v-for="module in MODULES_LIST" :key="module">
           <q-card
-            v-if="module !== MODULES.Headcount"
+            v-if="
+              module !== MODULES.Headcount &&
+              !(hideResearchFacilities && module === MODULES.ResearchFacilities)
+            "
             flat
             bordered
             class="q-pa-none q-mt-xl"

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -761,7 +761,10 @@ export const useModuleStore = defineStore('modules', () => {
     emissionBreakdownCarbonReportId.value = null;
   }
 
-  async function getEmissionBreakdown(carbonReportId: number) {
+  async function getEmissionBreakdown(
+    carbonReportId: number,
+    excludeModules: number[] = [],
+  ) {
     if (emissionBreakdownCarbonReportId.value === carbonReportId) return;
     if (
       emissionBreakdownInFlight &&
@@ -782,7 +785,12 @@ export const useModuleStore = defineStore('modules', () => {
         emissionBreakdownInFlightReportId.value === carbonReportId;
 
       try {
-        const path = `modules-stats/${encodeURIComponent(carbonReportId)}/emission-breakdown`;
+        const params = new URLSearchParams();
+        excludeModules.forEach((id) =>
+          params.append('exclude_modules', String(id)),
+        );
+        const qs = params.toString() ? `?${params.toString()}` : '';
+        const path = `modules-stats/${encodeURIComponent(carbonReportId)}/emission-breakdown${qs}`;
         const data = await api.get(path).json<EmissionBreakdownResponse>();
         if (!isLatestRequest()) {
           return;


### PR DESCRIPTION
## What does this change?

This PR introduces the ability to **exclude specific modules from results summary and emission breakdown**, with an initial use case for **toggling Research Facilities**.

### Backend
- Added `exclude_modules` query param to:
  - `GET /results-summary`
  - `GET /emission-breakdown`
- Updated:
  - `compute_results_summary` to exclude selected modules from:
    - per-module results
    - total emissions
  - `build_chart_breakdown` to:
    - skip excluded modules at row level
    - remove them from category breakdowns and totals
- Added unit tests covering:
  - single module exclusion
  - multiple module exclusion

### Frontend
- Added **“Hide Research Facilities” toggle** in Results page
- Connected toggle to:
  - `getResultsSummary`
  - `getEmissionBreakdown`
- Updated API layer to pass `exclude_modules` as query params
- Updated charts:
  - Dynamic scope overlays using `convertToPixel` (removes hardcoded layout assumptions)
  - Added research facilities subcategories (facilities, animal)
- Updated color mappings for consistency

### Docs
- Added full implementation plan in:
  - `docs/implementation-plans/772-toggle-research-facilities.md`

---

## Why is this needed?

- Users need the ability to **analyze carbon results without certain modules**, especially Research Facilities which can significantly skew totals.
- Previously:
  - Data was always fully included
  - Charts assumed fixed category counts → broke visually when data changed
- This change:
  - Enables **flexible, backend-driven filtering**
  - Makes charts **robust to dynamic datasets**
  - Establishes a **generic pattern for future module toggles**

---

## Type of change

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [] 📝 Documentation update  
- [x] 🎨 Design/UI improvement  
- [ ] 🔧 Configuration change  
- [ ] 🧹 Code cleanup  

---

## Related issues

- Closes #772  
- Related to #