### PR TITLE
feat: refactored seed factors so that it uses the csv data ingestion logic

### DIFF
--- a/backend/app/seed/seed_generic_factors.py
+++ b/backend/app/seed/seed_generic_factors.py
@@ -1,5 +1,4 @@
 import asyncio
-import csv
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -9,6 +8,7 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.db import SessionLocal
 from app.models.data_entry import DataEntryTypeEnum
+from app.models.module_type import get_module_type_for_data_entry_type
 from app.modules.external_cloud_and_ai import (
     schemas as schemas,
 )  # This ensures the handlers are registered
@@ -24,11 +24,7 @@ from app.modules.research_facilities import (
 from app.modules.research_facilities import (
     common_schemas as _rf_common_schemas,  # noqa: F401 — registers handlers
 )
-from app.schemas.factor import BaseFactorHandler
-from app.seed.seed_helper import (
-    get_factor_emission_type_id,
-)
-from app.services.factor_service import FactorService
+from app.services.data_ingestion.csv_providers.local_seed import LocalFactorCSVProvider
 
 logger = get_logger(__name__)
 settings = get_settings()
@@ -172,81 +168,34 @@ FACTOR_SEEDS: list[FactorSeedConfig] = [
 ]
 
 
-def get_float_str_or_none(value: str | None) -> float | str | None:
-    """Convert string to float or return None if empty."""
-    if value is None or value == "":
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return value
-
-
 async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
-    """Seed factors from a CSV according to the given config."""
-    service = FactorService(session)
+    """Seed factors from a CSV using the ingestion pipeline."""
+    first_type = config.data_entry_types[0]
+    module_type = get_module_type_for_data_entry_type(first_type)
+    if module_type is None:
+        raise ValueError(
+            f"Cannot determine module_type for data_entry_type: {first_type.name}"
+        )
 
-    for det in config.data_entry_types:
-        await service.bulk_delete_by_data_entry_type(det)
+    provider_config: dict = {
+        "local_file_path": str(config.path),
+        "module_type_id": module_type.value,
+        "year": 2025,
+        "data_entry_type_id": (
+            config.data_entry_types[0].value
+            if config.data_entry_type_column is None
+            else None
+        ),
+        "explicit_entry_type_ids": [det.value for det in config.data_entry_types],
+    }
 
-    name_to_enum = {det.name: det for det in config.data_entry_types}
-    det_column = config.data_entry_type_column
-    fixed_type = config.data_entry_types[0] if not det_column else None
+    provider = LocalFactorCSVProvider(config=provider_config, data_session=session)
+    result = await provider.process_csv_in_batches()
 
-    def resolve(row: dict) -> DataEntryTypeEnum | None:
-        if det_column:
-            det_name = row.get(det_column, "").strip()
-            det = name_to_enum.get(det_name)
-            if det is None:
-                logger.warning(
-                    f"Unknown data_entry_type '{det_name}' in CSV row {row},"
-                    f" expected one of {list(name_to_enum.keys())}"
-                )
-            return det
-        return fixed_type
-
-    factors = []
-    with open(config.path, mode="r") as csvfile:
-        reader = csv.DictReader(csvfile)
-        for row in reader:
-            data_entry_type = resolve(row)
-            if data_entry_type is None:
-                continue
-
-            handler = BaseFactorHandler.get_by_type(data_entry_type)
-            emission_type_id = get_factor_emission_type_id(data_entry_type, row)
-            required = handler.required_columns
-
-            classification = {}
-            for field_name in handler.classification_fields:
-                if not row.get(field_name) and field_name in required:
-                    logger.warning(
-                        f"Missing required classification field '{field_name}'"
-                        f" for {data_entry_type.name} factor: {row}"
-                    )
-                classification[field_name] = row.get(field_name) or None
-
-            values: dict[str, float | int | str | None] = {}
-            for field_name in handler.value_fields:
-                if not row.get(field_name) and field_name in required:
-                    logger.warning(
-                        f"Missing required value field '{field_name}'"
-                        f" for {data_entry_type.name} factor: {row}"
-                    )
-                values[field_name] = get_float_str_or_none(row.get(field_name))
-
-            factor = await service.prepare_create(
-                emission_type_id=emission_type_id,
-                data_entry_type_id=data_entry_type.value,
-                classification=classification,
-                values=values,
-                year=2025,  # Default year for seeded factors
-            )
-            factors.append(factor)
-
-    await service.bulk_create(factors)
     label = ", ".join(det.name for det in config.data_entry_types)
-    print(f"Created {len(factors)} factors for [{label}]")
+    inserted = result.get("inserted", 0)
+    skipped = result.get("skipped", 0)
+    print(f"Created {inserted} factors for [{label}] ({skipped} skipped)")
     await session.commit()
     logger.info(f"Seeded factors for [{label}].")
 

--- a/backend/app/seed/seed_generic_factors.py
+++ b/backend/app/seed/seed_generic_factors.py
@@ -24,6 +24,7 @@ from app.modules.research_facilities import (
 from app.modules.research_facilities import (
     common_schemas as _rf_common_schemas,  # noqa: F401 — registers handlers
 )
+from app.schemas.factor import BaseFactorHandler
 from app.services.data_ingestion.csv_providers.local_seed import LocalFactorCSVProvider
 
 logger = get_logger(__name__)
@@ -170,12 +171,26 @@ FACTOR_SEEDS: list[FactorSeedConfig] = [
 
 async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
     """Seed factors from a CSV using the ingestion pipeline."""
+    if not config.data_entry_types:
+        raise ValueError("At least one data_entry_type must be provided")
     first_type = config.data_entry_types[0]
     module_type = get_module_type_for_data_entry_type(first_type)
     if module_type is None:
         raise ValueError(
             f"Cannot determine module_type for data_entry_type: {first_type.name}"
         )
+
+    if config.data_entry_type_column is not None:
+        for det in config.data_entry_types:
+            handler = BaseFactorHandler.get_by_type(det)
+            actual = getattr(handler, "category_field", None)
+            if actual != config.data_entry_type_column:
+                raise ValueError(
+                    f"data_entry_type_column={config.data_entry_type_column!r} "
+                    f"does not match "
+                    f"{type(handler).__name__}.category_field={actual!r} "
+                    f"for data_entry_type={det.name}"
+                )
 
     provider_config: dict = {
         "local_file_path": str(config.path),

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -170,13 +170,7 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
             listed_entry_types = setup_result.get("valid_entry_types", [])
             # Delete existing factors for this data_entry_type and year
             # This ensures idempotent uploads - no duplicates
-            data_entry_type_to_iterates = []
-            if self.data_entry_type_id is not None:
-                data_entry_type_to_iterates.append(
-                    DataEntryTypeEnum(int(self.data_entry_type_id))
-                )
-            else:
-                data_entry_type_to_iterates.extend(listed_entry_types)
+            data_entry_type_to_iterates = self._get_types_to_delete(listed_entry_types)
             stats["factors_deleted"] = 0
             if len(data_entry_type_to_iterates) > 0 and self.year:
                 for data_entry_type in data_entry_type_to_iterates:
@@ -574,6 +568,18 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
         except ValueError:
             pass
         return value
+
+    def _get_types_to_delete(
+        self, listed_entry_types: list[DataEntryTypeEnum]
+    ) -> list[DataEntryTypeEnum]:
+        """Return the data entry types whose factors should be deleted before ingestion.
+
+        Override in subclasses to restrict deletion to a subset of types
+        (e.g. when a CSV covers only part of a module's types).
+        """
+        if self.data_entry_type_id is not None:
+            return [DataEntryTypeEnum(int(self.data_entry_type_id))]
+        return list(listed_entry_types)
 
     def _record_row_error(
         self,

--- a/backend/app/services/data_ingestion/csv_providers/local_seed.py
+++ b/backend/app/services/data_ingestion/csv_providers/local_seed.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List
 
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import IngestionState
 from app.services.data_ingestion.base_factor_csv_provider import FactorStatsDict
 from app.services.data_ingestion.csv_providers.factors import (
     ModulePerYearFactorCSVProvider,
@@ -132,7 +133,7 @@ class LocalFactorCSVProvider(ModulePerYearFactorCSVProvider):
             f"{stats['factors_deleted']} existing factors deleted"
         )
         return {
-            "state": "FINISHED",
+            "state": IngestionState.FINISHED,
             "result": result,
             "inserted": stats["rows_processed"],
             "skipped": stats["rows_skipped"],

--- a/backend/app/services/data_ingestion/csv_providers/local_seed.py
+++ b/backend/app/services/data_ingestion/csv_providers/local_seed.py
@@ -1,0 +1,151 @@
+"""LocalFactorCSVProvider: runs factor CSV ingestion directly from local disk.
+
+Used by seed scripts so they can reuse the full ingestion pipeline
+(row validation, batch processing, emission-type resolution, error stats)
+without requiring a running file-store service or DataIngestionJob records.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from app.core.logging import get_logger
+from app.models.data_entry import DataEntryTypeEnum
+from app.services.data_ingestion.base_factor_csv_provider import FactorStatsDict
+from app.services.data_ingestion.csv_providers.factors import (
+    ModulePerYearFactorCSVProvider,
+)
+
+logger = get_logger(__name__)
+
+
+class LocalFactorCSVProvider(ModulePerYearFactorCSVProvider):
+    """Factor CSV provider that reads from local disk instead of the file store.
+
+    Intended for seed scripts only. No DataIngestionJob records are created
+    and no file-store operations (upload / move) are performed.
+
+    Config keys
+    -----------
+    local_file_path : str
+        Absolute path to the CSV file on disk.
+    module_type_id : int
+        Module type that owns the factors being seeded.
+    data_entry_type_id : int | None
+        Fixed data-entry type for single-type CSVs.  Pass None when the type
+        is determined per-row via a category column.
+    year : int
+        Reference year for the seeded factors.
+    explicit_entry_type_ids : list[int] | None
+        When provided, deletion before seeding is scoped to exactly these
+        DataEntryTypeEnum values.  Useful when a CSV covers only a subset of
+        the module's types (e.g. purchases_common does not cover
+        additional_purchases).
+    """
+
+    def __init__(self, config: Dict[str, Any], data_session: Any):
+        # Pass job_session=None and user=None — no job tracking for seeds
+        super().__init__(
+            config=config,
+            user=None,
+            job_session=None,
+            data_session=data_session,
+        )
+        self._local_file_path: str | None = config.get("local_file_path")
+        raw_ids: list[int] | None = config.get("explicit_entry_type_ids")
+        self._explicit_types: list[DataEntryTypeEnum] | None = (
+            [DataEntryTypeEnum(i) for i in raw_ids] if raw_ids is not None else None
+        )
+
+    # ------------------------------------------------------------------
+    # Override: validate against local filesystem, not file store
+    # ------------------------------------------------------------------
+
+    async def validate_connection(self) -> bool:
+        if not self._local_file_path:
+            logger.warning("No local_file_path provided")
+            return False
+        exists = Path(self._local_file_path).is_file()
+        if not exists:
+            logger.warning(f"Local CSV file not found: {self._local_file_path}")
+        return exists
+
+    # ------------------------------------------------------------------
+    # Override: read directly from disk, skip file-store moves and DB job
+    # ------------------------------------------------------------------
+
+    async def _setup_and_validate(self) -> Dict[str, Any]:
+        if self.year is None:
+            raise ValueError("year is required for factor CSV ingestion")
+
+        if not self._local_file_path:
+            raise ValueError("Missing local_file_path in config")
+
+        local_path = Path(self._local_file_path)
+        if not local_path.is_file():
+            raise FileNotFoundError(f"CSV file not found: {self._local_file_path}")
+
+        csv_text = local_path.read_text(encoding="utf-8")
+        filename = local_path.name
+
+        entity_setup = await self._setup_handlers_and_context()
+        handlers = entity_setup["handlers"]
+        expected_columns = entity_setup["expected_columns"]
+        required_columns = entity_setup["required_columns"]
+
+        logger.info("Validating CSV headers for local seed")
+        self._validate_csv_headers(csv_text, expected_columns, required_columns)
+
+        return {
+            "csv_text": csv_text,
+            "handlers": handlers,
+            "expected_columns": expected_columns,
+            "required_columns": required_columns,
+            # Dummy values — _finalize_and_commit checks these only for file-store
+            "processing_path": None,
+            "filename": filename,
+            "valid_entry_types": entity_setup["valid_entry_types"],
+        }
+
+    # ------------------------------------------------------------------
+    # Override: skip file-store moves and job DB updates after processing
+    # ------------------------------------------------------------------
+
+    async def _finalize_and_commit(
+        self,
+        batch: List[Any],
+        factor_service: Any,
+        stats: FactorStatsDict,
+        setup_result: Dict[str, Any],
+    ) -> Dict[str, Any]:
+
+        if batch:
+            await self._process_batch(batch, factor_service)
+
+        await self.data_session.flush()
+
+        result = self._compute_ingestion_result(stats)
+
+        logger.info(
+            f"Local seed completed: {stats['rows_processed']} rows processed, "
+            f"{stats['rows_skipped']} skipped, "
+            f"{stats['row_errors_count']} errors, "
+            f"{stats['factors_deleted']} existing factors deleted"
+        )
+        return {
+            "state": "FINISHED",
+            "result": result,
+            "inserted": stats["rows_processed"],
+            "skipped": stats["rows_skipped"],
+            "stats": stats,
+        }
+
+    # ------------------------------------------------------------------
+    # Override: respect explicit deletion scope set per FactorSeedConfig
+    # ------------------------------------------------------------------
+
+    def _get_types_to_delete(
+        self, listed_entry_types: list[DataEntryTypeEnum]
+    ) -> list[DataEntryTypeEnum]:
+        if self._explicit_types is not None:
+            return self._explicit_types
+        return super()._get_types_to_delete(listed_entry_types)

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -288,3 +288,92 @@ async def test_finalize_and_commit_move_file_failure():
         setup_result={"processing_path": "processing/x", "filename": "x.csv"},
     )
     assert result["state"] == IngestionState.FINISHED
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_types_to_delete
+# ---------------------------------------------------------------------------
+
+
+def test_get_types_to_delete_with_configured_data_entry_type_id():
+    """When data_entry_type_id is set, only that single type is returned."""
+    provider = ConcreteFactorProvider(
+        {
+            "file_path": "tmp/test.csv",
+            "data_entry_type_id": DataEntryTypeEnum.member.value,
+        },
+        data_session=MagicMock(),
+    )
+    listed = [DataEntryTypeEnum.member, DataEntryTypeEnum.student]
+
+    result = provider._get_types_to_delete(listed)
+
+    assert result == [DataEntryTypeEnum.member]
+
+
+def test_get_types_to_delete_without_data_entry_type_id_returns_all():
+    """When data_entry_type_id is not set, all listed types are returned."""
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv"},
+        data_session=MagicMock(),
+    )
+    listed = [DataEntryTypeEnum.member, DataEntryTypeEnum.student]
+
+    result = provider._get_types_to_delete(listed)
+
+    assert result == listed
+
+
+def test_get_types_to_delete_empty_listed_without_id():
+    """Empty listed_entry_types results in an empty deletion list."""
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv"},
+        data_session=MagicMock(),
+    )
+
+    result = provider._get_types_to_delete([])
+
+    assert result == []
+
+
+def test_get_types_to_delete_subclass_override_restricts_scope():
+    """A subclass that overrides _get_types_to_delete can restrict deletion scope."""
+
+    class RestrictedProvider(ConcreteFactorProvider):
+        def _get_types_to_delete(
+            self, listed_entry_types: list[DataEntryTypeEnum]
+        ) -> list[DataEntryTypeEnum]:
+            return [DataEntryTypeEnum.member]
+
+    provider = RestrictedProvider(
+        {"file_path": "tmp/test.csv"},
+        data_session=MagicMock(),
+    )
+    listed = [
+        DataEntryTypeEnum.member,
+        DataEntryTypeEnum.student,
+        DataEntryTypeEnum.scientific,
+    ]
+
+    result = provider._get_types_to_delete(listed)
+
+    assert result == [DataEntryTypeEnum.member]
+    assert DataEntryTypeEnum.student not in result
+    assert DataEntryTypeEnum.scientific not in result
+
+
+def test_get_types_to_delete_configured_id_ignores_listed():
+    """Configured data_entry_type_id takes priority; listed types are ignored."""
+    provider = ConcreteFactorProvider(
+        {
+            "file_path": "tmp/test.csv",
+            "data_entry_type_id": DataEntryTypeEnum.scientific.value,
+        },
+        data_session=MagicMock(),
+    )
+    # listed contains types that do NOT include `scientific`
+    listed = [DataEntryTypeEnum.member, DataEntryTypeEnum.student]
+
+    result = provider._get_types_to_delete(listed)
+
+    assert result == [DataEntryTypeEnum.scientific]

--- a/docs/implementation-plans/859-seed-1-factors-ingestion.md
+++ b/docs/implementation-plans/859-seed-1-factors-ingestion.md
@@ -1,0 +1,67 @@
+## Plan: Refactor Seed Factors to Use Ingestion Machinery
+
+**TL;DR**: `seed_generic_factors.py` manually duplicates CSV parsing, handler resolution, and factor creation logic that already exists in `ModulePerYearFactorCSVProvider`. The refactoring introduces a thin `LocalFactorCSVProvider` subclass that bypasses file-store/job-tracking (API-only concerns) and rewrites `seed_factors()` to delegate to it.
+
+---
+
+### Phase 1 — Add deletion hook to `BaseFactorCSVProvider` _(small, non-breaking)_
+
+**File**: base_factor_csv_provider.py
+
+- Extract the `data_entry_type_to_iterates` block in `process_csv_in_batches` into a new overridable method `_get_types_to_delete(listed_entry_types)`.
+- This is needed because `purchases_common_factors.csv` covers **7 of 8** purchase types; module-type-based deletion would also erase `additional_purchases` factors seeded just before it. Scoping deletion to the explicit configured types preserves the current behavior.
+
+### Phase 2 — Create `LocalFactorCSVProvider` _(new file)_
+
+**New file**: `app/services/data_ingestion/csv_providers/local_seed.py`
+
+Extends `ModulePerYearFactorCSVProvider`. Config keys:
+
+| Key                       | Value                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `local_file_path`         | absolute path to seed CSV on disk                                             |
+| `module_type_id`          | derived via `get_module_type_for_data_entry_type(config.data_entry_types[0])` |
+| `data_entry_type_id`      | `data_entry_types[0].value` if no `data_entry_type_column`, else `None`       |
+| `year`                    | `2025` (same default)                                                         |
+| `explicit_entry_type_ids` | `[det.value for det in config.data_entry_types]` — scopes deletion            |
+
+Override 4 methods:
+
+1. `validate_connection()` — check local file exists (no file store)
+2. `_setup_and_validate()` — read CSV bytes from disk; skip file-store move + job DB updates; return `setup_result` with `csv_text` + handler info
+3. `_finalize_and_commit()` — skip file-store moves + job DB updates; just process last batch + flush session
+4. `_get_types_to_delete()` — return `explicit_entry_type_ids` when provided; else `super()`
+
+### Phase 3 — Refactor `seed_generic_factors.py`
+
+**File**: seed_generic_factors.py
+
+- Replace `seed_factors()` body: derive `module_type_id` and `data_entry_type_id` from `FactorSeedConfig`, instantiate `LocalFactorCSVProvider`, call `provider.process_csv_in_batches()`, print stats.
+- Remove: `get_float_str_or_none()`, manual classification/value extraction (both replaced by the provider's `_process_row` + `_convert_value`).
+- Keep: `FactorSeedConfig` dataclass, `FACTOR_SEEDS` list, `main()` — no external interface changes.
+
+---
+
+### Relevant Files
+
+- seed_generic_factors.py — main file to refactor
+- base_factor_csv_provider.py — add `_get_types_to_delete` hook
+- factors.py — `ModulePerYearFactorCSVProvider` to subclass
+- app/services/data_ingestion/csv_providers/local_seed.py — new file
+- module_type.py — `get_module_type_for_data_entry_type` to derive `module_type_id`
+
+### Verification
+
+1. `uv run pytest tests/ -k "factor" -v` — existing tests pass
+2. `uv run python -m app.seed.seed_generic_factors` — run refactored seed; check output stats match expected counts
+3. `make lint && make type-check`
+
+---
+
+### Decisions
+
+- **Approach chosen**: thin subclass adapter (`LocalFactorCSVProvider`) — only adds a small hook to the base class, leaves the production ingestion path untouched.
+- **Alternative rejected**: uploading local CSVs to file store + creating `DataIngestionJob` records — adds DB/storage overhead and requires the file store operational during seeding.
+- `LocalFactorCSVProvider` lives in `csv_providers/` alongside the other provider implementations.
+- No `DataIngestionJob` creation — seeds have no job tracking.
+- Year remains hardcoded `2025` in the seed.


### PR DESCRIPTION
## What does this change?

* Added a new CSV data ingestion provider for factors: `LocalFactorCSVProvider` uses local files. 
* Updated seed factors logic accordingly

## Why is this needed?

Do not duplicate code logic, ease maintenance.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #859

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
