### PR TITLE
feat(898): improve reduction objectives upload UX

### DIFF
--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,13 @@
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+<!-- rtk-instructions v2 -->
+
+# RTK (Rust Token Killer) - Token-Optimized Commands
+
+## Golden Rule
+
+**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+**Important**: Even in command chains with `&&`, use `rtk`:
+
+```bash
+# ❌ Wrong
+git add . && git commit -m "msg" && git push
+
+# ✅ Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## RTK Commands by Workflow
+
+### Build & Compile (80-90% savings)
+
+```bash
+rtk cargo build         # Cargo build output
+rtk cargo check         # Cargo check output
+rtk cargo clippy        # Clippy warnings grouped by file (80%)
+rtk tsc                 # TypeScript errors grouped by file/code (83%)
+rtk lint                # ESLint/Biome violations grouped (84%)
+rtk prettier --check    # Files needing format only (70%)
+rtk next build          # Next.js build with route metrics (87%)
+```
+
+### Test (90-99% savings)
+
+```bash
+rtk cargo test          # Cargo test failures only (90%)
+rtk vitest run          # Vitest failures only (99.5%)
+rtk playwright test     # Playwright failures only (94%)
+rtk test <cmd>          # Generic test wrapper - failures only
+```
+
+### Git (59-80% savings)
+
+```bash
+rtk git status          # Compact status
+rtk git log             # Compact log (works with all git flags)
+rtk git diff            # Compact diff (80%)
+rtk git show            # Compact show (80%)
+rtk git add             # Ultra-compact confirmations (59%)
+rtk git commit          # Ultra-compact confirmations (59%)
+rtk git push            # Ultra-compact confirmations
+rtk git pull            # Ultra-compact confirmations
+rtk git branch          # Compact branch list
+rtk git fetch           # Compact fetch
+rtk git stash           # Compact stash
+rtk git worktree        # Compact worktree
+```
+
+Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
+
+### GitHub (26-87% savings)
+
+```bash
+rtk gh pr view <num>    # Compact PR view (87%)
+rtk gh pr checks        # Compact PR checks (79%)
+rtk gh run list         # Compact workflow runs (82%)
+rtk gh issue list       # Compact issue list (80%)
+rtk gh api              # Compact API responses (26%)
+```
+
+### JavaScript/TypeScript Tooling (70-90% savings)
+
+```bash
+rtk pnpm list           # Compact dependency tree (70%)
+rtk pnpm outdated       # Compact outdated packages (80%)
+rtk pnpm install        # Compact install output (90%)
+rtk npm run <script>    # Compact npm script output
+rtk npx <cmd>           # Compact npx command output
+rtk prisma              # Prisma without ASCII art (88%)
+```
+
+### Files & Search (60-75% savings)
+
+```bash
+rtk ls <path>           # Tree format, compact (65%)
+rtk read <file>         # Code reading with filtering (60%)
+rtk grep <pattern>      # Search grouped by file (75%)
+rtk find <pattern>      # Find grouped by directory (70%)
+```
+
+### Analysis & Debug (70-90% savings)
+
+```bash
+rtk err <cmd>           # Filter errors only from any command
+rtk log <file>          # Deduplicated logs with counts
+rtk json <file>         # JSON structure without values
+rtk deps                # Dependency overview
+rtk env                 # Environment variables compact
+rtk summary <cmd>       # Smart summary of command output
+rtk diff                # Ultra-compact diffs
+```
+
+### Infrastructure (85% savings)
+
+```bash
+rtk docker ps           # Compact container list
+rtk docker images       # Compact image list
+rtk docker logs <c>     # Deduplicated logs
+rtk kubectl get         # Compact resource list
+rtk kubectl logs        # Deduplicated pod logs
+```
+
+### Network (65-70% savings)
+
+```bash
+rtk curl <url>          # Compact HTTP responses (70%)
+rtk wget <url>          # Compact download output (65%)
+```
+
+### Meta Commands
+
+```bash
+rtk gain                # View token savings statistics
+rtk gain --history      # View command history with savings
+rtk discover            # Analyze Claude Code sessions for missed RTK usage
+rtk proxy <cmd>         # Run command without filtering (for debugging)
+rtk init                # Add RTK instructions to CLAUDE.md
+rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
+```
+
+## Token Savings Overview
+
+| Category         | Commands                       | Typical Savings |
+| ---------------- | ------------------------------ | --------------- |
+| Tests            | vitest, playwright, cargo test | 90-99%          |
+| Build            | next, tsc, lint, prettier      | 70-87%          |
+| Git              | status, log, diff, add, commit | 59-80%          |
+| GitHub           | gh pr, gh run, gh issue        | 26-87%          |
+| Package Managers | pnpm, npm, npx                 | 70-90%          |
+| Files            | ls, read, grep, find           | 60-75%          |
+| Infrastructure   | docker, kubectl                | 85%             |
+| Network          | curl, wget                     | 65-70%          |
+
+Overall average: **60-90% token reduction** on common development operations.
+
+<!-- /rtk-instructions -->

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -34,6 +34,9 @@ class FileMetadata(BaseModel):
     path: str = Field(..., description="Storage path for the file")
     filename: str = Field(..., description="Original filename")
     uploaded_at: str = Field(..., description="Upload timestamp in ISO format")
+    rows_processed: Optional[int] = Field(
+        default=None, description="Number of rows successfully ingested"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
@@ -221,6 +221,7 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
                 config_key=handler.config_key,
                 filename=setup["filename"],
                 processed_path=setup.get("processed_path"),
+                rows_processed=stats["rows_processed"],
             )
 
             # -- Finalize ---------------------------------------------------
@@ -338,6 +339,7 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
         config_key: str,
         filename: str,
         processed_path: str | None = None,
+        rows_processed: int | None = None,
     ) -> None:
         """Write the validated CSV rows into year_configuration.config."""
         if not self.year:
@@ -388,6 +390,9 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
             "path": processed_path or "",
             "filename": filename,
             "uploaded_at": datetime.now(timezone.utc).isoformat(),
+            "rows_processed": rows_processed
+            if rows_processed is not None
+            else len(validated_rows),
         }
 
         # SQLAlchemy does not detect in-place mutations on JSON/dict columns.

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -101,7 +101,7 @@ function handleCancel() {
 </script>
 
 <template>
-  <q-card flat class="q-pa-lg" :style="cardStyle(buttonColor)">
+  <q-card flat class="q-pa-lg column" :style="cardStyle(buttonColor)">
     <!-- Title and description -->
     <div class="row items-center q-mb-xs">
       <div class="text-body2 text-weight-bold">
@@ -122,7 +122,7 @@ function handleCancel() {
     </div>
 
     <!-- Upload button row -->
-    <div class="row justify-between items-center full-width">
+    <div class="row justify-between items-center full-width" style="margin-top: auto">
       <div class="row q-mr-xs items-center" style="gap: 0.5rem">
         <q-spinner-rings v-if="isLoading" color="grey" />
         <q-btn
@@ -183,16 +183,19 @@ function handleCancel() {
         class="row items-center no-wrap"
         style="gap: 0.75rem"
       >
-        <div class="row items-end">
+        <div class="column">
           <div class="row items-center text-body2 text-weight-medium">
             <span class="text-positive q-mr-xs">✓</span>
             {{ jobInfo.fileName }}
           </div>
           <div class="text-caption text-grey-7">
-            {{ jobInfo.rowsProcessed }}
-            {{ $t('data_management_rows_imported') }}
+            <span v-if="jobInfo.rowsProcessed !== undefined">
+              {{ jobInfo.rowsProcessed }}
+              {{ $t('data_management_rows_imported') }}
+            </span>
             <span v-if="jobInfo.timestamp">
-              • {{ jobInfo.timestamp.toLocaleDateString() }}
+              {{ jobInfo.rowsProcessed !== undefined ? '•' : '' }}
+              {{ jobInfo.timestamp.toLocaleDateString() }}
             </span>
           </div>
         </div>

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -122,7 +122,10 @@ function handleCancel() {
     </div>
 
     <!-- Upload button row -->
-    <div class="row justify-between items-center full-width" style="margin-top: auto">
+    <div
+      class="row justify-between items-center full-width"
+      style="margin-top: auto"
+    >
       <div class="row q-mr-xs items-center" style="gap: 0.5rem">
         <q-spinner-rings v-if="isLoading" color="grey" />
         <q-btn

--- a/frontend/src/components/organisms/data-management/ReductionObjectivesSection.vue
+++ b/frontend/src/components/organisms/data-management/ReductionObjectivesSection.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue';
 import {
   useYearConfigStore,
   type ReductionObjectiveGoal,
+  type FileMetadata,
 } from 'src/stores/yearConfig';
 import { Notify } from 'quasar';
 import { useI18n } from 'vue-i18n';
@@ -11,7 +12,10 @@ import { inject } from 'vue';
 import {
   TargetType,
   type ImportRow,
+  type SyncJobResponse,
 } from 'src/stores/backofficeDataManagement';
+import UploadCard from 'src/components/molecules/data-management/UploadCard.vue';
+
 const props = defineProps<{
   selectedYear: number;
 }>();
@@ -62,10 +66,17 @@ watch(
   { immediate: true },
 );
 
-/** True when at least one goal has meaningful data filled. */
-const hasReductionGoals = computed(() =>
-  localGoals.value.some((g) => g.target_year > 0 && g.reference_year > 0),
-);
+/** True when all mandatory fields are filled: 3 CSV files + first goal. */
+const isComplete = computed(() => {
+  const files = yearConfigStore.config?.config?.reduction_objectives?.files;
+  return (
+    !!files?.institutional_footprint &&
+    !!files?.population_projections &&
+    !!files?.unit_scenarios &&
+    localGoals.value[0].target_year > 0 &&
+    localGoals.value[0].reference_year > 0
+  );
+});
 
 /** True when all filled-in goals pass validation (percentage displayed as 0–100). */
 const goalsAreValid = computed(() =>
@@ -109,17 +120,41 @@ async function saveReductionGoals(): Promise<void> {
   }
 }
 
-/** File refs for reduction objective CSV uploads. */
-/** Uploaded file names derived from the store. */
-const uploadedFileNames = computed(() => {
-  // TODO: add a way to download the files in .path
-  const files = yearConfigStore.config?.config?.reduction_objectives?.files;
+/** Convert a FileMetadata entry into a minimal SyncJobResponse so UploadCard can render file info and download. */
+function fileMetaToJob(file: FileMetadata | null | undefined): SyncJobResponse | undefined {
+  if (!file) return undefined;
   return {
-    footprint: files?.institutional_footprint?.filename ?? null,
-    population: files?.population_projections?.filename ?? null,
-    scenarios: files?.unit_scenarios?.filename ?? null,
+    job_id: 0,
+    meta: {
+      file_path: file.filename,
+      processed_file_path: file.path,
+      timestamp: file.uploaded_at,
+      rows_processed: file.rows_processed,
+    },
   };
-});
+}
+
+function downloadFile(file: FileMetadata | null | undefined): void {
+  if (!file?.path) return;
+  const a = document.createElement('a');
+  a.href = `/api/v1/files/${file.path}`;
+  a.download = file.filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+const reductionFiles = computed(
+  () => yearConfigStore.config?.config?.reduction_objectives?.files,
+);
+
+function csvButtonColor(file: FileMetadata | null | undefined): string {
+  return file ? 'positive' : 'accent';
+}
+
+function csvButtonLabel(file: FileMetadata | null | undefined): string {
+  return file ? $t('data_management_reupload_data') : $t('common_upload_csv');
+}
 </script>
 
 <template>
@@ -135,7 +170,7 @@ const uploadedFileNames = computed(() => {
               {{ $t('data_management_reduction_objectives') }}</span
             >
             <q-badge
-              v-if="!hasReductionGoals"
+              v-if="!isComplete"
               outline
               rounded
               color="accent"
@@ -148,131 +183,50 @@ const uploadedFileNames = computed(() => {
       </template>
       <q-separator />
       <!-- File Upload Section -->
-      <q-card flat class="q-pa-none row">
-        <q-card
-          flat
-          class="col q-px-lg q-py-xl"
-          style="border-right: 1px solid #d5d5d5"
-        >
-          <div class="row items-start align-center q-my-xs">
-            <q-icon name="barefoot" color="accent" size="xs" class="q-mr-sm" />
-            <div class="text-body1 text-weight-medium">
-              {{ $t('data_management_institution_carbon_footprint_title') }}
-            </div>
-          </div>
-          <div class="text-body2 text-secondary">
-            {{ $t('data_management_institution_carbon_footprint_description') }}
-          </div>
-          <div
-            v-if="uploadedFileNames.footprint"
-            class="text-caption text-positive q-mt-sm"
-          >
-            <q-icon name="check" /> {{ uploadedFileNames.footprint }}
-          </div>
-          <div class="row q-gutter-md q-mt-lg">
-            <q-btn
-              :color="'red'"
-              icon="add"
-              size="sm"
-              :label="$t('common_upload_csv')"
-              class="text-weight-medium"
-              :disable="false"
-              @click="
-                openDataEntryDialog(
-                  {
-                    reductionObjectiveTypeId: 0, // footprint
-                  } as ImportRow,
-                  TargetType.REDUCTION_OBJECTIVES,
-                )
-              "
-            />
-          </div>
-        </q-card>
-        <q-card
-          flat
-          class="col q-px-lg q-py-xl"
-          style="border-right: 1px solid #d5d5d5"
-        >
-          <div class="row items-start align-center q-mb-xs">
-            <q-icon
-              name="o_groups_2"
-              color="accent"
-              size="xs"
-              class="q-mr-sm"
-            />
-            <div class="text-body1 text-weight-medium">
-              {{ $t('data_management_population_projections_title') }}
-            </div>
-          </div>
-          <div class="text-body2 text-secondary">
-            {{ $t('data_management_population_projections_description') }}
-          </div>
-          <div
-            v-if="uploadedFileNames.population"
-            class="text-caption text-positive q-mt-sm"
-          >
-            <q-icon name="check" /> {{ uploadedFileNames.population }}
-          </div>
-          <div class="row q-gutter-md q-mt-lg">
-            <q-btn
-              :color="'red'"
-              icon="add"
-              size="sm"
-              :label="$t('common_upload_csv')"
-              class="text-weight-medium"
-              :disable="false"
-              @click="
-                openDataEntryDialog(
-                  {
-                    reductionObjectiveTypeId: 1, // population
-                  } as ImportRow,
-                  TargetType.REDUCTION_OBJECTIVES,
-                )
-              "
-            />
-          </div>
-        </q-card>
-        <q-card flat class="col q-px-lg q-py-xl border-right">
-          <div class="row items-start align-center q-mb-xs">
-            <q-icon
-              name="o_square_foot"
-              color="accent"
-              size="xs"
-              class="q-mr-sm"
-            />
-            <div class="text-body1 text-weight-medium">
-              {{ $t('data_management_unit_reduction_scenarios_title') }}
-            </div>
-          </div>
-          <div class="text-body2 text-secondary">
-            {{ $t('data_management_unit_reduction_scenarios_description') }}
-          </div>
-          <div
-            v-if="uploadedFileNames.scenarios"
-            class="text-caption text-positive q-mt-sm"
-          >
-            <q-icon name="check" /> {{ uploadedFileNames.scenarios }}
-          </div>
-          <div class="row q-gutter-md q-mt-lg">
-            <q-btn
-              :color="'red'"
-              icon="add"
-              size="sm"
-              :label="$t('common_upload_csv')"
-              class="text-weight-medium"
-              :disable="false"
-              @click="
-                openDataEntryDialog(
-                  {
-                    reductionObjectiveTypeId: 2, // scenarios
-                  } as ImportRow,
-                  TargetType.REDUCTION_OBJECTIVES,
-                )
-              "
-            />
-          </div>
-        </q-card>
-      </q-card>
+      <div class="row q-pa-md q-gutter-md">
+        <UploadCard
+          class="col"
+          :title="$t('data_management_institution_carbon_footprint_title')"
+          :description="$t('data_management_institution_carbon_footprint_description')"
+          :show-mandatory-indicator="true"
+          :button-color="csvButtonColor(reductionFiles?.institutional_footprint)"
+          :button-label="csvButtonLabel(reductionFiles?.institutional_footprint)"
+          button-icon="upload"
+          :row="({ reductionObjectiveTypeId: 0 } as ImportRow)"
+          :target-type="TargetType.REDUCTION_OBJECTIVES"
+          :last-job="fileMetaToJob(reductionFiles?.institutional_footprint)"
+          @upload="openDataEntryDialog($event, TargetType.REDUCTION_OBJECTIVES)"
+          @download="downloadFile(reductionFiles?.institutional_footprint)"
+        />
+        <UploadCard
+          class="col"
+          :title="$t('data_management_population_projections_title')"
+          :description="$t('data_management_population_projections_description')"
+          :show-mandatory-indicator="true"
+          :button-color="csvButtonColor(reductionFiles?.population_projections)"
+          :button-label="csvButtonLabel(reductionFiles?.population_projections)"
+          button-icon="upload"
+          :row="({ reductionObjectiveTypeId: 1 } as ImportRow)"
+          :target-type="TargetType.REDUCTION_OBJECTIVES"
+          :last-job="fileMetaToJob(reductionFiles?.population_projections)"
+          @upload="openDataEntryDialog($event, TargetType.REDUCTION_OBJECTIVES)"
+          @download="downloadFile(reductionFiles?.population_projections)"
+        />
+        <UploadCard
+          class="col"
+          :title="$t('data_management_unit_reduction_scenarios_title')"
+          :description="$t('data_management_unit_reduction_scenarios_description')"
+          :show-mandatory-indicator="true"
+          :button-color="csvButtonColor(reductionFiles?.unit_scenarios)"
+          :button-label="csvButtonLabel(reductionFiles?.unit_scenarios)"
+          button-icon="upload"
+          :row="({ reductionObjectiveTypeId: 2 } as ImportRow)"
+          :target-type="TargetType.REDUCTION_OBJECTIVES"
+          :last-job="fileMetaToJob(reductionFiles?.unit_scenarios)"
+          @upload="openDataEntryDialog($event, TargetType.REDUCTION_OBJECTIVES)"
+          @download="downloadFile(reductionFiles?.unit_scenarios)"
+        />
+      </div>
       <q-separator />
       <!-- Goals Section -->
       <q-item-section class="q-pt-xl q-pb-sm q-px-md">

--- a/frontend/src/components/organisms/data-management/ReductionObjectivesSection.vue
+++ b/frontend/src/components/organisms/data-management/ReductionObjectivesSection.vue
@@ -121,7 +121,9 @@ async function saveReductionGoals(): Promise<void> {
 }
 
 /** Convert a FileMetadata entry into a minimal SyncJobResponse so UploadCard can render file info and download. */
-function fileMetaToJob(file: FileMetadata | null | undefined): SyncJobResponse | undefined {
+function fileMetaToJob(
+  file: FileMetadata | null | undefined,
+): SyncJobResponse | undefined {
   if (!file) return undefined;
   return {
     job_id: 0,
@@ -187,12 +189,18 @@ function csvButtonLabel(file: FileMetadata | null | undefined): string {
         <UploadCard
           class="col"
           :title="$t('data_management_institution_carbon_footprint_title')"
-          :description="$t('data_management_institution_carbon_footprint_description')"
+          :description="
+            $t('data_management_institution_carbon_footprint_description')
+          "
           :show-mandatory-indicator="true"
-          :button-color="csvButtonColor(reductionFiles?.institutional_footprint)"
-          :button-label="csvButtonLabel(reductionFiles?.institutional_footprint)"
+          :button-color="
+            csvButtonColor(reductionFiles?.institutional_footprint)
+          "
+          :button-label="
+            csvButtonLabel(reductionFiles?.institutional_footprint)
+          "
           button-icon="upload"
-          :row="({ reductionObjectiveTypeId: 0 } as ImportRow)"
+          :row="{ reductionObjectiveTypeId: 0 } as ImportRow"
           :target-type="TargetType.REDUCTION_OBJECTIVES"
           :last-job="fileMetaToJob(reductionFiles?.institutional_footprint)"
           @upload="openDataEntryDialog($event, TargetType.REDUCTION_OBJECTIVES)"
@@ -201,12 +209,14 @@ function csvButtonLabel(file: FileMetadata | null | undefined): string {
         <UploadCard
           class="col"
           :title="$t('data_management_population_projections_title')"
-          :description="$t('data_management_population_projections_description')"
+          :description="
+            $t('data_management_population_projections_description')
+          "
           :show-mandatory-indicator="true"
           :button-color="csvButtonColor(reductionFiles?.population_projections)"
           :button-label="csvButtonLabel(reductionFiles?.population_projections)"
           button-icon="upload"
-          :row="({ reductionObjectiveTypeId: 1 } as ImportRow)"
+          :row="{ reductionObjectiveTypeId: 1 } as ImportRow"
           :target-type="TargetType.REDUCTION_OBJECTIVES"
           :last-job="fileMetaToJob(reductionFiles?.population_projections)"
           @upload="openDataEntryDialog($event, TargetType.REDUCTION_OBJECTIVES)"
@@ -215,12 +225,14 @@ function csvButtonLabel(file: FileMetadata | null | undefined): string {
         <UploadCard
           class="col"
           :title="$t('data_management_unit_reduction_scenarios_title')"
-          :description="$t('data_management_unit_reduction_scenarios_description')"
+          :description="
+            $t('data_management_unit_reduction_scenarios_description')
+          "
           :show-mandatory-indicator="true"
           :button-color="csvButtonColor(reductionFiles?.unit_scenarios)"
           :button-label="csvButtonLabel(reductionFiles?.unit_scenarios)"
           button-icon="upload"
-          :row="({ reductionObjectiveTypeId: 2 } as ImportRow)"
+          :row="{ reductionObjectiveTypeId: 2 } as ImportRow"
           :target-type="TargetType.REDUCTION_OBJECTIVES"
           :last-job="fileMetaToJob(reductionFiles?.unit_scenarios)"
           @upload="openDataEntryDialog($event, TargetType.REDUCTION_OBJECTIVES)"

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -9,10 +9,11 @@ import {
 } from 'src/constant/backoffice-module-config';
 import { MODULES_LIST, type Module } from 'src/constant/modules';
 
-interface FileMetadata {
+export interface FileMetadata {
   path: string;
   filename: string;
   uploaded_at: string;
+  rows_processed?: number;
 }
 
 export interface ReductionObjectiveGoal {


### PR DESCRIPTION
## Summary

- Replace bare upload buttons with `UploadCard` components, giving reduction objective CSVs the same filename display, download button, and re-upload flow as other submodules
- Fix incomplete badge: now requires all 3 CSVs **and** the first reduction goal to be filled
- Store `rows_processed` in `FileMetadata` (backend + schema) so the card can display row count after upload
- Pin `UploadCard` action row to bottom via `margin-top: auto` so buttons align across cards with variable-length descriptions
- Stack filename/metadata vertically in the file info section; hide row count gracefully when absent

## Test plan

- [ ] Upload each of the 3 reduction objective CSVs — card should show filename, row count, date, and download button
- [ ] Download button retrieves the correct file
- [ ] Incomplete badge disappears only when all 3 CSVs and the first goal are filled
- [ ] UploadCard button row aligns at the bottom across cards with different description lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)