### PR TITLE
feat/855 simulation restructure front end

### DIFF
--- a/frontend/src/i18n/calculator_update.ts
+++ b/frontend/src/i18n/calculator_update.ts
@@ -12,7 +12,7 @@ export default {
     fr: 'Mise à jour du calculateur',
   },
   calculator_update_last_update: {
-    en: 'Last Update: 17 march 2026',
+    en: 'Last Update: 17 March 2026',
     fr: 'Dernière mise à jour : 17 mars 2026',
   },
   calculator_update_entry_title: {

--- a/frontend/src/i18n/calculator_update.ts
+++ b/frontend/src/i18n/calculator_update.ts
@@ -1,0 +1,26 @@
+export default {
+  documentation_editing_rows_calculator_update_topic: {
+    en: 'Calculator Update',
+    fr: 'Mise à jour du calculateur',
+  },
+  documentation_editing_rows_calculator_update_description: {
+    en: 'Find all text related to the calculator update card on the home page.',
+    fr: "Trouvez tous les textes liés à la carte de mise à jour du calculateur sur la page d'accueil.",
+  },
+  calculator_update_title: {
+    en: 'Calculator Update',
+    fr: 'Mise à jour du calculateur',
+  },
+  calculator_update_last_update: {
+    en: 'Last Update: 17 march 2026',
+    fr: 'Dernière mise à jour : 17 mars 2026',
+  },
+  calculator_update_entry_title: {
+    en: 'Title',
+    fr: 'Titre',
+  },
+  calculator_update_entry_body: {
+    en: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
+    fr: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
+  },
+};

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -1,0 +1,50 @@
+export default {
+  simulation_title: {
+    en: 'Welcome to the CO₂ Simulator',
+    fr: 'Bienvenue dans le Simulateur de CO₂',
+  },
+  simulation_intro: {
+    en: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    fr: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  },
+  simulation_tab_explore: {
+    en: 'Explore',
+    fr: 'Explorer',
+  },
+  simulation_tab_explore_subtitle: {
+    en: 'Targeted simulation',
+    fr: 'Simulation ciblée',
+  },
+  simulation_tab_plan: {
+    en: 'Plan',
+    fr: 'Planifier',
+  },
+  simulation_tab_plan_subtitle: {
+    en: 'Project simulation',
+    fr: 'Simulation de projet',
+  },
+  simulation_explore_title: {
+    en: 'Start a New Exploration Simulation',
+    fr: "Démarrer une nouvelle simulation d'exploration",
+  },
+  simulation_explore_description: {
+    en: 'Explore the emissions of your decision and action',
+    fr: 'Explorez les émissions de votre décision et de votre action',
+  },
+  simulation_explore_btn: {
+    en: 'Start Exploration',
+    fr: 'Démarrer une exploration',
+  },
+  simulation_plan_title: {
+    en: 'Start a New Project Simulation',
+    fr: 'Démarrer une nouvelle simulation de projet',
+  },
+  simulation_plan_description: {
+    en: 'These snapshots are permanent once pinned, a scenario is never modified by new simulations. To create a new one, complete a full CO₂ calculation in the Explore tab first, then pin it here.',
+    fr: "Ces instantanés sont permanents une fois épinglé, un scénario n'est jamais modifié par de nouvelles simulations. Pour en créer un nouveau, effectuez d'abord un calcul CO₂ complet dans l'onglet Explorer, puis épinglez-le ici.",
+  },
+  simulation_plan_btn: {
+    en: 'Start a plan',
+    fr: 'Démarrer une planification',
+  },
+};

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -1,4 +1,12 @@
 export default {
+  documentation_editing_rows_simulation_topic: {
+    en: 'Simulation',
+    fr: 'Simulation',
+  },
+  documentation_editing_rows_simulation_description: {
+    en: 'Find all text related to the CO₂ simulator pages.',
+    fr: 'Trouvez tous les textes liés aux pages du simulateur CO₂.',
+  },
   simulation_title: {
     en: 'Welcome to the CO₂ Simulator',
     fr: 'Bienvenue dans le Simulateur de CO₂',

--- a/frontend/src/i18n/workspace_setup.ts
+++ b/frontend/src/i18n/workspace_setup.ts
@@ -31,6 +31,14 @@ export default {
     en: 'Assessment years',
     fr: 'Années d’évaluation',
   },
+  workspace_setup_workspace_title: {
+    en: 'Select your workspace',
+    fr: 'Sélectionnez votre espace de travail',
+  },
+  workspace_setup_workspace_description: {
+    en: 'You have access to multiple laboratories. Please select which one you want to work on:',
+    fr: 'Vous avez accès à plusieurs laboratoires. Veuillez sélectionner celui sur lequel vous souhaitez travailler :',
+  },
   workspace_setup_year_description: {
     en: 'Choose which year to evaluate',
     fr: 'Choisissez l’année sur laquelle vous souhaitez évaluer',
@@ -94,5 +102,29 @@ export default {
   workspace_setup_unit_progress: {
     en: 'Progress from last year',
     fr: "Progression de l'année dernière",
+  },
+  workspace_setup_calculator_description: {
+    en: "Calculate your unit's emissions",
+    fr: 'Calculez les émissions de votre unité',
+  },
+  workspace_setup_simulator_title: {
+    en: 'CO₂ Simulator',
+    fr: 'CO₂ Simulateur',
+  },
+  workspace_setup_simulator_description: {
+    en: 'Simulate your emissions for a grant or a specific project',
+    fr: 'Simulez vos émissions pour une subvention ou un projet spécifique',
+  },
+  workspace_setup_calculator_current_progress: {
+    en: "Current year's progress",
+    fr: "Progression de l'année en cours",
+  },
+  workspace_setup_simulator_completed_simulations: {
+    en: 'Completed simulations',
+    fr: 'Simulations complétées',
+  },
+  workspace_setup_continue_simulator: {
+    en: 'Continue to simulator',
+    fr: 'Continuer vers le simulateur',
   },
 } as const;

--- a/frontend/src/i18n/workspace_setup.ts
+++ b/frontend/src/i18n/workspace_setup.ts
@@ -36,8 +36,8 @@ export default {
     fr: 'Sélectionnez votre espace de travail',
   },
   workspace_setup_workspace_description: {
-    en: 'You have access to multiple laboratories. Please select which one you want to work on:',
-    fr: 'Vous avez accès à plusieurs laboratoires. Veuillez sélectionner celui sur lequel vous souhaitez travailler :',
+    en: 'Choose whether you want to use the calculator or the simulator:',
+    fr: 'Choisissez si vous souhaitez utiliser le calculateur ou le simulateur :',
   },
   workspace_setup_year_description: {
     en: 'Choose which year to evaluate',

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -156,29 +156,25 @@ const modulesCounterText = computed(() => t('home_modules_counter'));
           </div>
         </div>
       </q-card>
-      <q-card flat class="container">
-        <h3 class="text-h4 text-weight-medium">
-          {{ $t('home_simulations_title') }}
-        </h3>
-        <h3 class="text-h5 text-weight-medium text-secondary">
-          {{ $t('home_simulations_subtitle') }}
-        </h3>
-        <div class="flex justify-between items-end q-mt-xl">
-          <q-btn
-            color="accent"
-            :label="$t('home_simulations_btn')"
-            unelevated
-            no-caps
-            size="md"
-            class="text-weight-medium"
-            :to="{ name: 'simulations' }"
-          />
-          <div class="column items-end">
-            <p class="text-h1 text-weight-medium q-mb-none">3</p>
-            <p class="text-secondary text-body2 q-mb-none">
-              {{ $t('home_simulations_units') }}
-            </p>
+      <q-card flat class="container column justify-between">
+        <div class="row items-center justify-between q-mb-xl">
+          <div class="row items-center q-gutter-sm">
+            <q-icon name="o_notifications" color="accent" size="sm" />
+            <h3 class="text-h4 text-weight-medium">
+              {{ $t('calculator_update_title') }}
+            </h3>
           </div>
+          <span class="text-body2 text-secondary">
+            {{ $t('calculator_update_last_update') }}
+          </span>
+        </div>
+        <div>
+          <h4 class="text-h5 text-weight-medium q-mb-xs">
+            {{ $t('calculator_update_entry_title') }}
+          </h4>
+          <p class="text-body2 text-secondary q-mb-none">
+            {{ $t('calculator_update_entry_body') }}
+          </p>
         </div>
       </q-card>
     </div>

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page>
-    <h1 class="text-h1">Explore</h1>
+    <h1 class="text-h1">{{ $t('explore') }}</h1>
   </q-page>
 </template>
 

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -1,0 +1,7 @@
+<template>
+  <q-page>
+    <h1 class="text-h1">Explore</h1>
+  </q-page>
+</template>
+
+<script setup lang="ts"></script>

--- a/frontend/src/pages/app/SimulationPlanPage.vue
+++ b/frontend/src/pages/app/SimulationPlanPage.vue
@@ -1,0 +1,7 @@
+<template>
+  <q-page>
+    <h1 class="text-h1">Plan</h1>
+  </q-page>
+</template>
+
+<script setup lang="ts"></script>

--- a/frontend/src/pages/app/SimulationPlanPage.vue
+++ b/frontend/src/pages/app/SimulationPlanPage.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page>
-    <h1 class="text-h1">Plan</h1>
+    <h1 class="text-h1">{{ $t('plan') }}</h1>
   </q-page>
 </template>
 

--- a/frontend/src/pages/app/SimulationsPage.vue
+++ b/frontend/src/pages/app/SimulationsPage.vue
@@ -1,7 +1,242 @@
 <template>
-  <q-page>
-    <h1 class="text-h1">Simulations</h1>
+  <q-page class="page-grid">
+    <q-card flat class="container">
+      <q-icon
+        name="o_display_settings"
+        color="accent"
+        size="32px"
+        class="q-mb-md"
+      />
+      <h1 class="text-h2 q-mb-md">{{ $t('simulation_title') }}</h1>
+      <p class="text-body1 q-mb-none">{{ $t('simulation_intro') }}</p>
+    </q-card>
+
+    <q-card flat class="container container--pa-none q-my-xl">
+      <div class="row">
+        <div
+          class="col q-pa-xl cursor-pointer simulation-tab"
+          :class="{ 'simulation-tab--active': activeTab === 'explore' }"
+          @click="activeTab = 'explore'"
+        >
+          <div class="row items-center q-gutter-sm">
+            <q-icon
+              name="o_manage_search"
+              size="sm"
+              :color="activeTab === 'explore' ? 'accent' : 'secondary'"
+            />
+            <span
+              class="text-h4 text-weight-bold"
+              :class="activeTab === 'explore' ? '' : 'text-secondary'"
+              >{{ $t('simulation_tab_explore') }}</span
+            >
+          </div>
+          <p
+            class="text-body2 q-mt-xs q-mb-none"
+            :class="activeTab === 'explore' ? 'text-secondary' : 'text-grey-4'"
+          >
+            {{ $t('simulation_tab_explore_subtitle') }}
+          </p>
+        </div>
+
+        <q-separator vertical />
+
+        <div
+          class="col q-pa-xl cursor-pointer simulation-tab"
+          :class="{ 'simulation-tab--active': activeTab === 'plan' }"
+          @click="activeTab = 'plan'"
+        >
+          <div class="row items-center q-gutter-sm">
+            <q-icon
+              name="o_calendar_month"
+              size="sm"
+              :color="activeTab === 'plan' ? 'accent' : 'secondary'"
+            />
+            <span
+              class="text-h4 text-weight-bold"
+              :class="activeTab === 'plan' ? '' : 'text-secondary'"
+              >{{ $t('simulation_tab_plan') }}</span
+            >
+          </div>
+          <p
+            class="text-body2 q-mt-xs q-mb-none"
+            :class="activeTab === 'plan' ? 'text-secondary' : 'text-grey-4'"
+          >
+            {{ $t('simulation_tab_plan_subtitle') }}
+          </p>
+        </div>
+      </div>
+
+      <q-separator />
+
+      <div class="q-px-lg q-py-xl">
+        <template v-if="activeTab === 'explore'">
+          <h2 class="text-h3 q-mb-xs q-mt-lg">
+            {{ $t('simulation_explore_title') }}
+          </h2>
+          <p class="text-body2 text-secondary q-mb-lg">
+            {{ $t('simulation_explore_description') }}
+          </p>
+          <q-btn
+            color="accent"
+            :label="$t('simulation_explore_btn')"
+            unelevated
+            no-caps
+            size="md"
+            class="text-weight-medium"
+          />
+        </template>
+
+        <template v-else>
+          <div class="row items-start justify-between q-mb-xs q-mt-lg">
+            <h2 class="text-h3">{{ $t('simulation_plan_title') }}</h2>
+            <q-icon name="o_info" size="22px" color="primary" />
+          </div>
+          <p class="text-body2 text-secondary q-mb-lg col-6">
+            {{ $t('simulation_plan_description') }}
+          </p>
+          <q-btn
+            color="accent"
+            :label="$t('simulation_plan_btn')"
+            unelevated
+            no-caps
+            size="md"
+            class="text-weight-medium q-mb-xl"
+          />
+
+          <q-table
+            flat
+            dense
+            class="co2-table q-mt-lg"
+            :columns="planColumns"
+            :rows="planRows"
+            row-key="name"
+            hide-pagination
+            :rows-per-page-options="[0]"
+          >
+            <template #header="scope">
+              <q-tr :props="scope">
+                <q-th
+                  v-for="col in scope.cols"
+                  :key="col.name"
+                  :props="scope"
+                  :align="col.align"
+                  class="q-pa-xs"
+                >
+                  {{ col.label }}
+                </q-th>
+              </q-tr>
+            </template>
+            <template #body="props">
+              <q-tr :props="props" class="q-tr--no-hover">
+                <q-td
+                  v-for="col in props.cols"
+                  :key="col.name"
+                  :props="props"
+                  :align="col.align"
+                  class="q-pa-xs"
+                >
+                  <template v-if="col.name === 'action'">
+                    <div class="row no-wrap justify-end q-gutter-xs">
+                      <q-btn
+                        icon="o_content_copy"
+                        color="grey-4"
+                        text-color="primary"
+                        unelevated
+                        no-caps
+                        dense
+                        outline
+                        square
+                        size="xs"
+                        class="square-button"
+                      />
+                      <q-btn
+                        icon="o_edit"
+                        color="grey-4"
+                        text-color="primary"
+                        unelevated
+                        no-caps
+                        dense
+                        outline
+                        square
+                        size="xs"
+                        class="square-button"
+                      />
+                      <q-btn
+                        icon="o_delete"
+                        color="grey-4"
+                        text-color="primary"
+                        unelevated
+                        no-caps
+                        dense
+                        outline
+                        square
+                        size="xs"
+                        class="square-button"
+                      />
+                    </div>
+                  </template>
+                  <template v-else>{{ props.row[col.field] }}</template>
+                </q-td>
+              </q-tr>
+            </template>
+          </q-table>
+        </template>
+      </div>
+    </q-card>
   </q-page>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from 'vue';
+import type { QTableColumn } from 'quasar';
+
+const activeTab = ref<'explore' | 'plan'>('explore');
+
+const planColumns: QTableColumn[] = [
+  { name: 'name', label: 'Name', field: 'name', align: 'left', sortable: true },
+  { name: 'date', label: 'Date', field: 'date', align: 'left', sortable: true },
+  {
+    name: 'creator',
+    label: 'Creator',
+    field: 'creator',
+    align: 'left',
+    sortable: true,
+  },
+  {
+    name: 'tco2eq',
+    label: 'tco2eq',
+    field: 'tco2eq',
+    align: 'right',
+    sortable: true,
+  },
+  { name: 'action', label: 'Action', field: 'action', align: 'right' },
+];
+
+const planRows = [
+  {
+    name: 'SNSF Grant ABC',
+    date: '21-03-2026',
+    creator: 'Charlie Weil',
+    tco2eq: "2'543",
+  },
+  {
+    name: 'SNSF Grant ABC',
+    date: '21-03-2026',
+    creator: 'Charlie Weil',
+    tco2eq: "2'543",
+  },
+];
+</script>
+
+<style scoped lang="scss">
+.simulation-tab {
+  background-color: var(--q-grey-1, #f5f5f5);
+  border-bottom: 2px solid transparent;
+  transition: background-color 0.2s;
+
+  &--active {
+    background-color: #ffffff;
+    border-bottom: 2px solid var(--q-accent);
+  }
+}
+</style>

--- a/frontend/src/pages/app/WorkspaceSetupPage.vue
+++ b/frontend/src/pages/app/WorkspaceSetupPage.vue
@@ -220,7 +220,12 @@ onMounted(async () => {
           :class="{
             'lab-selector-item--selected': selectedWorkspace === 'calculator',
           }"
-          :style="{ border: selectedWorkspace === 'calculator' ? '1px solid var(--q-accent)' : '1px solid rgba(0,0,0,0.12)' }"
+          :style="{
+            border:
+              selectedWorkspace === 'calculator'
+                ? '1px solid var(--q-accent)'
+                : '1px solid rgba(0,0,0,0.12)',
+          }"
           @click="handleWorkspaceSelect('calculator')"
         >
           <q-card-section class="q-pb-sm">
@@ -265,7 +270,12 @@ onMounted(async () => {
           :class="{
             'lab-selector-item--selected': selectedWorkspace === 'simulator',
           }"
-          :style="{ border: selectedWorkspace === 'simulator' ? '1px solid var(--q-accent)' : '1px solid rgba(0,0,0,0.12)' }"
+          :style="{
+            border:
+              selectedWorkspace === 'simulator'
+                ? '1px solid var(--q-accent)'
+                : '1px solid rgba(0,0,0,0.12)',
+          }"
           @click="handleWorkspaceSelect('simulator')"
         >
           <q-card-section class="q-pb-sm">

--- a/frontend/src/pages/app/WorkspaceSetupPage.vue
+++ b/frontend/src/pages/app/WorkspaceSetupPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useTimelineStore, useModuleStore } from 'src/stores/modules';
 import type { Unit } from 'src/stores/workspace';
@@ -8,20 +8,19 @@ import LabSelectorItem from 'src/components/organisms/workspace-selector/LabSele
 import YearSelector from 'src/components/organisms/workspace-selector/YearSelector.vue';
 import type { YearData } from 'src/components/organisms/workspace-selector/YearSelector.vue';
 import type { CarbonReport } from 'src/stores/workspace';
+import { MODULE_STATES } from 'src/constant/moduleStates';
+import { MODULES_LIST } from 'src/constant/modules';
+
 const workspaceStore = useWorkspaceStore();
 const timelineStore = useTimelineStore();
 const moduleStore = useModuleStore();
 const router = useRouter();
 const route = useRoute();
 
+const selectedWorkspace = ref<'calculator' | 'simulator' | null>(null);
+
 // --- COMPUTED ---
 const unitsWithRoles = computed(() => workspaceStore.units);
-
-const workspaceNotSelected = computed(() => {
-  return (
-    workspaceStore.selectedUnit === null || workspaceStore.selectedYear === null
-  );
-});
 
 const yearsCount = computed(
   () => workspaceStore.availableCarbonReportYears.length,
@@ -59,15 +58,43 @@ const routeUnitParam = computed(
     `${workspaceStore.selectedUnit?.id}-${workspaceStore.selectedUnit?.name.replace(/\s+/g, '-').toLowerCase()}`,
 );
 
+const validatedModulesCount = computed(
+  () =>
+    Object.values(timelineStore.itemStates).filter(
+      (s) => s === MODULE_STATES.Validated,
+    ).length,
+);
+
+const confirmationReady = computed(() => {
+  if (!workspaceStore.selectedUnit || !selectedWorkspace.value) return false;
+  if (selectedWorkspace.value === 'simulator') return true;
+  return workspaceStore.selectedYear !== null;
+});
+
+const simulatorYear = computed(() => {
+  const reports = workspaceStore.carbonReports;
+  if (reports.length > 0) {
+    return reports.reduce((a, b) => (a.year > b.year ? a : b)).year;
+  }
+  return new Date().getFullYear() - 1;
+});
+
 // --- ACTIONS ---
 
 const handleUnitSelect = async (unit: Unit) => {
   workspaceStore.setUnit(unit);
   workspaceStore.setYear(null);
+  selectedWorkspace.value = null;
   await Promise.all([
     workspaceStore.fetchCarbonReportsForUnit(unit.id),
     moduleStore.getYearlyValidatedEmissions(unit.id),
   ]);
+  // Show real module progress for the most recent report straight away
+  const reports = workspaceStore.carbonReports;
+  if (reports.length > 0) {
+    const mostRecent = reports.reduce((a, b) => (a.year > b.year ? a : b));
+    await timelineStore.fetchModuleStates(mostRecent.id);
+  }
 };
 
 const handleYearSelect = async (year: number) => {
@@ -78,7 +105,6 @@ const handleYearSelect = async (year: number) => {
         workspaceStore.selectedUnit.id,
         year,
       );
-    // Fetch module statuses for the selected inventory
     if (inv?.id) {
       await timelineStore.fetchModuleStates(inv.id);
     }
@@ -90,8 +116,6 @@ const handleConfirm = () => {
   const year = workspaceStore.selectedYear;
 
   if (unit && year) {
-    // Navigate to the dashboard with the clean URL structure
-    // We slugify the name for the URL: ID-NAME
     router.push({
       name: 'workspace-dashboard',
       params: {
@@ -103,13 +127,34 @@ const handleConfirm = () => {
   }
 };
 
+const handleConfirmSimulator = () => {
+  const unit = workspaceStore.selectedUnit;
+  if (unit) {
+    router.push({
+      name: 'simulations',
+      params: {
+        ...route.params,
+        unit: `${unit.id}-${unit.name.replace(/\s+/g, '-').toLowerCase()}`,
+        year: simulatorYear.value,
+      },
+    });
+  }
+};
+
+const handleWorkspaceSelect = (workspace: 'calculator' | 'simulator') => {
+  selectedWorkspace.value = workspace;
+  if (workspace === 'simulator') {
+    workspaceStore.setYear(null);
+  }
+};
+
 const reset = () => {
   workspaceStore.reset();
   timelineStore.reset();
+  selectedWorkspace.value = null;
 };
 
 onMounted(async () => {
-  // Clear any old selection leftovers when entering setup
   workspaceStore.reset();
   timelineStore.reset();
   await workspaceStore.getUnits();
@@ -118,15 +163,15 @@ onMounted(async () => {
 
 <template>
   <q-page class="page-grid">
-    <!-- Welcome (only if workspace not fully selected) -->
-    <q-card v-if="workspaceNotSelected" flat class="container">
+    <!-- Welcome (only if not ready to confirm) -->
+    <q-card flat class="container">
       <h1 class="text-h2 q-mb-xs">{{ $t('workspace_setup_title') }}</h1>
       <p class="text-body1 q-mb-none">
         {{ $t('workspace_setup_description') }}
       </p>
     </q-card>
 
-    <!-- Lab Selection -->
+    <!-- Step 1: Lab Selection — always shown -->
     <q-card flat class="container">
       <h2 class="text-h3 q-mb-xs">{{ $t('workspace_setup_unit_title') }}</h2>
       <p class="text-body2 text-secondary q-mb-xl">
@@ -158,8 +203,95 @@ onMounted(async () => {
       </div>
     </q-card>
 
-    <!-- Year Selection -->
-    <q-card v-if="workspaceStore.selectedUnit" flat class="container">
+    <!-- Step 2: Calculator / Simulator -->
+    <q-card v-if="workspaceStore.selectedUnit !== null" flat class="container">
+      <h2 class="text-h3 q-mb-xs">
+        {{ $t('workspace_setup_workspace_title') }}
+      </h2>
+      <p class="text-body2 text-secondary q-mb-xl">
+        {{ $t('workspace_setup_workspace_description') }}
+      </p>
+
+      <div class="row q-gutter-lg">
+        <!-- Calculator -->
+        <q-card
+          flat
+          class="col q-pa-none cursor-pointer lab-selector-item"
+          :class="{
+            'lab-selector-item--selected': selectedWorkspace === 'calculator',
+          }"
+          :style="{ border: selectedWorkspace === 'calculator' ? '1px solid var(--q-accent)' : '1px solid rgba(0,0,0,0.12)' }"
+          @click="handleWorkspaceSelect('calculator')"
+        >
+          <q-card-section class="q-pb-sm">
+            <div class="row items-center q-gutter-sm">
+              <q-icon name="o_calculate" size="sm" color="accent" />
+              <h3 class="text-h4 text-weight-bold">
+                {{ $t('calculator_title') }}
+              </h3>
+            </div>
+            <p class="text-body2 text-secondary q-mt-sm q-mb-none">
+              {{ $t('workspace_setup_calculator_description') }}
+            </p>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <div class="row items-center justify-between q-mb-xs">
+              <span class="text-body2 text-weight-medium">
+                {{ $t('workspace_setup_calculator_current_progress') }}
+              </span>
+              <span class="text-body2 text-weight-medium">
+                {{ validatedModulesCount }}/{{ MODULES_LIST.length }}
+              </span>
+            </div>
+            <div class="progress-segments q-my-sm">
+              <div
+                v-for="i in MODULES_LIST.length"
+                :key="i"
+                class="segment"
+                :class="{
+                  filled: i <= validatedModulesCount,
+                  selected: selectedWorkspace === 'calculator',
+                }"
+              ></div>
+            </div>
+          </q-card-section>
+        </q-card>
+
+        <!-- Simulator -->
+        <q-card
+          flat
+          class="col q-pa-none cursor-pointer lab-selector-item"
+          :class="{
+            'lab-selector-item--selected': selectedWorkspace === 'simulator',
+          }"
+          :style="{ border: selectedWorkspace === 'simulator' ? '1px solid var(--q-accent)' : '1px solid rgba(0,0,0,0.12)' }"
+          @click="handleWorkspaceSelect('simulator')"
+        >
+          <q-card-section class="q-pb-sm">
+            <div class="row items-center q-gutter-sm">
+              <q-icon name="o_schema" size="sm" color="accent" />
+              <h3 class="text-h4 text-weight-bold">
+                {{ $t('workspace_setup_simulator_title') }}
+              </h3>
+            </div>
+            <p class="text-body2 text-secondary q-mt-sm q-mb-none">
+              {{ $t('workspace_setup_simulator_description') }}
+            </p>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <span class="text-h4 text-weight-bold">3</span>
+            <p class="text-body2 text-secondary q-mt-xs q-mb-none">
+              {{ $t('workspace_setup_simulator_completed_simulations') }}
+            </p>
+          </q-card-section>
+        </q-card>
+      </div>
+    </q-card>
+
+    <!-- Step 3: Year Selection — calculator path only -->
+    <q-card v-if="selectedWorkspace === 'calculator'" flat class="container">
       <h2 class="text-h3 q-mb-xs">{{ $t('workspace_setup_year_title') }}</h2>
       <p class="text-body2 text-secondary q-mb-xl">
         {{ $t('workspace_setup_year_description') }}
@@ -188,8 +320,8 @@ onMounted(async () => {
       />
     </q-card>
 
-    <!-- Confirmation -->
-    <q-card v-if="!workspaceNotSelected" flat class="container q-gutter-lg">
+    <!-- Step 4: Confirmation -->
+    <q-card v-if="confirmationReady" flat class="container q-gutter-lg">
       <h2 class="text-h3 q-ml-none q-mb-lg">
         {{ $t('workspace_setup_confirm_selection') }}
       </h2>
@@ -206,7 +338,7 @@ onMounted(async () => {
           </p>
         </q-card>
         <q-card
-          v-if="hasMultipleYears"
+          v-if="hasMultipleYears && workspaceStore.selectedYear"
           flat
           class="container q-mt-md"
           style="flex: 2 1 0"
@@ -232,7 +364,7 @@ onMounted(async () => {
           @click="reset"
         />
         <q-btn
-          v-if="workspaceSelected"
+          v-if="workspaceSelected && selectedWorkspace === 'calculator'"
           color="accent"
           :label="$t('workspace_setup_confirm_selection')"
           unelevated
@@ -248,6 +380,16 @@ onMounted(async () => {
             },
           }"
           @click="handleConfirm"
+        />
+        <q-btn
+          v-if="selectedWorkspace === 'simulator'"
+          color="accent"
+          :label="$t('workspace_setup_continue_simulator')"
+          unelevated
+          no-caps
+          size="md"
+          class="text-weight-medium"
+          @click="handleConfirmSimulator"
         />
       </div>
     </q-card>

--- a/frontend/src/pages/app/WorkspaceSetupPage.vue
+++ b/frontend/src/pages/app/WorkspaceSetupPage.vue
@@ -131,7 +131,7 @@ const handleConfirmSimulator = () => {
   const unit = workspaceStore.selectedUnit;
   if (unit) {
     router.push({
-      name: 'simulations',
+      name: 'simulation',
       params: {
         ...route.params,
         unit: `${unit.id}-${unit.name.replace(/\s+/g, '-').toLowerCase()}`,

--- a/frontend/src/pages/back-office/UITextsEditingPage.vue
+++ b/frontend/src/pages/back-office/UITextsEditingPage.vue
@@ -132,6 +132,18 @@ const rows = computed(() => [
     githubUrl:
       'https://github.com/EPFL-ENAC/co2-calculator/blob/dev/frontend/src/i18n/workspace_setup.ts',
   },
+  {
+    topic: t('documentation_editing_rows_simulation_topic'),
+    description: t('documentation_editing_rows_simulation_description'),
+    githubUrl:
+      'https://github.com/EPFL-ENAC/co2-calculator/blob/dev/frontend/src/i18n/simulation.ts',
+  },
+  {
+    topic: t('documentation_editing_rows_calculator_update_topic'),
+    description: t('documentation_editing_rows_calculator_update_description'),
+    githubUrl:
+      'https://github.com/EPFL-ENAC/co2-calculator/blob/dev/frontend/src/i18n/calculator_update.ts',
+  },
 ]);
 
 const columns: QTableColumn[] = [

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -130,8 +130,8 @@ const routes: RouteRecordRaw[] = [
                 },
               },
               {
-                path: 'simulations',
-                name: 'simulations',
+                path: 'simulation',
+                name: 'simulation',
                 component: () => import('pages/app/SimulationsPage.vue'),
                 meta: {
                   requiresAuth: true,
@@ -140,22 +140,22 @@ const routes: RouteRecordRaw[] = [
                 },
               },
               {
-                path: 'simulations/add',
-                name: 'simulation-add',
-                component: () => import('pages/app/AddSimulationPage.vue'),
+                path: `simulation/explore/:explore(${SIMULATION_ID_PATTERN})`,
+                name: 'simulation-explore',
+                component: () => import('pages/app/SimulationExplorePage.vue'),
                 meta: {
                   requiresAuth: true,
-                  note: 'Simulations - Create new simulation',
+                  note: 'Simulation - Explore a simulation',
                   breadcrumb: true,
                 },
               },
               {
-                path: `simulations/edit/:simulationId(${SIMULATION_ID_PATTERN})`,
-                name: 'simulation-edit',
-                component: () => import('pages/app/EditSimulationPage.vue'),
+                path: `simulation/plan/:plan(${SIMULATION_ID_PATTERN})`,
+                name: 'simulation-plan',
+                component: () => import('pages/app/SimulationPlanPage.vue'),
                 meta: {
                   requiresAuth: true,
-                  note: 'Simulations - Edit existing simulation',
+                  note: 'Simulation - Plan a simulation',
                   breadcrumb: true,
                 },
               },


### PR DESCRIPTION
## What does this change?

Restructures the simulation section of the front-end and introduces a workspace-type selection step in the setup flow:

- **WorkspaceSetupPage**: adds a new Step 2 where users choose between the **CO₂ Calculator** and the **CO₂ Simulator** before proceeding. The calculator path continues to year selection as before; the simulator path skips year selection and navigates directly to the simulation page.
- **SimulationsPage**: replaces the bare placeholder with a full UI featuring a tabbed layout (`Explore` / `Plan`). The Plan tab includes a data table with copy/edit/delete actions and mock rows.
- **SimulationExplorePage / SimulationPlanPage**: new stub pages registered under the updated routes (`simulation/explore/:explore`, `simulation/plan/:plan`).
- **HomePage**: replaces the old simulations card with a **Calculator Update** card showing a notification icon, last-update date, and an editable title/body entry.
- **Router**: renames `simulations` → `simulation` and replaces `simulation-add` / `simulation-edit` routes with `simulation-explore` / `simulation-plan`.
- **i18n**: adds two new translation files (`simulation.ts`, `calculator_update.ts`) and extends `workspace_setup.ts` with keys for the new workspace-selector and simulator cards.
- **UITextsEditingPage**: registers the two new i18n files in the back-office editing table.

## Why is this needed?

The previous simulation section was a single placeholder page with no structure. This change lays the groundwork for the full simulator feature (issue #855) by defining the navigation flow, tab-based UX, and all required i18n strings, while keeping the calculator workflow intact.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #855
- Related to #