### PR TITLE
fix(unit-user-sync): correct cf in unit-user table

### DIFF
--- a/backend/app/providers/role_provider.py
+++ b/backend/app/providers/role_provider.py
@@ -524,11 +524,19 @@ class AccredRoleProvider(RoleProvider):
                 if auth.get("state") != "active":
                     continue
 
-                accred_unit_id = auth.get("accredunitid")
-
-                if not accred_unit_id:
+                accred_unit_institutional_code = auth.get("accredunitid")
+                accred_unit_institutional_id = (
+                    auth.get("reason").get("resource").get("cf")
+                )
+                if not accred_unit_institutional_code:
                     logger.warning(
                         "Authorization missing accredunitid, skipping",
+                        extra={"auth_name": auth_name, "user_id": user_id},
+                    )
+                    continue
+                if not accred_unit_institutional_id:
+                    logger.warning(
+                        "Authorization missing cf, skipping",
                         extra={"auth_name": auth_name, "user_id": user_id},
                     )
                     continue
@@ -551,7 +559,9 @@ class AccredRoleProvider(RoleProvider):
                     roles.append(
                         Role(
                             role=auth_name,
-                            on=RoleScope(institutional_id=str(accred_unit_id)),
+                            on=RoleScope(
+                                institutional_id=str(accred_unit_institutional_id)
+                            ),
                         )
                     )
 

--- a/backend/app/repositories/unit_user_repo.py
+++ b/backend/app/repositories/unit_user_repo.py
@@ -113,6 +113,20 @@ class UnitUserRepository:
         await self.session.flush()
         return True
 
+    async def delete_by_user_id(self, user_id: int) -> int:
+        """Delete all UnitUser associations for a user.
+        Returns count of deleted rows."""
+        result = await self.session.exec(
+            select(UnitUser).where(UnitUser.user_id == user_id)
+        )
+        entities = result.all()
+        count = len(entities)
+        for entity in entities:
+            await self.session.delete(entity)
+        if count > 0:
+            await self.session.flush()
+        return count
+
     async def count(self, filters: Optional[dict] = None) -> int:
         """Count UnitUser associations with optional filters."""
         query = select(func.count()).select_from(UnitUser)

--- a/backend/app/services/unit_service.py
+++ b/backend/app/services/unit_service.py
@@ -244,6 +244,12 @@ class UnitService:
         await self.session.flush()  # Ensure unit IDs are populated
         return db_objs
 
+    async def get_by_institutional_ids(
+        self, institutional_ids: List[str]
+    ) -> List[Unit]:
+        """Get units by their institutional IDs (batch lookup, no policy checks)."""
+        return await self.unit_repo.get_by_institutional_ids(institutional_ids)
+
     async def count(self, filters: Optional[dict] = None) -> int:
         """Count units with optional filters."""
         return await self.unit_repo.count(filters)

--- a/backend/app/services/unit_user_service.py
+++ b/backend/app/services/unit_user_service.py
@@ -134,6 +134,16 @@ class UnitUserService:
 
         return True
 
+    async def delete_all_for_user(self, user_id: int) -> int:
+        """Delete all unit associations for a user. Returns count of deleted rows."""
+        count = await self.unit_user_repo.delete_by_user_id(user_id)
+        if count > 0:
+            logger.info(
+                "Deleted all UnitUser associations for user",
+                extra={"user_id": user_id, "deleted_count": count},
+            )
+        return count
+
     async def count(self, filters: Optional[dict] = None) -> int:
         """Count UnitUser associations."""
         return await self.unit_user_repo.count(filters)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -23,8 +23,6 @@ from app.core.policy import query_policy
 from app.core.role_priority import pick_role_for_institutional_id
 from app.models.unit import Unit
 from app.models.user import Role, RoleScope, User, UserProvider
-from app.providers.role_provider import get_role_provider
-from app.providers.unit_provider import get_unit_provider
 from app.repositories.user_repo import UpsertUserResult, UserRepository
 from app.services.unit_service import UnitService
 from app.services.unit_user_service import UnitUserService
@@ -41,17 +39,21 @@ class UserService:
         self.unit_user_service = UnitUserService(session)
         self.unit_service = UnitService(session)
 
-    def get_user_unit_ids(self, roles: Optional[List[Role]]) -> list[str]:
-        """Get list of unit IDs associated with a user (from RoleScope.unit for now)."""
+    def get_uniq_unit_institutional_id_from_roles(
+        self, roles: Optional[List[Role]]
+    ) -> list[str]:
+        """Get list of unit IDs associated with a user (from RoleScope.unit for now).
+        here unit ids should be unit institutional ids. a.k.a CF
+        """
         if not roles:
             return []
 
-        unit_ids: set[str] = set()
+        unit_institutional_ids: set[str] = set()
         for role in roles:
             if isinstance(role.on, RoleScope) and role.on.institutional_id:
-                unit_ids.add(role.on.institutional_id)
+                unit_institutional_ids.add(role.on.institutional_id)
 
-        return list(unit_ids)
+        return list(unit_institutional_ids)
 
     async def _upsert_user_identity(
         self,
@@ -120,114 +122,59 @@ class UserService:
         await self.session.flush()
         return user
 
-    async def unit_sync_from_provider(
-        self,
-        provider: UserProvider,
-        provider_unit_codes: list[str],
-        skip_principal_user_for_institutional_id: Optional[str] = None,
-    ) -> list[int]:
-        """
-        Sync units and their principals from provider.
-
-        Args:
-            provider: The user provider type (e.g., UserProvider.ACCRED)
-            provider_unit_codes: List of unit codes to sync
-            skip_principal_user_for_institutional_id: Optional - skip upserting
-                                                 the principal user
-                                                 if it matches this
-                                                 institutional_id.
-                                                 Used to avoid upserting the
-                                                 current user.
-        """
-        # Fetch full unit details from provider
-        unit_provider = get_unit_provider(provider_type=provider)
-        units = await unit_provider.get_units(unit_ids=provider_unit_codes)
-        # Upsert units with full metadata
-        # TODO: simplify the code, by assuming that provider returns all needed info
-        # unit_provider.fetch_all_units() all principal info!
-        # and upserting in one step without fetching principal users separately.
-        role_provider = get_role_provider(provider_type=provider)
-        unit_ids = []
-        for unit in units:
-            if not unit.principal_user_institutional_id:
-                raise ValueError(
-                    f"Unit {unit.id} missing principal_user_institutional_id"
-                )
-
-            # Upsert principal user if needed
-            principal_user = await role_provider.get_user_by_user_id(
-                unit.principal_user_institutional_id
-            )
-
-            # Skip upserting if it's the same as
-            # skip_principal_user_for_institutional_id
-            if (
-                principal_user
-                and unit.principal_user_institutional_id
-                != skip_principal_user_for_institutional_id
-            ):
-                await self.upsert_user(
-                    email=principal_user.get("email", ""),
-                    institutional_id=principal_user.get("institutional_id", ""),
-                    display_name=principal_user.get("display_name", None),
-                    id=None,
-                    roles=principal_user.get("roles", []),
-                    stop_recursion=True,
-                    provider=principal_user.get("provider", None),
-                    function=principal_user.get("function", None),
-                )
-
-            created_unit: Unit = await self.unit_service.upsert(
-                unit_data=unit,
-            )
-            if created_unit is None or created_unit.id is None:
-                raise ValueError(f"Failed to upsert unit {unit.id}")
-            unit_ids.append(created_unit.id)
-
-        # Flush all unit operations together
-        await self.session.flush()
-
-        return unit_ids
-
     async def unit_membership_sync_user(
         self,
         user: User,
         roles: List[Role],
-        unit_ids: List[int],
-        unit_codes: List[str],
+        units: List[Unit],
     ) -> None:
-        # step 5. Create/update UnitUser associations
-        if len(unit_codes) != len(unit_ids):
-            raise ValueError(
-                "Unit codes and IDs length mismatch during membership sync"
-            )
-        for unit_id, unit_code in zip(unit_ids, unit_codes):
-            chosen_role = pick_role_for_institutional_id(roles, unit_code)
+        """Sync UnitUser associations for a user based on their current roles.
+
+        Strategy: delete all existing associations, then recreate from current roles.
+        This handles role changes, unit remapping, and removed associations cleanly.
+        """
+        if user is None or user.id is None:
+            raise ValueError("User must have a valid ID for unit membership sync")
+
+        # 1. Delete all existing associations for this user
+        await self.unit_user_service.delete_all_for_user(user.id)
+
+        # 2. Recreate associations from current roles
+        created_count = 0
+        for unit in units:
+            if unit.institutional_id is None:
+                raise ValueError(
+                    "unit.institutional_id should exist before picking a role"
+                )
+            chosen_role = pick_role_for_institutional_id(roles, unit.institutional_id)
             if not chosen_role:
                 logger.warning(
                     "No valid role found for user-unit association",
                     extra={
                         "user_id": sanitize(user.id),
-                        "unit_id": sanitize(unit_id),
+                        "unit_id": sanitize(unit.id),
+                        "unit_institutional_id": sanitize(unit.institutional_id),
                     },
                 )
                 continue
-            if user is None or user.id is None:
-                raise ValueError("User must have a valid ID for unit membership sync")
+            if unit.id is None:
+                raise ValueError(
+                    "unit.id should exist before trying to create N-N relationship"
+                )
             await self.unit_user_service.upsert(
-                unit_id=unit_id,
+                unit_id=unit.id,
                 user_id=user.id,
                 role=chosen_role,
             )
+            created_count += 1
 
-        # Flush all unit_user operations together
         await self.session.flush()
 
         logger.info(
-            "User upserted with units",
+            "User unit memberships synced",
             extra={
                 "user_id": sanitize(user.id),
-                "unit_count": len(unit_ids),
+                "unit_count": created_count,
                 "provider": user.provider,
             },
         )
@@ -258,39 +205,51 @@ class UserService:
         if stop_recursion:
             return user
 
-        provider_unit_codes = self.get_user_unit_ids(roles)
-        if not provider_unit_codes:
+        unit_institutional_ids: list[str] = (
+            self.get_uniq_unit_institutional_id_from_roles(roles)
+        )
+        if not unit_institutional_ids:
+            # No unit-scoped roles — clean up any existing associations
+            if user.id is not None:
+                await self.unit_user_service.delete_all_for_user(user.id)
             return user
 
         if user.provider is None:
             raise ValueError("User provider is required for unit synchronization")
 
-        # Pulls units from the provider,
-        # upserts missing principal users,
-        # then upserts units.”
-        unit_ids = await self.unit_sync_from_provider(
-            provider=user.provider,
-            provider_unit_codes=provider_unit_codes,
-            skip_principal_user_for_institutional_id=user.institutional_id,
-        )
-
+        # we used to sync units on user upsert, but not anymore
         if roles is None:
             roles = []
-        # Upserts UnitUser relationships by resolving
-        # the user's role per unit
-        # (should be .id to .id mapping, not .institutional_id)
+
+        # 1. Resolve unit.ids from the database based on unit_institutional_ids
+        units = await self.unit_service.get_by_institutional_ids(unit_institutional_ids)
+
+        if not units:
+            logger.warning(
+                "No units found in DB for the given institutional IDs",
+                extra={
+                    "user_id": sanitize(user.id),
+                    "unit_institutional_ids": sanitize(unit_institutional_ids),
+                },
+            )
+            if user.id is None:
+                raise ValueError("User ID is required for unit synchronization")
+            # Still delete stale associations even if no units matched
+            await self.unit_user_service.delete_all_for_user(user.id)
+            return user
+
+        # 2 & 3. Delete old associations and recreate from current roles
         await self.unit_membership_sync_user(
             user=user,
             roles=roles,
-            unit_ids=unit_ids,
-            unit_codes=provider_unit_codes,
+            units=units,
         )
 
         logger.info(
             "User upserted with units",
             extra={
                 "id": user.id,
-                "unit_count": len(provider_unit_codes),
+                "unit_count": len(unit_institutional_ids),
                 "provider": user.provider,
             },
         )

--- a/backend/tests/unit/services/test_user_service.py
+++ b/backend/tests/unit/services/test_user_service.py
@@ -1,0 +1,339 @@
+"""Tests for UserService.unit_membership_sync_user and upsert_user sync logic."""
+
+import pytest
+from sqlmodel import select
+
+from app.models.unit import Unit
+from app.models.unit_user import UnitUser
+from app.models.user import (
+    Role,
+    RoleName,
+    RoleScope,
+    User,
+    UserProvider,
+)
+from app.services.user_service import UserService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(**overrides) -> User:
+    defaults = dict(
+        institutional_id="100000",
+        email="test@example.com",
+        provider=UserProvider.TEST,
+        display_name="Test User",
+    )
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_unit(institutional_id: str, institutional_code: str, **overrides) -> Unit:
+    defaults = dict(
+        institutional_id=institutional_id,
+        institutional_code=institutional_code,
+        name=f"Unit-{institutional_code}",
+        level=2,
+        provider=UserProvider.TEST,
+    )
+    defaults.update(overrides)
+    return Unit(**defaults)
+
+
+def _role(role_name: RoleName, institutional_id: str) -> Role:
+    return Role(role=role_name, on=RoleScope(institutional_id=institutional_id))
+
+
+async def _get_unit_users(session, user_id: int) -> list[UnitUser]:
+    result = await session.exec(select(UnitUser).where(UnitUser.user_id == user_id))
+    return list(result.all())
+
+
+# ---------------------------------------------------------------------------
+# Tests for unit_membership_sync_user
+# ---------------------------------------------------------------------------
+
+
+class TestUnitMembershipSyncUser:
+    """Tests for the unit_membership_sync_user method."""
+
+    async def test_creates_associations_for_matching_roles(self, db_session):
+        """Happy path: user with 2 unit-scoped roles gets 2 unit_users rows."""
+        user = _make_user()
+        unit_a = _make_unit("CF_A", "CODE_A")
+        unit_b = _make_unit("CF_B", "CODE_B")
+        db_session.add_all([user, unit_a, unit_b])
+        await db_session.flush()
+
+        roles = [
+            _role(RoleName.CO2_USER_STD, "CF_A"),
+            _role(RoleName.CO2_USER_PRINCIPAL, "CF_B"),
+        ]
+
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(
+            user=user, roles=roles, units=[unit_a, unit_b]
+        )
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 2
+
+        by_unit = {r.unit_id: r for r in rows}
+        assert by_unit[unit_a.id].role == RoleName.CO2_USER_STD
+        assert by_unit[unit_b.id].role == RoleName.CO2_USER_PRINCIPAL
+
+    async def test_removes_stale_associations(self, db_session):
+        """User had 2 units, now has 1 — the old association is deleted."""
+        user = _make_user()
+        unit_a = _make_unit("CF_A", "CODE_A")
+        unit_b = _make_unit("CF_B", "CODE_B")
+        db_session.add_all([user, unit_a, unit_b])
+        await db_session.flush()
+
+        # Seed an existing association for unit_b
+        db_session.add(
+            UnitUser(unit_id=unit_b.id, user_id=user.id, role=RoleName.CO2_USER_STD)
+        )
+        await db_session.flush()
+
+        # Now sync with only unit_a in roles
+        roles = [_role(RoleName.CO2_USER_STD, "CF_A")]
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(user=user, roles=roles, units=[unit_a])
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 1
+        assert rows[0].unit_id == unit_a.id
+
+    async def test_no_roles_deletes_all_associations(self, db_session):
+        """User has no matching roles — all associations are deleted."""
+        user = _make_user()
+        unit_a = _make_unit("CF_A", "CODE_A")
+        db_session.add_all([user, unit_a])
+        await db_session.flush()
+
+        # Seed existing association
+        db_session.add(
+            UnitUser(unit_id=unit_a.id, user_id=user.id, role=RoleName.CO2_USER_STD)
+        )
+        await db_session.flush()
+
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(user=user, roles=[], units=[])
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 0
+
+    async def test_role_upgrade(self, db_session):
+        """User was CO2_USER_STD on a unit, now CO2_USER_PRINCIPAL — role is updated."""
+        user = _make_user()
+        unit_a = _make_unit("CF_A", "CODE_A")
+        db_session.add_all([user, unit_a])
+        await db_session.flush()
+
+        # Seed existing association with STD role
+        db_session.add(
+            UnitUser(unit_id=unit_a.id, user_id=user.id, role=RoleName.CO2_USER_STD)
+        )
+        await db_session.flush()
+
+        roles = [_role(RoleName.CO2_USER_PRINCIPAL, "CF_A")]
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(user=user, roles=roles, units=[unit_a])
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 1
+        assert rows[0].role == RoleName.CO2_USER_PRINCIPAL
+
+    async def test_unknown_unit_institutional_id_skipped(self, db_session):
+        """Unit whose institutional_id doesn't match any role is skipped gracefully."""
+        user = _make_user()
+        unit_a = _make_unit("CF_A", "CODE_A")
+        unit_orphan = _make_unit("CF_ORPHAN", "CODE_ORPHAN")
+        db_session.add_all([user, unit_a, unit_orphan])
+        await db_session.flush()
+
+        # Roles only reference CF_A — CF_ORPHAN should be skipped
+        roles = [_role(RoleName.CO2_USER_STD, "CF_A")]
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(
+            user=user, roles=roles, units=[unit_a, unit_orphan]
+        )
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 1
+        assert rows[0].unit_id == unit_a.id
+
+    async def test_picks_highest_priority_role(self, db_session):
+        """When user has multiple roles on same unit, highest priority wins."""
+        user = _make_user()
+        unit_a = _make_unit("CF_A", "CODE_A")
+        db_session.add_all([user, unit_a])
+        await db_session.flush()
+
+        roles = [
+            _role(RoleName.CO2_USER_STD, "CF_A"),
+            _role(RoleName.CO2_USER_PRINCIPAL, "CF_A"),
+        ]
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(user=user, roles=roles, units=[unit_a])
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 1
+        assert rows[0].role == RoleName.CO2_USER_PRINCIPAL
+
+    async def test_raises_on_null_user_id(self, db_session):
+        """Raises ValueError if user.id is None."""
+        user = User(
+            institutional_id="999",
+            email="none@example.com",
+            provider=UserProvider.TEST,
+        )
+        # Don't flush — id stays None
+        svc = UserService(db_session)
+        with pytest.raises(ValueError, match="valid ID"):
+            await svc.unit_membership_sync_user(user=user, roles=[], units=[])
+
+    async def test_does_not_affect_other_users(self, db_session):
+        """Syncing user A should not touch user B's associations."""
+        user_a = _make_user(institutional_id="A", email="a@example.com")
+        user_b = _make_user(institutional_id="B", email="b@example.com")
+        unit = _make_unit("CF_X", "CODE_X")
+        db_session.add_all([user_a, user_b, unit])
+        await db_session.flush()
+
+        # Give user_b an association
+        db_session.add(
+            UnitUser(unit_id=unit.id, user_id=user_b.id, role=RoleName.CO2_USER_STD)
+        )
+        await db_session.flush()
+
+        # Sync user_a with no units
+        svc = UserService(db_session)
+        await svc.unit_membership_sync_user(user=user_a, roles=[], units=[])
+
+        # user_b's association should be untouched
+        rows_b = await _get_unit_users(db_session, user_b.id)
+        assert len(rows_b) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for upsert_user (integration of the full sync flow)
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertUserSync:
+    """Tests for the unit sync flow within upsert_user."""
+
+    async def test_upsert_user_resolves_units_and_creates_associations(
+        self, db_session
+    ):
+        """upsert_user resolves institutional_ids to unit.ids
+        and creates associations."""
+        unit_a = _make_unit("CF_A", "CODE_A")
+        db_session.add(unit_a)
+        await db_session.flush()
+
+        roles = [_role(RoleName.CO2_USER_STD, "CF_A")]
+
+        svc = UserService(db_session)
+        user = await svc.upsert_user(
+            id=None,
+            email="new@example.com",
+            institutional_id="200000",
+            display_name="New User",
+            roles=roles,
+            provider=UserProvider.TEST,
+        )
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 1
+        assert rows[0].unit_id == unit_a.id
+        assert rows[0].role == RoleName.CO2_USER_STD
+
+    async def test_upsert_user_cleans_stale_on_role_change(self, db_session):
+        """When roles change between upserts, old associations are cleaned up."""
+        unit_a = _make_unit("CF_A", "CODE_A")
+        unit_b = _make_unit("CF_B", "CODE_B")
+        db_session.add_all([unit_a, unit_b])
+        await db_session.flush()
+
+        svc = UserService(db_session)
+
+        # First upsert — roles on both units
+        roles_v1 = [
+            _role(RoleName.CO2_USER_STD, "CF_A"),
+            _role(RoleName.CO2_USER_STD, "CF_B"),
+        ]
+        user = await svc.upsert_user(
+            id=None,
+            email="change@example.com",
+            institutional_id="300000",
+            roles=roles_v1,
+            provider=UserProvider.TEST,
+        )
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 2
+
+        # Second upsert — role removed from unit_b
+        roles_v2 = [_role(RoleName.CO2_USER_PRINCIPAL, "CF_A")]
+        user = await svc.upsert_user(
+            id=user.id,
+            email="change@example.com",
+            institutional_id="300000",
+            roles=roles_v2,
+            provider=UserProvider.TEST,
+        )
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 1
+        assert rows[0].unit_id == unit_a.id
+        assert rows[0].role == RoleName.CO2_USER_PRINCIPAL
+
+    async def test_upsert_user_no_unit_roles_clears_all(self, db_session):
+        """User with no unit-scoped roles gets all associations cleared."""
+        unit_a = _make_unit("CF_A", "CODE_A")
+        db_session.add(unit_a)
+        await db_session.flush()
+
+        svc = UserService(db_session)
+
+        # First upsert with a role
+        roles_v1 = [_role(RoleName.CO2_USER_STD, "CF_A")]
+        user = await svc.upsert_user(
+            id=None,
+            email="clear@example.com",
+            institutional_id="400000",
+            roles=roles_v1,
+            provider=UserProvider.TEST,
+        )
+        assert len(await _get_unit_users(db_session, user.id)) == 1
+
+        # Second upsert with no unit-scoped roles
+        user = await svc.upsert_user(
+            id=user.id,
+            email="clear@example.com",
+            institutional_id="400000",
+            roles=[],
+            provider=UserProvider.TEST,
+        )
+        assert len(await _get_unit_users(db_session, user.id)) == 0
+
+    async def test_upsert_user_unknown_institutional_id_clears_associations(
+        self, db_session
+    ):
+        """Roles reference an institutional_id not in the DB — associations cleared."""
+        svc = UserService(db_session)
+
+        roles = [_role(RoleName.CO2_USER_STD, "CF_NONEXISTENT")]
+        user = await svc.upsert_user(
+            id=None,
+            email="ghost@example.com",
+            institutional_id="500000",
+            roles=roles,
+            provider=UserProvider.TEST,
+        )
+
+        rows = await _get_unit_users(db_session, user.id)
+        assert len(rows) == 0


### PR DESCRIPTION
## What does this change?

This pull request refactors and improves the user-unit association logic, focusing on syncing user roles and unit memberships more robustly and efficiently. The changes ensure that associations are always up-to-date by deleting old relationships before recreating them, and that all lookups and associations are based on institutional IDs (CF codes). Additionally, the code now handles missing or incomplete data more gracefully and introduces new helper methods for batch operations.

**User-Unit Association Refactor:**

* The user upsert flow no longer attempts to sync or upsert units from the provider during user upsert. Instead, it now fetches existing units from the database using institutional IDs, and deletes any stale associations if no units are found. Associations are always rebuilt from scratch based on the current roles.
* The `unit_membership_sync_user` method now deletes all existing `UnitUser` associations for a user before recreating them from the supplied units and roles, ensuring a clean and accurate mapping.
* Added `delete_by_user_id` to `UnitUserRepository` and `delete_all_for_user` to `UnitUserService` for efficient bulk deletion of user associations. [[1]](diffhunk://#diff-74c5772f6c4a361d21fe742686e09bed0084a754b7923ee10bae540a66121dccR116-R129) [[2]](diffhunk://#diff-a97cfbf7360933596198956d8e0181cf9c13156a16e4b2a442cc3d7b9fd905b2R137-R146)
* Added `get_by_institutional_ids` to `UnitService` for batch lookup of units by institutional IDs, supporting the new association logic.

**Role and ID Handling Improvements:**

* The code now extracts both `accredunitid` (institutional code) and the canonical institutional ID (`cf`) from authorization data, and skips any role assignments if either is missing, improving robustness. [[1]](diffhunk://#diff-a9d3a44bb1aad465fca89c83c4f6bd78c86a00f4b1c323f2f8a5aa557dabd66dL527-R542) [[2]](diffhunk://#diff-a9d3a44bb1aad465fca89c83c4f6bd78c86a00f4b1c323f2f8a5aa557dabd66dL554-R564)
* Renamed and clarified helper methods to consistently use "institutional ID" (CF code) for all unit lookups and associations, reducing ambiguity.
## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
