### PR TITLE
feat/181 result

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4538,31 +4538,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
@@ -7355,9 +7330,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15169,6 +15144,7 @@
       "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.123.0",
         "@rolldown/pluginutils": "1.0.0-rc.13"

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -466,36 +466,16 @@ const downloadCSV = () => {
 </script>
 
 <template>
-  <q-card flat class="container container--pa-none">
+  <q-card flat class="container container--pa-none full-width">
     <q-card-section class="flex justify-between items-center">
       <div>
         <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
-          {{ props.title ?? $t('results_carbon_footprint_per_person_title') }}
+          {{
+            props.title ?? $t('results_carbon_footprint_per_FTE_no_headcount')
+          }}
         </span>
       </div>
 
-      <div v-if="headcountValidated">
-        <q-btn
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_png')"
-          size="sm"
-          class="text-weight-medium q-mr-sm"
-          @click="downloadPNG"
-        />
-        <q-btn
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_csv')"
-          size="sm"
-          class="text-weight-medium"
-          @click="downloadCSV"
-        />
-      </div>
       <q-checkbox
         v-if="headcountValidated"
         v-model="toggleAdditionalData"
@@ -514,6 +494,33 @@ const downloadCSV = () => {
           :option="chartOption"
         />
       </q-card-section>
+
+      <q-card-actions
+        v-if="headcountValidated"
+        align="center"
+        class="q-px-md q-pb-md q-pt-none"
+      >
+        <q-btn
+          unelevated
+          no-caps
+          outline
+          icon="o_download"
+          :label="$t('common_download_as_png')"
+          size="sm"
+          class="text-weight-medium q-mr-xs"
+          @click="downloadPNG"
+        />
+        <q-btn
+          unelevated
+          no-caps
+          outline
+          icon="o_download"
+          :label="$t('common_download_as_csv')"
+          size="sm"
+          class="text-weight-medium"
+          @click="downloadCSV"
+        />
+      </q-card-actions>
     </template>
 
     <template v-else>
@@ -543,7 +550,7 @@ const downloadCSV = () => {
 }
 
 .chart {
-  width: 500px;
+  width: 200px;
   min-height: 500px;
 }
 

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1215,7 +1215,31 @@ const downloadCSV = () => {
 <template>
   <q-card flat class="container container--pa-none">
     <q-card-section class="flex justify-between items-center">
-      <div>
+      <div class="module-carbon-chart__title">
+        <q-icon
+          name="o_info"
+          size="18px"
+          color="black"
+          class="module-carbon-chart__info q-ml-sm"
+        >
+          <q-tooltip
+            class="bg-white text-black shadow-4 module-carbon-chart__tooltip"
+            max-width="800px"
+          >
+            <div class="text-body2 module-carbon-chart__tooltip-line">
+              <strong>Scope 1:</strong>
+              {{ $t('results_scopes_tooltip_scope_1_desc') }}
+            </div>
+            <div class="text-body2 q-mt-xs module-carbon-chart__tooltip-line">
+              <strong>Scope 2:</strong>
+              {{ $t('results_scopes_tooltip_scope_2_desc') }}
+            </div>
+            <div class="text-body2 q-mt-xs module-carbon-chart__tooltip-line">
+              <strong>Scope 3:</strong>
+              {{ $t('results_scopes_tooltip_scope_3_desc') }}
+            </div>
+          </q-tooltip>
+        </q-icon>
         <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
           {{ props.title ?? $t('unit_carbon_footprint_title') }}
         </span>
@@ -1263,8 +1287,35 @@ const downloadCSV = () => {
 </template>
 
 <style scoped>
+.module-carbon-chart {
+  display: flex;
+  flex-direction: column;
+}
+
+.module-carbon-chart__title {
+  display: flex;
+  align-items: center;
+}
+
+.module-carbon-chart__info {
+  cursor: help;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.module-carbon-chart__tooltip-line {
+  white-space: nowrap;
+}
+
+.module-carbon-chart__body {
+  flex: 1;
+}
+
 .chart {
   width: 500px;
   min-height: 500px;
+  @media (max-width: 1320px) {
+    width: 90%;
+  }
 }
 </style>

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1213,30 +1213,54 @@ const downloadCSV = () => {
 </script>
 
 <template>
-  <q-card flat class="container container--pa-none">
+  <q-card
+    flat
+    class="container container--pa-none full-width module-carbon-chart"
+  >
     <q-card-section class="flex justify-between items-center">
-      <div class="module-carbon-chart__title">
+      <div class="flex items-center no-wrap">
         <q-icon
           name="o_info"
-          size="18px"
-          color="black"
-          class="module-carbon-chart__info q-ml-sm"
+          size="xs"
+          color="primary"
+          class="cursor-pointer"
+          :aria-label="$t('unit_carbon_footprint_scope_tooltip_aria')"
         >
           <q-tooltip
-            class="bg-white text-black shadow-4 module-carbon-chart__tooltip"
-            max-width="800px"
+            anchor="center right"
+            self="top right"
+            class="u-tooltip text-body2"
+            max-width="min(92vw, 48rem)"
+            :offset="[8, 8]"
           >
-            <div class="text-body2 module-carbon-chart__tooltip-line">
-              <strong>Scope 1:</strong>
-              {{ $t('results_scopes_tooltip_scope_1_desc') }}
-            </div>
-            <div class="text-body2 q-mt-xs module-carbon-chart__tooltip-line">
-              <strong>Scope 2:</strong>
-              {{ $t('results_scopes_tooltip_scope_2_desc') }}
-            </div>
-            <div class="text-body2 q-mt-xs module-carbon-chart__tooltip-line">
-              <strong>Scope 3:</strong>
-              {{ $t('results_scopes_tooltip_scope_3_desc') }}
+            <div class="module-carbon-scope-tooltip">
+              <p>
+                <strong>{{
+                  $t('unit_carbon_footprint_scope_prefix', {
+                    scope: $t('charts-scope'),
+                    n: 1,
+                  })
+                }}</strong>
+                {{ $t('unit_carbon_footprint_scope_1_desc') }}
+              </p>
+              <p>
+                <strong>{{
+                  $t('unit_carbon_footprint_scope_prefix', {
+                    scope: $t('charts-scope'),
+                    n: 2,
+                  })
+                }}</strong>
+                {{ $t('unit_carbon_footprint_scope_2_desc') }}
+              </p>
+              <p>
+                <strong>{{
+                  $t('unit_carbon_footprint_scope_prefix', {
+                    scope: $t('charts-scope'),
+                    n: 3,
+                  })
+                }}</strong>
+                {{ $t('unit_carbon_footprint_scope_3_desc') }}
+              </p>
             </div>
           </q-tooltip>
         </q-icon>
@@ -1245,28 +1269,6 @@ const downloadCSV = () => {
         </span>
       </div>
 
-      <div>
-        <q-btn
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_png')"
-          size="sm"
-          class="text-weight-medium q-mr-sm"
-          @click="downloadPNG"
-        />
-        <q-btn
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_csv')"
-          size="sm"
-          class="text-weight-medium"
-          @click="downloadCSV"
-        />
-      </div>
       <q-checkbox
         v-model="toggleAdditionalData"
         :label="$t('results_module_carbon_toggle_additional_data')"
@@ -1274,7 +1276,10 @@ const downloadCSV = () => {
         color="accent"
       />
     </q-card-section>
-    <q-card-section class="chart-container flex justify-center items-center">
+
+    <q-card-section
+      class="chart-container flex justify-center items-center module-carbon-chart__body"
+    >
       <v-chart
         ref="chartRef"
         class="chart"
@@ -1283,6 +1288,29 @@ const downloadCSV = () => {
         @rendered="recalculateScopeRects"
       />
     </q-card-section>
+
+    <q-card-actions align="center" class="q-px-md q-pb-md q-pt-none">
+      <q-btn
+        unelevated
+        no-caps
+        outline
+        icon="o_download"
+        :label="$t('common_download_as_png')"
+        size="sm"
+        class="text-weight-medium q-mr-xs"
+        @click="downloadPNG"
+      />
+      <q-btn
+        unelevated
+        no-caps
+        outline
+        icon="o_download"
+        :label="$t('common_download_as_csv')"
+        size="sm"
+        class="text-weight-medium"
+        @click="downloadCSV"
+      />
+    </q-card-actions>
   </q-card>
 </template>
 
@@ -1290,21 +1318,7 @@ const downloadCSV = () => {
 .module-carbon-chart {
   display: flex;
   flex-direction: column;
-}
-
-.module-carbon-chart__title {
-  display: flex;
-  align-items: center;
-}
-
-.module-carbon-chart__info {
-  cursor: help;
-  padding: 4px;
-  border-radius: 4px;
-}
-
-.module-carbon-chart__tooltip-line {
-  white-space: nowrap;
+  height: 100%;
 }
 
 .module-carbon-chart__body {
@@ -1312,10 +1326,30 @@ const downloadCSV = () => {
 }
 
 .chart {
-  width: 500px;
+  width: 100%;
   min-height: 500px;
-  @media (max-width: 1320px) {
-    width: 90%;
+}
+
+@media (max-width: 1320px) {
+  .chart {
+    width: 95%;
   }
+}
+</style>
+
+<!-- Tooltip content is rendered in a portal; i18n supplies .module-carbon-scope-tooltip -->
+<style lang="scss">
+.module-carbon-scope-tooltip {
+  min-width: 36rem;
+}
+
+.module-carbon-scope-tooltip p {
+  margin: 0 0 0.5rem;
+  line-height: 1.45;
+  white-space: normal;
+}
+
+.module-carbon-scope-tooltip p:last-child {
+  margin-bottom: 0;
 }
 </style>

--- a/frontend/src/components/molecules/BigNumber.vue
+++ b/frontend/src/components/molecules/BigNumber.vue
@@ -8,7 +8,10 @@ const props = defineProps<{
   comparison?: string;
   comparisonHighlight?: string;
   color?: string;
+  tooltipPlacement?: 'title' | 'comparison';
 }>();
+
+const tooltipPlacement = computed(() => props.tooltipPlacement ?? 'title');
 
 const comparisonParts = computed(() => {
   if (!props.comparison) {
@@ -37,25 +40,30 @@ const comparisonParts = computed(() => {
 </script>
 
 <template>
-  <q-card flat class="container container--pa-none">
+  <q-card flat class="container container--pa-none full-width big-number">
     <q-card-section class="flex items-center q-mb-xs">
-      <q-icon v-if="$slots.tooltip" name="o_info" size="xs" color="primary">
-        <q-tooltip
-          v-if="$slots.tooltip"
-          anchor="center right"
-          self="top right"
-          class="u-tooltip"
-        >
+      <q-icon
+        v-if="$slots.tooltip && tooltipPlacement === 'title'"
+        name="o_info"
+        size="xs"
+        color="primary"
+      >
+        <q-tooltip anchor="center right" self="top right" class="u-tooltip">
           <slot name="tooltip"></slot>
         </q-tooltip>
       </q-icon>
-      <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
+      <span
+        class="text-body1 text-weight-medium q-mb-none"
+        :class="{
+          'q-ml-sm': $slots.tooltip && tooltipPlacement === 'title',
+        }"
+      >
         {{ title }}
       </span>
     </q-card-section>
 
-    <q-card-section class="flex no-wrap justify-between items-end">
-      <div>
+    <q-card-section class="flex no-wrap justify-between big-number__content">
+      <div class="big-number__value">
         <div
           class="text-h1 text-weight-medium q-mb-none"
           :class="color ? `text-${color}` : ''"
@@ -69,9 +77,20 @@ const comparisonParts = computed(() => {
 
       <div
         v-if="comparisonParts.length > 0"
-        class="text-caption q-mb-none text-right"
+        class="text-caption q-mb-none text-right big-number__comparison"
         style="width: 50%"
       >
+        <q-icon
+          v-if="$slots.tooltip && tooltipPlacement === 'comparison'"
+          name="o_info"
+          size="xs"
+          color="primary"
+          class="q-mr-xs"
+        >
+          <q-tooltip anchor="center right" self="top right" class="u-tooltip">
+            <slot name="tooltip"></slot>
+          </q-tooltip>
+        </q-icon>
         <span
           v-for="(part, index) in comparisonParts"
           :key="index"
@@ -83,3 +102,26 @@ const comparisonParts = computed(() => {
     </q-card-section>
   </q-card>
 </template>
+
+<style scoped lang="scss">
+.big-number {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.big-number__content {
+  margin-top: auto;
+  align-items: flex-end;
+}
+
+.big-number__value {
+  align-self: flex-end;
+}
+
+.big-number__comparison {
+  align-self: flex-start;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -87,8 +87,8 @@ export default {
     fr: 'Contact',
   },
   unit_carbon_footprint_title: {
-    en: 'My Unit Carbon Footprint',
-    fr: "Mon Empreinte Carbone de l'unité",
+    en: 'Unit carbon footprint',
+    fr: "Empreinte carbone de l'unité",
   },
   common_this_item: {
     en: 'this item',

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -2,7 +2,7 @@ import { MODULES } from 'src/constant/modules';
 
 export default {
   [MODULES.ExternalCloudAndAI]: {
-    en: 'External Clouds & AI',
+    en: 'External clouds & AI',
     fr: 'Clouds Externes & IA',
   },
   [`${MODULES.ExternalCloudAndAI}-description`]: {

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -2,7 +2,7 @@ import { MODULES } from 'src/constant/modules';
 
 export default {
   [MODULES.ProcessEmissions]: {
-    en: 'Process Emissions',
+    en: 'Process emissions',
     fr: 'Emissions de procédés',
   },
   [`${MODULES.ProcessEmissions}-description`]: {
@@ -22,7 +22,7 @@ export default {
     fr: 'Ajouter un gaz émis',
   },
   [`${MODULES.ProcessEmissions}-charts-title`]: {
-    en: 'Process Emissions Charts',
+    en: 'Process emissions charts',
     fr: 'Graphiques des émissions de procédés',
   },
   [`${MODULES.ProcessEmissions}-charts-no-data-message`]: {

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -110,7 +110,7 @@ export default {
   },
   // Legacy keys (keeping for backward compatibility)
   [MODULES.ProfessionalTravel]: {
-    en: 'Professional Travel',
+    en: 'Professional travel',
     fr: 'Voyages professionnels ',
   },
   [`${MODULES.ProfessionalTravel}-description`]: {

--- a/frontend/src/i18n/research_facilities.ts
+++ b/frontend/src/i18n/research_facilities.ts
@@ -5,7 +5,7 @@ import {
 
 export default {
   [MODULES.ResearchFacilities]: {
-    en: 'EPFL Research Facilities',
+    en: 'EPFL research facilities',
     fr: 'Infrastructures de recherche EPFL',
   },
   [`${MODULES.ResearchFacilities}-description`]: {

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -100,8 +100,8 @@ export default {
     fr: 'Empreinte carbone de {module}',
   },
   results_total_unit_carbon_footprint_tooltip: {
-    en: 'Calculated with the value of {value} {unit}',
-    fr: 'Calculé avec la valeur de {value} {unit}',
+    en: '1 km driven by car emits {value} {unit}',
+    fr: '1 km parcouru en voiture émet {value} {unit}',
   },
   results_carbon_footprint_per_fte_tooltip: {
     en: 'Carbon footprint per Full-Time Equivalent (FTE) employee',
@@ -110,6 +110,22 @@ export default {
   results_unit_carbon_footprint_tooltip: {
     en: 'Unit carbon footprint compared to previous year',
     fr: "Empreinte carbone de l'unité par rapport à l'année précédente",
+  },
+  results_carbon_footprint_per_person_title: {
+    en: 'Carbon footprint per person',
+    fr: 'Empreinte carbone par personne',
+  },
+  results_scopes_tooltip_scope_1_desc: {
+    en: 'Direct emissions / émissions directes',
+    fr: 'Direct emissions / émissions directes',
+  },
+  results_scopes_tooltip_scope_2_desc: {
+    en: 'Indirect emissions from electricity / émissions indirectes liées à l’achat d’électricité',
+    fr: 'Indirect emissions from electricity / émissions indirectes liées à l’achat d’électricité',
+  },
+  results_scopes_tooltip_scope_3_desc: {
+    en: 'Other indirect emissions / Autres émissions indirectes',
+    fr: 'Other indirect emissions / Autres émissions indirectes',
   },
   results_equivalent_to_car: {
     en: 'is equivalent to {km}km driven by car.',

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -1,6 +1,6 @@
 export default {
   results_btn: {
-    en: 'View Results',
+    en: 'View results',
     fr: 'Voir les résultats',
   },
   results_download_pdf: {
@@ -12,8 +12,20 @@ export default {
     fr: 'Mode daltonien',
   },
   results_view_uncertainties: {
-    en: 'View Uncertainties',
-    fr: 'Voir les incertitudes',
+    en: 'View confidence level',
+    fr: 'Afficher le niveau de confiance',
+  },
+  results_view_additional_data: {
+    en: 'Show additional categories',
+    fr: 'Afficher les catégories supplémentaires',
+  },
+  results_show_additional_data: {
+    en: 'Show additional data',
+    fr: 'Afficher les données additionnelles',
+  },
+  results_hide_additional_data: {
+    en: 'Hide additional data',
+    fr: 'Masquer les données additionnelles',
   },
   results_compare_years: {
     en: 'Compare years',
@@ -48,12 +60,8 @@ export default {
     fr: 'Empreinte carbone annuelle {year}',
   },
   results_total_unit_carbon_footprint: {
-    en: 'Total unit carbon footprint',
-    fr: "Empreinte carbone totale de l'unité",
-  },
-  results_carbon_footprint_per_person_title: {
-    en: 'Carbon Footprint per FTE',
-    fr: 'Empreinte carbone par ETP',
+    en: 'Total carbon footprint of the unit',
+    fr: 'Empreinte carbone totale de l’unité',
   },
   results_total_module_carbon_footprint: {
     en: 'Total {module} carbon footprint',
@@ -88,20 +96,24 @@ export default {
     fr: 'Empreinte carbone totale des infrastructures de recherche',
   },
   results_carbon_footprint_per_fte: {
+    en: 'Carbon footprint per FTE (total of {FTE})',
+    fr: 'Empreinte carbone par ETP (total de {FTE})',
+  },
+  results_carbon_footprint_per_FTE_no_headcount: {
     en: 'Carbon footprint per FTE',
     fr: 'Empreinte carbone par ETP',
   },
   results_unit_carbon_footprint: {
-    en: 'Unit carbon footprint',
-    fr: "Empreinte carbone de l'unité",
+    en: 'Comparison to previous year',
+    fr: 'Comparaison à l’année précédente',
   },
   results_module_carbon_footprint: {
     en: '{module} carbon footprint',
     fr: 'Empreinte carbone de {module}',
   },
   results_total_unit_carbon_footprint_tooltip: {
-    en: '1 km driven by car emits {value} {unit}',
-    fr: '1 km parcouru en voiture émet {value} {unit}',
+    en: 'A km driven by car is equivalent to {value} {unit}',
+    fr: 'Un km parcouru en voiture est équivalent à {value} {unit}',
   },
   results_carbon_footprint_per_fte_tooltip: {
     en: 'Carbon footprint per Full-Time Equivalent (FTE) employee',
@@ -111,25 +123,9 @@ export default {
     en: 'Unit carbon footprint compared to previous year',
     fr: "Empreinte carbone de l'unité par rapport à l'année précédente",
   },
-  results_carbon_footprint_per_person_title: {
-    en: 'Carbon footprint per person',
-    fr: 'Empreinte carbone par personne',
-  },
-  results_scopes_tooltip_scope_1_desc: {
-    en: 'Direct emissions / émissions directes',
-    fr: 'Direct emissions / émissions directes',
-  },
-  results_scopes_tooltip_scope_2_desc: {
-    en: 'Indirect emissions from electricity / émissions indirectes liées à l’achat d’électricité',
-    fr: 'Indirect emissions from electricity / émissions indirectes liées à l’achat d’électricité',
-  },
-  results_scopes_tooltip_scope_3_desc: {
-    en: 'Other indirect emissions / Autres émissions indirectes',
-    fr: 'Other indirect emissions / Autres émissions indirectes',
-  },
   results_equivalent_to_car: {
-    en: 'is equivalent to {km}km driven by car.',
-    fr: 'équivaut à {km}km parcouru en voiture.',
+    en: 'The value of the equivalence by car is {km}km',
+    fr: 'La valeur de l’équivalence par voiture est de {km}km',
   },
   results_paris_agreement_value: {
     en: 'The total carbon budget per person according to the Paris Agreement is {value}',
@@ -148,8 +144,8 @@ export default {
     fr: 'Par rapport à la valeur de {value}',
   },
   results_no_comparison_year_available: {
-    en: 'No comparison year available',
-    fr: 'Aucune année de comparaison disponible',
+    en: 'No comparison value is computed in this iteration',
+    fr: "Aucune valeur de comparaison n'est calculée dans cette itération",
   },
   results_value_of: {
     en: 'value of {value} t CO₂-eq',
@@ -159,24 +155,44 @@ export default {
     en: 'Show additional estimated categories',
     fr: 'Afficher les catégories supplémentaires',
   },
+  unit_carbon_footprint_scope_tooltip_aria: {
+    en: 'Definitions of GHG scopes 1, 2 and 3 in this chart',
+    fr: 'Définitions des scopes 1, 2 et 3 des GES dans ce graphique',
+  },
+  unit_carbon_footprint_scope_prefix: {
+    en: '{scope} {n}:',
+    fr: '{scope} {n} :',
+  },
+  unit_carbon_footprint_scope_1_desc: {
+    en: 'Direct emissions',
+    fr: 'Émissions directes',
+  },
+  unit_carbon_footprint_scope_2_desc: {
+    en: 'Indirect emissions from purchased electricity',
+    fr: "Émissions indirectes liées à l'achat d'électricité",
+  },
+  unit_carbon_footprint_scope_3_desc: {
+    en: 'Other indirect emissions',
+    fr: 'Autres émissions indirectes',
+  },
   results_hide_research_facilities: {
-    en: 'Hide Research Facilities',
+    en: 'Hide research facilities',
     fr: 'Masquer les infrastructures de recherche',
   },
   results_carbon_footprint_per_person: {
-    en: 'Carbon Footprint Per Person',
+    en: 'Carbon footprint per person',
     fr: 'Empreinte carbone par personne',
   },
   results_by_category_title: {
-    en: 'Results by Category',
+    en: 'Results by category',
     fr: 'Résultats par catégorie',
   },
   results_by_category_subtitle: {
-    en: 'Annual Carbon Footprint {year}',
-    fr: 'Bilan CO₂ Annuel {year}',
+    en: 'Annual carbon footprint {year}',
+    fr: 'Bilan CO₂ annuel {year}',
   },
   results_equipment_distribution_title: {
-    en: 'Equipment Distribution',
+    en: 'Equipment distribution',
     fr: 'Distribution des équipements',
   },
   results_validate_module_title: {
@@ -195,16 +211,20 @@ export default {
     en: 'Comparison with intermediate long-term objectives',
     fr: 'Comparaison avec les objectifs intermédiaires à long terme',
   },
+  results_additional_data: {
+    en: 'Additional data',
+    fr: 'Données additionnelles',
+  },
   uncertainty_low: {
-    en: 'Low Uncertainty',
+    en: 'Low uncertainty',
     fr: 'Faible incertitude',
   },
   uncertainty_medium: {
-    en: 'Moderate Uncertainty',
+    en: 'Moderate uncertainty',
     fr: 'Incertitude modérée',
   },
   uncertainty_high: {
-    en: 'High Uncertainty',
+    en: 'High uncertainty',
     fr: 'Forte incertitude',
   },
   'charts-unit-gas-category': {
@@ -225,16 +245,16 @@ export default {
     fr: 'Salles des bâtiments',
   },
   'charts-buildings-energy-combustion-category': {
-    en: 'Energy Combustion Emissions',
+    en: 'Energy combustion emissions',
     fr: 'Emissions de combustion d’énergie',
   },
   // Legacy key kept for backward compatibility with any existing references.
   'charts-building-energy-subcategory': {
-    en: 'Energy Combustion Emissions',
+    en: 'Energy combustion emissions',
     fr: 'Emissions de combustion d’énergie',
   },
   'charts-energy-combustion-subcategory': {
-    en: 'Energy Combustion Emissions',
+    en: 'Energy combustion emissions',
     fr: "Émissions de combustion d'énergie",
   },
   'charts-lighting-subcategory': {
@@ -326,7 +346,7 @@ export default {
     fr: 'Alimentation',
   },
   'charts-professional-travel-category': {
-    en: 'Professional Travel',
+    en: 'Professional travel',
     fr: 'Voyages professionnels',
   },
   'charts-it-category': {
@@ -334,7 +354,7 @@ export default {
     fr: 'Informatique',
   },
   'charts-research-core-facilities-category': {
-    en: 'Research Core Facilities',
+    en: 'Research core facilities',
     fr: 'Infrastructures de recherche',
   },
   'charts-purchases-category': {
@@ -354,7 +374,7 @@ export default {
     fr: 'Équipement',
   },
   'charts-external-cloud-category': {
-    en: 'External Cloud',
+    en: 'External cloud',
     fr: 'Cloud externe',
   },
   'emission-type-breakdown-info-equipment': {
@@ -446,23 +466,23 @@ export default {
     fr: 'Chauffage',
   },
   'charts-scientific-subcategory': {
-    en: 'Scientific Equipment',
+    en: 'Scientific equipment',
     fr: 'Équipement scientifique',
   },
   'charts-stockage-subcategory': {
-    en: 'Cloud Storage',
+    en: 'Cloud storage',
     fr: 'Stockage cloud',
   },
   'charts-virtualisation-subcategory': {
-    en: 'Cloud Virtualisation',
+    en: 'Cloud virtualisation',
     fr: 'Virtualisation cloud',
   },
   'charts-calcul-subcategory': {
-    en: 'Cloud Compute',
+    en: 'Cloud compute',
     fr: 'Calcul cloud',
   },
   'charts-ai-provider-subcategory': {
-    en: 'AI Provider',
+    en: 'AI provider',
     fr: 'Fournisseur IA',
   },
   'charts-ai-provider-google-subcategory': {
@@ -490,11 +510,11 @@ export default {
     fr: 'Autres',
   },
   'charts-research-facilities-subcategory': {
-    en: 'Research Facilities',
+    en: 'Research facilities',
     fr: 'Infrastructures de recherche',
   },
   'charts-research-animal-subcategory': {
-    en: 'Animal Facilities',
+    en: 'Animal facilities',
     fr: 'Infrastructures pour animaux',
   },
   'charts-rest-subcategory': {
@@ -518,15 +538,15 @@ export default {
     fr: 'RCP',
   },
   'charts-main-category': {
-    en: 'Main Categories',
+    en: 'Main categories',
     fr: 'Catégories principales',
   },
   'charts-additional-category': {
-    en: 'Additional Categories',
+    en: 'Additional categories',
     fr: 'Catégories supplémentaires',
   },
   results_treemap_title: {
-    en: 'Emissions Breakdown',
+    en: 'Emissions breakdown',
     fr: 'Répartition des émissions',
   },
   'no-chart-data': {
@@ -546,15 +566,215 @@ export default {
     fr: 'EPFL',
   },
   'charts-objective-tick': {
-    en: '2030 Objective',
+    en: '2030 objective',
     fr: 'Objectif 2030',
   },
   'charts-view-emission-breakdown': {
-    en: 'Emission Breakdown',
+    en: 'Emission breakdown',
     fr: 'Répartition des émissions',
   },
   'charts-view-emission-type': {
-    en: 'Emission Type',
+    en: 'Emission type',
     fr: "Type d'émission",
+  },
+  results_additional_title: {
+    en: 'Additional categories',
+    fr: 'Catégories additionnelles',
+  },
+  results_additional_subtitle: {
+    en: "These emissions are calculated based on EPFL's general assumptions and use only the number of staff as laboratory-specific data.",
+    fr: "Ces émissions sont calculées à partir des hypothèses générales de l'EPFL et utilisent uniquement le nombre de personnel comme donnée spécifique au laboratoire.",
+  },
+  results_additional_commuting_total: {
+    en: 'Total commuting carbon footprint',
+    fr: 'Empreinte carbone totale de la pendularité',
+  },
+  results_additional_food_total: {
+    en: 'Total food carbon footprint',
+    fr: "Empreinte carbone totale de l'alimentation",
+  },
+  results_additional_waste_total: {
+    en: 'Total waste carbon footprint',
+    fr: 'Empreinte carbone totale des déchets',
+  },
+  results_additional_waste_tooltip: {
+    en: 'All waste is recycled, apart from domestic waste which is incinerated.',
+    fr: 'Tous les déchets sont recyclés à l’exception de déchets municipaux qui sont incinérés.',
+  },
+  results_waste_tooltip: {
+    en: 'All waste is recycled, apart from domestic waste which is incinerated.',
+    fr: "Tous les déchets sont recyclés à l'exception de déchets municipaux qui sont incinérés.",
+  },
+  results_additional_commuting_breakdown_title: {
+    en: 'Breakdown of commuting carbon footprint by category',
+    fr: "Contribution des différentes catégories à l'empreinte carbone de la pendularité",
+  },
+  results_additional_food_breakdown_title: {
+    en: 'Breakdown of food carbon footprint by category',
+    fr: "Contribution des différentes catégories à l'empreinte carbone de l'alimentation",
+  },
+  results_additional_waste_breakdown_title: {
+    en: 'Breakdown of waste carbon footprint by category',
+    fr: "Contribution des différentes catégories à l'empreinte carbone des déchets",
+  },
+  results_additional_co2_chart_title: {
+    en: 'Emissions CO₂-eq',
+    fr: 'Émissions CO₂-éq',
+  },
+  results_additional_physical_chart_title: {
+    en: 'Physical quantity',
+    fr: 'Quantité physique',
+  },
+  results_grey_energy_title: {
+    en: 'Grey energy (embodied energy)',
+    fr: 'Énergie grise (énergie intrinsèque)',
+  },
+  results_grey_energy_placeholder: {
+    en: 'Grey energy data coming soon',
+    fr: "Données sur l'énergie grise bientôt disponibles",
+  },
+  results_additional_embodied_energy_tooltip: {
+    en: 'This corresponds to embedded energy emissions in buildings.',
+    fr: "Ces émissions correspondent à l'énergie grise des bâtiments.",
+  },
+  results_additional_embodied_energy_chart_tooltip: {
+    en: 'This analysis only covers current constructions, renovations and demolitions; it does not include buildings constructed, renovated or demolished in other years. The actual footprint of EPFL buildings is higher.',
+    fr: "Cette analyse ne concerne que les constructions, rénovations et démolitions en cours; elle n'inclut pas les bâtiments construits, rénovés ou démolis dans le passé. L'empreinte carbone réelle des bâtiments de l'EPFL est plus élevée.",
+  },
+  results_additional_embodied_energy_breakdown_title: {
+    en: 'Breakdown of construction and renovation carbon footprint by building',
+    fr: "Répartition de l'empreinte carbone des constructions et rénovations par bâtiment",
+  },
+  'charts-embodied-energy-subcategory': {
+    en: 'Embodied energy',
+    fr: 'Énergie grise',
+  },
+  // Commuting sub-type labels
+  'charts-walking-subcategory': {
+    en: 'Walking',
+    fr: 'Marche',
+  },
+  'charts-cycling-subcategory': {
+    en: 'Cycling',
+    fr: 'Vélo',
+  },
+  'charts-powered-two-wheeler-subcategory': {
+    en: 'Powered two-wheeler',
+    fr: 'Deux-roues motorisé',
+  },
+  'charts-public-transport-subcategory': {
+    en: 'Public transport',
+    fr: 'Transports en commun',
+  },
+  'charts-car-subcategory': {
+    en: 'Car',
+    fr: 'Voiture',
+  },
+  // Food sub-type labels
+  'charts-vegetarian-subcategory': {
+    en: 'Vegetarian',
+    fr: 'Végétarien',
+  },
+  'charts-non-vegetarian-subcategory': {
+    en: 'Non-vegetarian',
+    fr: 'Non-végétarien',
+  },
+  // Waste sub-type labels
+  'charts-incineration-subcategory': {
+    en: 'Incineration',
+    fr: 'Incinération',
+  },
+  'charts-composting-subcategory': {
+    en: 'Composting',
+    fr: 'Compostage',
+  },
+  'charts-biogas-subcategory': {
+    en: 'Biogas',
+    fr: 'Biogaz',
+  },
+  'charts-recycling-subcategory': {
+    en: 'Recycling',
+    fr: 'Recyclage',
+  },
+  'charts-organic-waste-food-leftovers-subcategory': {
+    en: 'Organic waste / food leftovers',
+    fr: 'Déchets organiques / restes alimentaires',
+  },
+  'charts-cooking-vegetable-oil-subcategory': {
+    en: 'Cooking vegetable oil',
+    fr: 'Huile végétale de cuisson',
+  },
+  'charts-cardboard-subcategory': {
+    en: 'Cardboard',
+    fr: 'Carton',
+  },
+  'charts-plastics-subcategory': {
+    en: 'Plastics',
+    fr: 'Plastiques',
+  },
+  'charts-glass-subcategory': {
+    en: 'Glass',
+    fr: 'Verre',
+  },
+  'charts-ferrous-metals-subcategory': {
+    en: 'Ferrous metals',
+    fr: 'Métaux ferreux',
+  },
+  'charts-non-ferrous-metals-subcategory': {
+    en: 'Non-ferrous metals',
+    fr: 'Métaux non ferreux',
+  },
+  'charts-electronics-subcategory': {
+    en: 'Electronics',
+    fr: 'Électronique',
+  },
+  'charts-pet-subcategory': {
+    en: 'PET',
+    fr: 'PET',
+  },
+  'charts-aluminum-subcategory': {
+    en: 'Aluminum',
+    fr: 'Aluminium',
+  },
+  'charts-textile-subcategory': {
+    en: 'Textile',
+    fr: 'Textile',
+  },
+  'charts-toner-and-ink-cartridges-subcategory': {
+    en: 'Toner & ink cartridges',
+    fr: 'Cartouches toner & encre',
+  },
+  'charts-inert-waste-subcategory': {
+    en: 'Inert waste',
+    fr: 'Déchets inertes',
+  },
+  // Waste display category labels (grouped)
+  'charts-domestic-subcategory': {
+    en: 'Domestic (incinerated)',
+    fr: 'Déchets municipaux (incinérés)',
+  },
+  'charts-organic-subcategory': {
+    en: 'Organic',
+    fr: 'Organique',
+  },
+  'charts-paper-subcategory': {
+    en: 'Paper',
+    fr: 'Papier',
+  },
+  'charts-plastic-subcategory': {
+    en: 'Plastic',
+    fr: 'Plastique',
+  },
+  'charts-metals-subcategory': {
+    en: 'Metals',
+    fr: 'Métaux',
+  },
+  'charts-wood-subcategory': {
+    en: 'Wood',
+    fr: 'Bois',
+  },
+  'charts-other-subcategory': {
+    en: 'Other',
+    fr: 'Autre',
   },
 } as const;

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -535,6 +535,31 @@ const getUncertainty = (
 </template>
 
 <style scoped lang="scss">
+.results-charts-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 1320px) {
+  .results-charts-grid {
+    grid-template-columns: repeat(3, 1fr);
+    align-items: start;
+  }
+
+  .results-charts-grid > :first-child {
+    grid-column: span 2;
+  }
+}
+
+.additional-expand-arrow {
+  transition: transform 150ms ease;
+}
+
+.additional-expand-arrow--open {
+  transform: rotate(180deg);
+}
+
 .validation-required-card {
   min-height: 200px;
   background-color: rgba(0, 0, 0, 0.02);

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -49,6 +49,15 @@ const currentYear = computed(() => {
 
 const resultsSummary = ref<ResultsSummary | null>(null);
 const resultsSummaryLoading = ref(false);
+const chartsReady = ref(false);
+
+const adjustedTotalTonnes = computed<number | null>(() => {
+  return resultsSummary.value?.unit_totals.total_tonnes_co2eq ?? null;
+});
+
+const adjustedTonnesPerFte = computed<number | null>(() => {
+  return resultsSummary.value?.unit_totals.tonnes_co2eq_per_fte ?? null;
+});
 
 const hideResearchFacilities = ref(false);
 
@@ -88,6 +97,13 @@ async function fetchEmissionBreakdown() {
 onMounted(() => {
   fetchResultsSummary();
   fetchEmissionBreakdown();
+
+  const schedule =
+    window.requestIdleCallback ??
+    ((cb: () => void) => window.setTimeout(cb, 0));
+  schedule(() => {
+    chartsReady.value = true;
+  });
 });
 
 // Watch for year/unit changes
@@ -219,8 +235,11 @@ const getUncertainty = (
         <BigNumber
           :title="$t('results_total_unit_carbon_footprint')"
           :number="
-            $formatTonnesCO2(resultsSummary.unit_totals.total_tonnes_co2eq)
+            $nOrDash(adjustedTotalTonnes, {
+              options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+            })
           "
+          tooltip-placement="comparison"
           :comparison="
             $t('results_equivalent_to_car', {
               km: $n(resultsSummary.unit_totals.equivalent_car_km),
@@ -238,9 +257,68 @@ const getUncertainty = (
           }}</template>
         </BigNumber>
         <BigNumber
-          :title="$t('results_carbon_footprint_per_fte')"
+          :title="$t('results_unit_carbon_footprint')"
           :number="
-            $formatTonnesCO2(resultsSummary.unit_totals.tonnes_co2eq_per_fte)
+            formatPercentChange(
+              resultsSummary.unit_totals.year_comparison_percentage,
+            )
+          "
+          :unit="
+            resultsSummary.unit_totals.year_comparison_percentage == null
+              ? $t('results_no_comparison_year_available')
+              : $t('results_compared_to', {
+                  year: (currentYear - 1).toString(),
+                })
+          "
+          :color="
+            resultsSummary.unit_totals.year_comparison_percentage == null
+              ? undefined
+              : resultsSummary.unit_totals.year_comparison_percentage < 0
+                ? 'positive'
+                : 'negative'
+          "
+          :comparison="
+            resultsSummary.unit_totals.year_comparison_percentage == null
+              ? undefined
+              : $t('results_compared_to_value_of', {
+                  value: `${$nOrDash(
+                    resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
+                    {
+                      options: {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      },
+                    },
+                  )}${$t('results_units_tonnes')}`,
+                })
+          "
+          :comparison-highlight="
+            resultsSummary.unit_totals.year_comparison_percentage == null
+              ? undefined
+              : `${$nOrDash(
+                  resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
+                  {
+                    options: {
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    },
+                  },
+                )}${$t('results_units_tonnes')}`
+          "
+        >
+        </BigNumber>
+        <BigNumber
+          :title="
+            resultsSummary.unit_totals.total_fte == null
+              ? $t('results_carbon_footprint_per_FTE_no_headcount')
+              : $t('results_carbon_footprint_per_fte', {
+                  FTE: resultsSummary.unit_totals.total_fte,
+                })
+          "
+          :number="
+            $nOrDash(adjustedTonnesPerFte, {
+              options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+            })
           "
           :comparison="
             $t('results_paris_agreement_value', {
@@ -250,66 +328,29 @@ const getUncertainty = (
           :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
           color="negative"
         >
-          <template #tooltip>{{
-            $t('results_paris_agreement_tooltip')
-          }}</template>
         </BigNumber>
-        <div
-          :class="{
-            'no-data-styling':
-              resultsSummary.unit_totals.year_comparison_percentage == null,
-          }"
-        >
-          <BigNumber
-            :title="$t('results_unit_carbon_footprint')"
-            :number="
-              formatPercentChange(
-                resultsSummary.unit_totals.year_comparison_percentage,
-              )
-            "
-            :unit="
-              $t('results_compared_to', {
-                year: (currentYear - 1).toString(),
-              })
-            "
-            :color="
-              resultsSummary.unit_totals.year_comparison_percentage == null
-                ? undefined
-                : resultsSummary.unit_totals.year_comparison_percentage < 0
-                  ? 'positive'
-                  : 'negative'
-            "
-            :comparison="
-              $t('results_compared_to_value_of', {
-                value: `${$formatTonnesCO2(
-                  resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
-                )}${$t('results_units_tonnes')}`,
-              })
-            "
-            :comparison-highlight="`${$formatTonnesCO2(
-              resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
-            )}${$t('results_units_tonnes')}`"
-          >
-          </BigNumber>
-        </div>
       </q-card>
-      <q-card flat class="grid-2-col">
-        <ModuleCarbonFootprintChart
-          :breakdown-data="moduleStore.state.emissionBreakdown"
-        />
-        <CarbonFootPrintPerPersonChart
-          :per-person-breakdown="
-            moduleStore.state.emissionBreakdown?.per_person_breakdown
-          "
-          :validated-categories="
-            moduleStore.state.emissionBreakdown?.validated_categories
-          "
-          :headcount-validated="
-            moduleStore.state.emissionBreakdown?.validated_categories?.includes(
-              'commuting',
-            ) ?? false
-          "
-        />
+      <q-card v-if="chartsReady" flat class="results-charts-grid">
+        <div class="results-charts-grid__main">
+          <ModuleCarbonFootprintChart
+            :breakdown-data="moduleStore.state.emissionBreakdown"
+          />
+        </div>
+        <div class="results-charts-grid__side">
+          <CarbonFootPrintPerPersonChart
+            :per-person-breakdown="
+              moduleStore.state.emissionBreakdown?.per_person_breakdown
+            "
+            :validated-categories="
+              moduleStore.state.emissionBreakdown?.validated_categories
+            "
+            :headcount-validated="
+              moduleStore.state.emissionBreakdown?.validated_categories?.includes(
+                'commuting',
+              ) ?? false
+            "
+          />
+        </div>
       </q-card>
 
       <q-card flat bordered class="q-pa-xl">
@@ -430,7 +471,54 @@ const getUncertainty = (
                       }}</template>
                     </BigNumber>
                     <BigNumber
-                      :title="$t('results_carbon_footprint_per_fte')"
+                      :title="
+                        $t('results_module_carbon_footprint', {
+                          module: $t(module),
+                        })
+                      "
+                      :number="
+                        formatPercentChange(
+                          getModuleResult(module)!.year_comparison_percentage,
+                        )
+                      "
+                      :unit="
+                        $t('results_compared_to', {
+                          year: (currentYear - 1).toString(),
+                        })
+                      "
+                      :color="
+                        getModuleResult(module)!.year_comparison_percentage ==
+                        null
+                          ? undefined
+                          : getModuleResult(module)!
+                                .year_comparison_percentage! < 0
+                            ? 'positive'
+                            : 'negative'
+                      "
+                      :comparison="
+                        $t('results_compared_to_value_of', {
+                          value: `${getModuleConfig(module).totalFormatter(
+                            getModuleResult(module)!
+                              .previous_year_total_tonnes_co2eq,
+                          )}${$t('results_units_tonnes')}`,
+                        })
+                      "
+                      :comparison-highlight="`${getModuleConfig(
+                        module,
+                      ).totalFormatter(
+                        getModuleResult(module)!
+                          .previous_year_total_tonnes_co2eq,
+                      )}${$t('results_units_tonnes')}`"
+                    >
+                    </BigNumber>
+                    <BigNumber
+                      :title="
+                        resultsSummary.unit_totals.total_fte == null
+                          ? $t('results_carbon_footprint_per_FTE_no_headcount')
+                          : $t('results_carbon_footprint_per_fte', {
+                              FTE: resultsSummary.unit_totals.total_fte,
+                            })
+                      "
                       :number="
                         getModuleConfig(module).totalFormatter(
                           getModuleResult(module)!.tonnes_co2eq_per_fte,
@@ -448,55 +536,6 @@ const getUncertainty = (
                         $t('results_paris_agreement_tooltip')
                       }}</template>
                     </BigNumber>
-                    <div
-                      :class="{
-                        'no-data-styling':
-                          getModuleResult(module)!.year_comparison_percentage ==
-                          null,
-                      }"
-                    >
-                      <BigNumber
-                        :title="
-                          $t('results_module_carbon_footprint', {
-                            module: $t(module),
-                          })
-                        "
-                        :number="
-                          formatPercentChange(
-                            getModuleResult(module)!.year_comparison_percentage,
-                          )
-                        "
-                        :unit="
-                          $t('results_compared_to', {
-                            year: (currentYear - 1).toString(),
-                          })
-                        "
-                        :color="
-                          getModuleResult(module)!.year_comparison_percentage ==
-                          null
-                            ? undefined
-                            : getModuleResult(module)!
-                                  .year_comparison_percentage! < 0
-                              ? 'positive'
-                              : 'negative'
-                        "
-                        :comparison="
-                          $t('results_compared_to_value_of', {
-                            value: `${getModuleConfig(module).totalFormatter(
-                              getModuleResult(module)!
-                                .previous_year_total_tonnes_co2eq,
-                            )}${$t('results_units_tonnes')}`,
-                          })
-                        "
-                        :comparison-highlight="`${getModuleConfig(
-                          module,
-                        ).totalFormatter(
-                          getModuleResult(module)!
-                            .previous_year_total_tonnes_co2eq,
-                        )}${$t('results_units_tonnes')}`"
-                      >
-                      </BigNumber>
-                    </div>
                   </q-card>
                 </template>
 
@@ -541,13 +580,13 @@ const getUncertainty = (
   gap: 16px;
 }
 
-@media (min-width: 1320px) {
+@media (min-width: 1024px) {
   .results-charts-grid {
     grid-template-columns: repeat(3, 1fr);
-    align-items: start;
+    align-items: stretch;
   }
 
-  .results-charts-grid > :first-child {
+  .results-charts-grid__main {
     grid-column: span 2;
   }
 }

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from 'vue';
-import { MODULES_LIST } from 'src/constant/modules';
+import {
+  computed,
+  defineAsyncComponent,
+  defineComponent,
+  h,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+} from 'vue';
+import { QSkeleton } from 'quasar';
+import { MODULES_LIST, MODULES, type Module } from 'src/constant/modules';
 import { MODULES_CONFIG } from 'src/constant/module-config';
 
 import { colorblindMode } from 'src/constant/charts';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
-import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
-import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
 import {
   getResultsSummary,
   type ResultsSummary,
@@ -15,12 +23,51 @@ import {
 } from 'src/api/modules';
 
 import Co2Timeline from 'src/components/organisms/layout/Co2Timeline.vue';
-import ModuleCharts from 'src/components/organisms/module/ModuleCharts.vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useTimelineStore, useModuleStore } from 'src/stores/modules';
-import { MODULES, Module } from 'src/constant/modules';
 import { MODULE_STATES, getModuleTypeId } from 'src/constant/moduleStates';
 import { useI18n } from 'vue-i18n';
+
+/** Keeps ECharts-heavy bundles out of the initial Results route chunk (Lighthouse / TTI). */
+const ChartChunkSkeleton = defineComponent({
+  name: 'ChartChunkSkeleton',
+  setup() {
+    return () =>
+      h(QSkeleton, {
+        type: 'rect',
+        height: '360px',
+        class: 'full-width q-ma-sm',
+      });
+  },
+});
+
+const ModuleCarbonFootprintChart = defineAsyncComponent({
+  loader: () =>
+    import('src/components/charts/results/ModuleCarbonFootprintChart.vue'),
+  loadingComponent: ChartChunkSkeleton,
+  delay: 0,
+});
+
+const CarbonFootPrintPerPersonChart = defineAsyncComponent({
+  loader: () =>
+    import('src/components/charts/results/CarbonFootPrintPerPersonChart.vue'),
+  loadingComponent: ChartChunkSkeleton,
+  delay: 0,
+});
+
+const ModuleCharts = defineAsyncComponent({
+  loader: () => import('src/components/organisms/module/ModuleCharts.vue'),
+  loadingComponent: ChartChunkSkeleton,
+  delay: 0,
+});
+
+/** Per-row expansion; body mounts only when opened (avoids N× chart bundles on load). */
+const resultsCategoryExpanded = reactive(
+  Object.fromEntries(MODULES_LIST.map((m) => [m, false])) as Record<
+    string,
+    boolean
+  >,
+);
 
 const FORMAT_INTEGER = {
   options: { minimumFractionDigits: 0, maximumFractionDigits: 0 },
@@ -80,8 +127,7 @@ async function fetchResultsSummary() {
       carbonReportId,
       excludedModules.value,
     );
-  } catch (error) {
-    console.error('Error fetching results summary:', error);
+  } catch {
     resultsSummary.value = null;
   } finally {
     resultsSummaryLoading.value = false;
@@ -231,57 +277,73 @@ const getUncertainty = (
           </div>
         </div>
       </q-card>
-      <q-card v-if="resultsSummary" flat class="grid-3-col">
-        <BigNumber
-          :title="$t('results_total_unit_carbon_footprint')"
-          :number="
-            $nOrDash(adjustedTotalTonnes, {
-              options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-            })
-          "
-          tooltip-placement="comparison"
-          :comparison="
-            $t('results_equivalent_to_car', {
-              km: $n(resultsSummary.unit_totals.equivalent_car_km),
-              value: `${$nOrDash(co2PerKmKg)}`,
-            })
-          "
-          :comparison-highlight="`${$n(resultsSummary.unit_totals.equivalent_car_km)}km`"
-          color="negative"
-        >
-          <template #tooltip>{{
-            $t('results_total_unit_carbon_footprint_tooltip', {
-              value: $nOrDash(co2PerKmKg),
-              unit: $t('results_kg_co2eq_per_km'),
-            })
-          }}</template>
-        </BigNumber>
-        <BigNumber
-          :title="$t('results_unit_carbon_footprint')"
-          :number="
-            formatPercentChange(
-              resultsSummary.unit_totals.year_comparison_percentage,
-            )
-          "
-          :unit="
-            resultsSummary.unit_totals.year_comparison_percentage == null
-              ? $t('results_no_comparison_year_available')
-              : $t('results_compared_to', {
-                  year: (currentYear - 1).toString(),
-                })
-          "
-          :color="
-            resultsSummary.unit_totals.year_comparison_percentage == null
-              ? undefined
-              : resultsSummary.unit_totals.year_comparison_percentage < 0
-                ? 'positive'
-                : 'negative'
-          "
-          :comparison="
-            resultsSummary.unit_totals.year_comparison_percentage == null
-              ? undefined
-              : $t('results_compared_to_value_of', {
-                  value: `${$nOrDash(
+      <template v-if="resultsSummary">
+        <q-card flat class="grid-3-col">
+          <BigNumber
+            :title="$t('results_total_unit_carbon_footprint')"
+            :number="
+              $nOrDash(adjustedTotalTonnes, {
+                options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+              })
+            "
+            tooltip-placement="comparison"
+            :comparison="
+              $t('results_equivalent_to_car', {
+                km: $n(resultsSummary.unit_totals.equivalent_car_km),
+                value: `${$nOrDash(co2PerKmKg)}`,
+              })
+            "
+            :comparison-highlight="`${$n(resultsSummary.unit_totals.equivalent_car_km)}km`"
+            color="negative"
+          >
+            <template #tooltip>{{
+              $t('results_total_unit_carbon_footprint_tooltip', {
+                value: $nOrDash(co2PerKmKg),
+                unit: $t('results_kg_co2eq_per_km'),
+              })
+            }}</template>
+          </BigNumber>
+          <BigNumber
+            :title="$t('results_unit_carbon_footprint')"
+            :number="
+              formatPercentChange(
+                resultsSummary.unit_totals.year_comparison_percentage,
+              )
+            "
+            :unit="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? $t('results_no_comparison_year_available')
+                : $t('results_compared_to', {
+                    year: (currentYear - 1).toString(),
+                  })
+            "
+            :color="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? undefined
+                : resultsSummary.unit_totals.year_comparison_percentage < 0
+                  ? 'positive'
+                  : 'negative'
+            "
+            :comparison="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? undefined
+                : $t('results_compared_to_value_of', {
+                    value: `${$nOrDash(
+                      resultsSummary.unit_totals
+                        .previous_year_total_tonnes_co2eq,
+                      {
+                        options: {
+                          minimumFractionDigits: 1,
+                          maximumFractionDigits: 1,
+                        },
+                      },
+                    )}${$t('results_units_tonnes')}`,
+                  })
+            "
+            :comparison-highlight="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? undefined
+                : `${$nOrDash(
                     resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
                     {
                       options: {
@@ -289,68 +351,78 @@ const getUncertainty = (
                         maximumFractionDigits: 1,
                       },
                     },
-                  )}${$t('results_units_tonnes')}`,
-                })
-          "
-          :comparison-highlight="
-            resultsSummary.unit_totals.year_comparison_percentage == null
-              ? undefined
-              : `${$nOrDash(
-                  resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
-                  {
-                    options: {
-                      minimumFractionDigits: 1,
-                      maximumFractionDigits: 1,
-                    },
-                  },
-                )}${$t('results_units_tonnes')}`
-          "
-        >
-        </BigNumber>
-        <BigNumber
-          :title="
-            resultsSummary.unit_totals.total_fte == null
-              ? $t('results_carbon_footprint_per_FTE_no_headcount')
-              : $t('results_carbon_footprint_per_fte', {
-                  FTE: resultsSummary.unit_totals.total_fte,
-                })
-          "
-          :number="
-            $nOrDash(adjustedTonnesPerFte, {
-              options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-            })
-          "
-          :comparison="
-            $t('results_paris_agreement_value', {
-              value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
-            })
-          "
-          :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
-          color="negative"
-        >
-        </BigNumber>
+                  )}${$t('results_units_tonnes')}`
+            "
+          >
+          </BigNumber>
+          <BigNumber
+            :title="
+              resultsSummary.unit_totals.total_fte == null
+                ? $t('results_carbon_footprint_per_FTE_no_headcount')
+                : $t('results_carbon_footprint_per_fte', {
+                    FTE: resultsSummary.unit_totals.total_fte,
+                  })
+            "
+            :number="
+              $nOrDash(adjustedTonnesPerFte, {
+                options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+              })
+            "
+            :comparison="
+              $t('results_paris_agreement_value', {
+                value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
+              })
+            "
+            :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
+            color="negative"
+          >
+          </BigNumber>
+        </q-card>
+      </template>
+      <q-card
+        v-else-if="resultsSummaryLoading"
+        flat
+        class="grid-3-col results-summary-skeleton"
+      >
+        <q-skeleton
+          v-for="n in 3"
+          :key="n"
+          type="rect"
+          height="160px"
+          class="full-width"
+        />
       </q-card>
-      <q-card v-if="chartsReady" flat class="results-charts-grid">
-        <div class="results-charts-grid__main">
-          <ModuleCarbonFootprintChart
-            :breakdown-data="moduleStore.state.emissionBreakdown"
-          />
-        </div>
-        <div class="results-charts-grid__side">
-          <CarbonFootPrintPerPersonChart
-            :per-person-breakdown="
-              moduleStore.state.emissionBreakdown?.per_person_breakdown
-            "
-            :validated-categories="
-              moduleStore.state.emissionBreakdown?.validated_categories
-            "
-            :headcount-validated="
-              moduleStore.state.emissionBreakdown?.validated_categories?.includes(
-                'commuting',
-              ) ?? false
-            "
-          />
-        </div>
+      <q-card flat class="results-charts-grid">
+        <template v-if="chartsReady">
+          <div class="results-charts-grid__main">
+            <ModuleCarbonFootprintChart
+              :breakdown-data="moduleStore.state.emissionBreakdown"
+            />
+          </div>
+          <div class="results-charts-grid__side">
+            <CarbonFootPrintPerPersonChart
+              :per-person-breakdown="
+                moduleStore.state.emissionBreakdown?.per_person_breakdown
+              "
+              :validated-categories="
+                moduleStore.state.emissionBreakdown?.validated_categories
+              "
+              :headcount-validated="
+                moduleStore.state.emissionBreakdown?.validated_categories?.includes(
+                  'commuting',
+                ) ?? false
+              "
+            />
+          </div>
+        </template>
+        <template v-else>
+          <div class="results-charts-grid__main">
+            <q-skeleton type="rect" height="360px" class="full-width q-ma-sm" />
+          </div>
+          <div class="results-charts-grid__side">
+            <q-skeleton type="rect" height="360px" class="full-width q-ma-sm" />
+          </div>
+        </template>
       </q-card>
 
       <q-card flat bordered class="q-pa-xl">
@@ -365,11 +437,17 @@ const getUncertainty = (
           </div>
         </div>
         <q-card-section class="q-px-none q-pt-lg q-pb-none">
-          <img
-            src="/placeholder.svg"
-            alt="Objectives 2040 placeholder"
-            class="objectives-placeholder-image"
-          />
+          <div class="objectives-placeholder-frame">
+            <img
+              src="/placeholder.svg"
+              alt=""
+              width="1380"
+              height="500"
+              decoding="async"
+              fetchpriority="low"
+              class="objectives-placeholder-image"
+            />
+          </div>
         </q-card-section>
       </q-card>
 
@@ -398,7 +476,10 @@ const getUncertainty = (
             bordered
             class="q-pa-none q-mt-xl"
           >
-            <q-expansion-item expand-separator>
+            <q-expansion-item
+              v-model="resultsCategoryExpanded[module]"
+              expand-separator
+            >
               <template #header>
                 <div class="flex justify-between items-center">
                   <module-icon
@@ -424,147 +505,151 @@ const getUncertainty = (
                   />
                 </div>
               </template>
-              <q-separator />
+              <template v-if="resultsCategoryExpanded[module]">
+                <q-separator />
 
-              <div class="q-px-lg">
-                <!-- Module has results in the summary -->
-                <template v-if="getModuleResult(module)">
-                  <!-- Per-module treemap -->
-                  <template v-if="isModuleValidated(module)">
-                    <ModuleCharts
-                      :type="module"
-                      :show-evolution-chart="
-                        module === MODULES.ProfessionalTravel
-                      "
-                    />
-                  </template>
-                  <q-card flat class="grid-3-col q-mb-lg">
-                    <BigNumber
-                      :title="
-                        getTotalModuleCarbonFootprintTitle(module as Module)
-                      "
-                      :number="
-                        getModuleConfig(module).totalFormatter(
-                          getModuleResult(module)!.total_tonnes_co2eq,
-                        )
-                      "
-                      :comparison="
-                        $t('results_equivalent_to_car', {
-                          km: $nOrDash(
-                            getModuleResult(module)!.equivalent_car_km,
-                            FORMAT_INTEGER,
-                          ),
-                          value: `${$nOrDash(co2PerKmKg)}`,
-                        })
-                      "
-                      :comparison-highlight="`${$nOrDash(
-                        getModuleResult(module)!.equivalent_car_km,
-                        FORMAT_INTEGER,
-                      )}km`"
-                      color="negative"
-                    >
-                      <template #tooltip>{{
-                        $t('results_total_unit_carbon_footprint_tooltip', {
-                          value: $nOrDash(co2PerKmKg),
-                          unit: $t('results_kg_co2eq_per_km'),
-                        })
-                      }}</template>
-                    </BigNumber>
-                    <BigNumber
-                      :title="
-                        $t('results_module_carbon_footprint', {
-                          module: $t(module),
-                        })
-                      "
-                      :number="
-                        formatPercentChange(
-                          getModuleResult(module)!.year_comparison_percentage,
-                        )
-                      "
-                      :unit="
-                        $t('results_compared_to', {
-                          year: (currentYear - 1).toString(),
-                        })
-                      "
-                      :color="
-                        getModuleResult(module)!.year_comparison_percentage ==
-                        null
-                          ? undefined
-                          : getModuleResult(module)!
-                                .year_comparison_percentage! < 0
-                            ? 'positive'
-                            : 'negative'
-                      "
-                      :comparison="
-                        $t('results_compared_to_value_of', {
-                          value: `${getModuleConfig(module).totalFormatter(
-                            getModuleResult(module)!
-                              .previous_year_total_tonnes_co2eq,
-                          )}${$t('results_units_tonnes')}`,
-                        })
-                      "
-                      :comparison-highlight="`${getModuleConfig(
-                        module,
-                      ).totalFormatter(
-                        getModuleResult(module)!
-                          .previous_year_total_tonnes_co2eq,
-                      )}${$t('results_units_tonnes')}`"
-                    >
-                    </BigNumber>
-                    <BigNumber
-                      :title="
-                        resultsSummary.unit_totals.total_fte == null
-                          ? $t('results_carbon_footprint_per_FTE_no_headcount')
-                          : $t('results_carbon_footprint_per_fte', {
-                              FTE: resultsSummary.unit_totals.total_fte,
-                            })
-                      "
-                      :number="
-                        getModuleConfig(module).totalFormatter(
-                          getModuleResult(module)!.tonnes_co2eq_per_fte,
-                        )
-                      "
-                      :comparison="
-                        $t('results_paris_agreement_value', {
-                          value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
-                        })
-                      "
-                      :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
-                      color="negative"
-                    >
-                      <template #tooltip>{{
-                        $t('results_paris_agreement_tooltip')
-                      }}</template>
-                    </BigNumber>
-                  </q-card>
-                </template>
-
-                <!-- Module not in results: show validation placeholder -->
-                <template v-else>
-                  <q-card flat bordered class="validation-required-card">
-                    <q-card-section class="validation-required-card__content">
-                      <q-icon
-                        name="o_info"
-                        size="md"
-                        color="accent"
-                        class="q-mb-md"
+                <div class="q-px-lg">
+                  <!-- Module has results in the summary -->
+                  <template v-if="getModuleResult(module)">
+                    <!-- Per-module treemap -->
+                    <template v-if="isModuleValidated(module)">
+                      <ModuleCharts
+                        :type="module"
+                        :show-evolution-chart="
+                          module === MODULES.ProfessionalTravel
+                        "
                       />
-                      <div
-                        class="text-h6 text-weight-medium text-center q-mb-sm"
+                    </template>
+                    <q-card flat class="grid-3-col q-mb-lg">
+                      <BigNumber
+                        :title="
+                          getTotalModuleCarbonFootprintTitle(module as Module)
+                        "
+                        :number="
+                          getModuleConfig(module).totalFormatter(
+                            getModuleResult(module)!.total_tonnes_co2eq,
+                          )
+                        "
+                        :comparison="
+                          $t('results_equivalent_to_car', {
+                            km: $nOrDash(
+                              getModuleResult(module)!.equivalent_car_km,
+                              FORMAT_INTEGER,
+                            ),
+                            value: `${$nOrDash(co2PerKmKg)}`,
+                          })
+                        "
+                        :comparison-highlight="`${$nOrDash(
+                          getModuleResult(module)!.equivalent_car_km,
+                          FORMAT_INTEGER,
+                        )}km`"
+                        color="negative"
                       >
-                        {{
-                          $t('results_validate_module_title', {
+                        <template #tooltip>{{
+                          $t('results_total_unit_carbon_footprint_tooltip', {
+                            value: $nOrDash(co2PerKmKg),
+                            unit: $t('results_kg_co2eq_per_km'),
+                          })
+                        }}</template>
+                      </BigNumber>
+                      <BigNumber
+                        :title="
+                          $t('results_module_carbon_footprint', {
                             module: $t(module),
                           })
-                        }}
-                      </div>
-                      <div class="text-body2 text-secondary text-center">
-                        {{ $t('results_validate_module_message') }}
-                      </div>
-                    </q-card-section>
-                  </q-card>
-                </template>
-              </div>
+                        "
+                        :number="
+                          formatPercentChange(
+                            getModuleResult(module)!.year_comparison_percentage,
+                          )
+                        "
+                        :unit="
+                          $t('results_compared_to', {
+                            year: (currentYear - 1).toString(),
+                          })
+                        "
+                        :color="
+                          getModuleResult(module)!.year_comparison_percentage ==
+                          null
+                            ? undefined
+                            : getModuleResult(module)!
+                                  .year_comparison_percentage! < 0
+                              ? 'positive'
+                              : 'negative'
+                        "
+                        :comparison="
+                          $t('results_compared_to_value_of', {
+                            value: `${getModuleConfig(module).totalFormatter(
+                              getModuleResult(module)!
+                                .previous_year_total_tonnes_co2eq,
+                            )}${$t('results_units_tonnes')}`,
+                          })
+                        "
+                        :comparison-highlight="`${getModuleConfig(
+                          module,
+                        ).totalFormatter(
+                          getModuleResult(module)!
+                            .previous_year_total_tonnes_co2eq,
+                        )}${$t('results_units_tonnes')}`"
+                      >
+                      </BigNumber>
+                      <BigNumber
+                        :title="
+                          resultsSummary.unit_totals.total_fte == null
+                            ? $t(
+                                'results_carbon_footprint_per_FTE_no_headcount',
+                              )
+                            : $t('results_carbon_footprint_per_fte', {
+                                FTE: resultsSummary.unit_totals.total_fte,
+                              })
+                        "
+                        :number="
+                          getModuleConfig(module).totalFormatter(
+                            getModuleResult(module)!.tonnes_co2eq_per_fte,
+                          )
+                        "
+                        :comparison="
+                          $t('results_paris_agreement_value', {
+                            value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
+                          })
+                        "
+                        :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
+                        color="negative"
+                      >
+                        <template #tooltip>{{
+                          $t('results_paris_agreement_tooltip')
+                        }}</template>
+                      </BigNumber>
+                    </q-card>
+                  </template>
+
+                  <!-- Module not in results: show validation placeholder -->
+                  <template v-else>
+                    <q-card flat bordered class="validation-required-card">
+                      <q-card-section class="validation-required-card__content">
+                        <q-icon
+                          name="o_info"
+                          size="md"
+                          color="accent"
+                          class="q-mb-md"
+                        />
+                        <div
+                          class="text-h6 text-weight-medium text-center q-mb-sm"
+                        >
+                          {{
+                            $t('results_validate_module_title', {
+                              module: $t(module),
+                            })
+                          }}
+                        </div>
+                        <div class="text-body2 text-secondary text-center">
+                          {{ $t('results_validate_module_message') }}
+                        </div>
+                      </q-card-section>
+                    </q-card>
+                  </template>
+                </div>
+              </template>
             </q-expansion-item>
           </q-card>
         </template>
@@ -622,6 +707,11 @@ const getUncertainty = (
   :deep(.text-h1) {
     color: rgba(0, 0, 0, 0.38) !important;
   }
+}
+
+.objectives-placeholder-frame {
+  aspect-ratio: 1380 / 500;
+  width: 100%;
 }
 
 .objectives-placeholder-image {


### PR DESCRIPTION
## What does this change?

A broad set of improvements across the results page, touching layout, components, and copy:

**Results page layout**
- Replaces the flat 2-column grid with a responsive `results-charts-grid` (full-width on mobile, 2/3 + 1/3 above 1024px) for the main chart and per-person chart
- Reorders the three summary KPIs: total footprint → year-on-year comparison → footprint per FTE
- Removes the `no-data-styling` wrapper div around year comparison `BigNumber`s; null state is now handled inside the component

**BigNumber component**
- Adds a `tooltipPlacement` prop (`'title'` | `'comparison'`) so the info icon can be anchored to either section
- Adds `full-width` and `big-number` classes; card now uses `height: 100%` and `flex-direction: column` so cards in the same row stretch to equal height
- Comparison block gets `white-space: normal` and `overflow-wrap: anywhere` to handle long strings gracefully

**Carbon footprint chart**
- Moves PNG/CSV download buttons from the card header to a `q-card-actions` footer below the chart
- Chart width changed from fixed `500px` to `100%`, with a `95%` fallback below 1320px
- Card adopts `flex-direction: column` with `flex: 1` on the chart body so it fills available height

**Per-FTE card**
- Title now conditionally shows total FTE count (`results_carbon_footprint_per_fte` with `{FTE}`) or falls back to a no-headcount label when `total_fte` is null
- Removes the Paris Agreement tooltip from the unit-level card (retained at module level)

**i18n**
- Adds keys for the upcoming additional-categories section: commuting, food, waste, embodied energy, and grey energy totals, breakdowns, and tooltips
- Adds subcategory label keys for all commuting modes, food types, and waste streams
- Normalises capitalisation to sentence case across ~30 existing keys in `results.ts` and `common.ts`
- Renames `results_carbon_footprint_per_person_title` → split into `results_carbon_footprint_per_fte` (with FTE count) and `results_carbon_footprint_per_FTE_no_headcount`
- Updates `results_equivalent_to_car`, `results_no_comparison_year_available`, `results_unit_carbon_footprint`, and `results_total_unit_carbon_footprint_tooltip` copy

## Why is this needed?

- The fixed-width chart and top-anchored download buttons produced a cramped, unbalanced layout at various screen sizes
- The tooltip was semantically misplaced on several `BigNumber` cards — it describes the comparison value, not the title
- The KPI ordering did not reflect the intended reading flow (total → trend → per-person)
- Missing i18n keys would have caused untranslated strings to appear once the additional-categories section ships
- Inconsistent capitalisation created visual noise across the results page

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #181 
- Related to #