### PR TITLE
fix: repare travel table in module page

### DIFF
--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -425,7 +425,7 @@ class DataEntryRepository:
 
         if institutional_id_filter is not None and is_travel_entry:
             statement = statement.where(
-                MemberEntry.data["user_institutional_id"].as_string()
+                DataEntry.data["user_institutional_id"].as_string()
                 == institutional_id_filter
             )
 


### PR DESCRIPTION
## What does this change?
What does this change?
Fixes the model reference in the where clause filter — changed MemberEntry to DataEntry when filtering by user_institutional_id in the travel entry query.
Why is this needed?
The travel table was broken because the filter was querying MemberEntry.data["user_institutional_id"] instead of DataEntry.data["user_institutional_id"], causing incorrect or missing results when displaying travel entries filtered by institutional ID.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #850 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
