### PR TITLE
feat: add input deactivation feature for submodules

### DIFF
--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -350,6 +350,10 @@ class SubmoduleConfig(BaseModel):
         default=None,
         description="Fixed threshold in kgCO2eq (null if not set)",
     )
+    inputs_deactivated: bool = Field(
+        default=False,
+        description="When True, the data-entry input form is hidden for end-users",
+    )
     latest_data_job: Optional[SyncJobSummary] = Field(
         default=None,
         description="Latest data entries sync job (read-only, injected by API)",

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -23,10 +23,12 @@ const props = defineProps<Props>();
 const {
   isSubmoduleEnabled,
   isSubmoduleIncomplete,
+  isSubmoduleInputsDeactivated,
   getImportRow,
   submoduleShowsImportRow,
   downloadLastCsv,
   updateSubmoduleEnabled,
+  updateSubmoduleInputsDeactivated,
   getSubmoduleThreshold,
   updateSubmoduleThreshold,
   computedFactorRunning,
@@ -80,6 +82,9 @@ async function handleCancelJob(jobId: number) {
   await backofficeStore.cancelJob(jobId, props.selectedYear);
   await handleJobCompleted();
 }
+
+const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
+  !isSubmoduleEnabled(sub);
 </script>
 
 <template>
@@ -94,7 +99,7 @@ async function handleCancelJob(jobId: number) {
         <div class="row items-center q-gutter-sm">
           <span
             class="text-body2 text-weight-medium"
-            :class="!isSubmoduleEnabled(submodule) ? 'text-grey-6' : ''"
+            :class="{ 'text-grey-6': !isSubmoduleEnabled(submodule) }"
             >{{ $t(submodule.labelKey) }}</span
           >
           <q-badge
@@ -153,11 +158,31 @@ async function handleCancelJob(jobId: number) {
       <q-card
         flat
         class="col q-px-lg q-pt-lg q-pb-md"
-        :style="
-          !isSubmoduleEnabled(submodule)
-            ? 'opacity: 0.45; pointer-events: none'
-            : undefined
-        "
+        :class="{ 'submodule-item--disabled': isSubmoduleDisabled(submodule) }"
+      >
+        <div class="row items-center q-mb-xs">
+          <q-icon name="edit_off" color="accent" size="xs" class="q-mr-sm" />
+          <div class="text-body2 text-weight-medium">
+            {{ $t('data_management_submodule_inputs_deactivation_title') }}
+          </div>
+        </div>
+        <div class="text-caption text-secondary q-mb-sm">
+          {{ $t('data_management_submodule_inputs_deactivation_description') }}
+        </div>
+        <q-checkbox
+          :model-value="isSubmoduleInputsDeactivated(submodule)"
+          color="accent"
+          :label="$t('data_management_submodule_inputs_deactivation_label')"
+          @update:model-value="
+            (val: boolean) => updateSubmoduleInputsDeactivated(submodule, val)
+          "
+        />
+      </q-card>
+      <q-separator class="q-my-xs" />
+      <q-card
+        flat
+        class="col q-px-lg q-pt-lg q-pb-md"
+        :class="{ 'submodule-item--disabled': isSubmoduleDisabled(submodule) }"
       >
         <div class="row items-center q-mb-xs">
           <q-icon
@@ -198,12 +223,8 @@ async function handleCancelJob(jobId: number) {
     <div
       v-if="submoduleShowsImportRow(submodule)"
       class="row q-pa-md"
-      :style="[
-        { gap: '1rem' },
-        !isSubmoduleEnabled(submodule)
-          ? { opacity: 0.45, pointerEvents: 'none' }
-          : {},
-      ]"
+      :class="{ 'submodule-item--disabled': isSubmoduleDisabled(submodule) }"
+      :style="{ gap: '1rem' }"
     >
       <UploadCardData
         v-if="getImportRow(submodule).hasData"
@@ -253,4 +274,9 @@ async function handleCancelJob(jobId: number) {
   </q-expansion-item>
 </template>
 
-<style scoped></style>
+<style scoped>
+.submodule-item--disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+</style>

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -702,8 +702,10 @@ const canEdit = computed(() => {
   );
 });
 
+// Disable all table editing/deleting interactions when input is disabled in backoffice configuration.
 const isDisabled = computed(
   () =>
+    props.disable ||
     timelineStore.itemStates[props.moduleType] === MODULE_STATES.Validated ||
     !canEdit.value,
 );

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -44,35 +44,45 @@
           :submodule-type="submodule.id"
           :module-config="moduleConfig"
           :submodule-config="submodule"
-          :disable="disable"
+          :disable="isTableDisabled"
         />
       </div>
       <q-separator />
-      <div v-if="hasModuleForm && !disable && canEdit" class="q-mx-lg">
-        <module-form
-          ref="formRef"
-          :fields="submodule.moduleFields"
-          :submodule-type="submodule.type"
-          :module-type="moduleType"
-          :item="item"
-          :has-subtitle="submodule.hasFormSubtitle"
-          :has-add-with-note="submodule.hasFormAddWithNote"
-          :add-button-label-key="submodule.addButtonLabelKey"
-          :has-tooltip="submodule.hasFormTooltip"
-          :unit-id="unitId"
-          :year="year"
-          :form-defaults="formDefaults"
-          @submit="submitForm"
-        />
-      </div>
       <div
-        v-else-if="submodule.moduleFields && !disable && !canEdit"
-        class="q-mx-lg q-my-md"
+        v-if="isInputDeactivated"
+        class="q-mx-lg q-my-md inputs-deactivated-notice"
       >
-        <q-badge color="warning" class="q-px-md q-py-sm">
-          {{ $t('common_view_only') }}
-        </q-badge>
+        <div class="inputs-deactivated-notice__content">
+          <q-icon name="edit_off" size="sm" color="accent" class="q-mb-sm" />
+          <div class="text-body2 text-weight-medium text-center text-primary">
+            {{ $t('module_submodule_inputs_deactivated_notice') }}
+          </div>
+        </div>
       </div>
+      <template v-else>
+        <div v-if="showModuleForm" class="q-mx-lg">
+          <module-form
+            ref="formRef"
+            :fields="submodule.moduleFields"
+            :submodule-type="submodule.type"
+            :module-type="moduleType"
+            :item="item"
+            :has-subtitle="submodule.hasFormSubtitle"
+            :has-add-with-note="submodule.hasFormAddWithNote"
+            :add-button-label-key="submodule.addButtonLabelKey"
+            :has-tooltip="submodule.hasFormTooltip"
+            :unit-id="unitId"
+            :year="year"
+            :form-defaults="formDefaults"
+            @submit="submitForm"
+          />
+        </div>
+        <div v-else-if="showViewOnlyBadge" class="q-mx-lg q-my-md">
+          <q-badge color="warning" class="q-px-md q-py-sm">
+            {{ $t('common_view_only') }}
+          </q-badge>
+        </div>
+      </template>
     </q-card-section>
   </q-expansion-item>
 </template>
@@ -158,6 +168,17 @@ const submoduleKey = computed(() => {
   return props.submodule.id;
 });
 
+const isInputDeactivated = computed(() => {
+  const unifiedConfig = yearConfigStore.getModule(props.moduleType as Module);
+  if (!unifiedConfig) return false;
+  const subConfig = unifiedConfig.submodules[submoduleKey.value];
+  return subConfig?.inputs_deactivated ?? false;
+});
+
+const isTableDisabled = computed(
+  () => props.disable || isInputDeactivated.value,
+);
+
 const backendThreshold = computed<Threshold | null>(() => {
   const unifiedConfig = yearConfigStore.getModule(props.moduleType as Module);
   if (!unifiedConfig) return null;
@@ -191,6 +212,8 @@ const canEdit = computed(() => {
   );
 });
 
+const isFormDisabled = computed(() => props.disable);
+
 const submoduleCount = computed(
   () =>
     moduleStore.state.data?.data_entry_types_total_items?.[
@@ -213,6 +236,14 @@ const hasModuleForm = computed(() => {
       0
   );
 });
+
+const showModuleForm = computed(
+  () => hasModuleForm.value && !isFormDisabled.value && canEdit.value,
+);
+
+const showViewOnlyBadge = computed(
+  () => Boolean(props.submodule.moduleFields) && !isFormDisabled.value,
+);
 
 const hasTableTooltip = computed(() => {
   if (!props.submodule.type) return false;
@@ -260,3 +291,19 @@ async function submitForm(payload: Record<string, FieldValue>) {
   }
 }
 </script>
+
+<style scoped>
+.inputs-deactivated-notice {
+  background-color: rgba(0, 0, 0, 0.02);
+  border: 1px dashed rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+}
+
+.inputs-deactivated-notice__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+</style>

--- a/frontend/src/composables/useSubmoduleConfig.ts
+++ b/frontend/src/composables/useSubmoduleConfig.ts
@@ -26,6 +26,7 @@ export function useSubmoduleConfig(options: UseSubmoduleConfigOptions) {
   const {
     isSubmoduleEnabled,
     isSubmoduleIncomplete,
+    isSubmoduleInputsDeactivated,
     getModule,
     getModuleNameFromSubmodule,
   } = yearConfigStore;
@@ -111,6 +112,35 @@ export function useSubmoduleConfig(options: UseSubmoduleConfigOptions) {
         config: {
           modules: {
             [moduleKey]: { submodules: { [subKey]: { enabled: value } } },
+          },
+        },
+      });
+      Notify.create({ type: 'positive', message: $t('year_config_saved') });
+    } catch {
+      Notify.create({
+        type: 'negative',
+        message: $t('year_config_save_error'),
+      });
+    }
+  }
+
+  async function updateSubmoduleInputsDeactivated(
+    sub: SubmoduleConfig,
+    value: boolean,
+  ): Promise<void> {
+    const moduleKey = String(sub.moduleTypeId);
+    const subKey =
+      sub.dataEntryTypeId !== undefined
+        ? String(sub.dataEntryTypeId)
+        : undefined;
+    if (!subKey) return;
+    try {
+      await yearConfigStore.updateConfig(options.selectedYear, {
+        config: {
+          modules: {
+            [moduleKey]: {
+              submodules: { [subKey]: { inputs_deactivated: value } },
+            },
           },
         },
       });
@@ -240,10 +270,12 @@ export function useSubmoduleConfig(options: UseSubmoduleConfigOptions) {
   return {
     isSubmoduleEnabled,
     isSubmoduleIncomplete,
+    isSubmoduleInputsDeactivated,
     getImportRow,
     submoduleShowsImportRow,
     downloadLastCsv,
     updateSubmoduleEnabled,
+    updateSubmoduleInputsDeactivated,
     getSubmoduleThreshold,
     updateSubmoduleThreshold,
     computedFactorRunning,

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -387,6 +387,18 @@ export default {
     en: 'Enable this submodule to make it visible to your institute.',
     fr: 'Activez ce sous-module pour le rendre visible pour votre institut.',
   },
+  data_management_submodule_inputs_deactivation_title: {
+    en: 'Deactivate input form',
+    fr: 'Désactiver le formulaire de saisie',
+  },
+  data_management_submodule_inputs_deactivation_description: {
+    en: 'When checked, users will not be able to add or edit data entries for this submodule.',
+    fr: 'Lorsque cette option est cochée, les utilisateurs ne pourront pas ajouter ou modifier des entrées de données pour ce sous-module.',
+  },
+  data_management_submodule_inputs_deactivation_label: {
+    en: 'Deactivate input form',
+    fr: 'Désactiver le formulaire de saisie',
+  },
   data_management_uncertainty_title: {
     en: 'Uncertainty',
     fr: 'Incertitude',

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -320,6 +320,10 @@ export default {
     en: 'View Only',
     fr: 'Lecture seule',
   },
+  module_submodule_inputs_deactivated_notice: {
+    en: 'Data entry for this section has been deactivated by the administrator.',
+    fr: "La saisie de données pour cette section a été désactivée par l'administrateur.",
+  },
   common_mandatory: {
     en: 'Mandatory',
     fr: 'Obligatoire',

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -37,6 +37,7 @@ interface ReductionObjectives {
 export interface SubmoduleConfig {
   enabled: boolean;
   threshold: number | null;
+  inputs_deactivated?: boolean;
   latest_data_job?: SyncJobSummary | null;
   latest_api_data_job?: SyncJobSummary | null;
   latest_factor_job?: SyncJobSummary | null;
@@ -255,6 +256,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
         merged[staticSub.key] = {
           enabled: true,
           threshold: null,
+          inputs_deactivated: false,
           key: staticSub.key,
           labelKey: staticSub.labelKey,
           moduleTypeId: staticSub.moduleTypeId,
@@ -382,6 +384,16 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     return mod?.submodules?.[subKey]?.enabled ?? true;
   }
 
+  function isSubmoduleInputsDeactivated(sub: ModuleUploadConfig): boolean {
+    const subKey =
+      sub.dataEntryTypeId !== undefined
+        ? String(sub.dataEntryTypeId)
+        : undefined;
+    if (!subKey) return false;
+    const mod = config.value?.config?.modules?.[String(sub.moduleTypeId)];
+    return mod?.submodules?.[subKey]?.inputs_deactivated ?? false;
+  }
+
   function isSubmoduleIncomplete(sub: ModuleUploadConfig): boolean {
     const mod = config.value?.config?.modules?.[String(sub.moduleTypeId)];
     const subConfig = sub.dataEntryTypeId
@@ -470,6 +482,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     isSubmoduleVisible,
     isModuleEnabled,
     isSubmoduleEnabled,
+    isSubmoduleInputsDeactivated,
     isModuleIncomplete,
     isSubmoduleIncomplete,
     getModuleUncertaintyTag,


### PR DESCRIPTION
## What does this change?
Adds a new "Deactivate input form" toggle in the back-office data management UI, allowing administrators to hide the data-entry form for a given submodule from end-users. When activated, users see a notice instead of the form. The setting is persisted in the year configuration (inputs_deactivated field on SubmoduleConfig).

## Why is this needed?
Some submodules may have their data managed externally (e.g. via API sync or CSV import) and should not accept manual entries from users. This gives administrators a way to lock down data entry on a per-submodule basis without fully disabling the submodule.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #496 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
