### PR TITLE
feat(619): add new csv provider for reduction objectives

### DIFF
--- a/backend/alembic/versions/2026_04_16_0918-4226efc73854_add_reduction_objectives_to_target_type_.py
+++ b/backend/alembic/versions/2026_04_16_0918-4226efc73854_add_reduction_objectives_to_target_type_.py
@@ -1,0 +1,41 @@
+# codeql[py/unused-global-variable]
+"""add REDUCTION_OBJECTIVES to target_type_enum
+
+Revision ID: 4226efc73854
+Revises: 707add_computed
+Create Date: 2026-04-16 09:18:59.871609
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4226efc73854"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "707add_computed"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    """maybe try https://github.com/Pogchamp-company/alembic-postgresql-enum"""
+    op.execute(
+        "ALTER TYPE target_type_enum ADD VALUE IF NOT EXISTS 'REDUCTION_OBJECTIVES'"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # PostgreSQL does not support removing individual enum values.
+    # A full enum-type recreation would be required; left as a no-op.
+    pass

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -37,6 +37,8 @@ router = APIRouter()
 class SyncRequestConfig(BaseModel):
     carbon_report_module_id: Optional[int] = None
     data_entry_type_id: Optional[int] = None
+    reduction_objective_type_id: Optional[int] = None
+    module_type_id: Optional[ModuleTypeEnum] = None
 
 
 class SyncRequest(BaseModel):
@@ -90,9 +92,8 @@ class ModuleRecalculationStatus(BaseModel):
     data_entry_types: list[RecalculationStatus]
 
 
-@router.post("/data-entries/{module_type_id}", response_model=SyncStatusResponse)
+@router.post("/dispatch", response_model=SyncStatusResponse)
 async def sync_module_data_entries(
-    module_type_id: ModuleTypeEnum,
     syncRequest: SyncRequest,
     request: Request,
     background_tasks: BackgroundTasks,
@@ -157,7 +158,6 @@ async def sync_module_data_entries(
     config["year"] = syncRequest.year
 
     provider = await ProviderFactory.create_provider(
-        module_type_id=ModuleTypeEnum(module_type_id),
         ingestion_method=syncRequest.ingestion_method,
         target_type=syncRequest.target_type,
         config=config,
@@ -170,7 +170,7 @@ async def sync_module_data_entries(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"""Provider '{syncRequest.ingestion_method}'
-                not supported for module '{module_type_id}'""",
+                not supported""",
         )
 
     if not await provider.validate_connection():
@@ -185,8 +185,13 @@ async def sync_module_data_entries(
     data_entry_type_id = config.get("data_entry_type_id") or getattr(
         syncRequest, "data_entry_type_id", None
     )
+    module_type_id = config.get("module_type_id") or getattr(
+        syncRequest, "module_type_id", None
+    )
+    if module_type_id is not None:
+        module_type_id = ModuleTypeEnum(module_type_id)
     job_id = await provider.create_job(
-        module_type_id=ModuleTypeEnum(module_type_id),
+        module_type_id=module_type_id,
         data_entry_type_id=data_entry_type_id,
         entity_type=entity_type,
         year=syncRequest.year,
@@ -262,10 +267,10 @@ async def sync_module_factors(
         "entity_type": EntityType.MODULE_PER_YEAR.value,
         "year": syncRequest.year,
         "data_entry_type_id": data_entry_type_id.value,
+        "module_type_id": ModuleTypeEnum(module_type_id),
     }
 
     provider = await ProviderFactory.create_provider(
-        module_type_id=ModuleTypeEnum(module_type_id),
         ingestion_method=syncRequest.ingestion_method,
         target_type=syncRequest.target_type,
         config=config,

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -2,6 +2,7 @@
 
 import copy
 import hashlib
+import io
 import os
 from datetime import datetime
 from typing import Any, Dict
@@ -11,6 +12,7 @@ from fastapi import (
     APIRouter,
     Depends,
     File,
+    Form,
     HTTPException,
     UploadFile,
     status,
@@ -35,6 +37,7 @@ from app.schemas.year_configuration import (
     YearConfigurationCreate,
     YearConfigurationResponse,
     YearConfigurationUpdate,
+    validate_reduction_objective_csv,
 )
 from app.services.year_config_service import (
     check_threshold_exceeded,
@@ -511,6 +514,8 @@ async def update_year_configuration(
     if payload.config is not None:
         result.config = _deep_merge(result.config, payload.config)
 
+    db.add(result)
+
     new_snapshot = {
         "is_started": result.is_started,
         "is_reports_synced": result.is_reports_synced,
@@ -566,7 +571,7 @@ async def update_year_configuration(
 async def upload_reduction_objective_file(
     year: int,
     file: UploadFile = File(..., description="File to upload"),
-    category: FileCategory = File(..., description="File category"),
+    category: FileCategory = Form(..., description="File category"),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -603,7 +608,22 @@ async def upload_reduction_objective_file(
             detail=f"File type not allowed. Allowed: {allowed_extensions}",
         )
 
-    # Save file
+    # Read file content
+    content = await file.read()
+
+    # For CSV uploads: validate rows before persisting anything
+    parsed_rows: list[dict] | None = None
+    if file_ext == ".csv":
+        try:
+            parsed_rows = validate_reduction_objective_csv(content, category)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"errors": exc.args[0]},
+            )
+
+    # Save file (re-wrap content so save_uploaded_file can read() it again)
+    file.file = io.BytesIO(content)
     file_metadata = await save_uploaded_file(file, category, year)
 
     # Map category to config key
@@ -643,8 +663,21 @@ async def upload_reduction_objective_file(
                 "population_projections": None,
                 "unit_scenarios": None,
             },
+            "institutional_footprint": None,
+            "population_projections": None,
+            "unit_scenarios": None,
             "goals": [],
         }
+    else:
+        # Ensure the three parsed-data keys exist in case this config was created
+        # before the feature was added (old rows won't have them).
+        ro = result.config["reduction_objectives"]
+        for key in (
+            "institutional_footprint",
+            "population_projections",
+            "unit_scenarios",
+        ):
+            ro.setdefault(key, None)
 
     result.config["reduction_objectives"]["files"][config_key] = {
         "path": file_metadata.path,
@@ -652,8 +685,13 @@ async def upload_reduction_objective_file(
         "uploaded_at": file_metadata.uploaded_at,
     }
 
+    # If the upload was a CSV, store the parsed rows alongside the metadata
+    if parsed_rows is not None:
+        result.config["reduction_objectives"][config_key] = parsed_rows
+
     # Reassign the whole dict so SQLAlchemy detects the change
     result.config = {**result.config}
+    db.add(result)
 
     # Create audit entry with diff
     new_snapshot = {
@@ -684,7 +722,7 @@ async def upload_reduction_objective_file(
             "user_id": current_user.id,
             "year": year,
             "category": category,
-            "filename": file_metadata.filename,
+            "uploaded_filename": file_metadata.filename,
         },
     )
 

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -73,6 +73,8 @@ class TargetType(int, Enum):
 
     DATA_ENTRIES = 0
     FACTORS = 1
+    REDUCTION_OBJECTIVES = 2
+    REFERENCE_DATA = 3
 
 
 class IngestionState(int, Enum):

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -1,9 +1,25 @@
 """Year configuration schemas for API request/response validation."""
 
+import csv
+import io
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from enum import IntEnum
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+)
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 # Type definitions
 UncertaintyTag = Literal["low", "medium", "high", "none"]
@@ -16,6 +32,235 @@ class FileMetadata(BaseModel):
     path: str = Field(..., description="Storage path for the file")
     filename: str = Field(..., description="Original filename")
     uploaded_at: str = Field(..., description="Upload timestamp in ISO format")
+
+
+# ---------------------------------------------------------------------------
+# Reduction-objective CSV row models
+# ---------------------------------------------------------------------------
+
+
+# TODO: use this instead of the csv validation? DTO create equivalent?
+class InstitutionalFootprintRow(BaseModel):
+    """Single row of an institutional_footprint CSV."""
+
+    year: int = Field(..., description="Reference year")
+    category: str = Field(..., description="Emission category (e.g. energy, food)")
+    co2: float = Field(..., description="CO2 equivalent in tCO2eq")
+
+    @field_validator("co2")
+    @classmethod
+    def co2_must_be_non_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError(f"co2 must be >= 0, got {v}")
+        return v
+
+
+class PopulationProjectionRow(BaseModel):
+    """Single row of a population_projections CSV."""
+
+    year: int = Field(..., description="Reference year")
+    pop: int = Field(..., description="Population headcount")
+
+    @field_validator("pop")
+    @classmethod
+    def pop_must_be_non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f"pop must be >= 0, got {v}")
+        return v
+
+
+class UnitScenarioRow(BaseModel):
+    """Single row of a unit_scenarios CSV."""
+
+    scenario: str = Field(..., description="Scenario name / label")
+    year: int = Field(..., description="Reference year")
+    reduction_percentage: float = Field(
+        ...,
+        description="Reduction fraction (0.0 = 0 %, 1.0 = 100 %)",
+    )
+
+    @field_validator("reduction_percentage")
+    @classmethod
+    def pct_must_be_valid(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError(
+                f"reduction_percentage must be between 0.0 and 1.0, got {v}"
+            )
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Category → row model + expected headers mapping
+# ---------------------------------------------------------------------------
+
+_ROW_MODEL: dict[str, type[BaseModel]] = {
+    "footprint": InstitutionalFootprintRow,
+    "population": PopulationProjectionRow,
+    "scenarios": UnitScenarioRow,
+}
+
+_EXPECTED_HEADERS: dict[str, set[str]] = {
+    "footprint": {"year", "category", "co2"},
+    "population": {"year", "pop"},
+    "scenarios": {"scenario", "year", "reduction_percentage"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Reduction-objective handler system (mirrors BaseFactorHandler pattern)
+# ---------------------------------------------------------------------------
+
+
+class ReductionObjectiveType(IntEnum):
+    """Maps to reduction_objective_type_id sent from frontend (0, 1, 2)."""
+
+    FOOTPRINT = 0  # institutional_footprint
+    POPULATION = 1  # population_projections
+    SCENARIOS = 2  # unit_scenarios
+
+
+REDUCTION_OBJECTIVE_HANDLERS: Dict[
+    "ReductionObjectiveType", "BaseReductionObjectiveHandler"
+] = {}
+
+
+class ReductionObjectiveHandlerMeta(type):
+    """Auto-registers subclasses by their ``objective_type``."""
+
+    def __new__(mcs, name, bases, namespace):
+        cls = super().__new__(mcs, name, bases, namespace)
+        if name != "BaseReductionObjectiveHandler" and bases:
+            obj_type = getattr(cls, "objective_type", None)
+            if obj_type is not None:
+                REDUCTION_OBJECTIVE_HANDLERS[obj_type] = cls()
+        return cls
+
+
+class BaseReductionObjectiveHandler(metaclass=ReductionObjectiveHandlerMeta):
+    """Base handler for reduction-objective CSV rows."""
+
+    objective_type: Optional[ReductionObjectiveType] = None
+    config_key: str = ""  # key inside year_config.reduction_objectives
+    create_dto: Type[BaseModel]
+
+    @classmethod
+    def get_by_type(
+        cls, objective_type: ReductionObjectiveType
+    ) -> "BaseReductionObjectiveHandler":
+        handler = REDUCTION_OBJECTIVE_HANDLERS.get(objective_type)
+        if handler is None:
+            raise ValueError(
+                f"No handler found for reduction_objective_type={objective_type}"
+            )
+        return handler
+
+    @property
+    def expected_columns(self) -> set[str]:
+        return set(self.create_dto.model_fields.keys())
+
+    @property
+    def required_columns(self) -> set[str]:
+        return {
+            name for name, f in self.create_dto.model_fields.items() if f.is_required()
+        }
+
+    def validate_create(self, payload: dict) -> BaseModel:
+        return self.create_dto.model_validate(payload)
+
+
+class FootprintHandler(BaseReductionObjectiveHandler):
+    objective_type = ReductionObjectiveType.FOOTPRINT
+    config_key = "institutional_footprint"
+    create_dto = InstitutionalFootprintRow
+
+
+class PopulationHandler(BaseReductionObjectiveHandler):
+    objective_type = ReductionObjectiveType.POPULATION
+    config_key = "population_projections"
+    create_dto = PopulationProjectionRow
+
+
+class ScenariosHandler(BaseReductionObjectiveHandler):
+    objective_type = ReductionObjectiveType.SCENARIOS
+    config_key = "unit_scenarios"
+    create_dto = UnitScenarioRow
+
+
+def validate_reduction_objective_csv(
+    content: bytes,
+    category: str,
+) -> list[dict]:
+    """Parse and validate a reduction-objective CSV file.
+
+    Decodes the raw bytes, checks that the header row matches the expected
+    columns for the given category, then validates every data row against the
+    corresponding Pydantic model.  All row errors are collected before raising
+    so the caller receives the full list in a single response.
+
+    Args:
+        content: Raw bytes of the uploaded CSV file.
+        category: One of ``"footprint"``, ``"population"``, ``"scenarios"``.
+
+    Returns:
+        List of validated row dicts (``model.model_dump()`` for each row).
+
+    Raises:
+        ValueError: If the category is unknown, the headers are wrong, or any
+            row fails validation.  The single argument is a list of
+            human-readable error strings.
+    """
+    if category not in _ROW_MODEL:
+        raise ValueError([f"Unknown category: {category!r}"])
+
+    # Decode — try UTF-8-SIG first (strips BOM if present), then plain UTF-8,
+    # then fall back to latin-1 for legacy Excel exports.
+    for encoding in ("utf-8-sig", "utf-8", "latin-1"):
+        try:
+            text = content.decode(encoding)
+            break
+        except UnicodeDecodeError:
+            continue
+    else:
+        raise ValueError(["Unable to decode CSV file. Please save it as UTF-8."])
+
+    reader = csv.DictReader(io.StringIO(text))
+
+    # Validate header presence
+    if reader.fieldnames is None:
+        raise ValueError(["CSV file appears to be empty (no header row found)."])
+
+    actual_headers = {h.strip() for h in reader.fieldnames}
+    expected_headers = _EXPECTED_HEADERS[category]
+    missing = expected_headers - actual_headers
+    if missing:
+        raise ValueError(
+            [
+                f"Missing required columns: {sorted(missing)}. "
+                f"Expected: {sorted(expected_headers)}, "
+                f"got: {sorted(actual_headers)}."
+            ]
+        )
+
+    row_model = _ROW_MODEL[category]
+    validated_rows: list[dict] = []
+    errors: list[str] = []
+
+    for row_idx, raw_row in enumerate(reader, start=2):  # row 1 = header
+        # Strip whitespace from keys and values
+        cleaned = {k.strip(): v.strip() for k, v in raw_row.items() if k is not None}
+        try:
+            validated = row_model.model_validate(cleaned)
+            validated_rows.append(validated.model_dump())
+        except ValidationError as exc:
+            for err in exc.errors():
+                field = ".".join(str(loc) for loc in err["loc"])
+                msg = err["msg"]
+                errors.append(f"Row {row_idx}, field '{field}': {msg}")
+
+    if errors:
+        raise ValueError(errors)
+
+    return validated_rows
 
 
 class ReductionObjectiveGoal(BaseModel):
@@ -32,13 +277,6 @@ class ReductionObjectiveGoal(BaseModel):
         ..., description="Reference year to calculate reduction from"
     )
 
-    @field_validator("target_year")
-    @classmethod
-    def validate_target_year(cls, v: int, info) -> int:
-        """Validate target_year is greater than configuration year."""
-        # Note: We can't access 'year' here directly, validation happens in service
-        return v
-
 
 class ReductionObjectives(BaseModel):
     """Reduction objectives configuration."""
@@ -54,6 +292,30 @@ class ReductionObjectives(BaseModel):
         },
         description="File metadata for reduction objective references",
     )
+
+    # Parsed CSV data — populated automatically on successful CSV upload.
+    institutional_footprint: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description=(
+            "Parsed rows from the institutional_footprint CSV "
+            "(list of {year, category, co2} dicts)"
+        ),
+    )
+    population_projections: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description=(
+            "Parsed rows from the population_projections CSV "
+            "(list of {year, pop} dicts)"
+        ),
+    )
+    unit_scenarios: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description=(
+            "Parsed rows from the unit_scenarios CSV "
+            "(list of {scenario, year, reduction_percentage} dicts)"
+        ),
+    )
+
     goals: List[ReductionObjectiveGoal] = Field(
         default_factory=list,
         description="List of institutional reduction goals",
@@ -103,36 +365,6 @@ class ModuleConfig(BaseModel):
     submodules: Dict[str, SubmoduleConfig] = Field(
         default_factory=dict,
         description="Configuration for each data entry type under this module",
-    )
-
-
-class SubmoduleConfigResponse(SubmoduleConfig):
-    """Submodule config enriched with latest sync job info (read-only)."""
-
-    latest_job: Optional[SyncJobSummary] = Field(
-        default=None,
-        description="Latest sync job for this submodule (computed, not stored)",
-    )
-
-
-class ModuleConfigResponse(BaseModel):
-    """Module config enriched with submodule job info (read-only)."""
-
-    enabled: bool = Field(default=True)
-    uncertainty_tag: UncertaintyTag = Field(default="medium")
-    submodules: Dict[str, SubmoduleConfigResponse] = Field(default_factory=dict)
-
-
-class YearConfigJSON(BaseModel):
-    """Complete year configuration JSON structure."""
-
-    modules: Dict[str, ModuleConfig] = Field(
-        default_factory=dict,
-        description="Module configurations keyed by module_type_id (as string)",
-    )
-    reduction_objectives: Optional[ReductionObjectives] = Field(
-        default=None,
-        description="Institutional reduction objectives and file references",
     )
 
 

--- a/backend/app/services/data_ingestion/base_provider.py
+++ b/backend/app/services/data_ingestion/base_provider.py
@@ -60,11 +60,11 @@ class DataIngestionProvider(ABC):
 
     async def create_job(
         self,
-        module_type_id: ModuleTypeEnum,
-        data_entry_type_id: Optional[int],
         ingestion_method: IngestionMethod,
         entity_type: EntityType,
         target_type: TargetType,
+        module_type_id: Optional[ModuleTypeEnum] = None,
+        data_entry_type_id: Optional[int] = None,
         year: Optional[int] = None,
         factor_type_id: FactorType | None = None,
         config: Dict[str, Any] | None = None,

--- a/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
@@ -1,0 +1,475 @@
+"""Base CSV provider for reduction-objective imports.
+
+Each CSV is validated row-by-row with Pydantic, then the entire result is
+stored as a JSON array inside ``year_configuration.config.reduction_objectives``.
+"""
+
+import csv
+import io
+import urllib.parse
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any, Dict, List, TypedDict
+
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import col, select
+
+from app.core.logging import get_logger
+from app.models.data_ingestion import (
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import User
+from app.models.year_configuration import YearConfiguration
+from app.repositories.data_ingestion import DataIngestionRepository
+from app.schemas.year_configuration import BaseReductionObjectiveHandler
+from app.services.data_ingestion.base_csv_provider import _validate_file_path
+from app.services.data_ingestion.base_provider import DataIngestionProvider
+
+logger = get_logger(__name__)
+
+
+class ReductionObjectiveStatsDict(TypedDict):
+    rows_processed: int
+    rows_skipped: int
+    row_errors: list[dict[str, Any]]
+    row_errors_count: int
+
+
+class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
+    """Base class for reduction-objective CSV ingestion.
+
+    Unlike factor/data-entry providers that create one DB row per CSV row,
+    this provider collects all validated rows and writes them as a single
+    JSON blob into ``year_configuration.config.reduction_objectives.<key>``.
+    """
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        user: User | None = None,
+        job_session: Any = None,
+        data_session: Any = None,
+    ):
+        super().__init__(config, user, job_session, data_session=data_session)
+        self.job_id = config.get("job_id")
+        self.year = config.get("year")
+        raw_file_path = config.get("file_path")
+        self.source_file_path = (
+            urllib.parse.unquote(raw_file_path) if raw_file_path else None
+        )
+        if self.source_file_path:
+            _validate_file_path(self.source_file_path)
+        self._files_store: Any = None
+        self._repo: Any = None
+        logger.info(
+            f"Initializing {self.__class__.__name__} for job_id={self.job_id}, "
+            f"file_path={self.source_file_path}"
+        )
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def provider_name(self) -> IngestionMethod:
+        return IngestionMethod.csv
+
+    @property
+    def target_type(self) -> TargetType:
+        return TargetType.REDUCTION_OBJECTIVES
+
+    @property
+    @abstractmethod
+    def entity_type(self) -> EntityType:
+        pass
+
+    @property
+    def files_store(self) -> Any:
+        if self._files_store is None:
+            from app.api.v1.files import make_files_store
+
+            self._files_store = make_files_store()
+        return self._files_store
+
+    @property
+    def repo(self) -> Any:
+        if self._repo is None:
+            self._repo = DataIngestionRepository(self.data_session)
+        return self._repo
+
+    # ------------------------------------------------------------------
+    # Abstract – subclasses must implement
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _resolve_handler(self) -> BaseReductionObjectiveHandler:
+        """Return the handler for the current upload (based on config)."""
+        pass
+
+    # ------------------------------------------------------------------
+    # DataIngestionProvider abstract stubs (not used for this flow)
+    # ------------------------------------------------------------------
+
+    async def fetch_data(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return []
+
+    async def transform_data(
+        self, raw_data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        return raw_data
+
+    async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {"inserted": 0, "skipped": 0, "errors": 0}
+
+    # ------------------------------------------------------------------
+    # Connection validation
+    # ------------------------------------------------------------------
+
+    async def validate_connection(self) -> bool:
+        logger.info(f"Validating connection for {self.__class__.__name__}")
+        try:
+            if not self.source_file_path:
+                logger.warning("No file_path provided in config")
+                return False
+            exists = await self.files_store.file_exists(self.source_file_path)
+            if exists:
+                logger.info(
+                    f"Successfully validated CSV file at {self.source_file_path}"
+                )
+                return True
+            logger.warning(f"CSV file not found at {self.source_file_path}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to validate CSV file: {str(e)}")
+            return False
+
+    # ------------------------------------------------------------------
+    # Main ingestion flow
+    # ------------------------------------------------------------------
+
+    async def ingest(
+        self,
+        filters: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        """Override ingest to use the reduction-objective CSV flow."""
+        try:
+            await self._update_job(
+                status_message="processing",
+                state=IngestionState.RUNNING,
+                result=None,
+                extra_metadata={"message": "Starting CSV processing..."},
+            )
+            result = await self._process_csv()
+            return {
+                "state": IngestionState.FINISHED,
+                "status_message": "Success",
+                "data": result,
+            }
+        except Exception as e:
+            await self._update_job(
+                status_message=f"failed: {str(e)}",
+                state=IngestionState.FINISHED,
+                result=IngestionResult.ERROR,
+                extra_metadata={"error": str(e)},
+            )
+            logger.error(f"Reduction-objective CSV ingestion failed: {str(e)}")
+            raise
+
+    async def _process_csv(self) -> Dict[str, Any]:
+        """Setup → validate rows → store JSON → finalize."""
+        try:
+            setup = await self._setup_and_validate()
+            handler: BaseReductionObjectiveHandler = setup["handler"]
+            csv_text: str = setup["csv_text"]
+
+            max_row_errors = int(self.config.get("max_row_errors", 100))
+            stats: ReductionObjectiveStatsDict = {
+                "rows_processed": 0,
+                "rows_skipped": 0,
+                "row_errors": [],
+                "row_errors_count": 0,
+            }
+
+            # -- Parse & validate every row ---------------------------------
+            validated_rows: list[dict] = []
+            csv_reader = csv.DictReader(io.StringIO(csv_text, newline=""))
+
+            for row_idx, raw_row in enumerate(csv_reader, start=1):
+                # Strip whitespace from keys and values
+                cleaned = {
+                    k.strip(): v.strip() for k, v in raw_row.items() if k is not None
+                }
+                try:
+                    validated = handler.validate_create(cleaned)
+                    validated_rows.append(validated.model_dump())
+                    stats["rows_processed"] += 1
+                except Exception as e:
+                    self._record_row_error(stats, row_idx, str(e), max_row_errors)
+
+            if stats["rows_processed"] == 0:
+                raise ValueError(
+                    "No rows could be validated — check CSV format and content"
+                )
+
+            # -- Store in year_configuration --------------------------------
+            await self._store_in_year_config(
+                validated_rows=validated_rows,
+                config_key=handler.config_key,
+                filename=setup["filename"],
+                processed_path=setup.get("processed_path"),
+            )
+
+            # -- Finalize ---------------------------------------------------
+            return await self._finalize(stats, setup)
+
+        except Exception as e:
+            logger.error(
+                f"Reduction-objective CSV processing failed: {str(e)}", exc_info=True
+            )
+            await self.data_session.rollback()
+            await self._update_job(
+                status_message=f"Processing failed: {str(e)}",
+                state=IngestionState.FINISHED,
+                result=IngestionResult.ERROR,
+                extra_metadata={"error": str(e)},
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    async def _setup_and_validate(self) -> Dict[str, Any]:
+        """Download CSV, move to processing/, resolve handler, validate headers."""
+        if not self.job and self.job_id:
+            self.job = await self.repo.get_job_by_id(self.job_id)
+            if not self.job:
+                raise ValueError(f"Job {self.job_id} not found")
+
+        await self._update_job(
+            status_message="Starting CSV processing",
+            state=IngestionState.RUNNING,
+            result=None,
+            extra_metadata={},
+        )
+
+        # Move file to processing/
+        tmp_path = self.source_file_path
+        if not tmp_path:
+            raise ValueError("Missing file_path in config")
+        _validate_file_path(tmp_path)
+        filename = tmp_path.split("/")[-1]
+        processing_path = f"processing/{self.job_id}/{filename}"
+
+        logger.info(f"Moving file from {tmp_path} to {processing_path}")
+        move_result = await self.files_store.move_file(tmp_path, processing_path)
+        if not move_result:
+            raise ValueError(
+                f"Failed to move file from {tmp_path} to {processing_path}"
+            )
+
+        # Download & decode
+        logger.info(f"Downloading CSV from {processing_path}")
+        file_content, _ = await self.files_store.get_file(processing_path)
+        csv_text = file_content.decode("utf-8-sig")
+
+        # Resolve handler
+        handler = self._resolve_handler()
+
+        # Validate headers
+        self._validate_csv_headers(
+            csv_text, handler.expected_columns, handler.required_columns
+        )
+
+        processed_path = f"processed/{self.job_id}/{filename}"
+
+        return {
+            "csv_text": csv_text,
+            "handler": handler,
+            "processing_path": processing_path,
+            "processed_path": processed_path,
+            "filename": filename,
+        }
+
+    # ------------------------------------------------------------------
+    # Header validation (same logic as BaseFactorCSVProvider)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_csv_headers(
+        csv_text: str,
+        expected_columns: set[str],
+        required_columns: set[str],
+    ) -> None:
+        reader = csv.DictReader(io.StringIO(csv_text, newline=""))
+        first_rows: list[dict] = []
+        try:
+            for idx, row in enumerate(reader):
+                if idx >= 5:
+                    break
+                first_rows.append(row)
+        except Exception as e:
+            raise ValueError(f"Failed to read CSV: {str(e)}")
+
+        if not first_rows:
+            raise ValueError("CSV file is empty")
+
+        if required_columns:
+            all_missing = all(
+                not required_columns.issubset(set(row.keys())) for row in first_rows
+            )
+            if all_missing:
+                missing = required_columns - set(first_rows[0].keys())
+                raise ValueError(
+                    f"CSV is missing required columns: {', '.join(sorted(missing))}"
+                )
+
+    # ------------------------------------------------------------------
+    # Store validated rows into year_configuration.config
+    # ------------------------------------------------------------------
+
+    async def _store_in_year_config(
+        self,
+        validated_rows: list[dict],
+        config_key: str,
+        filename: str,
+        processed_path: str | None = None,
+    ) -> None:
+        """Write the validated CSV rows into year_configuration.config."""
+        if not self.year:
+            raise ValueError("year is required")
+
+        stmt = select(YearConfiguration).where(col(YearConfiguration.year) == self.year)
+        result = (await self.data_session.exec(stmt)).first()
+        if not result:
+            raise ValueError(
+                f"No year_configuration found for year {self.year}. Create it first."
+            )
+
+        # Ensure reduction_objectives structure exists
+        if "reduction_objectives" not in result.config:
+            result.config["reduction_objectives"] = {
+                "files": {
+                    "institutional_footprint": None,
+                    "population_projections": None,
+                    "unit_scenarios": None,
+                },
+                "institutional_footprint": None,
+                "population_projections": None,
+                "unit_scenarios": None,
+                "goals": [],
+            }
+        else:
+            ro = result.config["reduction_objectives"]
+            for key in (
+                "institutional_footprint",
+                "population_projections",
+                "unit_scenarios",
+            ):
+                ro.setdefault(key, None)
+            ro.setdefault(
+                "files",
+                {
+                    "institutional_footprint": None,
+                    "population_projections": None,
+                    "unit_scenarios": None,
+                },
+            )
+
+        # Store parsed rows
+        result.config["reduction_objectives"][config_key] = validated_rows
+
+        # Store file metadata
+        result.config["reduction_objectives"]["files"][config_key] = {
+            "path": processed_path or "",
+            "filename": filename,
+            "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        # SQLAlchemy does not detect in-place mutations on JSON/dict columns.
+        # A shallow copy (e.g. `result.config = {**result.config}`) is unreliable
+        # because the identity of nested objects may not change.
+        # `flag_modified` explicitly marks the attribute as dirty so the
+        # unit-of-work includes it in the next flush/commit.
+        # See: https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.attributes.flag_modified
+        flag_modified(result, "config")
+        self.data_session.add(result)
+        await self.data_session.flush()
+
+        logger.info(
+            f"Stored {len(validated_rows)} rows in "
+            f"year_configuration.config.reduction_objectives.{config_key} "
+            f"for year={self.year}"
+        )
+
+    # ------------------------------------------------------------------
+    # Finalize
+    # ------------------------------------------------------------------
+
+    async def _finalize(
+        self,
+        stats: ReductionObjectiveStatsDict,
+        setup: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Move file to processed/, update job to FINISHED."""
+        processing_path = setup["processing_path"]
+        processed_path = setup["processed_path"]
+
+        logger.info(f"Moving file from {processing_path} to {processed_path}")
+        move_result = await self.files_store.move_file(processing_path, processed_path)
+        if not move_result:
+            logger.warning(
+                f"Failed to move file from {processing_path} to {processed_path}"
+            )
+
+        await self.data_session.flush()
+
+        # Compute result
+        result = self._compute_ingestion_result(stats)
+        status_message = (
+            f"Processed {stats['rows_processed']} rows, {stats['rows_skipped']} skipped"
+        )
+        await self._update_job(
+            status_message=status_message,
+            state=IngestionState.FINISHED,
+            result=result,
+            extra_metadata=dict(stats),
+        )
+
+        return {
+            "state": IngestionState.FINISHED,
+            "result": result,
+            "rows_processed": stats["rows_processed"],
+            "rows_skipped": stats["rows_skipped"],
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_ingestion_result(
+        stats: ReductionObjectiveStatsDict,
+    ) -> IngestionResult:
+        if stats["rows_processed"] == 0:
+            return IngestionResult.ERROR
+        if stats["rows_skipped"] == 0:
+            return IngestionResult.SUCCESS
+        return IngestionResult.WARNING
+
+    @staticmethod
+    def _record_row_error(
+        stats: ReductionObjectiveStatsDict,
+        row_idx: int,
+        reason: str,
+        max_row_errors: int,
+    ) -> None:
+        stats["rows_skipped"] += 1
+        stats["row_errors_count"] += 1
+        logger.warning(f"Row {row_idx}: {reason}")
+        if len(stats["row_errors"]) < max_row_errors:
+            stats["row_errors"].append({"row": row_idx, "reason": reason})

--- a/backend/app/services/data_ingestion/csv_providers/__init__.py
+++ b/backend/app/services/data_ingestion/csv_providers/__init__.py
@@ -9,9 +9,17 @@ from app.services.data_ingestion.csv_providers.module_per_year import (
 from app.services.data_ingestion.csv_providers.module_unit_specific import (
     ModuleUnitSpecificCSVProvider,
 )
+from app.services.data_ingestion.csv_providers.reduction_objectives import (
+    ModulePerYearReductionObjectivesApiProvider,
+)
+from app.services.data_ingestion.csv_providers.reference_data import (
+    ModulePerYearReferenceDataApiProvider,
+)
 
 __all__ = [
     "ModuleUnitSpecificCSVProvider",
     "ModulePerYearCSVProvider",
     "ModulePerYearFactorCSVProvider",
+    "ModulePerYearReductionObjectivesApiProvider",
+    "ModulePerYearReferenceDataApiProvider",
 ]

--- a/backend/app/services/data_ingestion/csv_providers/reduction_objectives.py
+++ b/backend/app/services/data_ingestion/csv_providers/reduction_objectives.py
@@ -1,0 +1,25 @@
+from app.core.logging import get_logger
+from app.models.data_ingestion import EntityType
+from app.schemas.year_configuration import (
+    BaseReductionObjectiveHandler,
+    ReductionObjectiveType,
+)
+from app.services.data_ingestion.base_reduction_objective_csv_provider import (
+    BaseReductionObjectiveCSVProvider,
+)
+
+logger = get_logger(__name__)
+
+
+class ModulePerYearReductionObjectivesApiProvider(BaseReductionObjectiveCSVProvider):
+    @property
+    def entity_type(self) -> EntityType:
+        return EntityType.MODULE_PER_YEAR
+
+    def _resolve_handler(self) -> BaseReductionObjectiveHandler:
+        type_id = self.config.get("reduction_objective_type_id")
+        if type_id is None:
+            raise ValueError("reduction_objective_type_id is required in config")
+        return BaseReductionObjectiveHandler.get_by_type(
+            ReductionObjectiveType(int(type_id))
+        )

--- a/backend/app/services/data_ingestion/csv_providers/reference_data.py
+++ b/backend/app/services/data_ingestion/csv_providers/reference_data.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict
+
+from app.core.logging import get_logger
+from app.models.data_ingestion import EntityType
+from app.services.data_ingestion.base_factor_csv_provider import (
+    BaseFactorCSVProvider,
+)
+
+logger = get_logger(__name__)
+
+
+class ModulePerYearReferenceDataApiProvider(BaseFactorCSVProvider):
+    @property
+    def entity_type(self) -> EntityType:
+        return EntityType.MODULE_PER_YEAR
+
+    async def _setup_handlers_and_context(self) -> Dict[str, Any]:
+        logger.info("Setup complete for reference data factor CSV: ")
+
+        return {}

--- a/backend/app/services/data_ingestion/provider_factory.py
+++ b/backend/app/services/data_ingestion/provider_factory.py
@@ -19,6 +19,8 @@ from app.services.data_ingestion.computed_providers.research_facilities_common i
 from app.services.data_ingestion.csv_providers import (
     ModulePerYearCSVProvider,
     ModulePerYearFactorCSVProvider,
+    ModulePerYearReductionObjectivesApiProvider,
+    ModulePerYearReferenceDataApiProvider,
     ModuleUnitSpecificCSVProvider,
 )
 
@@ -30,7 +32,7 @@ class ProviderFactory:
     # Registry of CSV/API providers.
     # Key: (module_type, ingestion_method, target_type, entity_type)
     PROVIDERS: dict[
-        tuple[ModuleTypeEnum, IngestionMethod, TargetType, EntityType],
+        tuple[ModuleTypeEnum | None, IngestionMethod, TargetType, EntityType],
         type[DataIngestionProvider],
     ] = {
         # MODULE_UNIT_SPECIFIC CSV Providers
@@ -63,6 +65,20 @@ class ProviderFactory:
             ): ModulePerYearFactorCSVProvider
             for module_type in ModuleTypeEnum
         },
+        ## MODULE_PER_YEAR REDUCTION OBJECTIVES
+        (
+            None,
+            IngestionMethod.csv,
+            TargetType.REDUCTION_OBJECTIVES,
+            EntityType.MODULE_PER_YEAR,
+        ): ModulePerYearReductionObjectivesApiProvider,
+        ## MODULE_PER_YEAR REFERENCE DATA
+        (
+            None,
+            IngestionMethod.csv,
+            TargetType.REFERENCE_DATA,
+            EntityType.MODULE_PER_YEAR,
+        ): ModulePerYearReferenceDataApiProvider,
         # API Providers
         (
             ModuleTypeEnum.professional_travel,
@@ -72,6 +88,7 @@ class ProviderFactory:
         ): ProfessionalTravelApiProvider,
     }
 
+    # WHAT IS THAT?
     # Registry of computed providers that are keyed by data_entry_type as well.
     # Key: (module_type, data_entry_type, ingestion_method, target_type, entity_type)
     COMPUTED_FACTOR_PROVIDERS: dict[
@@ -116,7 +133,7 @@ class ProviderFactory:
 
     @staticmethod
     def get_provider_by_keys(
-        module_type_id: ModuleTypeEnum,
+        module_type_id: Optional[ModuleTypeEnum],
         ingestion_method: IngestionMethod,
         target_type: TargetType,
         entity_type: EntityType,
@@ -134,6 +151,8 @@ class ProviderFactory:
                 det = DataEntryTypeEnum(data_entry_type_id)
             except ValueError:
                 det = None
+            if module_type_id is None:
+                raise ValueError("module_type_id is required for computed providers")
             if det is not None:
                 five_tuple_key = (
                     module_type_id,
@@ -152,7 +171,6 @@ class ProviderFactory:
     @classmethod
     async def create_provider(
         cls,
-        module_type_id: ModuleTypeEnum,
         ingestion_method: IngestionMethod,
         target_type: TargetType,
         config: dict,
@@ -178,6 +196,9 @@ class ProviderFactory:
             return None
 
         data_entry_type_id = config.get("data_entry_type_id")
+        module_type_id = config.get("module_type_id")
+        # if module_type_id is None:
+        #     return None
         provider_class = cls.get_provider_by_keys(
             module_type_id=module_type_id,
             ingestion_method=ingestion_method,

--- a/backend/app/services/year_config_service.py
+++ b/backend/app/services/year_config_service.py
@@ -42,6 +42,9 @@ def generate_default_year_config() -> Dict[str, Any]:
     return {
         "modules": modules,
         "reduction_objectives": {
+            "institutional_footprint": [],
+            "population_projections": [],
+            "unit_scenarios": [],
             "files": {
                 "institutional_footprint": None,
                 "population_projections": None,
@@ -84,35 +87,6 @@ def get_submodule_config(
         return None
     submodules = module_config.get("submodules", {})
     return submodules.get(str(data_entry_type.value))
-
-
-def update_module_threshold(
-    config: Dict[str, Any],
-    module_type: ModuleTypeEnum,
-    data_entry_type: DataEntryTypeEnum,
-    threshold: float | None,
-) -> Dict[str, Any]:
-    """Update threshold for a specific submodule.
-
-    Args:
-        config: Year configuration JSON.
-        module_type: Module type.
-        data_entry_type: Data entry type.
-        threshold: New threshold value (None to clear).
-
-    Returns:
-        Updated configuration.
-    """
-    module_config = get_module_config(config, module_type)
-    if not module_config:
-        return config
-
-    submodule_config = get_submodule_config(module_config, data_entry_type)
-    if not submodule_config:
-        return config
-
-    submodule_config["threshold"] = threshold
-    return config
 
 
 def check_threshold_exceeded(

--- a/backend/tests/integration/data_ingestion/test_csv_upload_e2e.py
+++ b/backend/tests/integration/data_ingestion/test_csv_upload_e2e.py
@@ -152,12 +152,15 @@ class TestCSVUploadBasic:
             "ingestion_method": IngestionMethod.csv.value,
             "target_type": 0,
             "year": 2025,
-            "data_entry_type_id": 1,  # member
             "file_path": file_path,
+            "config": {
+                "module_type_id": ModuleTypeEnum.headcount.value,
+                "data_entry_type_id": 1,  # member
+            },
         }
 
         response = client.post(
-            f"/api/v1/sync/data-entries/{ModuleTypeEnum.headcount.value}",
+            "/api/v1/sync/dispatch",
             json=ingestion_request,
             headers={"Authorization": f"Bearer {test_user.email}"},
         )

--- a/backend/tests/unit/schemas/test_year_configuration.py
+++ b/backend/tests/unit/schemas/test_year_configuration.py
@@ -1,0 +1,253 @@
+"""Tests for year_configuration schemas — validators, handlers, CSV parsing."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.year_configuration import (
+    BaseReductionObjectiveHandler,
+    FootprintHandler,
+    InstitutionalFootprintRow,
+    PopulationHandler,
+    PopulationProjectionRow,
+    ReductionObjectiveGoal,
+    ReductionObjectiveType,
+    ScenariosHandler,
+    SubmoduleConfig,
+    UnitScenarioRow,
+    YearConfigurationUpdate,
+    validate_reduction_objective_csv,
+)
+
+# ── Row model validators ─────────────────────────────────────────────────────
+
+
+class TestInstitutionalFootprintRow:
+    def test_valid(self):
+        row = InstitutionalFootprintRow(year=2024, category="energy", co2=123.4)
+        assert row.co2 == 123.4
+
+    def test_negative_co2_rejected(self):
+        with pytest.raises(ValidationError, match="co2 must be >= 0"):
+            InstitutionalFootprintRow(year=2024, category="energy", co2=-1.0)
+
+
+class TestPopulationProjectionRow:
+    def test_valid(self):
+        row = PopulationProjectionRow(year=2024, pop=5000)
+        assert row.pop == 5000
+
+    def test_negative_pop_rejected(self):
+        with pytest.raises(ValidationError, match="pop must be >= 0"):
+            PopulationProjectionRow(year=2024, pop=-1)
+
+
+class TestUnitScenarioRow:
+    def test_valid(self):
+        row = UnitScenarioRow(scenario="baseline", year=2024, reduction_percentage=0.5)
+        assert row.reduction_percentage == 0.5
+
+    def test_below_zero_rejected(self):
+        with pytest.raises(
+            ValidationError, match="reduction_percentage must be between"
+        ):
+            UnitScenarioRow(scenario="x", year=2024, reduction_percentage=-0.1)
+
+    def test_above_one_rejected(self):
+        with pytest.raises(
+            ValidationError, match="reduction_percentage must be between"
+        ):
+            UnitScenarioRow(scenario="x", year=2024, reduction_percentage=1.1)
+
+
+# ── Handler system ────────────────────────────────────────────────────────────
+
+
+class TestHandlerSystem:
+    def test_get_footprint_handler(self):
+        h = BaseReductionObjectiveHandler.get_by_type(ReductionObjectiveType.FOOTPRINT)
+        assert isinstance(h, FootprintHandler)
+        assert h.config_key == "institutional_footprint"
+
+    def test_get_population_handler(self):
+        h = BaseReductionObjectiveHandler.get_by_type(ReductionObjectiveType.POPULATION)
+        assert isinstance(h, PopulationHandler)
+        assert h.config_key == "population_projections"
+
+    def test_get_scenarios_handler(self):
+        h = BaseReductionObjectiveHandler.get_by_type(ReductionObjectiveType.SCENARIOS)
+        assert isinstance(h, ScenariosHandler)
+        assert h.config_key == "unit_scenarios"
+
+    def test_get_by_invalid_type(self):
+        with pytest.raises(ValueError, match="No handler found"):
+            BaseReductionObjectiveHandler.get_by_type(999)
+
+    def test_expected_columns(self):
+        h = BaseReductionObjectiveHandler.get_by_type(ReductionObjectiveType.FOOTPRINT)
+        assert h.expected_columns == {"year", "category", "co2"}
+
+    def test_required_columns(self):
+        h = BaseReductionObjectiveHandler.get_by_type(ReductionObjectiveType.POPULATION)
+        assert h.required_columns == {"year", "pop"}
+
+    def test_validate_create(self):
+        h = BaseReductionObjectiveHandler.get_by_type(ReductionObjectiveType.FOOTPRINT)
+        result = h.validate_create({"year": 2024, "category": "energy", "co2": 10.0})
+        assert isinstance(result, InstitutionalFootprintRow)
+
+
+# ── validate_reduction_objective_csv ──────────────────────────────────────────
+
+
+class TestValidateReductionObjectiveCSV:
+    def test_valid_footprint(self):
+        csv_bytes = b"year,category,co2\n2024,energy,100.5\n2023,food,50.0\n"
+        rows = validate_reduction_objective_csv(csv_bytes, "footprint")
+        assert len(rows) == 2
+        assert rows[0] == {"year": 2024, "category": "energy", "co2": 100.5}
+
+    def test_valid_population(self):
+        csv_bytes = b"year,pop\n2024,5000\n2025,6000\n"
+        rows = validate_reduction_objective_csv(csv_bytes, "population")
+        assert len(rows) == 2
+        assert rows[1]["pop"] == 6000
+
+    def test_valid_scenarios(self):
+        csv_bytes = b"scenario,year,reduction_percentage\nbaseline,2024,0.4\n"
+        rows = validate_reduction_objective_csv(csv_bytes, "scenarios")
+        assert len(rows) == 1
+        assert rows[0]["reduction_percentage"] == 0.4
+
+    def test_unknown_category(self):
+        with pytest.raises(ValueError, match="Unknown category"):
+            validate_reduction_objective_csv(b"a,b\n1,2\n", "unknown")
+
+    def test_empty_csv(self):
+        with pytest.raises(ValueError, match="empty"):
+            validate_reduction_objective_csv(b"", "footprint")
+
+    def test_missing_headers(self):
+        csv_bytes = b"year,co2\n2024,10\n"  # missing 'category'
+        with pytest.raises(ValueError, match="Missing required columns"):
+            validate_reduction_objective_csv(csv_bytes, "footprint")
+
+    def test_invalid_row_data(self):
+        csv_bytes = b"year,category,co2\n2024,energy,-5\n"
+        with pytest.raises(ValueError, match="Row 2"):
+            validate_reduction_objective_csv(csv_bytes, "footprint")
+
+    def test_utf8_bom(self):
+        csv_bytes = b"\xef\xbb\xbfyear,pop\n2024,100\n"
+        rows = validate_reduction_objective_csv(csv_bytes, "population")
+        assert len(rows) == 1
+
+    def test_latin1_encoding(self):
+        csv_bytes = "year,category,co2\n2024,énergie,10.0\n".encode("latin-1")
+        rows = validate_reduction_objective_csv(csv_bytes, "footprint")
+        assert rows[0]["category"] == "énergie"
+
+
+# ── SubmoduleConfig threshold validator ───────────────────────────────────────
+
+
+class TestSubmoduleConfig:
+    def test_valid_threshold(self):
+        s = SubmoduleConfig(threshold=10.0)
+        assert s.threshold == 10.0
+
+    def test_null_threshold(self):
+        s = SubmoduleConfig(threshold=None)
+        assert s.threshold is None
+
+    def test_negative_threshold_rejected(self):
+        with pytest.raises(ValidationError, match="threshold must be >= 0"):
+            SubmoduleConfig(threshold=-1.0)
+
+
+# ── ReductionObjectiveGoal ────────────────────────────────────────────────────
+
+
+class TestReductionObjectiveGoal:
+    def test_valid_goal(self):
+        g = ReductionObjectiveGoal(
+            target_year=2030, reduction_percentage=0.4, reference_year=2019
+        )
+        assert g.target_year == 2030
+
+    def test_percentage_out_of_range(self):
+        with pytest.raises(ValidationError):
+            ReductionObjectiveGoal(
+                target_year=2030, reduction_percentage=1.5, reference_year=2019
+            )
+
+
+# ── YearConfigurationUpdate threshold validator ──────────────────────────────
+
+
+class TestYearConfigurationUpdateValidation:
+    def test_valid_thresholds(self):
+        update = YearConfigurationUpdate(
+            config={
+                "modules": {
+                    "1": {
+                        "submodules": {
+                            "10": {"threshold": 100.0},
+                            "11": {"threshold": None},
+                        }
+                    }
+                }
+            }
+        )
+        assert update.config is not None
+
+    def test_negative_threshold_rejected(self):
+        with pytest.raises(ValidationError, match="threshold.*must be a number >= 0"):
+            YearConfigurationUpdate(
+                config={
+                    "modules": {
+                        "1": {
+                            "submodules": {
+                                "10": {"threshold": -5.0},
+                            }
+                        }
+                    }
+                }
+            )
+
+    def test_string_threshold_rejected(self):
+        with pytest.raises(ValidationError, match="threshold.*must be a number >= 0"):
+            YearConfigurationUpdate(
+                config={
+                    "modules": {
+                        "1": {
+                            "submodules": {
+                                "10": {"threshold": "abc"},
+                            }
+                        }
+                    }
+                }
+            )
+
+    def test_no_modules_passes(self):
+        update = YearConfigurationUpdate(config={"other_key": "value"})
+        assert update.config is not None
+
+    def test_none_config_passes(self):
+        update = YearConfigurationUpdate(config=None)
+        assert update.config is None
+
+    def test_non_dict_module_skipped(self):
+        update = YearConfigurationUpdate(config={"modules": {"1": "not_a_dict"}})
+        assert update.config is not None
+
+    def test_non_dict_submodules_skipped(self):
+        update = YearConfigurationUpdate(
+            config={"modules": {"1": {"submodules": "not_a_dict"}}}
+        )
+        assert update.config is not None
+
+    def test_non_dict_submodule_value_skipped(self):
+        update = YearConfigurationUpdate(
+            config={"modules": {"1": {"submodules": {"10": "not_a_dict"}}}}
+        )
+        assert update.config is not None

--- a/backend/tests/unit/services/data_ingestion/csv_providers/test_reduction_objectives.py
+++ b/backend/tests/unit/services/data_ingestion/csv_providers/test_reduction_objectives.py
@@ -1,0 +1,32 @@
+"""Tests for ModulePerYearReductionObjectivesApiProvider."""
+
+import pytest
+
+from app.models.data_ingestion import EntityType
+from app.services.data_ingestion.csv_providers.reduction_objectives import (
+    ModulePerYearReductionObjectivesApiProvider,
+)
+
+
+def _make_provider(**config_overrides):
+    config = {"job_id": "test", "year": 2024, **config_overrides}
+    return ModulePerYearReductionObjectivesApiProvider(config=config)
+
+
+def test_entity_type():
+    provider = _make_provider()
+    assert provider.entity_type == EntityType.MODULE_PER_YEAR
+
+
+def test_resolve_handler_missing_type_id():
+    provider = _make_provider()
+    with pytest.raises(ValueError, match="reduction_objective_type_id is required"):
+        provider._resolve_handler()
+
+
+def test_resolve_handler_valid():
+    # ReductionObjectiveType(0) = FOOTPRINT → institutional_footprint
+    provider = _make_provider(reduction_objective_type_id=0)
+    handler = provider._resolve_handler()
+    assert handler is not None
+    assert handler.config_key == "institutional_footprint"

--- a/backend/tests/unit/services/data_ingestion/csv_providers/test_reference_data.py
+++ b/backend/tests/unit/services/data_ingestion/csv_providers/test_reference_data.py
@@ -1,0 +1,25 @@
+"""Tests for ModulePerYearReferenceDataApiProvider."""
+
+import pytest
+
+from app.models.data_ingestion import EntityType
+from app.services.data_ingestion.csv_providers.reference_data import (
+    ModulePerYearReferenceDataApiProvider,
+)
+
+
+def _make_provider():
+    config = {"job_id": "test", "year": 2024}
+    return ModulePerYearReferenceDataApiProvider(config=config)
+
+
+def test_entity_type():
+    provider = _make_provider()
+    assert provider.entity_type == EntityType.MODULE_PER_YEAR
+
+
+@pytest.mark.asyncio
+async def test_setup_handlers_and_context():
+    provider = _make_provider()
+    result = await provider._setup_handlers_and_context()
+    assert result == {}

--- a/backend/tests/unit/services/data_ingestion/test_provider_factory.py
+++ b/backend/tests/unit/services/data_ingestion/test_provider_factory.py
@@ -56,9 +56,11 @@ def test_get_provider_by_keys_api_provider():
 
 @pytest.mark.asyncio
 async def test_create_provider_valid_entity_type():
-    config = {"entity_type": EntityType.MODULE_PER_YEAR.value}
+    config = {
+        "entity_type": EntityType.MODULE_PER_YEAR.value,
+        "module_type_id": ModuleTypeEnum.headcount,
+    }
     provider = await ProviderFactory.create_provider(
-        module_type_id=ModuleTypeEnum.headcount,
         ingestion_method=IngestionMethod.csv,
         target_type=TargetType.DATA_ENTRIES,
         config=config,
@@ -73,10 +75,9 @@ async def test_create_provider_valid_entity_type():
 @pytest.mark.asyncio
 async def test_create_provider_missing_entity_type():
     provider = await ProviderFactory.create_provider(
-        module_type_id=ModuleTypeEnum.headcount,
         ingestion_method=IngestionMethod.csv,
         target_type=TargetType.DATA_ENTRIES,
-        config={},
+        config={"module_type_id": ModuleTypeEnum.headcount},
         user=MagicMock(spec=User),
         job_session=None,
         data_session=MagicMock(),
@@ -87,9 +88,8 @@ async def test_create_provider_missing_entity_type():
 
 @pytest.mark.asyncio
 async def test_create_provider_invalid_entity_type():
-    config = {"entity_type": "not-valid"}
+    config = {"entity_type": "not-valid", "module_type_id": ModuleTypeEnum.headcount}
     provider = await ProviderFactory.create_provider(
-        module_type_id=ModuleTypeEnum.headcount,
         ingestion_method=IngestionMethod.csv,
         target_type=TargetType.DATA_ENTRIES,
         config=config,
@@ -103,9 +103,11 @@ async def test_create_provider_invalid_entity_type():
 
 @pytest.mark.asyncio
 async def test_create_provider_no_matching_provider():
-    config = {"entity_type": EntityType.MODULE_PER_YEAR.value}
+    config = {
+        "entity_type": EntityType.MODULE_PER_YEAR.value,
+        "module_type_id": ModuleTypeEnum.headcount,
+    }
     provider = await ProviderFactory.create_provider(
-        module_type_id=ModuleTypeEnum.headcount,
         ingestion_method=IngestionMethod.api,
         target_type=TargetType.DATA_ENTRIES,
         config=config,
@@ -139,6 +141,49 @@ def test_get_provider_by_keys_common_computed_5tuple():
         data_entry_type_id=DataEntryTypeEnum.research_facilities,
     )
     assert provider_class is ResearchFacilitiesCommonFactorUpdateProvider
+
+
+def test_get_provider_by_keys_invalid_data_entry_type_id():
+    """Invalid data_entry_type_id → det=None, falls back to 4-tuple."""
+    provider_class = ProviderFactory.get_provider_by_keys(
+        ModuleTypeEnum.headcount,
+        IngestionMethod.csv,
+        TargetType.DATA_ENTRIES,
+        EntityType.MODULE_UNIT_SPECIFIC,
+        data_entry_type_id=99999,  # invalid
+    )
+    # Falls through to 4-tuple lookup which should still match
+    assert provider_class is ModuleUnitSpecificCSVProvider
+
+
+def test_get_provider_by_keys_data_entry_type_without_module_type():
+    """data_entry_type_id provided but module_type_id=None → ValueError."""
+    with pytest.raises(ValueError, match="module_type_id is required"):
+        ProviderFactory.get_provider_by_keys(
+            module_type_id=None,
+            ingestion_method=IngestionMethod.computed,
+            target_type=TargetType.FACTORS,
+            entity_type=EntityType.MODULE_PER_YEAR,
+            data_entry_type_id=DataEntryTypeEnum.mice_and_fish_animal_facilities,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_provider_data_session_none_raises():
+    """Provider found but data_session is None → ValueError."""
+    config = {
+        "entity_type": EntityType.MODULE_PER_YEAR.value,
+        "module_type_id": ModuleTypeEnum.headcount,
+    }
+    with pytest.raises(ValueError, match="Data session is required"):
+        await ProviderFactory.create_provider(
+            ingestion_method=IngestionMethod.csv,
+            target_type=TargetType.DATA_ENTRIES,
+            config=config,
+            user=MagicMock(spec=User),
+            job_session=None,
+            data_session=None,
+        )
 
 
 def test_providers_by_class_name_includes_computed_providers():

--- a/backend/tests/unit/services/test_year_config_service.py
+++ b/backend/tests/unit/services/test_year_config_service.py
@@ -1,0 +1,145 @@
+"""Tests for year_config_service — pure-logic helpers with no DB dependency."""
+
+import pytest
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
+from app.services.year_config_service import (
+    check_threshold_exceeded,
+    generate_default_year_config,
+    get_module_config,
+    get_submodule_config,
+)
+
+# ── generate_default_year_config ──────────────────────────────────────────────
+
+
+def test_generate_default_year_config_has_modules():
+    cfg = generate_default_year_config()
+    assert "modules" in cfg
+    # Every ModuleTypeEnum member should have an entry
+    for module_type in ModuleTypeEnum:
+        assert str(module_type.value) in cfg["modules"]
+
+
+def test_generate_default_year_config_module_structure():
+    cfg = generate_default_year_config()
+    for module_type in ModuleTypeEnum:
+        mod = cfg["modules"][str(module_type.value)]
+        assert mod["enabled"] is True
+        assert mod["uncertainty_tag"] == "medium"
+        assert isinstance(mod["submodules"], dict)
+
+        expected_subs = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(module_type, [])
+        for det in expected_subs:
+            sub = mod["submodules"][str(det.value)]
+            assert sub == {"enabled": True, "threshold": None}
+
+
+def test_generate_default_year_config_reduction_objectives():
+    cfg = generate_default_year_config()
+    ro = cfg["reduction_objectives"]
+    assert ro["institutional_footprint"] == []
+    assert ro["population_projections"] == []
+    assert ro["unit_scenarios"] == []
+    assert ro["goals"] == []
+    assert ro["files"] == {
+        "institutional_footprint": None,
+        "population_projections": None,
+        "unit_scenarios": None,
+    }
+
+
+# ── get_module_config ─────────────────────────────────────────────────────────
+
+
+def test_get_module_config_found():
+    cfg = generate_default_year_config()
+    first_module = next(iter(ModuleTypeEnum))
+    result = get_module_config(cfg, first_module)
+    assert result is not None
+    assert result["enabled"] is True
+
+
+def test_get_module_config_missing():
+    result = get_module_config({"modules": {}}, next(iter(ModuleTypeEnum)))
+    assert result is None
+
+
+def test_get_module_config_empty():
+    result = get_module_config({}, next(iter(ModuleTypeEnum)))
+    assert result is None
+
+
+# ── get_submodule_config ──────────────────────────────────────────────────────
+
+
+def test_get_submodule_config_found():
+    cfg = generate_default_year_config()
+    # Pick a module that has submodules
+    for mt in ModuleTypeEnum:
+        dets = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(mt, [])
+        if dets:
+            mod = get_module_config(cfg, mt)
+            sub = get_submodule_config(mod, dets[0])
+            assert sub is not None
+            assert sub["enabled"] is True
+            return
+    pytest.skip("No module with submodules found")
+
+
+def test_get_submodule_config_none_module():
+    result = get_submodule_config(None, next(iter(DataEntryTypeEnum)))
+    assert result is None
+
+
+def test_get_submodule_config_empty_module():
+    result = get_submodule_config({}, next(iter(DataEntryTypeEnum)))
+    assert result is None
+
+
+# ── check_threshold_exceeded ──────────────────────────────────────────────────
+
+
+def _make_config_with_threshold(
+    module_type: ModuleTypeEnum,
+    data_entry_type: DataEntryTypeEnum,
+    threshold: float | None,
+) -> dict:
+    cfg = generate_default_year_config()
+    mod = cfg["modules"][str(module_type.value)]
+    mod["submodules"][str(data_entry_type.value)]["threshold"] = threshold
+    return cfg
+
+
+def _first_module_and_sub():
+    for mt in ModuleTypeEnum:
+        dets = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(mt, [])
+        if dets:
+            return mt, dets[0]
+    pytest.skip("No module with submodules found")
+
+
+def test_check_threshold_exceeded_true():
+    mt, det = _first_module_and_sub()
+    cfg = _make_config_with_threshold(mt, det, 100.0)
+    assert check_threshold_exceeded(cfg, mt, det, 200.0) is True
+
+
+def test_check_threshold_exceeded_false():
+    mt, det = _first_module_and_sub()
+    cfg = _make_config_with_threshold(mt, det, 100.0)
+    assert check_threshold_exceeded(cfg, mt, det, 50.0) is False
+
+
+def test_check_threshold_none():
+    mt, det = _first_module_and_sub()
+    cfg = _make_config_with_threshold(mt, det, None)
+    assert check_threshold_exceeded(cfg, mt, det, 999.0) is False
+
+
+def test_check_threshold_no_submodule():
+    mt = next(iter(ModuleTypeEnum))
+    det = next(iter(DataEntryTypeEnum))
+    # config with no submodules at all
+    assert check_threshold_exceeded({"modules": {}}, mt, det, 10.0) is False

--- a/backend/tests/unit/utils/test_report_computations.py
+++ b/backend/tests/unit/utils/test_report_computations.py
@@ -1,0 +1,117 @@
+"""Tests for report_computations utility functions."""
+
+import pytest
+
+from app.utils.report_computations import (
+    compute_results_summary,
+    compute_validated_totals,
+)
+
+
+class TestComputeValidatedTotals:
+    def test_basic(self):
+        result = compute_validated_totals(
+            emission_stats={"2": 2000.0, "3": 3000.0},
+            fte_stats={"1": 50.0},
+            headcount_type_id="1",
+        )
+        assert result["modules"][2] == 2.0  # 2000 kg -> 2 tonnes
+        assert result["modules"][3] == 3.0
+        assert result["total_tonnes_co2eq"] == 5.0
+        assert result["total_fte"] == 50.0
+
+    def test_headcount_uses_fte(self):
+        result = compute_validated_totals(
+            emission_stats={"1": 1000.0},
+            fte_stats={"1": 42.0},
+            headcount_type_id="1",
+        )
+        # headcount module should use FTE value, not emission
+        assert result["modules"][1] == 42.0
+
+    def test_empty(self):
+        result = compute_validated_totals(
+            emission_stats={}, fte_stats={}, headcount_type_id="1"
+        )
+        assert result["modules"] == {}
+        assert result["total_tonnes_co2eq"] == 0.0
+        assert result["total_fte"] == 0.0
+
+
+class TestComputeResultsSummary:
+    def test_basic(self):
+        result = compute_results_summary(
+            current_emissions={"2": 4000.0},
+            current_fte={"1": 10.0},
+            prev_emissions={"2": 2000.0},
+            co2_per_km_kg=0.2,
+            headcount_key="1",
+        )
+        assert len(result["module_results"]) == 1
+        mod = result["module_results"][0]
+        assert mod["module_type_id"] == 2
+        assert mod["total_tonnes_co2eq"] == 4.0
+        assert mod["previous_year_total_tonnes_co2eq"] == 2.0
+        assert mod["year_comparison_percentage"] == 100.0  # doubled
+        assert mod["equivalent_car_km"] == 20000.0
+
+        unit = result["unit_totals"]
+        assert unit["total_tonnes_co2eq"] == 4.0
+
+    def test_zero_co2_per_km_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            compute_results_summary(
+                current_emissions={},
+                current_fte={},
+                prev_emissions={},
+                co2_per_km_kg=0,
+                headcount_key="1",
+            )
+
+    def test_none_emissions_skipped(self):
+        result = compute_results_summary(
+            current_emissions={"2": None},
+            current_fte={},
+            prev_emissions={},
+            co2_per_km_kg=0.2,
+            headcount_key="1",
+        )
+        assert result["module_results"] == []
+        assert result["unit_totals"]["total_tonnes_co2eq"] is None
+
+    def test_exclude_module_type_ids(self):
+        result = compute_results_summary(
+            current_emissions={"2": 1000.0, "3": 2000.0},
+            current_fte={},
+            prev_emissions={},
+            co2_per_km_kg=0.2,
+            headcount_key="1",
+            exclude_module_type_ids={2},
+        )
+        assert len(result["module_results"]) == 1
+        assert result["module_results"][0]["module_type_id"] == 3
+
+    def test_no_previous_year(self):
+        result = compute_results_summary(
+            current_emissions={"2": 1000.0},
+            current_fte={"1": 5.0},
+            prev_emissions={},
+            co2_per_km_kg=0.2,
+            headcount_key="1",
+        )
+        mod = result["module_results"][0]
+        assert mod["previous_year_total_tonnes_co2eq"] is None
+        assert mod["year_comparison_percentage"] is None
+        assert mod["tonnes_co2eq_per_fte"] == 1.0 / 5.0
+
+    def test_no_fte(self):
+        result = compute_results_summary(
+            current_emissions={"2": 1000.0},
+            current_fte={},
+            prev_emissions={},
+            co2_per_km_kg=0.2,
+            headcount_key="1",
+        )
+        mod = result["module_results"][0]
+        assert mod["tonnes_co2eq_per_fte"] is None
+        assert result["unit_totals"]["tonnes_co2eq_per_fte"] is None

--- a/frontend/src/components/organisms/data-management/DataEntryDialog.vue
+++ b/frontend/src/components/organisms/data-management/DataEntryDialog.vue
@@ -66,6 +66,15 @@ watch(showDialog, (newVal) => {
   emit('update:modelValue', newVal);
 });
 
+function handleEnterKey() {
+  if (isUploading.value || isConnecting.value || isCopying.value) return;
+  if (selectedFiles.value && selectedFiles.value.length > 0) {
+    uploadFiles();
+  } else if (allApiFieldsFilled.value) {
+    connectAndSync();
+  }
+}
+
 function resetDialog() {
   activeTab.value = 'upload';
   selectedFiles.value = [];
@@ -262,14 +271,29 @@ async function initiateSync(
     year: props.year,
     provider_type: providerType === 'copy' ? 'csv' : providerType,
     target_type: props.targetType,
+    config: {},
   };
 
   if (props.row.dataEntryTypeId !== undefined) {
     syncParams.data_entry_type_id = props.row.dataEntryTypeId;
   }
 
-  if (props.row.factorVariant !== undefined) {
+  if (props.row.reductionObjectiveTypeId !== undefined) {
+    const existingConfig = syncParams.config as
+      | Record<string, unknown>
+      | undefined;
     syncParams.config = {
+      ...existingConfig,
+      reduction_objective_type_id: props.row.reductionObjectiveTypeId,
+    };
+  }
+
+  if (props.row.factorVariant !== undefined) {
+    const existingConfig = syncParams.config as
+      | Record<string, unknown>
+      | undefined;
+    syncParams.config = {
+      ...existingConfig,
       factor_variant: props.row.factorVariant,
     };
   }
@@ -287,7 +311,7 @@ async function initiateSync(
       source_job_id: sourceJobId,
     };
   }
-  const jobId = await dataManagementStore.initiateSync({
+  const syncPayload = {
     module_type_id: props.row.moduleTypeId,
     year: props.year,
     provider_type: providerType === 'copy' ? 'csv' : providerType,
@@ -295,7 +319,8 @@ async function initiateSync(
     data_entry_type_id: props.row.dataEntryTypeId,
     config: syncParams.config as Record<string, unknown>,
     file_path: filePath,
-  });
+  };
+  const jobId = await dataManagementStore.initiateSync(syncPayload);
 
   // Subscribe to job updates
   dataManagementStore.subscribeToJobUpdates(
@@ -396,6 +421,7 @@ async function initiateSync(
     class="modal modal--lg"
     persistent
     @keyup.escape="showDialog = false"
+    @keyup.enter="handleEnterKey"
   >
     <q-card class="column" style="width: 800px; max-width: 80vw">
       <q-card-section class="flex justify-between items-center flex-shrink">
@@ -569,6 +595,7 @@ async function initiateSync(
 
       <q-card-section class="q-pt-sm">
         <q-btn
+          aria-label="data-entry-save"
           :label="
             selectedFiles && selectedFiles.length > 0
               ? $t('data_management_upload')

--- a/frontend/src/components/organisms/data-management/ReductionObjectivesSection.vue
+++ b/frontend/src/components/organisms/data-management/ReductionObjectivesSection.vue
@@ -4,10 +4,14 @@ import {
   useYearConfigStore,
   type ReductionObjectiveGoal,
 } from 'src/stores/yearConfig';
-import { Notify, Loading } from 'quasar';
+import { Notify } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
-
+import { inject } from 'vue';
+import {
+  TargetType,
+  type ImportRow,
+} from 'src/stores/backofficeDataManagement';
 const props = defineProps<{
   selectedYear: number;
 }>();
@@ -16,6 +20,10 @@ const yearConfigStore = useYearConfigStore();
 const { t: $t } = useI18n();
 
 const reductionObjectivesExpanded = ref(false);
+
+const openDataEntryDialog = inject<
+  (row: ImportRow, targetType: TargetType | null) => void
+>('openDataEntryDialog')!;
 
 /** Default empty goal for a slot. */
 function emptyGoal(): ReductionObjectiveGoal {
@@ -102,12 +110,9 @@ async function saveReductionGoals(): Promise<void> {
 }
 
 /** File refs for reduction objective CSV uploads. */
-const footprintFile = ref<File | null>(null);
-const populationFile = ref<File | null>(null);
-const scenariosFile = ref<File | null>(null);
-
 /** Uploaded file names derived from the store. */
 const uploadedFileNames = computed(() => {
+  // TODO: add a way to download the files in .path
   const files = yearConfigStore.config?.config?.reduction_objectives?.files;
   return {
     footprint: files?.institutional_footprint?.filename ?? null,
@@ -115,26 +120,6 @@ const uploadedFileNames = computed(() => {
     scenarios: files?.unit_scenarios?.filename ?? null,
   };
 });
-
-/** Handle a reduction-objective file upload. */
-async function handleReductionFileUpload(
-  category: 'footprint' | 'population' | 'scenarios',
-  file: File | null,
-): Promise<void> {
-  if (!file) return;
-  Loading.show({ message: $t('uploading_file') });
-  try {
-    await yearConfigStore.uploadFile(props.selectedYear, category, file);
-    if (category === 'footprint') footprintFile.value = null;
-    if (category === 'population') populationFile.value = null;
-    if (category === 'scenarios') scenariosFile.value = null;
-    Notify.create({ type: 'positive', message: $t('file_upload_success') });
-  } catch {
-    Notify.create({ type: 'negative', message: $t('file_upload_error') });
-  } finally {
-    Loading.hide();
-  }
-}
 </script>
 
 <template>
@@ -185,21 +170,22 @@ async function handleReductionFileUpload(
             <q-icon name="check" /> {{ uploadedFileNames.footprint }}
           </div>
           <div class="row q-gutter-md q-mt-lg">
-            <q-file
-              v-model="footprintFile"
-              outlined
-              dense
-              accept=".csv"
+            <q-btn
+              :color="'red'"
+              icon="add"
+              size="sm"
               :label="$t('common_upload_csv')"
-              class="col"
-              @update:model-value="
-                handleReductionFileUpload('footprint', $event)
+              class="text-weight-medium"
+              :disable="false"
+              @click="
+                openDataEntryDialog(
+                  {
+                    reductionObjectiveTypeId: 0, // footprint
+                  } as ImportRow,
+                  TargetType.REDUCTION_OBJECTIVES,
+                )
               "
-            >
-              <template #prepend>
-                <q-icon name="o_upload" />
-              </template>
-            </q-file>
+            />
           </div>
         </q-card>
         <q-card
@@ -228,21 +214,22 @@ async function handleReductionFileUpload(
             <q-icon name="check" /> {{ uploadedFileNames.population }}
           </div>
           <div class="row q-gutter-md q-mt-lg">
-            <q-file
-              v-model="populationFile"
-              outlined
-              dense
-              accept=".csv"
+            <q-btn
+              :color="'red'"
+              icon="add"
+              size="sm"
               :label="$t('common_upload_csv')"
-              class="col"
-              @update:model-value="
-                handleReductionFileUpload('population', $event)
+              class="text-weight-medium"
+              :disable="false"
+              @click="
+                openDataEntryDialog(
+                  {
+                    reductionObjectiveTypeId: 1, // population
+                  } as ImportRow,
+                  TargetType.REDUCTION_OBJECTIVES,
+                )
               "
-            >
-              <template #prepend>
-                <q-icon name="o_upload" />
-              </template>
-            </q-file>
+            />
           </div>
         </q-card>
         <q-card flat class="col q-px-lg q-py-xl border-right">
@@ -267,21 +254,22 @@ async function handleReductionFileUpload(
             <q-icon name="check" /> {{ uploadedFileNames.scenarios }}
           </div>
           <div class="row q-gutter-md q-mt-lg">
-            <q-file
-              v-model="scenariosFile"
-              outlined
-              dense
-              accept=".csv"
+            <q-btn
+              :color="'red'"
+              icon="add"
+              size="sm"
               :label="$t('common_upload_csv')"
-              class="col"
-              @update:model-value="
-                handleReductionFileUpload('scenarios', $event)
+              class="text-weight-medium"
+              :disable="false"
+              @click="
+                openDataEntryDialog(
+                  {
+                    reductionObjectiveTypeId: 2, // scenarios
+                  } as ImportRow,
+                  TargetType.REDUCTION_OBJECTIVES,
+                )
               "
-            >
-              <template #prepend>
-                <q-icon name="o_upload" />
-              </template>
-            </q-file>
+            />
           </div>
         </q-card>
       </q-card>

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, provide } from 'vue';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
 import TempFilesBanner from 'src/components/organisms/data-management/TempFilesBanner.vue';
@@ -7,8 +7,13 @@ import { MODULES_LIST } from 'src/constant/modules';
 
 import ModuleConfig from 'src/components/organisms/data-management/ModuleConfig.vue';
 import ReductionObjectivesSection from 'src/components/organisms/data-management/ReductionObjectivesSection.vue';
+import DataEntryDialog from 'src/components/organisms/data-management/DataEntryDialog.vue';
 
-import { useBackofficeDataManagement } from 'src/stores/backofficeDataManagement';
+import {
+  useBackofficeDataManagement,
+  TargetType,
+  type ImportRow,
+} from 'src/stores/backofficeDataManagement';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { Notify, Loading } from 'quasar';
 import { useI18n } from 'vue-i18n';
@@ -101,6 +106,23 @@ watch(
 onMounted(() => {
   // intentionally empty — loading is handled by the yearConfigStore.loading watcher
 });
+
+// ── Data-entry dialog (provided to child components like ReductionObjectivesSection) ──
+const showDataEntryDialog = ref(false);
+const dialogCurrentRow = ref<ImportRow | null>(null);
+const dialogTargetType = ref<TargetType | null>(null);
+
+function openDataEntryDialog(row: ImportRow, targetType: TargetType | null) {
+  dialogCurrentRow.value = row;
+  dialogTargetType.value = targetType;
+  showDataEntryDialog.value = true;
+}
+
+provide('openDataEntryDialog', openDataEntryDialog);
+
+async function handleDialogCompleted() {
+  await yearConfigStore.fetchConfig(selectedYear.value);
+}
 </script>
 
 <template>
@@ -199,5 +221,14 @@ onMounted(() => {
         </q-tooltip>
       </q-btn>
     </div>
+
+    <data-entry-dialog
+      v-model="showDataEntryDialog"
+      :row="dialogCurrentRow || ({} as ImportRow)"
+      :year="selectedYear"
+      :target-type="dialogTargetType ?? TargetType.DATA_ENTRIES"
+      @completed="handleDialogCompleted"
+      @progressing="handleDialogCompleted"
+    />
   </q-page>
 </template>

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -24,6 +24,7 @@ export interface ImportRow {
   labelDataEntryKey?: string;
   moduleTypeId: number;
   dataEntryTypeId?: number;
+  reductionObjectiveTypeId?: number; // # Reduction-objective CSV row models 0: institutional_footprint; 1: population_projections; 2: unit_scenarios;
   factorVariant?: 'plane' | 'train';
   hasFactors: boolean;
   hasApi: boolean;
@@ -87,10 +88,14 @@ export enum IngestionMethod {
   MANUAL = 2,
   COMPUTED = 3,
 }
-
+// institutional_footprint
+// population_projections
+// unit_scenarios
 export enum TargetType {
   DATA_ENTRIES = 0,
   FACTORS = 1,
+  REDUCTION_OBJECTIVES = 2,
+  REFERENCE_DATA = 3,
 }
 
 export enum EntityType {
@@ -363,6 +368,9 @@ provider_type
         if (data_entry_type_id !== undefined && data_entry_type_id !== null) {
           mergedConfig.data_entry_type_id = data_entry_type_id;
         }
+        if (module_type_id !== undefined && module_type_id !== null) {
+          mergedConfig.module_type_id = module_type_id;
+        }
         if (
           carbon_report_module_id !== undefined &&
           carbon_report_module_id !== null
@@ -385,8 +393,10 @@ provider_type
           requestBody.file_path = file_path;
         }
 
+        const urlPath = `sync/dispatch`;
+
         const response = (await api
-          .post(`sync/data-entries/${module_type_id}`, {
+          .post(urlPath, {
             json: requestBody,
           })
           .json()) as { job_id: number };

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/constant/backoffice-module-config';
 import { MODULES_LIST } from 'src/constant/modules';
 
-export interface FileMetadata {
+interface FileMetadata {
   path: string;
   filename: string;
   uploaded_at: string;
@@ -20,13 +20,16 @@ export interface ReductionObjectiveGoal {
   reference_year: number;
 }
 
-export interface ReductionObjectives {
+interface ReductionObjectives {
   files: {
     institutional_footprint: FileMetadata | null;
     population_projections: FileMetadata | null;
     unit_scenarios: FileMetadata | null;
   };
   goals: ReductionObjectiveGoal[];
+  institutional_footprint: [];
+  population_projections: [];
+  unit_scenarios: [];
 }
 
 export interface SubmoduleConfig {
@@ -54,7 +57,7 @@ export interface ModuleConfig {
   submodules: Record<string, SubmoduleConfig>;
 }
 
-export interface YearConfig {
+interface YearConfig {
   modules: Record<string, ModuleConfig>;
   reduction_objectives: ReductionObjectives;
 }
@@ -68,20 +71,20 @@ export interface YearConfigurationResponse {
   updated_at: string;
 }
 
-export interface YearConfigurationCreate {
+interface YearConfigurationCreate {
   is_started?: boolean;
   is_reports_synced?: boolean;
   config?: Partial<YearConfig>;
 }
 
 /** Partial module config allowing nested partial submodule updates. */
-export interface ModuleConfigUpdate {
+interface ModuleConfigUpdate {
   enabled?: boolean;
   uncertainty_tag?: ModuleConfig['uncertainty_tag'];
   submodules?: Record<string, Partial<SubmoduleConfig>>;
 }
 
-export interface YearConfigurationUpdate {
+interface YearConfigurationUpdate {
   is_started?: boolean;
   is_reports_synced?: boolean;
   config?: {
@@ -90,20 +93,10 @@ export interface YearConfigurationUpdate {
   };
 }
 
-export interface FileUploadResponse {
-  success: boolean;
-  file: FileMetadata;
-  message: string;
-}
-
-export type FileCategory = 'footprint' | 'population' | 'scenarios';
-
 export const useYearConfigStore = defineStore('yearConfig', () => {
   // State
   const config = ref<YearConfigurationResponse | null>(null);
   const loading = ref(false);
-  const error = ref<string | null>(null);
-  const currentYear = ref<number | null>(null);
   /** True when the backend returned 404 — no configuration exists yet for this year. */
   const notFound = ref(false);
 
@@ -112,9 +105,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     year: number,
   ): Promise<YearConfigurationResponse | null> {
     loading.value = true;
-    error.value = null;
     notFound.value = false;
-    currentYear.value = year;
 
     try {
       const response = (await api
@@ -131,8 +122,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
           return null;
         }
       }
-      error.value =
-        err instanceof Error ? err.message : 'Failed to fetch configuration';
       throw err;
     } finally {
       loading.value = false;
@@ -144,7 +133,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     payload?: YearConfigurationCreate,
   ): Promise<YearConfigurationResponse> {
     loading.value = true;
-    error.value = null;
 
     try {
       const response = (await api
@@ -155,10 +143,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
       config.value = response;
       notFound.value = false;
       return response;
-    } catch (err: unknown) {
-      error.value =
-        err instanceof Error ? err.message : 'Failed to create configuration';
-      throw err;
     } finally {
       loading.value = false;
     }
@@ -169,7 +153,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     payload: YearConfigurationUpdate,
   ): Promise<YearConfigurationResponse> {
     loading.value = true;
-    error.value = null;
 
     try {
       const response = (await api
@@ -179,86 +162,9 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
         .json()) as YearConfigurationResponse;
       config.value = response;
       return response;
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        error.value = err.message ?? 'Failed to update configuration';
-      } else {
-        error.value = 'Failed to update configuration';
-      }
-      throw err;
     } finally {
       loading.value = false;
     }
-  }
-
-  async function uploadFile(
-    year: number,
-    category: FileCategory,
-    file: File,
-  ): Promise<FileUploadResponse> {
-    loading.value = true;
-    error.value = null;
-
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('category', category);
-
-    try {
-      const response = (await api
-        .post(`year-configuration/${year}/upload`, {
-          body: formData,
-        })
-        .json()) as FileUploadResponse;
-
-      // Refresh config after upload
-      await fetchConfig(year);
-      return response;
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        error.value = err.message ?? 'Failed to upload file';
-      } else {
-        error.value = 'Failed to upload file';
-      }
-      throw err;
-    } finally {
-      loading.value = false;
-    }
-  }
-
-  async function checkThreshold(
-    year: number,
-    moduleTypeId: number,
-    dataEntryTypeId: number,
-    value: number,
-  ): Promise<{ exceeded: boolean; threshold: number | null; value: number }> {
-    try {
-      const response = (await api
-        .get('year-configuration/check-threshold', {
-          searchParams: {
-            year,
-            module_type_id: moduleTypeId,
-            data_entry_type_id: dataEntryTypeId,
-            value,
-          },
-        })
-        .json()) as {
-        exceeded: boolean;
-        threshold: number | null;
-        value: number;
-      };
-      return response;
-    } catch (err: unknown) {
-      console.error('Failed to check threshold:', err);
-      return { exceeded: false, threshold: null, value };
-    }
-  }
-
-  function reset() {
-    config.value = null;
-    loading.value = false;
-    error.value = null;
-    currentYear.value = null;
-    notFound.value = false;
   }
 
   /** All current ingestion jobs for the loaded year. */
@@ -362,8 +268,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     // State
     config,
     loading,
-    error,
-    currentYear,
     notFound,
     // Computed
     latestJobs,
@@ -377,8 +281,5 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     fetchConfig,
     createConfig,
     updateConfig,
-    uploadFile,
-    checkThreshold,
-    reset,
   };
 });


### PR DESCRIPTION
## What does this change?

This pull request introduces support for reduction objectives in the data ingestion and year configuration subsystems. It adds a new `REDUCTION_OBJECTIVES` target type, enables uploading and validating reduction objective CSV files, and extends the year configuration schema to store parsed CSV data. The changes also refactor API endpoints for greater flexibility and improve error handling and validation for reduction objective data.

**Support for reduction objectives in data ingestion and configuration:**

* Added `REDUCTION_OBJECTIVES` and `REFERENCE_DATA` to the `TargetType` enum and updated the database schema to include the new value in `target_type_enum` (`backend/app/models/data_ingestion.py`, `backend/alembic/versions/2026_04_16_0918-4226efc73854_add_reduction_objectives_to_target_type_.py`) [[1]](diffhunk://#diff-2fc623253460a2cee05c77680105a103950ebb3b71a3eeee62fb170dd7953c59R76-R77) [[2]](diffhunk://#diff-ceb55b2639db8c7c1f80b57e400d2ca9842b6ae9f2072ae41cd6d48c64c13750R1-R41).
* Refactored the data sync API: changed the endpoint from `/data-entries/{module_type_id}` to `/dispatch`, moved `module_type_id` and `reduction_objective_type_id` into the request body, and adjusted provider/job creation logic accordingly (`backend/app/api/v1/data_sync.py`) [[1]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6R40-R41) [[2]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6L93-L95) [[3]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6L160) [[4]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6L173-R173) [[5]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6R188-R194) [[6]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6R270-L268).

**CSV upload, validation, and schema extension:**

* Implemented robust CSV validation for reduction objective uploads, including header checks and row-level validation with detailed error reporting. Parsed rows are now stored in the year configuration alongside file metadata (`backend/app/schemas/year_configuration.py`, `backend/app/api/v1/year_configuration.py`) [[1]](diffhunk://#diff-7eb48bd16352a261d12011197e46a3536c60d572ab3a0b3a9d14715fe49f1a7bR3-R22) [[2]](diffhunk://#diff-7eb48bd16352a261d12011197e46a3536c60d572ab3a0b3a9d14715fe49f1a7bR37-R265) [[3]](diffhunk://#diff-7eb48bd16352a261d12011197e46a3536c60d572ab3a0b3a9d14715fe49f1a7bR295-R318) [[4]](diffhunk://#diff-1f2676fb1b995bae1185f4c4ed10b3629326948fd9a07a40ed1bb1cd3ffbf703L606-R626) [[5]](diffhunk://#diff-1f2676fb1b995bae1185f4c4ed10b3629326948fd9a07a40ed1bb1cd3ffbf703R666-R694).
* Updated the year configuration schema to include `institutional_footprint`, `population_projections`, and `unit_scenarios` fields for storing parsed CSV data (`backend/app/schemas/year_configuration.py`).

**API and validation improvements:**

* Changed the file upload endpoint to accept `category` as a form field (not a file), and ensured the database object is added after config changes for proper persistence (`backend/app/api/v1/year_configuration.py`) [[1]](diffhunk://#diff-1f2676fb1b995bae1185f4c4ed10b3629326948fd9a07a40ed1bb1cd3ffbf703L569-R574) [[2]](diffhunk://#diff-1f2676fb1b995bae1185f4c4ed10b3629326948fd9a07a40ed1bb1cd3ffbf703R517-R518).
* Improved error messages and audit logging for file uploads and ingestion failures (`backend/app/api/v1/year_configuration.py`).

These changes collectively provide robust support for uploading, validating, and storing reduction objective data, and lay the groundwork for further integration of reduction objectives into the data ingestion pipeline.
## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #619 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
