### PR TITLE
feat(707): added sync factors implementation for research facilities

### DIFF
--- a/backend/alembic/versions/2026_04_08_1000-707_add_computed_to_ingestion_method_enum.py
+++ b/backend/alembic/versions/2026_04_08_1000-707_add_computed_to_ingestion_method_enum.py
@@ -1,0 +1,41 @@
+# codeql[py/unused-global-variable]
+"""add computed to ingestion_method_enum
+
+Revision ID: 707add_computed
+Revises: 78a9e8951a27
+Create Date: 2026-04-08 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "707add_computed"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "78a9e8951a27"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Native PostgreSQL enum — ALTER TYPE ... ADD VALUE cannot run inside a
+    # transaction in PostgreSQL < 12. PostgreSQL 12+ allows it, but the new
+    # value is not visible until the transaction commits; that is acceptable here.
+    op.execute("ALTER TYPE ingestion_method_enum ADD VALUE IF NOT EXISTS 'computed'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # PostgreSQL does not support removing individual enum values.
+    # A full enum-type recreation would be required; left as a no-op.
+    pass

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -9,6 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.core.security import is_permitted, require_permission
+from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import (
     DataIngestionJob,
     EntityType,
@@ -196,25 +197,102 @@ async def sync_module_data_entries(
     }
 
 
-@router.post("/factors/{module_id}/{factor_type_id}", response_model=SyncStatusResponse)
+@router.post(
+    "/factors/{module_type_id}/{data_entry_type_id}", response_model=SyncStatusResponse
+)
 async def sync_module_factors(
-    module_id: int,
-    factor_type_id: int,
+    module_type_id: ModuleTypeEnum,
+    data_entry_type_id: DataEntryTypeEnum,
     syncRequest: SyncRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
         require_permission("backoffice.data_management", "sync")
     ),
 ):
     """
-    Sync factors for a specific module.
+    Sync (recompute) factors for a specific module and data-entry type.
 
     **Required Permission**: `backoffice.data_management.sync`
 
-    Implementation similar to sync_module_data_entries,
-    but tailored for factor synchronization.
+    ``year`` is **mandatory** for this endpoint — factor updates are always
+    year-scoped.
+
+    Example request body for computed factor update:
+    {
+        "ingestion_method": 3,
+        "target_type": 1,
+        "year": 2025
+    }
     """
-    pass
+    if syncRequest.year is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="year is required for factor sync",
+        )
+
+    config: dict = {
+        "entity_type": EntityType.MODULE_PER_YEAR.value,
+        "year": syncRequest.year,
+        "data_entry_type_id": data_entry_type_id.value,
+    }
+
+    provider = await ProviderFactory.create_provider(
+        module_type_id=ModuleTypeEnum(module_type_id),
+        ingestion_method=syncRequest.ingestion_method,
+        target_type=syncRequest.target_type,
+        config=config,
+        user=current_user,
+        job_session=db,
+        data_session=db,
+    )
+
+    if not provider:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Provider '{syncRequest.ingestion_method}' not supported for "
+                f"module '{module_type_id}' / data-entry type '{data_entry_type_id}'"
+            ),
+        )
+
+    if not await provider.validate_connection():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Cannot connect to {syncRequest.ingestion_method}",
+        )
+
+    job_id = await provider.create_job(
+        module_type_id=ModuleTypeEnum(module_type_id),
+        data_entry_type_id=data_entry_type_id.value,
+        entity_type=EntityType.MODULE_PER_YEAR,
+        year=syncRequest.year,
+        ingestion_method=syncRequest.ingestion_method,
+        target_type=syncRequest.target_type,
+        config=config,
+        db=db,
+        request_context={
+            "ip_address": extract_ip_address(request),
+            "route_path": request.url.path,
+            "route_payload": await extract_route_payload(request),
+        },
+    )
+    await db.commit()
+
+    background_tasks.add_task(
+        run_ingestion,
+        provider_name=provider.__class__.__name__,
+        job_id=job_id,
+        filters=syncRequest.filters or {},
+    )
+
+    return {
+        "job_id": job_id,
+        "state": IngestionState.NOT_STARTED,
+        "message": f"Sync initiated using {syncRequest.ingestion_method}",
+        "progress": None,
+    }
 
 
 @router.get("/jobs/by-status", response_model=list[DataIngestionJob])

--- a/backend/app/models/data_entry.py
+++ b/backend/app/models/data_entry.py
@@ -48,7 +48,6 @@ class DataEntryTypeEnum(int, Enum):
     # Implementation of the module "Research facilities" and its sub-modules:
     research_facilities = 70
     mice_and_fish_animal_facilities = 71
-    other_research_facilities = 72
 
 
 class DataEntrySourceEnum(int, Enum):

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -51,11 +51,14 @@ class IngestionMethod(int, Enum):
     :vartype csv: Literal[1]
     :var manual: Description
     :vartype manual: Literal[2]
+    :var computed: Recompute factor values from existing emission data
+    :vartype computed: Literal[3]
     """
 
     api = 0
     csv = 1
     manual = 2
+    computed = 3
 
 
 class TargetType(int, Enum):

--- a/backend/app/services/data_ingestion/computed_providers/__init__.py
+++ b/backend/app/services/data_ingestion/computed_providers/__init__.py
@@ -1,0 +1,1 @@
+# Computed (emission-derived) factor update providers

--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
@@ -74,9 +74,10 @@ class ResearchFacilitiesAnimalFactorUpdateProvider(BaseFactorUpdateProvider):
             session: Database session (read-only; writes batched by caller).
 
         Returns:
-            Dict of ``{"kg_co2eq_sum_<source>": <float>}`` for every source
-            that has non-zero totals, or ``None`` if
-            ``researchfacility_id`` is absent (factor is skipped, not errored).
+            Dict of ``{"kg_co2eq_sum_<source>": <float>}`` for every configured
+            source, including ``0.0`` totals when no emissions match, or
+            ``None`` if ``researchfacility_id`` is absent (factor is skipped,
+            not errored).
 
         Raises:
             ValueError: When the Unit or CarbonReport cannot be found — these

--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
@@ -1,0 +1,141 @@
+"""Factor update provider for research facilities animal (mice & fish) factors.
+
+Recomputes the kg_co2eq_sum_* fields on each factor by aggregating
+DataEntryEmission totals from the corresponding Unit's CarbonReport.
+"""
+
+from typing import Any, Dict, Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.data_entry_emission import EmissionType, get_all_nodes
+from app.models.factor import Factor
+from app.repositories.carbon_report_repo import CarbonReportRepository
+from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
+from app.repositories.unit_repo import UnitRepository
+from app.services.data_ingestion.factor_update_provider import BaseFactorUpdateProvider
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Build a frozen mapping from source name → set of valid emission_type_id ints.
+# This covers every node in each sub-tree (root + intermediates + leaves) so
+# that emissions stored at any granularity level are correctly classified.
+# ---------------------------------------------------------------------------
+_purchases_additional_ids: frozenset[int] = frozenset(
+    e.value for e in get_all_nodes(EmissionType.purchases__additional)
+)
+_purchases_all_ids: frozenset[int] = frozenset(
+    e.value for e in get_all_nodes(EmissionType.purchases)
+)
+
+# Mapping: factor value-field source name → frozenset of valid emission_type_ids
+SOURCE_EMISSION_MAP: Dict[str, frozenset[int]] = {
+    "processemissions": frozenset(
+        e.value for e in get_all_nodes(EmissionType.process_emissions)
+    ),
+    "building_energycombustions": frozenset(
+        e.value for e in get_all_nodes(EmissionType.buildings__combustion)
+    ),
+    "building_rooms": frozenset(
+        e.value for e in get_all_nodes(EmissionType.buildings__rooms)
+    ),
+    # purchases_additional is a sub-tree of purchases; common = all - additional
+    "purchases_common": _purchases_all_ids - _purchases_additional_ids,
+    "purchases_additional": _purchases_additional_ids,
+    "equipments": frozenset(e.value for e in get_all_nodes(EmissionType.equipment)),
+}
+
+
+class ResearchFacilitiesAnimalFactorUpdateProvider(BaseFactorUpdateProvider):
+    """Recomputes kg_co2eq_sum_* factor values for mice & fish animal facilities.
+
+    For each factor, uses ``classification.researchfacility_id`` to resolve
+    the corresponding Unit, then aggregates DataEntryEmission totals across
+    the whole CarbonReport (all module types) for the requested year.
+
+    Only the ``kg_co2eq_sum_*`` keys are overwritten; shares, use_unit, and
+    total_use are left untouched.
+    """
+
+    async def compute_factor_values(
+        self,
+        factor: Factor,
+        year: int,
+        session: AsyncSession,
+    ) -> Optional[Dict[str, Any]]:
+        """Compute updated kg_co2eq_sum_* values from actual emission data.
+
+        Args:
+            factor: The factor record whose classification holds
+                    ``researchfacility_id``.
+            year: Reference year for the CarbonReport lookup.
+            session: Database session (read-only; writes batched by caller).
+
+        Returns:
+            Dict of ``{"kg_co2eq_sum_<source>": <float>}`` for every source
+            that has non-zero totals, or ``None`` if
+            ``researchfacility_id`` is absent (factor is skipped, not errored).
+
+        Raises:
+            ValueError: When the Unit or CarbonReport cannot be found — these
+                        are surfaced as errors, not silent skips.
+        """
+        researchfacility_id: Optional[str] = factor.classification.get(
+            "researchfacility_id"
+        )
+        if not researchfacility_id:
+            logger.warning(
+                f"Factor {factor.id} has no researchfacility_id in classification; "
+                "skipping"
+            )
+            return None
+
+        # 1. Resolve Unit by institutional_id (= researchfacility_id)
+        unit = await UnitRepository(session).get_by_institutional_id(
+            researchfacility_id
+        )
+        if unit is None:
+            raise ValueError(
+                f"Unit not found for researchfacility_id={researchfacility_id!r}"
+            )
+        if unit.id is None:
+            raise ValueError(
+                f"Unit has no database id for "
+                f"researchfacility_id={researchfacility_id!r}"
+            )
+
+        # 2. Resolve CarbonReport for this unit and year
+        carbon_report = await CarbonReportRepository(session).get_by_unit_and_year(
+            unit.id, year
+        )
+        if carbon_report is None:
+            raise ValueError(
+                f"CarbonReport not found for unit_id={unit.id}, year={year} "
+                f"(researchfacility_id={researchfacility_id!r})"
+            )
+        if carbon_report.id is None:
+            raise ValueError(
+                f"CarbonReport has no database id for unit_id={unit.id}, year={year}"
+            )
+
+        # 3. Aggregate all emissions across the entire CarbonReport, broken
+        #    down by (module_type_id, emission_type_id).  We use all modules so
+        #    that process, buildings, equipment, and purchase contributions are
+        #    captured regardless of which CarbonReportModule they live in.
+        breakdown = await DataEntryEmissionRepository(session).get_emission_breakdown(
+            carbon_report.id
+        )
+        # breakdown: list of (module_type_id, emission_type_id, kg_co2eq_sum)
+
+        # 4. Aggregate per source using the SOURCE_EMISSION_MAP
+        source_totals: Dict[str, float] = {src: 0.0 for src in SOURCE_EMISSION_MAP}
+        for _module_type_id, emission_type_id, kg in breakdown:
+            for source, valid_ids in SOURCE_EMISSION_MAP.items():
+                if emission_type_id in valid_ids:
+                    source_totals[source] += kg
+                    break  # each emission type belongs to exactly one source bucket
+
+        # 5. Return only keys with actual data
+        return {f"kg_co2eq_sum_{src}": total for src, total in source_totals.items()}

--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
@@ -1,0 +1,100 @@
+"""Factor update provider for research facilities common (DE type 70) factors.
+
+Recomputes kg_co2eq_sum on each factor by summing ALL DataEntryEmission
+totals from the corresponding facility's CarbonReport regardless of module
+type or emission type.
+"""
+
+from typing import Any, Dict, Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.factor import Factor
+from app.repositories.carbon_report_repo import CarbonReportRepository
+from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
+from app.repositories.unit_repo import UnitRepository
+from app.services.data_ingestion.factor_update_provider import BaseFactorUpdateProvider
+
+logger = get_logger(__name__)
+
+
+class ResearchFacilitiesCommonFactorUpdateProvider(BaseFactorUpdateProvider):
+    """Recomputes kg_co2eq_sum for research_facilities (data_entry_type=70) factors.
+
+    For each factor, uses ``classification.researchfacility_id`` to resolve
+    the corresponding Unit, then sums ALL DataEntryEmission totals across the
+    whole CarbonReport for the requested year into a single ``kg_co2eq_sum``.
+
+    Only ``kg_co2eq_sum`` is overwritten; ``use_unit`` and ``total_use`` are
+    left untouched (handled by base-class merge logic).
+    """
+
+    async def compute_factor_values(
+        self,
+        factor: Factor,
+        year: int,
+        session: AsyncSession,
+    ) -> Optional[Dict[str, Any]]:
+        """Compute updated kg_co2eq_sum from actual emission data.
+
+        Args:
+            factor: The factor record whose classification holds
+                    ``researchfacility_id``.
+            year: Reference year for the CarbonReport lookup.
+            session: Database session (read-only; writes batched by caller).
+
+        Returns:
+            ``{"kg_co2eq_sum": <total float>}``, or ``None`` if
+            ``researchfacility_id`` is absent (factor is skipped, not errored).
+
+        Raises:
+            ValueError: When the Unit or CarbonReport cannot be found — these
+                        are surfaced as errors, not silent skips.
+        """
+        researchfacility_id: Optional[str] = factor.classification.get(
+            "researchfacility_id"
+        )
+        if not researchfacility_id:
+            logger.warning(
+                f"Factor {factor.id} has no researchfacility_id in classification; "
+                "skipping"
+            )
+            return None
+
+        # 1. Resolve Unit by institutional_id (= researchfacility_id)
+        unit = await UnitRepository(session).get_by_institutional_id(
+            researchfacility_id
+        )
+        if unit is None:
+            raise ValueError(
+                f"Unit not found for researchfacility_id={researchfacility_id!r}"
+            )
+        if unit.id is None:
+            raise ValueError(
+                f"Unit has no database id for "
+                f"researchfacility_id={researchfacility_id!r}"
+            )
+
+        # 2. Resolve CarbonReport for this unit and year
+        carbon_report = await CarbonReportRepository(session).get_by_unit_and_year(
+            unit.id, year
+        )
+        if carbon_report is None:
+            raise ValueError(
+                f"CarbonReport not found for unit_id={unit.id}, year={year} "
+                f"(researchfacility_id={researchfacility_id!r})"
+            )
+        if carbon_report.id is None:
+            raise ValueError(
+                f"CarbonReport has no database id for unit_id={unit.id}, year={year}"
+            )
+
+        # 3. Aggregate ALL emissions across the entire CarbonReport into one total
+        breakdown = await DataEntryEmissionRepository(session).get_emission_breakdown(
+            carbon_report.id
+        )
+        # breakdown: list of (module_type_id, emission_type_id, kg_co2eq_sum)
+        total: float = sum(kg for _module_type_id, _emission_type_id, kg in breakdown)
+
+        return {"kg_co2eq_sum": total}

--- a/backend/app/services/data_ingestion/factor_update_provider.py
+++ b/backend/app/services/data_ingestion/factor_update_provider.py
@@ -1,0 +1,182 @@
+"""Abstract base provider for recomputing factor values from existing emissions."""
+
+from abc import abstractmethod
+from typing import Any, Dict, Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import (
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.factor import Factor
+from app.repositories.factor_repo import FactorRepository
+from app.services.data_ingestion.base_provider import DataIngestionProvider
+
+logger = get_logger(__name__)
+
+
+class BaseFactorUpdateProvider(DataIngestionProvider):
+    """Abstract provider that recomputes factor values from existing emission data.
+
+    Subclasses implement ``compute_factor_values`` with the source-specific
+    aggregation logic. The ``ingest`` loop handles retrieval, updates, stats
+    tracking, and job-status reporting uniformly.
+    """
+
+    @property
+    def provider_name(self) -> IngestionMethod:
+        """Return the ingestion method identifier."""
+        return IngestionMethod.computed
+
+    @property
+    def target_type(self) -> TargetType:
+        """Return the target type for this provider."""
+        return TargetType.FACTORS
+
+    @property
+    def entity_type(self) -> EntityType:
+        """Return the entity type for this provider."""
+        return EntityType.MODULE_PER_YEAR
+
+    async def validate_connection(self) -> bool:
+        """Always valid — no external connection required."""
+        return True
+
+    async def fetch_data(self, filters: Dict[str, Any]) -> list[Dict[str, Any]]:
+        """Not used; ingest is overridden directly."""
+        return []
+
+    async def transform_data(
+        self, raw_data: list[Dict[str, Any]]
+    ) -> list[Dict[str, Any]]:
+        """Not used; ingest is overridden directly."""
+        return raw_data
+
+    async def _load_data(self, data: list[Dict[str, Any]]) -> Dict[str, Any]:
+        """Not used; ingest is overridden directly."""
+        return {"inserted": 0, "skipped": 0, "errors": 0}
+
+    @abstractmethod
+    async def compute_factor_values(
+        self,
+        factor: Factor,
+        year: int,
+        session: AsyncSession,
+    ) -> Optional[Dict[str, Any]]:
+        """Compute an updated values dict for a single factor.
+
+        Args:
+            factor: The factor record to update.
+            year: The reference year for emission data.
+            session: Database session (read-only inside this call; writes are
+                     batched by the caller).
+
+        Returns:
+            A partial values dict whose keys will be merged into ``factor.values``
+            (existing keys not present here are preserved). Return ``None`` to
+            skip this factor without counting it as an error.
+
+        Raises:
+            ValueError: For hard errors such as a missing Unit or CarbonReport
+                        that must be surfaced clearly.
+        """
+
+    async def ingest(
+        self,
+        filters: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        """Walk all factors for (data_entry_type_id, year) and recompute values.
+
+        For each factor, calls ``compute_factor_values`` and merges the result
+        into the existing factor.values (only the returned keys are overwritten;
+        shares, use_unit, and total_use are left untouched unless explicitly
+        returned).
+
+        Args:
+            filters: Unused; kept for interface compatibility.
+
+        Returns:
+            Dict with ``state``, ``status_message``, and ``data`` (stats dict).
+        """
+        await self._update_job(
+            status_message="processing",
+            state=IngestionState.RUNNING,
+            result=None,
+            extra_metadata={"message": "Starting factor values recomputation..."},
+        )
+
+        data_entry_type_id_raw = self.config.get("data_entry_type_id")
+        year_raw = self.config.get("year")
+
+        if data_entry_type_id_raw is None:
+            raise ValueError("data_entry_type_id is required for factor update")
+        if year_raw is None:
+            raise ValueError("year is required for factor update")
+
+        year = int(year_raw)
+        data_entry_type = DataEntryTypeEnum(int(data_entry_type_id_raw))
+
+        factor_repo = FactorRepository(self.data_session)
+        factors = await factor_repo.list_by_data_entry_type(
+            data_entry_type_id=data_entry_type,
+            year=year,
+        )
+
+        await self._update_job(
+            status_message="processing",
+            state=IngestionState.RUNNING,
+            result=None,
+            extra_metadata={"message": f"Found {len(factors)} factors to process"},
+        )
+
+        stats: Dict[str, Any] = {
+            "updated": 0,
+            "skipped": 0,
+            "errors": 0,
+            "error_details": [],
+        }
+
+        for factor in factors:
+            if factor.id is None:
+                stats["skipped"] += 1
+                continue
+            try:
+                updated_values = await self.compute_factor_values(
+                    factor, year, self.data_session
+                )
+                if updated_values is None:
+                    stats["skipped"] += 1
+                    continue
+
+                # Merge: only overwrite the returned keys; preserve all others
+                merged_values = {**factor.values, **updated_values}
+                await factor_repo.update(factor.id, {"values": merged_values})
+                stats["updated"] += 1
+
+            except Exception as e:
+                stats["errors"] += 1
+                stats["error_details"].append({"factor_id": factor.id, "error": str(e)})
+                logger.error(f"Error updating factor {factor.id}: {e}")
+
+        result_outcome = (
+            IngestionResult.WARNING if stats["errors"] > 0 else IngestionResult.SUCCESS
+        )
+        status_msg = (
+            f"Completed with {stats['errors']} error(s)"
+            if stats["errors"] > 0
+            else "Success"
+        )
+        return {
+            "state": IngestionState.FINISHED,
+            "status_message": status_msg,
+            "data": {
+                "result": result_outcome,
+                "stats": stats,
+            },
+        }

--- a/backend/app/services/data_ingestion/provider_factory.py
+++ b/backend/app/services/data_ingestion/provider_factory.py
@@ -10,6 +10,12 @@ from app.services.data_ingestion.api_providers.professional_travel_api_provider 
     ProfessionalTravelApiProvider,
 )
 from app.services.data_ingestion.base_provider import DataIngestionProvider
+from app.services.data_ingestion.computed_providers.research_facilities_animal import (
+    ResearchFacilitiesAnimalFactorUpdateProvider,
+)
+from app.services.data_ingestion.computed_providers.research_facilities_common import (
+    ResearchFacilitiesCommonFactorUpdateProvider,
+)
 from app.services.data_ingestion.csv_providers import (
     ModulePerYearCSVProvider,
     ModulePerYearFactorCSVProvider,
@@ -21,7 +27,7 @@ class ProviderFactory:
     """Factory to create the right provider based on module + provider
     type + entity type"""
 
-    # Registry of available providers
+    # Registry of CSV/API providers.
     # Key: (module_type, ingestion_method, target_type, entity_type)
     PROVIDERS: dict[
         tuple[ModuleTypeEnum, IngestionMethod, TargetType, EntityType],
@@ -66,8 +72,37 @@ class ProviderFactory:
         ): ProfessionalTravelApiProvider,
     }
 
+    # Registry of computed providers that are keyed by data_entry_type as well.
+    # Key: (module_type, data_entry_type, ingestion_method, target_type, entity_type)
+    COMPUTED_FACTOR_PROVIDERS: dict[
+        tuple[
+            ModuleTypeEnum,
+            DataEntryTypeEnum,
+            IngestionMethod,
+            TargetType,
+            EntityType,
+        ],
+        type[DataIngestionProvider],
+    ] = {
+        (
+            ModuleTypeEnum.research_facilities,
+            DataEntryTypeEnum.mice_and_fish_animal_facilities,
+            IngestionMethod.computed,
+            TargetType.FACTORS,
+            EntityType.MODULE_PER_YEAR,
+        ): ResearchFacilitiesAnimalFactorUpdateProvider,
+        (
+            ModuleTypeEnum.research_facilities,
+            DataEntryTypeEnum.research_facilities,
+            IngestionMethod.computed,
+            TargetType.FACTORS,
+            EntityType.MODULE_PER_YEAR,
+        ): ResearchFacilitiesCommonFactorUpdateProvider,
+    }
+
     PROVIDERS_BY_CLASS_NAME: dict[str, type[DataIngestionProvider]] = {
-        v.__name__: v for _, v in PROVIDERS.items()
+        **{v.__name__: v for _, v in PROVIDERS.items()},
+        **{v.__name__: v for _, v in COMPUTED_FACTOR_PROVIDERS.items()},
     }
 
     @staticmethod
@@ -90,9 +125,26 @@ class ProviderFactory:
         """
         Get the appropriate provider class by routing keys.
 
-        entity_type determines which provider variant to use
-        (e.g., MODULE_UNIT_SPECIFIC vs MODULE_PER_YEAR).
+        For computed providers, a 5-tuple lookup using data_entry_type is
+        attempted first; falls back to the 4-tuple PROVIDERS dict for CSV/API
+        providers that don't carry a data_entry_type in their key.
         """
+        if data_entry_type_id is not None:
+            try:
+                det = DataEntryTypeEnum(data_entry_type_id)
+            except ValueError:
+                det = None
+            if det is not None:
+                five_tuple_key = (
+                    module_type_id,
+                    det,
+                    ingestion_method,
+                    target_type,
+                    entity_type,
+                )
+                result = ProviderFactory.COMPUTED_FACTOR_PROVIDERS.get(five_tuple_key)
+                if result is not None:
+                    return result
         return ProviderFactory.PROVIDERS.get(
             (module_type_id, ingestion_method, target_type, entity_type)
         )

--- a/backend/tests/unit/services/data_ingestion/test_provider_factory.py
+++ b/backend/tests/unit/services/data_ingestion/test_provider_factory.py
@@ -4,11 +4,18 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import EntityType, IngestionMethod, TargetType
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
 from app.services.data_ingestion.api_providers.professional_travel_api_provider import (
     ProfessionalTravelApiProvider,
+)
+from app.services.data_ingestion.computed_providers.research_facilities_animal import (
+    ResearchFacilitiesAnimalFactorUpdateProvider,
+)
+from app.services.data_ingestion.computed_providers.research_facilities_common import (
+    ResearchFacilitiesCommonFactorUpdateProvider,
 )
 from app.services.data_ingestion.csv_providers import (
     ModulePerYearCSVProvider,
@@ -108,3 +115,43 @@ async def test_create_provider_no_matching_provider():
     )
 
     assert provider is None
+
+
+def test_get_provider_by_keys_animal_computed_5tuple():
+    """5-tuple lookup for mice_and_fish → AnimalFactorUpdateProvider."""
+    provider_class = ProviderFactory.get_provider_by_keys(
+        ModuleTypeEnum.research_facilities,
+        IngestionMethod.computed,
+        TargetType.FACTORS,
+        EntityType.MODULE_PER_YEAR,
+        data_entry_type_id=DataEntryTypeEnum.mice_and_fish_animal_facilities,
+    )
+    assert provider_class is ResearchFacilitiesAnimalFactorUpdateProvider
+
+
+def test_get_provider_by_keys_common_computed_5tuple():
+    """5-tuple lookup for research_facilities (DE=70) → CommonFactorUpdateProvider."""
+    provider_class = ProviderFactory.get_provider_by_keys(
+        ModuleTypeEnum.research_facilities,
+        IngestionMethod.computed,
+        TargetType.FACTORS,
+        EntityType.MODULE_PER_YEAR,
+        data_entry_type_id=DataEntryTypeEnum.research_facilities,
+    )
+    assert provider_class is ResearchFacilitiesCommonFactorUpdateProvider
+
+
+def test_providers_by_class_name_includes_computed_providers():
+    """PROVIDERS_BY_CLASS_NAME dict exposes both computed provider classes."""
+    assert (
+        ProviderFactory.PROVIDERS_BY_CLASS_NAME.get(
+            "ResearchFacilitiesAnimalFactorUpdateProvider"
+        )
+        is ResearchFacilitiesAnimalFactorUpdateProvider
+    )
+    assert (
+        ProviderFactory.PROVIDERS_BY_CLASS_NAME.get(
+            "ResearchFacilitiesCommonFactorUpdateProvider"
+        )
+        is ResearchFacilitiesCommonFactorUpdateProvider
+    )

--- a/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
+++ b/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
@@ -1,0 +1,157 @@
+"""Tests for ResearchFacilitiesCommonFactorUpdateProvider."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.data_ingestion.computed_providers.research_facilities_common import (
+    ResearchFacilitiesCommonFactorUpdateProvider,
+)
+
+
+def _make_provider() -> ResearchFacilitiesCommonFactorUpdateProvider:
+    return ResearchFacilitiesCommonFactorUpdateProvider(
+        config={}, data_session=MagicMock()
+    )
+
+
+def _make_factor(researchfacility_id: str | None) -> MagicMock:
+    factor = MagicMock()
+    factor.id = 42
+    factor.classification = (
+        {"researchfacility_id": researchfacility_id}
+        if researchfacility_id is not None
+        else {}
+    )
+    return factor
+
+
+def _make_unit(unit_id: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(id=unit_id)
+
+
+def _make_carbon_report(report_id: int = 10) -> SimpleNamespace:
+    return SimpleNamespace(id=report_id)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_sums_all_emissions():
+    """Multiple emission rows from different modules → kg_co2eq_sum = sum of all."""
+    provider = _make_provider()
+    factor = _make_factor("RF-001")
+    session = MagicMock()
+
+    breakdown = [
+        (1, 100, 500.0),
+        (2, 200, 300.0),
+        (3, 300, 200.0),
+    ]
+
+    with (
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.UnitRepository"
+        ) as MockUnitRepo,
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.CarbonReportRepository"
+        ) as MockCRRepo,
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.DataEntryEmissionRepository"
+        ) as MockDEERepo,
+    ):
+        MockUnitRepo.return_value.get_by_institutional_id = AsyncMock(
+            return_value=_make_unit(1)
+        )
+        MockCRRepo.return_value.get_by_unit_and_year = AsyncMock(
+            return_value=_make_carbon_report(10)
+        )
+        MockDEERepo.return_value.get_emission_breakdown = AsyncMock(
+            return_value=breakdown
+        )
+
+        result = await provider.compute_factor_values(factor, 2025, session)
+
+    assert result == {"kg_co2eq_sum": 1000.0}
+
+
+@pytest.mark.asyncio
+async def test_unit_not_found_raises_value_error():
+    """Unit not found → ValueError raised."""
+    provider = _make_provider()
+    factor = _make_factor("RF-MISSING")
+    session = MagicMock()
+
+    with patch(
+        "app.services.data_ingestion.computed_providers.research_facilities_common.UnitRepository"
+    ) as MockUnitRepo:
+        MockUnitRepo.return_value.get_by_institutional_id = AsyncMock(return_value=None)
+
+        with pytest.raises(ValueError, match="Unit not found"):
+            await provider.compute_factor_values(factor, 2025, session)
+
+
+@pytest.mark.asyncio
+async def test_carbon_report_not_found_raises_value_error():
+    """CarbonReport not found → ValueError raised."""
+    provider = _make_provider()
+    factor = _make_factor("RF-001")
+    session = MagicMock()
+
+    with (
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.UnitRepository"
+        ) as MockUnitRepo,
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.CarbonReportRepository"
+        ) as MockCRRepo,
+    ):
+        MockUnitRepo.return_value.get_by_institutional_id = AsyncMock(
+            return_value=_make_unit(1)
+        )
+        MockCRRepo.return_value.get_by_unit_and_year = AsyncMock(return_value=None)
+
+        with pytest.raises(ValueError, match="CarbonReport not found"):
+            await provider.compute_factor_values(factor, 2025, session)
+
+
+@pytest.mark.asyncio
+async def test_zero_emissions_returns_zero_sum():
+    """Empty emission breakdown → returns {"kg_co2eq_sum": 0.0}."""
+    provider = _make_provider()
+    factor = _make_factor("RF-002")
+    session = MagicMock()
+
+    with (
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.UnitRepository"
+        ) as MockUnitRepo,
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.CarbonReportRepository"
+        ) as MockCRRepo,
+        patch(
+            "app.services.data_ingestion.computed_providers.research_facilities_common.DataEntryEmissionRepository"
+        ) as MockDEERepo,
+    ):
+        MockUnitRepo.return_value.get_by_institutional_id = AsyncMock(
+            return_value=_make_unit(1)
+        )
+        MockCRRepo.return_value.get_by_unit_and_year = AsyncMock(
+            return_value=_make_carbon_report(10)
+        )
+        MockDEERepo.return_value.get_emission_breakdown = AsyncMock(return_value=[])
+
+        result = await provider.compute_factor_values(factor, 2025, session)
+
+    assert result == {"kg_co2eq_sum": 0.0}
+
+
+@pytest.mark.asyncio
+async def test_missing_researchfacility_id_returns_none():
+    """Missing researchfacility_id in classification → returns None (factor skipped)."""
+    provider = _make_provider()
+    factor = _make_factor(None)
+    session = MagicMock()
+
+    result = await provider.compute_factor_values(factor, 2025, session)
+
+    assert result is None

--- a/docs/implementation-plans/707-update-computed-factors-1-animals.md
+++ b/docs/implementation-plans/707-update-computed-factors-1-animals.md
@@ -1,0 +1,94 @@
+# Plan: 707 — Implement sync_module_factors (Backend only)
+
+Using example of Research facilities module, this feature aims at allowing a backoffice manager to update factors that are already stored in the database. The update logic is module data entry type dependent.
+
+**TL;DR**: Implement the sync_module_factors stub in app/api/v1/data_sync.py. For (module_type, data_entry_type, year), the endpoint walks all factors stored for those parameters and recomputes their values fields by pulling actual DataEntryEmission totals — using classification.researchfacility_id to locate the correct Unit → CarbonReport → CarbonReportModule → emissions. Reuses the existing DataIngestionJob + background-task infrastructure, so callers poll via SSE identically to sync_module_data_entries.
+
+## Phase 1 — New ingestion method
+
+### Step 1 – Add IngestionMethod.computed = 3 to DataIngestionMethod enum
+
+- File: `data_ingestion.py`
+- Distinguishes "compute from existing emissions" from csv/api imports.
+- Requires an Alembic migration: `ALTER TYPE ingestion_method_enum ADD VALUE 'computed'` (native PostgreSQL enum — no transaction wrapper).
+
+## Phase 2 — Factor-update provider
+
+### Step 2 – Abstract BaseFactorUpdateProvider (new file)
+
+- `backend/app/services/data_ingestion/factor_update_provider.py`
+- Extends DataIngestionProvider; defines abstract compute_factor_values(factor, year, session) → dict | None.
+- Concrete ingest() loop: fetch all factors for (data_entry_type_id, year) via FactorRepository.list_by_data_entry_type, call compute_factor_values, apply FactorRepository.update, track stats.
+
+### Step 3 – Concrete ResearchFacilitiesAnimalFactorUpdateProvider (new file)
+
+- `backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py`
+- For each factor:
+  1. Read researchfacility_id from factor.classification.
+  2. `UnitRepository.get_by_institutional_id(researchfacility_id)` → Unit.
+  3. `CarbonReportRepository.get_by_unit_and_year(unit_id, year)` → CarbonReport.
+  4. `CarbonReportModuleRepository` → find module for (carbon_report_id, module_type_id=research_facilities).
+  5. `DataEntryEmissionRepository.get_stats(carbon_report_module_id, aggregate_by="emission_type_id")` → sums per emission_type.
+  6. Map EmissionType leaf → source name (e.g. process_emissions → processemissions, buildings\_\_rooms → building_rooms, etc.).
+  7. Return updated values dict: only overwrite kg*co2eq_sum*{source} keys; leave shares / use_unit / total_use untouched.
+  8. Surface missing unit/carbon-report with a clear error — no silent skip.
+
+### Step 4 – Register in ProviderFactory
+
+- File: `provider_factory.py`
+- Add entry: (ModuleTypeEnum.research_facilities, IngestionMethod.computed, TargetType.FACTORS, EntityType.MODULE_PER_YEAR) → ResearchFacilitiesAnimalFactorUpdateProvider.
+
+## Phase 3 — API endpoint
+
+### Step 5 – Implement sync_module_factors stub (depends on Steps 1–4)
+
+- File: `data_sync.py`
+- Fix route path typo: {module_id} → {module_type_id}.
+- Remove duplicate permission check body (decorator already handles it).
+- Validate syncRequest.year is mandatory.
+- Set entity_type = EntityType.MODULE_PER_YEAR, call ProviderFactory.create_provider(..., ingestion_method=IngestionMethod.computed), create job, schedule background task, return SyncStatusResponse — mirrors sync_module_data_entries exactly.
+
+## Phase 4 — Tests
+
+### Step 6 – Unit tests for ResearchFacilitiesAnimalFactorUpdateProvider
+
+- New file: `backend/tests/unit/services/data_ingestion/test_research_facilities_animal_factor_update.py`
+- Cases: happy path (all sources), unit not found, carbon report not found, partial sources present.
+
+### Step 7 – Extend test_provider_factory.py (parallel with step 6)
+
+- Assert new (research_facilities, computed, FACTORS, MODULE_PER_YEAR) key resolves to the new provider.
+
+## Relevant files
+
+- `data_sync.py` — fill in stub
+- `data_ingestion.py` — add computed = 3
+- `backend/app/services/data_ingestion/factor_update_provider.py` — new abstract base
+- `backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py` — new concrete provider
+- `provider_factory.py` — register
+- `factor_repo.py` — reuse list_by_data_entry_type
+- `data_entry_emission_repo.py` — reuse get_stats
+- `versions` — new migration for native enum value
+- `backend/tests/unit/services/data_ingestion/test_research_facilities_animal_factor_update.py` — new
+- `test_provider_factory.py` — extend
+
+## Verification
+
+1. make lint + make typecheck (ruff + mypy strict) pass on all changed files.
+2. New test file: all 4 cases pass.
+3. Provider factory test: new registration asserted.
+4. Manual: POST /data-sync/factors/research_facilities/mice_and_fish_animal_facilities body {"ingestion_method": 3, "target_type": 1, "year": 2025} → returns job_id; SSE polling → FINISHED/SUCCESS; Factor.values.kg_co2eq_sum_processemissions updated per facility.
+5. ModulePerYearFactorCSVProvider tests still pass (no regression on CSV factor ingestion).
+
+## Decisions
+
+- IngestionMethod.computed = 3 avoids conflating this with api in job history.
+- year is mandatory for this endpoint (unlike data-entry sync).
+- Route typo {module_id} → {module_type_id} fixed as part of this PR.
+- ResearchFacilitiesCommonFactorUpdateProvider (single kg_co2eq_sum) is out of scope.
+
+## Further considerations
+
+1. CarbonReportModuleRepository gap — confirm whether a method get_by_carbon_report_id_and_module_type already exists; if not, add it before Step 3 is executable.
+2. Emission aggregation scope — get_stats aggregates all DataEntryEmission rows for a carbon_report_module_id; confirm that the research_facilities module stores all lab-emission sub-types (process, buildings, rooms, equipment, purchases) under a single CarbonReportModule, or whether separate modules need to be joined.
+3. Alembic native-enum migration — ALTER TYPE … ADD VALUE cannot run inside a transaction; verify alembic.ini settings (transaction_per_migration) or add op.execute with explicit connect_args={"isolation_level": "AUTOCOMMIT"}.

--- a/docs/implementation-plans/707-update-computed-factors-2-common.md
+++ b/docs/implementation-plans/707-update-computed-factors-2-common.md
@@ -1,0 +1,92 @@
+# Plan: 707-ext — sync_module_factors for research_facilities common (DE type 70)
+
+## TL;DR
+
+Add `ResearchFacilitiesCommonFactorUpdateProvider` that recomputes `kg_co2eq_sum`
+(single total) for data_entry_type=70 (research_facilities) factors, by summing ALL
+DataEntryEmission totals from the corresponding facility's CarbonReport.
+Mirrors the animal provider pattern but with a single-field output. Also updates the
+ProviderFactory to use 5-tuple keys for computed providers so both 70 and 71
+can coexist.
+
+---
+
+## Phase 1 — Factory key update (enables both providers to coexist)
+
+### Step 1 — Update `provider_factory.py` to use 5-tuple for computed providers
+
+- File: `backend/app/services/data_ingestion/provider_factory.py`
+- Remove the existing 4-tuple entry: `(research_facilities, computed, FACTORS, MODULE_PER_YEAR)`
+- Add new import: `ResearchFacilitiesCommonFactorUpdateProvider`
+- Add two 5-tuple entries to a dedicated `COMPUTED_FACTOR_PROVIDERS` dict (or extend PROVIDERS):
+  - `(research_facilities, mice_and_fish_animal_facilities, computed, FACTORS, MODULE_PER_YEAR)` → `ResearchFacilitiesAnimalFactorUpdateProvider`
+  - `(research_facilities, research_facilities, computed, FACTORS, MODULE_PER_YEAR)` → `ResearchFacilitiesCommonFactorUpdateProvider`
+- Update `get_provider_by_keys`: when `data_entry_type_id` is provided, try 5-tuple `(module_type, data_entry_type, ingestion_method, target_type, entity_type)` first; fall back to 4-tuple if not found (for CSV/API providers that don't have data_entry_type in key).
+- Update `PROVIDERS_BY_CLASS_NAME` to include common provider.
+
+## Phase 2 — New concrete provider
+
+### Step 2 — Add `ResearchFacilitiesCommonFactorUpdateProvider` (new file)
+
+- File: `backend/app/services/data_ingestion/computed_providers/research_facilities_common.py`
+- Extends `BaseFactorUpdateProvider`
+- `compute_factor_values(factor, year, session)`:
+  1. Read `researchfacility_id` from `factor.classification.get("researchfacility_id")`
+  2. Return `None` + warning log if absent (same pattern as animal provider)
+  3. `UnitRepository(session).get_by_institutional_id(researchfacility_id)` → Unit (raise ValueError if None)
+  4. `CarbonReportRepository(session).get_by_unit_and_year(unit.id, year)` → CarbonReport (raise ValueError if None)
+  5. `DataEntryEmissionRepository(session).get_emission_breakdown(carbon_report.id)` → list of (module_type_id, emission_type_id, kg)
+  6. Sum all `kg` values → `total: float`
+  7. Return `{"kg_co2eq_sum": total}`
+- Only `kg_co2eq_sum` is overwritten; `use_unit` and `total_use` are left untouched (handled by base class merge logic).
+
+## Phase 3 — Tests
+
+### Step 3 — Unit tests for `ResearchFacilitiesCommonFactorUpdateProvider` (new file)
+
+- File: `backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py`
+- Mirror structure of `test_research_facilities_animal_factor_update.py`
+- Cases:
+  1. Happy path: multiple emission rows from different modules → `kg_co2eq_sum` = sum of all
+  2. Unit not found → `ValueError` raised
+  3. CarbonReport not found → `ValueError` raised
+  4. Zero emissions → returns `{"kg_co2eq_sum": 0.0}`
+  5. Missing `researchfacility_id` in classification → returns `None` (skipped)
+
+### Step 4 — Extend `test_provider_factory.py` (parallel with Step 3)
+
+- File: `backend/tests/unit/services/data_ingestion/test_provider_factory.py`
+- Add assertion: 5-tuple `(research_facilities, research_facilities, computed, FACTORS, MODULE_PER_YEAR)` → `ResearchFacilitiesCommonFactorUpdateProvider`
+- Update existing assertion for animal provider to use the new 5-tuple key
+
+---
+
+## Relevant files
+
+- `backend/app/services/data_ingestion/provider_factory.py` — update registration (5-tuple) + lookup
+- `backend/app/services/data_ingestion/computed_providers/research_facilities_common.py` — NEW
+- `backend/app/services/data_ingestion/computed_providers/__init__.py` — no change needed (comment-only)
+- `backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py` — reference only
+- `backend/app/services/data_ingestion/factor_update_provider.py` — reference/no change
+- `backend/app/api/v1/data_sync.py` — no change needed (already passes data_entry_type_id in config)
+- `backend/app/repositories/data_entry_emission_repo.py` — reuse get_emission_breakdown()
+- `backend/app/repositories/unit_repo.py` — reuse get_by_institutional_id()
+- `backend/app/repositories/carbon_report_repo.py` — reuse get_by_unit_and_year()
+- `backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py` — NEW
+- `backend/tests/unit/services/data_ingestion/test_provider_factory.py` — extend
+
+## Verification
+
+1. `make lint && make typecheck` pass on all changed files.
+2. New test file: all 5 cases pass.
+3. Updated provider factory test: new and updated registrations asserted.
+4. Manual: `POST /data-sync/factors/research_facilities/research_facilities` body `{"ingestion_method": 3, "target_type": 1, "year": 2025}` → returns job_id; SSE polling → FINISHED/SUCCESS; `Factor.values.kg_co2eq_sum` updated per facility.
+5. Regression: `POST /data-sync/factors/research_facilities/mice_and_fish_animal_facilities` still resolves to `ResearchFacilitiesAnimalFactorUpdateProvider` (5-tuple lookup).
+
+## Decisions
+
+- 5-tuple factory key for computed providers; CSV/API providers remain 4-tuple (fallback).
+- `kg_co2eq_sum` = ALL emission types across entire CarbonReport (via `get_emission_breakdown()`).
+- `use_unit` and `total_use` left untouched — billing/usage denominator comes from CSV ingestion.
+- No Alembic migration needed (no schema change).
+- No changes to `data_sync.py` or `factor_update_provider.py`.

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -580,6 +580,10 @@ export default {
     en: 'Factors computed successfully',
     fr: 'Facteurs calculés avec succès',
   },
+  data_management_compute_factors_warning: {
+    en: 'Factors computed with warnings',
+    fr: 'Facteurs calculés avec avertissements',
+  },
   data_management_compute_factors_error: {
     en: 'Factor computation failed',
     fr: 'Le calcul des facteurs a échoué',

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -564,4 +564,24 @@ export default {
     en: 'File upload failed',
     fr: 'Échec du téléversement du fichier',
   },
+  data_management_compute_factors: {
+    en: 'Compute Factors',
+    fr: 'Calculer les facteurs',
+  },
+  data_management_compute_factors_confirm_title: {
+    en: 'Recompute Factors',
+    fr: 'Recalculer les facteurs',
+  },
+  data_management_compute_factors_confirm_message: {
+    en: 'This will recompute the emission factors from the existing data entries for this submodule. Any previously computed factors will be overwritten. Do you want to proceed?',
+    fr: "Ceci recalculera les facteurs d'émission à partir des données existantes pour ce sous-module. Les facteurs précédemment calculés seront écrasés. Souhaitez-vous continuer ?",
+  },
+  data_management_compute_factors_success: {
+    en: 'Factors computed successfully',
+    fr: 'Facteurs calculés avec succès',
+  },
+  data_management_compute_factors_error: {
+    en: 'Factor computation failed',
+    fr: 'Le calcul des facteurs a échoué',
+  },
 } as const;

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -284,6 +284,10 @@ export default {
     en: 'Cancel',
     fr: 'Annuler',
   },
+  common_confirm: {
+    en: 'Confirm',
+    fr: 'Confirmer',
+  },
   common_save: {
     en: 'Save',
     fr: 'Enregistrer',

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -15,6 +15,7 @@ import {
   TargetType,
   type ImportRow,
   type SyncJobResponse,
+  type JobUpdatePayload,
 } from 'src/stores/backofficeDataManagement';
 import {
   useYearConfigStore,
@@ -534,6 +535,85 @@ function openDataEntryDialog(row: ImportRow, targetType: TargetType | null) {
   dialogCurrentRow.value = row;
   dialogTargetType.value = targetType;
   showDataEntryDialog.value = true;
+}
+
+// ── Computed Factor Sync (Research Facilities only) ───────────────────────────
+
+const showComputedFactorConfirm = ref(false);
+const pendingComputedFactorSub = ref<SubmoduleConfig | null>(null);
+const computedFactorRunning = ref<Record<string, boolean>>({});
+
+function openComputedFactorConfirm(sub: SubmoduleConfig): void {
+  pendingComputedFactorSub.value = sub;
+  showComputedFactorConfirm.value = true;
+}
+
+async function confirmComputedFactorSync(): Promise<void> {
+  const sub = pendingComputedFactorSub.value;
+  if (!sub || sub.dataEntryTypeId === undefined) return;
+  showComputedFactorConfirm.value = false;
+
+  computedFactorRunning.value[sub.key] = true;
+  try {
+    const jobId = await backofficeDataManagement.initiateComputedFactorSync(
+      sub.moduleTypeId,
+      sub.dataEntryTypeId,
+      selectedYear.value,
+    );
+
+    backofficeDataManagement.subscribeToJobUpdates(
+      jobId,
+      (payload?: JobUpdatePayload) => {
+        const result = payload?.result;
+        let color: string;
+        let message: string;
+        if (result === IngestionResult.WARNING) {
+          color = 'warning';
+          message = $t('data_management_compute_factors_success');
+        } else if (result === IngestionResult.SUCCESS) {
+          color = 'positive';
+          message = $t('data_management_compute_factors_success');
+        } else {
+          color = 'negative';
+          message = $t('data_management_compute_factors_error');
+        }
+        Notify.create({
+          type: color as 'positive' | 'negative' | 'warning',
+          message,
+          position: 'top',
+          timeout: 5000,
+        });
+        computedFactorRunning.value[sub.key] = false;
+        void handleJobCompleted();
+      },
+      (payload?: JobUpdatePayload) => {
+        Notify.create({
+          type: 'negative',
+          message: $t('data_management_compute_factors_error'),
+          caption: payload?.status_message ?? '',
+          position: 'top',
+          timeout: 5000,
+        });
+        computedFactorRunning.value[sub.key] = false;
+        void handleJobCompleted();
+      },
+      () => {
+        computedFactorRunning.value[sub.key] = false;
+      },
+      () => {
+        void handleJobProgressing();
+      },
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : '';
+    Notify.create({
+      type: 'negative',
+      message: $t('data_management_compute_factors_error'),
+      caption: msg,
+      position: 'top',
+    });
+    computedFactorRunning.value[sub.key] = false;
+  }
 }
 
 function downloadLastCsv(row: ImportRow, targetType: TargetType) {
@@ -1228,6 +1308,25 @@ onMounted(() => {
                               )
                             "
                           />
+                          <template
+                            v-if="module === MODULES.ResearchFacilities"
+                          >
+                            <q-spinner-rings
+                              v-if="computedFactorRunning[submodule.key]"
+                              color="grey"
+                            />
+                            <q-btn
+                              v-else
+                              color="accent"
+                              outline
+                              icon="calculate"
+                              size="sm"
+                              :label="$t('data_management_compute_factors')"
+                              class="text-weight-medium"
+                              :disable="getImportRow(submodule).isDisabled"
+                              @click="openComputedFactorConfirm(submodule)"
+                            />
+                          </template>
                         </div>
                         <div
                           v-if="getImportRow(submodule).lastFactorJob?.meta"
@@ -1792,5 +1891,33 @@ onMounted(() => {
       @completed="handleJobCompleted"
       @progressing="handleJobProgressing"
     />
+
+    <!-- Computed factor sync confirmation dialog (Research Facilities) -->
+    <q-dialog v-model="showComputedFactorConfirm" persistent>
+      <q-card style="min-width: 420px">
+        <q-card-section class="row items-center q-pb-none">
+          <q-icon name="calculate" color="accent" size="sm" class="q-mr-sm" />
+          <div class="text-h6">
+            {{ $t('data_management_compute_factors_confirm_title') }}
+          </div>
+        </q-card-section>
+        <q-card-section class="text-body2">
+          {{ $t('data_management_compute_factors_confirm_message') }}
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn
+            flat
+            :label="$t('common_cancel')"
+            @click="showComputedFactorConfirm = false"
+          />
+          <q-btn
+            color="accent"
+            unelevated
+            :label="$t('common_confirm')"
+            @click="confirmComputedFactorSync()"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
   </q-page>
 </template>

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -542,6 +542,9 @@ function openDataEntryDialog(row: ImportRow, targetType: TargetType | null) {
 const showComputedFactorConfirm = ref(false);
 const pendingComputedFactorSub = ref<SubmoduleConfig | null>(null);
 const computedFactorRunning = ref<Record<string, boolean>>({});
+const anyComputedFactorRunning = computed(() =>
+  Object.values(computedFactorRunning.value).some(Boolean),
+);
 
 function openComputedFactorConfirm(sub: SubmoduleConfig): void {
   pendingComputedFactorSub.value = sub;
@@ -565,24 +568,30 @@ async function confirmComputedFactorSync(): Promise<void> {
       jobId,
       (payload?: JobUpdatePayload) => {
         const result = payload?.result;
-        let color: string;
-        let message: string;
         if (result === IngestionResult.WARNING) {
-          color = 'warning';
-          message = $t('data_management_compute_factors_success');
+          Notify.create({
+            type: 'warning',
+            message: $t('data_management_compute_factors_warning'),
+            caption: payload?.status_message ?? '',
+            position: 'top',
+            timeout: 5000,
+          });
         } else if (result === IngestionResult.SUCCESS) {
-          color = 'positive';
-          message = $t('data_management_compute_factors_success');
+          Notify.create({
+            type: 'positive',
+            message: $t('data_management_compute_factors_success'),
+            position: 'top',
+            timeout: 5000,
+          });
         } else {
-          color = 'negative';
-          message = $t('data_management_compute_factors_error');
+          Notify.create({
+            type: 'negative',
+            message: $t('data_management_compute_factors_error'),
+            caption: payload?.status_message ?? '',
+            position: 'top',
+            timeout: 5000,
+          });
         }
-        Notify.create({
-          type: color as 'positive' | 'negative' | 'warning',
-          message,
-          position: 'top',
-          timeout: 5000,
-        });
         computedFactorRunning.value[sub.key] = false;
         void handleJobCompleted();
       },
@@ -1323,7 +1332,10 @@ onMounted(() => {
                               size="sm"
                               :label="$t('data_management_compute_factors')"
                               class="text-weight-medium"
-                              :disable="getImportRow(submodule).isDisabled"
+                              :disable="
+                                getImportRow(submodule).isDisabled ||
+                                anyComputedFactorRunning
+                              "
                               @click="openComputedFactorConfirm(submodule)"
                             />
                           </template>

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -471,11 +471,16 @@ provider_type
             const isSuccess =
               state === IngestionState.FINISHED &&
               result === IngestionResult.SUCCESS;
+            // WARNING is a terminal state: job finished but with partial issues.
+            // Treat it as completed so callers can reset spinners and display the warning.
+            const isWarning =
+              state === IngestionState.FINISHED &&
+              result === IngestionResult.WARNING;
             const isFailure =
               state === IngestionState.FINISHED &&
               result === IngestionResult.ERROR;
 
-            if (isSuccess) {
+            if (isSuccess || isWarning) {
               onCompleted?.(update);
             }
 

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -85,6 +85,7 @@ export enum IngestionMethod {
   API = 0,
   CSV = 1,
   MANUAL = 2,
+  COMPUTED = 3,
 }
 
 export enum TargetType {
@@ -567,6 +568,47 @@ provider_type
       }
     }
 
+    /**
+     * Trigger a computed factor recomputation for a given module / data-entry type.
+     * Uses the dedicated /sync/factors endpoint with ingestion_method=COMPUTED.
+     *
+     * Returns the created job_id.
+     */
+    async function initiateComputedFactorSync(
+      moduleTypeId: number,
+      dataEntryTypeId: number,
+      year: number,
+    ): Promise<number> {
+      if (loading.value) throw new Error('Another operation is in progress');
+
+      loading.value = true;
+      error.value = null;
+
+      try {
+        const response = (await api
+          .post(`sync/factors/${moduleTypeId}/${dataEntryTypeId}`, {
+            json: {
+              ingestion_method: IngestionMethod.COMPUTED,
+              target_type: TargetType.FACTORS,
+              year,
+            },
+          })
+          .json()) as { job_id: number };
+
+        return response.job_id;
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          error.value =
+            err.message ?? 'Failed to initiate computed factor sync';
+        } else {
+          error.value = 'Failed to initiate computed factor sync';
+        }
+        throw err;
+      } finally {
+        loading.value = false;
+      }
+    }
+
     async function reset(): Promise<void> {
       loading.value = false;
       error.value = null;
@@ -594,6 +636,7 @@ provider_type
       fetchLatestSyncJobsByYear,
       getPreviousYearSuccessfulJobs,
       initiateSync,
+      initiateComputedFactorSync,
       subscribeToJobUpdates,
       unsubscribeFromJobUpdates,
       reset,


### PR DESCRIPTION
## What does this change?

* Added new data ingestion `computed` for factors that have their values computed from the data entries (or any other logic)
* Applied to Research facilities module: facilities and animals data entry types
* Implemented sync factors endpoint, as a background task
* Added buttons to data management page for Research facilities to trigger this factor computation

<img width="1145" height="543" alt="image" src="https://github.com/user-attachments/assets/77c7bccc-d50d-4970-896e-1c429ca24b78" />


## Why is this needed?

Research facilities factors depend on the emissions of facilities units.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #707

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
