### PR TITLE
Feat/853 reporting exports usage csv

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -781,7 +781,7 @@ async def report_usage(
     modules: Optional[List[str]] = Query(
         None,
         description="""Filter by module states, format: 'module_name:state'
-        (e.g., 'headcount:0' for default, 'headcount:1' for in-progress, 
+        (e.g., 'headcount:0' for default, 'headcount:1' for in-progress,
         'headcount:2' for validated)""",
     ),
     years: Optional[List[int]] = Query(
@@ -867,7 +867,7 @@ async def report_detailed(
     modules: Optional[List[str]] = Query(
         None,
         description="""Filter by module states, format: 'module_name:state'
-        (e.g., 'headcount:0' for default, 'headcount:1' for in-progress, 
+        (e.g., 'headcount:0' for default, 'headcount:1' for in-progress,
         'headcount:2' for validated)""",
     ),
     years: Optional[List[int]] = Query(

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -1,9 +1,10 @@
 """CarbonReportModule repository for database operations."""
 
+from datetime import datetime, timezone
 from math import ceil
 from typing import Any, List, Optional
 
-from sqlmodel import and_, case, col, desc, func, or_, select
+from sqlmodel import col, func, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.constants import ModuleStatus
@@ -436,6 +437,8 @@ class CarbonReportModuleRepository:
             col(User.display_name).label("principal_user_name"),
             col(CarbonReport.id).label("carbon_report_id"),
             col(CarbonReport.completion_progress).label("completion_progress"),
+            col(CarbonReport.last_updated).label("last_updated"),
+            col(CarbonReport.stats).label("report_stats"),
         ]
 
         # 2. Unpack them into the select statement
@@ -475,10 +478,7 @@ class CarbonReportModuleRepository:
         )
 
         paginated_units = (await self.session.exec(units_stmt)).all()
-        page_report_ids = [u.carbon_report_id for u in paginated_units]
 
-        # Build an aggregated emission breakdown from module stats by_emission_type
-        # so frontend can reuse result-page charts with reporting filters.
         module_stats_stmt = select(
             CarbonReportModule.module_type_id,
             CarbonReportModule.status,
@@ -545,107 +545,26 @@ class CarbonReportModuleRepository:
             validated_module_type_ids=validated_module_type_ids,
         )
 
-        # --- STEP 3: The Heavy Math (Restricted to max 50 reports) ---
-        # We no longer need to join CarbonReport here,
-        # because we already have the specific IDs
-        # 1. Define the columns in a list to bypass overload limits
-        module_totals_cte_columns: List[Any] = [
-            col(CarbonReportModule.id).label("module_id"),
-            CarbonReportModule.carbon_report_id,
-            CarbonReportModule.module_type_id,
-            CarbonReportModule.status,
-            func.max(DataEntry.updated_at).label("updated_at"),
-            func.sum(func.coalesce(DataEntryEmission.kg_co2eq, 0) / 1000.0).label(
-                "tco2_total"
-            ),
-        ]
-
-        # 2. Build the query using unpacking (*)
-        module_totals_cte = (
-            select(*module_totals_cte_columns)
-            .join(
-                DataEntry,
-                DataEntry.carbon_report_module_id == CarbonReportModule.id,
-                isouter=True,
-            )
-            .join(
-                DataEntryEmission,
-                DataEntryEmission.data_entry_id == DataEntry.id,
-                isouter=True,
-            )
-            .where(col(CarbonReportModule.carbon_report_id).in_(page_report_ids))
-            # Combine into a single group_by
-            .group_by(
-                CarbonReportModule.id,
-                CarbonReportModule.carbon_report_id,
-                CarbonReportModule.module_type_id,
-                CarbonReportModule.status,
-            )
-            .cte("module_totals")
-        )
-
-        highest_rank_sub = (
-            select(
-                module_totals_cte.c.carbon_report_id,
-                module_totals_cte.c.module_type_id,
-                func.row_number()
-                .over(
-                    partition_by=module_totals_cte.c.carbon_report_id,
-                    order_by=desc(module_totals_cte.c.tco2_total),
-                )
-                .label("rn"),
-            )
-            .where(module_totals_cte.c.status == ModuleStatus.VALIDATED)
-            .subquery()
-        )
-
-        # 1. Group your columns into a list
-        columns = [
-            module_totals_cte.c.carbon_report_id,
-            func.count(
-                case((module_totals_cte.c.status == ModuleStatus.VALIDATED, 1))
-            ).label("val_count"),
-            func.count(module_totals_cte.c.module_id).label("total_count"),
-            func.max(module_totals_cte.c.updated_at).label("last_update"),
-            func.sum(module_totals_cte.c.tco2_total).label("total_footprint"),
-            highest_rank_sub.c.module_type_id.label("highest_cat_id"),
-        ]
-
-        # 2. Unpack them into select()
-        agg_stmt = (
-            select(*columns)
-            .outerjoin(
-                highest_rank_sub,
-                and_(
-                    highest_rank_sub.c.carbon_report_id
-                    == module_totals_cte.c.carbon_report_id,
-                    highest_rank_sub.c.rn == 1,
-                ),
-            )
-            .group_by(
-                module_totals_cte.c.carbon_report_id,
-                highest_rank_sub.c.module_type_id,
-            )
-        )
-
-        agg_results = (await self.session.exec(agg_stmt)).all()
-
-        # --- STEP 4: Merge in Python ---
-        # Create a dictionary mapping report_id to its aggregations for O(1) lookup
-        agg_map = {row.carbon_report_id: row for row in agg_results}
-
+        # --- STEP 3: Use cached stats from CarbonReport ---
+        # Build reporting data using pre-computed stats
         reporting_data = []
         for u in paginated_units:
             aff = u.path_name if u.path_name and len(u.path_name) > 0 else "N/A"
 
-            # Get the aggregations for this specific unit's report,
-            # or default empty values
-            aggs = agg_map.get(u.carbon_report_id)
+            report_stats = u.report_stats if isinstance(u.report_stats, dict) else {}
+            total_footprint_kg = report_stats.get("total", 0) or 0
+            total_footprint_tonnes = total_footprint_kg / 1000.0
+            highest_category_module_id = report_stats.get("highest_category_module_id")
 
-            completion_progress = u.completion_progress or "0/7"
+            last_update_dt = None
+            if u.last_updated is not None:
+                last_update_dt = datetime.fromtimestamp(u.last_updated, tz=timezone.utc)
+
+            completion_progress = u.completion_progress or "0/8"
             completion_status_value = self._get_completion_status_from_progress(
                 completion_progress
             )
+
             reporting_data.append(
                 {
                     "id": u.unit_id,
@@ -653,13 +572,11 @@ class CarbonReportModuleRepository:
                     "affiliation": aff,
                     "validation_status": completion_progress,
                     "principal_user": u.principal_user_name or "Unknown",
-                    "last_update": aggs.last_update if aggs else None,
+                    "last_update": last_update_dt,
                     "highest_result_category": self._map_module_id_to_name(
-                        aggs.highest_cat_id if aggs else None
+                        highest_category_module_id
                     ),
-                    "total_carbon_footprint": round(float(aggs.total_footprint or 0), 2)
-                    if aggs
-                    else 0.0,
+                    "total_carbon_footprint": round(total_footprint_tonnes, 2),
                     "view_url": f"/backoffice/unit/{u.unit_id}",
                     "completion": completion_status_value,
                     "completion_progress": completion_progress,
@@ -806,14 +723,22 @@ class CarbonReportModuleRepository:
         cursor = await self.session.stream(statement)
         async for partition in cursor.partitions(500):
             for row in partition:
+                last_updated_iso = None
+                if row.last_updated is not None:
+                    last_updated_iso = datetime.fromtimestamp(
+                        row.last_updated, tz=timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+                module_status_str = ModuleStatus(row.status).name
+
                 report.append(
                     {
                         "year": row.year,
                         "unit_institutional_id": row.unit_institutional_id,
                         "unit_path_name": row.unit_path_name,
                         "module_name": ModuleTypeEnum(row.module_type_id).name,
-                        "module_status": row.status,
-                        "last_updated": row.last_updated,
+                        "module_status": module_status_str,
+                        "last_updated": last_updated_iso,
                     }
                 )
 

--- a/backend/app/schemas/backoffice.py
+++ b/backend/app/schemas/backoffice.py
@@ -1,9 +1,9 @@
 """Backoffice reporting schemas for API request/response validation."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 from app.core.constants import ModuleStatus
 
@@ -22,10 +22,10 @@ class UnitReportingData(BaseModel):
     principal_user: str
 
     # Date of last module validation
-    last_update: Optional[datetime]
+    last_update: Optional[datetime] = None
 
     # Name of the module with the highest tCO2-eq
-    highest_result_category: Optional[str]
+    highest_result_category: Optional[str] = None
 
     # Numeric value for the sum of emissions
     total_carbon_footprint: float = Field(..., description="Total tCO2-eq")
@@ -42,8 +42,15 @@ class UnitReportingData(BaseModel):
     # Progress string from carbon_reports.completion_progress (e.g. "5/7")
     completion_progress: Optional[str] = None
 
+    @field_serializer("last_update")
+    def serialize_last_update(self, dt: Optional[datetime]) -> Optional[str]:
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
+
     class Config:
-        # Allows using the field names or the original aliases
         populate_by_name = True
 
 

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -260,13 +260,18 @@ class CarbonReportModuleService:
         )
 
         await self.repo.update_stats(carbon_report_module_id, stats)
+
+        now_utc = int(datetime.now(timezone.utc).timestamp())
+        module.last_updated = now_utc
+        self.session.add(module)
+
         logger.info(
             f"Stats recomputed for module {sanitize(carbon_report_module_id)}: "
             f"total={stats['total']:.2f} kgCO2eq, "
-            f"{len(stats['by_emission_type'])} emission types"
+            f"{len(stats['by_emission_type'])} emission types, "
+            f"last_updated={now_utc}"
         )
 
-        # Trigger parent carbon report stats recomputation
         from app.services.carbon_report_service import CarbonReportService
 
         report_service = CarbonReportService(self.session)

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -154,7 +154,17 @@ class CarbonReportService:
         _it_et_id_strs = {str(et.value) for et in IT_EMISSION_TYPES}
         it_total_kg = sum(v for k, v in by_emission_type.items() if k in _it_et_id_strs)
 
-        # Build aggregated stats dict
+        # Find highest category module (validated modules only)
+        highest_category_module_id: Optional[int] = None
+        highest_category_total = 0.0
+        for module in modules:
+            if module.status != ModuleStatus.VALIDATED:
+                continue
+            module_total = module.stats.get("total", 0) if module.stats else 0
+            if module_total and module_total > highest_category_total:
+                highest_category_total = module_total
+                highest_category_module_id = module.module_type_id
+
         stats = {
             "scope1": scope1_total,
             "scope2": scope2_total,
@@ -164,15 +174,15 @@ class CarbonReportService:
             "by_emission_type": by_emission_type,
             "computed_at": datetime.now(timezone.utc).isoformat(),
             "entry_count": total_entry_count,
+            "highest_category_module_id": highest_category_module_id,
         }
 
-        # Update carbon_report with aggregated stats and progress
         report = await self.repo.get(carbon_report_id)
         report_id_sanitized = sanitize(carbon_report_id)
         if report:
             report.stats = stats
+            report.last_updated = int(datetime.now(timezone.utc).timestamp())
             await self.session.flush()
-            # Also recompute progress and overall status
             await self.recompute_report_progress(carbon_report_id)
             logger.info(
                 f"Report stats recomputed for carbon_report_id={report_id_sanitized}: "
@@ -224,13 +234,13 @@ class CarbonReportService:
         # Build completion progress string
         completion_progress = f"{completed_modules}/{total_modules}"
 
-        # Update carbon_report
         report = await self.repo.get(carbon_report_id)
         report_id_sanitized = sanitize(carbon_report_id)
         status_name = ModuleStatus(overall_status).name
         if report:
             report.completion_progress = completion_progress
             report.overall_status = overall_status
+            report.last_updated = int(datetime.now(timezone.utc).timestamp())
             await self.session.flush()
             logger.info(
                 f"Report progress updated for carbon_report_id={report_id_sanitized}: "

--- a/backend/tests/unit/repositories/test_carbon_report_module_repo.py
+++ b/backend/tests/unit/repositories/test_carbon_report_module_repo.py
@@ -44,19 +44,19 @@ class TestGetCompletionStatusFromProgress:
 
     def test_not_started(self):
         assert (
-            CarbonReportModuleRepository._get_completion_status_from_progress("0/7")
+            CarbonReportModuleRepository._get_completion_status_from_progress("0/8")
             == ModuleStatus.NOT_STARTED
         )
 
     def test_in_progress(self):
         assert (
-            CarbonReportModuleRepository._get_completion_status_from_progress("3/7")
+            CarbonReportModuleRepository._get_completion_status_from_progress("3/8")
             == ModuleStatus.IN_PROGRESS
         )
 
     def test_validated(self):
         assert (
-            CarbonReportModuleRepository._get_completion_status_from_progress("7/7")
+            CarbonReportModuleRepository._get_completion_status_from_progress("8/8")
             == ModuleStatus.VALIDATED
         )
 
@@ -271,7 +271,7 @@ class TestGetUsageReport:
         results = await repo.get_usage_report(years=[2024])
         assert len(results) == 2
         assert results[0]["module_name"] == "headcount"
-        assert results[0]["module_status"] == ModuleStatus.VALIDATED
+        assert results[0]["module_status"] == "VALIDATED"
 
     async def test_empty_result_with_no_data(self, db_session):
         repo = CarbonReportModuleRepository(db_session)
@@ -373,7 +373,7 @@ class TestGetReportingOverview:
             db_session,
             unit_id=unit.id,
             year=2024,
-            completion_progress="3/7",
+            completion_progress="3/8",
             overall_status=ModuleStatus.IN_PROGRESS,
         )
         repo = CarbonReportModuleRepository(db_session)

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -10,7 +10,7 @@ export function formatRelativeTime(
   locale: string,
   prefix = 'Active',
 ): string {
-  const date = new Date(dateString);
+  const date = parseUtcDate(dateString);
   const now = new Date();
   const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
 
@@ -33,4 +33,38 @@ export function formatRelativeTime(
 
   // Less than a minute ago
   return `${prefix} ${rtf.format(0, 'minute')}`;
+}
+
+export function parseUtcDate(dateString: string): Date {
+  if (!dateString) {
+    return new Date(NaN);
+  }
+
+  if (
+    dateString.endsWith('Z') ||
+    dateString.includes('+') ||
+    dateString.includes('-')
+  ) {
+    return new Date(dateString);
+  }
+
+  const isoMatch = dateString.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/,
+  );
+  if (isoMatch) {
+    const [, year, month, day, hour, minute, second, ms] = isoMatch;
+    return new Date(
+      Date.UTC(
+        parseInt(year, 10),
+        parseInt(month, 10) - 1,
+        parseInt(day, 10),
+        parseInt(hour, 10),
+        parseInt(minute, 10),
+        parseInt(second, 10),
+        ms ? parseInt(ms.padEnd(3, '0').slice(0, 3), 10) : 0,
+      ),
+    );
+  }
+
+  return new Date(dateString);
 }


### PR DESCRIPTION
## What does this change?

### Summary
Fixed the last_update timestamp display in the backoffice reporting API that was showing incorrect relative times (e.g., "2 hours ago" instead of "2 minutes ago" when in Switzerland/UTC+2).
Changes
### Frontend
- frontend/src/utils/date.ts: Added parseUtcDate() function to handle UTC timestamps without timezone indicators
### Backend
- backend/app/schemas/backoffice.py: Added field_serializer for last_update to ensure timezone info in JSON responses
- backend/app/services/carbon_report_module_service.py: Updated last_updated when stats are recomputed
- backend/app/services/carbon_report_service.py: Updated last_updated in recompute_report_stats() and recompute_report_progress(); added highest_category_module_id to cached stats
- backend/app/repositories/carbon_report_module_repo.py: 
  - get_usage_report(): Returns ISO format timestamps with Z suffix and string enum for module_status
  - get_reporting_overview(): Simplified to use cached CarbonReport.last_updated and stats instead of complex CTEs
### Tests
- Updated completion progress tests to use "8/8" instead of "7/7" (8 modules total)
- Updated module_status assertion to expect string "VALIDATED" instead of enum
Performance Improvements
- Replaced heavy CTE queries with cached stats from CarbonReport.stats
- Avoids scanning all DataEntry rows to calculate MAX(updated_at)
- Added highest_category_module_id to avoid recalculating on every query

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #
- Related to #853 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
