### PR TITLE
feat/585 add IT focus IT enhancements

### DIFF
--- a/backend/app/utils/it_breakdown.py
+++ b/backend/app/utils/it_breakdown.py
@@ -157,6 +157,25 @@ def build_it_breakdown(
         (total_it_kg / total_emissions_kg * 100.0) if total_emissions_kg > 0 else 0.0
     )
 
+    # IT share within validated IT source modules only
+    validated_source_module_ids: set[int] = set()
+    for mod_ids in _IT_CATEGORY_MODULE_IDS.values():
+        if mod_ids.issubset(validated_ids):
+            validated_source_module_ids |= mod_ids
+    validated_it_kg = sum(
+        category_kg[cat]
+        for cat, mod_ids in _IT_CATEGORY_MODULE_IDS.items()
+        if mod_ids.issubset(validated_ids)
+    )
+    total_validated_source_kg = sum(
+        kg for mid, _, kg in filtered_rows if mid in validated_source_module_ids
+    )
+    percentage_of_source_modules = (
+        (validated_it_kg / total_validated_source_kg * 100.0)
+        if total_validated_source_kg > 0
+        else 0.0
+    )
+
     # Build scope breakdown
     scope_2_kg = category_kg[IT_CATEGORY_EQUIPMENT]
     scope_3_kg = (
@@ -224,6 +243,7 @@ def build_it_breakdown(
         "total_it_tonnes_co2eq": total_it_tonnes,
         "total_it_per_fte": total_it_per_fte,
         "percentage_of_total": percentage_of_total,
+        "percentage_of_source_modules": percentage_of_source_modules,
         "categories": categories,
         "scope_breakdown": {
             "scope_2": scope_2_kg / 1000.0,

--- a/frontend/.lighthouserc.ci.json
+++ b/frontend/.lighthouserc.ci.json
@@ -7,8 +7,7 @@
         "http://localhost:8080/en/login",
         "http://localhost:8080/en/login-test",
         "http://localhost:8080/en/workspace-setup",
-        "http://localhost:8080/en/MOCK/2024/home",
-        "http://localhost:8080/en/MOCK/2024/results"
+        "http://localhost:8080/en/MOCK/2024/home"
       ],
       "numberOfRuns": 1,
       "settings": {

--- a/frontend/.lighthouserc.json
+++ b/frontend/.lighthouserc.json
@@ -8,7 +8,6 @@
         "http://localhost:8080/en/login-test",
         "http://localhost:8080/en/workspace-setup",
         "http://localhost:8080/en/MOCK/2024/home",
-        "http://localhost:8080/en/MOCK/2024/results",
         "http://localhost:8080/en/MOCK/2024/simulations",
         "http://localhost:8080/en/MOCK/2024/simulations/add",
         "http://localhost:8080/en/MOCK/2024/simulations/edit/abc123",

--- a/frontend/src/components/molecules/BigNumber.vue
+++ b/frontend/src/components/molecules/BigNumber.vue
@@ -6,6 +6,7 @@ const props = withDefaults(
     title: string;
     number: string;
     unit?: string;
+    hideUnit?: boolean;
     bordered?: boolean;
     comparison?: string;
     comparisonHighlight?: string;
@@ -15,6 +16,7 @@ const props = withDefaults(
   {
     bordered: true,
     unit: undefined,
+    hideUnit: false,
     comparison: undefined,
     comparisonHighlight: undefined,
     color: undefined,
@@ -54,7 +56,7 @@ const comparisonParts = computed(() => {
   <q-card
     flat
     :bordered="bordered"
-    :class="['container', 'container--pa-none']"
+    :class="['container', 'container--pa-none', 'big-number']"
   >
     <q-card-section class="flex items-center q-mb-xs">
       <q-icon
@@ -85,7 +87,7 @@ const comparisonParts = computed(() => {
         >
           {{ number }}
         </div>
-        <div class="text-secondary text-body2 q-mb-none">
+        <div v-if="!hideUnit" class="text-secondary text-body2 q-mb-none">
           {{ unit ? unit : $t('results_units_tonnes') }}
         </div>
       </div>
@@ -135,7 +137,7 @@ const comparisonParts = computed(() => {
 }
 
 .big-number__comparison {
-  align-self: flex-start;
+  align-self: flex-end;
   white-space: normal;
   overflow-wrap: anywhere;
 }

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -18,10 +18,6 @@ import type { ItBreakdownResponse } from 'src/stores/modules';
 
 use([CanvasRenderer, BarChart, TooltipComponent, GridComponent]);
 
-const FORMAT_INTEGER = {
-  options: { minimumFractionDigits: 0, maximumFractionDigits: 0 },
-};
-
 const props = withDefaults(
   defineProps<{
     data: ItBreakdownResponse | null;
@@ -88,6 +84,7 @@ interface CategoryBar {
   categoryKey: string;
   segments: BarSegment[];
   total: number;
+  validated: boolean;
 }
 
 /**
@@ -100,31 +97,53 @@ const categoryBars = computed<CategoryBar[]>(() => {
 
   const bars: CategoryBar[] = [];
 
-  for (const cat of props.data.categories) {
-    if (cat.tonnes_co2eq <= 0) continue;
-    if (!isItCategoryModuleValidated(cat.category_key)) continue;
+  // Index API data by key — non-validated categories may be absent from the response
+  const dataByKey = Object.fromEntries(
+    props.data.categories.map((c) => [c.category_key, c]),
+  );
 
-    const label = t(CATEGORY_LABEL_MAP[cat.category_key] ?? cat.category_key);
+  // Iterate the fixed order so all 4 rows are always present (validated or not)
+  for (const categoryKey of IT_FOCUS_CATEGORY_ORDER) {
+    const validated = isItCategoryModuleValidated(categoryKey);
+    const label = t(CATEGORY_LABEL_MAP[categoryKey] ?? categoryKey);
     const color =
-      categoryColor.value[
-        cat.category_key as keyof typeof categoryColor.value
-      ] ?? '#999';
-    const items = cat.top_items ?? [];
+      categoryColor.value[categoryKey as keyof typeof categoryColor.value] ??
+      '#999';
 
+    if (!validated) {
+      bars.push({
+        label,
+        categoryKey,
+        segments: [],
+        total: 0,
+        validated: false,
+      });
+      continue;
+    }
+
+    const cat = dataByKey[categoryKey];
+    if (!cat || cat.tonnes_co2eq <= 0) {
+      // Validated but no data: still show the row (empty bar, black label)
+      bars.push({
+        label,
+        categoryKey,
+        segments: [],
+        total: 0,
+        validated: true,
+      });
+      continue;
+    }
+
+    const items = cat.top_items ?? [];
     const segments: BarSegment[] = [];
 
     if (items.length === 0) {
-      // No detail: single segment for the whole category
-      segments.push({
-        name: label,
-        value: cat.tonnes_co2eq,
-        color,
-      });
+      segments.push({ name: label, value: cat.tonnes_co2eq, color });
     } else {
       items.forEach((item) => {
         if (item.value <= 0) return;
         let name = item.name;
-        if (cat.category_key === 'external_cloud_and_ai') {
+        if (categoryKey === 'external_cloud_and_ai') {
           name = t(CLOUD_AI_LABEL_MAP[item.name] ?? item.name);
         } else if (item.name === 'rest') {
           name = t('it-focus-rest');
@@ -135,42 +154,31 @@ const categoryBars = computed<CategoryBar[]>(() => {
 
     bars.push({
       label,
-      categoryKey: cat.category_key,
+      categoryKey,
       segments,
       total: cat.tonnes_co2eq,
+      validated: true,
     });
   }
-
-  const orderRank = (key: string): number => {
-    const i = IT_FOCUS_CATEGORY_ORDER.indexOf(
-      key as (typeof IT_FOCUS_CATEGORY_ORDER)[number],
-    );
-    return i === -1 ? IT_FOCUS_CATEGORY_ORDER.length : i;
-  };
-
-  bars.sort((a, b) => {
-    const d = orderRank(a.categoryKey) - orderRank(b.categoryKey);
-    return d !== 0 ? d : a.categoryKey.localeCompare(b.categoryKey);
-  });
 
   return bars;
 });
 
+// Show chart as long as there's at least one bar (validated or grayed-out)
 const hasData = computed(() => categoryBars.value.length > 0);
+
+/** Set of translated labels for validated categories (used for axis styling). */
+const validatedLabels = computed(
+  () =>
+    new Set(categoryBars.value.filter((b) => b.validated).map((b) => b.label)),
+);
 
 /** Tonnes from categories whose parent module is validated (aligned with visible bars). */
 const displayTotalItTonnes = computed(() =>
-  categoryBars.value.reduce((sum, bar) => sum + bar.total, 0),
+  categoryBars.value
+    .filter((b) => b.validated)
+    .reduce((sum, bar) => sum + bar.total, 0),
 );
-
-/** Same rule as module totals: equivalent_car_km = kg_co2eq / co2_per_km_kg */
-const itEquivalentCarKm = computed(() => {
-  if (props.co2PerKmKg <= 0) return null;
-  const total = displayTotalItTonnes.value;
-  if (total <= 0) return null;
-  const kg = total * 1000;
-  return kg / props.co2PerKmKg;
-});
 
 /** Collect all unique segment names across all bars (union for stacking) */
 const allSegmentKeys = computed(() => {
@@ -212,7 +220,8 @@ const segmentLabelMap = computed(() => {
 });
 
 const chartHeight = computed(() => {
-  return Math.max(200, categoryBars.value.length * 60 + 120);
+  // Always 4 rows (IT_FOCUS_CATEGORY_ORDER), validated or not
+  return Math.max(200, IT_FOCUS_CATEGORY_ORDER.length * 60 + 120);
 });
 
 const barChartOption = computed<EChartsOption>(() => {
@@ -258,6 +267,10 @@ const barChartOption = computed<EChartsOption>(() => {
           value?: number;
           name?: string;
         };
+        const name = p.name || '';
+        if (!validatedLabels.value.has(name)) {
+          return `<strong>${name}</strong><br/><span style="color:#aaa">${t('results_validate_module_title', { module: name })}</span>`;
+        }
         const val = Number(p.value) || 0;
         if (val <= 0) return '';
         return `${p.marker || ''} <strong>${p.seriesName || ''}</strong>: ${formatTonnesForChart(val)}${t('results_units_tonnes')}`;
@@ -283,9 +296,24 @@ const barChartOption = computed<EChartsOption>(() => {
       type: 'category',
       data: yLabels,
       axisLabel: {
-        fontSize: 10,
         width: 150,
         overflow: 'truncate',
+        formatter: (value: string) => {
+          if (validatedLabels.value.has(value)) {
+            return `{validated|${value}}`;
+          }
+          return `{unvalidated|${value}}`;
+        },
+        rich: {
+          validated: {
+            color: '#000000',
+            fontSize: 10,
+          },
+          unvalidated: {
+            color: '#aaaaaa',
+            fontSize: 10,
+          },
+        },
       },
     },
     series: series as echarts.SeriesOption[],
@@ -305,34 +333,25 @@ const barChartOption = computed<EChartsOption>(() => {
     <q-separator class="q-mt-xl" />
 
     <!-- Summary numbers -->
-    <q-card v-if="data" flat class="grid-1-col q-mt-lg q-mb-lg q-px-lg">
+    <div v-if="data" class="grid-2-col q-mt-lg q-mb-lg q-px-lg">
       <BigNumber
         :title="$t('it-focus-total')"
         :number="`${formatTonnesCO2(displayTotalItTonnes)}`"
-        :comparison="
-          itEquivalentCarKm != null
-            ? $t('results_equivalent_to_car', {
-                km: $nOrDash(itEquivalentCarKm, FORMAT_INTEGER),
-                value: `${$nOrDash(co2PerKmKg)}`,
-              })
-            : undefined
-        "
-        :comparison-highlight="
-          itEquivalentCarKm != null
-            ? `${$nOrDash(itEquivalentCarKm, FORMAT_INTEGER)}km`
-            : undefined
-        "
+        comparison="TBD"
         color="accent"
-        tooltip-placement="comparison"
-      >
-        <template v-if="co2PerKmKg > 0" #tooltip>{{
-          $t('results_total_unit_carbon_footprint_tooltip', {
-            value: $nOrDash(co2PerKmKg),
-            unit: $t('results_kg_co2eq_per_km'),
-          })
-        }}</template>
-      </BigNumber>
-    </q-card>
+      />
+      <BigNumber
+        :title="$t('it-focus-share-of-total')"
+        :number="
+          data.percentage_of_source_modules != null
+            ? `${Math.round(data.percentage_of_source_modules)}%`
+            : '-'
+        "
+        :comparison="$t('it-focus-share-of-total-hint')"
+        hide-unit
+        color="accent"
+      />
+    </div>
 
     <template v-if="!loading && data">
       <!-- Stacked horizontal bar chart - one bar per IT category, segments = top items -->

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -795,8 +795,12 @@ export default {
     fr: 'Empreinte carbone IT par ETP',
   },
   'it-focus-share-of-total': {
-    en: 'IT share of total emissions',
-    fr: 'Part IT des émissions totales',
+    en: 'IT share of  footprint',
+    fr: "Part IT de l'empreinte ",
+  },
+  'it-focus-share-of-total-hint': {
+    en: 'Based on validated categories only',
+    fr: 'Basé uniquement sur les catégories validées',
   },
   'it-focus-equipment-it': {
     en: 'IT equipment - energy use',
@@ -848,8 +852,8 @@ export default {
     fr: 'Scope 3',
   },
   'it-focus-rest': {
-    en: 'Other',
-    fr: 'Autres',
+    en: 'Rest ',
+    fr: 'Rest',
   },
   'it-focus-research-facilities': {
     en: 'IT research facilities',

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -70,6 +70,7 @@ export interface ItBreakdownResponse {
   total_it_tonnes_co2eq: number;
   total_it_per_fte: number;
   percentage_of_total: number;
+  percentage_of_source_modules: number;
   categories: ItBreakdownCategory[];
   scope_breakdown: {
     scope_2: number;


### PR DESCRIPTION
## What does this change?
Non-validated IT categories now appear in the bar chart with greyed-out labels and empty bars (matching the module carbon footprint chart behaviour), instead of being hidden entirely
- Adds a second "IT share of footprint" BigNumber alongside the total, showing IT emissions as a percentage of total emissions from validated IT source modules only (equipment, purchases, cloud & AI, research facilities)
- Replaces the car equivalence text with "TBD" pending final copy

## Why is this needed?
Users need visibility into which IT categories are not yet validated (greyed labels serve as a prompt), and a quick at-a-glance share metric scoped to the IT source modules rather than the full unit footprint.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Related issues

- Closes #826 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
