### PR TITLE
feat/854 unified ECharts tooltip component v2

### DIFF
--- a/frontend/src/components/charts/EvolutionOverTimeChart.vue
+++ b/frontend/src/components/charts/EvolutionOverTimeChart.vue
@@ -129,15 +129,25 @@ const chartOption = computed((): EChartsOption => {
       trigger: 'axis',
       formatter: (params: unknown) => {
         const arr = Array.isArray(params) ? params : [];
-        if (!arr.length) { emitTooltip(null); return ''; }
-        const title = arr[0].axisValue != null ? String(arr[0].axisValue) : undefined;
+        if (!arr.length) {
+          emitTooltip(null);
+          return '';
+        }
+        const title =
+          arr[0].axisValue != null ? String(arr[0].axisValue) : undefined;
         emitTooltip({
           title,
-          rows: arr.map((item: { seriesName?: string; value?: number; color?: string }) => ({
-            label: item.seriesName ?? '',
-            value: item.value != null ? item.value.toFixed(0) : '-',
-            color: item.color ?? '#888',
-          })),
+          rows: arr.map(
+            (item: {
+              seriesName?: string;
+              value?: number;
+              color?: string;
+            }) => ({
+              label: item.seriesName ?? '',
+              value: item.value != null ? item.value.toFixed(0) : '-',
+              color: item.color ?? '#888',
+            }),
+          ),
         });
         return '';
       },

--- a/frontend/src/components/charts/EvolutionOverTimeChart.vue
+++ b/frontend/src/components/charts/EvolutionOverTimeChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch, onMounted } from 'vue';
+import { computed, nextTick, ref, watch, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -11,6 +11,8 @@ import {
   GridComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from './results/TooltipEcharts.vue';
+import { useEchartsTooltip } from './results/useEchartsTooltip';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 
@@ -126,22 +128,18 @@ const chartOption = computed((): EChartsOption => {
     tooltip: {
       trigger: 'axis',
       formatter: (params: unknown) => {
-        const p = params as Array<{
-          seriesName?: string;
-          value?: number;
-          color?: string;
-          axisValue?: string | number;
-        }>;
-        if (!p || p.length === 0) {
-          return '';
-        }
-        const heading = p[0].axisValue != null ? String(p[0].axisValue) : '';
-        let tooltip = heading ? `<strong>${heading}</strong><br/>` : '';
-        p.forEach((item) => {
-          tooltip += `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:${item.color};"></span>`;
-          tooltip += `${item.seriesName}: <strong>${item.value?.toFixed(0)}</strong><br/>`;
+        const arr = Array.isArray(params) ? params : [];
+        if (!arr.length) { emitTooltip(null); return ''; }
+        const title = arr[0].axisValue != null ? String(arr[0].axisValue) : undefined;
+        emitTooltip({
+          title,
+          rows: arr.map((item: { seriesName?: string; value?: number; color?: string }) => ({
+            label: item.seriesName ?? '',
+            value: item.value != null ? item.value.toFixed(0) : '-',
+            color: item.color ?? '#888',
+          })),
         });
-        return tooltip;
+        return '';
       },
     },
     legend: {
@@ -243,6 +241,14 @@ const chartOption = computed((): EChartsOption => {
 });
 
 const chartRef = ref<InstanceType<typeof VChart>>();
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
 </script>
 
 <template>
@@ -271,7 +277,15 @@ const chartRef = ref<InstanceType<typeof VChart>>();
       class="chart"
       autoresize
       :option="chartOption"
+      @vue:mounted="onChartReady"
     />
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </q-card-section>
 </template>
 

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -12,10 +12,13 @@ import {
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 import EvolutionOverTimeChart from './EvolutionOverTimeChart.vue';
+import TooltipEcharts from './results/TooltipEcharts.vue';
+import { useEchartsTooltip } from './results/useEchartsTooltip';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 
 import type { EmissionTreemapCategory } from 'src/composables/useEmissionTreemap';
+import { formatTonnesForChart } from 'src/utils/number';
 
 const { t } = useI18n();
 const moduleStore = useModuleStore();
@@ -165,15 +168,19 @@ const chartOption = computed((): EChartsOption => {
       formatter: (params: unknown) => {
         const p = params as {
           seriesName?: string;
-          marker?: string;
+          color?: string;
           data?: { value: number; originalValue: number };
         };
         const val = p.data?.originalValue ?? 0;
-        if (val <= 0) return '';
-        return (
-          `${p.marker || ''} <strong>${p.seriesName || ''}</strong><br/>` +
-          `${p.seriesName || ''}: <strong>${val.toFixed(1)}</strong>`
-        );
+        if (val <= 0) { emitTooltip(null); return ''; }
+        emitTooltip({
+          rows: [{
+            label: p.seriesName ?? '',
+            value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+            color: p.color ?? '#888',
+          }],
+        });
+        return '';
       },
     },
     legend: { show: false },
@@ -205,6 +212,15 @@ const chartOption = computed((): EChartsOption => {
 });
 
 const chartRef = ref<InstanceType<typeof VChart>>();
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
+
 const showEvolutionDialogRef = ref(false);
 
 const hasMultipleYears = computed(() => {
@@ -302,7 +318,15 @@ const babyBlueScheme = computed(() => {
       autoresize
       :option="chartOption"
       :style="{ height: height ?? '200px' }"
+      @vue:mounted="onChartReady"
     />
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </q-card-section>
 
   <q-dialog v-model="isEvolutionDialogOpen">

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -172,13 +172,18 @@ const chartOption = computed((): EChartsOption => {
           data?: { value: number; originalValue: number };
         };
         const val = p.data?.originalValue ?? 0;
-        if (val <= 0) { emitTooltip(null); return ''; }
+        if (val <= 0) {
+          emitTooltip(null);
+          return '';
+        }
         emitTooltip({
-          rows: [{
-            label: p.seriesName ?? '',
-            value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
-            color: p.color ?? '#888',
-          }],
+          rows: [
+            {
+              label: p.seriesName ?? '',
+              value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+              color: p.color ?? '#888',
+            },
+          ],
         });
         return '';
       },

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -5,6 +5,7 @@ import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart } from 'echarts/charts';
 import TooltipEcharts from './TooltipEcharts.vue';
+import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
 import type { EChartsOption } from 'echarts';
 import { graphic } from 'echarts';
 import { CHART_CATEGORY_COLOR_SCHEMES, colors } from 'src/constant/charts';
@@ -343,36 +344,36 @@ const chartOption = computed((): EChartsOption => {
         type: 'shadow',
       },
       formatter: (params: unknown) => {
-        emitTooltip(params);
+        const arr = Array.isArray(params) ? params : params ? [params] : [];
+        if (!arr.length) {
+          emitTooltip(null);
+          return '';
+        }
+
+        const firstParam = arr[0] as Record<string, unknown>;
+        const data = firstParam.data as Record<string, unknown> | undefined;
+        const title = String(firstParam.axisValue ?? firstParam.name ?? '');
+
+        const rows: TooltipRow[] = [];
+
+        for (const param of [...arr].reverse()) {
+          const p = param as Record<string, unknown>;
+          const series = seriesArray.find((s) => s.name === p.seriesName);
+          const key = series?.encode.y;
+          const dataValue = Number(data?.[key]) || 0;
+          if (dataValue > 0 && series) {
+            rows.push({
+              label: series.name,
+              value: formatTonnesForChart(dataValue),
+              color: (series.itemStyle?.color as string) ?? '#888',
+            });
+          }
+        }
+
+        const state: TooltipState = { title, rows };
+        emitTooltip(state);
         return '';
       },
-      // formatter: (params: unknown) => {
-      //   const arr = Array.isArray(params) ? params : params ? [params] : [];
-      //   if (!arr.length) return '';
-
-      //   const firstParam = arr[0] as Record<string, unknown>;
-      //   const data = firstParam.data as Record<string, unknown> | undefined;
-      //   const name = (firstParam.axisValue || firstParam.name || '') as string;
-
-      //   let total = 0;
-      //   let tooltip = `<strong>${name}</strong><br/>`;
-
-      //   arr.reverse().forEach((param) => {
-      //     const p = param as Record<string, unknown>;
-      //     const series = seriesArray.find((s) => s.name === p.seriesName);
-      //     const key = series?.encode.y;
-      //     const dataValue = Number(data?.[key]) || 0;
-
-      //     if (dataValue > 0) {
-      //       tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
-      //       total += dataValue;
-      //     }
-      //   });
-
-      //   const totalDisplay = formatTonnesForChart(total);
-
-      //   return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;
-      // },
     },
 
     grid: {
@@ -564,14 +565,11 @@ const downloadCSV = () => {
           :option="chartOption"
           @vue:mounted="onChartReady"
         />
-        <!-- ✅ REAL VUE TOOLTIP -->
         <Teleport to="body">
-          {{ tooltip.x }} {{ tooltip.y }} {{ style }}
           <tooltip-echarts
             v-if="tooltip.visible"
-            :data="tooltip.data"
+            :tooltip-state="tooltip.data"
             :style="style"
-            class="echart-tooltip"
           />
         </Teleport>
       </q-card-section>

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart } from 'echarts/charts';
+import TooltipEcharts from './TooltipEcharts.vue';
 import type { EChartsOption } from 'echarts';
 import { graphic } from 'echarts';
 import { CHART_CATEGORY_COLOR_SCHEMES, colors } from 'src/constant/charts';
@@ -15,6 +16,8 @@ import {
   GraphicComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+
+import { useEchartsTooltip } from './useEchartsTooltip';
 
 use([
   CanvasRenderer,
@@ -42,15 +45,34 @@ const toggleAdditionalData = ref(false);
 const effectiveToggle = computed(
   () => props.viewAdditionalData ?? toggleAdditionalData.value,
 );
+
+// ✅ TOOLTIP COMPOSABLE
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const chartRef = ref<InstanceType<typeof VChart>>();
+
+const onChartReady = async () => {
+  await nextTick();
+
+  const chart = chartRef.value?.chart;
+
+  if (!chart) {
+    console.warn('ECharts instance not ready yet');
+    return;
+  }
+
+  attach(chart);
+};
+
 const SHOW_EPFL_REFERENCE_ROW = false;
 const SHOW_OBJECTIVE_ROW = false;
 const SHOW_OBJECTIVE_BAR = SHOW_OBJECTIVE_ROW;
 
+// --- KEEP ALL YOUR EXISTING COMPUTEDS UNCHANGED ---
+
 const validatedPPKeys = computed(() => {
   if (!props.validatedCategories) return new Set<string>();
-  const keys = new Set(props.validatedCategories);
-
-  return new Set(keys);
+  return new Set(props.validatedCategories);
 });
 
 const myUnitRow = computed<Record<string, unknown>>(() => {
@@ -106,7 +128,6 @@ const datasetSource = computed(() => {
 
 const additionalSeriesData = computed(() => {
   if (!effectiveToggle.value) return [];
-
   return [
     {
       name: t('charts-commuting-category'),
@@ -321,34 +342,37 @@ const chartOption = computed((): EChartsOption => {
       axisPointer: {
         type: 'shadow',
       },
-
       formatter: (params: unknown) => {
-        const arr = Array.isArray(params) ? params : params ? [params] : [];
-        if (!arr.length) return '';
-
-        const firstParam = arr[0] as Record<string, unknown>;
-        const data = firstParam.data as Record<string, unknown> | undefined;
-        const name = (firstParam.axisValue || firstParam.name || '') as string;
-
-        let total = 0;
-        let tooltip = `<strong>${name}</strong><br/>`;
-
-        arr.reverse().forEach((param) => {
-          const p = param as Record<string, unknown>;
-          const series = seriesArray.find((s) => s.name === p.seriesName);
-          const key = series?.encode.y;
-          const dataValue = Number(data?.[key]) || 0;
-
-          if (dataValue > 0) {
-            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
-            total += dataValue;
-          }
-        });
-
-        const totalDisplay = formatTonnesForChart(total);
-
-        return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;
+        emitTooltip(params);
+        return '';
       },
+      // formatter: (params: unknown) => {
+      //   const arr = Array.isArray(params) ? params : params ? [params] : [];
+      //   if (!arr.length) return '';
+
+      //   const firstParam = arr[0] as Record<string, unknown>;
+      //   const data = firstParam.data as Record<string, unknown> | undefined;
+      //   const name = (firstParam.axisValue || firstParam.name || '') as string;
+
+      //   let total = 0;
+      //   let tooltip = `<strong>${name}</strong><br/>`;
+
+      //   arr.reverse().forEach((param) => {
+      //     const p = param as Record<string, unknown>;
+      //     const series = seriesArray.find((s) => s.name === p.seriesName);
+      //     const key = series?.encode.y;
+      //     const dataValue = Number(data?.[key]) || 0;
+
+      //     if (dataValue > 0) {
+      //       tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
+      //       total += dataValue;
+      //     }
+      //   });
+
+      //   const totalDisplay = formatTonnesForChart(total);
+
+      //   return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;
+      // },
     },
 
     grid: {
@@ -358,6 +382,7 @@ const chartOption = computed((): EChartsOption => {
       bottom: '0%',
       containLabel: true,
     },
+
     xAxis: {
       type: 'category',
       axisLabel: {
@@ -366,6 +391,7 @@ const chartOption = computed((): EChartsOption => {
         fontSize: 11,
       },
     },
+
     yAxis: {
       type: 'value',
       name: t('tco2eq'),
@@ -380,6 +406,7 @@ const chartOption = computed((): EChartsOption => {
         formatter: '{value}',
       },
     },
+
     graphic: [
       {
         type: 'rect',
@@ -403,6 +430,7 @@ const chartOption = computed((): EChartsOption => {
         },
       },
     ],
+
     dataset: {
       dimensions: [
         'category',
@@ -425,8 +453,6 @@ const chartOption = computed((): EChartsOption => {
     series: seriesArray as echarts.SeriesOption[],
   };
 });
-
-const chartRef = ref<InstanceType<typeof VChart>>();
 
 const downloadPNG = async () => {
   const chart = chartRef.value?.chart;
@@ -536,7 +562,18 @@ const downloadCSV = () => {
           class="chart"
           autoresize
           :option="chartOption"
+          @vue:mounted="onChartReady"
         />
+        <!-- ✅ REAL VUE TOOLTIP -->
+        <Teleport to="body">
+          {{ tooltip.x }} {{ tooltip.y }} {{ style }}
+          <tooltip-echarts
+            v-if="tooltip.visible"
+            :data="tooltip.data"
+            :style="style"
+            class="echart-tooltip"
+          />
+        </Teleport>
       </q-card-section>
     </template>
 

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -17,6 +17,8 @@ import {
   DatasetComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from './TooltipEcharts.vue';
+import { useEchartsTooltip } from './useEchartsTooltip';
 
 use([
   CanvasRenderer,
@@ -367,15 +369,22 @@ const chartOption = computed((): EChartsOption => {
       formatter: (params: unknown) => {
         const p = params as {
           seriesName?: string;
-          marker?: string;
+          color?: string;
           seriesIndex?: number;
           data?: Record<string, unknown>;
         };
         const dimKey = segmentKeys[p.seriesIndex ?? 0];
         const row = p.data;
         const val = row && dimKey !== undefined ? Number(row[dimKey]) || 0 : 0;
-        if (val <= 0) return '';
-        return `${p.marker || ''} <strong>${p.seriesName || ''}</strong>: ${formatTonnesForChart(val)}${t('results_units_tonnes')}`;
+        if (val <= 0) { emitTooltip(null); return ''; }
+        emitTooltip({
+          rows: [{
+            label: p.seriesName ?? '',
+            value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+            color: p.color ?? '#888',
+          }],
+        });
+        return '';
       },
     },
     legend: { show: false },
@@ -415,6 +424,16 @@ const chartHeight = computed(() => {
   const barCount = chartData.value.bars.length;
   return Math.max(200, barCount * 60 + 60);
 });
+
+const chartRef = ref<InstanceType<typeof VChart>>();
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
 </script>
 
 <template>
@@ -422,15 +441,24 @@ const chartHeight = computed(() => {
     <div class="flex justify-center items-center">
       <v-chart
         v-if="chartData.bars.length"
+        ref="chartRef"
         class="chart"
         autoresize
         :option="chartOption"
         :style="{ height: chartHeight + 'px' }"
+        @vue:mounted="onChartReady"
       />
       <span v-else class="text-body2 text-secondary">
         {{ $t('no-chart-data') }}
       </span>
     </div>
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </div>
 </template>
 

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -376,13 +376,18 @@ const chartOption = computed((): EChartsOption => {
         const dimKey = segmentKeys[p.seriesIndex ?? 0];
         const row = p.data;
         const val = row && dimKey !== undefined ? Number(row[dimKey]) || 0 : 0;
-        if (val <= 0) { emitTooltip(null); return ''; }
+        if (val <= 0) {
+          emitTooltip(null);
+          return '';
+        }
         emitTooltip({
-          rows: [{
-            label: p.seriesName ?? '',
-            value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
-            color: p.color ?? '#888',
-          }],
+          rows: [
+            {
+              label: p.seriesName ?? '',
+              value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+              color: p.color ?? '#888',
+            },
+          ],
         });
         return '';
       },

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1074,7 +1074,10 @@ const chartOption = computed((): EChartsOption => {
 
       formatter: (params: unknown) => {
         const arr = Array.isArray(params) ? params : params ? [params] : [];
-        if (!arr.length) { emitTooltip(null); return ''; }
+        if (!arr.length) {
+          emitTooltip(null);
+          return '';
+        }
         const first = arr[0] as {
           data?: Record<string, unknown>;
           axisValue?: string;

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -19,6 +19,9 @@ import {
   GraphicComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from './TooltipEcharts.vue';
+import { useEchartsTooltip } from './useEchartsTooltip';
+import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
 
 use([
   CanvasRenderer,
@@ -1071,17 +1074,14 @@ const chartOption = computed((): EChartsOption => {
 
       formatter: (params: unknown) => {
         const arr = Array.isArray(params) ? params : params ? [params] : [];
-        if (!arr.length) return '';
-        const p = arr[0] as {
+        if (!arr.length) { emitTooltip(null); return ''; }
+        const first = arr[0] as {
           data?: Record<string, unknown>;
           axisValue?: string;
           name?: string;
-          seriesName?: string;
-          marker?: string;
-          value?: number | number[];
         };
-        const data = p.data;
-        const name = p.axisValue || p.name || '';
+        const data = first.data;
+        const name = String(first.axisValue || first.name || '');
         const isValidated = validatedLabels.value.has(name);
 
         if (!isValidated) {
@@ -1090,37 +1090,54 @@ const chartOption = computed((): EChartsOption => {
             : additionalBuildingsLabels.value.has(name)
               ? t('buildings')
               : name;
-          return `<strong>${name}</strong><br/><span style="color:#aaa">${t('results_validate_module_title', { module: moduleName })}</span>`;
+          emitTooltip({
+            title: name,
+            rows: [],
+            tone: 'muted',
+            footer: t('results_validate_module_title', { module: moduleName }),
+          });
+          return '';
         }
 
+        const rows: TooltipRow[] = [];
         let total = 0;
-        let tooltip = `<strong>${name}</strong><br/>`;
 
-        arr.reverse().forEach((param: unknown) => {
+        for (const param of [...arr].reverse()) {
           const p = param as {
             seriesName?: string;
             seriesIndex?: number;
-            marker?: string;
-            value?: number | number[];
-            data?: Record<string, unknown>;
           };
           const series =
             typeof p.seriesIndex === 'number'
               ? seriesArray[p.seriesIndex]
               : seriesArray.find((s) => s.name === p.seriesName);
           const key = series?.encode.y;
-
-          if (!data || !key) return;
+          if (!data || !key) continue;
           const dataValue = Number(data[key]) || 0;
           if (dataValue > 0) {
-            tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
+            rows.push({
+              label: series?.name ?? String(p.seriesName ?? ''),
+              value: formatTonnesForChart(dataValue),
+              color: (series?.itemStyle?.color as string) ?? '#888',
+            });
             total += dataValue;
           }
-        });
+        }
 
-        const totalDisplay = formatTonnesForChart(total);
-
-        return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;
+        const state: TooltipState = {
+          title: name,
+          rows,
+          ...(rows.length > 1
+            ? {
+                separatorRow: {
+                  label: t('results_objectives_total'),
+                  value: formatTonnesForChart(total),
+                },
+              }
+            : {}),
+        };
+        emitTooltip(state);
+        return '';
       },
     },
 
@@ -1217,6 +1234,15 @@ const chartOption = computed((): EChartsOption => {
 });
 
 const chartRef = ref<InstanceType<typeof VChart>>();
+
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
 
 const downloadPNG = async () => {
   const chart = chartRef.value?.chart;
@@ -1379,7 +1405,15 @@ const downloadCSV = () => {
         autoresize
         :option="chartOption"
         @rendered="recalculateScopeRects"
+        @vue:mounted="onChartReady"
       />
+      <Teleport to="body">
+        <tooltip-echarts
+          v-if="tooltip.visible"
+          :tooltip-state="tooltip.data"
+          :style="style"
+        />
+      </Teleport>
     </q-card-section>
   </q-card>
 </template>

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -312,7 +312,9 @@ function buildTooltipState(rawParams: unknown): TooltipState {
   const separatorRow: TooltipRow | undefined = populationParam
     ? {
         label: t('results_objectives_population_forecast'),
-        value: formatTooltipPopulation(extractSeriesValue(populationParam.value)),
+        value: formatTooltipPopulation(
+          extractSeriesValue(populationParam.value),
+        ),
         color: '#ff0000',
       }
     : undefined;

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUpdated, ref } from 'vue';
+import { computed, nextTick, onMounted, onUpdated, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -15,6 +15,8 @@ import {
   TooltipComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from './TooltipEcharts.vue';
+import { useEchartsTooltip } from './useEchartsTooltip';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import {
@@ -24,7 +26,13 @@ import {
   RESULTS_CATEGORY_LABEL_KEYS,
   RESULTS_CATEGORY_ORDER,
 } from 'src/constant/charts';
-import { formatTonnesForChart } from 'src/utils/number';
+import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
+import {
+  normalizeAxisParams,
+  extractSeriesValue,
+  formatTooltipTonnes,
+  formatTooltipPopulation,
+} from 'src/utils/chart-tooltip-extractors';
 
 interface Props {
   hideResearchFacilities?: boolean;
@@ -221,16 +229,17 @@ function categoryLabel(categoryKey: string): string {
 
 const TOOLTIP_CATEGORY_ORDER = RESULTS_CATEGORY_ORDER;
 
-type TooltipAxisParam = {
-  axisValue?: string;
-  seriesName?: string;
-  value?: number | (number | null)[] | null;
-};
+// ── Teleport tooltip composable ───────────────────────────────────────────────
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
 
-function normalizeTooltipParams(rawParams: unknown): TooltipAxisParam[] {
-  if (!Array.isArray(rawParams)) return [];
-  return rawParams as TooltipAxisParam[];
-}
+const chartRef = ref<InstanceType<typeof VChart>>();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
 
 function tooltipAxisValueToYearLabel(rawAxisValue: unknown): string {
   // When tooltip is driven by the hidden numeric axis, axisValue can be an index
@@ -238,30 +247,14 @@ function tooltipAxisValueToYearLabel(rawAxisValue: unknown): string {
   const n = Number(rawAxisValue);
   if (!Number.isFinite(n)) return String(rawAxisValue ?? '');
 
+  // If the value is a year in our array (category axis), return it directly.
+  if (years.value.includes(n)) return String(n);
+
   const idx = Math.min(
     Math.max(Math.round(n), 0),
     Math.max(years.value.length - 1, 0),
   );
   return String(years.value[idx] ?? rawAxisValue);
-}
-
-function extractTooltipSeriesValue(
-  raw: TooltipAxisParam['value'],
-): number | null {
-  if (typeof raw === 'number') return raw;
-  if (!Array.isArray(raw)) return null;
-  return (raw.length >= 2 ? raw[1] : raw[0]) as number | null;
-}
-
-function formatTooltipTonnes(value: number | null): string {
-  if (value == null) return '-';
-  if (value < 0) return value.toFixed(1);
-  return formatTonnesForChart(value);
-}
-
-function formatTooltipPopulation(value: number | null): string {
-  if (value == null) return '-';
-  return INT_FORMATTER.format(Math.round(value));
 }
 
 function tooltipSortIndex(seriesName: string): number {
@@ -271,88 +264,60 @@ function tooltipSortIndex(seriesName: string): number {
   return idx === -1 ? 999 : idx;
 }
 
-function renderTooltipTotalLine(params: TooltipAxisParam[]): string {
-  const p = params.find(
-    (x) => String(x.seriesName) === 'total' && x.value != null,
+function buildTooltipState(rawParams: unknown): TooltipState {
+  const params = normalizeAxisParams(rawParams);
+  if (!params.length) return null;
+
+  const title = tooltipAxisValueToYearLabel(params[0]?.axisValue);
+
+  const totalParam = params.find(
+    (p) => String(p.seriesName) === 'total' && p.value != null,
   );
-  if (!p) return '';
+  const populationParam = params.find(
+    (p) => String(p.seriesName) === 'population' && p.value != null,
+  );
 
-  const v = extractTooltipSeriesValue(p.value);
-  const formatted = formatTooltipTonnes(v);
-  const dotColor = accentColorHex.value ?? colors.value.cobalt.darker;
-  const label = t('results_objectives_total');
+  const rows: TooltipRow[] = [];
 
-  return `
-    <div class="objective-tooltip__line objective-tooltip__line--total">
-      <span class="objective-tooltip__dot" style="--dot-color:${dotColor};"></span>
-      <span class="objective-tooltip__label objective-tooltip__label--strong">${label}</span>
-      <span class="objective-tooltip__value objective-tooltip__value--strong">${formatted}</span>
-    </div>
-  `;
-}
+  if (totalParam) {
+    rows.push({
+      label: t('results_objectives_total'),
+      value: formatTooltipTonnes(extractSeriesValue(totalParam.value)),
+      color: accentColorHex.value ?? colors.value.cobalt.darker,
+    });
+  }
 
-function renderTooltipCategoryLines(params: TooltipAxisParam[]): string {
-  return params
+  const categoryRows = params
     .filter((p) => p.seriesName && p.value != null)
     .filter(
       (p) =>
         String(p.seriesName) !== 'population' &&
         String(p.seriesName) !== 'total',
     )
-    .sort((a, b) => {
-      const ak = String(a.seriesName ?? '');
-      const bk = String(b.seriesName ?? '');
-      return tooltipSortIndex(ak) - tooltipSortIndex(bk);
-    })
-    .map((p) => {
-      const key = String(p.seriesName);
-      const color = categoryColor(key);
-      const value = extractTooltipSeriesValue(p.value);
-      const formatted = formatTooltipTonnes(value);
-      const label = categoryLabel(key);
+    .sort(
+      (a, b) =>
+        tooltipSortIndex(String(a.seriesName ?? '')) -
+        tooltipSortIndex(String(b.seriesName ?? '')),
+    )
+    .map(
+      (p): TooltipRow => ({
+        label: categoryLabel(String(p.seriesName)),
+        value: formatTooltipTonnes(extractSeriesValue(p.value)),
+        color: categoryColor(String(p.seriesName)),
+      }),
+    );
 
-      return `
-        <div class="objective-tooltip__line">
-          <span class="objective-tooltip__dot" style="--dot-color:${color};"></span>
-          <span class="objective-tooltip__label">${label}</span>
-          <span class="objective-tooltip__value">${formatted}</span>
-        </div>
-      `;
-    })
-    .join('');
-}
+  rows.push(...categoryRows);
 
-function renderTooltipPopulationLine(params: TooltipAxisParam[]): string {
-  const p = params.find(
-    (x) => String(x.seriesName) === 'population' && x.value != null,
-  );
-  if (!p) return '';
+  const separatorRow: TooltipRow | undefined = populationParam
+    ? {
+        label: t('results_objectives_population_forecast'),
+        value: formatTooltipPopulation(extractSeriesValue(populationParam.value)),
+        color: '#ff0000',
+      }
+    : undefined;
 
-  const v = extractTooltipSeriesValue(p.value);
-  const formatted = formatTooltipPopulation(v);
-  const label = t('results_objectives_population_forecast');
-
-  return `
-    <div class="objective-tooltip__section">
-      <div class="objective-tooltip__line">
-        <span class="objective-tooltip__dot objective-tooltip__dot--population"></span>
-        <span class="objective-tooltip__label">${label}</span>
-        <span class="objective-tooltip__value">${formatted}</span>
-      </div>
-    </div>
-  `;
-}
-
-function renderTooltipContainer(args: {
-  yearLabel: string;
-  totalLine: string;
-  categoryLines: string;
-  populationLine: string;
-}): string {
-  return `<div class="objective-tooltip">
-    <div class="objective-tooltip__title">${args.yearLabel}</div>
-    ${args.totalLine}${args.categoryLines}${args.populationLine}
-  </div>`;
+  return { title, rows, separatorRow };
 }
 
 // ── Data fetch ───────────────────────────────────────────────────────────────
@@ -642,15 +607,8 @@ const chartOption = computed<EChartsOption | null>(() => {
         type: 'line',
       },
       formatter: (rawParams: unknown) => {
-        const params = normalizeTooltipParams(rawParams);
-        const rawAxisValue = params[0]?.axisValue ?? '';
-
-        return renderTooltipContainer({
-          yearLabel: tooltipAxisValueToYearLabel(rawAxisValue),
-          totalLine: renderTooltipTotalLine(params),
-          categoryLines: renderTooltipCategoryLines(params),
-          populationLine: renderTooltipPopulationLine(params),
-        });
+        emitTooltip(buildTooltipState(rawParams));
+        return '';
       },
     },
     legend: { show: false },
@@ -721,9 +679,11 @@ const chartOption = computed<EChartsOption | null>(() => {
   <div class="objective-chart">
     <VChart
       v-if="chartOption && !showEpflEmptyState"
+      ref="chartRef"
       :option="chartOption"
       autoresize
       class="objective-chart__canvas"
+      @vue:mounted="onChartReady"
     />
     <q-card v-else flat class="objective-empty-card">
       <q-card-section class="objective-empty-card__content">
@@ -736,6 +696,13 @@ const chartOption = computed<EChartsOption | null>(() => {
         </div>
       </q-card-section>
     </q-card>
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </div>
 </template>
 
@@ -781,65 +748,5 @@ const chartOption = computed<EChartsOption | null>(() => {
   color: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
-}
-</style>
-
-<style lang="scss">
-/* ECharts tooltip is rendered outside component root; keep these global. */
-.objective-tooltip {
-  min-width: 220px;
-}
-
-.objective-tooltip__title {
-  font-weight: 600;
-  margin-bottom: 6px;
-}
-
-.objective-tooltip__line {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  line-height: 1.35;
-}
-
-.objective-tooltip__line--total {
-  margin-bottom: 4px;
-}
-
-.objective-tooltip__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  display: inline-block;
-  flex: 0 0 auto;
-  background: var(--dot-color);
-}
-
-.objective-tooltip__dot--population {
-  background: #ff0000;
-}
-
-.objective-tooltip__label {
-  flex: 1;
-  opacity: 0.9;
-}
-
-.objective-tooltip__label--strong {
-  opacity: 0.95;
-  font-weight: 600;
-}
-
-.objective-tooltip__value {
-  font-variant-numeric: tabular-nums;
-}
-
-.objective-tooltip__value--strong {
-  font-weight: 600;
-}
-
-.objective-tooltip__section {
-  margin-top: 6px;
-  padding-top: 6px;
-  border-top: 1px solid rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUpdated, ref } from 'vue';
+import { computed, nextTick, onMounted, onUpdated, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -14,6 +14,15 @@ import {
   TooltipComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from './TooltipEcharts.vue';
+import { useEchartsTooltip } from './useEchartsTooltip';
+import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
+import {
+  normalizeAxisParams,
+  extractSeriesValue,
+  formatTooltipTonnes,
+  formatTooltipPopulation,
+} from 'src/utils/chart-tooltip-extractors';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useModuleStore, useTimelineStore } from 'src/stores/modules';
@@ -24,7 +33,6 @@ import {
   RESULTS_CATEGORY_ORDER,
 } from 'src/constant/charts';
 import { MODULE_STATES } from 'src/constant/moduleStates';
-import { formatTonnesForChart } from 'src/utils/number';
 
 interface Props {
   hideResearchFacilities?: boolean;
@@ -123,35 +131,17 @@ const ADDITIONAL_UNIT_CATEGORY_KEYS = new Set([
 ]);
 const TOOLTIP_CATEGORY_ORDER = RESULTS_CATEGORY_ORDER;
 
-type TooltipAxisParam = {
-  axisValue?: string;
-  seriesName?: string;
-  value?: number | (number | null)[] | null;
+// ── Teleport tooltip composable ───────────────────────────────────────────────
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const chartRef = ref<InstanceType<typeof VChart>>();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
 };
-
-function normalizeTooltipParams(rawParams: unknown): TooltipAxisParam[] {
-  if (!Array.isArray(rawParams)) return [];
-  return rawParams as TooltipAxisParam[];
-}
-
-function extractTooltipSeriesValue(
-  raw: TooltipAxisParam['value'],
-): number | null {
-  if (typeof raw === 'number') return raw;
-  if (!Array.isArray(raw)) return null;
-  return (raw.length >= 2 ? raw[1] : raw[0]) as number | null;
-}
-
-function formatTooltipTonnes(value: number | null): string {
-  if (value == null) return '-';
-  if (value < 0) return value.toFixed(1);
-  return formatTonnesForChart(value);
-}
-
-function formatTooltipPopulation(value: number | null): string {
-  if (value == null) return '-';
-  return INT_FORMATTER.format(Math.round(value));
-}
 
 function tooltipSortIndex(seriesName: string): number {
   const idx = TOOLTIP_CATEGORY_ORDER.indexOf(
@@ -160,62 +150,43 @@ function tooltipSortIndex(seriesName: string): number {
   return idx === -1 ? 999 : idx;
 }
 
-function renderTooltipCategoryLines(params: TooltipAxisParam[]): string {
-  return params
+function buildTooltipState(rawParams: unknown): TooltipState {
+  const params = normalizeAxisParams(rawParams);
+  if (!params.length) return null;
+
+  const title = String(params[0]?.axisValue ?? '');
+
+  const populationParam = params.find(
+    (p) => String(p.seriesName) === 'population' && p.value != null,
+  );
+
+  const rows: TooltipRow[] = params
     .filter((p) => p.seriesName && p.value != null)
     .filter((p) => String(p.seriesName) !== 'population')
-    .sort((a, b) => {
-      const ak = String(a.seriesName ?? '');
-      const bk = String(b.seriesName ?? '');
-      return tooltipSortIndex(ak) - tooltipSortIndex(bk);
-    })
-    .map((p) => {
-      const key = String(p.seriesName);
-      const color = categoryColor(key);
-      const value = extractTooltipSeriesValue(p.value);
-      const formatted = formatTooltipTonnes(value);
-      const label = categoryLabel(key);
-      return `
-        <div style="display:flex;align-items:center;gap:8px;line-height:1.35;">
-          <span style="width:8px;height:8px;border-radius:999px;background:${color};display:inline-block;"></span>
-          <span style="flex:1;opacity:0.9;">${label}</span>
-          <span style="font-variant-numeric:tabular-nums;">${formatted}</span>
-        </div>
-      `;
-    })
-    .join('');
-}
+    .sort(
+      (a, b) =>
+        tooltipSortIndex(String(a.seriesName ?? '')) -
+        tooltipSortIndex(String(b.seriesName ?? '')),
+    )
+    .map(
+      (p): TooltipRow => ({
+        label: categoryLabel(String(p.seriesName)),
+        value: formatTooltipTonnes(extractSeriesValue(p.value)),
+        color: categoryColor(String(p.seriesName)),
+      }),
+    );
 
-function renderTooltipPopulationLine(params: TooltipAxisParam[]): string {
-  const p = params.find(
-    (x) => String(x.seriesName) === 'population' && x.value != null,
-  );
-  if (!p) return '';
+  const separatorRow: TooltipRow | undefined = populationParam
+    ? {
+        label: t('results_objectives_population_forecast'),
+        value: formatTooltipPopulation(
+          extractSeriesValue(populationParam.value),
+        ),
+        color: '#ff0000',
+      }
+    : undefined;
 
-  const v = extractTooltipSeriesValue(p.value);
-  const formatted = formatTooltipPopulation(v);
-  const label = t('results_objectives_population_forecast');
-
-  return `
-    <div style="margin-top:6px;padding-top:6px;border-top:1px solid rgba(0,0,0,0.12);">
-      <div style="display:flex;align-items:center;gap:8px;line-height:1.35;">
-        <span style="width:8px;height:8px;border-radius:999px;background:#ff0000;display:inline-block;"></span>
-        <span style="flex:1;opacity:1;">${label}</span>
-        <span style="font-variant-numeric:tabular-nums;">${formatted}</span>
-      </div>
-    </div>
-  `;
-}
-
-function renderTooltipContainer(args: {
-  yearLabel: string;
-  categoryLines: string;
-  populationLine: string;
-}): string {
-  return `<div style="min-width:220px;">
-    <div style="font-weight:600;margin-bottom:6px;">${args.yearLabel}</div>
-    ${args.categoryLines}${args.populationLine}
-  </div>`;
+  return { title, rows, separatorRow };
 }
 
 const validatedEmissionCategoryKeys = computed(() => {
@@ -473,14 +444,8 @@ const chartOption = computed<EChartsOption | null>(() => {
         label: { backgroundColor: '#6a7985' },
       },
       formatter: (rawParams: unknown) => {
-        const params = normalizeTooltipParams(rawParams);
-        const yearLabel = String(params[0]?.axisValue ?? '');
-
-        return renderTooltipContainer({
-          yearLabel,
-          categoryLines: renderTooltipCategoryLines(params),
-          populationLine: renderTooltipPopulationLine(params),
-        });
+        emitTooltip(buildTooltipState(rawParams));
+        return '';
       },
     },
     legend: { show: false },
@@ -552,9 +517,11 @@ const chartOption = computed<EChartsOption | null>(() => {
       <div class="objective-chart">
         <VChart
           v-if="chartOption"
+          ref="chartRef"
           :option="chartOption"
           autoresize
           class="objective-chart__canvas"
+          @vue:mounted="onChartReady"
         />
         <div v-else class="objective-chart__empty" />
       </div>
@@ -642,6 +609,13 @@ const chartOption = computed<EChartsOption | null>(() => {
         </div>
       </section>
     </div>
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </div>
 </template>
 

--- a/frontend/src/components/charts/results/TooltipEcharts.vue
+++ b/frontend/src/components/charts/results/TooltipEcharts.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="echart-tooltip">
+    {{ data }}
+    <slot :data="data" />
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  data: any[];
+}>();
+</script>
+
+<style>
+.echart-tooltip {
+  background: #1f1f1f;
+  color: white;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+}
+</style>

--- a/frontend/src/components/charts/results/TooltipEcharts.vue
+++ b/frontend/src/components/charts/results/TooltipEcharts.vue
@@ -1,24 +1,54 @@
 <template>
-  <div class="echart-tooltip">
-    {{ data }}
-    <slot :data="data" />
+  <div v-if="tooltipState" class="chart-tooltip">
+    <p v-if="tooltipState.title" class="chart-tooltip__title">
+      {{ tooltipState.title }}
+    </p>
+
+    <div
+      v-for="(row, i) in tooltipState.rows"
+      :key="i"
+      class="chart-tooltip__row"
+    >
+      <span
+        v-if="row.color"
+        class="chart-tooltip__dot"
+        :style="{ '--dot-color': row.color }"
+      />
+      <span class="chart-tooltip__label">{{ row.label }}</span>
+      <span class="chart-tooltip__value">{{ row.value }}</span>
+    </div>
+
+    <div
+      v-if="tooltipState.separatorRow"
+      class="chart-tooltip__row chart-tooltip__row--separator row items-center"
+    >
+      <span
+        v-if="tooltipState.separatorRow.color"
+        class="chart-tooltip__dot"
+        :style="{ '--dot-color': tooltipState.separatorRow.color }"
+      />
+      <span class="chart-tooltip__label col">{{
+        tooltipState.separatorRow.label
+      }}</span>
+      <span class="chart-tooltip__value text-weight-medium">{{
+        tooltipState.separatorRow.value
+      }}</span>
+    </div>
+
+    <p
+      v-if="tooltipState.footer"
+      class="chart-tooltip__footer"
+      :class="{ 'chart-tooltip__footer--muted': tooltipState.tone === 'muted' }"
+    >
+      {{ tooltipState.footer }}
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
+import type { TooltipState } from 'src/types/chartTooltip';
+
 defineProps<{
-  data: any[];
+  tooltipState: TooltipState;
 }>();
 </script>
-
-<style>
-.echart-tooltip {
-  background: #1f1f1f;
-  color: white;
-  padding: 8px 10px;
-  border-radius: 6px;
-  font-size: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  white-space: nowrap;
-}
-</style>

--- a/frontend/src/components/charts/results/useEchartsTooltip.ts
+++ b/frontend/src/components/charts/results/useEchartsTooltip.ts
@@ -1,0 +1,92 @@
+import { ref, computed, onBeforeUnmount } from 'vue';
+
+type TooltipState = {
+  visible: boolean;
+  x: number;
+  y: number;
+  data?: any;
+};
+
+export function useEchartsTooltip() {
+  const tooltip = ref<TooltipState>({
+    visible: false,
+    x: 0,
+    y: 0,
+    data: undefined,
+  });
+
+  const cleanupFns: Array<() => void> = [];
+  const lastMouse = { x: 0, y: 0 };
+
+  function emitTooltip(params) {
+    tooltip.value = {
+      visible: true,
+      x: lastMouse.x,
+      y: lastMouse.y,
+      data: params,
+    };
+  }
+
+  function attach(chart: any) {
+    const zr = chart.getZr();
+
+    zr.on('mousemove', (e: any) => {
+      lastMouse.x = e.offsetX;
+      lastMouse.y = e.offsetY;
+    });
+
+    chart.on('updateAxisPointer', (params: any) => {
+      const axis = params.axesInfo?.[0];
+
+      if (!axis) {
+        tooltip.value.visible = false;
+        return;
+      }
+
+      tooltip.value.visible = true;
+      tooltip.value.x = lastMouse.x;
+      tooltip.value.y = lastMouse.y;
+    });
+
+    zr.on('globalout', () => {
+      tooltip.value.visible = false;
+    });
+  }
+
+  onBeforeUnmount(() => {
+    cleanupFns.forEach((fn) => fn());
+  });
+
+  const style = computed(() => {
+    const offset = 12;
+
+    let x = tooltip.value.x + offset;
+    let y = tooltip.value.y + offset;
+
+    const maxW = 280;
+    const maxH = 160;
+
+    if (x + maxW > window.innerWidth) {
+      x = tooltip.value.x - maxW;
+    }
+
+    if (y + maxH > window.innerHeight) {
+      y = tooltip.value.y - maxH;
+    }
+
+    return {
+      position: 'fixed',
+      left: `${x}px`,
+      top: `${y}px`,
+      pointerEvents: 'none',
+      zIndex: 9999,
+    };
+  });
+
+  return {
+    tooltip,
+    style,
+    attach,
+    emitTooltip,
+  };
+}

--- a/frontend/src/components/charts/results/useEchartsTooltip.ts
+++ b/frontend/src/components/charts/results/useEchartsTooltip.ts
@@ -1,51 +1,78 @@
 import { ref, computed, onBeforeUnmount } from 'vue';
+import type { TooltipState } from 'src/types/chartTooltip';
+import type { EChartsType } from 'echarts/types/dist/shared';
 
-type TooltipState = {
+type InternalTooltipState = {
   visible: boolean;
   x: number;
   y: number;
-  data?: any;
+  data: TooltipState;
+};
+
+type ZrMouseEvent = {
+  offsetX: number;
+  offsetY: number;
+};
+
+type ZrOnHandler = ((e: ZrMouseEvent) => void) | (() => void);
+
+type ZrLike = {
+  on: (event: string, handler: ZrOnHandler) => void;
+};
+
+type UpdateAxisPointerParams = {
+  axesInfo?: Array<Record<string, unknown>>;
 };
 
 export function useEchartsTooltip() {
-  const tooltip = ref<TooltipState>({
+  const tooltip = ref<InternalTooltipState>({
     visible: false,
     x: 0,
     y: 0,
-    data: undefined,
+    data: null,
   });
 
   const cleanupFns: Array<() => void> = [];
   const lastMouse = { x: 0, y: 0 };
 
-  function emitTooltip(params) {
+  function emitTooltip(state: TooltipState) {
+    if (state === null) {
+      tooltip.value.visible = false;
+      tooltip.value.data = null;
+      return;
+    }
     tooltip.value = {
       visible: true,
       x: lastMouse.x,
       y: lastMouse.y,
-      data: params,
+      data: state,
     };
   }
 
-  function attach(chart: any) {
-    const zr = chart.getZr();
+  function attach(chart: EChartsType) {
+    const zr = chart.getZr() as ZrLike;
+    const canvas: HTMLElement = chart.getDom();
 
-    zr.on('mousemove', (e: any) => {
-      lastMouse.x = e.offsetX;
-      lastMouse.y = e.offsetY;
+    zr.on('mousemove', (e: ZrMouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      lastMouse.x = rect.left + e.offsetX;
+      lastMouse.y = rect.top + e.offsetY;
     });
 
-    chart.on('updateAxisPointer', (params: any) => {
+    chart.on('updateAxisPointer', (params: UpdateAxisPointerParams) => {
       const axis = params.axesInfo?.[0];
-
       if (!axis) {
         tooltip.value.visible = false;
         return;
       }
-
       tooltip.value.visible = true;
       tooltip.value.x = lastMouse.x;
       tooltip.value.y = lastMouse.y;
+    });
+
+    // Hide when mouse leaves a data item (needed for trigger:'item' charts)
+    chart.on('mouseout', () => {
+      tooltip.value.visible = false;
     });
 
     zr.on('globalout', () => {

--- a/frontend/src/components/molecules/HeadCountBarChart.vue
+++ b/frontend/src/components/molecules/HeadCountBarChart.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart } from 'echarts/charts';
@@ -13,8 +13,11 @@ import {
   GraphicComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from 'src/components/charts/results/TooltipEcharts.vue';
+import { useEchartsTooltip } from 'src/components/charts/results/useEchartsTooltip';
 
 import { colors } from 'src/constant/charts';
+import { MODULES } from 'src/constant/modules';
 
 use([
   CanvasRenderer,
@@ -27,6 +30,15 @@ use([
 ]);
 
 const { t, te } = useI18n();
+const chartRef = ref<InstanceType<typeof VChart>>();
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
 
 const props = withDefaults(
   defineProps<{
@@ -56,6 +68,33 @@ const chartOptions = computed<EChartsOption>(() => {
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'shadow' },
+      formatter: (params: unknown) => {
+        const arr = Array.isArray(params) ? params : params ? [params] : [];
+        if (!arr.length) {
+          emitTooltip(null);
+          return '';
+        }
+        const p = arr[0] as {
+          data?: { category: string; value: number };
+          name?: string;
+        };
+        const val = p.data?.value ?? 0;
+        const name = p.data?.category ?? p.name ?? '';
+        if (val <= 0) {
+          emitTooltip(null);
+          return '';
+        }
+        emitTooltip({
+          rows: [
+            {
+              label: name,
+              value: `${Math.round(val * 10) / 10} ${t('module_total_result_title_unit', { type: MODULES.Headcount })}`,
+              color: '#00a79f',
+            },
+          ],
+        });
+        return '';
+      },
     },
     legend: { show: false },
     grid: { left: '3%', right: '4%', bottom: '50px', containLabel: true },
@@ -98,7 +137,19 @@ const chartOptions = computed<EChartsOption>(() => {
 
 <template>
   <div class="head-count-bar-chart">
-    <v-chart :option="chartOptions" autoresize />
+    <v-chart
+      ref="chartRef"
+      :option="chartOptions"
+      autoresize
+      @vue:mounted="onChartReady"
+    />
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </div>
 </template>
 

--- a/frontend/src/components/organisms/AdditionalCategoriesSection.vue
+++ b/frontend/src/components/organisms/AdditionalCategoriesSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -7,6 +7,8 @@ import { PieChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import { TooltipComponent, LegendComponent } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from 'src/components/charts/results/TooltipEcharts.vue';
+import { useEchartsTooltip } from 'src/components/charts/results/useEchartsTooltip';
 import {
   CHART_CATEGORY_COLOR_SCHEMES,
   CHART_SUBCATEGORY_COLOR_SCHEMES,
@@ -36,6 +38,16 @@ const props = defineProps<{
 }>();
 
 const { t, te } = useI18n();
+
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const commutingCO2Ref = ref<InstanceType<typeof VChart>>();
+const commutingPhysicalRef = ref<InstanceType<typeof VChart>>();
+const foodCO2Ref = ref<InstanceType<typeof VChart>>();
+const foodPhysicalRef = ref<InstanceType<typeof VChart>>();
+const wasteCO2Ref = ref<InstanceType<typeof VChart>>();
+const wastePhysicalRef = ref<InstanceType<typeof VChart>>();
+const embodiedEnergyCO2Ref = ref<InstanceType<typeof VChart>>();
 
 /** Defer canvas init until the grid is near the viewport (Lighthouse / main-thread). */
 const additionalGridRef = ref<HTMLElement | null>(null);
@@ -83,6 +95,20 @@ onMounted(() => {
 onBeforeUnmount(() => {
   chartVisibilityObserver?.disconnect();
   chartVisibilityObserver = null;
+});
+
+watch(chartsInView, async (v) => {
+  if (!v) return;
+  await nextTick();
+  for (const r of [
+    commutingCO2Ref, commutingPhysicalRef,
+    foodCO2Ref, foodPhysicalRef,
+    wasteCO2Ref, wastePhysicalRef,
+    embodiedEnergyCO2Ref,
+  ]) {
+    const chart = r.value?.chart;
+    if (chart) attach(chart);
+  }
 });
 
 function getCategoryAccent(
@@ -153,7 +179,7 @@ const commutingEntries = computed((): DisplayEntry[] => {
 });
 
 const commutingCO2Option = computed(() =>
-  buildDoughnutOption({ t, te }, 'commuting', commutingEntries.value, false),
+  buildDoughnutOption({ t, te }, 'commuting', commutingEntries.value, false, emitTooltip),
 );
 
 const commutingPhysicalOption = computed(() => {
@@ -162,6 +188,7 @@ const commutingPhysicalOption = computed(() => {
     'commuting',
     commutingEntries.value,
     true,
+    emitTooltip,
   );
 });
 
@@ -180,11 +207,11 @@ const foodEntries = computed((): DisplayEntry[] => {
 });
 
 const foodCO2Option = computed(() =>
-  buildDoughnutOption({ t, te }, 'food', foodEntries.value, false),
+  buildDoughnutOption({ t, te }, 'food', foodEntries.value, false, emitTooltip),
 );
 
 const foodPhysicalOption = computed(() => {
-  return buildDoughnutOption({ t, te }, 'food', foodEntries.value, true);
+  return buildDoughnutOption({ t, te }, 'food', foodEntries.value, true, emitTooltip);
 });
 
 // ── waste ─────────────────────────────────────────────────────────────────
@@ -230,11 +257,11 @@ const wasteGrouped = computed((): DisplayEntry[] => {
 });
 
 const wasteCO2Option = computed(() =>
-  buildDoughnutOption({ t, te }, 'waste', wasteGrouped.value, false),
+  buildDoughnutOption({ t, te }, 'waste', wasteGrouped.value, false, emitTooltip),
 );
 
 const wastePhysicalOption = computed(() => {
-  return buildDoughnutOption({ t, te }, 'waste', wasteGrouped.value, true);
+  return buildDoughnutOption({ t, te }, 'waste', wasteGrouped.value, true, emitTooltip);
 });
 
 const commutingLegend = computed(() =>
@@ -283,7 +310,7 @@ const embodiedEnergyCO2Option = computed((): EChartsOption => {
       quantity_unit: 'kg',
     }),
   );
-  return buildDoughnutOption({ t, te }, 'embodied_energy', entries, false);
+  return buildDoughnutOption({ t, te }, 'embodied_energy', entries, false, emitTooltip);
 });
 
 const embodiedEnergyLegend = computed(() =>
@@ -373,6 +400,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
                 <VChart
                   v-if="chartsInView"
+                  ref="commutingCO2Ref"
                   :key="`commuting-co2-${commutingEntries.length}`"
                   :option="commutingCO2Option"
                   :autoresize="chartsInView"
@@ -390,6 +418,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
                 <VChart
                   v-if="chartsInView"
+                  ref="commutingPhysicalRef"
                   :key="`commuting-qty-${commutingEntries.length}`"
                   :option="commutingPhysicalOption"
                   :autoresize="chartsInView"
@@ -450,6 +479,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
                 <VChart
                   v-if="chartsInView"
+                  ref="foodCO2Ref"
                   :option="foodCO2Option"
                   :autoresize="chartsInView"
                   class="chart"
@@ -464,6 +494,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
                 <VChart
                   v-if="chartsInView"
+                  ref="foodPhysicalRef"
                   :option="foodPhysicalOption"
                   :autoresize="chartsInView"
                   class="chart"
@@ -528,6 +559,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
                 <VChart
                   v-if="chartsInView"
+                  ref="wasteCO2Ref"
                   :option="wasteCO2Option"
                   :autoresize="chartsInView"
                   class="chart"
@@ -542,6 +574,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
                 <VChart
                   v-if="chartsInView"
+                  ref="wastePhysicalRef"
                   :option="wastePhysicalOption"
                   :autoresize="chartsInView"
                   class="chart"
@@ -643,6 +676,7 @@ const embodiedEnergyLegend = computed(() =>
               </div>
               <VChart
                 v-if="chartsInView"
+                ref="embodiedEnergyCO2Ref"
                 :option="embodiedEnergyCO2Option"
                 :autoresize="chartsInView"
                 class="chart"
@@ -678,6 +712,13 @@ const embodiedEnergyLegend = computed(() =>
         </div>
       </q-card>
     </div>
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </div>
 </template>
 

--- a/frontend/src/components/organisms/AdditionalCategoriesSection.vue
+++ b/frontend/src/components/organisms/AdditionalCategoriesSection.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  watch,
+} from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -101,9 +109,12 @@ watch(chartsInView, async (v) => {
   if (!v) return;
   await nextTick();
   for (const r of [
-    commutingCO2Ref, commutingPhysicalRef,
-    foodCO2Ref, foodPhysicalRef,
-    wasteCO2Ref, wastePhysicalRef,
+    commutingCO2Ref,
+    commutingPhysicalRef,
+    foodCO2Ref,
+    foodPhysicalRef,
+    wasteCO2Ref,
+    wastePhysicalRef,
     embodiedEnergyCO2Ref,
   ]) {
     const chart = r.value?.chart;
@@ -179,7 +190,13 @@ const commutingEntries = computed((): DisplayEntry[] => {
 });
 
 const commutingCO2Option = computed(() =>
-  buildDoughnutOption({ t, te }, 'commuting', commutingEntries.value, false, emitTooltip),
+  buildDoughnutOption(
+    { t, te },
+    'commuting',
+    commutingEntries.value,
+    false,
+    emitTooltip,
+  ),
 );
 
 const commutingPhysicalOption = computed(() => {
@@ -211,7 +228,13 @@ const foodCO2Option = computed(() =>
 );
 
 const foodPhysicalOption = computed(() => {
-  return buildDoughnutOption({ t, te }, 'food', foodEntries.value, true, emitTooltip);
+  return buildDoughnutOption(
+    { t, te },
+    'food',
+    foodEntries.value,
+    true,
+    emitTooltip,
+  );
 });
 
 // ── waste ─────────────────────────────────────────────────────────────────
@@ -257,11 +280,23 @@ const wasteGrouped = computed((): DisplayEntry[] => {
 });
 
 const wasteCO2Option = computed(() =>
-  buildDoughnutOption({ t, te }, 'waste', wasteGrouped.value, false, emitTooltip),
+  buildDoughnutOption(
+    { t, te },
+    'waste',
+    wasteGrouped.value,
+    false,
+    emitTooltip,
+  ),
 );
 
 const wastePhysicalOption = computed(() => {
-  return buildDoughnutOption({ t, te }, 'waste', wasteGrouped.value, true, emitTooltip);
+  return buildDoughnutOption(
+    { t, te },
+    'waste',
+    wasteGrouped.value,
+    true,
+    emitTooltip,
+  );
 });
 
 const commutingLegend = computed(() =>
@@ -310,7 +345,13 @@ const embodiedEnergyCO2Option = computed((): EChartsOption => {
       quantity_unit: 'kg',
     }),
   );
-  return buildDoughnutOption({ t, te }, 'embodied_energy', entries, false, emitTooltip);
+  return buildDoughnutOption(
+    { t, te },
+    'embodied_energy',
+    entries,
+    false,
+    emitTooltip,
+  );
 });
 
 const embodiedEnergyLegend = computed(() =>

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -325,11 +325,13 @@ const barChartOption = computed<EChartsOption>(() => {
           return '';
         }
         emitTooltip({
-          rows: [{
-            label: p.seriesName ?? '',
-            value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
-            color: p.color ?? '#888',
-          }],
+          rows: [
+            {
+              label: p.seriesName ?? '',
+              value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+              color: p.color ?? '#888',
+            },
+          ],
         });
         return '';
       },

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -7,6 +7,8 @@ import { BarChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import { TooltipComponent, GridComponent } from 'echarts/components';
 import VChart from 'vue-echarts';
+import TooltipEcharts from 'src/components/charts/results/TooltipEcharts.vue';
+import { useEchartsTooltip } from 'src/components/charts/results/useEchartsTooltip';
 
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import { CHART_CATEGORY_COLOR_SCHEMES, colors } from 'src/constant/charts';
@@ -36,6 +38,16 @@ const props = withDefaults(
 
 const { t } = useI18n();
 const timelineStore = useTimelineStore();
+
+const chartRef = ref<InstanceType<typeof VChart>>();
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
 
 function isItCategoryModuleValidated(categoryKey: string): boolean {
   const mod = IT_FOCUS_CATEGORY_TO_MODULE[categoryKey];
@@ -293,17 +305,33 @@ const barChartOption = computed<EChartsOption>(() => {
       formatter: (params: unknown) => {
         const p = params as {
           seriesName?: string;
-          marker?: string;
           value?: number;
           name?: string;
+          color?: string;
         };
         const name = p.name || '';
         if (!validatedLabels.value.has(name)) {
-          return `<strong>${name}</strong><br/><span style="color:#aaa">${t('results_validate_module_title', { module: name })}</span>`;
+          emitTooltip({
+            title: name,
+            rows: [],
+            tone: 'muted',
+            footer: t('results_validate_module_title', { module: name }),
+          });
+          return '';
         }
         const val = Number(p.value) || 0;
-        if (val <= 0) return '';
-        return `${p.marker || ''} <strong>${p.seriesName || ''}</strong>: ${formatTonnesForChart(val)}${t('results_units_tonnes')}`;
+        if (val <= 0) {
+          emitTooltip(null);
+          return '';
+        }
+        emitTooltip({
+          rows: [{
+            label: p.seriesName ?? '',
+            value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+            color: p.color ?? '#888',
+          }],
+        });
+        return '';
       },
     },
     legend: { show: false },
@@ -414,9 +442,11 @@ const barChartOption = computed<EChartsOption>(() => {
           <span class="q-ml-sm">{{ $t('it-focus-breakdown-bar-title') }}</span>
         </div>
         <v-chart
+          ref="chartRef"
           :option="barChartOption"
           autoresize
           :style="{ height: chartHeight + 'px', width: '100%' }"
+          @vue:mounted="onChartReady"
         />
       </q-card>
     </template>
@@ -425,5 +455,12 @@ const barChartOption = computed<EChartsOption>(() => {
     <div v-else-if="loading" class="flex justify-center q-pa-xl">
       <q-spinner color="accent" size="40px" />
     </div>
+    <Teleport to="body">
+      <tooltip-echarts
+        v-if="tooltip.visible"
+        :tooltip-state="tooltip.data"
+        :style="style"
+      />
+    </Teleport>
   </div>
 </template>

--- a/frontend/src/composables/results/useAdditionalCategoryCharts.ts
+++ b/frontend/src/composables/results/useAdditionalCategoryCharts.ts
@@ -3,6 +3,7 @@ import {
   CHART_SUBCATEGORY_COLOR_SCHEMES,
   getChartSubcategoryColor,
 } from 'src/constant/charts';
+import type { TooltipState } from 'src/types/chartTooltip';
 
 export type AdditionalCategoryKey =
   | 'commuting'
@@ -32,6 +33,7 @@ export function buildDoughnutOption(
   category: AdditionalCategoryKey,
   entries: DisplayEntry[],
   useQuantity: boolean,
+  emitTooltip?: (state: TooltipState) => void,
 ): EChartsOption {
   const colorScheme = CHART_SUBCATEGORY_COLOR_SCHEMES.value[category] ?? {};
   const noBreakdownColor = '#D5D5D5';
@@ -77,17 +79,19 @@ export function buildDoughnutOption(
     animation: false,
     tooltip: {
       trigger: 'item',
-      appendToBody: true,
-      extraCssText: 'z-index: 9999;',
       formatter: (params: unknown) => {
-        const p = params as { name?: unknown; percent?: unknown };
+        const p = params as { name?: unknown; percent?: unknown; color?: unknown };
         const name = String(p.name ?? '');
         const percent =
           typeof p.percent === 'number' ? p.percent : Number(p.percent);
         const percentDisplay = Number.isFinite(percent) ? percent : 0;
-        const percentText = Number.isFinite(percentDisplay)
-          ? percentDisplay.toFixed(0)
-          : '0';
+        const percentText = percentDisplay.toFixed(0);
+        if (emitTooltip) {
+          emitTooltip({
+            rows: [{ label: name, value: `${percentText}%`, color: String(p.color ?? '#888') }],
+          });
+          return '';
+        }
         return `${name}: ${percentText}%`;
       },
     },

--- a/frontend/src/composables/results/useAdditionalCategoryCharts.ts
+++ b/frontend/src/composables/results/useAdditionalCategoryCharts.ts
@@ -80,7 +80,11 @@ export function buildDoughnutOption(
     tooltip: {
       trigger: 'item',
       formatter: (params: unknown) => {
-        const p = params as { name?: unknown; percent?: unknown; color?: unknown };
+        const p = params as {
+          name?: unknown;
+          percent?: unknown;
+          color?: unknown;
+        };
         const name = String(p.name ?? '');
         const percent =
           typeof p.percent === 'number' ? p.percent : Number(p.percent);
@@ -88,7 +92,13 @@ export function buildDoughnutOption(
         const percentText = percentDisplay.toFixed(0);
         if (emitTooltip) {
           emitTooltip({
-            rows: [{ label: name, value: `${percentText}%`, color: String(p.color ?? '#888') }],
+            rows: [
+              {
+                label: name,
+                value: `${percentText}%`,
+                color: String(p.color ?? '#888'),
+              },
+            ],
           });
           return '';
         }

--- a/frontend/src/css/05-components/_chart-tooltip.scss
+++ b/frontend/src/css/05-components/_chart-tooltip.scss
@@ -1,0 +1,83 @@
+@use '../02-tokens/decisions' as dec;
+
+.chart-tooltip {
+  background: dec.$tooltip-background;
+  color: dec.$tooltip-color;
+  font-size: dec.$tooltip-fontsize;
+  border-radius: dec.$tooltip-border-radius;
+  box-shadow: dec.$tooltip-box-shadow;
+  padding: 8px 12px;
+  min-width: 12rem;
+  max-width: min(92vw, 48rem);
+  width: max-content;
+
+  &__title {
+    margin: 0 0 var(--semantic-spacing-xs);
+    font-size: var(--semantic-font-size-base);
+    font-weight: var(--semantic-font-weight-medium);
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+    gap: var(--semantic-spacing-sm);
+    margin-bottom: 2px;
+    font-size: 0.875em;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+
+    &--separator {
+      margin-top: var(--semantic-spacing-xs);
+      padding-top: var(--semantic-spacing-xs);
+      border-top: 1px solid rgb(0 0 0 / 15%);
+      margin-bottom: 0;
+    }
+  }
+
+  &__label {
+    font-size: dec.$tooltip-fontsize;
+    font-weight: var(--semantic-font-weight-medium);
+    color: dec.$tooltip-color;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: var(--dot-color);
+    flex-shrink: 0;
+  }
+
+  &__value {
+    font-variant-numeric: tabular-nums;
+    font-size: dec.$tooltip-fontsize;
+    font-weight: var(--semantic-font-weight-medium);
+    color: dec.$tooltip-color;
+    flex: 0 0 auto;
+    margin-left: var(--semantic-spacing-sm);
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  &__footer {
+    margin: var(--semantic-spacing-xs) 0 0;
+    padding-top: var(--semantic-spacing-xs);
+    border-top: 1px solid rgb(0 0 0 / 15%);
+    font-size: 0.875em;
+    font-weight: var(--semantic-font-weight-medium);
+    color: dec.$tooltip-color;
+
+    &--muted {
+      color: var(--semantic-color-text-muted);
+    }
+  }
+}

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -41,6 +41,7 @@
   // example component imports
   @import './05-components/_atoms/icon';
   @import './05-components/_atoms/link';
+  @import './05-components/chart-tooltip';
   @import './05-components/_organisms/navigation';
   @import './05-components/_organisms/login-card';
   @import './05-components/_organisms/timeline';

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -480,4 +480,8 @@ export default {
     en: 'Carbon footprint from the use of research infrastructures',
     fr: "Empreinte carbone liée à l'utilisation des infrastructures de recherche",
   },
+  headcount_fte: {
+    en: 'FTE',
+    fr: 'EPT',
+  },
 };

--- a/frontend/src/types/chartTooltip.ts
+++ b/frontend/src/types/chartTooltip.ts
@@ -1,0 +1,9 @@
+export type TooltipRow = { label: string; value: string; color?: string };
+
+export type TooltipState = {
+  title?: string;
+  rows: TooltipRow[];
+  separatorRow?: TooltipRow;
+  footer?: string;
+  tone?: 'default' | 'muted';
+} | null;

--- a/frontend/src/utils/chart-tooltip-extractors.ts
+++ b/frontend/src/utils/chart-tooltip-extractors.ts
@@ -1,0 +1,36 @@
+import { formatTonnesForChart } from 'src/utils/number';
+
+export type TooltipAxisParam = {
+  axisValue?: unknown;
+  seriesName?: string;
+  value?: number | (number | null)[] | null;
+  marker?: string;
+};
+
+export function normalizeAxisParams(raw: unknown): TooltipAxisParam[] {
+  if (!Array.isArray(raw)) return [];
+  return raw as TooltipAxisParam[];
+}
+
+export function extractSeriesValue(
+  raw: TooltipAxisParam['value'],
+): number | null {
+  if (typeof raw === 'number') return raw;
+  if (!Array.isArray(raw)) return null;
+  return (raw.length >= 2 ? raw[1] : raw[0]) as number | null;
+}
+
+const INT_FORMATTER = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+});
+
+export function formatTooltipTonnes(v: number | null): string {
+  if (v == null) return '-';
+  if (v < 0) return v.toFixed(1);
+  return formatTonnesForChart(v);
+}
+
+export function formatTooltipPopulation(v: number | null): string {
+  if (v == null) return '-';
+  return INT_FORMATTER.format(Math.round(v));
+}


### PR DESCRIPTION
## What does this change?

Introduces a unified, reusable ECharts tooltip system across all chart components. Instead of each chart building its own HTML string inside the ECharts `formatter` callback, every chart now calls `emitTooltip(state)` and returns `''`, delegating rendering to a shared `TooltipEcharts.vue` component mounted via `<Teleport to="body">`.

A new `useEchartsTooltip` composable tracks mouse position via the ZRenderer, listens to `updateAxisPointer` / `mouseout` / `globalout` events, and computes a `fixed`-position style to place the tooltip near the cursor. A shared `TooltipState` type (`src/types/chartTooltip.ts`) defines the data contract (title, rows, separatorRow, footer, tone), and shared formatting helpers (`chart-tooltip-extractors.ts`) replace duplicated inline functions across `ReductionObjectiveEpflView` and `ReductionObjectiveUnitView`. Global styles for the tooltip are added in `_chart-tooltip.scss`.

Charts migrated: `EvolutionOverTimeChart`, `GenericEmissionTreeMapChart`, `CarbonFootPrintPerPersonChart`, `EmissionTypeBreakdownChart`, `ModuleCarbonFootprintChart`, `ReductionObjectiveEpflView`, `ReductionObjectiveUnitView`, `HeadCountBarChart`, `AdditionalCategoriesSection`, `ItFocusSection`, and the shared `buildDoughnutOption` helper.

## Why is this needed?

Each chart was independently constructing tooltip HTML strings with inconsistent styling, duplicated logic, and no shared type contract. This made visual consistency hard to maintain and the tooltip code brittle. The new system centralises all tooltip rendering in one Vue component with a single SCSS file, making it easy to restyle globally and extend with new fields (e.g. `separatorRow`, `footer`, `tone`).

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues

- Closes #854
- Related to #