### PR TITLE
feat/840 remove emit per factor

### DIFF
--- a/backend/app/models/data_entry_emission.py
+++ b/backend/app/models/data_entry_emission.py
@@ -329,11 +329,6 @@ class EmissionComputation:
     # Signature: (ctx: dict, factor_values: dict) -> Optional[float]
     formula_func: Optional[Callable[[dict, dict], Optional[float]]] = None
 
-    # When True, emit one DataEntryEmission per factor (with sub-type
-    # emission_type_id) instead of summing all factors into one row.
-    # The meta dict will include `quantity` and `quantity_unit`.
-    emit_per_factor: bool = False
-
 
 ####
 

--- a/backend/app/modules/headcount/schemas.py
+++ b/backend/app/modules/headcount/schemas.py
@@ -190,7 +190,6 @@ class HeadcountMemberModuleHandler(BaseModuleHandler):
                 formula_key="ef_kg_co2eq_per_unit",
                 quantity_key="fte",
                 multiplier_key="number_of_unit_per_fte",
-                emit_per_factor=True,
             )
         ]
 
@@ -246,7 +245,6 @@ class HeadcountStudentModuleHandler(BaseModuleHandler):
                 formula_key="ef_kg_co2eq_per_unit",
                 quantity_key="fte",
                 multiplier_key="number_of_unit_per_fte",
-                emit_per_factor=True,
             )
         ]
 

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -27,6 +27,26 @@ settings = get_settings()
 logger = get_logger(__name__)
 
 
+def _pick_emission_type_id(
+    comp_emission_type: EmissionType, factor_emission_type_id: int
+) -> int:
+    """Return the more specific emission_type_id between computation and factor.
+
+    When a factor stores a generic parent (e.g. buildings__rooms,
+    professional_travel__plane)
+    but the computation targets a specific leaf, the computation's type must be used so
+    the emission is recognised in EMISSION_SCOPE.  When the factor is more specific
+    (e.g. headcount food sub-types), the factor's type is preferred.
+    """
+    try:
+        factor_et = EmissionType(factor_emission_type_id)
+        if factor_et.level > comp_emission_type.level:
+            return factor_emission_type_id
+    except ValueError:
+        pass
+    return comp_emission_type.value
+
+
 class DataEntryEmissionService:
     """Service for data entry business logic."""
 
@@ -165,7 +185,9 @@ class DataEntryEmissionService:
                         results.append(
                             DataEntryEmission(
                                 data_entry_id=data_entry.id,
-                                emission_type_id=factor.emission_type_id,
+                                emission_type_id=_pick_emission_type_id(
+                                    comp.emission_type, factor.emission_type_id
+                                ),
                                 primary_factor_id=factor.id,
                                 kg_co2eq=float(csv_kg_co2eq),
                                 meta={
@@ -214,7 +236,9 @@ class DataEntryEmissionService:
                     results.append(
                         DataEntryEmission(
                             data_entry_id=data_entry.id,
-                            emission_type_id=factor.emission_type_id,
+                            emission_type_id=_pick_emission_type_id(
+                                comp.emission_type, factor.emission_type_id
+                            ),
                             primary_factor_id=factor.id,
                             kg_co2eq=per_factor_kg,
                             meta={

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -138,117 +138,91 @@ class DataEntryEmissionService:
 
             for comp in computations:
                 factors = await self._fetch_factors(comp, year)
-                kg_co2eq: float | None = None
 
                 # Check if CSV provides an override value (takes precedence)
                 csv_kg_co2eq = data_entry.data.get("kg_co2eq")
                 if csv_kg_co2eq is not None:
-                    # Use CSV-provided value as override
                     logger.info(
                         f"Using CSV-provided kg_co2eq={csv_kg_co2eq} override for "
                         f"emission_type={emission_type.name!r} "
                         f"data_entry_id={data_entry.id!r}"
                     )
-                    kg_co2eq = float(csv_kg_co2eq)
-                else:
-                    if comp.emit_per_factor:
-                        # Emit one row per factor with the factor's own
-                        # emission_type_id.
-                        # Skip the aggregate computation entirely to avoid double
-                        # formula evaluation (and duplicated warnings).
-                        for factor in factors:
-                            per_factor_kg = self._apply_formula(
-                                ctx, factor.values or {}, comp
+                    if not factors:
+                        results.append(
+                            DataEntryEmission(
+                                data_entry_id=data_entry.id,
+                                emission_type_id=emission_type.value,
+                                primary_factor_id=None,
+                                kg_co2eq=float(csv_kg_co2eq),
+                                meta={
+                                    "factors_used": [],
+                                    **ctx,
+                                },
                             )
-                            if per_factor_kg is None:
-                                continue
-                            quantity: float | None = None
-                            if (
-                                comp.quantity_key
-                                and ctx.get(comp.quantity_key) is not None
-                            ):
-                                base_qty = float(ctx[comp.quantity_key])
-                                multiplier = float(
-                                    (factor.values or {}).get(
-                                        comp.multiplier_key, comp.multiplier_default
-                                    )
-                                    if comp.multiplier_key
-                                    else comp.multiplier_default
-                                )
-                                quantity = base_qty * multiplier
-                            quantity_unit: str | None = (factor.values or {}).get(
-                                "unit"
-                            )
-                            results.append(
-                                DataEntryEmission(
-                                    data_entry_id=data_entry.id,
-                                    emission_type_id=factor.emission_type_id,
-                                    primary_factor_id=factor.id,
-                                    kg_co2eq=per_factor_kg,
-                                    meta={
-                                        "factors_used": [
-                                            {"id": factor.id, "values": factor.values}
-                                        ],
-                                        "quantity": quantity,
-                                        "quantity_unit": quantity_unit,
-                                        **ctx,
-                                    },
-                                )
-                            )
-                        continue
-
-                    # Compute kg_co2eq using factors and formulas
-                    for factor in factors:
-                        # If there are multiple factors for this computation,
-                        # we sum their contributions
-                        # only use case: headcount (multiple factors per emission)
-                        kg_co2eq = 0 if kg_co2eq is None else kg_co2eq
-                        temp_kg_co2eq: float | None = self._apply_formula(
-                            ctx, factor.values or {}, comp
                         )
-                        if temp_kg_co2eq is not None:
-                            kg_co2eq = kg_co2eq + temp_kg_co2eq
-                        if temp_kg_co2eq is None:
-                            # Log which values are missing for debugging
-                            missing_ctx_keys = [
-                                key
-                                for key in [comp.quantity_key, comp.multiplier_key]
-                                if key and ctx.get(key) is None
-                            ]
-                            missing_factor_keys = [
-                                key
-                                for key in [comp.formula_key, comp.multiplier_key]
-                                if key and factor.values.get(key) is None
-                            ]
-                            logger.warning(
-                                f"Formula returned None for "
-                                f"emission_type={emission_type.name!r} "
-                                f"data_entry_id={data_entry.id!r} - "
-                                f"Missing context keys: {missing_ctx_keys}, "
-                                f"Missing factor keys: {missing_factor_keys}"
+                        continue
+                    for factor in factors:
+                        results.append(
+                            DataEntryEmission(
+                                data_entry_id=data_entry.id,
+                                emission_type_id=factor.emission_type_id,
+                                primary_factor_id=factor.id,
+                                kg_co2eq=float(csv_kg_co2eq),
+                                meta={
+                                    "factors_used": [
+                                        {"id": factor.id, "values": factor.values}
+                                    ],
+                                    **ctx,
+                                },
                             )
-                            continue
-                if kg_co2eq is not None:
-                    emission_chosen_factor: Factor | None = (
-                        factors[0] if factors is not None and len(factors) > 0 else None
-                    )  # attach first factor for reference
+                        )
+                    continue
+
+                for factor in factors:
+                    per_factor_kg = self._apply_formula(ctx, factor.values or {}, comp)
+                    if per_factor_kg is None:
+                        missing_ctx_keys = [
+                            key
+                            for key in [comp.quantity_key, comp.multiplier_key]
+                            if key and ctx.get(key) is None
+                        ]
+                        missing_factor_keys = [
+                            key
+                            for key in [comp.formula_key, comp.multiplier_key]
+                            if key and (factor.values or {}).get(key) is None
+                        ]
+                        logger.warning(
+                            f"Formula returned None for "
+                            f"emission_type={emission_type.name!r} "
+                            f"data_entry_id={data_entry.id!r} - "
+                            f"Missing context keys: {missing_ctx_keys}, "
+                            f"Missing factor keys: {missing_factor_keys}"
+                        )
+                        continue
+                    quantity: float | None = None
+                    if comp.quantity_key and ctx.get(comp.quantity_key) is not None:
+                        base_qty = float(ctx[comp.quantity_key])
+                        multiplier = float(
+                            (factor.values or {}).get(
+                                comp.multiplier_key, comp.multiplier_default
+                            )
+                            if comp.multiplier_key
+                            else comp.multiplier_default
+                        )
+                        quantity = base_qty * multiplier
+                    quantity_unit: str | None = (factor.values or {}).get("unit")
                     results.append(
                         DataEntryEmission(
                             data_entry_id=data_entry.id,
-                            emission_type_id=emission_type.value,
-                            primary_factor_id=emission_chosen_factor.id
-                            if emission_chosen_factor is not None
-                            else None,
-                            kg_co2eq=kg_co2eq,
+                            emission_type_id=factor.emission_type_id,
+                            primary_factor_id=factor.id,
+                            kg_co2eq=per_factor_kg,
                             meta={
                                 "factors_used": [
-                                    {
-                                        "id": factor.id,
-                                        "values": factor.values,
-                                    }
-                                    for factor in factors
-                                    if factor is not None
+                                    {"id": factor.id, "values": factor.values}
                                 ],
+                                "quantity": quantity,
+                                "quantity_unit": quantity_unit,
                                 **ctx,
                             },
                         )

--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -552,13 +552,6 @@ MODULE_TYPE_TO_PER_FTE_KEY: dict[int, str] = {
 }
 
 
-HEADCOUNT_PER_FTE_KG: dict[EmissionType, float] = {
-    EmissionType.food: 420.0,
-    EmissionType.waste: 125.0,
-    EmissionType.commuting: 1375.0,
-}
-
-
 def _resolve_emission_type(emission_type_id: int) -> EmissionType | None:
     try:
         return EmissionType(emission_type_id)
@@ -639,8 +632,7 @@ def build_chart_breakdown(
             headcount-derived additional categories.
         headcount_validated: Whether headcount module is validated for the
             report. When ``True`` and ``total_fte > 0``, additional categories
-            are synthesized from real DB rows (or ``HEADCOUNT_PER_FTE_KG`` as
-            fallback when no sub-type rows are present).
+            are sourced from real DB sub-type rows.
         buildings_validated: Whether buildings module is validated. Controls
             validation status for embodied_energy additional category.
         validated_module_type_ids: Set of validated module type IDs used to
@@ -658,16 +650,13 @@ def build_chart_breakdown(
           (``embodied_energy``) when present.
         - ``per_person_breakdown``: snake_case metric keys normalized by FTE.
         - ``validated_categories``: validated category keys (snake_case).
-        - ``total_tonnes_co2eq``: global total including real emissions and
-          synthesized headcount emissions when applicable.
+        - ``total_tonnes_co2eq``: global total of all DB-sourced emissions in tonnes.
         - ``total_fte``: passthrough total FTE.
 
     Notes:
         - Unknown emission_type IDs are ignored.
         - Headcount sub-type rows (food__, waste__, commuting__) flow into
           ``additional_breakdown`` directly.
-        - If no sub-type rows exist for a category and headcount is validated,
-          falls back to ``HEADCOUNT_PER_FTE_KG`` synthetic totals.
         - If ``total_fte <= 0``, per-person values are ``0.0`` and additional
           headcount rows remain empty even when headcount is validated.
     """
@@ -727,37 +716,18 @@ def build_chart_breakdown(
     ]
 
     # Build additional_breakdown from real DB sub-type rows.
-    # Fall back to HEADCOUNT_PER_FTE_KG synthetic values per category when that
-    # category has no real rows (backward compatibility with pre-emit_per_factor data).
-    fallback_data: dict[EmissionType, float] = (
-        {et: per_fte_kg * total_fte for et, per_fte_kg in HEADCOUNT_PER_FTE_KG.items()}
-        if headcount_validated and total_fte > 0
-        else {}
-    )
-
     additional_breakdown = []
-    fallback_kg_applied = 0.0
     for category in ADDITIONAL_BREAKDOWN_ORDER:
         real_cat = additional_data.get(category, {})
-        if real_cat:
-            additional_breakdown.append(
-                _build_category_row(
-                    category,
-                    real_cat,
-                    additional_quantities.get(category),
-                )
+        additional_breakdown.append(
+            _build_category_row(
+                category,
+                real_cat,
+                additional_quantities.get(category),
             )
-        else:
-            # Fallback: synthesize from HEADCOUNT_PER_FTE_KG for headcount categories
-            fallback_cat = {
-                et: kg
-                for et, kg in fallback_data.items()
-                if EMISSION_SCOPE[et]["category"] is category
-            }
-            additional_breakdown.append(_build_category_row(category, fallback_cat))
-            fallback_kg_applied += sum(fallback_cat.values())
+        )
 
-    additional_total_kg = additional_kg + fallback_kg_applied
+    additional_total_kg = additional_kg
 
     per_person: dict[str, float] = {
         pp_key: (module_totals_kg.get(mid, 0.0) / total_fte / 1000.0)
@@ -768,12 +738,6 @@ def build_chart_breakdown(
     if headcount_validated and total_fte > 0:
         for category in _HEADCOUNT_ADDITIONAL:
             cat_kg = sum(additional_data.get(category, {}).values())
-            if cat_kg <= 0:
-                cat_kg = sum(
-                    kg
-                    for et, kg in fallback_data.items()
-                    if EMISSION_SCOPE[et]["category"] is category
-                )
             per_person[category.value] = cat_kg / total_fte / 1000.0
 
     total_tonnes = (real_kg + additional_total_kg) / 1000.0

--- a/backend/tests/unit/utils/test_emission_category.py
+++ b/backend/tests/unit/utils/test_emission_category.py
@@ -5,7 +5,6 @@ import pytest
 from app.models.data_entry_emission import EmissionType
 from app.models.module_type import ModuleTypeEnum
 from app.utils.emission_category import (
-    HEADCOUNT_PER_FTE_KG,
     MODULE_BREAKDOWN_ORDER,
     build_chart_breakdown,
     build_treemap,
@@ -78,20 +77,6 @@ def test_build_chart_breakdown_separates_building_categories():
 
     assert room["lighting"] == pytest.approx(3.0)
     assert combustion["combustion"] == pytest.approx(2.0)
-
-
-def test_build_chart_breakdown_headcount_goes_to_additional_breakdown():
-    result = build_chart_breakdown([], total_fte=20.0, headcount_validated=True)
-
-    food = _row_by_category(result["additional_breakdown"], "food")
-    commuting = _row_by_category(result["additional_breakdown"], "commuting")
-
-    assert food["food"] == pytest.approx(
-        HEADCOUNT_PER_FTE_KG[EmissionType.food] * 20.0 / 1000.0
-    )
-    assert commuting["commuting"] == pytest.approx(
-        HEADCOUNT_PER_FTE_KG[EmissionType.commuting] * 20.0 / 1000.0
-    )
 
 
 def test_build_chart_breakdown_per_person_exposes_only_value_keys():

--- a/docs/implementation-plans/840-remove-emit-per-factor.md
+++ b/docs/implementation-plans/840-remove-emit-per-factor.md
@@ -1,0 +1,88 @@
+# Plan: Remove `emit_per_factor` — Always Emit One Emission per Factor
+
+## Context
+
+The `prepare_create()` method in `data_entry_emission_service.py` has two code paths:
+
+- **`emit_per_factor=True`** (lines 154-198): creates one `DataEntryEmission` per factor, using `factor.emission_type_id`
+- **`emit_per_factor=False`** (lines 200-255): aggregates multiple factors into one `DataEntryEmission` row, summing `kg_co2eq` values
+
+Only headcount (member/student) uses `emit_per_factor=True`. All other handlers use the default `False` and always resolve exactly **1 factor** per computation — so the aggregation loop effectively produces 1 row anyway.
+
+**Goal:** Remove the branching. Always create one `DataEntryEmission` per factor. No intermediate aggregation in Python.
+
+## Impact Analysis
+
+| Handler                                                   | Current factors per comp                | Behavior change                                                                                                            |
+| --------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Headcount (member/student)                                | Many (food, waste, commuting sub-types) | None — already `emit_per_factor=True`                                                                                      |
+| All others (travel, purchase, equipment, buildings, etc.) | 1                                       | Minimal — `emission_type_id` sourced from `factor.emission_type_id` instead of `emission_type.value` (should be identical) |
+
+## Changes
+
+### 1. `backend/app/models/data_entry_emission.py`
+
+- Remove `emit_per_factor` field from `EmissionComputation` (lines 332-335)
+
+### 2. `backend/app/modules/headcount/schemas.py`
+
+- Remove `emit_per_factor=True` from both `MemberHandler.resolve_computations()` (line 193) and `StudentHandler.resolve_computations()` (line 249)
+
+### 3. `backend/app/services/data_entry_emission_service.py` — `prepare_create()`
+
+Replace the `if comp.emit_per_factor: ... else: ...` block (lines 154-255) with a single unified loop:
+
+```python
+for factor in factors:
+    per_factor_kg = self._apply_formula(ctx, factor.values or {}, comp)
+    if per_factor_kg is None:
+        # log warning (keep existing missing-key diagnostics)
+        continue
+
+    # Compute quantity for meta (used by chart breakdown)
+    quantity: float | None = None
+    if comp.quantity_key and ctx.get(comp.quantity_key) is not None:
+        base_qty = float(ctx[comp.quantity_key])
+        multiplier = float(
+            (factor.values or {}).get(comp.multiplier_key, comp.multiplier_default)
+            if comp.multiplier_key
+            else comp.multiplier_default
+        )
+        quantity = base_qty * multiplier
+    quantity_unit: str | None = (factor.values or {}).get("unit")
+
+    results.append(
+        DataEntryEmission(
+            data_entry_id=data_entry.id,
+            emission_type_id=factor.emission_type_id,
+            primary_factor_id=factor.id,
+            kg_co2eq=per_factor_kg,
+            meta={
+                "factors_used": [{"id": factor.id, "values": factor.values}],
+                "quantity": quantity,
+                "quantity_unit": quantity_unit,
+                **ctx,
+            },
+        )
+    )
+```
+
+The CSV `kg_co2eq` override (lines 143-152) stays but applies per-factor instead of once.
+
+### 4. `backend/app/utils/emission_category.py`
+
+- Remove the comment referencing "pre-emit_per_factor" (line 731). The `HEADCOUNT_PER_FTE_KG` fallback itself can stay — it only triggers when no real emission rows exist, which handles truly legacy data.
+
+## Files touched
+
+1. `backend/app/models/data_entry_emission.py` — remove field
+2. `backend/app/modules/headcount/schemas.py` — remove kwarg
+3. `backend/app/services/data_entry_emission_service.py` — simplify `prepare_create()`
+4. `backend/app/utils/emission_category.py` — update comment
+
+## Verification
+
+1. `pytest backend/` — run full backend test suite
+2. Specifically check headcount emission tests produce the same per-sub-type rows
+3. Check that non-headcount handlers still produce correct single-factor emissions
+4. Verify chart breakdown endpoint returns correct values (emission_category tests)


### PR DESCRIPTION
## What does this change?
Removes the emit_per_factor branching logic from the emission computation pipeline. The service now always emits one DataEntryEmission per factor, using factor.emission_type_id directly. Also removes the HEADCOUNT_PER_FTE_KG fallback dictionary and its synthetic value generation in build_chart_breakdown().

## Why is this needed?
The emit_per_factor=True code path existed solely for headcount (member/student) handlers. All other handlers always resolved exactly one factor per computation, making the aggregation loop redundant. Unifying both paths reduces complexity, eliminates a conditional branch, and ensures consistent behavior: every computation always produces one row per factor with its own emission_type_id, quantity, and quantity_unit in meta. The fallback synthetic values (HEADCOUNT_PER_FTE_KG) are also removed since real DB sub-type rows are now always produced.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues

- Closes #
- Related to #840 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
