### PR TITLE
feat: add reduction objective chart for EPFL and my unit

### DIFF
--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -94,15 +94,8 @@ const categoryRows = computed<EmissionBreakdownCategoryRow[]>(() => {
     categories.includes(String(row.category ?? '')),
   ) as EmissionBreakdownCategoryRow[];
 
-  const canonicalizeCategoryKey = (raw: unknown): string => {
-    const key = String(raw ?? '');
-    return key === 'purchase' ? 'purchases' : key;
-  };
-
   return rows.map((row) => {
-    const categoryKey = canonicalizeCategoryKey(
-      row.category_key ?? row.category,
-    );
+    const categoryKey = String(row.category_key ?? row.category ?? '');
     const allowedBarNames = new Set(CATEGORY_CHART_KEYS[categoryKey] ?? []);
     const isFilterApplicable = row.emissions.some((e) =>
       allowedBarNames.has((e.parent_key ?? e.key) as string),

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -8,6 +8,7 @@ import type { EChartsOption } from 'echarts';
 import {
   getChartSubcategoryColor,
   CHART_CATEGORY_COLOR_SCALES,
+  RESULTS_CATEGORY_LABEL_KEYS,
 } from 'src/constant/charts';
 import {
   TooltipComponent,
@@ -33,20 +34,7 @@ import {
 } from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
 
-const CATEGORY_LABEL_MAP: Record<string, string> = {
-  process_emissions: 'charts-process-emissions-category',
-  buildings_room: 'charts-buildings-room-category',
-  buildings_energy_combustion: 'charts-buildings-energy-combustion-category',
-  equipment: 'equipment-electric-consumption',
-  external_cloud_and_ai: 'external-cloud-and-ai',
-  purchases: 'purchase',
-  research_facilities: 'charts-research-facilities-category',
-  professional_travel: 'professional-travel',
-  commuting: 'charts-commuting-category',
-  food: 'charts-food-category',
-  waste: 'charts-waste-category',
-  embodied_energy: 'charts-embodied-energy-category',
-};
+const CATEGORY_LABEL_MAP: Record<string, string> = RESULTS_CATEGORY_LABEL_KEYS;
 
 const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   co2: 'charts-co2-subcategory',
@@ -150,18 +138,9 @@ function sortBarsByDisplayOrder(
   });
 }
 
-function canonicalizeCategoryKey(raw: string): string {
-  const key = String(raw ?? '');
-  // API occasionally returns singular `purchase` while frontend uses `purchases`.
-  if (key === 'purchase') return 'purchases';
-  return key;
-}
-
 function getRowCategoryKey(row: EmissionBreakdownCategoryRow): string {
   // Some endpoints return only `category` and omit `category_key`.
-  return canonicalizeCategoryKey(
-    String(row.category_key ?? row.category ?? ''),
-  );
+  return String(row.category_key ?? row.category ?? '');
 }
 
 const chartData = computed(() => {

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -6,7 +6,11 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import { graphic } from 'echarts';
-import { colors, getChartSubcategoryColor } from 'src/constant/charts';
+import {
+  colors,
+  getChartSubcategoryColor,
+  RESULTS_CATEGORY_LABEL_KEYS,
+} from 'src/constant/charts';
 import {
   TooltipComponent,
   LegendComponent,
@@ -331,20 +335,7 @@ function recalculateScopeRects() {
   });
 }
 
-const CATEGORY_LABEL_MAP: Record<string, string> = {
-  commuting: 'charts-commuting-category', // Headcount
-  food: 'charts-food-category',
-  waste: 'charts-waste-category',
-  process_emissions: 'charts-process-emissions-category',
-  buildings_room: 'charts-buildings-room-category',
-  buildings_energy_combustion: 'charts-buildings-energy-combustion-category',
-  embodied_energy: 'charts-embodied-energy-category',
-  equipment: 'equipment-electric-consumption',
-  external_cloud_and_ai: 'external-cloud-and-ai',
-  purchases: 'purchase',
-  professional_travel: 'professional-travel',
-  research_facilities: 'charts-research-facilities-category',
-};
+const CATEGORY_LABEL_MAP: Record<string, string> = RESULTS_CATEGORY_LABEL_KEYS;
 
 function translateCategory(
   entry: Record<string, unknown>,
@@ -359,7 +350,7 @@ function normalizeCategoryRowKeys(
 ): Record<string, unknown> {
   const cat = String(entry.category ?? entry.category_key ?? '');
   // Backend sometimes uses `other` for purchases; keep equipment `other` untouched.
-  if (cat === 'purchases' || cat === 'purchase') {
+  if (cat === 'purchases') {
     const next = { ...entry };
     if (next.other_purchases == null && next.other != null) {
       next.other_purchases = next.other;
@@ -458,10 +449,10 @@ const MAIN_CATEGORY_ORDER_IDS = [
   'charts-process-emissions-category',
   'charts-buildings-energy-combustion-category',
   'charts-buildings-room-category',
-  'equipment-electric-consumption',
-  'external-cloud-and-ai',
-  'professional-travel',
-  'purchase',
+  'charts-equipment-electric-consumption-category',
+  'charts-external-cloud-category',
+  'charts-professional-travel-category',
+  'charts-purchases-category',
   'charts-research-facilities-category',
 ];
 

--- a/frontend/src/components/charts/results/ReductionObjectiveChart.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveChart.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ReductionObjectiveEpflView from 'src/components/charts/results/ReductionObjectiveEpflView.vue';
+import ReductionObjectiveUnitView from 'src/components/charts/results/ReductionObjectiveUnitView.vue';
+
+type ModuleChartView = 'epfl' | 'unit';
+
+interface Props {
+  hideResearchFacilities?: boolean;
+  hideAdditionalData?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  hideResearchFacilities: false,
+  hideAdditionalData: false,
+});
+
+const moduleChartView = ref<ModuleChartView>('epfl');
+
+const moduleChartViewModel = computed({
+  get: () => moduleChartView.value,
+  set: (v: ModuleChartView) => {
+    moduleChartView.value = v;
+  },
+});
+
+const { t } = useI18n();
+
+const chartTitle = computed(() =>
+  moduleChartView.value === 'epfl'
+    ? t('results_objectives_epfl_chart_title')
+    : t('results_objectives_unit_chart_title'),
+);
+</script>
+<template>
+  <div
+    class="row items-start justify-between q-pa-xl q-pb-none q-col-gutter-md"
+  >
+    <div class="col-12 col-sm">
+      <div class="flex items-center no-wrap q-gutter-sm">
+        <h2 class="text-h2 text-weight-medium q-mb-none">
+          {{ $t('results_objectives_2040_title') }}
+        </h2>
+        <q-icon name="o_info" size="sm" class="text-primary">
+          <q-tooltip class="text-body2 text-black" max-width="320px">
+            {{ $t('results_objectives_2030_tooltip') }}
+          </q-tooltip>
+        </q-icon>
+      </div>
+      <div class="text-body1 text-secondary">
+        {{ $t('results_objectives_2040_section_subtitle') }}
+      </div>
+    </div>
+
+    <div class="col-12 col-sm-auto flex items-center justify-center">
+      <q-btn-toggle
+        v-model="moduleChartViewModel"
+        dense
+        no-caps
+        unelevated
+        toggle-color="accent"
+        toggle-text-color="white"
+        color="grey-2"
+        text-color="grey-7"
+        :options="[
+          { value: 'epfl', slot: 'epfl' },
+          { value: 'unit', slot: 'unit' },
+        ]"
+        class="chart-view-toggle"
+      >
+        <template #epfl>
+          {{ $t('results_objectives_2040_epfl_button') }}
+        </template>
+        <template #unit>
+          {{ $t('results_objectives_2040_unit_button') }}
+        </template>
+      </q-btn-toggle>
+    </div>
+  </div>
+
+  <q-separator class="q-mb-md" />
+
+  <q-card-section class="q-pa-none">
+    <div class="q-pl-xl q-pt-lg">
+      <div class="flex items-center no-wrap q-mb-xs">
+        <div class="text-body1 text-weight-medium q-mb-none">
+          {{ chartTitle }}
+        </div>
+      </div>
+
+      <div
+        v-if="moduleChartView === 'epfl'"
+        class="o text-body2 text-secondary"
+      >
+        {{ $t('results_objectives_2040_subtitle') }}
+        (
+        <a
+          class="objective-subtitle__link"
+          href="https://e4s.center/fr/resources/reports/carbon-removal-net-zero-and-implications-for-switzerland/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ $t('results_objectives_2040_subtitle_link_label') }}
+        </a>
+        )
+      </div>
+
+      <div v-else class="text-body2 text-secondary">
+        {{ $t('results_objectives_unit_chart_tooltip') }}
+      </div>
+    </div>
+
+    <q-separator class="q-mt-xl" />
+
+    <div class="q-pl-xl">
+      <ReductionObjectiveEpflView
+        v-if="moduleChartView === 'epfl'"
+        :hide-research-facilities="props.hideResearchFacilities"
+      />
+      <ReductionObjectiveUnitView
+        v-else
+        :hide-research-facilities="props.hideResearchFacilities"
+        :hide-additional-data="props.hideAdditionalData"
+      />
+    </div>
+  </q-card-section>
+</template>

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -1,0 +1,845 @@
+<script setup lang="ts">
+import { computed, onMounted, onUpdated, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { BarChart, LineChart } from 'echarts/charts';
+import type { EChartsOption } from 'echarts';
+import { graphic } from 'echarts';
+import {
+  GraphicComponent,
+  GridComponent,
+  LegendComponent,
+  TitleComponent,
+  ToolboxComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import VChart from 'vue-echarts';
+import { useYearConfigStore } from 'src/stores/yearConfig';
+import { useWorkspaceStore } from 'src/stores/workspace';
+import {
+  CHART_CATEGORY_COLOR_SCHEMES,
+  colors,
+  getModuleForCategoryKey,
+  RESULTS_CATEGORY_LABEL_KEYS,
+  RESULTS_CATEGORY_ORDER,
+} from 'src/constant/charts';
+import { formatTonnesForChart } from 'src/utils/number';
+
+interface Props {
+  hideResearchFacilities?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  hideResearchFacilities: false,
+});
+
+use([
+  CanvasRenderer,
+  BarChart,
+  LineChart,
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent,
+  ToolboxComponent,
+  GraphicComponent,
+]);
+
+type FootprintRow = { year: number; category: string; co2: number };
+type PopulationRow = { year: number; pop: number };
+
+const { t, te } = useI18n();
+
+const INT_FORMATTER = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+});
+
+const yearConfigStore = useYearConfigStore();
+const workspaceStore = useWorkspaceStore();
+
+const currentYear = computed(
+  () => workspaceStore.selectedYear ?? new Date().getFullYear(),
+);
+
+const YEARS_END = 2040;
+
+function buildPiecewiseEasedTotalsByYear(params: {
+  years: readonly number[];
+  startYear: number;
+  startTotal: number;
+  anchors: ReadonlyArray<{ year: number; total: number }>;
+}): Record<number, number> {
+  const { years, startYear, startTotal } = params;
+
+  const anchors = [...params.anchors]
+    .filter((a) => a.year >= startYear)
+    .sort((a, b) => a.year - b.year);
+
+  const points: Array<{ year: number; total: number }> = [
+    { year: startYear, total: startTotal },
+    ...anchors,
+  ];
+
+  const yearSet = new Set(years);
+  const out: Record<number, number> = {};
+
+  for (let i = 0; i < points.length; i += 1) {
+    const p0 = points[i];
+    const p1 = points[i + 1];
+
+    if (!p1) {
+      for (const y of years) {
+        if (y < p0.year) continue;
+        out[y] = p0.total;
+      }
+      break;
+    }
+
+    const span = p1.year - p0.year;
+    for (let y = p0.year; y <= p1.year; y += 1) {
+      if (!yearSet.has(y)) continue;
+      const tt = span === 0 ? 1 : (y - p0.year) / span;
+      const eased = 1 - Math.pow(1 - tt, 2);
+      out[y] = p0.total + (p1.total - p0.total) * eased;
+    }
+  }
+
+  return out;
+}
+
+const reductionObjectives = computed(() => {
+  const ro = yearConfigStore.config?.config?.reduction_objectives;
+  return ro ?? null;
+});
+
+const epflFootprintRows = computed<FootprintRow[]>(() => {
+  const raw = reductionObjectives.value?.institutional_footprint ?? [];
+  return (raw as unknown[]).filter(Boolean).map((r) => {
+    const row = r as FootprintRow;
+    return {
+      ...row,
+      co2: typeof row.co2 === 'number' ? row.co2 / 1000 : row.co2,
+    };
+  }) as FootprintRow[];
+});
+
+const epflPopulationRows = computed<PopulationRow[]>(() => {
+  const raw = reductionObjectives.value?.population_projections ?? [];
+  return (raw as unknown[]).filter(Boolean) as PopulationRow[];
+});
+
+const epflGoals = computed(
+  () => reductionObjectives.value?.goals?.slice() ?? [],
+);
+
+const yearsStart = computed(() => {
+  const candidates: number[] = [];
+
+  for (const r of epflFootprintRows.value) {
+    if (typeof r.year === 'number') candidates.push(r.year);
+  }
+  for (const r of epflPopulationRows.value) {
+    if (typeof r.year === 'number') candidates.push(r.year);
+  }
+  for (const g of epflGoals.value) {
+    if (typeof g?.reference_year === 'number')
+      candidates.push(g.reference_year);
+  }
+
+  const rawMin = candidates.length
+    ? Math.min(...candidates)
+    : currentYear.value;
+  return Math.min(Math.max(rawMin, 0), YEARS_END);
+});
+
+const years = computed(() => {
+  const start = yearsStart.value;
+  return Array.from({ length: YEARS_END - start + 1 }, (_, i) => start + i);
+});
+
+const epflFootprintRowsForChart = computed(() => {
+  const rows = epflFootprintRows.value;
+  if (!props.hideResearchFacilities) return rows;
+  return rows.filter((r) => r.category !== 'research_facilities');
+});
+
+const epflFootprintByYearCategory = computed(() => {
+  const out = new Map<number, Map<string, number>>();
+  for (const r of epflFootprintRowsForChart.value) {
+    if (typeof r.year !== 'number') continue;
+    const key = r.category;
+    const bucket = out.get(r.year) ?? new Map<string, number>();
+    bucket.set(
+      key,
+      (bucket.get(key) ?? 0) + (typeof r.co2 === 'number' ? r.co2 : 0),
+    );
+    out.set(r.year, bucket);
+  }
+  return out;
+});
+
+const epflFootprintTotalsByYear = computed(() => {
+  const out = new Map<number, number>();
+  for (const [year, byCat] of epflFootprintByYearCategory.value.entries()) {
+    let sum = 0;
+    for (const v of byCat.values()) sum += v;
+    out.set(year, sum);
+  }
+  return out;
+});
+
+function getEpflYearCategorySums(year: number): Record<string, number> {
+  const byCat = epflFootprintByYearCategory.value.get(year);
+  if (!byCat) return {};
+  return Object.fromEntries(byCat.entries());
+}
+
+function getEpflYearTotal(year: number): number {
+  return epflFootprintTotalsByYear.value.get(year) ?? 0;
+}
+
+const epflBaselineYear = computed(() => {
+  return years.value.find((y) => getEpflYearTotal(y) > 0) ?? yearsStart.value;
+});
+
+function categoryColor(categoryKey: string): string {
+  return CHART_CATEGORY_COLOR_SCHEMES.value[categoryKey] ?? '#CFD4EE';
+}
+
+function categoryLabel(categoryKey: string): string {
+  const labelKey =
+    RESULTS_CATEGORY_LABEL_KEYS[
+      categoryKey as keyof typeof RESULTS_CATEGORY_LABEL_KEYS
+    ];
+  if (labelKey && te(labelKey)) return t(labelKey);
+
+  const mod = getModuleForCategoryKey(categoryKey);
+  if (mod && te(mod)) return t(mod);
+  return categoryKey;
+}
+
+const TOOLTIP_CATEGORY_ORDER = RESULTS_CATEGORY_ORDER;
+
+type TooltipAxisParam = {
+  axisValue?: string;
+  seriesName?: string;
+  value?: number | (number | null)[] | null;
+};
+
+function normalizeTooltipParams(rawParams: unknown): TooltipAxisParam[] {
+  if (!Array.isArray(rawParams)) return [];
+  return rawParams as TooltipAxisParam[];
+}
+
+function tooltipAxisValueToYearLabel(rawAxisValue: unknown): string {
+  // When tooltip is driven by the hidden numeric axis, axisValue can be an index
+  // (e.g. "3.5"). Map it back to the closest year label.
+  const n = Number(rawAxisValue);
+  if (!Number.isFinite(n)) return String(rawAxisValue ?? '');
+
+  const idx = Math.min(
+    Math.max(Math.round(n), 0),
+    Math.max(years.value.length - 1, 0),
+  );
+  return String(years.value[idx] ?? rawAxisValue);
+}
+
+function extractTooltipSeriesValue(
+  raw: TooltipAxisParam['value'],
+): number | null {
+  if (typeof raw === 'number') return raw;
+  if (!Array.isArray(raw)) return null;
+  return (raw.length >= 2 ? raw[1] : raw[0]) as number | null;
+}
+
+function formatTooltipTonnes(value: number | null): string {
+  if (value == null) return '-';
+  if (value < 0) return value.toFixed(1);
+  return formatTonnesForChart(value);
+}
+
+function formatTooltipPopulation(value: number | null): string {
+  if (value == null) return '-';
+  return INT_FORMATTER.format(Math.round(value));
+}
+
+function tooltipSortIndex(seriesName: string): number {
+  const idx = TOOLTIP_CATEGORY_ORDER.indexOf(
+    seriesName as (typeof TOOLTIP_CATEGORY_ORDER)[number],
+  );
+  return idx === -1 ? 999 : idx;
+}
+
+function renderTooltipTotalLine(params: TooltipAxisParam[]): string {
+  const p = params.find(
+    (x) => String(x.seriesName) === 'total' && x.value != null,
+  );
+  if (!p) return '';
+
+  const v = extractTooltipSeriesValue(p.value);
+  const formatted = formatTooltipTonnes(v);
+  const dotColor = accentColorHex.value ?? colors.value.cobalt.darker;
+  const label = t('results_objectives_total');
+
+  return `
+    <div class="objective-tooltip__line objective-tooltip__line--total">
+      <span class="objective-tooltip__dot" style="--dot-color:${dotColor};"></span>
+      <span class="objective-tooltip__label objective-tooltip__label--strong">${label}</span>
+      <span class="objective-tooltip__value objective-tooltip__value--strong">${formatted}</span>
+    </div>
+  `;
+}
+
+function renderTooltipCategoryLines(params: TooltipAxisParam[]): string {
+  return params
+    .filter((p) => p.seriesName && p.value != null)
+    .filter(
+      (p) =>
+        String(p.seriesName) !== 'population' &&
+        String(p.seriesName) !== 'total',
+    )
+    .sort((a, b) => {
+      const ak = String(a.seriesName ?? '');
+      const bk = String(b.seriesName ?? '');
+      return tooltipSortIndex(ak) - tooltipSortIndex(bk);
+    })
+    .map((p) => {
+      const key = String(p.seriesName);
+      const color = categoryColor(key);
+      const value = extractTooltipSeriesValue(p.value);
+      const formatted = formatTooltipTonnes(value);
+      const label = categoryLabel(key);
+
+      return `
+        <div class="objective-tooltip__line">
+          <span class="objective-tooltip__dot" style="--dot-color:${color};"></span>
+          <span class="objective-tooltip__label">${label}</span>
+          <span class="objective-tooltip__value">${formatted}</span>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function renderTooltipPopulationLine(params: TooltipAxisParam[]): string {
+  const p = params.find(
+    (x) => String(x.seriesName) === 'population' && x.value != null,
+  );
+  if (!p) return '';
+
+  const v = extractTooltipSeriesValue(p.value);
+  const formatted = formatTooltipPopulation(v);
+  const label = t('results_objectives_population_forecast');
+
+  return `
+    <div class="objective-tooltip__section">
+      <div class="objective-tooltip__line">
+        <span class="objective-tooltip__dot objective-tooltip__dot--population"></span>
+        <span class="objective-tooltip__label">${label}</span>
+        <span class="objective-tooltip__value">${formatted}</span>
+      </div>
+    </div>
+  `;
+}
+
+function renderTooltipContainer(args: {
+  yearLabel: string;
+  totalLine: string;
+  categoryLines: string;
+  populationLine: string;
+}): string {
+  return `<div class="objective-tooltip">
+    <div class="objective-tooltip__title">${args.yearLabel}</div>
+    ${args.totalLine}${args.categoryLines}${args.populationLine}
+  </div>`;
+}
+
+// ── Data fetch ───────────────────────────────────────────────────────────────
+const lastFetchedYear = ref<number | null>(null);
+
+function readCssVarHex(name: string): string | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+const accentColorHex = ref<string | null>(null);
+
+async function ensureYearConfigFetched(): Promise<void> {
+  const y = currentYear.value;
+  if (lastFetchedYear.value === y) return;
+  lastFetchedYear.value = y;
+  await yearConfigStore.fetchConfig(y);
+}
+
+onMounted(async () => {
+  accentColorHex.value = readCssVarHex('--q-accent');
+  await ensureYearConfigFetched();
+});
+
+onUpdated(async () => {
+  await ensureYearConfigFetched();
+});
+
+const populationSeries = computed(() => {
+  const pop = epflPopulationRows.value;
+  if (!pop.length) return null;
+  const popByYear = Object.fromEntries(pop.map((r) => [r.year, r.pop]));
+  const firstPopYear = pop.reduce<number | null>((min, r) => {
+    if (typeof r.year !== 'number') return min;
+    if (typeof r.pop !== 'number') return min;
+    return min == null ? r.year : Math.min(min, r.year);
+  }, null);
+  const firstPopValue =
+    firstPopYear == null ? null : (popByYear[firstPopYear] ?? null);
+
+  const baselineYear = epflBaselineYear.value;
+  const baselineIdx = Math.max(0, years.value.indexOf(baselineYear));
+  const lastIdx = years.value.length - 1;
+
+  const popAtBaseline = (() => {
+    const v = popByYear[baselineYear];
+    if (typeof v === 'number') return v;
+    if (firstPopYear != null && baselineYear < firstPopYear) {
+      return typeof firstPopValue === 'number' ? firstPopValue : null;
+    }
+    return null;
+  })();
+
+  const popForYear = (y: number): number | null => {
+    const v = popByYear[y];
+    if (typeof v === 'number') return v;
+    if (firstPopYear != null && y < firstPopYear) {
+      return typeof firstPopValue === 'number' ? firstPopValue : null;
+    }
+    return null;
+  };
+
+  return {
+    name: 'population',
+    type: 'line',
+    xAxisIndex: 1,
+    yAxisIndex: 1,
+    showSymbol: false,
+    symbol: 'circle',
+    symbolSize: 7,
+    zlevel: 6,
+    z: 60,
+    lineStyle: { type: 'dotted', width: 2, color: '#ff0000' },
+    itemStyle: {
+      color: '#ff0000',
+      borderColor: '#ffffff',
+      borderWidth: 2,
+    },
+    tooltip: { show: false },
+    data:
+      popAtBaseline == null
+        ? years.value.map((y) => popForYear(y))
+        : [
+            { value: [baselineIdx - 0.5, popAtBaseline] },
+            { value: [baselineIdx + 0.5, popAtBaseline] },
+            ...years.value
+              .filter((y) => y >= baselineYear + 1)
+              .map((y) => ({
+                value: [years.value.indexOf(y), popForYear(y)],
+              })),
+            { value: [lastIdx + 0.5, popForYear(years.value[lastIdx])] },
+          ],
+  };
+});
+
+type EpflSeriesPayload = {
+  stackedSeries: unknown[];
+  totalsByYear: Record<number, number>;
+  baselineYear: number;
+};
+
+const epflSeriesData = computed<EpflSeriesPayload | null>(() => {
+  const footprint = epflFootprintRowsForChart.value;
+  const goals = epflGoals.value;
+  if (footprint.length === 0) return null;
+
+  const baselineYear = epflBaselineYear.value;
+  const baselineByCat = getEpflYearCategorySums(baselineYear);
+  const baselineTotal = Object.values(baselineByCat).reduce((a, b) => a + b, 0);
+  if (baselineTotal <= 0) return null;
+
+  const anchors: Array<{ year: number; total: number }> = [];
+  for (const g of goals) {
+    const refTotal = getEpflYearTotal(g.reference_year);
+    if (refTotal <= 0) continue;
+    anchors.push({
+      year: g.target_year,
+      total: refTotal * (1 - g.reduction_percentage),
+    });
+  }
+
+  const totalsByYear = buildPiecewiseEasedTotalsByYear({
+    years: years.value,
+    startYear: baselineYear,
+    startTotal: baselineTotal,
+    anchors,
+  });
+
+  const baselineIdx = Math.max(0, years.value.indexOf(baselineYear));
+  const lastIdx = years.value.length - 1;
+
+  const categoryKeys = [
+    ...TOOLTIP_CATEGORY_ORDER.filter((k) => baselineByCat[k] != null),
+    ...Object.keys(baselineByCat).filter(
+      (k) => !TOOLTIP_CATEGORY_ORDER.includes(k as never),
+    ),
+  ];
+
+  const totalColor = accentColorHex.value ?? colors.value.cobalt.darker;
+  const totalLineData = [
+    { value: [baselineIdx - 0.5, baselineTotal] },
+    { value: [baselineIdx + 0.5, baselineTotal] },
+    ...years.value
+      .filter((y) => y >= baselineYear + 1)
+      .map((y) => ({ value: [years.value.indexOf(y), totalsByYear[y] ?? 0] })),
+    { value: [lastIdx + 0.5, totalsByYear[years.value[lastIdx]] ?? 0] },
+  ];
+
+  const totalAreaSeries = {
+    name: 'total',
+    type: 'line',
+    xAxisIndex: 1,
+    showSymbol: false,
+    symbol: 'none',
+    lineStyle: { width: 0 },
+    itemStyle: { opacity: 0 },
+    areaStyle: {
+      color: new graphic.LinearGradient(0, 0, 0, 1, [
+        { offset: 0, color: totalColor },
+        { offset: 1, color: 'rgba(255,255,255,0)' },
+      ]),
+      opacity: 0.18,
+    },
+    emphasis: { disabled: true },
+    zlevel: 1,
+    z: 1,
+    data: totalLineData,
+    tooltip: { show: false },
+  };
+
+  const totalLineSeries = {
+    name: 'total',
+    type: 'line',
+    xAxisIndex: 1,
+    showSymbol: false,
+    symbol: 'circle',
+    symbolSize: 8,
+    lineStyle: { width: 2.5, color: totalColor },
+    itemStyle: {
+      color: totalColor,
+      borderColor: '#ffffff',
+      borderWidth: 2,
+    },
+    areaStyle: { opacity: 0 },
+    emphasis: { focus: 'series' },
+    zlevel: 5,
+    z: 50,
+    data: totalLineData,
+    tooltip: { show: false },
+  };
+
+  const baselineStackedBars = categoryKeys
+    .map((cat) => {
+      const color = categoryColor(cat);
+      return {
+        name: cat,
+        type: 'bar',
+        stack: 'baseline',
+        barWidth: '100%',
+        itemStyle: { color },
+        emphasis: { focus: 'series' },
+        zlevel: 2,
+        z: 2,
+        data: years.value.map((y) => {
+          if (y !== baselineYear) return null;
+          return baselineByCat[cat] ?? 0;
+        }),
+      };
+    })
+    .reverse();
+
+  return {
+    stackedSeries: [...baselineStackedBars, totalAreaSeries, totalLineSeries],
+    totalsByYear,
+    baselineYear,
+  };
+});
+
+const showEpflEmptyState = computed(() => !epflSeriesData.value);
+
+const chartOption = computed<EChartsOption | null>(() => {
+  const payload = epflSeriesData.value;
+  if (!payload) return null;
+  const popSeries = populationSeries.value;
+  const popRows = epflPopulationRows.value;
+  const popByYear = Object.fromEntries(popRows.map((r) => [r.year, r.pop]));
+  const firstPopYear = popRows.reduce<number | null>((min, r) => {
+    if (typeof r.year !== 'number') return min;
+    if (typeof r.pop !== 'number') return min;
+    return min == null ? r.year : Math.min(min, r.year);
+  }, null);
+  const firstPopValue =
+    firstPopYear == null ? null : (popByYear[firstPopYear] ?? null);
+  const popForYear = (y: number): number | null => {
+    const v = popByYear[y];
+    if (typeof v === 'number') return v;
+    if (firstPopYear != null && y < firstPopYear) {
+      return typeof firstPopValue === 'number' ? firstPopValue : null;
+    }
+    return null;
+  };
+
+  const totalTooltipSeries = {
+    name: 'total',
+    type: 'line',
+    xAxisIndex: 0,
+    yAxisIndex: 0,
+    showSymbol: false,
+    symbol: 'none',
+    lineStyle: { width: 0 },
+    itemStyle: { opacity: 0 },
+    silent: true,
+    data: years.value.map((y) =>
+      y < payload.baselineYear ? null : (payload.totalsByYear[y] ?? 0),
+    ),
+  };
+
+  const populationTooltipSeries = {
+    name: 'population',
+    type: 'line',
+    xAxisIndex: 0,
+    yAxisIndex: 1,
+    showSymbol: false,
+    symbol: 'none',
+    lineStyle: { width: 0 },
+    itemStyle: { opacity: 0 },
+    silent: true,
+    data: years.value.map((y) => popForYear(y)),
+  };
+
+  return {
+    axisPointer: {
+      // Link category (year labels) and hidden numeric x-axis (index-based)
+      // so "axis" tooltips include series rendered on xAxisIndex: 1.
+      link: [{ xAxisIndex: [0, 1] }],
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'line',
+      },
+      formatter: (rawParams: unknown) => {
+        const params = normalizeTooltipParams(rawParams);
+        const rawAxisValue = params[0]?.axisValue ?? '';
+
+        return renderTooltipContainer({
+          yearLabel: tooltipAxisValueToYearLabel(rawAxisValue),
+          totalLine: renderTooltipTotalLine(params),
+          categoryLines: renderTooltipCategoryLines(params),
+          populationLine: renderTooltipPopulationLine(params),
+        });
+      },
+    },
+    legend: { show: false },
+    grid: {
+      left: 48,
+      right: 64,
+      top: 24,
+      bottom: 24,
+      containLabel: true,
+    },
+    xAxis: [
+      {
+        type: 'category',
+        boundaryGap: true,
+        axisLabel: { interval: 0 },
+        axisTick: { interval: 0, alignWithLabel: true },
+        data: years.value.map(String),
+      },
+      {
+        type: 'value',
+        min: -0.5,
+        max: years.value.length - 1 + 0.5,
+        axisPointer: { show: false },
+        axisLabel: { show: false },
+        axisTick: { show: false },
+        axisLine: { show: false },
+        splitLine: { show: false },
+      },
+    ],
+    yAxis: [
+      {
+        type: 'value',
+        name: t('results_units_tonnes'),
+        min: 0,
+        nameGap: 36,
+        nameLocation: 'middle',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { formatter: (v: number) => `${v.toFixed(1)}` },
+        splitLine: { show: false },
+      },
+      {
+        type: 'value',
+        name: t('results_objectives_population_axis'),
+        min: 0,
+        position: 'right',
+        nameGap: 56,
+        nameLocation: 'middle',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { formatter: (v: number) => INT_FORMATTER.format(v) },
+        splitLine: { show: false },
+      },
+    ],
+    series: popSeries
+      ? [
+          ...payload.stackedSeries,
+          popSeries,
+          totalTooltipSeries,
+          populationTooltipSeries,
+        ]
+      : [...payload.stackedSeries, totalTooltipSeries, populationTooltipSeries],
+  } as EChartsOption;
+});
+</script>
+
+<template>
+  <div class="objective-chart">
+    <VChart
+      v-if="chartOption && !showEpflEmptyState"
+      :option="chartOption"
+      autoresize
+      class="objective-chart__canvas"
+    />
+    <q-card v-else flat class="objective-empty-card">
+      <q-card-section class="objective-empty-card__content">
+        <q-icon name="o_info" size="md" color="accent" class="q-mb-md" />
+        <div class="text-h6 text-weight-medium text-center q-mb-sm">
+          {{ $t('results_objectives_epfl_no_data_title') }}
+        </div>
+        <div class="text-body2 text-secondary text-center">
+          {{ $t('results_objectives_epfl_no_data_message') }}
+        </div>
+      </q-card-section>
+    </q-card>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.objective-chart {
+  height: 100%;
+  min-height: 620px;
+}
+
+.objective-chart__canvas {
+  width: 100%;
+  height: 100%;
+  min-height: 620px;
+}
+
+.objective-chart__empty {
+  height: 100%;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.01);
+  border: 1px dashed rgba(0, 0, 0, 0.01);
+  border-radius: 8px;
+}
+
+.objective-empty-card {
+  min-height: 620px;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.objective-empty-card__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+}
+
+.objective-subtitle__link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+</style>
+
+<style lang="scss">
+/* ECharts tooltip is rendered outside component root; keep these global. */
+.objective-tooltip {
+  min-width: 220px;
+}
+
+.objective-tooltip__title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.objective-tooltip__line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.35;
+}
+
+.objective-tooltip__line--total {
+  margin-bottom: 4px;
+}
+
+.objective-tooltip__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  display: inline-block;
+  flex: 0 0 auto;
+  background: var(--dot-color);
+}
+
+.objective-tooltip__dot--population {
+  background: #ff0000;
+}
+
+.objective-tooltip__label {
+  flex: 1;
+  opacity: 0.9;
+}
+
+.objective-tooltip__label--strong {
+  opacity: 0.95;
+  font-weight: 600;
+}
+
+.objective-tooltip__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.objective-tooltip__value--strong {
+  font-weight: 600;
+}
+
+.objective-tooltip__section {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+</style>

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -1,0 +1,759 @@
+<script setup lang="ts">
+import { computed, onMounted, onUpdated, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { LineChart } from 'echarts/charts';
+import type { EChartsOption } from 'echarts';
+import {
+  GraphicComponent,
+  GridComponent,
+  LegendComponent,
+  TitleComponent,
+  ToolboxComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import VChart from 'vue-echarts';
+import { useYearConfigStore } from 'src/stores/yearConfig';
+import { useWorkspaceStore } from 'src/stores/workspace';
+import { useModuleStore, useTimelineStore } from 'src/stores/modules';
+import {
+  CHART_CATEGORY_COLOR_SCHEMES,
+  getModuleForCategoryKey,
+  RESULTS_CATEGORY_LABEL_KEYS,
+  RESULTS_CATEGORY_ORDER,
+} from 'src/constant/charts';
+import { MODULE_STATES } from 'src/constant/moduleStates';
+import { formatTonnesForChart } from 'src/utils/number';
+
+interface Props {
+  hideResearchFacilities?: boolean;
+  hideAdditionalData?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  hideResearchFacilities: false,
+  hideAdditionalData: false,
+});
+
+use([
+  CanvasRenderer,
+  LineChart,
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent,
+  ToolboxComponent,
+  GraphicComponent,
+]);
+
+type PopulationRow = { year: number; pop: number };
+
+const { t, te } = useI18n();
+
+const INT_FORMATTER = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+});
+
+const yearConfigStore = useYearConfigStore();
+const workspaceStore = useWorkspaceStore();
+const moduleStore = useModuleStore();
+const timelineStore = useTimelineStore();
+
+const currentYear = computed(
+  () => workspaceStore.selectedYear ?? new Date().getFullYear(),
+);
+
+const YEARS_END = 2040;
+
+const reductionObjectives = computed(() => {
+  const ro = yearConfigStore.config?.config?.reduction_objectives;
+  return ro ?? null;
+});
+
+const epflPopulationRows = computed<PopulationRow[]>(() => {
+  const raw = reductionObjectives.value?.population_projections ?? [];
+  return (raw as unknown[]).filter(Boolean) as PopulationRow[];
+});
+
+const yearsStart = computed(() => {
+  const candidates: number[] = [];
+  for (const r of epflPopulationRows.value) {
+    if (typeof r.year === 'number') candidates.push(r.year);
+  }
+  const rawMin = candidates.length
+    ? Math.min(...candidates)
+    : currentYear.value;
+  return Math.min(Math.max(rawMin, 0), YEARS_END);
+});
+
+const years = computed(() => {
+  const start = yearsStart.value;
+  return Array.from({ length: YEARS_END - start + 1 }, (_, i) => start + i);
+});
+
+function categoryColor(categoryKey: string): string {
+  return CHART_CATEGORY_COLOR_SCHEMES.value[categoryKey] ?? '#CFD4EE';
+}
+
+function categoryLabel(categoryKey: string): string {
+  const labelKey =
+    RESULTS_CATEGORY_LABEL_KEYS[
+      categoryKey as keyof typeof RESULTS_CATEGORY_LABEL_KEYS
+    ];
+  if (labelKey && te(labelKey)) return t(labelKey);
+
+  const mod = getModuleForCategoryKey(categoryKey);
+  if (mod && te(mod)) return t(mod);
+  return categoryKey;
+}
+
+function categoryTooltipKey(categoryKey: string): string {
+  return `results_objectives_unit_category_tooltip_${categoryKey}`;
+}
+
+// ── Unit-mode sliders (right panel) ─────────────────────────────────────────
+const unitScenarioPreset = ref<'bau' | 'middle' | 'ambitious'>('bau');
+const UNIT_CATEGORY_KEYS = RESULTS_CATEGORY_ORDER;
+const ADDITIONAL_UNIT_CATEGORY_KEYS = new Set([
+  'commuting',
+  'food',
+  'waste',
+  'embodied_energy',
+]);
+const TOOLTIP_CATEGORY_ORDER = RESULTS_CATEGORY_ORDER;
+
+type TooltipAxisParam = {
+  axisValue?: string;
+  seriesName?: string;
+  value?: number | (number | null)[] | null;
+};
+
+function normalizeTooltipParams(rawParams: unknown): TooltipAxisParam[] {
+  if (!Array.isArray(rawParams)) return [];
+  return rawParams as TooltipAxisParam[];
+}
+
+function extractTooltipSeriesValue(
+  raw: TooltipAxisParam['value'],
+): number | null {
+  if (typeof raw === 'number') return raw;
+  if (!Array.isArray(raw)) return null;
+  return (raw.length >= 2 ? raw[1] : raw[0]) as number | null;
+}
+
+function formatTooltipTonnes(value: number | null): string {
+  if (value == null) return '-';
+  if (value < 0) return value.toFixed(1);
+  return formatTonnesForChart(value);
+}
+
+function formatTooltipPopulation(value: number | null): string {
+  if (value == null) return '-';
+  return INT_FORMATTER.format(Math.round(value));
+}
+
+function tooltipSortIndex(seriesName: string): number {
+  const idx = TOOLTIP_CATEGORY_ORDER.indexOf(
+    seriesName as (typeof TOOLTIP_CATEGORY_ORDER)[number],
+  );
+  return idx === -1 ? 999 : idx;
+}
+
+function renderTooltipCategoryLines(params: TooltipAxisParam[]): string {
+  return params
+    .filter((p) => p.seriesName && p.value != null)
+    .filter((p) => String(p.seriesName) !== 'population')
+    .sort((a, b) => {
+      const ak = String(a.seriesName ?? '');
+      const bk = String(b.seriesName ?? '');
+      return tooltipSortIndex(ak) - tooltipSortIndex(bk);
+    })
+    .map((p) => {
+      const key = String(p.seriesName);
+      const color = categoryColor(key);
+      const value = extractTooltipSeriesValue(p.value);
+      const formatted = formatTooltipTonnes(value);
+      const label = categoryLabel(key);
+      return `
+        <div style="display:flex;align-items:center;gap:8px;line-height:1.35;">
+          <span style="width:8px;height:8px;border-radius:999px;background:${color};display:inline-block;"></span>
+          <span style="flex:1;opacity:0.9;">${label}</span>
+          <span style="font-variant-numeric:tabular-nums;">${formatted}</span>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function renderTooltipPopulationLine(params: TooltipAxisParam[]): string {
+  const p = params.find(
+    (x) => String(x.seriesName) === 'population' && x.value != null,
+  );
+  if (!p) return '';
+
+  const v = extractTooltipSeriesValue(p.value);
+  const formatted = formatTooltipPopulation(v);
+  const label = t('results_objectives_population_forecast');
+
+  return `
+    <div style="margin-top:6px;padding-top:6px;border-top:1px solid rgba(0,0,0,0.12);">
+      <div style="display:flex;align-items:center;gap:8px;line-height:1.35;">
+        <span style="width:8px;height:8px;border-radius:999px;background:#ff0000;display:inline-block;"></span>
+        <span style="flex:1;opacity:1;">${label}</span>
+        <span style="font-variant-numeric:tabular-nums;">${formatted}</span>
+      </div>
+    </div>
+  `;
+}
+
+function renderTooltipContainer(args: {
+  yearLabel: string;
+  categoryLines: string;
+  populationLine: string;
+}): string {
+  return `<div style="min-width:220px;">
+    <div style="font-weight:600;margin-bottom:6px;">${args.yearLabel}</div>
+    ${args.categoryLines}${args.populationLine}
+  </div>`;
+}
+
+const validatedEmissionCategoryKeys = computed(() => {
+  const list = moduleStore.state.emissionBreakdown?.validated_categories ?? [];
+  return new Set(list);
+});
+
+function isOwningModuleValidated(categoryKey: string): boolean {
+  const mod = getModuleForCategoryKey(categoryKey);
+  if (!mod) return true;
+  return timelineStore.itemStates[mod] === MODULE_STATES.Validated;
+}
+
+function isEmissionCategoryValidated(categoryKey: string): boolean {
+  return validatedEmissionCategoryKeys.value.has(categoryKey);
+}
+
+function isUnitCategoryInteractive(categoryKey: string): boolean {
+  if (categoryKey === 'research_facilities' && props.hideResearchFacilities) {
+    return false;
+  }
+  return (
+    isEmissionCategoryValidated(categoryKey) &&
+    isOwningModuleValidated(categoryKey)
+  );
+}
+
+const visibleUnitCategoryKeys = computed(() =>
+  UNIT_CATEGORY_KEYS.filter((c) => {
+    if (props.hideAdditionalData && ADDITIONAL_UNIT_CATEGORY_KEYS.has(c)) {
+      return false;
+    }
+    return isUnitCategoryInteractive(c);
+  }),
+);
+
+const hasAnyInteractiveUnitCategory = computed(
+  () => visibleUnitCategoryKeys.value.length > 0,
+);
+
+const unitSliderLevels = ref<Record<string, number>>(
+  Object.fromEntries(UNIT_CATEGORY_KEYS.map((c) => [c, 1])),
+);
+
+function annualReductionForLevel(level: number): number {
+  const clamped = Math.max(1, Math.min(5, level));
+  return (clamped - 1) * 0.02;
+}
+
+function applyScenarioPreset(preset: typeof unitScenarioPreset.value) {
+  const level = preset === 'bau' ? 1 : preset === 'middle' ? 3 : 5;
+  if (!hasAnyInteractiveUnitCategory.value) return;
+
+  const next = { ...unitSliderLevels.value };
+  for (const c of visibleUnitCategoryKeys.value) {
+    next[c] = level;
+  }
+  unitSliderLevels.value = next;
+}
+
+const unitScenarioPresetModel = computed({
+  get: () => unitScenarioPreset.value,
+  set: (v: typeof unitScenarioPreset.value) => {
+    unitScenarioPreset.value = v;
+    applyScenarioPreset(v);
+  },
+});
+
+function resetUnitSliders(): void {
+  unitScenarioPreset.value = 'bau';
+  unitSliderLevels.value = Object.fromEntries(
+    UNIT_CATEGORY_KEYS.map((c) => [c, 1]),
+  );
+}
+
+// ── Data fetch ───────────────────────────────────────────────────────────────
+const lastFetchedYear = ref<number | null>(null);
+
+function readCssVarHex(name: string): string | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+const accentColorHex = ref<string | null>(null);
+
+async function ensureYearConfigFetched(): Promise<void> {
+  const y = currentYear.value;
+  if (lastFetchedYear.value === y) return;
+  lastFetchedYear.value = y;
+  await yearConfigStore.fetchConfig(y);
+}
+
+function ensureSlidersResetIfLocked(): void {
+  if (hasAnyInteractiveUnitCategory.value) return;
+  unitSliderLevels.value = Object.fromEntries(
+    UNIT_CATEGORY_KEYS.map((c) => [c, 1]),
+  );
+}
+
+onMounted(async () => {
+  accentColorHex.value = readCssVarHex('--q-accent');
+  await ensureYearConfigFetched();
+  ensureSlidersResetIfLocked();
+});
+
+onUpdated(async () => {
+  await ensureYearConfigFetched();
+  ensureSlidersResetIfLocked();
+});
+
+const populationSeries = computed(() => {
+  const pop = epflPopulationRows.value;
+  if (!pop.length) return null;
+  const popByYear = Object.fromEntries(pop.map((r) => [r.year, r.pop]));
+  const firstPopYear = pop.reduce<number | null>((min, r) => {
+    if (typeof r.year !== 'number') return min;
+    if (typeof r.pop !== 'number') return min;
+    return min == null ? r.year : Math.min(min, r.year);
+  }, null);
+  const firstPopValue =
+    firstPopYear == null ? null : (popByYear[firstPopYear] ?? null);
+
+  return {
+    name: 'population',
+    type: 'line',
+    yAxisIndex: 1,
+    showSymbol: false,
+    symbol: 'circle',
+    symbolSize: 7,
+    zlevel: 6,
+    z: 60,
+    lineStyle: { type: 'dotted', width: 2, color: '#ff0000' },
+    itemStyle: {
+      color: '#ff0000',
+      borderColor: '#ffffff',
+      borderWidth: 2,
+    },
+    data: years.value.map((y) => {
+      const v = popByYear[y];
+      if (typeof v === 'number') return v;
+      if (firstPopYear != null && y < firstPopYear) return firstPopValue;
+      return null;
+    }),
+  };
+});
+
+const unitSeriesData = computed(() => {
+  const payload = moduleStore.state.emissionBreakdown;
+  if (!payload) return null;
+  const breakdown = payload.module_breakdown ?? [];
+  const additionalBreakdown = payload.additional_breakdown ?? [];
+  const baselineYear = Math.min(
+    Math.max(currentYear.value, yearsStart.value),
+    YEARS_END,
+  );
+
+  const baselineByCat: Record<string, number> = {};
+
+  const sumRowTonnes = (row: {
+    emissions?: Array<{ value?: unknown }>;
+  }): number => {
+    const emissions = row.emissions ?? [];
+    return emissions.reduce((s, e) => {
+      const v = typeof e.value === 'number' ? e.value : 0;
+      return s + v;
+    }, 0);
+  };
+
+  for (const row of breakdown) {
+    const key = row.category_key;
+    if (props.hideAdditionalData && ADDITIONAL_UNIT_CATEGORY_KEYS.has(key)) {
+      continue;
+    }
+    if (!isUnitCategoryInteractive(key)) continue;
+    baselineByCat[key] = (baselineByCat[key] ?? 0) + sumRowTonnes(row);
+  }
+
+  for (const row of additionalBreakdown) {
+    const key = row.category_key;
+    if (props.hideAdditionalData && ADDITIONAL_UNIT_CATEGORY_KEYS.has(key)) {
+      continue;
+    }
+    if (
+      !UNIT_CATEGORY_KEYS.includes(key as (typeof UNIT_CATEGORY_KEYS)[number])
+    ) {
+      continue;
+    }
+    if (!isUnitCategoryInteractive(key)) continue;
+    baselineByCat[key] = (baselineByCat[key] ?? 0) + sumRowTonnes(row);
+  }
+
+  const pop = epflPopulationRows.value;
+  const popByYear = Object.fromEntries(pop.map((r) => [r.year, r.pop]));
+  const popBase = popByYear[baselineYear] ?? null;
+
+  const series = visibleUnitCategoryKeys.value
+    .filter((c) => isUnitCategoryInteractive(c) && (baselineByCat[c] ?? 0) > 0)
+    .map((c) => {
+      const color = CHART_CATEGORY_COLOR_SCHEMES.value[c] ?? '#CFD4EE';
+      const level = unitSliderLevels.value[c] ?? 1;
+      const annualReduction = annualReductionForLevel(level);
+
+      const data = years.value.map((y) => {
+        if (y < baselineYear) return null;
+        if (y === baselineYear) return baselineByCat[c] ?? 0;
+
+        const yearsAhead = y - baselineYear;
+        const popFactor = popBase && popByYear[y] ? popByYear[y] / popBase : 1;
+        const reducedFactor = Math.pow(1 - annualReduction, yearsAhead);
+        return (baselineByCat[c] ?? 0) * popFactor * reducedFactor;
+      });
+
+      return {
+        name: c,
+        type: 'line',
+        stack: 'Total',
+        showSymbol: false,
+        symbol: 'circle',
+        symbolSize: 8,
+        lineStyle: { width: 1, color },
+        itemStyle: {
+          color,
+          borderColor: '#ffffff',
+          borderWidth: 2,
+        },
+        areaStyle: { color },
+        emphasis: { focus: 'series' },
+        data,
+      };
+    })
+    .reverse();
+
+  return { stackedSeries: series };
+});
+
+const showUnitEmptyState = computed(() => !hasAnyInteractiveUnitCategory.value);
+
+const chartOption = computed<EChartsOption | null>(() => {
+  const payload = unitSeriesData.value;
+  if (!payload) return null;
+  const popSeries = populationSeries.value;
+
+  return {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+        label: { backgroundColor: '#6a7985' },
+      },
+      formatter: (rawParams: unknown) => {
+        const params = normalizeTooltipParams(rawParams);
+        const yearLabel = String(params[0]?.axisValue ?? '');
+
+        return renderTooltipContainer({
+          yearLabel,
+          categoryLines: renderTooltipCategoryLines(params),
+          populationLine: renderTooltipPopulationLine(params),
+        });
+      },
+    },
+    legend: { show: false },
+    grid: {
+      left: 48,
+      right: 64,
+      top: 24,
+      bottom: 24,
+      containLabel: true,
+    },
+    xAxis: [
+      {
+        type: 'category',
+        boundaryGap: false,
+        axisLabel: { interval: 0 },
+        axisTick: { interval: 0, alignWithLabel: true },
+        data: years.value.map(String),
+      },
+    ],
+    yAxis: [
+      {
+        type: 'value',
+        name: t('results_units_tonnes'),
+        min: 0,
+        nameGap: 36,
+        nameLocation: 'middle',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { formatter: (v: number) => `${v.toFixed(1)}` },
+        splitLine: { show: false },
+      },
+      {
+        type: 'value',
+        name: t('results_objectives_population_axis'),
+        min: 0,
+        position: 'right',
+        nameGap: 56,
+        nameLocation: 'middle',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { formatter: (v: number) => INT_FORMATTER.format(v) },
+        splitLine: { show: false },
+      },
+    ],
+    series: popSeries
+      ? [...payload.stackedSeries, popSeries]
+      : [...payload.stackedSeries],
+  } as EChartsOption;
+});
+</script>
+
+<template>
+  <div class="row items-stretch q-col-gutter-md">
+    <div v-if="showUnitEmptyState" class="col-12">
+      <q-card flat class="objective-empty-card">
+        <q-card-section class="objective-empty-card__content">
+          <q-icon name="o_info" size="md" color="accent" class="q-mb-md" />
+          <div class="text-h6 text-weight-medium text-center q-mb-sm">
+            {{ $t('results_objectives_unit_no_validated_title') }}
+          </div>
+          <div class="text-body2 text-secondary text-center">
+            {{ $t('results_objectives_unit_no_validated_message') }}
+          </div>
+        </q-card-section>
+      </q-card>
+    </div>
+
+    <div v-else class="col-12 col-lg">
+      <div class="objective-chart">
+        <VChart
+          v-if="chartOption"
+          :option="chartOption"
+          autoresize
+          class="objective-chart__canvas"
+        />
+        <div v-else class="objective-chart__empty" />
+      </div>
+    </div>
+
+    <div v-if="!showUnitEmptyState" class="col-12 col-lg-3">
+      <section class="unit-controls">
+        <div class="q-pt-xl q-px-lg">
+          <div class="row items-center justify-between q-mb-xs">
+            <div class="text-caption text-secondary">Scenario</div>
+            <q-btn
+              no-caps
+              unelevated
+              outline
+              color="accent"
+              label="Reset"
+              size="sm"
+              class="text-weight-medium"
+              :disable="!hasAnyInteractiveUnitCategory"
+              @click="resetUnitSliders"
+            />
+          </div>
+          <q-select
+            v-model="unitScenarioPresetModel"
+            dense
+            outlined
+            emit-value
+            map-options
+            hide-bottom-space
+            :disable="!hasAnyInteractiveUnitCategory"
+            :options="[
+              { label: 'BAU', value: 'bau' },
+              { label: 'Middle of the road', value: 'middle' },
+              { label: 'Ambitious', value: 'ambitious' },
+            ]"
+          />
+        </div>
+
+        <q-separator class="q-my-lg" />
+
+        <div class="unit-controls__sliders">
+          <div class="unit-controls__scroll column">
+            <div
+              v-for="cat in visibleUnitCategoryKeys"
+              :key="cat"
+              class="objective-slider q-px-xl"
+              :style="{ '--cat-color': categoryColor(cat) }"
+            >
+              <div class="objective-slider__header">
+                <div class="objective-slider__label text-caption text-primary">
+                  <span class="objective-slider__label-text">
+                    {{ categoryLabel(cat) }}
+                  </span>
+                  <q-icon
+                    name="o_info"
+                    size="14px"
+                    class="objective-slider__label-info text-secondary"
+                  >
+                    <q-tooltip class="text-body2 text-black" max-width="260px">
+                      {{
+                        $t(categoryTooltipKey(cat), {
+                          category: categoryLabel(cat),
+                        })
+                      }}
+                    </q-tooltip>
+                  </q-icon>
+                </div>
+                <div class="objective-slider__value text-caption text-primary">
+                  {{ unitSliderLevels[cat] }}
+                </div>
+              </div>
+              <q-slider
+                v-model="unitSliderLevels[cat]"
+                :min="1"
+                :max="5"
+                :step="1"
+                snap
+                dense
+                track-color="grey-4"
+                thumb-size="12px"
+                track-size="2px"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.objective-chart {
+  height: 100%;
+  min-height: 620px;
+}
+
+.objective-chart__canvas {
+  width: 100%;
+  height: 100%;
+  min-height: 620px;
+}
+
+.objective-chart__empty {
+  height: 100%;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.01);
+  border: 1px dashed rgba(0, 0, 0, 0.01);
+  border-radius: 8px;
+}
+
+.objective-empty-card {
+  min-height: 620px;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.objective-empty-card__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+}
+
+.unit-controls {
+  height: 100%;
+  min-height: 620px;
+  background: transparent;
+  margin: 0;
+  box-sizing: border-box;
+  border-left: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.unit-controls__sliders {
+  overflow: visible;
+}
+
+.unit-controls :deep(.q-slider__marker-labels),
+.unit-controls :deep(.q-slider__markers) {
+  display: none;
+}
+
+.unit-controls :deep(.q-slider) {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.unit-controls__scroll {
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 520px;
+}
+
+/* Minimal override: allow per-category HEX colors for thumb + selection. */
+.objective-slider :deep(.q-slider__selection),
+.objective-slider :deep(.q-slider__selection-bar),
+.objective-slider :deep(.q-slider__selection-area) {
+  background: var(--cat-color) !important;
+}
+
+.objective-slider :deep(.q-slider__thumb) {
+  background: var(--cat-color) !important;
+  color: var(--cat-color) !important;
+  border-radius: 999px !important;
+}
+
+.objective-slider__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  column-gap: 12px;
+}
+
+.objective-slider__label {
+  min-width: 0;
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 6px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.55;
+}
+
+.objective-slider__label-text {
+  min-width: 0;
+}
+
+.objective-slider__label-info {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.objective-slider__value {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  line-height: 1.5;
+}
+</style>

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -218,13 +218,9 @@ const moduleTreemapData = computed(() => {
   const breakdown = moduleStore.state.emissionBreakdown?.module_breakdown;
   if (!breakdown || breakdown.length === 0) return [];
   const categories = MODULE_TO_CATEGORIES.value[props.type] ?? [];
-  const canonicalizeCategoryKey = (raw: unknown): string => {
-    const key = String(raw ?? '');
-    return key === 'purchase' ? 'purchases' : key;
-  };
   const getRowCategoryKey = (row: Record<string, unknown>): string =>
-    canonicalizeCategoryKey(
-      (row as { category_key?: unknown }).category_key ?? row.category,
+    String(
+      (row as { category_key?: unknown }).category_key ?? row.category ?? '',
     );
 
   const filteredKeys = Object.fromEntries(
@@ -241,13 +237,9 @@ const moduleCategoryRows = computed(() => {
   const breakdown = moduleStore.state.emissionBreakdown;
   if (!breakdown) return [];
   const categories = MODULE_TO_CATEGORIES.value[props.type] ?? [];
-  const canonicalizeCategoryKey = (raw: unknown): string => {
-    const key = String(raw ?? '');
-    return key === 'purchase' ? 'purchases' : key;
-  };
   const getRowCategoryKey = (row: Record<string, unknown>): string =>
-    canonicalizeCategoryKey(
-      (row as { category_key?: unknown }).category_key ?? row.category,
+    String(
+      (row as { category_key?: unknown }).category_key ?? row.category ?? '',
     );
 
   return breakdown.module_breakdown.filter((row) =>

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue';
 import { useColorblindStore } from 'src/stores/colorblind';
 import { storeToRefs } from 'pinia';
-import { MODULES } from './modules';
+import { MODULES, type Module } from './modules';
 
 /** Interpolate between two `#RRGGBB` colours. */
 function lerpHex(a: string, b: string, t: number): string {
@@ -341,15 +341,50 @@ export const CHART_CATEGORY_COLOR_SCHEMES = computed(() => ({
   buildings_energy_combustion: colors.value.apricot.darker,
   buildings_room: colors.value.lilac.darker,
   equipment: colors.value.plum.darker,
-  external_cloud_and_ai: colors.value.lavender.dark,
-  purchases: colors.value.lavender.darker,
+  external_cloud_and_ai: colors.value.lavender.darker,
+  purchases: colors.value.lightGreen.darker,
   research_facilities: colors.value.paleYellowGreen.darker,
   professional_travel: colors.value.babyBlue.darker,
   commuting: colors.value.aqua.darker,
   food: colors.value.mint.darker,
   waste: colors.value.periwinkle.darker,
-  embodied_energy: colors.value.skyBlue.dark,
+  embodied_energy: colors.value.skyBlue.darker,
 }));
+
+/** Category ordering shared across Results charts (Reduction objectives, tooltips, sliders). */
+export const RESULTS_CATEGORY_ORDER = [
+  'process_emissions',
+  'buildings_energy_combustion',
+  'buildings_room',
+  'equipment',
+  'external_cloud_and_ai',
+  'professional_travel',
+  'purchases',
+  'research_facilities',
+  'commuting',
+  'food',
+  'waste',
+  'embodied_energy',
+] as const;
+
+/** Category key → i18n key for consistent Results chart labels. */
+export const RESULTS_CATEGORY_LABEL_KEYS: Record<
+  (typeof RESULTS_CATEGORY_ORDER)[number],
+  string
+> = {
+  process_emissions: 'charts-process-emissions-category',
+  buildings_room: 'charts-buildings-room-category',
+  buildings_energy_combustion: 'charts-buildings-energy-combustion-category',
+  equipment: 'charts-equipment-electric-consumption-category',
+  external_cloud_and_ai: 'charts-external-cloud-category',
+  purchases: 'charts-purchases-category',
+  research_facilities: 'charts-research-facilities-category',
+  professional_travel: 'charts-professional-travel-category',
+  commuting: 'charts-commuting-category',
+  food: 'charts-food-category',
+  waste: 'charts-waste-category',
+  embodied_energy: 'charts-embodied-energy-category',
+};
 
 // Maps chart category name -> full color scale (shared across charts)
 export const CHART_CATEGORY_COLOR_SCALES = computed(() => ({
@@ -515,6 +550,13 @@ export const MODULE_TO_CATEGORIES = computed(
     [MODULES.ResearchFacilities]: ['research_facilities'],
   }),
 );
+
+export function getModuleForCategoryKey(categoryKey: string): Module | null {
+  for (const [mod, categories] of Object.entries(MODULE_TO_CATEGORIES.value)) {
+    if (categories.includes(categoryKey)) return mod as Module;
+  }
+  return null;
+}
 
 // Helper function to add 0.5 opacity to hex color for uncertainty visualization using hex8 format
 export const uncertaintyColor = (hex: string): string => {

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -39,6 +39,18 @@ export default {
     en: 't CO₂-eq',
     fr: 't CO₂-eq',
   },
+  results_units_population: {
+    en: 'population',
+    fr: 'population',
+  },
+  results_objectives_population_forecast: {
+    en: 'EPFL population forecast',
+    fr: 'Prévision de la population EPFL',
+  },
+  results_objectives_population_axis: {
+    en: 'EPFL population',
+    fr: 'Population EPFL',
+  },
   results_kg_co2eq_per_km: {
     en: 'kg CO₂-eq/km',
     fr: 'kg CO₂-eq/km',
@@ -236,12 +248,116 @@ export default {
     fr: 'Aucune donnée de construction ou rénovation pour ce rapport. Veuillez renseigner les données de bâtiments pour voir les répartitions.',
   },
   results_objectives_2040_title: {
-    en: 'Reduction objective 2040',
-    fr: 'Objectif de réduction 2040',
+    en: '2040 Reduction goal',
+    fr: 'Objectif de réduction 2040 ',
+  },
+  results_objectives_2040_section_subtitle: {
+    en: 'CO₂ emissions trajectory between now and 2040',
+    fr: 'Trajectoire des émissions CO₂ d’ici à 2040',
   },
   results_objectives_2040_subtitle: {
-    en: 'Comparison with intermediate long-term objectives',
-    fr: 'Comparaison avec les objectifs intermédiaires à long terme',
+    en: 'The goal is to reach -40% by 2030 and -90% by 2040 with respect to 2019. The overall goal is net zero by 2040.',
+    fr: "L’objectif est de -40 % d'ici 2030 et -90 % d'ici 2040 par rapport à 2019. L'objectif global est d'atteindre la neutralité carbone d'ici 2040.",
+  },
+  results_objectives_2040_subtitle_link_label: {
+    en: 'Study',
+    fr: 'Étude',
+  },
+  results_objectives_unit_category_tooltip_process_emissions: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_buildings_energy_combustion: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_buildings_room: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_equipment: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_external_cloud_and_ai: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_purchases: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_research_facilities: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_professional_travel: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_commuting: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_food: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_waste: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_unit_category_tooltip_embodied_energy: {
+    en: 'Placeholder tooltip for {category}',
+    fr: 'Texte placeholder pour {category}',
+  },
+  results_objectives_2040_epfl_button: {
+    en: 'EPFL',
+    fr: 'EPFL',
+  },
+  results_objectives_2040_unit_button: {
+    en: 'My unit',
+    fr: 'Mon unité',
+  },
+  results_objectives_2030_tooltip: {
+    en: "This section presents two graphs. The first illustrates the reference “net zero” trajectory for EPFL, aligned with the CO₂ emission reduction targets set by the Swiss Confederation and the Climate Act. The second allows you to simulate the evolution of your unit's emissions and adjust each category in order to converge towards this reference trajectory.",
+    fr: 'Cette section présente deux graphiques. Le premier illustre la trajectoire « net zéro » de référence pour l’EPFL, alignée sur les objectifs de réduction des émissions de CO₂ fixés par la Confédération et la Loi Climat. Le second vous permet de simuler l’évolution des émissions de votre unité et d’ajuster chaque catégorie afin de converger vers cette trajectoire de référence.',
+  },
+  results_objectives_epfl_chart_title: {
+    en: 'EPFL carbon footprint goals over the years',
+    fr: 'Objectifs CO2 de l’EPFL au fil des années',
+  },
+  results_objectives_epfl_chart_tooltip: {
+    en: 'The goal is to reach -40% by 2030 and -90% by 2040 with respect to 2019. The overall goal is net zero by 2040.',
+    fr: "L’objectif est de -40 % d'ici 2030 et -90 % d'ici 2040 par rapport à 2019. L'objectif global est d'atteindre la neutralité carbone d'ici 2040.",
+  },
+  results_objectives_total: {
+    en: 'Total carbon footprint',
+    fr: 'Emission totale',
+  },
+  results_objectives_unit_chart_title: {
+    en: 'My unit carbon footprint by category over the years',
+    fr: 'Empreinte carbone de mon unité par catégorie au fil des années',
+  },
+  results_objectives_unit_chart_tooltip: {
+    en: 'Play around with the different reduction sliders to see if your unit can follow the EPFL objective trajectory.',
+    fr: "Jouez avec les différents curseurs de réduction pour voir si votre unité peut suivre la trajectoire des objectifs de l'EPFL.",
+  },
+  results_objectives_epfl_no_data_title: {
+    en: 'EPFL objectives not available yet',
+    fr: 'Objectifs EPFL pas encore disponibles',
+  },
+  results_objectives_epfl_no_data_message: {
+    en: 'EPFL reduction objectives data has not been loaded yet.',
+    fr: "Les données d'objectifs de réduction EPFL ne sont pas encore chargées.",
+  },
+  results_objectives_unit_no_validated_title: {
+    en: 'Validate modules to see reduction objectives',
+    fr: 'Validez des modules pour voir les objectifs de réduction',
+  },
+  results_objectives_unit_no_validated_message: {
+    en: 'Validate at least one module/category to unlock the unit simulation sliders.',
+    fr: 'Validez au moins un module/catégorie pour déverrouiller les curseurs de simulation.',
   },
   results_additional_data: {
     en: 'Additional data',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -27,6 +27,7 @@ import { IT_FOCUS_SOURCE_MODULES } from 'src/constant/itFocus';
 import { MODULE_STATES, getModuleTypeId } from 'src/constant/moduleStates';
 import { useI18n } from 'vue-i18n';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import ReductionObjectiveChart from 'src/components/charts/results/ReductionObjectiveChart.vue';
 
 const yearConfigStore = useYearConfigStore();
 
@@ -627,31 +628,12 @@ const getUncertainty = (
         </div>
       </q-card>
 
-      <q-card v-if="mountBelowFold" flat bordered class="q-pa-lg defer-render">
-        <div class="flex justify-between items-center">
-          <div>
-            <h2 class="text-h2 text-weight-medium">
-              {{ $t('results_objectives_2040_title') }}
-            </h2>
-            <span class="text-body1 text-secondary">{{
-              $t('results_objectives_2040_subtitle')
-            }}</span>
-          </div>
-        </div>
-        <q-card-section class="q-px-none q-pt-lg q-pb-none">
-          <div class="objectives-placeholder-frame">
-            <img
-              src="/placeholder.svg"
-              alt=""
-              width="1380"
-              height="500"
-              loading="lazy"
-              decoding="async"
-              fetchpriority="low"
-              class="objectives-placeholder-image"
-            />
-          </div>
-        </q-card-section>
+      <!-- Reduction Objective -->
+      <q-card v-if="mountBelowFold" flat bordered class="defer-render">
+        <ReductionObjectiveChart
+          :hide-research-facilities="hideResearchFacilities"
+          :hide-additional-data="hideAdditionalData"
+        />
       </q-card>
 
       <div v-if="mountBelowFold" class="defer-render">

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -428,9 +428,28 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     );
   }
 
+  /** True when reduction objectives goals or CSV files are not fully configured. */
+  const isReductionObjectiveIncomplete = computed(() => {
+    if (!config.value) return false;
+    const ro = config.value.config?.reduction_objectives;
+    if (!ro) return true;
+    const hasGoal = ro.goals.some(
+      (g) => g.target_year > 0 && g.reference_year > 0,
+    );
+    const files = ro.files;
+    const allFilesUploaded =
+      !!files?.institutional_footprint &&
+      !!files?.population_projections &&
+      !!files?.unit_scenarios;
+    return !hasGoal || !allFilesUploaded;
+  });
+
   /** True when any enabled module has mandatory uploads missing or failed. */
   const anyModuleIncomplete = computed(
-    () => !!config.value && MODULES_LIST.some((m) => isModuleIncomplete(m)),
+    () =>
+      !!config.value &&
+      (MODULES_LIST.some((m) => isModuleIncomplete(m)) ||
+        isReductionObjectiveIncomplete.value),
   );
 
   function getModuleConfig(module: Module): ModuleConfig | null {
@@ -469,6 +488,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     notFound,
     // Computed
     anyModuleIncomplete,
+    isReductionObjectiveIncomplete,
     unifiedModuleConfig,
     visibleModules,
     recalculationStatus,


### PR DESCRIPTION
## What does this change?

This PR introduces the **Reduction Objective (2040) feature** in the Results page, replacing the placeholder with a fully interactive chart and simulation system.

Key additions:
- New `ReductionObjectiveChart` component with:
  - Stacked emissions projection by category
  - Population projection overlay
  - Interactive sliders to simulate reduction scenarios per category
  - Scenario presets (BAU, Middle, Ambitious)
- Dynamic filtering of categories based on validation state
- Integration with `yearConfig` to fetch reduction objectives and population data
- New shared constants:
  - `RESULTS_CATEGORY_ORDER`
  - `RESULTS_CATEGORY_LABEL_KEYS`
- Improved category handling (removed legacy canonicalization like `purchase → purchases`)
- Updated color mappings for consistency across charts
- New i18n keys for objectives, tooltips, and UI labels
- Detection of incomplete reduction objective configuration in store

## Why is this needed?

Previously, the Results page displayed a static placeholder for reduction objectives.

This change:
- Enables **real simulation of emissions trajectories** at unit level
- Allows users to **experiment with reduction strategies per category**
- Aligns unit projections with **EPFL’s long-term climate targets (2030 / 2040)**
- Improves clarity and consistency across charts (labels, colors, ordering)
- Ensures the feature is only usable when relevant data is validated and available

## Type of change

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [x] 📝 Documentation update  
- [x] 🎨 Design/UI improvement  
- [x] 🔧 Configuration change  
- [ ] 🧹 Code cleanup  


## Related issues

- Closes #476
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.