### PR TITLE
fix(927): pass year to factor values endpoint

### DIFF
--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -42,6 +42,7 @@ async def get_factor(
     data_entry_type_id: DataEntryTypeEnum,
     kind: str,
     subkind: str = Query(default=None, alias="sub_class"),
+    year: int = Query(...),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -52,6 +53,7 @@ async def get_factor(
         data_entry_type=data_entry_type_id,
         kind=kind,
         subkind=subkind,
+        year=year,
     )
     if factor:
         # For combustion factors, `unit` lives in `classification` rather than `values`.

--- a/frontend/src/api/factors.ts
+++ b/frontend/src/api/factors.ts
@@ -20,13 +20,15 @@ export async function getFactorValues(
   submodule: AllSubmoduleTypes,
   equipmentClass: string,
   subClass?: string | null,
+  year?: string | number | null,
 ): Promise<ValueFactorResponse | null> {
-  let path = `factors/${encodeURIComponent(
-    enumSubmodule[submodule],
-  )}/classes/${encodeURIComponent(equipmentClass)}/values`;
-  if (subClass) {
-    path += `?sub_class=${encodeURIComponent(subClass)}`;
-  }
+  const params = new URLSearchParams();
+  if (subClass) params.set('sub_class', subClass);
+  if (year != null) params.set('year', String(year));
+  const query = params.toString();
+  const path =
+    `factors/${encodeURIComponent(enumSubmodule[submodule])}/classes/${encodeURIComponent(equipmentClass)}/values` +
+    (query ? `?${query}` : '');
   const res = await api.get(path).json<ValueFactorResponse | null>();
   return res ?? null;
 }

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -521,12 +521,17 @@ if (props.moduleType === MODULES.EquipmentElectricConsumption) {
 }
 
 const { dynamicOptions, loadingClasses, loadingSubclasses } =
-  useEquipmentClassOptions(form, toRef(props, 'submoduleType'), {
-    classFieldId: kindFieldId.value ?? undefined,
-    subClassFieldId: subkindFieldId.value ?? undefined,
-    fetchFactorValuesOnChange: true,
-    ...useEquipmentClassOptionsConfig,
-  });
+  useEquipmentClassOptions(
+    form,
+    toRef(props, 'submoduleType'),
+    {
+      classFieldId: kindFieldId.value ?? undefined,
+      subClassFieldId: subkindFieldId.value ?? undefined,
+      fetchFactorValuesOnChange: true,
+      ...useEquipmentClassOptionsConfig,
+    },
+    toRef(props, 'year'),
+  );
 
 const { dynamicOptions: buildingRoomDynamicOptions } =
   useBuildingRoomDynamicOptions(

--- a/frontend/src/composables/useEquipmentClassOptions.ts
+++ b/frontend/src/composables/useEquipmentClassOptions.ts
@@ -34,6 +34,7 @@ export function useEquipmentClassOptions<
   entity: TEntity,
   submoduleType: Ref<AllSubmoduleTypes>,
   config: FieldConfig = {},
+  year?: Ref<string | number | undefined>,
 ) {
   const classFieldId = config.classFieldId ?? '';
   const subClassFieldId = config.subClassFieldId ?? '';
@@ -135,9 +136,12 @@ export function useEquipmentClassOptions<
       return;
     }
 
+    const yearValue = year?.value;
+    if (yearValue == null) return;
+
     loadingPowerFactor.value = true;
     try {
-      const pf = await store.fetchPowerFactor(sub, cls, subCls);
+      const pf = await store.fetchPowerFactor(sub, cls, subCls, yearValue);
       if (pf) {
         if (primaryValueFieldId && primaryValueFieldId in entity)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/stores/factors.ts
+++ b/frontend/src/stores/factors.ts
@@ -62,8 +62,9 @@ export const useFactorsStore = defineStore('factors', () => {
     submodule: AllSubmoduleTypes,
     equipmentClass: string,
     subClass?: string | null,
+    year?: string | number | null,
   ): Promise<ValueFactorResponse | null> {
-    return await getFactorValues(submodule, equipmentClass, subClass);
+    return await getFactorValues(submodule, equipmentClass, subClass, year);
   }
 
   return {


### PR DESCRIPTION
## Summary

- Backend `GET /factors/{type}/classes/{kind}/values` now accepts a required `year` query param and forwards it to `get_by_classification`, fixing the `ValueError` thrown when year was `None`
- Frontend `getFactorValues` (API), `fetchPowerFactor` (store), and `useEquipmentClassOptions` (composable) all thread `year` through the call chain
- `ModuleForm.vue` passes `toRef(props, 'year')` as a new 4th argument to `useEquipmentClassOptions`; `loadPowerFactor` silently skips the fetch if year is not yet set

## Test plan

- [ ] Open an equipment electric consumption form, select a class and subclass — confirm active/standby power values are auto-filled without a 500
- [ ] Verify the network request includes `?year=<year>` (or `&year=<year>`) in the values endpoint call
- [ ] Confirm the inline table selects (ModuleInlineSelect) still work — they don't call `loadPowerFactor` so no year is needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)