### PR TITLE
feat: correct chart colors

### DIFF
--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -7,9 +7,9 @@ This module is the backend contract for chart-related category semantics:
     ``category``, ``category_key``, and an ``emissions`` list, with extra
     flattened YY/parent keys for charting convenience.
 - ``per_person_breakdown`` keys are snake_case and stable:
-    ``process_emissions``, ``buildings``, ``equipment``,
-    ``research_facilities``, ``professional_travel``, ``purchases``,
-    ``external_cloud_and_ai``, plus headcount keys
+    ``process_emissions``, ``buildings_room``, ``buildings_energy_combustion``,
+    ``equipment``, ``research_facilities``, ``professional_travel``,
+    ``purchases``, ``external_cloud_and_ai``, plus headcount keys
     ``commuting``, ``food``, ``waste`` when applicable.
 """
 
@@ -648,7 +648,9 @@ def build_chart_breakdown(
           categories. Contains headcount-derived categories (``commuting``,
           ``food``, ``waste``) and building-derived embodied energy
           (``embodied_energy``) when present.
-        - ``per_person_breakdown``: snake_case metric keys normalized by FTE.
+        - ``per_person_breakdown``: category-level snake_case metric keys
+          normalized by FTE. Buildings is split into ``buildings_room`` and
+          ``buildings_energy_combustion`` (not a single ``buildings`` key).
         - ``validated_categories``: validated category keys (snake_case).
         - ``total_tonnes_co2eq``: global total of all DB-sourced emissions in tonnes.
         - ``total_fte``: passthrough total FTE.
@@ -730,13 +732,20 @@ def build_chart_breakdown(
     additional_total_kg = additional_kg
 
     per_person: dict[str, float] = {
-        pp_key: (module_totals_kg.get(mid, 0.0) / total_fte / 1000.0)
-        if total_fte > 0
-        else 0.0
-        for mid, pp_key in MODULE_TYPE_TO_PER_FTE_KEY.items()
+        category.value: (
+            sum(category_data.get(category, {}).values()) / total_fte / 1000.0
+            if total_fte > 0
+            else 0.0
+        )
+        for category in MODULE_BREAKDOWN_ORDER
+        if CATEGORY_TO_MODULE_PER_UNIT.get(category) not in exclude_module_type_ids
     }
     if headcount_validated and total_fte > 0:
         for category in _HEADCOUNT_ADDITIONAL:
+            cat_kg = sum(additional_data.get(category, {}).values())
+            per_person[category.value] = cat_kg / total_fte / 1000.0
+    if buildings_validated and total_fte > 0:
+        for category in _BUILDINGS_ADDITIONAL:
             cat_kg = sum(additional_data.get(category, {}).values())
             per_person[category.value] = cat_kg / total_fte / 1000.0
 

--- a/backend/tests/unit/utils/test_emission_category.py
+++ b/backend/tests/unit/utils/test_emission_category.py
@@ -90,13 +90,14 @@ def test_build_chart_breakdown_per_person_exposes_only_value_keys():
     per_person = result["per_person_breakdown"]
 
     assert per_person == {
-        "buildings": pytest.approx(0.0),
+        "process_emissions": pytest.approx(0.0),
+        "buildings_energy_combustion": pytest.approx(0.0),
+        "buildings_room": pytest.approx(0.0),
         "equipment": pytest.approx(0.8),
+        "external_cloud_and_ai": pytest.approx(0.0),
+        "purchases": pytest.approx(0.0),
         "research_facilities": pytest.approx(0.0),
         "professional_travel": pytest.approx(0.2),
-        "purchases": pytest.approx(0.0),
-        "external_cloud_and_ai": pytest.approx(0.0),
-        "process_emissions": pytest.approx(0.0),
     }
 
 
@@ -144,9 +145,7 @@ def test_build_chart_breakdown_excludes_single_module():
 
     categories = [r["category"] for r in result_excluded["module_breakdown"]]
     assert "research_facilities" not in categories
-    assert result_excluded["per_person_breakdown"][
-        "research_facilities"
-    ] == pytest.approx(0.0)
+    assert "research_facilities" not in result_excluded["per_person_breakdown"]
     assert result_excluded["total_tonnes_co2eq"] < result_full["total_tonnes_co2eq"]
 
 

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -94,10 +94,16 @@ const categoryRows = computed<EmissionBreakdownCategoryRow[]>(() => {
     categories.includes(String(row.category ?? '')),
   ) as EmissionBreakdownCategoryRow[];
 
+  const canonicalizeCategoryKey = (raw: unknown): string => {
+    const key = String(raw ?? '');
+    return key === 'purchase' ? 'purchases' : key;
+  };
+
   return rows.map((row) => {
-    const allowedBarNames = new Set(
-      CATEGORY_CHART_KEYS[row.category_key] ?? [],
+    const categoryKey = canonicalizeCategoryKey(
+      row.category_key ?? row.category,
     );
+    const allowedBarNames = new Set(CATEGORY_CHART_KEYS[categoryKey] ?? []);
     const isFilterApplicable = row.emissions.some((e) =>
       allowedBarNames.has((e.parent_key ?? e.key) as string),
     );

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -35,6 +35,7 @@ const LABEL_KEY_MAP: Record<string, string> = {
   // equipment
   scientific: 'charts-scientific-subcategory',
   it: 'charts-equipment-it',
+  other: 'charts-other-equipment-subcategory',
   // external cloud & AI
   stockage: 'charts-stockage-subcategory',
   virtualisation: 'charts-virtualisation-subcategory',
@@ -49,8 +50,9 @@ const LABEL_KEY_MAP: Record<string, string> = {
   consumable_accessories: 'charts-consumables-subcategory',
   biological_chemical_gaseous: 'charts-bio-chemicals-subcategory',
   services: 'charts-services-subcategory',
-  vehicles: 'charts-other-purchases-subcategory',
-  additional: 'charts-other-purchases-subcategory',
+  vehicles: 'charts-vehicles-subcategory',
+  other_purchases: 'charts-other-purchases-subcategory',
+  additional: 'charts-additional-purchases-subcategory',
   // research facilities
   facilities: 'charts-research-facilities-subcategory',
   animal: 'charts-research-animal-subcategory',
@@ -117,7 +119,7 @@ const chartOption = computed((): EChartsOption => {
       itemStyle: {
         color: cat.color,
         borderColor: '#fff',
-        borderWidth: 1,
+        borderWidth: 0,
       },
       label: {
         show: pct >= 0.09,

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -50,11 +50,6 @@ const validatedPPKeys = computed(() => {
   if (!props.validatedCategories) return new Set<string>();
   const keys = new Set(props.validatedCategories);
 
-  // Per-person data merges both buildings categories into one key.
-  if (keys.has('buildings_room') || keys.has('buildings_energy_combustion')) {
-    keys.add('buildings');
-  }
-
   return new Set(keys);
 });
 
@@ -122,7 +117,7 @@ const additionalSeriesData = computed(() => {
         y: 'commuting',
       },
       itemStyle: {
-        color: colors.value.skyBlue.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.commuting,
       },
       label: {
         show: false,
@@ -167,7 +162,7 @@ const additionalSeriesData = computed(() => {
         y: 'embodied_energy',
       },
       itemStyle: {
-        color: colors.value.skyBlue.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.embodied_energy,
       },
       label: {
         show: false,
@@ -187,22 +182,37 @@ const chartOption = computed((): EChartsOption => {
         y: 'process_emissions',
       },
       itemStyle: {
-        color: colors.value.apricot.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.process_emissions,
       },
       label: {
         show: false,
       },
     },
     {
-      name: t('buildings'),
+      name: t('charts-buildings-energy-combustion-category'),
       type: 'bar' as const,
       stack: 'total',
       encode: {
         x: 'category',
-        y: 'buildings',
+        y: 'buildings_energy_combustion',
       },
       itemStyle: {
-        color: colors.value.lilac.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.buildings_energy_combustion,
+      },
+      label: {
+        show: false,
+      },
+    },
+    {
+      name: t('charts-buildings-room-category'),
+      type: 'bar' as const,
+      stack: 'total',
+      encode: {
+        x: 'category',
+        y: 'buildings_room',
+      },
+      itemStyle: {
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.buildings_room,
       },
       label: {
         show: false,
@@ -217,22 +227,22 @@ const chartOption = computed((): EChartsOption => {
         y: 'equipment',
       },
       itemStyle: {
-        color: colors.value.mauve.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.equipment,
       },
       label: {
         show: false,
       },
     },
     {
-      name: t('research-facilities'),
+      name: t('external-cloud-and-ai'),
       type: 'bar' as const,
       stack: 'total',
       encode: {
         x: 'category',
-        y: 'research_facilities',
+        y: 'external_cloud_and_ai',
       },
       itemStyle: {
-        color: colors.value.paleYellowGreen.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.external_cloud_and_ai,
       },
       label: {
         show: false,
@@ -269,15 +279,15 @@ const chartOption = computed((): EChartsOption => {
       },
     },
     {
-      name: t('external-cloud-and-ai'),
+      name: t('research-facilities'),
       type: 'bar' as const,
       stack: 'total',
       encode: {
         x: 'category',
-        y: 'external_cloud_and_ai',
+        y: 'research_facilities',
       },
       itemStyle: {
-        color: CHART_CATEGORY_COLOR_SCHEMES.value.external_cloud_and_ai,
+        color: colors.value.paleYellowGreen.darker,
       },
       label: {
         show: false,
@@ -397,7 +407,8 @@ const chartOption = computed((): EChartsOption => {
       dimensions: [
         'category',
         'process_emissions',
-        'buildings',
+        'buildings_room',
+        'buildings_energy_combustion',
         'equipment',
         'research_facilities',
         'professional_travel',

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -27,7 +27,10 @@ use([
 ]);
 
 import type { EmissionBreakdownCategoryRow } from 'src/stores/modules';
-import { CATEGORY_CHART_KEYS } from 'src/composables/useEmissionTreemap';
+import {
+  CATEGORY_CHART_KEYS,
+  normalizeParentKey,
+} from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
 
 const CATEGORY_LABEL_MAP: Record<string, string> = {
@@ -64,14 +67,15 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   wood_logs: 'charts-wood-logs-subcategory',
   scientific: 'charts-scientific-subcategory',
   it: 'charts-equipment-it',
-  other: 'charts-other-purchases-subcategory',
+  other: 'charts-other-equipment-subcategory',
   scientific_equipment: 'charts-scientific-subcategory',
   it_equipment: 'charts-equipment-it',
   consumable_accessories: 'charts-consumables-subcategory',
   biological_chemical_gaseous: 'charts-bio-chemicals-subcategory',
   services: 'charts-services-subcategory',
-  vehicles: 'charts-other-purchases-subcategory',
-  additional: 'charts-other-purchases-subcategory',
+  vehicles: 'charts-vehicles-subcategory',
+  additional: 'charts-additional-purchases-subcategory',
+  other_purchases: 'charts-other-purchases-subcategory',
   goods_and_services: 'charts-services-subcategory',
   plane: 'charts-plane-subcategory',
   train: 'charts-train-subcategory',
@@ -146,6 +150,20 @@ function sortBarsByDisplayOrder(
   });
 }
 
+function canonicalizeCategoryKey(raw: string): string {
+  const key = String(raw ?? '');
+  // API occasionally returns singular `purchase` while frontend uses `purchases`.
+  if (key === 'purchase') return 'purchases';
+  return key;
+}
+
+function getRowCategoryKey(row: EmissionBreakdownCategoryRow): string {
+  // Some endpoints return only `category` and omit `category_key`.
+  return canonicalizeCategoryKey(
+    String(row.category_key ?? row.category ?? ''),
+  );
+}
+
 const chartData = computed(() => {
   const emptyResult = {
     bars: [] as Record<string, unknown>[],
@@ -159,7 +177,9 @@ const chartData = computed(() => {
 
   // --- Top-class breakdown mode ---
   if (props.topClassBreakdown?.length) {
-    const categoryKey = props.categoryRows[0]?.category_key ?? '';
+    const categoryKey = props.categoryRows[0]
+      ? getRowCategoryKey(props.categoryRows[0])
+      : '';
     const bars: Record<string, unknown>[] = [];
     const segmentKeysSet = new Set<string>();
     const barCategoryMap = new Map<string, string>();
@@ -167,10 +187,11 @@ const chartData = computed(() => {
     let segCounter = 0;
 
     for (const subcategory of props.topClassBreakdown) {
+      const normalizedName = normalizeParentKey(categoryKey, subcategory.name);
       const compoundKey = `${categoryKey}_${subcategory.name}`;
       const barData: Record<string, unknown> = { xx_category: compoundKey };
       barCategoryMap.set(compoundKey, categoryKey);
-      barLabelMap.set(compoundKey, subcategory.name);
+      barLabelMap.set(compoundKey, normalizedName);
 
       for (const child of subcategory.children) {
         // Use a numeric suffix to guarantee unique, parseable segment keys
@@ -203,24 +224,31 @@ const chartData = computed(() => {
   const barLabelMap = new Map<string, string>(); // compoundKey → display barName
 
   for (const row of props.categoryRows) {
+    const categoryKey = getRowCategoryKey(row);
+    if (!categoryKey) continue;
+    const allowedParents = CATEGORY_CHART_KEYS[categoryKey] ?? [];
     for (const emission of row.emissions) {
       const value = Number(emission.value) || 0;
       if (value <= 0) continue;
 
-      const barName = emission.parent_key ?? emission.key;
+      const rawBarName = emission.parent_key ?? emission.key;
+      const barName = normalizeParentKey(categoryKey, String(rawBarName));
+      if (allowedParents.length > 0 && !allowedParents.includes(barName)) {
+        continue;
+      }
       const collapseAiChildren =
-        row.category_key === 'external_cloud_and_ai' && barName === 'ai';
+        categoryKey === 'external_cloud_and_ai' && barName === 'ai';
       const segmentKey = collapseAiChildren ? barName : emission.key;
-      const compoundKey = `${row.category_key}_${barName}`;
+      const compoundKey = `${categoryKey}_${barName}`;
 
       if (!barMap.has(compoundKey)) {
         barMap.set(compoundKey, {});
-        barCategoryMap.set(compoundKey, row.category_key);
+        barCategoryMap.set(compoundKey, categoryKey);
         barLabelMap.set(compoundKey, barName);
       }
       const bar = barMap.get(compoundKey)!;
       // Segment keys must also be unique per compound key to avoid collisions across categories
-      const compoundSegment = `${row.category_key}_${segmentKey}`;
+      const compoundSegment = `${categoryKey}_${segmentKey}`;
       bar[compoundSegment] = (bar[compoundSegment] ?? 0) + value;
     }
   }
@@ -273,19 +301,23 @@ function translateSubcategory(key: string): string {
   return i18nKey ? t(i18nKey) : subcategoryKey;
 }
 
-function translateBar(barName: string): string {
-  // Try subcategory label first, then category label
-  const subKey = SUBCATEGORY_LABEL_MAP[barName];
+function translateBar(categoryKey: string, barName: string): string {
+  const baseName =
+    String(barName ?? '').split('__')[0] ?? String(barName ?? '');
+  const subKey = SUBCATEGORY_LABEL_MAP[baseName];
   if (subKey) return t(subKey);
-  const catKey = CATEGORY_LABEL_MAP[barName];
+  const catKey = CATEGORY_LABEL_MAP[baseName];
   if (catKey) return t(catKey);
-  return barName;
+  return baseName || barName;
 }
 
 const shadeOrder = ['darker', 'dark', 'default', 'light', 'lighter'] as const;
 
-// Track index per category so each bar within a category gets a distinct shade
-const segmentColorMap = computed(() => {
+// Maps bar compound key → its designated color.
+// Using a per-bar map (rather than per-segment) ensures each bar row gets its
+// own distinct shade even when multiple bars share the same segment keys
+// (e.g. buildings_room subcategories all share room-type segment keys).
+const barColorMap = computed(() => {
   const map: Record<string, string> = {};
   const { bars, barCategoryMap, barLabelMap } = chartData.value;
   const categoryBarIndex = new Map<string, number>();
@@ -299,23 +331,18 @@ const segmentColorMap = computed(() => {
 
     const scale = CHART_CATEGORY_COLOR_SCALES.value[catKey];
     const specificBarColor = getChartSubcategoryColor(catKey, barName, '');
-    const barColor =
+    map[compoundKey] =
       specificBarColor ||
       (scale ? scale[shadeOrder[barIndex % shadeOrder.length]] : '#999999');
-
-    for (const [key, val] of Object.entries(bar)) {
-      if (key === 'xx_category') continue;
-      if (typeof val === 'number' && val > 0) {
-        map[key] = barColor;
-      }
-    }
   });
 
   return map;
 });
 
-function getSegmentColor(segmentKey: string): string {
-  return segmentColorMap.value[segmentKey] ?? '#999999';
+function getBarColor(dataIndex: number): string {
+  const bar = chartData.value.bars[dataIndex];
+  if (!bar) return '#999999';
+  return barColorMap.value[bar.xx_category as string] ?? '#999999';
 }
 
 const chartOption = computed((): EChartsOption => {
@@ -325,9 +352,13 @@ const chartOption = computed((): EChartsOption => {
 
   const source = bars.map((bar) => ({
     ...bar,
-    [barKey]: translateBar(
-      barLabelMap.get(bar[barKey] as string) ?? (bar[barKey] as string),
-    ),
+    [barKey]: (() => {
+      const compoundKey = bar[barKey] as string;
+      const categoryKey = chartData.value.barCategoryMap.get(compoundKey) ?? '';
+      const rawBarName =
+        barLabelMap.get(compoundKey) ?? (bar[barKey] as string);
+      return translateBar(categoryKey, rawBarName);
+    })(),
   }));
 
   const series = segmentKeys.map((key) => ({
@@ -339,18 +370,15 @@ const chartOption = computed((): EChartsOption => {
       x: key,
     },
     itemStyle: {
-      color: getSegmentColor(key),
+      color: (params: unknown) =>
+        getBarColor((params as { dataIndex: number }).dataIndex),
       borderColor: '#fff',
       borderWidth: 1,
     },
     // Between IT Focus (32px) and default auto width (often very thick)
-    barWidth: 60,
+    barWidth: 58,
     label: { show: false },
-    emphasis: {
-      focus: 'series' as const,
-      blurScope: 'coordinateSystem' as const,
-    },
-    blur: { itemStyle: { opacity: 0.4 } },
+    emphasis: { disabled: true },
   }));
 
   return {
@@ -411,8 +439,8 @@ const chartHeight = computed(() => {
 </script>
 
 <template>
-  <q-card flat class="container container--pa-none q-mb-md">
-    <q-card-section class="flex justify-center items-center">
+  <div class="q-mb-md">
+    <div class="flex justify-center items-center">
       <v-chart
         v-if="chartData.bars.length"
         class="chart"
@@ -423,8 +451,8 @@ const chartHeight = computed(() => {
       <span v-else class="text-body2 text-secondary">
         {{ $t('no-chart-data') }}
       </span>
-    </q-card-section>
-  </q-card>
+    </div>
+  </div>
 </template>
 
 <style scoped>

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -354,6 +354,23 @@ function translateCategory(
   return { ...entry, category: i18nKey ? t(i18nKey) : cat };
 }
 
+function normalizeCategoryRowKeys(
+  entry: Record<string, unknown>,
+): Record<string, unknown> {
+  const cat = String(entry.category ?? entry.category_key ?? '');
+  // Backend sometimes uses `other` for purchases; keep equipment `other` untouched.
+  if (cat === 'purchases' || cat === 'purchase') {
+    const next = { ...entry };
+    if (next.other_purchases == null && next.other != null) {
+      next.other_purchases = next.other;
+    }
+    // Prevent collisions with equipment's `other` series key.
+    delete next.other;
+    return next;
+  }
+  return entry;
+}
+
 function zeroNumericValues(
   entry: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -477,6 +494,7 @@ const datasetSource = computed(() => {
         const category = String(entry.category ?? '');
         return isCategoryValidated(category) ? entry : zeroNumericValues(entry);
       })
+      .map(normalizeCategoryRowKeys)
       .map(translateCategory),
   );
 
@@ -497,6 +515,7 @@ const datasetSource = computed(() => {
           return { ...entry, __validated: true };
         })
         .map(withAdditionalCategoryTotals)
+        .map(normalizeCategoryRowKeys)
         .map(translateCategory),
     );
     allData = [...baseData, ...additionalData];
@@ -732,6 +751,21 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
+      name: t('charts-heating-elec-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'heating_elec' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'buildings_room',
+          'heating_elec',
+          colors.value.lilac.light,
+        ),
+      },
+      label: { show: false },
+    },
+    {
       name: t('charts-lighting-subcategory'),
       type: 'bar' as const,
       stack: 'total',
@@ -776,21 +810,6 @@ const chartOption = computed((): EChartsOption => {
       },
       label: { show: false },
     },
-    {
-      name: t('charts-heating-elec-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'heating_elec' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'buildings_room',
-          'heating_elec',
-          colors.value.lilac.light,
-        ),
-      },
-      label: { show: false },
-    },
     // Equipment — subcategories: scientific, it, other
     {
       name: t('charts-scientific-subcategory'),
@@ -802,7 +821,7 @@ const chartOption = computed((): EChartsOption => {
         color: getSubcategoryColor(
           'equipment',
           'scientific',
-          colors.value.mauve.darker,
+          colors.value.plum.darker,
         ),
       },
       label: { show: false },
@@ -814,12 +833,12 @@ const chartOption = computed((): EChartsOption => {
       animation: true,
       encode: { x: 'category', y: 'it' },
       itemStyle: {
-        color: getSubcategoryColor('equipment', 'it', colors.value.mauve.dark),
+        color: getSubcategoryColor('equipment', 'it', colors.value.plum.dark),
       },
       label: { show: false },
     },
     {
-      name: t('charts-other-purchases-subcategory'),
+      name: t('charts-other-equipment-subcategory'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -828,7 +847,7 @@ const chartOption = computed((): EChartsOption => {
         color: getSubcategoryColor(
           'equipment',
           'other',
-          colors.value.mauve.default,
+          colors.value.plum.default,
         ),
       },
       label: { show: false },
@@ -910,7 +929,7 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
-      name: t('charts-other-purchases-subcategory'),
+      name: t('charts-vehicles-subcategory'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -926,6 +945,21 @@ const chartOption = computed((): EChartsOption => {
     },
     {
       name: t('charts-other-purchases-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'other_purchases' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'purchases',
+          'other_purchases',
+          colors.value.lavender.dark,
+        ),
+      },
+      label: { show: false },
+    },
+    {
+      name: t('charts-additional-purchases-subcategory'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -1168,6 +1202,7 @@ const chartOption = computed((): EChartsOption => {
         'biological_chemical_gaseous',
         'services',
         'vehicles',
+        'other_purchases',
         'additional',
         'plane',
         'train',

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -65,7 +65,7 @@ const CLOUD_AI_LABEL_MAP: Record<string, string> = {
 
 /** Map category_key → single color (dark shade) */
 const categoryColor = computed(() => ({
-  equipment_it: colors.value.periwinkle.dark,
+  equipment_it: colors.value.plum.dark,
   purchases_it: colors.value.lightGreen.dark,
   external_cloud_and_ai:
     CHART_CATEGORY_COLOR_SCHEMES.value.external_cloud_and_ai,

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -13,11 +13,11 @@
       </span>
     </template>
     <template v-else>
-      <div class="flex w-full items-center justify-between">
+      <div class="flex w-full items-center justify-between q-mx-lg">
         <div class="text-body1 text-weight-medium q-ml-sm q-mb-none text-black">
           {{ carbonFootprintTitle }}
         </div>
-        <div class="flex items-center no-wrap q-gutter-xs q-mb-sm">
+        <div class="flex items-center no-wrap q-gutter-xs">
           <q-btn
             v-if="emissionTypeInfoKey && moduleChartView === 'type'"
             flat
@@ -42,11 +42,7 @@
             <q-btn
               unelevated
               dense
-              :style="
-                moduleChartView === 'type'
-                  ? { backgroundColor: activeColor, color: '#fff' }
-                  : {}
-              "
+              :style="moduleChartView === 'type' ? activeButtonStyle : {}"
               :class="moduleChartView !== 'type' ? 'toggle-inactive' : ''"
               icon="stacked_bar_chart"
               size="sm"
@@ -55,11 +51,7 @@
             <q-btn
               unelevated
               dense
-              :style="
-                moduleChartView === 'breakdown'
-                  ? { backgroundColor: activeColor, color: '#fff' }
-                  : {}
-              "
+              :style="moduleChartView === 'breakdown' ? activeButtonStyle : {}"
               :class="moduleChartView !== 'breakdown' ? 'toggle-inactive' : ''"
               icon="grid_view"
               size="sm"
@@ -68,29 +60,34 @@
           </div>
         </div>
       </div>
+      <q-separator class="q-my-lg" />
+      <div class="q-mx-lg">
+        <template v-if="moduleChartView === 'breakdown'">
+          <generic-emission-tree-map-chart
+            v-if="moduleTreemapData.length"
+            :key="type"
+            :data="moduleTreemapData"
+            :show-evolution-dialog="
+              type === MODULES.ProfessionalTravel && showEvolutionChart
+            "
+          />
+          <span v-else class="text-body2 text-secondary">
+            {{ $t('no-chart-data') }}
+          </span>
+        </template>
+        <template v-else>
+          <emission-type-breakdown-chart
+            v-if="moduleCategoryRows.length"
+            :key="type"
+            :category-rows="moduleCategoryRows"
+            :top-class-breakdown="topClassBreakdownData"
+          />
 
-      <template v-if="moduleChartView === 'breakdown'">
-        <generic-emission-tree-map-chart
-          v-if="moduleTreemapData.length"
-          :data="moduleTreemapData"
-          :show-evolution-dialog="
-            type === MODULES.ProfessionalTravel && showEvolutionChart
-          "
-        />
-        <span v-else class="text-body2 text-secondary">
-          {{ $t('no-chart-data') }}
-        </span>
-      </template>
-      <template v-else>
-        <emission-type-breakdown-chart
-          v-if="moduleCategoryRows.length"
-          :category-rows="moduleCategoryRows"
-          :top-class-breakdown="topClassBreakdownData"
-        />
-        <span v-else class="text-body2 text-secondary">
-          {{ $t('no-chart-data') }}
-        </span>
-      </template>
+          <span v-else class="text-body2 text-secondary">
+            {{ $t('no-chart-data') }}
+          </span>
+        </template>
+      </div>
     </template>
   </q-card-section>
 </template>
@@ -111,6 +108,7 @@ import {
 } from 'src/composables/useEmissionTreemap';
 import {
   CHART_CATEGORY_COLOR_SCALES,
+  CHART_SUBCATEGORY_COLOR_SCHEMES,
   MODULE_TO_CATEGORIES,
 } from 'src/constant/charts';
 import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakdownInfo';
@@ -141,6 +139,21 @@ const activeColor = computed(() => {
       firstCategory as keyof typeof CHART_CATEGORY_COLOR_SCALES.value
     ];
   return scale?.darker ?? '#00a79f';
+});
+
+const activeButtonStyle = computed((): Record<string, string> => {
+  if (props.type === MODULES.Buildings) {
+    const roomColor =
+      CHART_CATEGORY_COLOR_SCALES.value['buildings_room']?.darker ?? '#00a79f';
+    const combustionColor =
+      CHART_SUBCATEGORY_COLOR_SCHEMES.value['buildings_energy_combustion']
+        ?.combustion ?? '#00a79f';
+    return {
+      background: `linear-gradient(to right, ${combustionColor}, ${roomColor})`,
+      color: '#fff',
+    };
+  }
+  return { backgroundColor: activeColor.value, color: '#fff' };
 });
 
 // Modules that support the top-class breakdown chart
@@ -176,6 +189,13 @@ watch(
   { immediate: true },
 );
 
+// Re-fetch top-class breakdown when the module type changes (e.g. navigating
+// from purchases to equipment) so stale data from the previous module is replaced.
+watch(
+  () => props.type,
+  () => fetchTopClassBreakdownIfNeeded(),
+);
+
 watch(
   emissionBreakdownRefreshSequence,
   (sequence) => {
@@ -198,18 +218,42 @@ const moduleTreemapData = computed(() => {
   const breakdown = moduleStore.state.emissionBreakdown?.module_breakdown;
   if (!breakdown || breakdown.length === 0) return [];
   const categories = MODULE_TO_CATEGORIES.value[props.type] ?? [];
+  const canonicalizeCategoryKey = (raw: unknown): string => {
+    const key = String(raw ?? '');
+    return key === 'purchase' ? 'purchases' : key;
+  };
+  const getRowCategoryKey = (row: Record<string, unknown>): string =>
+    canonicalizeCategoryKey(
+      (row as { category_key?: unknown }).category_key ?? row.category,
+    );
+
   const filteredKeys = Object.fromEntries(
     Object.entries(CATEGORY_CHART_KEYS).filter(([k]) => categories.includes(k)),
   ) as Record<string, string[]>;
-  return buildModuleTreemapData(breakdown, filteredKeys);
+  // Defensive: ensure we only feed rows belonging to this module's categories.
+  const filteredRows = breakdown.filter((r) =>
+    categories.includes(getRowCategoryKey(r as Record<string, unknown>)),
+  );
+  return buildModuleTreemapData(filteredRows, filteredKeys);
 });
 
 const moduleCategoryRows = computed(() => {
   const breakdown = moduleStore.state.emissionBreakdown;
   if (!breakdown) return [];
   const categories = MODULE_TO_CATEGORIES.value[props.type] ?? [];
+  const canonicalizeCategoryKey = (raw: unknown): string => {
+    const key = String(raw ?? '');
+    return key === 'purchase' ? 'purchases' : key;
+  };
+  const getRowCategoryKey = (row: Record<string, unknown>): string =>
+    canonicalizeCategoryKey(
+      (row as { category_key?: unknown }).category_key ?? row.category,
+    );
+
   return breakdown.module_breakdown.filter((row) =>
-    categories.includes(row.category),
+    categories.includes(
+      getRowCategoryKey(row as unknown as Record<string, unknown>),
+    ),
   );
 });
 

--- a/frontend/src/composables/useEmissionTreemap.ts
+++ b/frontend/src/composables/useEmissionTreemap.ts
@@ -24,11 +24,44 @@ export interface EmissionTreemapCategory {
   children: EmissionTreemapChild[];
 }
 
+/**
+ * Normalize raw emission parent_key / key values to canonical chart keys.
+ * Purchases subcategories use several alternate backend names that must be
+ * mapped to the canonical keys used in CATEGORY_CHART_KEYS and color schemes.
+ */
+const PURCHASES_PREFIX_MAP: Array<[string, string]> = [
+  ['other_purchase', 'other_purchases'],
+  ['other', 'other_purchases'],
+  ['additional', 'additional'],
+  ['scientific_equipment', 'scientific_equipment'],
+  ['it_equipment', 'it_equipment'],
+  ['consumable', 'consumable_accessories'],
+  ['biological_chemical_gaseous', 'biological_chemical_gaseous'],
+  ['service', 'services'],
+  ['vehicle', 'vehicles'],
+  ['vehicule', 'vehicles'],
+];
+
+export function normalizeParentKey(
+  categoryKey: string,
+  rawKey: string,
+): string {
+  const baseKey = String(rawKey ?? '').split('__')[0] ?? '';
+  if (!baseKey) return baseKey;
+  if (categoryKey === 'purchases') {
+    const match = PURCHASES_PREFIX_MAP.find(([prefix]) =>
+      baseKey.startsWith(prefix),
+    );
+    if (match) return match[1]!;
+  }
+  return baseKey;
+}
+
 // Mirrors backend CATEGORY_CHART_KEYS in emission_breakdown.py
 export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
-  process_emissions: ['ch4', 'co2', 'n2o', 'refrigerants'],
+  process_emissions: ['co2', 'ch4', 'n2o', 'refrigerants'],
   buildings_energy_combustion: ['combustion', 'heating_thermal'],
-  buildings_room: ['lighting', 'cooling', 'ventilation', 'heating_elec'],
+  buildings_room: ['heating_elec', 'lighting', 'cooling', 'ventilation'],
   equipment: ['scientific', 'it', 'other'],
   external_cloud_and_ai: ['clouds', 'ai'],
   purchases: [
@@ -38,7 +71,7 @@ export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
     'biological_chemical_gaseous',
     'services',
     'vehicles',
-    'other',
+    'other_purchases',
     'additional',
   ],
   research_facilities: ['facilities', 'animal'],
@@ -110,9 +143,10 @@ export function buildModuleTreemapData(
       children = [];
       for (const parentKey of subKeys) {
         for (const emission of rawEmissions) {
-          const emParentKey = emission.parent_key
+          const rawParentKey = emission.parent_key
             ? String(emission.parent_key)
             : String(emission.key);
+          const emParentKey = normalizeParentKey(cat, rawParentKey);
           if (emParentKey !== parentKey) continue;
           const val = Number(emission.value) || 0;
           if (val <= 0) continue;

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -3,6 +3,18 @@ import { useColorblindStore } from 'src/stores/colorblind';
 import { storeToRefs } from 'pinia';
 import { MODULES } from './modules';
 
+/** Interpolate between two `#RRGGBB` colours. */
+function lerpHex(a: string, b: string, t: number): string {
+  const mix = (i: number) => {
+    const av = parseInt(a.slice(i, i + 2), 16);
+    const bv = parseInt(b.slice(i, i + 2), 16);
+    return Math.round(av + (bv - av) * t)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return '#' + mix(1) + mix(3) + mix(5);
+}
+
 // Get the store instance and export colorblindMode for backward compatibility
 const colorblindStore = useColorblindStore();
 const { enabled: colorblindMode } = storeToRefs(colorblindStore);
@@ -109,6 +121,23 @@ const colorDefinitions = {
       default: '#C0D3EB',
       light: '#D9E5F4',
       lighter: '#EDF3FA',
+    },
+  },
+  // 5.25 — between lilac (pink) and lavender (violet)
+  plum: {
+    default: {
+      darker: '#C19ACD',
+      dark: '#CFB0DA',
+      default: '#DDC6E6',
+      light: '#EADCF1',
+      lighter: '#F3ECF7',
+    },
+    colorblind: {
+      darker: '#6385C6',
+      dark: '#7FA0D6',
+      default: '#9FBBE6',
+      light: '#C1D4F2',
+      lighter: '#E0EBF9',
     },
   },
   // 5.5 — midpoints between periwinkle steps, giving 9 shades total for waste
@@ -292,6 +321,7 @@ export const colors = computed(() => {
     lavender: colorDefinitions.lavender[mode],
     mauve: colorDefinitions.mauve[mode],
     lilac: colorDefinitions.lilac[mode],
+    plum: colorDefinitions.plum[mode],
     cobalt: colorDefinitions.cobalt[mode],
     periwinkle: colorDefinitions.periwinkle[mode],
     skyBlue: colorDefinitions.skyBlue[mode],
@@ -307,10 +337,10 @@ export const colors = computed(() => {
 
 // Maps chart category name → hex color (matches ModuleCarbonFootprintChart color ordering)
 export const CHART_CATEGORY_COLOR_SCHEMES = computed(() => ({
-  process_emissions: colors.value.apricot.darker,
-  buildings_energy_combustion: colors.value.lilac.light,
+  process_emissions: colors.value.peach.darker,
+  buildings_energy_combustion: colors.value.apricot.darker,
   buildings_room: colors.value.lilac.darker,
-  equipment: colors.value.mauve.darker,
+  equipment: colors.value.plum.darker,
   external_cloud_and_ai: colors.value.lavender.dark,
   purchases: colors.value.lavender.darker,
   research_facilities: colors.value.paleYellowGreen.darker,
@@ -323,10 +353,10 @@ export const CHART_CATEGORY_COLOR_SCHEMES = computed(() => ({
 
 // Maps chart category name -> full color scale (shared across charts)
 export const CHART_CATEGORY_COLOR_SCALES = computed(() => ({
-  process_emissions: colors.value.apricot,
-  buildings_energy_combustion: colors.value.lilac,
+  process_emissions: colors.value.peach,
+  buildings_energy_combustion: colors.value.apricot,
   buildings_room: colors.value.lilac,
-  equipment: colors.value.lilac,
+  equipment: colors.value.plum,
   external_cloud_and_ai: colors.value.lavender,
   purchases: colors.value.lightGreen,
   research_facilities: colors.value.paleYellowGreen,
@@ -341,10 +371,10 @@ export const CHART_CATEGORY_COLOR_SCALES = computed(() => ({
 export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
   (): Record<string, Record<string, string>> => ({
     buildings_room: {
-      lighting: colors.value.lilac.dark,
-      cooling: colors.value.lilac.default,
-      ventilation: colors.value.lilac.light,
-      heating_elec: colors.value.lilac.lighter,
+      heating_elec: colors.value.lilac.dark,
+      lighting: colors.value.lilac.default,
+      cooling: colors.value.lilac.light,
+      ventilation: colors.value.lilac.lighter,
       heating_thermal: colors.value.lilac.lighter,
       office: colors.value.lilac.darker,
       laboratories: colors.value.lilac.dark,
@@ -364,15 +394,15 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
       wood_logs: colors.value.yellow.darker,
     },
     process_emissions: {
-      co2: colors.value.apricot.darker,
-      ch4: colors.value.apricot.dark,
-      n2o: colors.value.apricot.default,
-      refrigerants: colors.value.apricot.light,
+      co2: colors.value.peach.darker,
+      ch4: colors.value.peach.dark,
+      n2o: colors.value.peach.default,
+      refrigerants: colors.value.peach.light,
     },
     equipment: {
-      scientific: colors.value.periwinkle.darker,
-      it: colors.value.periwinkle.dark,
-      other: colors.value.periwinkle.default,
+      scientific: colors.value.plum.darker,
+      it: colors.value.plum.dark,
+      other: colors.value.plum.default,
     },
     professional_travel: {
       plane: colors.value.babyBlue.darker,
@@ -393,17 +423,26 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
       facilities: colors.value.paleYellowGreen.darker,
       animal: colors.value.paleYellowGreen.dark,
     },
-    purchases: {
-      scientific_equipment: colors.value.lightGreen.darker,
-      it_equipment: colors.value.lightGreen.dark,
-      consumable_accessories: colors.value.lightGreen.default,
-      biological_chemical_gaseous: colors.value.lightGreen.light,
-      services: colors.value.lightGreen.lighter,
-      vehicles: colors.value.lightGreen.default,
-      other: colors.value.lightGreen.dark,
-      additional: colors.value.lightGreen.light,
-      ln2: colors.value.lightGreen.darker,
-    },
+    purchases: (() => {
+      const keys = [
+        'scientific_equipment',
+        'it_equipment',
+        'consumable_accessories',
+        'biological_chemical_gaseous',
+        'services',
+        'vehicles',
+        'other_purchases',
+        'additional',
+      ];
+      const { darker, lighter } = colors.value.lightGreen;
+      const shade = (i: number) =>
+        lerpHex(darker, lighter, i / (keys.length - 1));
+      return {
+        ...Object.fromEntries(keys.map((k, i) => [k, shade(i)])),
+        other: shade(6),
+        ln2: lighter,
+      };
+    })(),
     commuting: {
       walking: colors.value.aqua.darker,
       cycling: colors.value.aqua.dark,

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -449,9 +449,21 @@ export default {
     en: 'Services',
     fr: 'Services',
   },
-  'charts-other-purchases-subcategory': {
-    en: 'Other Equipment',
+  'charts-vehicles-subcategory': {
+    en: 'Vehicles',
+    fr: 'Véhicules',
+  },
+  'charts-additional-purchases-subcategory': {
+    en: 'Additional purchases',
+    fr: 'Achats supplémentaires',
+  },
+  'charts-other-equipment-subcategory': {
+    en: 'Other equipment',
     fr: 'Autre équipement',
+  },
+  'charts-other-purchases-subcategory': {
+    en: 'Other purchases',
+    fr: 'Autres achats',
   },
   'charts-gc-subcategory': {
     en: 'GC',

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -18,12 +18,10 @@
         :module-config="staticModuleConfig"
       />
       <q-card class="container container--pa-none" flat>
-        <div class="q-px-lg">
-          <module-charts
-            :type="currentModuleType"
-            :show-evolution-chart="false"
-          />
-        </div>
+        <module-charts
+          :type="currentModuleType"
+          :show-evolution-chart="false"
+        />
       </q-card>
       <!-- module tables iteration -->
       <module-table-section

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -719,7 +719,7 @@ const getUncertainty = (
               <template v-if="resultsCategoryExpanded[module]">
                 <q-separator />
 
-                <div class="q-px-lg">
+                <div>
                   <!-- Module has results in the summary -->
                   <template v-if="getModuleResult(module)">
                     <!-- Per-module treemap -->
@@ -731,7 +731,7 @@ const getUncertainty = (
                         "
                       />
                     </template>
-                    <q-card flat class="grid-3-col q-mb-lg">
+                    <q-card flat class="grid-3-col q-mb-lg q-px-lg">
                       <BigNumber
                         :title="
                           getTotalModuleCarbonFootprintTitle(module as Module)

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -776,6 +776,7 @@ export const useModuleStore = defineStore('modules', () => {
   ) {
     state.loadingTopClassBreakdown = true;
     state.errorTopClassBreakdown = null;
+    state.topClassBreakdown = [];
     try {
       const path = `modules/${encodeURIComponent(unit)}/${encodeURIComponent(year)}/${encodeURIComponent(moduleId)}/top-class-breakdown`;
       const data = await api.get(path).json<Array<Record<string, unknown>>>();


### PR DESCRIPTION
# feat: correct chart colors

## What does this change?

This PR corrects chart colors, labels, and data keys across the frontend and backend for the emission breakdown charts.

**Backend:**
- Splits the `buildings` per-person breakdown key into `buildings_room` and `buildings_energy_combustion` (removing the merged `buildings` key)
- Removes `MODULE_TYPE_TO_PER_FTE_KEY` in favor of deriving per-person values directly from `category_data`, filtered by `MODULE_BREAKDOWN_ORDER`
- Adds `_BUILDINGS_ADDITIONAL` handling so building subcategories contribute correctly to `per_person_breakdown`

**Frontend — colors:**
- Introduces a new `plum` color scale (between lilac and lavender) and assigns it to `equipment` (previously `mauve`/`periwinkle`)
- Reassigns `process_emissions` from `apricot` to `peach`
- Moves `buildings_energy_combustion` to `apricot`
- Replaces hardcoded `colors.value.skyBlue.darker` with proper color scheme references for `commuting` and `embodied_energy`

**Frontend — data/keys:**
- Normalizes the `purchase` → `purchases` category key mismatch between backend and frontend
- Renames `other` → `other_purchases` in the purchases subcategory to avoid collisions with equipment's `other` key
- Adds `normalizeParentKey()` composable utility to canonicalize raw backend emission keys
- Fixes `vehicles` and `additional` label keys (were both mapped to `charts-other-purchases-subcategory`)
- Adds missing `heating_elec` series to `ModuleCarbonFootprintChart`

**Frontend — layout/UX:**
- Wraps module chart sections in a consistent `q-mx-lg` container with a separator
- Removes the wrapping `q-card` from `EmissionTypeBreakdownChart` (now a plain `div`)
- Adds `key` binding on treemap and breakdown charts so they re-render on module type change
- Clears `topClassBreakdown` before fetching to avoid stale data when switching modules
- Sets treemap `borderWidth` to 0 (removes white tile borders)
- Disables emphasis/blur animations on the breakdown chart bars

## Why is this needed?

Several charts were displaying incorrect colors (wrong palette assigned to a category), ambiguous or swapped labels ("Other Equipment" used for both equipment and purchases), and stale/missing data (buildings not split, `purchase` vs `purchases` key mismatch, stale top-class breakdown when navigating between modules). This fixes the visual and data correctness of the results and module pages.

## Type of change

- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #761