### PR TITLE
feat(781): completion status filter — clearable, i18n, API cleanup

### DIFF
--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -721,7 +721,7 @@ class CarbonReportModuleRepository:
         )
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
-        if completion_status:
+        if completion_status is not None:
             statement = statement.where(
                 col(CarbonReport.overall_status) == int(completion_status)
             )
@@ -878,7 +878,7 @@ class CarbonReportModuleRepository:
         # Additional filters based on provided parameters
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
-        if completion_status:
+        if completion_status is not None:
             statement = statement.where(
                 col(CarbonReport.overall_status) == int(completion_status)
             )
@@ -992,7 +992,7 @@ class CarbonReportModuleRepository:
         )
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
-        if completion_status:
+        if completion_status is not None:
             statement = statement.where(
                 col(CarbonReport.overall_status) == int(completion_status)
             )

--- a/frontend/src/api/backoffice.ts
+++ b/frontend/src/api/backoffice.ts
@@ -32,7 +32,7 @@ export async function exportReport(
   return api.get('backoffice/export', { searchParams }).blob();
 }
 
-function _applyReportFilters(
+export function applyUnitFiltersToParams(
   searchParams: URLSearchParams,
   unitFilters: UnitFilters,
   withModules: boolean = true,
@@ -49,6 +49,7 @@ function _applyReportFilters(
   }
   if (
     unitFilters.completion_status !== undefined &&
+    unitFilters.completion_status !== null &&
     unitFilters.completion_status !== ''
   ) {
     searchParams.append(
@@ -81,10 +82,8 @@ export async function downloadUsageReportFile(
   if (format === 'pdf') {
     throw new Error('PDF format is not supported for usage report');
   }
-  const searchParams = new URLSearchParams({
-    format,
-  });
-  _applyReportFilters(searchParams, unitFilters);
+  const searchParams = new URLSearchParams({ format });
+  applyUnitFiltersToParams(searchParams, unitFilters);
 
   return api.get('backoffice/report/usage', { searchParams }).blob();
 }
@@ -96,10 +95,8 @@ export async function downloadDetailedReportFile(
   if (format === 'pdf') {
     throw new Error('PDF format is not supported for detailed report');
   }
-  const searchParams = new URLSearchParams({
-    format,
-  });
-  _applyReportFilters(searchParams, unitFilters);
+  const searchParams = new URLSearchParams({ format });
+  applyUnitFiltersToParams(searchParams, unitFilters);
 
   return api.get('backoffice/report/detailed', { searchParams }).blob();
 }
@@ -111,10 +108,8 @@ export async function downloadResultsReportFile(
   if (format === 'pdf') {
     throw new Error('PDF format is not supported for results report');
   }
-  const searchParams = new URLSearchParams({
-    format,
-  });
-  _applyReportFilters(searchParams, unitFilters, false);
+  const searchParams = new URLSearchParams({ format });
+  applyUnitFiltersToParams(searchParams, unitFilters, false);
 
   return api.get('backoffice/report/results', { searchParams }).blob();
 }

--- a/frontend/src/components/organisms/backoffice/reporting/ReportExport.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportExport.vue
@@ -9,8 +9,8 @@ import {
   downloadUsageReportFile,
   downloadDetailedReportFile,
   downloadResultsReportFile,
-} from 'src/api/reporting';
-import type { ReportFormat, ReportType } from 'src/api/reporting';
+} from 'src/api/backoffice';
+import type { ReportFormat, ReportType } from 'src/api/backoffice';
 import { type UnitFilters } from 'src/stores/backoffice';
 const { t } = useI18n();
 

--- a/frontend/src/components/organisms/backoffice/reporting/ReportingFilters.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportingFilters.vue
@@ -9,7 +9,7 @@ const emit = defineEmits<{
     filters: {
       path_affiliation: number[];
       path_lvl4: number[];
-      completion_status: number | string;
+      completion_status: number | string | undefined;
     },
   ): void;
 }>();
@@ -39,7 +39,7 @@ function handleFiltersChange() {
   emit('update:filters', {
     path_affiliation: selectedAffiliationUnits.value || [],
     path_lvl4: selectedLevel4Units.value || [],
-    completion_status: completion.value,
+    completion_status: completion.value ?? undefined,
   });
 }
 </script>
@@ -163,13 +163,25 @@ function handleFiltersChange() {
         v-model="completion"
         outlined
         dense
+        clearable
         :options="[
-          { label: t('backoffice_reporting_csv_validated'), value: 2 },
-          { label: t('backoffice_reporting_csv_in_progress'), value: 1 },
-          { label: t('backoffice_reporting_csv_default'), value: 0 },
+          {
+            label: t('backoffice_reporting_filter_completion_not_started'),
+            value: 0,
+          },
+          {
+            label: t('backoffice_reporting_filter_completion_in_progress'),
+            value: 1,
+          },
+          {
+            label: t('backoffice_reporting_filter_completion_completed'),
+            value: 2,
+          },
         ]"
         option-value="value"
         option-label="label"
+        emit-value
+        map-options
         :label="$t('backoffice_reporting_row_completion_label')"
         class="full-width"
         style="flex-grow: 1"

--- a/frontend/src/components/organisms/backoffice/reporting/ReportingStatCards.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportingStatCards.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { ReportingStats } from 'src/api/reporting';
+import type { ReportingStats } from 'src/api/backoffice';
 import { MODULE_STATES } from 'src/constant/moduleStates';
 
 const { t } = useI18n();

--- a/frontend/src/constant/report.ts
+++ b/frontend/src/constant/report.ts
@@ -1,5 +1,5 @@
 // export type ReportType = 'usage' | 'results' | 'combined';
-import type { ReportType } from 'src/api/reporting';
+import type { ReportType } from 'src/api/backoffice';
 
 export const REPORT_TYPES = [
   {

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -84,8 +84,8 @@ export default {
     fr: 'Unités',
   },
   backoffice_reporting_row_completion_label: {
-    en: 'Statut de validation',
-    fr: 'Validation status',
+    en: 'Completion status',
+    fr: "Statut d'avancement",
   },
   backoffice_reporting_column_unit: {
     en: 'Unit',
@@ -161,6 +161,19 @@ export default {
     en: 'Comprehensive report including both usage statistics and CO₂-eq results, ideal for executive summaries and annual reporting.',
     fr: "Rapport complet incluant à la fois les statistiques d'utilisation et les résultats de CO₂-éq, idéal pour les synthèses et les rapports annuels.",
   },
+  backoffice_reporting_filter_completion_not_started: {
+    en: 'Not started',
+    fr: 'Non commencé',
+  },
+  backoffice_reporting_filter_completion_in_progress: {
+    en: 'In Progress',
+    fr: 'En cours',
+  },
+  backoffice_reporting_filter_completion_completed: {
+    en: 'Completed',
+    fr: 'Complété',
+  },
+
   backoffice_reporting_csv_validated: {
     en: 'Validated',
     fr: 'Validé',

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -13,7 +13,7 @@ import ModuleSelector, {
 } from 'src/components/organisms/backoffice/reporting/ModuleSelector.vue';
 import ReportingStatCards from 'src/components/organisms/backoffice/reporting/ReportingStatCards.vue';
 import ReportingStatCardUnit from 'src/components/organisms/backoffice/reporting/ReportingStatCardUnit.vue';
-import { type ReportingStats } from 'src/api/reporting';
+import { type ReportingStats } from 'src/api/backoffice';
 import ReportingYear from 'src/components/organisms/backoffice/reporting/ReportingYear.vue';
 import ReportingFilters from 'src/components/organisms/backoffice/reporting/ReportingFilters.vue';
 import UnitsTable from 'src/components/organisms/backoffice/reporting/UnitsTable.vue';

--- a/frontend/src/stores/backoffice.ts
+++ b/frontend/src/stores/backoffice.ts
@@ -1,26 +1,12 @@
 import { defineStore } from 'pinia';
 import { reactive, ref } from 'vue';
 import { api } from 'src/api/http';
+import { applyUnitFiltersToParams } from 'src/api/backoffice';
 import type { ModuleState } from 'src/constant/moduleStates';
 import type { EmissionBreakdownResponse } from 'src/stores/modules';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE_UNITS = 10;
-
-// interface ModuleCompletion {
-//   status: ModuleState;
-//   outlier_values: number;
-// }
-
-// "id": 1574,
-// "unit_name": "Abbott, Guerrero and Rhodes",
-// "affiliation": "SV",
-// "validation_status": "3/9",
-// "principal_user": "Melissa Paul",
-// "last_update": "2026-02-20T15:19:37.859926",
-// "highest_result_category": "Module infrastructure",
-// "total_carbon_footprint": 231.91,
-// "view_url": "/backoffice/unit/1574"
 
 interface BackofficeUnitData {
   id: string | number;
@@ -58,7 +44,6 @@ export interface UnitFilters {
   path_lvl4?: Array<number | string>;
   years?: string[];
   completion_status?: number | string;
-  outlier_values?: boolean | null;
   search?: string;
   modules?: Array<{ module: string; state: ModuleState }>;
 }
@@ -94,45 +79,6 @@ export const useBackofficeStore = defineStore('backoffice', () => {
     descending: false,
   });
 
-  // const affiliations = computed(() => {
-  //   const uniqueAffiliations = new Set<string>();
-  //   allUnits.value.forEach((unit) => {
-  //     if (unit.affiliation) {
-  //       uniqueAffiliations.add(unit.affiliation);
-  //     }
-  //   });
-  //   return Array.from(uniqueAffiliations).sort();
-  // });
-
-  // const availableUnits = computed(() => {
-  //   const uniqueUnits = new Set<number>();
-  //   allUnits.value.forEach((unit) => {
-  //     if (unit.unit) {
-  //       uniqueUnits.add(unit.unit);
-  //     }
-  //   });
-  //   return Array.from(uniqueUnits).sort();
-  // });
-
-  // async function getAllUnits() {
-  //   try {
-  //     allUnitsLoading.value = true;
-  //     allUnitsErrors.value = [];
-  //     const data = await api
-  //       .get('backoffice/units')
-  //       .json<BackofficeUnitData[]>();
-  //     allUnits.value = data || [];
-  //   } catch (error) {
-  //     console.error('Error getting all units:', error);
-  //     const errorObj =
-  //       error instanceof Error ? error : new Error('Failed to get all units');
-  //     allUnitsErrors.value = [errorObj];
-  //     allUnits.value = [];
-  //   } finally {
-  //     allUnitsLoading.value = false;
-  //   }
-  // }
-
   async function getUnits(filters?: UnitFilters) {
     console.log(
       '📡 [BackofficeStore] getUnits called with pagination:',
@@ -163,57 +109,11 @@ export const useBackofficeStore = defineStore('backoffice', () => {
         });
       }
 
-      // Add hierarchy filters
-      if (filters?.path_affiliation && filters.path_affiliation.length > 0) {
-        filters.path_affiliation.forEach((v) =>
-          searchParams.append('path_affiliation', String(v)),
-        );
-      }
-
-      if (filters?.path_lvl4 && filters.path_lvl4.length > 0) {
-        filters.path_lvl4.forEach((v) =>
-          searchParams.append('path_lvl4', String(v)),
-        );
-      }
-
-      if (filters?.years && filters.years.length > 0) {
-        filters.years.forEach((v) => searchParams.append('years', String(v)));
-      }
-
-      // Add status/search filters
-      if (
-        filters?.completion_status !== undefined &&
-        filters?.completion_status !== ''
-      ) {
-        searchParams.append(
-          'completion_status',
-          String(filters.completion_status),
-        );
-      }
-
-      if (filters?.search?.trim()) {
-        searchParams.append('search', filters.search.trim());
-      }
-
-      // Add boolean filter (outlier_values)
-      if (
-        filters?.outlier_values !== null &&
-        filters?.outlier_values !== undefined
-      ) {
-        searchParams.append('outlier_values', String(filters.outlier_values));
-      }
-
-      // Add module filters
-      if (filters?.modules !== undefined) {
-        if (filters.modules.length === 0) {
-          // Empty array means modules are enabled but no states selected
-          // Send empty string to backend - it will return empty results
+      if (filters) {
+        applyUnitFiltersToParams(searchParams, filters);
+        // Empty modules array means filter is active but nothing selected → no results
+        if (filters.modules !== undefined && filters.modules.length === 0) {
           searchParams.append('modules', '');
-        } else {
-          // Send module filters
-          filters.modules.forEach((f) => {
-            searchParams.append('modules', `${f.module}:${f.state}`);
-          });
         }
       }
 


### PR DESCRIPTION
## Summary

- **Clearable completion status filter**: dropdown now shows Not started / In Progress / Completed with a clear button (was missing `clearable`, `emit-value`, `map-options`)
- **i18n**: dedicated filter keys (`filter_completion_*`) separate from CSV export keys; fixed swapped en/fr on the label
- **Bug fix**: `null` was leaking into query params when the filter was cleared, sending `completion_status=null` to the backend — fixed at the emit source (`?? undefined`) and guarded in `applyUnitFiltersToParams`
- **Refactor**: renamed `api/reporting.ts` → `api/backoffice.ts`; extracted and exported `applyUnitFiltersToParams` as a shared helper used by both the store and export functions; removed dead `outlier_values` filter

## Test plan

- [ ] Select each completion status value — verify correct integer (0/1/2) appears in the `completion_status` query param
- [ ] Clear the completion filter — verify `completion_status` does **not** appear in the query params
- [ ] Verify affiliation and level 4 filters still work alongside completion filter
- [ ] Verify all export downloads (usage, detailed, results) still apply filters correctly
- [ ] Check both EN and FR locales for the filter label and dropdown options

🤖 Generated with [Claude Code](https://claude.com/claude-code)