### PR TITLE
feat: use SQL totals in IT breakdown

### DIFF
--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -20,7 +20,11 @@ from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.services.data_entry_service import DataEntryService
 from app.services.unit_totals_service import UnitTotalsService
 from app.utils.emission_category import build_chart_breakdown
-from app.utils.it_breakdown import build_it_breakdown
+from app.utils.it_breakdown import (
+    IT_EMISSION_TYPES,
+    build_it_breakdown,
+    get_validated_source_module_type_ids,
+)
 from app.utils.report_computations import (
     compute_results_summary,
     compute_validated_totals,
@@ -265,9 +269,6 @@ async def get_it_breakdown(
     )
     total_fte = sum(fte_stats.values())
 
-    # Compute total emissions for percentage calculation
-    total_emissions_kg = sum(row[2] for row in emission_rows)
-
     result = await db.execute(
         select(
             CarbonReportModule.id,
@@ -289,8 +290,18 @@ async def get_it_breakdown(
     # Map module_type_id → carbon_report_module_id
     crm_by_type = {row[1]: row[0] for row in module_rows}
 
+    validated_source_module_type_ids = get_validated_source_module_type_ids(
+        validated_module_type_ids
+    )
+
     # Fetch top-class breakdowns for equipment IT and purchases IT
     emission_svc = DataEntryEmissionService(db)
+    sql_totals = await emission_svc.get_it_emission_sql_totals(
+        carbon_report_id=carbon_report_id,
+        it_emission_type_ids=[et.value for et in IT_EMISSION_TYPES],
+        validated_source_module_type_ids=validated_source_module_type_ids,
+        exclude_module_type_ids=exclude_set,
+    )
     top_class_detail: dict[str, list] = {}
 
     equip_crm_id = crm_by_type.get(ModuleTypeEnum.equipment_electric_consumption.value)
@@ -323,7 +334,7 @@ async def get_it_breakdown(
     return build_it_breakdown(
         rows=emission_rows_no_qty,
         total_fte=total_fte,
-        total_emissions_kg=total_emissions_kg,
+        sql_totals=sql_totals,
         validated_module_type_ids=validated_module_type_ids,
         top_class_detail=top_class_detail,
         exclude_module_type_ids=exclude_set,

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import Select, case, literal, or_
+from sqlalchemy import ColumnElement, Select, and_, case, literal, or_
 from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -12,6 +12,7 @@ from app.models.data_entry import DataEntry, DataEntryTypeEnum
 from app.models.data_entry_emission import DataEntryEmission, EmissionType
 from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
+from app.utils.it_breakdown import ITSqlTotals
 
 
 class DataEntryEmissionRepository:
@@ -180,7 +181,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
             )
             .where(
-                CarbonReportModule.carbon_report_id == carbon_report_id,
+                col(CarbonReportModule.carbon_report_id) == carbon_report_id,
                 CarbonReportModule.status == ModuleStatus.VALIDATED,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
             )
@@ -221,7 +222,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
             )
             .where(
-                CarbonReportModule.carbon_report_id == carbon_report_id,
+                col(CarbonReportModule.carbon_report_id) == carbon_report_id,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
             )
             .group_by(
@@ -270,7 +271,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
             )
             .where(
-                CarbonReportModule.carbon_report_id == carbon_report_id,
+                col(CarbonReportModule.carbon_report_id) == carbon_report_id,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
             )
             .group_by(
@@ -291,6 +292,100 @@ class DataEntryEmissionRepository:
             )
             for row in rows
         ]
+
+    async def get_it_emission_sql_totals(
+        self,
+        carbon_report_id: int,
+        it_emission_type_ids: list[int],
+        validated_source_module_type_ids: list[int],
+        exclude_module_type_ids: set[int] | frozenset[int] = frozenset(),
+    ) -> ITSqlTotals:
+        """Compute IT emission totals via a single SQL query
+        using conditional aggregation.
+
+        Four pre-computed totals replace the Python-level aggregation that was
+        previously performed inside ``build_it_breakdown``:
+
+        - ``it_total_kg``: sum of IT-typed emissions (excluding excluded modules).
+        - ``overall_total_kg``: sum of all emissions (excluding excluded modules).
+        - ``validated_source_total_kg``: total emissions from validated IT source
+          modules (denominator for ``percentage_of_source_modules``).
+        - ``validated_it_kg``: IT emissions from validated IT source modules
+          (numerator for ``percentage_of_source_modules``).
+        """
+        is_it_emission = col(DataEntryEmission.emission_type_id).in_(
+            it_emission_type_ids
+        )
+        is_validated_source = col(CarbonReportModule.module_type_id).in_(
+            validated_source_module_type_ids
+        )
+
+        base_where: list[ColumnElement[bool]] = [
+            col(CarbonReportModule.carbon_report_id) == carbon_report_id,
+            col(DataEntryEmission.kg_co2eq).isnot(None),
+        ]
+        if exclude_module_type_ids:
+            base_where.append(
+                col(CarbonReportModule.module_type_id).notin_(exclude_module_type_ids)
+            )
+
+        query = (
+            select(
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (is_it_emission, col(DataEntryEmission.kg_co2eq)),
+                            else_=None,
+                        )
+                    ),
+                    0.0,
+                ).label("it_total_kg"),
+                func.coalesce(
+                    func.sum(col(DataEntryEmission.kg_co2eq)),
+                    0.0,
+                ).label("overall_total_kg"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (is_validated_source, col(DataEntryEmission.kg_co2eq)),
+                            else_=None,
+                        )
+                    ),
+                    0.0,
+                ).label("validated_source_total_kg"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                and_(is_validated_source, is_it_emission),
+                                col(DataEntryEmission.kg_co2eq),
+                            ),
+                            else_=None,
+                        )
+                    ),
+                    0.0,
+                ).label("validated_it_kg"),
+            )
+            .join(
+                DataEntry,
+                col(DataEntryEmission.data_entry_id) == col(DataEntry.id),
+            )
+            .join(
+                CarbonReportModule,
+                col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
+            )
+            .where(*base_where)
+        )
+
+        result = await self.session.execute(query)
+        row = result.one()
+
+        return {
+            "it_total_kg": float(row.it_total_kg),
+            "overall_total_kg": float(row.overall_total_kg),
+            "validated_source_total_kg": float(row.validated_source_total_kg),
+            "validated_it_kg": float(row.validated_it_kg),
+        }
 
     async def get_embodied_energy_by_building(
         self,
@@ -317,7 +412,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
             )
             .where(
-                CarbonReportModule.carbon_report_id == carbon_report_id,
+                col(CarbonReportModule.carbon_report_id) == carbon_report_id,
                 col(DataEntry.data_entry_type_id)
                 == DataEntryTypeEnum.building_embodied_energy.value,
                 col(DataEntryEmission.emission_type_id)
@@ -366,7 +461,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
             )
             .where(
-                CarbonReportModule.carbon_report_id == carbon_report_id,
+                col(CarbonReportModule.carbon_report_id) == carbon_report_id,
                 col(DataEntry.data_entry_type_id)
                 == DataEntryTypeEnum.building_embodied_energy.value,
                 col(DataEntryEmission.emission_type_id)

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -15,6 +15,7 @@ from app.schemas.carbon_report import (
     CarbonReportUpdate,
 )
 from app.services.carbon_report_module_service import CarbonReportModuleService
+from app.utils.it_breakdown import IT_EMISSION_TYPES
 
 logger = get_logger(__name__)
 
@@ -149,12 +150,17 @@ class CarbonReportService:
         # Calculate grand total
         total = scope1_total + scope2_total + scope3_total
 
+        # Pre-compute IT total so IT-breakdown endpoints can read it from cached stats
+        _it_et_id_strs = {str(et.value) for et in IT_EMISSION_TYPES}
+        it_total_kg = sum(v for k, v in by_emission_type.items() if k in _it_et_id_strs)
+
         # Build aggregated stats dict
         stats = {
             "scope1": scope1_total,
             "scope2": scope2_total,
             "scope3": scope3_total,
             "total": total,
+            "it_total_kg": it_total_kg,
             "by_emission_type": by_emission_type,
             "computed_at": datetime.now(timezone.utc).isoformat(),
             "entry_count": total_entry_count,

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -21,6 +21,7 @@ from app.repositories.data_entry_emission_repo import (
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.factor_service import FactorService
 from app.utils.data_entry_emission_type_map import resolve_emission_types
+from app.utils.it_breakdown import ITSqlTotals
 
 settings = get_settings()
 logger = get_logger(__name__)
@@ -498,6 +499,26 @@ class DataEntryEmissionService:
         """
         return await self.repo.get_emission_breakdown_with_quantity(
             carbon_report_id=carbon_report_id,
+        )
+
+    async def get_it_emission_sql_totals(
+        self,
+        carbon_report_id: int,
+        it_emission_type_ids: list[int],
+        validated_source_module_type_ids: list[int],
+        exclude_module_type_ids: set[int] | frozenset[int] = frozenset(),
+    ) -> ITSqlTotals:
+        """Compute IT emission totals in SQL.
+
+        Delegates to the repository. Returns a dict with
+        ``it_total_kg``, ``overall_total_kg``, ``validated_source_total_kg``,
+        and ``validated_it_kg``.
+        """
+        return await self.repo.get_it_emission_sql_totals(
+            carbon_report_id=carbon_report_id,
+            it_emission_type_ids=it_emission_type_ids,
+            validated_source_module_type_ids=validated_source_module_type_ids,
+            exclude_module_type_ids=exclude_module_type_ids,
         )
 
     async def get_embodied_energy_by_building(

--- a/backend/app/utils/it_breakdown.py
+++ b/backend/app/utils/it_breakdown.py
@@ -10,10 +10,20 @@ Aggregates IT-related emissions from four source modules:
   facility emissions (Scope 3)
 """
 
-from typing import Any
+from typing import Any, TypedDict
 
 from app.models.data_entry_emission import EmissionType
 from app.models.module_type import ModuleTypeEnum
+
+
+class ITSqlTotals(TypedDict):
+    """Pre-computed SQL totals passed into ``build_it_breakdown``."""
+
+    it_total_kg: float
+    overall_total_kg: float
+    validated_it_kg: float
+    validated_source_total_kg: float
+
 
 # ---------------------------------------------------------------------------
 # IT category definitions
@@ -71,6 +81,22 @@ _IT_CATEGORY_MODULE_IDS: dict[str, set[int]] = {
     IT_CATEGORY_RESEARCH: {ModuleTypeEnum.research_facilities.value},
 }
 
+
+def get_validated_source_module_type_ids(
+    validated_module_type_ids: set[int],
+) -> list[int]:
+    """Return all IT source module type IDs whose category is fully validated.
+
+    A category is considered fully validated when every module type ID it
+    maps to is present in *validated_module_type_ids*.
+    """
+    result: list[int] = []
+    for mod_ids in _IT_CATEGORY_MODULE_IDS.values():
+        if mod_ids.issubset(validated_module_type_ids):
+            result.extend(mod_ids)
+    return result
+
+
 # Ordered list of IT categories for deterministic output
 IT_CATEGORIES_ORDER: list[str] = [
     IT_CATEGORY_EQUIPMENT,
@@ -96,22 +122,23 @@ def _categorize_it_emission(emission_type: EmissionType) -> str | None:
 def build_it_breakdown(
     rows: list[tuple[int, int, float]],
     total_fte: float = 0.0,
-    total_emissions_kg: float = 0.0,
     validated_module_type_ids: set[int] | None = None,
     top_class_detail: dict[str, list[dict[str, Any]]] | None = None,
     exclude_module_type_ids: set[int] | frozenset[int] = frozenset(),
+    *,
+    sql_totals: ITSqlTotals,
 ) -> dict[str, Any]:
     """Build an IT-focused emission breakdown from raw aggregated rows.
 
     Args:
         rows: Aggregated tuples of ``(module_type_id, emission_type_id, kg_co2eq)``.
         total_fte: Total headcount FTE for per-person normalization.
-        total_emissions_kg: Total emissions (all modules) in kg for percentage
-            calculation. When zero, recomputed from ``rows`` after applying
-            ``exclude_module_type_ids`` (matches chart breakdown behaviour).
         validated_module_type_ids: Set of validated module type IDs.
         exclude_module_type_ids: Module type IDs to omit (same as emission
             breakdown / results summary).
+        sql_totals: Pre-computed SQL totals from
+            ``DataEntryEmissionService.get_it_emission_sql_totals``
+            typed as :class:`ITSqlTotals`.
 
     Returns:
         A dictionary with ``total_it_tonnes_co2eq``, ``total_it_per_fte``,
@@ -119,10 +146,6 @@ def build_it_breakdown(
     """
     exclude = exclude_module_type_ids or frozenset()
     filtered_rows = [r for r in rows if r[0] not in exclude]
-    # Align % of total with chart breakdown when modules are excluded.
-    if exclude:
-        total_emissions_kg = sum(kg for _, _, kg in filtered_rows)
-
     validated_ids = validated_module_type_ids or set()
 
     # Accumulate kg per IT category and per emission type within cloud/AI
@@ -149,26 +172,16 @@ def build_it_breakdown(
                 key = "ai"
             cloud_ai_detail[key] = cloud_ai_detail.get(key, 0.0) + kg_co2eq
 
-    total_it_kg = sum(category_kg.values())
+    total_it_kg = sql_totals["it_total_kg"]
+    effective_total_kg = sql_totals["overall_total_kg"]
+    validated_it_kg = sql_totals["validated_it_kg"]
+    total_validated_source_kg = sql_totals["validated_source_total_kg"]
+
     total_it_tonnes = total_it_kg / 1000.0
     total_it_per_fte = (total_it_kg / total_fte / 1000.0) if total_fte > 0 else 0.0
 
     percentage_of_total = (
-        (total_it_kg / total_emissions_kg * 100.0) if total_emissions_kg > 0 else 0.0
-    )
-
-    # IT share within validated IT source modules only
-    validated_source_module_ids: set[int] = set()
-    for mod_ids in _IT_CATEGORY_MODULE_IDS.values():
-        if mod_ids.issubset(validated_ids):
-            validated_source_module_ids |= mod_ids
-    validated_it_kg = sum(
-        category_kg[cat]
-        for cat, mod_ids in _IT_CATEGORY_MODULE_IDS.items()
-        if mod_ids.issubset(validated_ids)
-    )
-    total_validated_source_kg = sum(
-        kg for mid, _, kg in filtered_rows if mid in validated_source_module_ids
+        (total_it_kg / effective_total_kg * 100.0) if effective_total_kg > 0 else 0.0
     )
     percentage_of_source_modules = (
         (validated_it_kg / total_validated_source_kg * 100.0)

--- a/backend/tests/unit/utils/test_it_breakdown.py
+++ b/backend/tests/unit/utils/test_it_breakdown.py
@@ -14,6 +14,20 @@ from app.utils.it_breakdown import (
 )
 
 
+def _sql(
+    it_kg: float,
+    overall_kg: float,
+    validated_it_kg: float = 0.0,
+    validated_source_kg: float = 0.0,
+) -> dict:
+    return {
+        "it_total_kg": it_kg,
+        "overall_total_kg": overall_kg,
+        "validated_it_kg": validated_it_kg,
+        "validated_source_total_kg": validated_source_kg,
+    }
+
+
 def _cat_by_key(categories: list[dict], key: str) -> dict:
     return next(c for c in categories if c["category_key"] == key)
 
@@ -37,7 +51,9 @@ class TestBuildItBreakdown:
                 2_000.0,
             ),
         ]
-        result = build_it_breakdown(rows, total_fte=10.0, total_emissions_kg=20_000.0)
+        result = build_it_breakdown(
+            rows, total_fte=10.0, sql_totals=_sql(10_000, 20_000)
+        )
 
         assert result["total_it_tonnes_co2eq"] == pytest.approx(10.0)
         assert result["total_it_per_fte"] == pytest.approx(1.0)
@@ -54,7 +70,7 @@ class TestBuildItBreakdown:
         assert cloud["tonnes_co2eq"] == pytest.approx(2.0)
 
     def test_empty_input_returns_zero_filled(self):
-        result = build_it_breakdown([], total_fte=10.0, total_emissions_kg=100_000.0)
+        result = build_it_breakdown([], total_fte=10.0, sql_totals=_sql(0, 100_000))
 
         assert result["total_it_tonnes_co2eq"] == 0.0
         assert result["total_it_per_fte"] == 0.0
@@ -72,7 +88,7 @@ class TestBuildItBreakdown:
                 5_000.0,
             ),
         ]
-        result = build_it_breakdown(rows, total_fte=0.0, total_emissions_kg=5_000.0)
+        result = build_it_breakdown(rows, total_fte=0.0, sql_totals=_sql(5_000, 5_000))
 
         assert result["total_it_per_fte"] == 0.0
         assert result["total_it_tonnes_co2eq"] == pytest.approx(5.0)
@@ -85,7 +101,7 @@ class TestBuildItBreakdown:
                 5_000.0,
             ),
         ]
-        result = build_it_breakdown(rows, total_emissions_kg=0.0)
+        result = build_it_breakdown(rows, sql_totals=_sql(5_000, 0))
 
         assert result["percentage_of_total"] == 0.0
 
@@ -107,7 +123,7 @@ class TestBuildItBreakdown:
                 8_000.0,
             ),
         ]
-        result = build_it_breakdown(rows, total_emissions_kg=20_000.0)
+        result = build_it_breakdown(rows, sql_totals=_sql(2_000, 20_000))
 
         assert result["total_it_tonnes_co2eq"] == pytest.approx(2.0)
 
@@ -129,7 +145,7 @@ class TestBuildItBreakdown:
                 1_000.0,
             ),
         ]
-        result = build_it_breakdown(rows)
+        result = build_it_breakdown(rows, sql_totals=_sql(8_000, 8_000))
 
         assert result["scope_breakdown"]["scope_2"] == pytest.approx(4.0)
         assert result["scope_breakdown"]["scope_3"] == pytest.approx(4.0)
@@ -157,7 +173,7 @@ class TestBuildItBreakdown:
                 300.0,
             ),
         ]
-        result = build_it_breakdown(rows)
+        result = build_it_breakdown(rows, sql_totals=_sql(3_800, 3_800))
         cloud = _cat_by_key(result["categories"], IT_CATEGORY_CLOUD_AI)
 
         emissions = {e["key"]: e["value"] for e in cloud["emissions"]}
@@ -176,6 +192,7 @@ class TestBuildItBreakdown:
         result = build_it_breakdown(
             [],
             validated_module_type_ids=validated,
+            sql_totals=_sql(0, 0),
         )
         assert result["validated"] is True
         assert result["partially_validated"] is False
@@ -186,13 +203,16 @@ class TestBuildItBreakdown:
         result = build_it_breakdown(
             [],
             validated_module_type_ids=validated,
+            sql_totals=_sql(0, 0),
         )
         assert result["validated"] is False
         assert result["partially_validated"] is True
         assert result["validated_sources"] == [IT_CATEGORY_EQUIPMENT]
 
     def test_validation_none(self):
-        result = build_it_breakdown([], validated_module_type_ids=set())
+        result = build_it_breakdown(
+            [], validated_module_type_ids=set(), sql_totals=_sql(0, 0)
+        )
         assert result["validated"] is False
         assert result["partially_validated"] is False
         assert result["validated_sources"] == []
@@ -210,7 +230,7 @@ class TestBuildItBreakdown:
                 7_000.0,
             ),
         ]
-        result = build_it_breakdown(rows)
+        result = build_it_breakdown(rows, sql_totals=_sql(10_000, 10_000))
 
         equip = _cat_by_key(result["categories"], IT_CATEGORY_EQUIPMENT)
         purch = _cat_by_key(result["categories"], IT_CATEGORY_PURCHASES)
@@ -218,7 +238,7 @@ class TestBuildItBreakdown:
         assert purch["percentage"] == pytest.approx(70.0)
 
     def test_categories_order_is_deterministic(self):
-        result = build_it_breakdown([])
+        result = build_it_breakdown([], sql_totals=_sql(0, 0))
         keys = [c["category_key"] for c in result["categories"]]
         assert keys == IT_CATEGORIES_ORDER
 
@@ -231,7 +251,7 @@ class TestBuildItBreakdown:
                 1_000.0,
             ),
         ]
-        result = build_it_breakdown(rows)
+        result = build_it_breakdown(rows, sql_totals=_sql(1_000, 1_000))
         assert result["total_it_tonnes_co2eq"] == pytest.approx(1.0)
 
     def test_exclude_modules_drops_research_and_recomputes_percentage_denominator(self):
@@ -250,8 +270,8 @@ class TestBuildItBreakdown:
         exclude = {ModuleTypeEnum.research_facilities.value}
         result = build_it_breakdown(
             rows,
-            total_emissions_kg=10_000.0,
             exclude_module_type_ids=exclude,
+            sql_totals=_sql(1_000, 1_000),
         )
         assert result["total_it_tonnes_co2eq"] == pytest.approx(1.0)
         assert result["percentage_of_total"] == pytest.approx(100.0)
@@ -269,6 +289,7 @@ class TestBuildItBreakdown:
             [],
             validated_module_type_ids=validated,
             exclude_module_type_ids=exclude,
+            sql_totals=_sql(0, 0),
         )
         assert result["validated"] is True
         assert IT_CATEGORY_RESEARCH not in result["validated_sources"]


### PR DESCRIPTION
## What does this change?
Replaces Python-level IT emission aggregation with a single SQL query using conditional aggregation (get_it_emission_sql_totals). The four key totals (it_total_kg, overall_total_kg, validated_source_total_kg, validated_it_kg) are now computed in the database and passed as sql_totals to build_it_breakdown, removing the need for Python-side summation over raw rows. Also exposes _IT_CATEGORY_MODULE_IDS and IT_EMISSION_TYPES from it_breakdown.py and adds it_total_kg to the cached carbon report stats.

## Why is this needed?
The previous approach computed totals by summing over all emission rows in Python, which was error-prone when modules were excluded (the denominator logic was inconsistent with the chart breakdown behavior). Moving aggregation to SQL ensures correctness, consistency with other breakdown endpoints, and better performance by avoiding large in-memory row iteration.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues
- Related to #840 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
