### PR TITLE
fix/861 bar chart order

### DIFF
--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -65,6 +65,7 @@ class EmissionBreakdownCategoryRow(TypedDict):
     category: str
     category_key: str
     emissions: list[EmissionBreakdownValue]
+    parent_keys_order: list[str]
 
 
 EMISSION_SCOPE: dict[EmissionType, EmissionMeta] = {
@@ -596,6 +597,8 @@ def _build_category_row(
     }
     emissions: list[EmissionBreakdownValue] = []
     parent_sums: dict[str, float] = {}
+    parent_keys_order: list[str] = []
+    seen_bar_keys: set[str] = set()
     for emission_type, kg_co2eq in sorted(values_kg.items(), key=lambda i: i[0].value):
         if kg_co2eq <= 0:
             continue
@@ -608,7 +611,12 @@ def _build_category_row(
         parent_key = emission.get("parent_key")
         if parent_key is not None:
             parent_sums[parent_key] = parent_sums.get(parent_key, 0.0) + value
+        bar_key = parent_key if parent_key is not None else key
+        if bar_key not in seen_bar_keys:
+            seen_bar_keys.add(bar_key)
+            parent_keys_order.append(bar_key)
     flat["emissions"] = emissions
+    flat["parent_keys_order"] = parent_keys_order
     flat.update(parent_sums)
     return flat
 

--- a/backend/tests/unit/utils/test_emission_category.py
+++ b/backend/tests/unit/utils/test_emission_category.py
@@ -212,3 +212,106 @@ def test_build_treemap_basic():
 def test_build_treemap_zero_total():
     assert build_treemap([]) == []
     assert build_treemap([("zero", 0.0)]) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# parent_keys_order contract
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_parent_keys_order_child_emission_uses_parent_bar_key():
+    """A depth-2 emission (plane__eco) contributes its *parent* key ('plane')
+    to parent_keys_order, not its own leaf key ('eco')."""
+    rows = [
+        (
+            ModuleTypeEnum.professional_travel.value,
+            EmissionType.professional_travel__plane__eco.value,
+            5_000.0,
+        ),
+    ]
+
+    result = build_chart_breakdown(rows)
+    travel = _row_by_category(result["module_breakdown"], "professional_travel")
+
+    assert "parent_keys_order" in travel
+    assert travel["parent_keys_order"] == ["plane"]
+    # The child leaf key must NOT leak into parent_keys_order
+    assert "eco" not in travel["parent_keys_order"]
+
+
+def test_parent_keys_order_multiple_children_same_parent_deduplicated():
+    """Multiple children of the same parent (plane__business + plane__eco)
+    must produce exactly one 'plane' entry in parent_keys_order, and the
+    parent sum must equal the combined tonnage."""
+    rows = [
+        (
+            ModuleTypeEnum.professional_travel.value,
+            EmissionType.professional_travel__plane__business.value,
+            3_000.0,
+        ),
+        (
+            ModuleTypeEnum.professional_travel.value,
+            EmissionType.professional_travel__plane__eco.value,
+            7_000.0,
+        ),
+    ]
+
+    result = build_chart_breakdown(rows)
+    travel = _row_by_category(result["module_breakdown"], "professional_travel")
+
+    assert travel["parent_keys_order"] == ["plane"]
+    assert travel["plane"] == pytest.approx(10.0)
+
+
+def test_parent_keys_order_reflects_first_seen_value_sorted_order():
+    """parent_keys_order follows the first-seen ordering produced by iterating
+    emission types in ascending EmissionType.value order.
+
+    train__class_1 (50101) < plane__eco (50203), so 'train' must appear
+    before 'plane' regardless of the order rows are supplied in."""
+    rows = [
+        # Deliberately listed in reverse value order to prove input order
+        # does not drive parent_keys_order -- only EmissionType.value sort does.
+        (
+            ModuleTypeEnum.professional_travel.value,
+            EmissionType.professional_travel__plane__eco.value,  # 50203
+            6_000.0,
+        ),
+        (
+            ModuleTypeEnum.professional_travel.value,
+            EmissionType.professional_travel__train__class_1.value,  # 50101
+            4_000.0,
+        ),
+    ]
+
+    result = build_chart_breakdown(rows)
+    travel = _row_by_category(result["module_breakdown"], "professional_travel")
+
+    # train (50101) is encountered first in the ascending value scan
+    assert travel["parent_keys_order"] == ["train", "plane"]
+
+
+def test_parent_keys_order_standalone_leaf_uses_own_key():
+    """An emission type with no logical parent (level-1 subcategory leaf)
+    uses its own leaf key directly as the bar key and appears in
+    parent_keys_order in ascending EmissionType.value order."""
+    # equipment__scientific (80100) and equipment__it (80200) are both
+    # level-1 leaves: no parent_key is set, so bar_key == key.
+    rows = [
+        (
+            ModuleTypeEnum.equipment_electric_consumption.value,
+            EmissionType.equipment__scientific.value,  # 80100
+            8_000.0,
+        ),
+        (
+            ModuleTypeEnum.equipment_electric_consumption.value,
+            EmissionType.equipment__it.value,  # 80200
+            2_000.0,
+        ),
+    ]
+
+    result = build_chart_breakdown(rows)
+    equipment = _row_by_category(result["module_breakdown"], "equipment")
+
+    # 80100 < 80200 -> "scientific" is first-seen, then "it"
+    assert equipment["parent_keys_order"] == ["scientific", "it"]

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -7,15 +7,20 @@ import EmissionTypeBreakdownChart from 'src/components/charts/results/EmissionTy
 import {
   MODULE_TO_CATEGORIES,
   CHART_CATEGORY_COLOR_SCALES,
+  CHART_CATEGORY_COLOR_SCHEMES,
+  CHART_SUBCATEGORY_COLOR_SCHEMES,
 } from 'src/constant/charts';
 import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakdownInfo';
 import { MODULES } from 'src/constant/modules';
 import {
-  buildModuleTreemapData,
   CATEGORY_CHART_KEYS,
   type EmissionTreemapCategory,
+  type EmissionTreemapChild,
 } from 'src/composables/useEmissionTreemap';
-import type { EmissionBreakdownCategoryRow } from 'src/stores/modules';
+import type {
+  EmissionBreakdownCategoryRow,
+  EmissionBreakdownValue,
+} from 'src/stores/modules';
 
 interface BreakdownData {
   module_breakdown: Array<Record<string, unknown>>;
@@ -82,17 +87,6 @@ function selectTab(tab: TabKey) {
   selectedTab.value = tab;
 }
 
-type BreakdownRow = { category: string; [key: string]: number | string };
-
-function toRow(r: Record<string, unknown>): BreakdownRow {
-  const row: BreakdownRow = { category: String(r.category ?? '') };
-  for (const [k, v] of Object.entries(r)) {
-    if (k === 'category') continue;
-    if (typeof v === 'number' || typeof v === 'string') row[k] = v;
-  }
-  return row;
-}
-
 const categoryRows = computed<EmissionBreakdownCategoryRow[]>(() => {
   if (!props.breakdownData || !activeTab.value) return [];
   const categories = MODULE_TO_CATEGORIES.value[activeTab.value] ?? [];
@@ -120,12 +114,86 @@ const categoryRows = computed<EmissionBreakdownCategoryRow[]>(() => {
 const treemapData = computed<EmissionTreemapCategory[]>(() => {
   if (!props.breakdownData || !activeTab.value) return [];
 
+  const catColorSchemes = CHART_CATEGORY_COLOR_SCHEMES.value as Record<
+    string,
+    string
+  >;
+  const subColorSchemes = CHART_SUBCATEGORY_COLOR_SCHEMES.value as Record<
+    string,
+    Record<string, string>
+  >;
+
   const categories = MODULE_TO_CATEGORIES.value[activeTab.value] ?? [];
-  const filteredKeys = Object.fromEntries(
-    Object.entries(CATEGORY_CHART_KEYS).filter(([k]) => categories.includes(k)),
-  );
-  const rows = props.breakdownData.module_breakdown.map(toRow);
-  return buildModuleTreemapData(rows, filteredKeys);
+  // Read directly from raw module_breakdown to get every leaf emission
+  // without the categoryRows allowedBarNames filter stripping them out.
+  const moduleRows = props.breakdownData
+    .module_breakdown as EmissionBreakdownCategoryRow[];
+
+  const result: EmissionTreemapCategory[] = [];
+
+  for (const rawRow of moduleRows) {
+    const cat = String(rawRow.category_key || rawRow.category || '');
+    if (!categories.includes(cat) || !(cat in CATEGORY_CHART_KEYS)) continue;
+
+    const catColor = catColorSchemes[cat] ?? '#999999';
+    const subColors = subColorSchemes[cat] ?? {};
+    const catKeys = CATEGORY_CHART_KEYS[cat] ?? [];
+    const rawEmissions = (rawRow.emissions as EmissionBreakdownValue[]) ?? [];
+
+    // Group leaf emissions by their parent subcategory key.
+    // Use explicit parent_key when present so that leaf items like
+    // {key:'eco', parent_key:'plane'} are grouped under 'plane', not 'eco'.
+    const byParent = new Map<string, EmissionBreakdownValue[]>();
+    for (const emission of rawEmissions) {
+      const parentKey = emission.parent_key
+        ? String(emission.parent_key)
+        : String(emission.key);
+      if (!catKeys.includes(parentKey)) continue;
+      if (!byParent.has(parentKey)) byParent.set(parentKey, []);
+      byParent.get(parentKey)!.push(emission);
+    }
+
+    const children: EmissionTreemapChild[] = [];
+    let catTotal = 0;
+
+    // Emit leaves in CATEGORY_CHART_KEYS parent order
+    for (const parentKey of catKeys) {
+      const emissions = byParent.get(parentKey) ?? [];
+      const parentColor = subColors[parentKey] ?? catColor;
+      for (const emission of emissions) {
+        const val = Number(emission.value) || 0;
+        if (val <= 0) continue;
+        children.push({
+          name: emission.key,
+          value: val,
+          percentage: 0,
+          color: parentColor,
+        });
+        catTotal += val;
+      }
+    }
+
+    if (catTotal <= 0 || children.length === 0) continue;
+
+    children.forEach((c) => {
+      c.percentage = (c.value / catTotal) * 100;
+    });
+
+    result.push({
+      name: cat,
+      value: catTotal,
+      percentage: 0,
+      color: catColor,
+      children,
+    });
+  }
+
+  const grandTotal = result.reduce((s, c) => s + c.value, 0);
+  result.forEach((cat) => {
+    cat.percentage = grandTotal > 0 ? (cat.value / grandTotal) * 100 : 0;
+  });
+
+  return result;
 });
 
 const emissionTypeInfoKey = computed(() =>

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
-import { TreemapChart } from 'echarts/charts';
+import { BarChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import {
   TooltipComponent,
@@ -14,17 +14,14 @@ import VChart from 'vue-echarts';
 import EvolutionOverTimeChart from './EvolutionOverTimeChart.vue';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
-import { formatTonnesForChart } from 'src/utils/number';
-import type {
-  EmissionTreemapCategory,
-  EmissionTreemapChild,
-} from 'src/composables/useEmissionTreemap';
+
+import type { EmissionTreemapCategory } from 'src/composables/useEmissionTreemap';
 
 const { t } = useI18n();
 const moduleStore = useModuleStore();
 const workspaceStore = useWorkspaceStore();
 
-const TREEMAP_LABEL_KEY_MAP: Record<string, string> = {
+const LABEL_KEY_MAP: Record<string, string> = {
   // process_emissions
   co2: 'charts-co2-subcategory',
   ch4: 'charts-ch4-subcategory',
@@ -44,6 +41,8 @@ const TREEMAP_LABEL_KEY_MAP: Record<string, string> = {
   calcul: 'charts-calcul-subcategory',
   provider: 'charts-ai-provider-subcategory',
   ai_provider: 'charts-ai-provider-subcategory',
+  ai: 'charts-ai-provider-subcategory',
+  clouds: 'charts-clouds-subcategory',
   // purchases
   scientific_equipment: 'charts-scientific-subcategory',
   it_equipment: 'charts-equipment-it',
@@ -58,16 +57,22 @@ const TREEMAP_LABEL_KEY_MAP: Record<string, string> = {
   // professional travel
   plane: 'charts-plane-subcategory',
   train: 'charts-train-subcategory',
+  // professional travel ZZ items
+  class_1: 'charts-class-1-subcategory',
+  class_2: 'charts-class-2-subcategory',
+  first: 'charts-first-class-subcategory',
+  business: 'charts-business-class-subcategory',
+  eco: 'charts-eco-class-subcategory',
 };
 
 function resolveLabel(raw: string): string {
-  const key = TREEMAP_LABEL_KEY_MAP[raw];
+  const key = LABEL_KEY_MAP[raw];
   return key ? t(key) : raw.replace(/_/g, ' ');
 }
 
 use([
   CanvasRenderer,
-  TreemapChart,
+  BarChart,
   TooltipComponent,
   LegendComponent,
   GridComponent,
@@ -79,164 +84,123 @@ const props = defineProps<{
   showEvolutionDialog?: boolean;
 }>();
 
-type TreemapNode = {
-  name: string;
-  value: number;
-  itemStyle: { color: string };
-  children?: TreemapNode[];
-};
-
-function toTreemapNode(
-  node: EmissionTreemapCategory | EmissionTreemapChild,
-): TreemapNode {
-  const label = resolveLabel(node.name);
-  const treeNode: TreemapNode = {
-    name: label,
-    value: node.value,
-    itemStyle: { color: node.color },
-  };
-  if (
-    'children' in node &&
-    Array.isArray(node.children) &&
-    node.children.length > 0
-  ) {
-    treeNode.children = node.children.map((child) => toTreemapNode(child));
-  }
-  return treeNode;
-}
-
-const treemapData = computed(() => {
-  return props.data
-    .filter((item) => item.value > 0 && item.children.length > 0)
-    .map((item) => toTreemapNode(item));
-});
+const visibleData = computed(() =>
+  props.data.flatMap((cat) => cat.children.filter((c) => c.value > 0)),
+);
 
 const legendData = computed(() => {
   const seen = new Set<string>();
-  return props.data
-    .filter((cat) => cat.value > 0)
-    .flatMap((cat) =>
-      cat.children
-        .filter((c) => c.value > 0)
-        .map((c) => ({ name: resolveLabel(c.name), color: c.color })),
-    )
-    .filter((item) => {
-      if (seen.has(item.name)) return false;
-      seen.add(item.name);
-      return true;
-    });
+  const items: { name: string; color: string }[] = [];
+  for (const child of visibleData.value) {
+    // For ZZ items, show the YY parent in the legend (deduplicated).
+    const legendKey = child.parentKey ?? child.name;
+    if (seen.has(legendKey)) continue;
+    seen.add(legendKey);
+    items.push({ name: resolveLabel(legendKey), color: child.color });
+  }
+  return items;
 });
 
-const chartOption = computed(
-  (): EChartsOption => ({
-    backgroundColor: 'transparent',
-    grid: { top: 0, bottom: 0, left: 0, right: 0, containLabel: false },
-    legend: { show: false },
+const chartOption = computed((): EChartsOption => {
+  const total = visibleData.value.reduce((s, c) => s + c.value, 0);
+
+  const series = visibleData.value.map((cat) => {
+    const pct = total > 0 ? cat.value / total : 0;
+    const label = resolveLabel(cat.name);
+
+    return {
+      name: label,
+      type: 'bar' as const,
+      stack: 'total',
+      barWidth: '100%',
+      data: [{ value: pct * 100, originalValue: cat.value }],
+      itemStyle: {
+        color: cat.color,
+        borderColor: '#fff',
+        borderWidth: 1,
+      },
+      label: {
+        show: pct >= 0.09,
+        position: 'inside' as const,
+        formatter: label,
+        color: '#fff',
+        fontWeight: 'bold' as const,
+        fontSize: 13,
+        backgroundColor: 'rgba(0,0,0,0.15)',
+        borderRadius: 3,
+        padding: [5, 10],
+        overflow: 'truncate' as const,
+      },
+      emphasis: {
+        focus: 'none' as const,
+        label: {
+          show: true,
+          position: 'inside' as const,
+          formatter: label,
+          color: '#fff',
+          fontWeight: 'bold' as const,
+          fontSize: 13,
+
+          overflow: 'truncate' as const,
+        },
+        itemStyle: {
+          color: cat.color,
+          borderColor: '#fff',
+          borderWidth: 1,
+        },
+      },
+      blur: {
+        itemStyle: { opacity: 0.9 },
+        label: { opacity: 1 },
+      },
+    };
+  });
+
+  return {
+    animation: false,
     tooltip: {
       trigger: 'item',
       formatter: (params: unknown) => {
         const p = params as {
-          name?: string;
-          value?: number;
-          treePathInfo?: Array<{ name: string }>;
-          itemStyle?: { color?: string };
-          color?: string;
-          data?: { name?: string; itemStyle?: { color?: string } };
+          seriesName?: string;
+          marker?: string;
+          data?: { value: number; originalValue: number };
         };
-
-        const name = p.name ?? p.data?.name ?? '';
-        const value = p.value ?? 0;
-        const color =
-          p.data?.itemStyle?.color ??
-          p.itemStyle?.color ??
-          p.color ??
-          '#999999';
-
-        const path = (p.treePathInfo?.map((i) => i.name) ?? []).filter(Boolean);
-        const levels = path.length > 1 ? path.slice(1) : path;
-        const categoryName = levels[0] ?? name;
-        const displayName = levels[levels.length - 1] ?? name;
-
+        const val = p.data?.originalValue ?? 0;
+        if (val <= 0) return '';
         return (
-          `<span style="display:inline-block;margin-right:5px;border-radius:10px;` +
-          `width:10px;height:10px;background-color:${color};"></span>` +
-          `<strong>${categoryName}</strong><br/>` +
-          `${displayName}: <strong>${formatTonnesForChart(value)}</strong>`
+          `${p.marker || ''} <strong>${p.seriesName || ''}</strong><br/>` +
+          `${p.seriesName || ''}: <strong>${val.toFixed(1)}</strong>`
         );
       },
     },
-    series: [
-      {
-        type: 'treemap',
-        data: treemapData.value,
-        roam: false,
-        nodeClick: false,
-        breadcrumb: { show: false },
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        width: '100%',
-        height: '100%',
-        label: {
-          show: true,
-          formatter: '{b}',
-          fontSize: 14,
-          fontWeight: 'bold',
-          color: 'white',
-        },
-        upperLabel: { show: false, height: 0, color: 'white' },
-        itemStyle: { borderColor: 'transparent', borderWidth: 0, gapWidth: 1 },
-        emphasis: {
-          itemStyle: { borderColor: 'transparent', borderWidth: 0 },
-          label: { show: true, fontSize: 16, color: 'white' },
-        },
-        sort: false,
-        levels: [
-          {
-            itemStyle: {
-              borderColor: 'transparent',
-              borderWidth: 0,
-              gapWidth: 5,
-            },
-            upperLabel: {
-              show: false,
-              fontSize: 16,
-              fontWeight: 'bold',
-              color: '#333',
-              height: 0,
-            },
-            label: { show: false, fontSize: 14, color: '#333' },
-          },
-          {
-            itemStyle: {
-              borderColor: 'transparent',
-              borderWidth: 0,
-              gapWidth: 3,
-            },
-            upperLabel: {
-              show: false,
-              fontSize: 12,
-              fontWeight: 'bold',
-              color: '#fff',
-              height: 22,
-            },
-            label: { show: true, fontSize: 12, color: '#fff' },
-          },
-          {
-            itemStyle: {
-              borderColor: 'transparent',
-              borderWidth: 0,
-              gapWidth: 1,
-            },
-            upperLabel: { show: false },
-            label: { show: true, fontSize: 11, color: '#fff' },
-          },
-        ],
-      },
-    ],
-  }),
-);
+    legend: { show: false },
+    grid: {
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      containLabel: false,
+    },
+    yAxis: {
+      type: 'category',
+      data: [''],
+      axisLabel: { show: false },
+      axisTick: { show: false },
+      axisLine: { show: false },
+    },
+    xAxis: {
+      type: 'value',
+      min: 0,
+      max: 100,
+      axisLabel: { show: false },
+      axisTick: { show: false },
+      axisLine: { show: false },
+      splitLine: { show: false },
+    },
+    series,
+  };
+});
 
 const chartRef = ref<InstanceType<typeof VChart>>();
 const showEvolutionDialogRef = ref(false);
@@ -267,9 +231,7 @@ const isEvolutionDialogOpen = computed({
   },
 });
 
-// The evolution dialog always uses babyBlue (professional travel color)
 const babyBlueScheme = computed(() => {
-  // Access a color from the first category that has data, or fallback
   const first = props.data[0];
   return first
     ? {
@@ -290,7 +252,7 @@ const babyBlueScheme = computed(() => {
 </script>
 
 <template>
-  <div class="flex justify-between items-center">
+  <div class="flex justify-between items-center q-mb-xs">
     <q-card-section
       v-if="legendData.length > 0"
       class="legend-container q-pa-none"
@@ -309,6 +271,7 @@ const babyBlueScheme = computed(() => {
         </div>
       </div>
     </q-card-section>
+
     <q-btn
       v-if="showEvolutionDialog"
       color="primary"
@@ -332,6 +295,7 @@ const babyBlueScheme = computed(() => {
   <q-card-section class="chart-container q-pa-none">
     <v-chart
       ref="chartRef"
+      :key="visibleData.map((c) => c.name).join('|')"
       class="chart"
       autoresize
       :option="chartOption"
@@ -339,7 +303,7 @@ const babyBlueScheme = computed(() => {
     />
   </q-card-section>
 
-  <q-dialog v-model="isEvolutionDialogOpen" class="evolution-dialog">
+  <q-dialog v-model="isEvolutionDialogOpen">
     <q-card style="width: 700px; max-width: 80vw">
       <q-card-section class="row items-center q-py-md">
         <div class="text-h4 text-weight-medium">

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -363,6 +363,7 @@ const chartOption = computed((): EChartsOption => {
     },
     yAxis: {
       type: 'category',
+      inverse: true,
       axisLabel: {
         fontSize: 10,
         width: 150,

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -27,6 +27,7 @@ use([
 ]);
 
 import type { EmissionBreakdownCategoryRow } from 'src/stores/modules';
+import { CATEGORY_CHART_KEYS } from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
 
 const CATEGORY_LABEL_MAP: Record<string, string> = {
@@ -124,6 +125,27 @@ const categoryKeyPrefixes = Object.keys(CATEGORY_LABEL_MAP);
 // Maps compound segment keys → display labels (used in top-class mode)
 const segmentLabelOverrides = new Map<string, string>();
 
+/**
+ * Sort bars within each category by the CATEGORY_CHART_KEYS display order.
+ * Shared by the default and top-class breakdown branches so both produce
+ * a deterministic, visually intended order rather than backend/DB iteration order.
+ */
+function sortBarsByDisplayOrder(
+  bars: Record<string, unknown>[],
+  barCategoryMap: Map<string, string>,
+  barLabelMap: Map<string, string>,
+): void {
+  bars.sort((a, b) => {
+    const aCat = barCategoryMap.get(a.xx_category as string) ?? '';
+    const bCat = barCategoryMap.get(b.xx_category as string) ?? '';
+    if (aCat !== bCat) return 0; // preserve cross-category order
+    const keys = CATEGORY_CHART_KEYS[aCat] ?? [];
+    const aIdx = keys.indexOf(barLabelMap.get(a.xx_category as string) ?? '');
+    const bIdx = keys.indexOf(barLabelMap.get(b.xx_category as string) ?? '');
+    return (aIdx === -1 ? 999 : aIdx) - (bIdx === -1 ? 999 : bIdx);
+  });
+}
+
 const chartData = computed(() => {
   const emptyResult = {
     bars: [] as Record<string, unknown>[],
@@ -159,6 +181,8 @@ const chartData = computed(() => {
       }
       bars.push(barData);
     }
+
+    sortBarsByDisplayOrder(bars, barCategoryMap, barLabelMap);
 
     return {
       bars,
@@ -213,6 +237,8 @@ const chartData = computed(() => {
     }
     bars.push(barData);
   }
+
+  sortBarsByDisplayOrder(bars, barCategoryMap, barLabelMap);
 
   return {
     bars,

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -201,10 +201,7 @@ const moduleTreemapData = computed(() => {
   const filteredKeys = Object.fromEntries(
     Object.entries(CATEGORY_CHART_KEYS).filter(([k]) => categories.includes(k)),
   ) as Record<string, string[]>;
-  return buildModuleTreemapData(
-    breakdown as Array<{ category: string; [key: string]: string | number }>,
-    filteredKeys,
-  );
+  return buildModuleTreemapData(breakdown, filteredKeys);
 });
 
 const moduleCategoryRows = computed(() => {

--- a/frontend/src/composables/useEmissionTreemap.ts
+++ b/frontend/src/composables/useEmissionTreemap.ts
@@ -2,12 +2,18 @@ import {
   CHART_CATEGORY_COLOR_SCHEMES,
   CHART_SUBCATEGORY_COLOR_SCHEMES,
 } from 'src/constant/charts';
+import type {
+  EmissionBreakdownCategoryRow,
+  EmissionBreakdownValue,
+} from 'src/stores/modules';
 
 export interface EmissionTreemapChild {
   name: string;
   value: number;
   percentage: number;
   color: string;
+  /** YY-level parent key, present when the child is a ZZ-level item */
+  parentKey?: string;
 }
 
 export interface EmissionTreemapCategory {
@@ -20,11 +26,11 @@ export interface EmissionTreemapCategory {
 
 // Mirrors backend CATEGORY_CHART_KEYS in emission_breakdown.py
 export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
-  process_emissions: ['co2', 'ch4', 'n2o', 'refrigerants'],
-  buildings_energy_combustion: ['heating_thermal', 'combustion'],
+  process_emissions: ['ch4', 'co2', 'n2o', 'refrigerants'],
+  buildings_energy_combustion: ['combustion', 'heating_thermal'],
   buildings_room: ['lighting', 'cooling', 'ventilation', 'heating_elec'],
   equipment: ['scientific', 'it', 'other'],
-  external_cloud_and_ai: ['stockage', 'virtualisation', 'calcul', 'provider'],
+  external_cloud_and_ai: ['clouds', 'ai'],
   purchases: [
     'scientific_equipment',
     'it_equipment',
@@ -40,14 +46,34 @@ export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
 };
 
 /**
- * Builds a treemap hierarchy from flat module_breakdown rows returned by the API.
+ * Categories that should be rendered at YY level (subcategory) rather than
+ * drilling to ZZ (item) level. Buildings uses ZZ for room types
+ * (office, labs…) which is too granular for the chart.
+ */
+const YY_LEVEL_CATEGORIES = new Set([
+  'buildings_room',
+  'buildings_energy_combustion',
+  // Cloud items (stockage, virtualisation, calcul) are ZZ keys stored directly
+  // on the flat row; AI providers aggregate under the `ai` parent sum.
+  // Both are read via flat key lookup rather than the emissions list.
+  'external_cloud_and_ai',
+]);
+
+/**
+ * Builds a treemap hierarchy from module_breakdown rows returned by the API.
  *
- * @param rows - flat per-category rows from `emission_breakdown.module_breakdown`
- * @param categoryChartKeys - maps each category name to its list of subcategory keys;
- *   pass a subset of CATEGORY_CHART_KEYS to filter to specific module categories
+ * For most categories, uses the `emissions` list on each row to render the
+ * deepest available level (ZZ items such as train class or cabin class),
+ * grouping by `parent_key` for color assignment. Categories in
+ * `YY_LEVEL_CATEGORIES` are capped at YY (subcategory) level using the
+ * pre-aggregated flat parent sums on the row.
+ *
+ * @param rows - per-category rows from `emission_breakdown.module_breakdown`
+ * @param categoryChartKeys - maps each category name to its list of YY parent
+ *   keys used for filtering and color lookup
  */
 export function buildModuleTreemapData(
-  rows: Array<{ category: string; [key: string]: number | string }>,
+  rows: EmissionBreakdownCategoryRow[],
   categoryChartKeys: Record<string, string[]>,
 ): EmissionTreemapCategory[] {
   const colorByCategory = CHART_CATEGORY_COLOR_SCHEMES.value as Record<
@@ -62,31 +88,73 @@ export function buildModuleTreemapData(
   const result: EmissionTreemapCategory[] = [];
 
   for (const cat of Object.keys(categoryChartKeys)) {
-    const row = rows.find((r) => r.category === cat);
+    const row = rows.find((r) => r.category_key === cat || r.category === cat);
     if (!row) continue;
 
     const subKeys = categoryChartKeys[cat] ?? [];
     const catColor = colorByCategory[cat] ?? '#999999';
     const subColors = subcolorByCategory[cat] ?? {};
+    const rawEmissions = (row.emissions as EmissionBreakdownValue[]) ?? [];
 
     let catTotal: number;
     let children: EmissionTreemapChild[];
 
-    if (subKeys.length > 0) {
+    if (
+      subKeys.length > 0 &&
+      rawEmissions.length > 0 &&
+      !YY_LEVEL_CATEGORIES.has(cat)
+    ) {
+      // Use the emissions list to render the deepest available level (ZZ).
+      // Iterate subKeys (CATEGORY_CHART_KEYS order) so treemap left→right
+      // matches the breakdown chart top→bottom order.
+      children = [];
+      for (const parentKey of subKeys) {
+        for (const emission of rawEmissions) {
+          const emParentKey = emission.parent_key
+            ? String(emission.parent_key)
+            : String(emission.key);
+          if (emParentKey !== parentKey) continue;
+          const val = Number(emission.value) || 0;
+          if (val <= 0) continue;
+          children.push({
+            name: emission.key,
+            value: val,
+            percentage: 0, // filled below
+            color: subColors[parentKey] ?? catColor,
+            ...(emission.parent_key
+              ? { parentKey: String(emission.parent_key) }
+              : {}),
+          });
+        }
+      }
+      catTotal = children.reduce((s, c) => s + c.value, 0);
+    } else if (subKeys.length > 0) {
+      // YY-level categories (e.g. buildings) or rows without an emissions
+      // array: use the pre-aggregated flat parent sums on the row.
       children = subKeys
-        .map((k) => ({ key: k, val: Number(row[k]) || 0 }))
+        .map((k) => ({
+          key: k,
+          val: Number((row as Record<string, unknown>)[k]) || 0,
+        }))
         .filter(({ val }) => val > 0)
         .map(({ key, val }) => ({
           name: key,
           value: val,
-          percentage: 0, // filled below
+          percentage: 0,
           color: subColors[key] ?? catColor,
         }));
       catTotal = children.reduce((s, c) => s + c.value, 0);
     } else {
       // No predefined subkeys — sum all numeric non-metadata values
       catTotal = Object.entries(row)
-        .filter(([k]) => k !== 'category' && !k.endsWith('StdDev'))
+        .filter(
+          ([k]) =>
+            k !== 'category' &&
+            k !== 'category_key' &&
+            k !== 'emissions' &&
+            k !== 'parent_keys_order' &&
+            !k.endsWith('StdDev'),
+        )
         .reduce((s, [, v]) => s + (Number(v) || 0), 0);
       children = [];
     }
@@ -120,7 +188,7 @@ export function buildModuleTreemapData(
  * @param moduleBreakdown - `emission_breakdown.module_breakdown` from the API
  */
 export function buildResultsTreemapData(
-  moduleBreakdown: Array<{ category: string; [key: string]: number | string }>,
+  moduleBreakdown: EmissionBreakdownCategoryRow[],
 ): EmissionTreemapCategory[] {
   return buildModuleTreemapData(moduleBreakdown, CATEGORY_CHART_KEYS);
 }

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -469,6 +469,26 @@ export default {
     en: 'Plane',
     fr: 'Avion',
   },
+  'charts-class-1-subcategory': {
+    en: 'Class 1',
+    fr: 'Classe 1',
+  },
+  'charts-class-2-subcategory': {
+    en: 'Class 2',
+    fr: 'Classe 2',
+  },
+  'charts-first-class-subcategory': {
+    en: 'First',
+    fr: 'Première',
+  },
+  'charts-business-class-subcategory': {
+    en: 'Business',
+    fr: 'Affaires',
+  },
+  'charts-eco-class-subcategory': {
+    en: 'Eco',
+    fr: 'Éco',
+  },
   'charts-clouds-subcategory': {
     en: 'Clouds',
     fr: 'Clouds',
@@ -514,8 +534,8 @@ export default {
     fr: 'Calcul cloud',
   },
   'charts-ai-provider-subcategory': {
-    en: 'AI provider',
-    fr: 'Fournisseur IA',
+    en: 'AI',
+    fr: 'IA',
   },
   'charts-ai-provider-google-subcategory': {
     en: 'Google',

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -102,6 +102,7 @@ export interface EmissionBreakdownCategoryRow {
   category: string;
   category_key: string;
   emissions: EmissionBreakdownValue[];
+  parent_keys_order: string[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## What does this change?
 
Fixes the display order of bars and segments across all emission breakdown charts:
 
- Bar segments in `GenericEmissionTreeMapChart` (now a stacked bar chart) now render in the order defined by `CATEGORY_CHART_KEYS`, not by backend enum value.
- Bars in `EmissionTypeBreakdownChart` are sorted within each category according to `CATEGORY_CHART_KEYS` display order, and the y-axis is inverted so the first key appears at the top.
- The `buildings_energy_combustion` key order was corrected: `combustion` now precedes `heating_thermal`.
- The backend computes and exposes a `parent_keys_order` field on each `EmissionBreakdownCategoryRow`, preserving the first-seen order of parent bar keys for use by the frontend.
- The treemap was replaced with a horizontal stacked bar chart, rebuilding the data pipeline from raw `module_breakdown` rows to correctly group leaf emissions under their `parent_key`.
## Why is this needed?
 
Emission types are sorted by enum value in the backend, which does not always match the intended visual order (e.g. `train` comes before `plane` by enum value, but `plane` should lead in the chart). This caused chart bars and segments to appear in an arbitrary, confusing order that did not reflect the intended category display hierarchy defined in `CATEGORY_CHART_KEYS`.
 
## Type of change
 
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement

## Related issues
 
- Closes #861 
- Related to #
 