### PR TITLE
feat(854): added unit context to permissions, simplified permissions handling

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -125,18 +125,23 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
         return False
 
     def as_scope_key(s):
-        # Note: not using affiliation for now
+        # Note: affiliation-based permissions are not implemented yet,
+        # so we return empty string for now to avoid granting permissions
+        # based on unrecognized scope formats, but this can be updated in
+        # the future when affiliation-based permissions are implemented
         if is_global_scope(s):
             return ""
         if isinstance(s, RoleScope):
             if s.institutional_id and s.institutional_id is not None:
                 return f"/{s.institutional_id}"
-            return ""
+            if s.affiliation:
+                return ""
         elif isinstance(s, dict):
             if "institutional_id" in s and s["institutional_id"] is not None:
                 return f"/{s['institutional_id']}"
-            return ""
-        # Default to empty string for unrecognized formats
+            if "affiliation" in s:
+                return ""
+        # Default to no scope if unrecognized format (should not grant permissions)
         return "/?"
 
     # Helper to merge permission actions and keep unique actions

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -105,27 +105,8 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
     if not roles:
         return {}
 
-    # Initialize with all permissions set to False
-    permissions = {
-        "backoffice.reporting": {"view": False, "export": False},
-        "backoffice.users": {"view": False, "edit": False, "export": False},
-        "backoffice.data_management": {
-            "view": False,
-            "edit": False,
-            "export": False,
-            "sync": False,
-        },
-        "backoffice.documentation": {"view": False, "edit": False},
-        "system.users": {"edit": False},
-        "modules.headcount": {"view": False, "edit": False},
-        "modules.equipment": {"view": False, "edit": False},
-        "modules.professional_travel": {"view": False, "edit": False},
-        "modules.buildings": {"view": False, "edit": False},
-        "modules.purchase": {"view": False, "edit": False},
-        "modules.research_facilities": {"view": False, "edit": False},
-        "modules.external_cloud_and_ai": {"view": False, "edit": False},
-        "modules.process_emissions": {"view": False, "edit": False},
-    }
+    # Initialize with no permissions
+    permissions: dict[str, list[str]] = {}
 
     # Helper to check if scope is global (handles both GlobalScope objects and dicts)
     def is_global_scope(s):
@@ -140,12 +121,38 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
         if isinstance(s, RoleScope):
             return True
         if isinstance(s, dict):
-            return "unit" in s or "affiliation" in s
+            return "institutional_id" in s or "affiliation" in s
         return False
+
+    def as_scope_key(s):
+        # Note: not using affiliation for now
+        if is_global_scope(s):
+            return ""
+        if isinstance(s, RoleScope):
+            if s.institutional_id and s.institutional_id is not None:
+                return f"/{s.institutional_id}"
+            return ""
+        elif isinstance(s, dict):
+            if "institutional_id" in s and s["institutional_id"] is not None:
+                return f"/{s['institutional_id']}"
+            return ""
+        # Default to empty string for unrecognized formats
+        return "/?"
+
+    # Helper to merge permission actions and keep unique actions
+    def merge_actions(existing, new):
+        if existing:
+            return list(set(existing) | set(new))
+        return new
 
     for role in roles:
         role_name = role.role if isinstance(role.role, str) else role.role.value
         scope = role.on
+        # Note: for now scope will apply only to modules.* permissions, backoffice
+        # or system roles will generally be global but can also have institutional scope
+        # for future flexibility (currently treated the same as global since we don't
+        # have affiliation-based permissions yet)
+        scope_key = as_scope_key(scope)
 
         # BACKOFFICE ROLES - Only affect backoffice.* permissions
         # Compare using enum value for consistency
@@ -154,96 +161,141 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
             # Backoffice metier can have either global scope or affiliation scope
             # Grants full backoffice access for reporting, docs, and data updates
             if is_global_scope(scope) or is_role_scope(scope):
-                permissions["backoffice.reporting"] = {"view": True, "export": True}
-                permissions["backoffice.users"] = {
-                    "view": True,
-                    "edit": True,
-                    "export": True,
-                }
-                permissions["backoffice.data_management"] = {
-                    "view": True,
-                    "edit": True,
-                    "export": True,
-                    "sync": True,
-                }
-                permissions["backoffice.documentation"] = {"view": True, "edit": True}
+                permissions["backoffice.reporting"] = merge_actions(
+                    permissions.get("backoffice.reporting"), ["view", "export"]
+                )
+                permissions["backoffice.users"] = merge_actions(
+                    permissions.get("backoffice.users"), ["view", "edit", "export"]
+                )
+                permissions["backoffice.data_management"] = merge_actions(
+                    permissions.get("backoffice.data_management"),
+                    [
+                        "view",
+                        "edit",
+                        "export",
+                        "sync",
+                    ],
+                )
+                permissions["backoffice.documentation"] = merge_actions(
+                    permissions.get("backoffice.documentation"), ["view", "edit"]
+                )
 
         # USER ROLES - Only affect modules.* permissions
         elif role_name == RoleName.CO2_USER_PRINCIPAL.value:
             if is_role_scope(scope):
-                permissions["modules.headcount"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.equipment"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.professional_travel"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.buildings"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.purchase"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.research_facilities"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.external_cloud_and_ai"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
-                permissions["modules.process_emissions"] = {
-                    "view": True,
-                    "edit": True,
-                    "sync": True,
-                }
+                permissions[f"modules.headcount{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.headcount{scope_key}"),
+                    ["view", "edit", "sync"],
+                )
+                permissions[f"modules.equipment{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.equipment{scope_key}"),
+                    ["view", "edit", "sync"],
+                )
+                permissions[f"modules.professional_travel{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.professional_travel{scope_key}"),
+                    [
+                        "view",
+                        "edit",
+                        "sync",
+                    ],
+                )
+                permissions[f"modules.buildings{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.buildings{scope_key}"),
+                    [
+                        "view",
+                        "edit",
+                        "sync",
+                    ],
+                )
+                permissions[f"modules.purchase{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.purchase{scope_key}"),
+                    [
+                        "view",
+                        "edit",
+                        "sync",
+                    ],
+                )
+                permissions[f"modules.research_facilities{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.research_facilities{scope_key}"),
+                    [
+                        "view",
+                        "edit",
+                        "sync",
+                    ],
+                )
+                permissions[f"modules.external_cloud_and_ai{scope_key}"] = (
+                    merge_actions(
+                        permissions.get(f"modules.external_cloud_and_ai{scope_key}"),
+                        [
+                            "view",
+                            "edit",
+                            "sync",
+                        ],
+                    )
+                )
+                permissions[f"modules.process_emissions{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.process_emissions{scope_key}"),
+                    [
+                        "view",
+                        "edit",
+                        "sync",
+                    ],
+                )
                 # Principals can assign co2.user.std role to unit members
                 # This grants backoffice.users.edit for unit-scoped role assignment
-                permissions["backoffice.users"]["edit"] = True
+                permissions["backoffice.users"] = merge_actions(
+                    permissions.get("backoffice.users"), ["edit"]
+                )
 
         elif role_name == RoleName.CO2_USER_STD.value:
             if is_role_scope(scope):
-                permissions["modules.professional_travel"] = {
-                    "view": True,
-                    "edit": True,
-                }
-                permissions["modules.external_cloud_and_ai"] = {
-                    "view": True,
-                    "edit": True,
-                }
+                permissions[f"modules.professional_travel{scope_key}"] = merge_actions(
+                    permissions.get(f"modules.professional_travel{scope_key}"),
+                    [
+                        "view",
+                        "edit",
+                    ],
+                )
+                permissions[f"modules.external_cloud_and_ai{scope_key}"] = (
+                    merge_actions(
+                        permissions.get(f"modules.external_cloud_and_ai{scope_key}"),
+                        [
+                            "view",
+                            "edit",
+                        ],
+                    )
+                )
 
         # SYSTEM ROLES - Affect system.* permissions (and potentially backoffice.*)
         elif role_name == RoleName.CO2_SUPERADMIN.value:
             if is_global_scope(scope):
                 # Super admin has full system and backoffice access
-                permissions["system.users"]["edit"] = True
-                permissions["backoffice.reporting"] = {"view": True, "export": True}
-                permissions["backoffice.users"] = {
-                    "view": True,
-                    "edit": True,
-                    "export": True,
-                }
-                permissions["backoffice.data_management"] = {
-                    "view": True,
-                    "edit": True,
-                    "export": True,
-                    "sync": True,
-                }
-                permissions["backoffice.documentation"] = {"view": True, "edit": True}
+                permissions["system.users"] = merge_actions(
+                    permissions.get("system.users"), ["edit"]
+                )
+                permissions["backoffice.reporting"] = merge_actions(
+                    permissions.get("backoffice.reporting"), ["view", "export"]
+                )
+                permissions["backoffice.users"] = merge_actions(
+                    permissions.get("backoffice.users"),
+                    [
+                        "view",
+                        "edit",
+                        "export",
+                    ],
+                )
+                permissions["backoffice.data_management"] = merge_actions(
+                    permissions.get("backoffice.data_management"),
+                    [
+                        "view",
+                        "edit",
+                        "export",
+                        "sync",
+                    ],
+                )
+                permissions["backoffice.documentation"] = merge_actions(
+                    permissions.get("backoffice.documentation"), ["view", "edit"]
+                )
 
     return permissions
 

--- a/backend/app/schemas/unit.py
+++ b/backend/app/schemas/unit.py
@@ -10,10 +10,11 @@ from app.models.unit import Unit, UnitBase
 class UnitWithUserRole(BaseModel):
     """Schema for unit with current user's role from join."""
 
-    id: int = Field(..., description="EPFL unit/unit ID")
+    id: int = Field(..., description="DB ID")
     name: str = Field(
         ..., min_length=1, max_length=255, description="Unit name like 'ENAC-IT4R'"
     )
+    institutional_id: str = Field(..., description="EPFL unit/unit ID")
     current_user_role: str = Field(
         ..., description="Current user's role within this unit"
     )

--- a/backend/app/services/unit_service.py
+++ b/backend/app/services/unit_service.py
@@ -131,6 +131,7 @@ class UnitService:
             {
                 "id": unit.id,
                 "name": unit.name,
+                "institutional_id": unit.institutional_id,
                 "current_user_role": role,
                 "principal_user_institutional_id": unit.principal_user_institutional_id,
                 "principal_user_name": principal_user_name,

--- a/backend/app/utils/permissions.py
+++ b/backend/app/utils/permissions.py
@@ -43,55 +43,10 @@ def has_permission(
         perm_set = permissions[path]
 
         # Check the action
-        if not isinstance(perm_set, dict) or action not in perm_set:
+        if not isinstance(perm_set, list) or action not in perm_set:
             return False
 
-        return bool(perm_set[action])
+        return True
 
     except (KeyError, TypeError, AttributeError):
         return False
-
-
-def get_permission_value(permissions: Optional[dict], full_path: str) -> Optional[bool]:
-    """Get the value of a specific permission using full dot-notation path.
-
-    Args:
-        permissions: The permissions dict (from user.permissions)
-        full_path: Full dot-notation path including action
-
-    Returns:
-        Optional[bool]: The permission value, or None if not found
-
-    Examples:
-        >>> perms = {"modules.headcount": {"view": True, "edit": False}}
-        >>> get_permission_value(perms, "modules.headcount.view")
-        True
-        >>> get_permission_value(perms, "modules.headcount.edit")
-        False
-        >>> get_permission_value(perms, "modules.equipment.view")
-        None
-    """
-    if not permissions:
-        return None
-
-    try:
-        # Split into resource path and action
-        # e.g., "modules.headcount.view" -> ["modules.headcount", "view"]
-        parts = full_path.rsplit(".", 1)
-        if len(parts) != 2:
-            return None
-
-        resource_path, action = parts
-
-        # Look up in flat structure
-        if resource_path not in permissions:
-            return None
-
-        perm_set = permissions[resource_path]
-        if not isinstance(perm_set, dict) or action not in perm_set:
-            return None
-
-        return bool(perm_set[action])
-
-    except (KeyError, TypeError, AttributeError, ValueError):
-        return None

--- a/backend/app/utils/permissions.py
+++ b/backend/app/utils/permissions.py
@@ -24,7 +24,7 @@ def has_permission(
         bool: True if the permission exists and is True, False otherwise
 
     Examples:
-        >>> perms = {"modules.headcount": {"view": True, "edit": False}}
+        >>> perms = {"modules.headcount": ["view"]}
         >>> has_permission(perms, "modules.headcount", "view")
         True
         >>> has_permission(perms, "modules.headcount", "edit")

--- a/backend/tests/unit/core/test_policy.py
+++ b/backend/tests/unit/core/test_policy.py
@@ -254,7 +254,7 @@ class TestQueryPolicyPermissionCheck:
                     }
                 ],
             },
-            "path": "modules.professional_travel",
+            "path": "modules.professional_travel/123",
             "action": "view",
         }
 

--- a/backend/tests/unit/models/test_user_base_calculate_permissions.py
+++ b/backend/tests/unit/models/test_user_base_calculate_permissions.py
@@ -25,27 +25,27 @@ class TestUserBaseCalculatePermissions:
             Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="12345"))
         ]
         perms = user_base.calculate_permissions()
-        assert "modules.professional_travel" in perms
-        assert perms["modules.professional_travel"]["view"] is True
+        assert "modules.professional_travel/12345" in perms
+        assert "view" in perms["modules.professional_travel/12345"]
 
     def test_calculate_permissions_with_dict_roles(self):
         """Test calculate_permissions with roles_raw as dicts."""
         user_base = UserBase()
         user_base.roles_raw = [
-            {"role": f"{RoleName.CO2_USER_STD.value}", "on": {"unit": "12345"}},
+            {"role": f"{RoleName.CO2_USER_STD.value}", "on": {"institutional_id": "12345"}},
         ]
         perms = user_base.calculate_permissions()
-        assert "modules.professional_travel" in perms
-        assert perms["modules.professional_travel"]["view"] is True
+        assert "modules.professional_travel/12345" in perms
+        assert "view" in perms["modules.professional_travel/12345"]
 
     def test_calculate_permissions_superadmin(self):
         """Test calculate_permissions with superadmin role."""
         user_base = UserBase()
         user_base.roles = [Role(role=RoleName.CO2_SUPERADMIN, on=GlobalScope())]
         perms = user_base.calculate_permissions()
-        assert perms["backoffice.users"]["view"] is True
-        assert perms["backoffice.users"]["edit"] is True
-        assert perms["backoffice.users"]["export"] is True
+        assert "view" in perms["backoffice.users"]
+        assert "edit" in perms["backoffice.users"]
+        assert "export" in perms["backoffice.users"]
 
     def test_calculate_permissions_multiple_roles(self):
         """Test calculate_permissions with multiple roles."""
@@ -56,5 +56,5 @@ class TestUserBaseCalculatePermissions:
         ]
         perms = user_base.calculate_permissions()
         # Should have both backoffice and module permissions
-        assert perms["backoffice.users"]["view"] is True
-        assert perms["modules.professional_travel"]["view"] is True
+        assert "view" in perms["backoffice.users"]
+        assert "view" in perms["modules.professional_travel/12345"]

--- a/backend/tests/unit/models/test_user_base_calculate_permissions.py
+++ b/backend/tests/unit/models/test_user_base_calculate_permissions.py
@@ -32,7 +32,10 @@ class TestUserBaseCalculatePermissions:
         """Test calculate_permissions with roles_raw as dicts."""
         user_base = UserBase()
         user_base.roles_raw = [
-            {"role": f"{RoleName.CO2_USER_STD.value}", "on": {"institutional_id": "12345"}},
+            {
+                "role": f"{RoleName.CO2_USER_STD.value}",
+                "on": {"institutional_id": "12345"},
+            },
         ]
         perms = user_base.calculate_permissions()
         assert "modules.professional_travel/12345" in perms

--- a/backend/tests/unit/utils/test_permissions.py
+++ b/backend/tests/unit/utils/test_permissions.py
@@ -84,7 +84,9 @@ class TestCalculateUserPermissions:
 
     def test_user_std_unit_scope(self):
         """Test user std with unit scope grants view and edit for professional_travel."""  # noqa: E501
-        roles = [Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208"))]
+        roles = [
+            Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208"))
+        ]
         result = calculate_user_permissions(roles)
 
         assert "modules.headcount/10208" not in result
@@ -129,7 +131,9 @@ class TestCalculateUserPermissions:
         """Test multiple user roles for same unit combine correctly."""
         roles = [
             Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208")),
-            Role(role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(institutional_id="10208")),
+            Role(
+                role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(institutional_id="10208")
+            ),
         ]
         result = calculate_user_permissions(roles)
 

--- a/backend/tests/unit/utils/test_permissions.py
+++ b/backend/tests/unit/utils/test_permissions.py
@@ -15,7 +15,6 @@ from app.models.user import (
     calculate_user_permissions,
 )
 from app.utils.permissions import (
-    get_permission_value,
     has_permission,
 )
 
@@ -33,21 +32,21 @@ class TestCalculateUserPermissions:
         roles = [Role(role=RoleName.CO2_SUPERADMIN, on=GlobalScope())]
         result = calculate_user_permissions(roles)
 
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
-        assert result["backoffice.users"]["export"] is True
-        assert result["system.users"]["edit"] is True
-        assert result["modules.headcount"]["view"] is False
-        assert result["modules.equipment"]["view"] is False
+        assert "view" in result["backoffice.users"]
+        assert "edit" in result["backoffice.users"]
+        assert "export" in result["backoffice.users"]
+        assert "edit" in result["system.users"]
+        assert "modules.headcount" not in result
+        assert "modules.equipment" not in result
 
     def test_backoffice_metier_global_scope(self):
         """Test backoffice metier with global scope grants full backoffice access."""
         roles = [Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())]
         result = calculate_user_permissions(roles)
 
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
-        assert result["backoffice.users"]["export"] is True
+        assert "view" in result["backoffice.users"]
+        assert "edit" in result["backoffice.users"]
+        assert "export" in result["backoffice.users"]
 
     def test_superadmin_wrong_scope(self):
         """Test superadmin with unit scope does not grant permissions."""
@@ -59,91 +58,85 @@ class TestCalculateUserPermissions:
         ]
         result = calculate_user_permissions(roles)
 
-        assert result["backoffice.users"]["view"] is False
-        assert result["backoffice.users"]["edit"] is False
+        assert "backoffice.users" not in result
 
     def test_user_principal_unit_scope(self):
         """Test user principal with unit scope grants module permissions."""
         roles = [Role(role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(unit="10208"))]
         result = calculate_user_permissions(roles)
 
-        assert result["modules.headcount"]["view"] is True
-        assert result["modules.headcount"]["edit"] is True
-        assert result["modules.equipment"]["view"] is True
-        assert result["modules.equipment"]["edit"] is True
-        assert result["modules.professional_travel"]["view"] is True
-        assert result["modules.professional_travel"]["edit"] is True
-        assert result["modules.buildings"]["view"] is True
-        assert result["modules.buildings"]["edit"] is True
-        assert result["modules.purchase"]["view"] is True
-        assert result["modules.purchase"]["edit"] is True
-        assert result["modules.research_facilities"]["view"] is True
-        assert result["modules.research_facilities"]["edit"] is True
-        assert result["modules.external_cloud_and_ai"]["view"] is True
-        assert result["modules.external_cloud_and_ai"]["edit"] is True
+        assert "view" in result["modules.headcount"]
+        assert "edit" in result["modules.headcount"]
+        assert "view" in result["modules.equipment"]
+        assert "edit" in result["modules.equipment"]
+        assert "view" in result["modules.professional_travel"]
+        assert "edit" in result["modules.professional_travel"]
+        assert "view" in result["modules.buildings"]
+        assert "edit" in result["modules.buildings"]
+        assert "view" in result["modules.purchase"]
+        assert "edit" in result["modules.purchase"]
+        assert "view" in result["modules.research_facilities"]
+        assert "edit" in result["modules.research_facilities"]
+        assert "view" in result["modules.external_cloud_and_ai"]
+        assert "edit" in result["modules.external_cloud_and_ai"]
         # Principal also gets backoffice.users.edit for unit-scoped role assignment
-        assert result["backoffice.users"]["edit"] is True
+        assert "edit" in result["backoffice.users"]
 
     def test_user_std_unit_scope(self):
         """Test user std with unit scope grants view and edit for professional_travel."""  # noqa: E501
-        roles = [Role(role=RoleName.CO2_USER_STD, on=RoleScope(unit="10208"))]
+        roles = [Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208"))]
         result = calculate_user_permissions(roles)
 
-        assert result["modules.headcount"]["view"] is False
-        assert result["modules.headcount"]["edit"] is False
-        assert result["modules.equipment"]["view"] is False
-        assert result["modules.equipment"]["edit"] is False
-        assert result["modules.professional_travel"]["view"] is True
-        assert result["modules.professional_travel"]["edit"] is True
-        assert result["modules.buildings"]["view"] is False
-        assert result["modules.buildings"]["edit"] is False
-        assert result["modules.purchase"]["view"] is False
-        assert result["modules.purchase"]["edit"] is False
-        assert result["modules.research_facilities"]["view"] is False
-        assert result["modules.research_facilities"]["edit"] is False
-        assert result["modules.external_cloud_and_ai"]["view"] is True
-        assert result["modules.external_cloud_and_ai"]["edit"] is True
+        assert "modules.headcount/10208" not in result
+        assert "modules.equipment/10208" not in result
+        assert "modules.professional_travel/10208" in result
+        assert "view" in result["modules.professional_travel/10208"]
+        assert "edit" in result["modules.professional_travel/10208"]
+        assert "modules.buildings/10208" not in result
+        assert "modules.purchase/10208" not in result
+        assert "modules.research_facilities/10208" not in result
+        assert "modules.external_cloud_and_ai/10208" in result
+        assert "view" in result["modules.external_cloud_and_ai/10208"]
+        assert "edit" in result["modules.external_cloud_and_ai/10208"]
 
     def test_user_roles_wrong_scope(self):
         """Test user roles with global scope do not grant permissions."""
         roles = [Role(role=RoleName.CO2_USER_STD, on=GlobalScope())]
         result = calculate_user_permissions(roles)
 
-        assert result["modules.headcount"]["view"] is False
-        assert result["modules.headcount"]["edit"] is False
+        assert "modules.headcount/10208" not in result
 
     def test_combined_backoffice_and_user_roles(self):
         """Test that permissions from different domains combine."""
         roles = [
             Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope()),
-            Role(role=RoleName.CO2_USER_STD, on=RoleScope(unit="10208")),
+            Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208")),
         ]
         result = calculate_user_permissions(roles)
 
         # Backoffice permissions
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
+        assert "backoffice.users" in result
+        assert "view" in result["backoffice.users"]
+        assert "edit" in result["backoffice.users"]
 
         # Module permissions - CO2_USER_STD grants professional_travel.view and edit
-        assert result["modules.professional_travel"]["view"] is True
-        assert result["modules.professional_travel"]["edit"] is True
-        assert result["modules.headcount"]["view"] is False
-        assert result["modules.headcount"]["edit"] is False
-        assert result["modules.equipment"]["view"] is False
-        assert result["modules.equipment"]["edit"] is False
+        assert "view" in result["modules.professional_travel/10208"]
+        assert "edit" in result["modules.professional_travel/10208"]
+        assert "modules.headcount/10208" not in result
+        assert "modules.equipment/10208" not in result
 
     def test_multiple_user_roles_same_unit(self):
         """Test multiple user roles for same unit combine correctly."""
         roles = [
-            Role(role=RoleName.CO2_USER_STD, on=RoleScope(unit="10208")),
-            Role(role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(unit="10208")),
+            Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208")),
+            Role(role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(institutional_id="10208")),
         ]
         result = calculate_user_permissions(roles)
 
-        assert result["modules.headcount"]["view"] is True
-        assert result["modules.headcount"]["edit"] is True
-        assert result["modules.professional_travel"]["view"] is True
-        assert result["modules.professional_travel"]["edit"] is True
+        assert "view" in result["modules.headcount/10208"]
+        assert "edit" in result["modules.headcount/10208"]
+        assert "view" in result["modules.professional_travel/10208"]
+        assert "edit" in result["modules.professional_travel/10208"]
 
     def test_role_name_as_string(self):
         """Test that role name can be string or enum."""
@@ -156,8 +149,8 @@ class TestCalculateUserPermissions:
         roles = [role]
         result = calculate_user_permissions(roles)
 
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
+        assert "view" in result["backoffice.users"]
+        assert "edit" in result["backoffice.users"]
 
     def test_all_permissions_initialized(self):
         """Test that all permissions are initialized even with no roles."""
@@ -175,9 +168,9 @@ class TestCalculateUserPermissions:
         result = calculate_user_permissions(roles)
 
         # Superadmin should grant all backoffice permissions
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
-        assert result["backoffice.users"]["export"] is True
+        assert "view" in result["backoffice.users"]
+        assert "edit" in result["backoffice.users"]
+        assert "export" in result["backoffice.users"]
 
 
 class TestHasPermission:
@@ -186,7 +179,7 @@ class TestHasPermission:
     def test_has_permission_view_true(self):
         """Test has_permission returns True for valid view permission."""
         perms = {
-            "modules.headcount": {"view": True, "edit": False},
+            "modules.headcount": ["view", "edit"],
         }
         result = has_permission(perms, "modules.headcount", "view")
         assert result is True
@@ -194,7 +187,7 @@ class TestHasPermission:
     def test_has_permission_edit_false(self):
         """Test has_permission returns False for false edit permission."""
         perms = {
-            "modules.headcount": {"view": True, "edit": False},
+            "modules.headcount": ["view"],
         }
         result = has_permission(perms, "modules.headcount", "edit")
         assert result is False
@@ -202,7 +195,7 @@ class TestHasPermission:
     def test_has_permission_missing_path(self):
         """Test has_permission returns False for missing path."""
         perms = {
-            "modules.headcount": {"view": True},
+            "modules.headcount": ["view"],
         }
         result = has_permission(perms, "modules.equipment", "view")
         assert result is False
@@ -210,7 +203,7 @@ class TestHasPermission:
     def test_has_permission_missing_action(self):
         """Test has_permission returns False for missing action."""
         perms = {
-            "modules.headcount": {"view": True},
+            "modules.headcount": ["view"],
         }
         result = has_permission(perms, "modules.headcount", "export")
         assert result is False
@@ -228,7 +221,7 @@ class TestHasPermission:
     def test_has_permission_export_action(self):
         """Test has_permission works with export action."""
         perms = {
-            "backoffice.users": {"view": True, "edit": True, "export": True},
+            "backoffice.users": ["view", "edit", "export"],
         }
         result = has_permission(perms, "backoffice.users", "export")
         assert result is True
@@ -236,7 +229,7 @@ class TestHasPermission:
     def test_has_permission_default_action_view(self):
         """Test has_permission defaults to view action."""
         perms = {
-            "modules.headcount": {"view": True, "edit": False},
+            "modules.headcount": ["view", "edit"],
         }
         result = has_permission(perms, "modules.headcount")
         assert result is True
@@ -248,218 +241,3 @@ class TestHasPermission:
         }
         result = has_permission(perms, "modules.headcount", "view")
         assert result is False
-
-
-class TestGetPermissionValue:
-    """Tests for get_permission_value helper function."""
-
-    def test_get_permission_value_view_true(self):
-        """Test get_permission_value returns True for valid permission."""
-        perms = {
-            "modules.headcount": {"view": True, "edit": False},
-        }
-        result = get_permission_value(perms, "modules.headcount.view")
-        assert result is True
-
-    def test_get_permission_value_edit_false(self):
-        """Test get_permission_value returns False for false permission."""
-        perms = {
-            "modules.headcount": {"view": True, "edit": False},
-        }
-        result = get_permission_value(perms, "modules.headcount.edit")
-        assert result is False
-
-    def test_get_permission_value_missing_path(self):
-        """Test get_permission_value returns None for missing path."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "modules.equipment.view")
-        assert result is None
-
-    def test_get_permission_value_missing_action(self):
-        """Test get_permission_value returns None for missing action."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "modules.headcount.export")
-        assert result is None
-
-    def test_get_permission_value_none_permissions(self):
-        """Test get_permission_value handles None permissions."""
-        result = get_permission_value(None, "modules.headcount.view")
-        assert result is None
-
-    def test_get_permission_value_empty_dict(self):
-        """Test get_permission_value handles empty dict."""
-        result = get_permission_value({}, "modules.headcount.view")
-        assert result is None
-
-    def test_get_permission_value_invalid_path_format(self):
-        """Test get_permission_value handles invalid path format."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "invalid")
-        assert result is None
-
-    def test_get_permission_value_too_many_dots(self):
-        """Test get_permission_value handles paths with too many dots."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "modules.headcount.view.extra")
-        # Should still work, splits from right
-        assert result is None
-
-    def test_get_permission_value_export_action(self):
-        """Test get_permission_value works with export action."""
-        perms = {
-            "backoffice.users": {"view": True, "edit": True, "export": True},
-        }
-        result = get_permission_value(perms, "backoffice.users.export")
-        assert result is True
-
-    def test_get_permission_value_invalid_structure(self):
-        """Test get_permission_value handles invalid permission structure."""
-        perms = {
-            "modules.headcount": "invalid",
-        }
-        result = get_permission_value(perms, "modules.headcount.view")
-        assert result is None
-
-    def test_get_permission_value_empty_path(self):
-        """Test get_permission_value with empty path."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "")
-        assert result is None
-
-    def test_get_permission_value_no_dot(self):
-        """Test get_permission_value with path that has no dot."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "invalid")
-        assert result is None
-
-    def test_has_permission_with_none_action(self):
-        """Test has_permission with None action."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        # Should default to "view"
-        result = has_permission(perms, "modules.headcount")
-        assert result is True
-
-    def test_has_permission_with_empty_action(self):
-        """Test has_permission with empty action string."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = has_permission(perms, "modules.headcount", "")
-        assert result is False
-
-    def test_calculate_user_permissions_with_none_roles(self):
-        """Test calculate_user_permissions with None roles."""
-        result = calculate_user_permissions(None)
-        assert result == {}
-
-    def test_calculate_user_permissions_backoffice_metier_with_affiliation_scope(self):
-        """Test backoffice metier with affiliation scope grants full backoffice."""
-        roles = [
-            Role(
-                role=RoleName.CO2_BACKOFFICE_METIER,
-                on=RoleScope(affiliation="TEST-AFF"),
-            )
-        ]
-        result = calculate_user_permissions(roles)
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
-        assert result["backoffice.users"]["export"] is True
-
-    def test_calculate_user_permissions_user_principal_global_scope(self):
-        """Test user principal with global scope does not grant permissions."""
-        roles = [Role(role=RoleName.CO2_USER_PRINCIPAL, on=GlobalScope())]
-        result = calculate_user_permissions(roles)
-        # Global scope for user roles should not grant permissions
-        assert result["modules.headcount"]["view"] is False
-        assert result["modules.equipment"]["view"] is False
-
-    def test_calculate_user_permissions_superadmin_global_scope(self):
-        """Test superadmin with global scope grants system and backoffice perms."""
-        roles = [Role(role=RoleName.CO2_SUPERADMIN, on=GlobalScope())]
-        result = calculate_user_permissions(roles)
-        assert result["system.users"]["edit"] is True
-        assert result["backoffice.users"]["view"] is True
-        assert result["backoffice.users"]["edit"] is True
-        assert result["modules.headcount"]["view"] is False
-
-    def test_calculate_user_permissions_superadmin_unit_scope(self):
-        """Test superadmin with unit scope does not grant permissions."""
-        roles = [
-            Role(role=RoleName.CO2_SUPERADMIN, on=RoleScope(institutional_id="12345"))
-        ]
-        result = calculate_user_permissions(roles)
-        assert result["system.users"]["edit"] is False
-
-    def test_calculate_user_permissions_role_as_string(self):
-        """Test calculate_user_permissions with role name as string."""
-        # Create role with string role name directly
-        role_dict = {
-            "role": RoleName.CO2_USER_PRINCIPAL.value,
-            "on": {"unit": "12345"},
-        }
-        role = Role(**role_dict)
-        roles = [role]
-        result = calculate_user_permissions(roles)
-        assert result["modules.headcount"]["view"] is True
-        assert result["modules.headcount"]["edit"] is True
-
-    def test_calculate_user_permissions_invalid_role_scope(self):
-        """Test calculate_user_permissions with role that has wrong scope."""
-        # Test that roles with wrong scope don't grant permissions
-        roles = [
-            Role(role=RoleName.CO2_SUPERADMIN, on=RoleScope(institutional_id="12345"))
-        ]
-        result = calculate_user_permissions(roles)
-        # Superadmin with unit scope (not global) should not grant permissions
-        assert result["system.users"]["edit"] is False
-        assert result["backoffice.users"]["view"] is False
-        assert result["modules.headcount"]["view"] is False
-
-    def test_calculate_user_permissions_multiple_units(self):
-        """Test calculate_user_permissions with roles for multiple units."""
-        roles = [
-            Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="12345")),
-            Role(role=RoleName.CO2_USER_STD, on=RoleScope(unit="99999")),
-        ]
-        result = calculate_user_permissions(roles)
-        # Should grant permissions (same role, different units)
-        assert result["modules.professional_travel"]["view"] is True
-        assert result["modules.professional_travel"]["edit"] is True
-
-    def test_has_permission_with_false_value(self):
-        """Test has_permission with explicitly False value."""
-        perms = {
-            "modules.headcount": {"view": False, "edit": False},
-        }
-        result = has_permission(perms, "modules.headcount", "view")
-        assert result is False
-
-    def test_get_permission_value_with_false_value(self):
-        """Test get_permission_value with explicitly False value."""
-        perms = {
-            "modules.headcount": {"view": False},
-        }
-        result = get_permission_value(perms, "modules.headcount.view")
-        assert result is False
-
-    def test_get_permission_value_with_zero_dots(self):
-        """Test get_permission_value with path that has no dots."""
-        perms = {
-            "modules.headcount": {"view": True},
-        }
-        result = get_permission_value(perms, "invalidpath")
-        assert result is None

--- a/backend/tests/unit/utils/test_permissions.py
+++ b/backend/tests/unit/utils/test_permissions.py
@@ -62,23 +62,27 @@ class TestCalculateUserPermissions:
 
     def test_user_principal_unit_scope(self):
         """Test user principal with unit scope grants module permissions."""
-        roles = [Role(role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(unit="10208"))]
+        roles = [
+            Role(
+                role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(institutional_id="10208")
+            )
+        ]
         result = calculate_user_permissions(roles)
 
-        assert "view" in result["modules.headcount"]
-        assert "edit" in result["modules.headcount"]
-        assert "view" in result["modules.equipment"]
-        assert "edit" in result["modules.equipment"]
-        assert "view" in result["modules.professional_travel"]
-        assert "edit" in result["modules.professional_travel"]
-        assert "view" in result["modules.buildings"]
-        assert "edit" in result["modules.buildings"]
-        assert "view" in result["modules.purchase"]
-        assert "edit" in result["modules.purchase"]
-        assert "view" in result["modules.research_facilities"]
-        assert "edit" in result["modules.research_facilities"]
-        assert "view" in result["modules.external_cloud_and_ai"]
-        assert "edit" in result["modules.external_cloud_and_ai"]
+        assert "view" in result["modules.headcount/10208"]
+        assert "edit" in result["modules.headcount/10208"]
+        assert "view" in result["modules.equipment/10208"]
+        assert "edit" in result["modules.equipment/10208"]
+        assert "view" in result["modules.professional_travel/10208"]
+        assert "edit" in result["modules.professional_travel/10208"]
+        assert "view" in result["modules.buildings/10208"]
+        assert "edit" in result["modules.buildings/10208"]
+        assert "view" in result["modules.purchase/10208"]
+        assert "edit" in result["modules.purchase/10208"]
+        assert "view" in result["modules.research_facilities/10208"]
+        assert "edit" in result["modules.research_facilities/10208"]
+        assert "view" in result["modules.external_cloud_and_ai/10208"]
+        assert "edit" in result["modules.external_cloud_and_ai/10208"]
         # Principal also gets backoffice.users.edit for unit-scoped role assignment
         assert "edit" in result["backoffice.users"]
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -535,6 +534,7 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -636,7 +636,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -702,7 +701,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -751,7 +749,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -825,6 +822,45 @@
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
       }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -4083,7 +4119,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4499,6 +4534,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
@@ -4517,6 +4575,14 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
@@ -5263,7 +5329,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -5543,6 +5608,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5563,6 +5629,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5573,6 +5640,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5586,6 +5654,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5600,7 +5669,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -5667,7 +5737,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5899,7 +5970,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6019,7 +6089,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -6500,7 +6569,6 @@
       "integrity": "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rolldown/pluginutils": "1.0.0-rc.2"
       },
@@ -6922,7 +6990,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7426,7 +7493,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -7639,7 +7705,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8545,7 +8610,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -8808,7 +8872,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "0.2.2",
@@ -8984,7 +9049,6 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
@@ -9248,7 +9312,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9335,7 +9398,6 @@
       "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -10037,9 +10099,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -11343,7 +11405,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -12432,7 +12493,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -12779,6 +12839,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13918,7 +13979,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -14131,9 +14191,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",
@@ -14149,7 +14209,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14354,7 +14413,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14399,7 +14457,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14747,7 +14804,6 @@
       "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.18.5.tgz",
       "integrity": "sha512-5ItDSsNjqBVRrC7SqcdvT1F5mghVyJ/KmaWNwnaT5mM91a7gWpT/d7wTCIFxxDbWLZdkHKI+cpdudEqnfcSw9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.18.1",
         "npm": ">= 6.13.4",
@@ -14811,7 +14867,6 @@
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14822,7 +14877,6 @@
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15086,7 +15140,6 @@
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
         "@rolldown/pluginutils": "1.0.0-rc.15"
@@ -15128,7 +15181,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15435,7 +15487,6 @@
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -15457,7 +15508,6 @@
       "integrity": "sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "colorjs.io": "^0.5.0",
@@ -16291,7 +16341,6 @@
       "integrity": "sha512-UUm5eGSm6BLhkcFP0WbxkmAHJZfVN2ViLpIZOqiIPS++q32VYn+CLFC0lrTYTDqYvaG7i4BK4uowXYujzE4NdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -16582,7 +16631,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -17160,7 +17208,6 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -17468,7 +17515,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17802,6 +17848,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17819,6 +17866,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17836,6 +17884,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17853,6 +17902,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17870,6 +17920,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17887,6 +17938,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17904,6 +17956,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17921,6 +17974,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17938,6 +17992,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17955,6 +18010,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17972,6 +18028,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17989,6 +18046,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18006,6 +18064,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18023,6 +18082,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18040,6 +18100,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18057,6 +18118,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18074,6 +18136,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18091,6 +18154,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18108,6 +18172,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18125,6 +18190,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18142,6 +18208,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18159,6 +18226,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18176,6 +18244,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18193,6 +18262,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18210,6 +18280,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18227,6 +18298,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18238,6 +18310,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -18295,7 +18368,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",
@@ -18397,7 +18469,6 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -826,47 +826,6 @@
         "postcss-selector-parser": "^7.1.1"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/core/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -15127,6 +15086,7 @@
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
         "@rolldown/pluginutils": "1.0.0-rc.15"

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -2,31 +2,23 @@
 import { computed } from 'vue';
 import Co2LanguageSelector from 'src/components/atoms/Co2LanguageSelector.vue';
 import { useAuthStore } from 'src/stores/auth';
+import { useWorkspaceStore } from 'src/stores/workspace';
 import { useRouter } from 'vue-router';
 import { useRoute } from 'vue-router';
-
 import { isBackOfficeRoute } from 'src/router/routes';
-import { hasPermission } from 'src/utils/permission';
+import { PermissionAction } from 'src/constant/permissions';
 
 const authStore = useAuthStore();
 const router = useRouter();
 const route = useRoute();
+const workspaceStore = useWorkspaceStore();
 
 const unitName = computed(() => {
-  if (!route.params.unit) return '';
-  const unit = decodeURIComponent(route.params.unit as string);
-  // Extract name from format: {id}-{name}
-  // The name part is everything after the first dash
-  const parts = unit.split('-');
-  if (parts.length > 1) {
-    // Join all parts except the first (which is the ID) and replace dashes with spaces
-    return parts.slice(1).join('-').replace(/-/g, ' ');
-  }
-  return unit;
+  return workspaceStore.selectedUnit?.name || '';
 });
 
 const year = computed(() => {
-  return route.params.year || '';
+  return workspaceStore.selectedYear || '';
 });
 
 const workspaceDisplay = computed(() => {
@@ -39,7 +31,7 @@ const handleLogout = async () => {
 };
 
 const hasBackOfficeAccess = computed(() => {
-  return hasPermission(authStore.user?.permissions, 'backoffice.users', 'view');
+  return authStore.hasUserPermission('backoffice.users', PermissionAction.VIEW);
 });
 
 const isInBackOfficeRoute = computed(() => isBackOfficeRoute(route));

--- a/frontend/src/components/layout/Co2Sidebar.vue
+++ b/frontend/src/components/layout/Co2Sidebar.vue
@@ -3,8 +3,8 @@ import { computed, ref } from 'vue';
 import { NavItem } from 'src/constant/navigation';
 import { useRouter } from 'vue-router';
 import { useAuthStore } from 'src/stores/auth';
-import { hasPermission } from 'src/utils/permission';
 import { ROLES } from 'src/constant/roles';
+import { PermissionAction } from 'src/constant/permissions';
 
 interface Props {
   items: Record<string, NavItem>;
@@ -20,7 +20,7 @@ function navigateToRoute(routeName: string) {
 }
 
 const hasBackOfficeEditPermission = computed(() => {
-  return hasPermission(authStore.user?.permissions, 'backoffice.users', 'edit');
+  return authStore.hasUserPermission('backoffice.users', PermissionAction.EDIT);
 });
 
 const hasSuperAdminRole = computed(() => {

--- a/frontend/src/components/organisms/layout/Co2Timeline.vue
+++ b/frontend/src/components/organisms/layout/Co2Timeline.vue
@@ -4,7 +4,6 @@ import { useTimelineStore } from 'src/stores/modules';
 import Co2TimelineItem from 'src/components/molecules/Co2TimelineItem.vue';
 import { useRoute } from 'vue-router';
 import { useAuthStore } from 'src/stores/auth';
-import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
 import { PermissionAction } from 'src/constant/permissions';
 import type { Module } from 'src/constant/modules';
 import { timelineItems } from 'src/constant/timelineItems';
@@ -19,11 +18,7 @@ function hasModulePermission(
   module: Module,
   action: PermissionAction,
 ): boolean {
-  return hasPermission(
-    authStore.user?.permissions,
-    getModulePermissionPath(module),
-    action,
-  );
+  return authStore.hasUserModulePermission(module, action);
 }
 
 const visibleTimelineItems = computed(() => {

--- a/frontend/src/components/organisms/module/HeadcountMemberSelect.vue
+++ b/frontend/src/components/organisms/module/HeadcountMemberSelect.vue
@@ -43,7 +43,6 @@ import { ref, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { MODULES } from 'src/constant/modules';
 import { useAuthStore } from 'src/stores/auth';
-import { hasPermission } from 'src/utils/permission';
 import {
   getHeadcountMembers,
   type HeadcountMemberDropdownItem,
@@ -73,7 +72,7 @@ const loading = ref(false);
 const members = ref<HeadcountMemberDropdownItem[]>([]);
 const authStore = useAuthStore();
 const canEditHeadcount = computed(() =>
-  hasPermission(authStore.user?.permissions, 'modules.headcount', 'edit'),
+  authStore.hasUserModulePermission(MODULES.Headcount, 'edit'),
 );
 const isNotValidated = computed(
   () => members.value.length === 0 && !canEditHeadcount.value,

--- a/frontend/src/components/organisms/module/HeadcountMemberSelect.vue
+++ b/frontend/src/components/organisms/module/HeadcountMemberSelect.vue
@@ -47,6 +47,7 @@ import {
   getHeadcountMembers,
   type HeadcountMemberDropdownItem,
 } from 'src/api/modules';
+import { PermissionAction } from 'src/constant/permissions';
 
 const { t: $t } = useI18n();
 
@@ -72,7 +73,7 @@ const loading = ref(false);
 const members = ref<HeadcountMemberDropdownItem[]>([]);
 const authStore = useAuthStore();
 const canEditHeadcount = computed(() =>
-  authStore.hasUserModulePermission(MODULES.Headcount, 'edit'),
+  authStore.hasUserModulePermission(MODULES.Headcount, PermissionAction.EDIT),
 );
 const isNotValidated = computed(
   () => members.value.length === 0 && !canEditHeadcount.value,

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -357,7 +357,6 @@ import {
   TargetType,
 } from 'src/stores/backofficeDataManagement';
 import type { JobUpdatePayload } from 'src/stores/backofficeDataManagement';
-import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
 import { PermissionAction } from 'src/constant/permissions';
 import { getTemplateFileName } from 'src/constant/templateMapping';
 import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
@@ -690,14 +689,8 @@ const hasModuleUpload = computed(() => {
 
 // Permission check: can user edit this module?
 const canEdit = computed(() => {
-  const permissionPath = getModulePermissionPath(props.moduleType);
-  if (!permissionPath) {
-    // Module doesn't require permission, allow editing (backward compatibility)
-    return true;
-  }
-  return hasPermission(
-    authStore.user?.permissions,
-    permissionPath,
+  return authStore.hasUserModulePermission(
+    props.moduleType,
     PermissionAction.EDIT,
   );
 });

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -98,7 +98,6 @@ import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useAuthStore } from 'src/stores/auth';
-import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
 import { PermissionAction } from 'src/constant/permissions';
 import type {
   ModuleResponse,
@@ -200,14 +199,8 @@ const effectiveThreshold = computed<Threshold>(() => {
 
 // Permission check: can user edit this module?
 const canEdit = computed(() => {
-  const permissionPath = getModulePermissionPath(props.moduleType);
-  if (!permissionPath) {
-    // Module doesn't require permission, allow editing (backward compatibility)
-    return true;
-  }
-  return hasPermission(
-    authStore.user?.permissions,
-    permissionPath,
+  return authStore.hasUserModulePermission(
+    props.moduleType,
     PermissionAction.EDIT,
   );
 });

--- a/frontend/src/constant/permissions.ts
+++ b/frontend/src/constant/permissions.ts
@@ -10,13 +10,6 @@
  * Available actions that can be performed on a permission resource.
  *
  * @enum {string}
- * @example
- * ```typescript
- * const action = PermissionAction.VIEW;
- * if (hasPermission(user.permissions, 'modules.headcount', action)) {
- *   // User can view headcount module
- * }
- * ```
  */
 export enum PermissionAction {
   /** View/read access to a resource */
@@ -26,33 +19,6 @@ export enum PermissionAction {
   /** Export/download access to a resource */
   EXPORT = 'export',
 }
-
-/**
- * Valid permission paths in the system.
- *
- * These paths use dot-notation to represent the resource hierarchy.
- * Each path corresponds to a specific resource that can have permissions.
- *
- * @example
- * ```typescript
- * const path: PermissionPath = 'modules.headcount';
- * const canEdit = hasPermission(permissions, path, PermissionAction.EDIT);
- * ```
- */
-export type PermissionPath =
-  | 'backoffice.reporting'
-  | 'backoffice.users'
-  | 'backoffice.data_management'
-  | 'backoffice.documentation'
-  | 'modules.headcount'
-  | 'modules.equipment'
-  | 'modules.professional_travel'
-  | 'modules.buildings'
-  | 'modules.purchase'
-  | 'modules.research_facilities'
-  | 'modules.external_cloud_and_ai'
-  | 'modules.process_emissions'
-  | 'system.users';
 
 /**
  * Permission set for a single resource.

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -13,7 +13,6 @@ import {
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useAuthStore } from 'src/stores/auth';
-import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
 import { PermissionAction } from 'src/constant/permissions';
 import type { Module } from 'src/constant/modules';
 import { useTimelineStore } from 'src/stores/modules';
@@ -62,11 +61,7 @@ function hasModulePermission(
   module: Module,
   action: PermissionAction,
 ): boolean {
-  return hasPermission(
-    authStore.user?.permissions,
-    getModulePermissionPath(module),
-    action,
-  );
+  return authStore.hasUserModulePermission(module, action);
 }
 const timelineStore = useTimelineStore();
 

--- a/frontend/src/router/guards/permissionGuard.ts
+++ b/frontend/src/router/guards/permissionGuard.ts
@@ -3,11 +3,6 @@ import type {
   RouteLocationNormalized,
   NavigationGuardReturn,
 } from 'vue-router';
-import {
-  getPermissionValue,
-  hasPermission,
-  getModulePermissionPath,
-} from 'src/utils/permission';
 import { PermissionAction } from 'src/constant/permissions';
 import type { Module } from 'src/constant/modules';
 
@@ -18,40 +13,20 @@ import type { Module } from 'src/constant/modules';
  * has the required permission. If the permission is granted, navigation proceeds.
  * If not, the user is redirected to the unauthorized page.
  *
- * @param path - The permission path (e.g., 'modules.headcount')
+ * @param path - The permission path (e.g., 'backoffice.users')
  * @param action - The action to check (defaults to 'view')
  * @returns A navigation guard function compatible with Vue Router's `beforeEnter`
- *
- * @example
- * ```typescript
- * // Usage in routes
- * {
- *   path: '/headcount',
- *   component: HeadcountPage,
- *   beforeEnter: requirePermission('modules.headcount', 'view')
- * }
- *
- * // With edit permission
- * {
- *   path: '/equipment/edit',
- *   component: EditEquipmentPage,
- *   beforeEnter: requirePermission('modules.equipment', 'edit')
- * }
- * ```
  */
 export function requirePermission(
   path: string,
-  action: string = PermissionAction.VIEW,
+  action: PermissionAction = PermissionAction.VIEW,
 ) {
   return (): NavigationGuardReturn => {
     // Lighthouse CI bypass: allow all routes regardless of permissions.
     if (window.__LIGHTHOUSE_BYPASS__) return true;
 
     const authStore = useAuthStore();
-    const hasRequiredPermission = getPermissionValue(
-      authStore.user?.permissions,
-      `${path}.${action}`,
-    );
+    const hasRequiredPermission = authStore.hasUserPermission(path, action);
     if (hasRequiredPermission === true) {
       return true;
     } else {
@@ -79,18 +54,9 @@ export function requireModuleEditPermission() {
     const authStore = useAuthStore();
     const module = to.params.module as Module;
 
-    // Get the permission path for this module
-    const permissionPath = getModulePermissionPath(module);
-
-    // If module doesn't have a permission path, allow access (not yet protected)
-    if (!permissionPath) {
-      return true;
-    }
-
     // First check if user has view permission (standard users without view should be blocked)
-    const hasViewPermission = hasPermission(
-      authStore.user?.permissions,
-      permissionPath,
+    const hasViewPermission = authStore.hasUserModulePermission(
+      module,
       PermissionAction.VIEW,
     );
 
@@ -100,9 +66,8 @@ export function requireModuleEditPermission() {
     }
 
     // Check if user has edit permission (required for data entry for other modules)
-    const hasEditPermission = hasPermission(
-      authStore.user?.permissions,
-      permissionPath,
+    const hasEditPermission = authStore.hasUserModulePermission(
+      module,
       PermissionAction.EDIT,
     );
 

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -9,6 +9,7 @@ import {
   requireModuleEditPermission,
 } from './guards/permissionGuard';
 import { moduleEnabledGuard } from './guards/moduleEnabledGuard';
+import { PermissionAction } from 'src/constant/permissions';
 
 // Route parameter validation patterns
 const LANGUAGE_PATTERN = 'en|fr';
@@ -178,13 +179,19 @@ const routes: RouteRecordRaw[] = [
             redirect: {
               name: BACKOFFICE_NAV.BACKOFFICE_REPORTING.routeName,
             },
-            beforeEnter: requirePermission('backoffice.users', 'view'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.VIEW,
+            ),
           },
           {
             path: 'back-office/user-management',
             name: BACKOFFICE_NAV.BACKOFFICE_USER_MANAGEMENT.routeName,
             component: () => import('pages/back-office/UserManagementPage.vue'),
-            beforeEnter: requirePermission('backoffice.users', 'edit'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.EDIT,
+            ),
             meta: {
               requiresAuth: true,
               note: 'Back Office - User roles and permissions (admin only)',
@@ -196,7 +203,10 @@ const routes: RouteRecordRaw[] = [
             path: 'back-office/data-management',
             name: BACKOFFICE_NAV.BACKOFFICE_DATA_MANAGEMENT.routeName,
             component: () => import('pages/back-office/DataManagementPage.vue'),
-            beforeEnter: requirePermission('backoffice.users', 'edit'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.EDIT,
+            ),
             meta: {
               requiresAuth: true,
               note: 'Back Office - Data management (admin only)',
@@ -209,7 +219,10 @@ const routes: RouteRecordRaw[] = [
             name: BACKOFFICE_NAV.BACKOFFICE_DOCUMENTATION_EDITING.routeName,
             component: () =>
               import('pages/back-office/DocumentationEditingPage.vue'),
-            beforeEnter: requirePermission('backoffice.users', 'view'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.VIEW,
+            ),
             meta: {
               requiresAuth: true,
               note: 'Back Office - Documentation and translation management via GitHub',
@@ -221,7 +234,10 @@ const routes: RouteRecordRaw[] = [
             path: 'back-office/reporting',
             name: BACKOFFICE_NAV.BACKOFFICE_REPORTING.routeName,
             component: () => import('pages/back-office/ReportingPage.vue'),
-            beforeEnter: requirePermission('backoffice.users', 'view'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.VIEW,
+            ),
             meta: {
               requiresAuth: true,
 
@@ -234,7 +250,10 @@ const routes: RouteRecordRaw[] = [
             path: 'back-office/ui-texts-editing',
             name: BACKOFFICE_NAV.BACKOFFICE_UI_TEXTS_EDITING.routeName,
             component: () => import('pages/back-office/UITextsEditingPage.vue'),
-            beforeEnter: requirePermission('backoffice.users', 'view'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.VIEW,
+            ),
             meta: {
               requiresAuth: true,
               note: 'Back Office - UI translation text management via GitHub',
@@ -246,7 +265,10 @@ const routes: RouteRecordRaw[] = [
             path: 'back-office/logs',
             name: BACKOFFICE_NAV.BACKOFFICE_LOGS.routeName,
             component: () => import('pages/system/LogsPage.vue'),
-            beforeEnter: requirePermission('system.users', 'edit'),
+            beforeEnter: requirePermission(
+              'system.users',
+              PermissionAction.EDIT,
+            ),
             meta: {
               requiresAuth: true,
               note: 'Back Office - Audit logs (superadmin only)',
@@ -258,7 +280,10 @@ const routes: RouteRecordRaw[] = [
             path: 'back-office/documentation',
             name: 'back-office-documentation',
             component: () => import('pages/back-office/DocumentationPage.vue'),
-            beforeEnter: requirePermission('backoffice.users', 'view'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.VIEW,
+            ),
             meta: {
               requiresAuth: true,
               note: 'Documentation - Back Office documentation',

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -123,22 +123,13 @@ export const useAuthStore = defineStore('auth', () => {
       path,
       action,
     );
-    console.log(
-      `[global] Checking permission for path: ${path} and action: ${action}`,
-    );
     if (globallyPermitted) return true;
     // append workspace context to permission path if available
     const institutionalId = workspaceStore.selectedUnit?.institutional_id;
     if (institutionalId) {
       path = `${path}/${institutionalId}`;
-      console.log(
-        `[workspace] Checking permission for path: ${path} and action: ${action}`,
-      );
       return hasPermission(user.value.permissions, path, action);
     }
-    console.log(
-      `[workspace] No institutional ID found for path: ${path} and action: ${action}`,
-    );
     return false;
   }
 
@@ -155,7 +146,7 @@ export const useAuthStore = defineStore('auth', () => {
     action: PermissionAction = PermissionAction.VIEW,
   ): boolean {
     const path = getModulePermissionPath(module);
-    if (!path) return false; // FIXME If module doesn't have a permission path, treat as no access
+    if (!path) return false; // If module doesn't have a permission path, treat as no access
     return hasUserPermission(path, action);
   }
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -8,7 +8,9 @@ import {
 } from 'src/api/http';
 import { Router } from 'vue-router';
 import { computed } from 'vue';
-
+import { PermissionAction } from 'src/constant/permissions';
+import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
+import { Module } from 'src/constant/modules';
 interface User {
   id: string;
   email: string;
@@ -100,6 +102,38 @@ export const useAuthStore = defineStore('auth', () => {
     return user.value !== null;
   });
 
+  /**
+   * Check if current user has a specific permission.
+   *
+   * @param path The permission path to check (e.g., 'modules.headcount')
+   * @param action The action to check (e.g., 'view')
+   * @returns boolean indicating if the user has the specified permission
+   */
+  function hasUserPermission(
+    path: string,
+    action: PermissionAction = PermissionAction.VIEW,
+  ): boolean {
+    if (!user.value) return false;
+    return hasPermission(user.value.permissions, path, action);
+  }
+
+  /**
+   * Check if current user has a specific permission for a module.
+   * This is a convenience function that derives the permission path from the module.
+   *
+   * @param module The module to check permissions for
+   * @param action The action to check (e.g., 'view')
+   * @returns boolean indicating if the user has the specified permission for the module
+   */
+  function hasUserModulePermission(
+    module: Module,
+    action: PermissionAction = PermissionAction.VIEW,
+  ): boolean {
+    const path = getModulePermissionPath(module);
+    if (!path) return false; // FIXME If module doesn't have a permission path, treat as no access
+    return hasUserPermission(path, action);
+  }
+
   return {
     user,
     loading,
@@ -110,5 +144,7 @@ export const useAuthStore = defineStore('auth', () => {
     login_test,
     logout,
     isAuthenticated,
+    hasUserPermission,
+    hasUserModulePermission,
   };
 });

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -11,6 +11,7 @@ import { computed } from 'vue';
 import { PermissionAction } from 'src/constant/permissions';
 import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
 import { Module } from 'src/constant/modules';
+import { useWorkspaceStore } from './workspace';
 interface User {
   id: string;
   email: string;
@@ -33,6 +34,8 @@ interface User {
 export const useAuthStore = defineStore('auth', () => {
   const user = ref<User | null>(null);
   const loading = ref(false);
+
+  const workspaceStore = useWorkspaceStore();
 
   const displayName = computed(() => {
     if (!user.value) return '';
@@ -113,8 +116,30 @@ export const useAuthStore = defineStore('auth', () => {
     path: string,
     action: PermissionAction = PermissionAction.VIEW,
   ): boolean {
-    if (!user.value) return false;
-    return hasPermission(user.value.permissions, path, action);
+    if (!user.value || !user.value.permissions) return false;
+    // Check for global permission first (without workspace context)
+    const globallyPermitted = hasPermission(
+      user.value.permissions,
+      path,
+      action,
+    );
+    console.log(
+      `[global] Checking permission for path: ${path} and action: ${action}`,
+    );
+    if (globallyPermitted) return true;
+    // append workspace context to permission path if available
+    const institutionalId = workspaceStore.selectedUnit?.institutional_id;
+    if (institutionalId) {
+      path = `${path}/${institutionalId}`;
+      console.log(
+        `[workspace] Checking permission for path: ${path} and action: ${action}`,
+      );
+      return hasPermission(user.value.permissions, path, action);
+    }
+    console.log(
+      `[workspace] No institutional ID found for path: ${path} and action: ${action}`,
+    );
+    return false;
   }
 
   /**

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -8,6 +8,7 @@ export const WORKSPACE_DEFAULT_YEAR = 2025;
 export interface Unit {
   id: number;
   name: string;
+  institutional_id: string;
   principal_user_id: string;
   principal_user_function: string;
   principal_user_name: string;

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -54,23 +54,13 @@ export function hasPermission(
     return false;
   }
 
-  // Edge case: path is null/undefined or not a string
-  if (!path || typeof path !== 'string') {
+  // Edge case: path is null/undefined or not a string or empty/whitespace-only
+  if (!path || typeof path !== 'string' || path.trim().length === 0) {
     return false;
   }
 
-  // Edge case: path is empty or whitespace-only
-  if (path.trim().length === 0) {
-    return false;
-  }
-
-  // Edge case: action is null/undefined or not a string
-  if (!action || typeof action !== 'string') {
-    return false;
-  }
-
-  // Edge case: action is empty or whitespace-only
-  if (action.trim().length === 0) {
+  // Edge case: action is null/undefined or not a string or empty/whitespace-only
+  if (!action || typeof action !== 'string' || action.trim().length === 0) {
     return false;
   }
 
@@ -82,30 +72,13 @@ export function hasPermission(
 
     const permSet = permissions[path];
 
-    // Edge case: permission set is null/undefined
-    if (permSet === null || permSet === undefined) {
+    // Edge case: permission set is null/undefined or not an array (should be an array of allowed actions)
+    if (permSet === null || permSet === undefined || !Array.isArray(permSet)) {
       return false;
     }
 
-    // Edge case: permission set is not an object (could be array, primitive, etc.)
-    if (typeof permSet !== 'object' || Array.isArray(permSet)) {
-      return false;
-    }
-
-    // Edge case: action not in permission set
-    if (!(action in permSet)) {
-      return false;
-    }
-
-    const value = permSet[action];
-
-    // Edge case: value is null/undefined (explicitly check for null)
-    if (value === null || value === undefined) {
-      return false;
-    }
-
-    // Return the boolean value (coerce to boolean for safety)
-    return Boolean(value);
+    // Check if the action exists in the permission set
+    return permSet.includes(action);
   } catch (error) {
     // Edge case: any unexpected error (TypeError, etc.)
     // Log in development for debugging, but return false in production

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -7,10 +7,7 @@
  * @see {@link ../constant/permissions | Permission types}
  */
 
-import type {
-  FlatUserPermissions,
-  PermissionPath,
-} from 'src/constant/permissions';
+import type { FlatUserPermissions } from 'src/constant/permissions';
 import { PermissionAction } from 'src/constant/permissions';
 import { MODULES, type Module } from 'src/constant/modules';
 
@@ -44,8 +41,8 @@ import { MODULES, type Module } from 'src/constant/modules';
  */
 export function hasPermission(
   permissions: FlatUserPermissions | null | undefined,
-  path: PermissionPath | string,
-  action: PermissionAction | string = PermissionAction.VIEW,
+  path: string,
+  action: PermissionAction = PermissionAction.VIEW,
 ): boolean {
   // Null safety: return false if permissions is null/undefined
   if (!permissions) {
@@ -120,195 +117,11 @@ export function hasPermission(
 }
 
 /**
- * Get the value of a specific permission using a full dot-notation path.
- *
- * This function parses a full path like "modules.headcount.view" and returns
- * the permission value. Returns `undefined` if the path is invalid or the
- * permission doesn't exist.
- *
- * @param permissions - The permissions object (from user.permissions), can be null/undefined
- * @param fullPath - Full dot-notation path including action (e.g., 'backoffice.users.edit')
- * @returns The permission value (`true`/`false`), or `undefined` if not found
- *
- * @example
- * ```typescript
- * // Get edit permission for backoffice users
- * const canEditUsers = getPermissionValue(
- *   user.permissions,
- *   'backoffice.users.edit'
- * );
- * if (canEditUsers === true) {
- *   // User can edit backoffice users
- * }
- *
- * // Check if permission exists (undefined means it doesn't exist)
- * const viewPerm = getPermissionValue(
- *   user.permissions,
- *   'modules.headcount.view'
- * );
- * if (viewPerm === undefined) {
- *   // Permission path is invalid or doesn't exist
- * }
- * ```
- */
-export function getPermissionValue(
-  permissions: FlatUserPermissions | null | undefined,
-  fullPath: string,
-): boolean | undefined {
-  // Null safety: return undefined if permissions is null/undefined
-  if (!permissions) {
-    return undefined;
-  }
-
-  // Edge case: permissions is not an object (could be array, primitive, etc.)
-  if (typeof permissions !== 'object' || Array.isArray(permissions)) {
-    return undefined;
-  }
-
-  // Edge case: fullPath is null/undefined or not a string
-  if (!fullPath || typeof fullPath !== 'string') {
-    return undefined;
-  }
-
-  // Edge case: fullPath is empty or whitespace-only
-  const trimmedPath = fullPath.trim();
-  if (trimmedPath.length === 0) {
-    return undefined;
-  }
-
-  try {
-    // Split into resource path and action from the right (like Python's rsplit)
-    // e.g., "modules.headcount.view" -> ["modules.headcount", "view"]
-    const lastDotIndex = trimmedPath.lastIndexOf('.');
-    if (lastDotIndex === -1) {
-      // Edge case: no dot found, invalid path format (needs at least "resource.action")
-      return undefined;
-    }
-
-    // Edge case: dot is at the start or end (e.g., ".action" or "resource.")
-    if (lastDotIndex === 0 || lastDotIndex === trimmedPath.length - 1) {
-      return undefined;
-    }
-
-    const resourcePath = trimmedPath.substring(0, lastDotIndex);
-    const action = trimmedPath.substring(lastDotIndex + 1);
-
-    // Edge case: empty resource path or action after split
-    if (!resourcePath || !action) {
-      return undefined;
-    }
-
-    // Edge case: resource path or action is whitespace-only after trimming
-    if (resourcePath.trim().length === 0 || action.trim().length === 0) {
-      return undefined;
-    }
-
-    return getPermissionValueByParts(
-      permissions,
-      resourcePath.trim(),
-      action.trim(),
-    );
-  } catch (error) {
-    // Edge case: any unexpected error (TypeError, etc.)
-    // Log in development for debugging, but return undefined in production
-    if (process.env.NODE_ENV === 'development') {
-      console.warn('Error getting permission value:', error, { fullPath });
-    }
-    return undefined;
-  }
-}
-
-/**
- * Internal helper function to get permission value by resource path and action.
- *
- * @param permissions - The permissions object
- * @param resourcePath - The resource path (e.g., 'modules.headcount')
- * @param action - The action (e.g., 'view')
- * @returns The permission value or undefined
- */
-function getPermissionValueByParts(
-  permissions: FlatUserPermissions,
-  resourcePath: string,
-  action: string,
-): boolean | undefined {
-  // Edge case: resourcePath is null/undefined or not a string
-  if (!resourcePath || typeof resourcePath !== 'string') {
-    return undefined;
-  }
-
-  // Edge case: action is null/undefined or not a string
-  if (!action || typeof action !== 'string') {
-    return undefined;
-  }
-
-  // Edge case: resourcePath or action is empty or whitespace-only
-  if (resourcePath.trim().length === 0 || action.trim().length === 0) {
-    return undefined;
-  }
-
-  try {
-    // Edge case: resource path not in permissions
-    if (!(resourcePath in permissions)) {
-      return undefined;
-    }
-
-    const permSet = permissions[resourcePath];
-
-    // Edge case: permission set is null/undefined
-    if (permSet === null || permSet === undefined) {
-      return undefined;
-    }
-
-    // Edge case: permission set is not an object (could be array, primitive, etc.)
-    if (typeof permSet !== 'object' || Array.isArray(permSet)) {
-      return undefined;
-    }
-
-    // Edge case: action not in permission set
-    if (!(action in permSet)) {
-      return undefined;
-    }
-
-    // Return the boolean value
-    const value = permSet[action];
-
-    // Edge case: value is null/undefined (explicitly check for null)
-    if (value === null || value === undefined) {
-      return undefined;
-    }
-
-    // Return boolean value (coerce to boolean for consistency)
-    return Boolean(value);
-  } catch (error) {
-    // Edge case: any unexpected error
-    if (process.env.NODE_ENV === 'development') {
-      console.warn('Error in getPermissionValueByParts:', error, {
-        resourcePath,
-        action,
-      });
-    }
-    return undefined;
-  }
-}
-
-/**
  * Maps frontend module names to backend permission paths.
  * Only modules with defined permissions are included.
  *
  * @param module - The frontend module identifier (e.g., 'headcount', 'equipment-electric-consumption')
  * @returns The permission path (e.g., 'modules.headcount', 'modules.equipment') or null if not protected
- *
- * @example
- * ```typescript
- * const path = getModulePermissionPath('headcount');
- * // Returns: 'modules.headcount'
- *
- * const path = getModulePermissionPath('equipment-electric-consumption');
- * // Returns: 'modules.equipment'
- *
- * const path = getModulePermissionPath('professional-travel');
- * // Returns: null (not yet protected)
- * ```
  */
 export function getModulePermissionPath(module: Module): string | null {
   const modulePermissionMap: Record<Module, string | null> = {

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -14,30 +14,14 @@ import { MODULES, type Module } from 'src/constant/modules';
 /**
  * Check if a user has a specific permission.
  *
- * This function checks if a permission exists and is set to `true` for the given
- * path and action. Returns `false` for any edge cases (null permissions, missing
+ * This function checks if an action is allowed for the given permission
+ * path. Returns `false` for any edge cases (null permissions, missing
  * paths, invalid actions, etc.).
  *
  * @param permissions - The permissions object (from user.permissions), can be null/undefined
  * @param path - The permission path (e.g., 'modules.headcount')
  * @param action - The action to check (defaults to 'view')
  * @returns `true` if the permission exists and is `true`, `false` otherwise
- *
- * @example
- * ```typescript
- * // Check if user can view headcount module
- * const canView = hasPermission(user.permissions, 'modules.headcount', 'view');
- * if (canView) {
- *   // Show headcount module
- * }
- *
- * // Check if user can edit equipment (using enum)
- * const canEdit = hasPermission(
- *   user.permissions,
- *   'modules.equipment',
- *   PermissionAction.EDIT
- * );
- * ```
  */
 export function hasPermission(
   permissions: FlatUserPermissions | null | undefined,


### PR DESCRIPTION
## What does this change?

Backend:
* Use role's scope to contextualize permissions
* Changed dict of actions for a list of permitted actions
* Removed unused permissions related code

Frontend:
* Use workspace's unit to contextualize permissions evaluation
* Removed unused permissions related code

Note: affiliation still not handled.

## Why is this needed?

More specific permissions, to allow different roles in different units.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #854

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
