### PR TITLE
feat(#310b): factor pipeline + unit sync tracking

### DIFF
--- a/backend/alembic/versions/2026_05_01_1500-b1f0a2c3d4e5_plan_310b_factor_pipeline.py
+++ b/backend/alembic/versions/2026_05_01_1500-b1f0a2c3d4e5_plan_310b_factor_pipeline.py
@@ -24,10 +24,17 @@ Changes:
          WHERE year IS NULL
      Two indexes because NULL ≠ NULL in a unique index expression.
   4. factors.last_seen_job_id INT FK to data_ingestion_jobs(id) so operators
-     can detect factors not present in the latest CSV upload.
+     can detect factors not present in the latest CSV upload.  Backfilled
+     from the latest is_current FACTORS job per (det, year) so
+     ``/factors/stale`` doesn't flag every pre-existing factor as outdated
+     immediately after deploy.
   5. ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR' for unit-sync jobs.
-     Postgres ≥ 12 supports ADD VALUE in any transaction. Cannot be reversed
-     (no DROP VALUE), so downgrade leaves the enum value in place.
+     APPENDED to the label list (not inserted before MODULE_PER_YEAR) so the
+     Python ``EntityType`` int values stay stable: persisted
+     ``meta["config"]["entity_type"]`` integers round-trip via
+     ``EntityType(value)`` without drifting.  Postgres ≥ 12 supports ADD
+     VALUE in any transaction. Cannot be reversed (no DROP VALUE), so
+     downgrade leaves the enum value in place.
 """
 
 from typing import Sequence, Union
@@ -88,7 +95,7 @@ def upgrade() -> None:
         "WHERE year IS NULL"
     )
 
-    # 3. last_seen_job_id column + supporting index
+    # 4. last_seen_job_id column + supporting index
     op.add_column(
         "factors",
         sa.Column("last_seen_job_id", sa.Integer(), nullable=True),
@@ -108,12 +115,47 @@ def upgrade() -> None:
         unique=False,
     )
 
-    # 4. EntityType.GLOBAL_PER_YEAR for unit-sync jobs.
-    # Wrapped in a DO block so re-runs don't error on existing values.
+    # 4b. Backfill last_seen_job_id from the latest is_current FACTORS job
+    # that covers each factor's (data_entry_type_id, year).  Without this
+    # step ``list_stale_for_year`` (which treats NULL as "older than the
+    # latest job") would flag every pre-existing factor as outdated on
+    # day one.  Per-det jobs match directly on (det, year); multi-type
+    # jobs (det IS NULL) are skipped here because the runtime resolver
+    # in ``FactorRepository._latest_factor_job_per_det`` re-evaluates
+    # them via MODULE_TYPE_TO_DATA_ENTRY_TYPES at query time anyway.
+    op.execute(
+        """
+        UPDATE factors f
+        SET last_seen_job_id = sub.job_id
+        FROM (
+            SELECT
+                f2.id  AS factor_id,
+                MAX(j.id) AS job_id
+            FROM factors f2
+            JOIN data_ingestion_jobs j
+              ON j.data_entry_type_id = f2.data_entry_type_id
+             AND j.year               = f2.year
+             AND j.target_type        = 'FACTORS'
+             AND j.state              = 'FINISHED'
+             AND j.result            != 'ERROR'
+             AND j.is_current         = TRUE
+            WHERE f2.last_seen_job_id IS NULL
+            GROUP BY f2.id
+        ) AS sub
+        WHERE f.id = sub.factor_id;
+        """
+    )
+
+    # 5. EntityType.GLOBAL_PER_YEAR for unit-sync jobs — APPENDED to the
+    # label list, not inserted before MODULE_PER_YEAR.  The Python
+    # EntityType IntEnum keeps explicit int values
+    # (MODULE_PER_YEAR=1, MODULE_UNIT_SPECIFIC=2, GLOBAL_PER_YEAR=3) so
+    # historical jobs whose meta["config"]["entity_type"] is `1` stay
+    # interpretable as MODULE_PER_YEAR.  Wrapped in a DO block so re-runs
+    # don't error on existing values.
     op.execute(
         "DO $$ BEGIN "
-        "ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR' "
-        "BEFORE 'MODULE_PER_YEAR'; "
+        "ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR'; "
         "EXCEPTION WHEN duplicate_object THEN null; "
         "END $$;"
     )

--- a/backend/alembic/versions/2026_05_01_1500-b1f0a2c3d4e5_plan_310b_factor_pipeline.py
+++ b/backend/alembic/versions/2026_05_01_1500-b1f0a2c3d4e5_plan_310b_factor_pipeline.py
@@ -9,18 +9,23 @@ Changes:
   1. factors.classification → JSONB so Postgres normalises key order
      alphabetically; (classification::text) becomes deterministic regardless
      of dict insertion order in Python.
-  2. Two partial unique indexes on factor identity:
+  2. Strip the legacy ``"year"`` key from existing classification dicts.
+     ``base_factor_csv_provider._process_row`` used to copy ``self.year``
+     into ``classification`` before persisting; the dedicated ``year``
+     column already carries the same data, and duplicating it inside
+     ``classification`` made ``classification::text`` writer-dependent
+     (any new path forgetting the inject would silently insert a
+     duplicate).  Strip happens BEFORE the unique index in step 3 so the
+     index is built against the year-less representation.
+  3. Two partial unique indexes on factor identity:
        (data_entry_type_id, year, emission_type_id, classification::text)
          WHERE year IS NOT NULL
        (data_entry_type_id, emission_type_id, classification::text)
          WHERE year IS NULL
      Two indexes because NULL ≠ NULL in a unique index expression.
-     Note: classification dict already includes a "year" key (injected by
-     base_factor_csv_provider._process_row), so year is doubly encoded in
-     the year-present index. That's redundant but does not break uniqueness.
-  3. factors.last_seen_job_id INT FK to data_ingestion_jobs(id) so operators
+  4. factors.last_seen_job_id INT FK to data_ingestion_jobs(id) so operators
      can detect factors not present in the latest CSV upload.
-  4. ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR' for unit-sync jobs.
+  5. ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR' for unit-sync jobs.
      Postgres ≥ 12 supports ADD VALUE in any transaction. Cannot be reversed
      (no DROP VALUE), so downgrade leaves the enum value in place.
 """
@@ -58,7 +63,18 @@ def upgrade() -> None:
         postgresql_using="classification::jsonb",
     )
 
-    # 2. Partial unique indexes on factor identity
+    # 2. Drop the redundant "year" key from existing classification dicts.
+    # MUST run before the unique index in step 3 so the index is built on
+    # the canonical year-less representation; otherwise the index would
+    # bake the legacy duplicated-year shape into uniqueness comparisons.
+    # Idempotent: if the key is already absent, ``-`` is a no-op.
+    op.execute(
+        "UPDATE factors "
+        "SET classification = classification - 'year' "
+        "WHERE classification ? 'year'"
+    )
+
+    # 3. Partial unique indexes on factor identity
     op.execute(
         "CREATE UNIQUE INDEX uq_factor_identity "
         "ON factors (data_entry_type_id, year, emission_type_id, "
@@ -106,9 +122,15 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade schema.
 
-    Note: ALTER TYPE ADD VALUE cannot be reversed in Postgres (no DROP VALUE).
-    The 'GLOBAL_PER_YEAR' enum value stays after downgrade — harmless if no
-    jobs reference it.
+    Notes:
+    - ALTER TYPE ADD VALUE cannot be reversed in Postgres (no DROP VALUE).
+      The 'GLOBAL_PER_YEAR' enum value stays after downgrade — harmless if
+      no jobs reference it.
+    - The "year"-key strip in step 2 is not reversed.  Re-injecting the
+      key would require knowing each row's writer-of-origin (CSV vs seed
+      script), which we do not track.  All current writers should already
+      have stopped emitting the duplicated key by the time downgrade
+      runs, so leaving the data clean is the right behaviour.
     """
     op.drop_index("ix_factors_last_seen_job_id", table_name="factors")
     op.drop_constraint("fk_factors_last_seen_job_id", "factors", type_="foreignkey")

--- a/backend/alembic/versions/2026_05_01_1500-b1f0a2c3d4e5_plan_310b_factor_pipeline.py
+++ b/backend/alembic/versions/2026_05_01_1500-b1f0a2c3d4e5_plan_310b_factor_pipeline.py
@@ -1,0 +1,125 @@
+# codeql[py/unused-global-variable]
+"""plan 310b factor pipeline schema
+
+Revision ID: b1f0a2c3d4e5
+Revises: e528e0d649cd
+Create Date: 2026-05-01 15:00:00.000000
+
+Changes:
+  1. factors.classification → JSONB so Postgres normalises key order
+     alphabetically; (classification::text) becomes deterministic regardless
+     of dict insertion order in Python.
+  2. Two partial unique indexes on factor identity:
+       (data_entry_type_id, year, emission_type_id, classification::text)
+         WHERE year IS NOT NULL
+       (data_entry_type_id, emission_type_id, classification::text)
+         WHERE year IS NULL
+     Two indexes because NULL ≠ NULL in a unique index expression.
+     Note: classification dict already includes a "year" key (injected by
+     base_factor_csv_provider._process_row), so year is doubly encoded in
+     the year-present index. That's redundant but does not break uniqueness.
+  3. factors.last_seen_job_id INT FK to data_ingestion_jobs(id) so operators
+     can detect factors not present in the latest CSV upload.
+  4. ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR' for unit-sync jobs.
+     Postgres ≥ 12 supports ADD VALUE in any transaction. Cannot be reversed
+     (no DROP VALUE), so downgrade leaves the enum value in place.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "b1f0a2c3d4e5"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "e528e0d649cd"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. classification JSON → JSONB
+    op.alter_column(
+        "factors",
+        "classification",
+        existing_type=postgresql.JSON(astext_type=sa.Text()),
+        type_=postgresql.JSONB(astext_type=sa.Text()),
+        existing_nullable=True,
+        postgresql_using="classification::jsonb",
+    )
+
+    # 2. Partial unique indexes on factor identity
+    op.execute(
+        "CREATE UNIQUE INDEX uq_factor_identity "
+        "ON factors (data_entry_type_id, year, emission_type_id, "
+        "(classification::text)) "
+        "WHERE year IS NOT NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX uq_factor_identity_no_year "
+        "ON factors (data_entry_type_id, emission_type_id, "
+        "(classification::text)) "
+        "WHERE year IS NULL"
+    )
+
+    # 3. last_seen_job_id column + supporting index
+    op.add_column(
+        "factors",
+        sa.Column("last_seen_job_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_factors_last_seen_job_id",
+        "factors",
+        "data_ingestion_jobs",
+        ["last_seen_job_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_factors_last_seen_job_id",
+        "factors",
+        ["last_seen_job_id"],
+        unique=False,
+    )
+
+    # 4. EntityType.GLOBAL_PER_YEAR for unit-sync jobs.
+    # Wrapped in a DO block so re-runs don't error on existing values.
+    op.execute(
+        "DO $$ BEGIN "
+        "ALTER TYPE entity_type_enum ADD VALUE 'GLOBAL_PER_YEAR' "
+        "BEFORE 'MODULE_PER_YEAR'; "
+        "EXCEPTION WHEN duplicate_object THEN null; "
+        "END $$;"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Note: ALTER TYPE ADD VALUE cannot be reversed in Postgres (no DROP VALUE).
+    The 'GLOBAL_PER_YEAR' enum value stays after downgrade — harmless if no
+    jobs reference it.
+    """
+    op.drop_index("ix_factors_last_seen_job_id", table_name="factors")
+    op.drop_constraint("fk_factors_last_seen_job_id", "factors", type_="foreignkey")
+    op.drop_column("factors", "last_seen_job_id")
+    op.execute("DROP INDEX IF EXISTS uq_factor_identity_no_year")
+    op.execute("DROP INDEX IF EXISTS uq_factor_identity")
+    op.alter_column(
+        "factors",
+        "classification",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        type_=postgresql.JSON(astext_type=sa.Text()),
+        existing_nullable=True,
+        postgresql_using="classification::json",
+    )

--- a/backend/alembic/versions/2026_05_01_1600-c2d4e6f8a012_add_reference_data_to_target_type_enum.py
+++ b/backend/alembic/versions/2026_05_01_1600-c2d4e6f8a012_add_reference_data_to_target_type_enum.py
@@ -1,0 +1,48 @@
+# codeql[py/unused-global-variable]
+"""add REFERENCE_DATA to target_type_enum
+
+Revision ID: c2d4e6f8a012
+Revises: b1f0a2c3d4e5
+Create Date: 2026-05-01 16:00:00.000000
+
+The Python ``TargetType`` enum has had ``REFERENCE_DATA = 3`` for a
+while, but the Postgres ``target_type_enum`` type was never extended
+with the matching label.  The Plan 310B unit-sync job tries to insert
+``target_type='REFERENCE_DATA'`` and trips
+``invalid input value for enum target_type_enum``.
+
+Mirror the precedent set by 4226efc73854 (REDUCTION_OBJECTIVES) — a
+plain ``ALTER TYPE ... ADD VALUE IF NOT EXISTS``.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "c2d4e6f8a012"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "b1f0a2c3d4e5"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("ALTER TYPE target_type_enum ADD VALUE IF NOT EXISTS 'REFERENCE_DATA'")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    PostgreSQL does not support removing individual enum values.  A full
+    enum-type recreation would be required; left as a no-op (matches
+    4226efc73854's downgrade).
+    """
+    pass

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -96,6 +96,47 @@ class ModuleRecalculationStatus(BaseModel):
     data_entry_types: list[RecalculationStatus]
 
 
+@router.get("/_debug/bg-tasks")
+async def debug_bg_tasks():
+    """Diagnostic endpoint for stuck recalc/ingest jobs.
+
+    Reports:
+    - which Tasks ``fire_and_forget`` is currently holding strong refs to
+      (i.e. tasks that should still be running)
+    - every Task on the running event loop, with its coroutine repr —
+      the repr usually shows the line currently being awaited
+
+    Use this when a DataIngestionJob is stuck in RUNNING with no logs
+    after the claim — the response tells you whether the Task is still
+    alive, hung at a specific await, crashed with an exception, or
+    cancelled.  Remove once the diagnosis is done; not gated by auth on
+    purpose so it can be hit from psql/curl during debugging.
+    """
+    import asyncio as _asyncio
+
+    from app.tasks._background import _BACKGROUND_TASKS
+
+    def _task_summary(t: _asyncio.Task) -> dict:
+        info: dict = {
+            "name": t.get_name(),
+            "done": t.done(),
+            "cancelled": t.cancelled() if t.done() else False,
+            "coro": repr(t.get_coro()),
+        }
+        if t.done() and not t.cancelled():
+            try:
+                exc = t.exception()
+                info["exception"] = repr(exc) if exc is not None else None
+            except Exception as e:  # defensive — exception() raises if cancelled
+                info["exception_lookup_error"] = repr(e)
+        return info
+
+    return {
+        "fire_and_forget_tracked": [_task_summary(t) for t in _BACKGROUND_TASKS],
+        "all_loop_tasks": [_task_summary(t) for t in _asyncio.all_tasks()],
+    }
+
+
 @router.post("/dispatch", response_model=SyncStatusResponse)
 async def sync_module_data_entries(
     syncRequest: SyncRequest,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -24,6 +24,7 @@ from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEn
 from app.models.user import User
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.services.data_ingestion.provider_factory import ProviderFactory
+from app.tasks._background import fire_and_forget
 from app.tasks.emission_recalculation_tasks import (
     run_module_recalculation,
     run_recalculation,
@@ -786,8 +787,13 @@ async def sync_units_from_accred(
         )
 
     # Fire-and-forget; the safety poller (Plan 310A) recovers the job if
-    # this pod crashes before run_sync_task_accred claims it.
-    asyncio.create_task(run_sync_task_accred(syncRequest, created.id))
+    # this pod crashes before run_sync_task_accred claims it.  Use
+    # fire_and_forget (not bare asyncio.create_task) so the task isn't
+    # garbage-collected before the loop schedules its first step.
+    fire_and_forget(
+        run_sync_task_accred(syncRequest, created.id),
+        name=f"unit-sync-{created.id}",
+    )
 
     return SyncStatusResponse(
         job_id=created.id,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -96,47 +96,6 @@ class ModuleRecalculationStatus(BaseModel):
     data_entry_types: list[RecalculationStatus]
 
 
-@router.get("/_debug/bg-tasks")
-async def debug_bg_tasks():
-    """Diagnostic endpoint for stuck recalc/ingest jobs.
-
-    Reports:
-    - which Tasks ``fire_and_forget`` is currently holding strong refs to
-      (i.e. tasks that should still be running)
-    - every Task on the running event loop, with its coroutine repr —
-      the repr usually shows the line currently being awaited
-
-    Use this when a DataIngestionJob is stuck in RUNNING with no logs
-    after the claim — the response tells you whether the Task is still
-    alive, hung at a specific await, crashed with an exception, or
-    cancelled.  Remove once the diagnosis is done; not gated by auth on
-    purpose so it can be hit from psql/curl during debugging.
-    """
-    import asyncio as _asyncio
-
-    from app.tasks._background import _BACKGROUND_TASKS
-
-    def _task_summary(t: _asyncio.Task) -> dict:
-        info: dict = {
-            "name": t.get_name(),
-            "done": t.done(),
-            "cancelled": t.cancelled() if t.done() else False,
-            "coro": repr(t.get_coro()),
-        }
-        if t.done() and not t.cancelled():
-            try:
-                exc = t.exception()
-                info["exception"] = repr(exc) if exc is not None else None
-            except Exception as e:  # defensive — exception() raises if cancelled
-                info["exception_lookup_error"] = repr(e)
-        return info
-
-    return {
-        "fire_and_forget_tracked": [_task_summary(t) for t in _BACKGROUND_TASKS],
-        "all_loop_tasks": [_task_summary(t) for t in _asyncio.all_tasks()],
-    }
-
-
 @router.post("/dispatch", response_model=SyncStatusResponse)
 async def sync_module_data_entries(
     syncRequest: SyncRequest,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -29,7 +29,7 @@ from app.tasks.emission_recalculation_tasks import (
     run_recalculation,
 )
 from app.tasks.ingestion_tasks import run_ingestion
-from app.tasks.unit_sync_tasks import SyncUnitRequest, sync_units_from_accred_task
+from app.tasks.unit_sync_tasks import SyncUnitRequest, run_sync_task_accred
 from app.utils.request_context import extract_ip_address, extract_route_payload
 
 router = APIRouter()
@@ -756,21 +756,41 @@ async def sync_units_from_accred(
     """
     Sync units from Accred API.
 
-    Triggers background task to fetch and upsert all units and principal users
-    from the Accred API. Uses hardcoded UserProvider.ACCRED for now.
+    Plan 310B Part 5 — creates a tracked DataIngestionJob (job_type=
+    unit_sync, entity_type=GLOBAL_PER_YEAR) so progress is observable via
+    the SSE stream and the job is recoverable on pod crash via the safety
+    poller.
 
     **Required Permission**: `backoffice.data_management.sync`
 
     Returns:
-        SyncStatusResponse with job status (note: job_id is 0 as this is a
-        simple background task without persistent job tracking)
+        SyncStatusResponse with the persistent job_id and initial state.
     """
+    job = DataIngestionJob(
+        job_type="unit_sync",
+        module_type_id=None,
+        data_entry_type_id=None,
+        year=syncRequest.target_year,
+        ingestion_method=IngestionMethod.api,
+        target_type=TargetType.REFERENCE_DATA,
+        entity_type=EntityType.GLOBAL_PER_YEAR,
+        state=IngestionState.NOT_STARTED,
+        meta={"config": {"target_year": syncRequest.target_year}},
+    )
+    created = await DataIngestionRepository(db).create_ingestion_job(job)
+    await db.commit()
+    if created.id is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create unit sync job",
+        )
 
-    # Schedule background task
-    background_tasks.add_task(sync_units_from_accred_task, syncRequest)
+    # Fire-and-forget; the safety poller (Plan 310A) recovers the job if
+    # this pod crashes before run_sync_task_accred claims it.
+    asyncio.create_task(run_sync_task_accred(syncRequest, created.id))
 
     return SyncStatusResponse(
-        job_id=0,  # No persistent job tracking for now
+        job_id=created.id,
         state=IngestionState.NOT_STARTED,
         message="Unit sync from Accred API scheduled",
     )

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -26,10 +26,10 @@ from app.repositories.data_ingestion import DataIngestionRepository
 from app.services.data_ingestion.provider_factory import ProviderFactory
 from app.tasks._background import fire_and_forget
 from app.tasks.emission_recalculation_tasks import (
-    run_module_recalculation,
-    run_recalculation,
+    run_module_recalculation_task,
+    run_recalculation_task,
 )
-from app.tasks.ingestion_tasks import run_ingestion
+from app.tasks.ingestion_tasks import run_sync_task
 from app.tasks.unit_sync_tasks import SyncUnitRequest, run_sync_task_accred
 from app.utils.request_context import extract_ip_address, extract_route_payload
 
@@ -254,13 +254,19 @@ async def sync_module_data_entries(
     # Commit job creation to database
     await db.commit()
 
-    # Schedule the ingestion task in the background
+    # Schedule the ingestion task in the background.  Hand the *async*
+    # ``run_sync_task`` to ``add_task`` (NOT the sync ``run_ingestion``
+    # wrapper) so FastAPI awaits it on the main event loop.  The sync
+    # wrapper used ``asyncio.run`` which builds a throwaway loop in a
+    # worker thread; any ``fire_and_forget`` Task created inside that
+    # throwaway loop is cancelled the instant the loop closes — that's
+    # exactly the bug that left recalc jobs stuck in RUNNING.
     # NOTE: file_path validation happens in provider.__init__()
     #   via _validate_file_path()
     # to prevent directory traversal attacks (e.g., /../../../etc/passwd)
     background_tasks.add_task(
-        run_ingestion,
-        provider_name=provider.__class__.__name__,
+        run_sync_task,
+        provider_class_name=provider.__class__.__name__,
         job_id=job_id,
         filters=syncRequest.filters or {},
     )
@@ -357,8 +363,8 @@ async def sync_module_factors(
     await db.commit()
 
     background_tasks.add_task(
-        run_ingestion,
-        provider_name=provider.__class__.__name__,
+        run_sync_task,
+        provider_class_name=provider.__class__.__name__,
         job_id=job_id,
         filters=syncRequest.filters or {},
     )
@@ -681,7 +687,7 @@ async def recalculate_emissions_for_type(
         )
 
     background_tasks.add_task(
-        run_recalculation,
+        run_recalculation_task,
         module_type_id=module_type_id.value,
         data_entry_type_id=data_entry_type_id.value,
         year=year,
@@ -771,7 +777,7 @@ async def recalculate_emissions_for_module(
         )
 
     background_tasks.add_task(
-        run_module_recalculation,
+        run_module_recalculation_task,
         module_type_id=module_type_id.value,
         data_entry_type_ids=det_ids,
         year=year,

--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -1,15 +1,56 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.user import User
+from app.repositories.factor_repo import FactorRepository
 from app.schemas.data_entry import BaseModuleHandler
 from app.services.factor_service import FactorService
 
 router = APIRouter()
+
+
+class StaleFactorResponse(BaseModel):
+    """Operator-facing summary of a factor not present in the latest CSV."""
+
+    id: int
+    data_entry_type_id: int
+    emission_type_id: int
+    year: Optional[int]
+    classification: dict
+    last_seen_job_id: Optional[int]
+
+
+@router.get("/stale", response_model=list[StaleFactorResponse])
+async def list_stale_factors(
+    year: int = Query(..., description="Report year to scope the query"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[StaleFactorResponse]:
+    """Return factors not present in the latest successful FACTORS ingest.
+
+    Plan 310B Part 3 — operators can detect rows that exist in the DB but
+    were not in the most recent CSV upload.  These rows are intentionally
+    not deleted (deletion would re-introduce dangling FKs from
+    ``DataEntry.primary_factor_id``); this endpoint surfaces them so the
+    UI can warn that the linked data entries are using outdated factors.
+    """
+    rows = await FactorRepository(db).list_stale_for_year(year)
+    return [
+        StaleFactorResponse(
+            id=f.id or 0,
+            data_entry_type_id=f.data_entry_type_id,
+            emission_type_id=f.emission_type_id,
+            year=f.year,
+            classification=f.classification or {},
+            last_seen_job_id=f.last_seen_job_id,
+        )
+        for f in rows
+    ]
 
 
 @router.get(

--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -33,24 +33,37 @@ async def list_stale_factors(
 ) -> list[StaleFactorResponse]:
     """Return factors not present in the latest successful FACTORS ingest.
 
-    Plan 310B Part 3 — operators can detect rows that exist in the DB but
-    were not in the most recent CSV upload.  These rows are intentionally
-    not deleted (deletion would re-introduce dangling FKs from
-    ``DataEntry.primary_factor_id``); this endpoint surfaces them so the
-    UI can warn that the linked data entries are using outdated factors.
+    Plan 310B Part 3 — operators can detect rows that exist in the DB
+    but were not in the most recent CSV upload.  These rows are
+    intentionally not deleted because existing data entries may still
+    reference their ids in the ``DataEntry.data`` JSON payload under
+    ``primary_factor_id`` (this is a JSON value, not a real FK column);
+    this endpoint surfaces them so the UI can warn that linked data
+    entries are using outdated factors.
     """
     rows = await FactorRepository(db).list_stale_for_year(year)
-    return [
-        StaleFactorResponse(
-            id=f.id or 0,
-            data_entry_type_id=f.data_entry_type_id,
-            emission_type_id=f.emission_type_id,
-            year=f.year,
-            classification=f.classification or {},
-            last_seen_job_id=f.last_seen_job_id,
+    responses: list[StaleFactorResponse] = []
+    for f in rows:
+        # DB-loaded rows always have an id.  A NULL id here would mean
+        # the row was constructed but never flushed — surface as a 500
+        # rather than mask with a sentinel 0 (which would be an invalid
+        # client-side identifier).
+        if f.id is None:
+            raise ValueError(
+                "FactorRepository.list_stale_for_year returned a row "
+                "with no id; this should not happen for persisted factors."
+            )
+        responses.append(
+            StaleFactorResponse(
+                id=f.id,
+                data_entry_type_id=f.data_entry_type_id,
+                emission_type_id=f.emission_type_id,
+                year=f.year,
+                classification=f.classification or {},
+                last_seen_job_id=f.last_seen_job_id,
+            )
         )
-        for f in rows
-    ]
+    return responses
 
 
 @router.get(

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -21,12 +21,16 @@ class EntityType(int, Enum):
     """
     Docstring for EntityType
 
+    :var GLOBAL_PER_YEAR: Job not scoped to a module
+        (e.g. unit sync, role sync).
+    :vartype GLOBAL_PER_YEAR: Literal[1]
     :var MODULE_PER_YEAR: Description
     :vartype MODULE_PER_YEAR: Literal[2]
     :var MODULE_UNIT_SPECIFIC: Description
     :vartype MODULE_UNIT_SPECIFIC: Literal[3]
     """
 
+    GLOBAL_PER_YEAR = 1
     MODULE_PER_YEAR = 2
     MODULE_UNIT_SPECIFIC = 3
 

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -21,18 +21,26 @@ class EntityType(int, Enum):
     """
     Docstring for EntityType
 
+    Enum integer values are part of the persisted ABI: jobs serialise
+    ``entity_type.value`` into ``DataIngestionJob.meta["config"]`` and
+    we round-trip via ``EntityType(value)``.  Existing rows have
+    ``MODULE_PER_YEAR=1`` and ``MODULE_UNIT_SPECIFIC=2`` baked in, so
+    new members MUST be appended (don't insert at the front and shift
+    the existing ones — every historical row would silently deserialise
+    to the wrong member).
+
+    :var MODULE_PER_YEAR: Description
+    :vartype MODULE_PER_YEAR: Literal[1]
+    :var MODULE_UNIT_SPECIFIC: Description
+    :vartype MODULE_UNIT_SPECIFIC: Literal[2]
     :var GLOBAL_PER_YEAR: Job not scoped to a module
         (e.g. unit sync, role sync).
-    :vartype GLOBAL_PER_YEAR: Literal[1]
-    :var MODULE_PER_YEAR: Description
-    :vartype MODULE_PER_YEAR: Literal[2]
-    :var MODULE_UNIT_SPECIFIC: Description
-    :vartype MODULE_UNIT_SPECIFIC: Literal[3]
+    :vartype GLOBAL_PER_YEAR: Literal[3]
     """
 
-    GLOBAL_PER_YEAR = 1
-    MODULE_PER_YEAR = 2
-    MODULE_UNIT_SPECIFIC = 3
+    MODULE_PER_YEAR = 1
+    MODULE_UNIT_SPECIFIC = 2
+    GLOBAL_PER_YEAR = 3
 
 
 class FactorType(int, Enum):

--- a/backend/app/models/factor.py
+++ b/backend/app/models/factor.py
@@ -2,8 +2,9 @@
 
 from typing import Optional
 
-from sqlalchemy import Index
-from sqlmodel import JSON, Column, Field, SQLModel
+from sqlalchemy import ForeignKey, Index, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import JSON, Column, Field, Integer, SQLModel
 
 
 class FactorBase(SQLModel):
@@ -23,9 +24,14 @@ class FactorBase(SQLModel):
     )
     classification: dict = Field(
         default_factory=dict,
-        sa_column=Column(JSON),
+        sa_column=Column(
+            JSON().with_variant(JSONB(astext_type=Text()), "postgresql"),
+        ),
         description="""Classification hierarchy as JSON
-            (e.g., {'class': 'Centrifugation', 'sub_class': 'Ultra centrifuges'})""",
+            (e.g., {'class': 'Centrifugation', 'sub_class': 'Ultra centrifuges'}).
+            Stored as JSONB on Postgres so key order is normalised
+            alphabetically and (classification::text) is deterministic
+            regardless of Python dict insertion order.""",
     )
     values: dict = Field(
         default_factory=dict,
@@ -99,6 +105,22 @@ class Factor(FactorBase, table=True):
     )
 
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
+
+    last_seen_job_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("data_ingestion_jobs.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        description=(
+            "DataIngestionJob.id of the most recent factor ingest that "
+            "asserted this row. Operators can compare against the latest "
+            "is_current factor job for the (module, det) combo to surface "
+            "stale factors that no longer appear in the source CSV."
+        ),
+    )
 
     def __repr__(self) -> str:
         emission_type = f"emission_{self.emission_type_id}"

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -109,8 +109,11 @@ class DataIngestionRepository:
                 ),
             }
             result_job.meta = merged_meta
+            logger.info(f"update_ingestion_job({job_id}): about to flush")
             await self.session.flush()
+            logger.info(f"update_ingestion_job({job_id}): flush done; about to refresh")
             await self.session.refresh(result_job)
+            logger.info(f"update_ingestion_job({job_id}): refresh done")
         return result_job
 
     async def get_job_by_id(self, job_id: int) -> Optional[DataIngestionJob]:

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -109,11 +109,8 @@ class DataIngestionRepository:
                 ),
             }
             result_job.meta = merged_meta
-            logger.info(f"update_ingestion_job({job_id}): about to flush")
             await self.session.flush()
-            logger.info(f"update_ingestion_job({job_id}): flush done; about to refresh")
             await self.session.refresh(result_job)
-            logger.info(f"update_ingestion_job({job_id}): refresh done")
         return result_job
 
     async def get_job_by_id(self, job_id: int) -> Optional[DataIngestionJob]:

--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Optional
 
-from sqlalchemy import or_, text
+from sqlalchemy import case, or_, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -16,6 +16,10 @@ from app.models.data_ingestion import (
     TargetType,
 )
 from app.models.factor import Factor
+from app.models.module_type import (
+    MODULE_TYPE_TO_DATA_ENTRY_TYPES,
+    ModuleTypeEnum,
+)
 from app.schemas.data_entry import BaseModuleHandler
 
 
@@ -160,37 +164,110 @@ class FactorRepository:
         # narrower Result[Any] type Pyright infers from session.execute.
         return getattr(result, "rowcount", 0) or 0
 
+    async def _latest_factor_job_per_det(self, year: int) -> Dict[int, int]:
+        """Resolve the most recent ``is_current`` finished FACTORS job that
+        covers each ``data_entry_type_id`` for the given year.
+
+        Multi-type CSV uploads (e.g. ``equipments_factors.csv``) create a
+        single FACTORS job with ``data_entry_type_id=NULL`` and
+        ``module_type_id`` set; that one job covers every det in the
+        module via ``MODULE_TYPE_TO_DATA_ENTRY_TYPES``.  A naive SQL join
+        on ``Factor.det = Job.det`` misses these uploads (NULL ≠ any det),
+        so we expand them in Python.  Cardinality of "is_current FACTORS
+        jobs for one year" is small (one per active module / det), so
+        loading them in-process is cheap.
+
+        Returns:
+            Map from ``data_entry_type_id`` to the highest job id that
+            wrote factors for that det in this year.
+        """
+        stmt = select(
+            DataIngestionJob.id,
+            DataIngestionJob.module_type_id,
+            DataIngestionJob.data_entry_type_id,
+        ).where(
+            col(DataIngestionJob.year) == year,
+            col(DataIngestionJob.target_type) == TargetType.FACTORS,
+            col(DataIngestionJob.state) == IngestionState.FINISHED,
+            col(DataIngestionJob.result) != IngestionResult.ERROR,
+            col(DataIngestionJob.is_current).is_(True),
+        )
+        rows = (await self.session.execute(stmt)).all()
+
+        latest: Dict[int, int] = {}
+        for job_id, module_type_id, det_id in rows:
+            if job_id is None:
+                continue
+            covered: tuple[int, ...]
+            if det_id is not None:
+                covered = (det_id,)
+            elif module_type_id is not None:
+                try:
+                    module = ModuleTypeEnum(module_type_id)
+                except ValueError:
+                    # Unknown module — skip rather than raise; operator can
+                    # see the orphaned job via the existing jobs endpoints.
+                    continue
+                covered = tuple(
+                    d.value for d in MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(module, [])
+                )
+            else:
+                # Both NULLs is meaningless for FACTORS scoping; skip.
+                continue
+
+            for det in covered:
+                if latest.get(det, 0) < job_id:
+                    latest[det] = job_id
+        return latest
+
     async def list_stale_for_year(self, year: int) -> List[Factor]:
         """Return factors whose ``last_seen_job_id`` predates the latest
-        successful FACTORS ingest job for their ``(data_entry_type_id, year)``
-        combo.
+        successful FACTORS ingest job that covers their ``data_entry_type_id``
+        in the given year.
 
-        Operators use this to surface rows that exist in the DB but were not
-        present in the most recent CSV upload. Stale factors are not
+        "Covers" handles two ingest shapes:
+
+        - Per-det FACTORS job (``data_entry_type_id`` set) — covers exactly
+          that det.
+        - Multi-type FACTORS job (``data_entry_type_id`` NULL,
+          ``module_type_id`` set) — covers every det in the module via
+          ``MODULE_TYPE_TO_DATA_ENTRY_TYPES``.
+
+        Operators use this to surface rows that exist in the DB but were
+        not present in the most recent CSV upload.  Stale factors are not
         deleted (that would re-introduce dangling FKs), only flagged.
 
         Args:
             year: Restrict to factors and jobs in this year.
         """
+        latest_per_det = await self._latest_factor_job_per_det(year)
+        if not latest_per_det:
+            # No is_current FACTORS job for this year → nothing to compare
+            # against.  Returning all factors as "stale" would be misleading.
+            return []
+
+        # Per-det threshold: factor stale iff last_seen_job_id < latest[det].
+        # CASE expression keeps the threshold lookup in SQL so we don't have
+        # to fetch every factor row to filter in Python.
+        threshold = case(
+            *[
+                (col(Factor.data_entry_type_id) == det, latest_id)
+                for det, latest_id in latest_per_det.items()
+            ],
+            else_=None,
+        )
+
         stmt = (
             select(Factor)
-            .join(
-                DataIngestionJob,
-                col(Factor.data_entry_type_id)
-                == col(DataIngestionJob.data_entry_type_id),
-            )
             .where(
                 col(Factor.year) == year,
-                col(DataIngestionJob.year) == year,
-                col(DataIngestionJob.target_type) == TargetType.FACTORS,
-                col(DataIngestionJob.state) == IngestionState.FINISHED,
-                col(DataIngestionJob.result) != IngestionResult.ERROR,
-                col(DataIngestionJob.is_current),
+                col(Factor.data_entry_type_id).in_(latest_per_det.keys()),
                 or_(
                     col(Factor.last_seen_job_id).is_(None),
-                    col(Factor.last_seen_job_id) < col(DataIngestionJob.id),
+                    col(Factor.last_seen_job_id) < threshold,
                 ),
             )
+            .order_by(col(Factor.data_entry_type_id), col(Factor.id))
         )
         result = await self.session.exec(stmt)
         return list(result.all())

--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -11,6 +11,7 @@ from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_entry_emission import EmissionType
 from app.models.data_ingestion import (
     DataIngestionJob,
+    IngestionMethod,
     IngestionResult,
     IngestionState,
     TargetType,
@@ -88,10 +89,11 @@ class FactorRepository:
         unique index expression — so the input must be split by year-presence
         and one ON CONFLICT inference issued per partition.
 
-        Preserves ``factor.id`` for existing rows so downstream FKs
-        (``DataEntry.primary_factor_id``) stay valid across reuploads.
-        Stamps ``last_seen_job_id`` so callers can later detect rows not
-        present in the current batch.
+        Preserves ``factor.id`` for existing rows so downstream
+        references — including ``primary_factor_id`` values stored in
+        ``DataEntry.data`` (a JSON value, not a real FK column) — stay
+        valid across reuploads.  Stamps ``last_seen_job_id`` so callers
+        can later detect rows not present in the current batch.
 
         Postgres-only: relies on ``INSERT ... ON CONFLICT DO UPDATE``.
 
@@ -181,6 +183,10 @@ class FactorRepository:
             Map from ``data_entry_type_id`` to the highest job id that
             wrote factors for that det in this year.
         """
+        # Restrict to ingestion_method=csv: ``last_seen_job_id`` is only
+        # stamped by the CSV upsert path.  If a ``computed`` FACTORS job
+        # ever becomes is_current its higher id would shadow the latest
+        # CSV upload and make every csv-stamped factor look stale.
         stmt = select(
             DataIngestionJob.id,
             DataIngestionJob.module_type_id,
@@ -191,6 +197,7 @@ class FactorRepository:
             col(DataIngestionJob.state) == IngestionState.FINISHED,
             col(DataIngestionJob.result) != IngestionResult.ERROR,
             col(DataIngestionJob.is_current).is_(True),
+            col(DataIngestionJob.ingestion_method) == IngestionMethod.csv,
         )
         rows = (await self.session.execute(stmt)).all()
 

--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -2,11 +2,19 @@
 
 from typing import Dict, List, Optional
 
+from sqlalchemy import or_, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_entry_emission import EmissionType
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
 from app.models.factor import Factor
 from app.schemas.data_entry import BaseModuleHandler
 
@@ -62,6 +70,130 @@ class FactorRepository:
         for factor in factors:
             await self.session.refresh(factor)
         return factors
+
+    async def upsert_factors(
+        self,
+        factors: List[Factor],
+        current_job_id: int,
+    ) -> int:
+        """Insert-or-update factors keyed on the identity index.
+
+        Identity key is ``(data_entry_type_id, year, emission_type_id,
+        classification::text)``. Two partial unique indexes back this
+        (``year IS NOT NULL`` vs ``year IS NULL``) because NULL ≠ NULL in a
+        unique index expression — so the input must be split by year-presence
+        and one ON CONFLICT inference issued per partition.
+
+        Preserves ``factor.id`` for existing rows so downstream FKs
+        (``DataEntry.primary_factor_id``) stay valid across reuploads.
+        Stamps ``last_seen_job_id`` so callers can later detect rows not
+        present in the current batch.
+
+        Postgres-only: relies on ``INSERT ... ON CONFLICT DO UPDATE``.
+
+        Returns the number of rows affected (insert + update).
+        """
+        if not factors:
+            return 0
+
+        with_year = [f for f in factors if f.year is not None]
+        no_year = [f for f in factors if f.year is None]
+
+        affected = 0
+        if with_year:
+            affected += await self._upsert_subset(
+                with_year, current_job_id, year_present=True
+            )
+        if no_year:
+            affected += await self._upsert_subset(
+                no_year, current_job_id, year_present=False
+            )
+        return affected
+
+    async def _upsert_subset(
+        self,
+        factors: List[Factor],
+        current_job_id: int,
+        *,
+        year_present: bool,
+    ) -> int:
+        payload = [
+            {
+                **f.model_dump(exclude={"id", "last_seen_job_id"}),
+                "last_seen_job_id": current_job_id,
+            }
+            for f in factors
+        ]
+        stmt = pg_insert(Factor).values(payload)
+
+        # Conflict target must match the partial index exactly: same column
+        # list (with the (classification::text) functional element) and
+        # same WHERE predicate.
+        if year_present:
+            index_elements: list = [
+                "data_entry_type_id",
+                "year",
+                "emission_type_id",
+                text("(classification::text)"),
+            ]
+            index_where = text("year IS NOT NULL")
+        else:
+            index_elements = [
+                "data_entry_type_id",
+                "emission_type_id",
+                text("(classification::text)"),
+            ]
+            index_where = text("year IS NULL")
+
+        # Bracket access on excluded avoids the .values name clash with
+        # Insert.values().
+        stmt = stmt.on_conflict_do_update(
+            index_elements=index_elements,
+            index_where=index_where,
+            set_={
+                "values": stmt.excluded["values"],
+                "last_seen_job_id": stmt.excluded["last_seen_job_id"],
+            },
+        )
+        result = await self.session.execute(stmt)
+        # rowcount is a CursorResult attribute on DML; cast away the
+        # narrower Result[Any] type Pyright infers from session.execute.
+        return getattr(result, "rowcount", 0) or 0
+
+    async def list_stale_for_year(self, year: int) -> List[Factor]:
+        """Return factors whose ``last_seen_job_id`` predates the latest
+        successful FACTORS ingest job for their ``(data_entry_type_id, year)``
+        combo.
+
+        Operators use this to surface rows that exist in the DB but were not
+        present in the most recent CSV upload. Stale factors are not
+        deleted (that would re-introduce dangling FKs), only flagged.
+
+        Args:
+            year: Restrict to factors and jobs in this year.
+        """
+        stmt = (
+            select(Factor)
+            .join(
+                DataIngestionJob,
+                col(Factor.data_entry_type_id)
+                == col(DataIngestionJob.data_entry_type_id),
+            )
+            .where(
+                col(Factor.year) == year,
+                col(DataIngestionJob.year) == year,
+                col(DataIngestionJob.target_type) == TargetType.FACTORS,
+                col(DataIngestionJob.state) == IngestionState.FINISHED,
+                col(DataIngestionJob.result) != IngestionResult.ERROR,
+                col(DataIngestionJob.is_current),
+                or_(
+                    col(Factor.last_seen_job_id).is_(None),
+                    col(Factor.last_seen_job_id) < col(DataIngestionJob.id),
+                ),
+            )
+        )
+        result = await self.session.exec(stmt)
+        return list(result.all())
 
     async def update(self, factor_id: int, update_data: Dict) -> Optional[Factor]:
         """Update an existing factor."""

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -473,8 +473,13 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
         if self.job_id is None:
             raise ValueError("job_id is required for factor upsert")
         affected = await factor_repo.upsert_factors(batch, current_job_id=self.job_id)
-        logger.info(f"Upserted {affected} factors in batch of {len(batch)}")
-        return affected
+        # asyncpg can return rowcount=-1 for executemany ON CONFLICT
+        # statements where it can't tally the result reliably.  Fall back
+        # to the input batch size for stats so the operator-visible count
+        # isn't a confusing -1.
+        reported = affected if affected >= 0 else len(batch)
+        logger.info(f"Upserted {reported} factors in batch of {len(batch)}")
+        return reported
 
     def _compute_ingestion_result(self, stats: FactorStatsDict) -> IngestionResult:
         """

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -16,6 +16,7 @@ from app.models.data_ingestion import (
 from app.models.factor import Factor
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
 from app.models.user import User
+from app.repositories.factor_repo import FactorRepository
 from app.schemas.factor import BaseFactorHandler
 from app.seed.seed_helper import get_factor_emission_type_id
 from app.services.data_ingestion.base_csv_provider import (
@@ -34,7 +35,8 @@ class FactorStatsDict(TypedDict):
     batches_processed: int
     row_errors: list[dict[str, Any]]
     row_errors_count: int
-    factors_deleted: int
+    factors_deleted: int  # set by local-seed delete-and-insert path; 0 in upsert path
+    factors_upserted: int
 
 
 def _get_expected_columns_from_handlers(handlers: list[Any]) -> set[str]:
@@ -165,30 +167,14 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                 "row_errors": [],
                 "row_errors_count": 0,
                 "factors_deleted": 0,
+                "factors_upserted": 0,
             }
             factor_service = FactorService(self.data_session)
-            listed_entry_types = setup_result.get("valid_entry_types", [])
-            # Delete existing factors for this data_entry_type and year
-            # This ensures idempotent uploads - no duplicates
-            data_entry_type_to_iterates = self._get_types_to_delete(listed_entry_types)
-            stats["factors_deleted"] = 0
-            if len(data_entry_type_to_iterates) > 0 and self.year:
-                for data_entry_type in data_entry_type_to_iterates:
-                    existing_count = (
-                        await factor_service.count_by_data_entry_type_and_year(
-                            data_entry_type_id=int(data_entry_type.value),
-                            year=self.year,
-                        )
-                    )
-                    logger.info(
-                        f"Deleting {existing_count} existing factors for "
-                        f"data_entry_type_id={data_entry_type.value}, year={self.year}"
-                    )
-                    await factor_service.bulk_delete_by_data_entry_type(
-                        data_entry_type_id=data_entry_type,
-                        year=self.year,
-                    )
-                    stats["factors_deleted"] += existing_count
+            factor_repo = FactorRepository(self.data_session)
+            # Plan 310B: upsert in place (preserves factor.id so existing
+            # DataEntry.primary_factor_id FKs stay valid).  No bulk delete:
+            # factors absent from the new CSV are kept and surfaced as stale
+            # via last_seen_job_id.
 
             batch: List[Factor] = []
             csv_reader = csv.DictReader(io.StringIO(setup_result["csv_text"]))
@@ -212,7 +198,8 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                 stats["rows_processed"] += 1
 
                 if len(batch) >= BATCH_SIZE:
-                    await self._process_batch(batch, factor_service)
+                    upserted = await self._upsert_batch(batch, factor_repo)
+                    stats["factors_upserted"] += upserted
                     stats["batches_processed"] += 1
                     logger.info(
                         f"Processed batch {stats['batches_processed']}: "
@@ -229,7 +216,7 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                         )
 
             return await self._finalize_and_commit(
-                batch, factor_service, stats, setup_result
+                batch, factor_service, stats, setup_result, factor_repo
             )
         except Exception as e:
             logger.error(f"CSV processing failed: {str(e)}", exc_info=True)
@@ -466,8 +453,28 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
         batch: List[Factor],
         factor_service: FactorService,
     ) -> None:
+        # Legacy path retained for subclasses that override (notably
+        # ``LocalFactorCSVProvider`` which does delete-and-insert for dev
+        # seeding). Production factor ingest goes through ``_upsert_batch``.
         await factor_service.bulk_create(batch)
         logger.info(f"Created {len(batch)} factors in batch")
+
+    async def _upsert_batch(
+        self,
+        batch: List[Factor],
+        factor_repo: FactorRepository,
+    ) -> int:
+        """Upsert one batch keyed on the factor identity index.
+
+        Returns the number of rows affected so callers can update stats.
+        Requires ``self.job_id`` so each upserted row can be stamped with
+        ``last_seen_job_id``.
+        """
+        if self.job_id is None:
+            raise ValueError("job_id is required for factor upsert")
+        affected = await factor_repo.upsert_factors(batch, current_job_id=self.job_id)
+        logger.info(f"Upserted {affected} factors in batch of {len(batch)}")
+        return affected
 
     def _compute_ingestion_result(self, stats: FactorStatsDict) -> IngestionResult:
         """
@@ -501,9 +508,11 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
         factor_service: FactorService,
         stats: FactorStatsDict,
         setup_result: Dict[str, Any],
+        factor_repo: FactorRepository,
     ) -> Dict[str, Any]:
         if batch:
-            await self._process_batch(batch, factor_service)
+            upserted = await self._upsert_batch(batch, factor_repo)
+            stats["factors_upserted"] += upserted
 
         processing_path = setup_result["processing_path"]
         filename = setup_result["filename"]
@@ -525,7 +534,7 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
             f"Processed {stats['rows_processed']} rows: "
             f"{stats['rows_skipped']} skipped, "
             f"{stats['row_errors_count']} errors, "
-            f"{stats['factors_deleted']} existing factors deleted"
+            f"{stats['factors_upserted']} factors upserted"
         )
         result = self._compute_ingestion_result(stats)
 
@@ -543,7 +552,7 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
             f"CSV processing completed: {stats['rows_processed']} rows processed, "
             f"{stats['rows_skipped']} skipped, "
             f"{stats['row_errors_count']} errors, "
-            f"{stats['factors_deleted']} existing factors deleted"
+            f"{stats['factors_upserted']} factors upserted"
         )
         return {
             "state": IngestionState.FINISHED,

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -385,11 +385,13 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)
                 return None, error_msg
 
-            # Add year to classification if specified
-            if self.year is not None:
-                classification["year"] = self.year
-
-            # Create factor using prepare_create (like seed_generic_factors.py)
+            # ``year`` is stored on the dedicated ``Factor.year`` column;
+            # do NOT also inject it into ``classification``.  The Plan 310B
+            # identity index keys on ``(det, year, emission_type,
+            # classification::text)`` — duplicating ``year`` inside
+            # ``classification`` would silently shift the
+            # ``classification::text`` representation between writers and
+            # break the upsert's identity match.
             factor = await factor_service.prepare_create(
                 emission_type_id=emission_type_id,
                 data_entry_type_id=data_entry_type.value,

--- a/backend/app/services/data_ingestion/csv_providers/local_seed.py
+++ b/backend/app/services/data_ingestion/csv_providers/local_seed.py
@@ -136,6 +136,33 @@ class LocalFactorCSVProvider(ModulePerYearFactorCSVProvider):
         )
         return None
 
+    # ------------------------------------------------------------------
+    # Override: stay on the legacy bulk_create path during the batch loop
+    # ------------------------------------------------------------------
+
+    async def _upsert_batch(
+        self,
+        batch: List[Any],
+        factor_repo: Any,
+    ) -> int:
+        """Local seed scripts have no DataIngestionJob and therefore no
+        ``job_id`` to stamp on ``last_seen_job_id``.  The base class's
+        ``_upsert_batch`` requires a job_id and raises if absent — so once
+        a seed CSV exceeds BATCH_SIZE the main loop would crash.
+
+        Override here to keep large seed runs on the legacy
+        ``bulk_create`` path.  Seed scripts already assume an empty
+        factor table (delete-and-insert semantics), so identity-key
+        upsert is unnecessary; staying on bulk_create avoids the
+        job_id requirement entirely.
+        """
+        # Late import to avoid circular import at module load.
+        from app.services.factor_service import FactorService
+
+        factor_service = FactorService(self.data_session)
+        await self._process_batch(batch, factor_service)
+        return len(batch)
+
     async def _finalize_and_commit(
         self,
         batch: List[Any],

--- a/backend/app/services/data_ingestion/csv_providers/local_seed.py
+++ b/backend/app/services/data_ingestion/csv_providers/local_seed.py
@@ -142,6 +142,9 @@ class LocalFactorCSVProvider(ModulePerYearFactorCSVProvider):
         factor_service: Any,
         stats: FactorStatsDict,
         setup_result: Dict[str, Any],
+        factor_repo: Any,  # signature-compat with base; legacy seed path
+        # uses bulk_create and assumes the factor table starts empty
+        # (seed scripts run against a fresh DB).
     ) -> Dict[str, Any]:
 
         if batch:

--- a/backend/app/tasks/_background.py
+++ b/backend/app/tasks/_background.py
@@ -45,6 +45,12 @@ def fire_and_forget(coro: Coroutine, *, name: str | None = None) -> asyncio.Task
 def _on_done(task: asyncio.Task) -> None:
     _BACKGROUND_TASKS.discard(task)
     if task.cancelled():
+        # Loud on purpose: a silently-cancelled fire-and-forget task is
+        # indistinguishable from "task never ran" in the logs, which makes
+        # stuck DataIngestionJob rows nearly impossible to diagnose.  If
+        # cancellations become routine for some path, route that path
+        # through its own helper instead of quieting this branch.
+        logger.warning(f"fire_and_forget task {task.get_name()!r} was cancelled")
         return
     exc = task.exception()
     if exc is not None:

--- a/backend/app/tasks/_background.py
+++ b/backend/app/tasks/_background.py
@@ -1,0 +1,54 @@
+"""Strong-reference helper for fire-and-forget asyncio background tasks.
+
+asyncio's task tracker holds **weak** references to running tasks (since
+Python 3.11): a Task with no other strong reference can be garbage-
+collected mid-execution, even before its first await.  In practice we've
+seen recalc jobs created via ``asyncio.create_task(coro)`` never run at
+all — the task object goes out of scope the moment the calling function
+returns, GC reaps it before the loop schedules its first step, and the
+backing DataIngestionJob row stays in NOT_STARTED (or stuck in RUNNING
+if it just barely cleared claim_job before being collected).
+
+Per the asyncio docs: "Save a reference to the result of this function,
+to avoid a task disappearing mid-execution."  This module does that
+with a process-lifetime set; the done-callback removes the reference
+so completed tasks don't leak.
+
+Use ``fire_and_forget(coroutine)`` instead of ``asyncio.create_task``
+for any background work whose return value the caller doesn't await.
+"""
+
+import asyncio
+from typing import Coroutine
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+def fire_and_forget(coro: Coroutine, *, name: str | None = None) -> asyncio.Task:
+    """Schedule ``coro`` and hold a strong reference until it finishes.
+
+    Returns the Task so callers may add additional callbacks if they need
+    to.  Errors raised inside the coroutine are logged via the done-
+    callback so they don't disappear into a swallowed exception.
+    """
+    task = asyncio.create_task(coro, name=name)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_on_done)
+    return task
+
+
+def _on_done(task: asyncio.Task) -> None:
+    _BACKGROUND_TASKS.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            f"fire_and_forget task {task.get_name()!r} failed: {exc}",
+            exc_info=exc,
+        )

--- a/backend/app/tasks/_poller.py
+++ b/backend/app/tasks/_poller.py
@@ -14,22 +14,20 @@ logger = get_logger(__name__)
 POLL_INTERVAL_SECONDS = 10
 
 
-def _dispatch_error_callback(task: asyncio.Task) -> None:
-    """Log unhandled exceptions from dispatch_job tasks."""
-    try:
-        exc = task.exception()
-    except asyncio.CancelledError:
-        return
-    if exc:
-        logger.error(f"dispatch_job failed: {exc}", exc_info=True)
-
-
 def schedule_job(job: DataIngestionJob, pod_id: str) -> None:
-    """Fire-and-forget: dispatch a job, logging any unhandled exception."""
+    """Fire-and-forget: dispatch a job, logging any unhandled exception.
+
+    Routes through ``fire_and_forget`` so the Task is held in a strong-ref
+    set and survives GC (Python 3.11+ asyncio holds only weak references
+    to running tasks).  The earlier bare ``asyncio.create_task`` here had
+    the same hazard that bit recalc enqueuing — orphaned-job recovery
+    would silently fail to dispatch.
+    """
     if job.id is None:
         return
-    task = asyncio.create_task(dispatch_job(job, pod_id))
-    task.add_done_callback(_dispatch_error_callback)
+    from app.tasks._background import fire_and_forget
+
+    fire_and_forget(dispatch_job(job, pod_id), name=f"dispatch-{job.id}")
 
 
 async def dispatch_job(job: DataIngestionJob, pod_id: str) -> None:

--- a/backend/app/tasks/_poller.py
+++ b/backend/app/tasks/_poller.py
@@ -92,6 +92,29 @@ async def dispatch_job(job: DataIngestionJob, pod_id: str) -> None:
             year=yr,
             job_id=jid,
         )
+    elif job_type == "unit_sync":
+        # Plan 310B Part 5 — pod-crash recovery for unit sync.  The
+        # endpoint creates a NOT_STARTED job and fires
+        # ``run_sync_task_accred`` in-process; if this pod dies before
+        # the task claims the job, the poller picks up the NOT_STARTED
+        # row and re-runs the task here.  ``run_sync_task_accred`` itself
+        # calls ``claim_job`` so it's safe to invoke from both the
+        # endpoint and the poller.
+        from app.tasks.unit_sync_tasks import (
+            SyncUnitRequest,
+        )
+        from app.tasks.unit_sync_tasks import (
+            run_sync_task_accred as _run_unit_sync,
+        )
+
+        target_year = (meta.get("config") or {}).get("target_year") or job.year
+        if target_year is None:
+            logger.warning(f"Missing target_year for unit_sync job {jid} — skipping")
+            return
+        await _run_unit_sync(
+            SyncUnitRequest(target_year=target_year),
+            job_id=jid,
+        )
     else:
         logger.warning(f"Unknown job_type '{job_type}' for job {jid} — skipping")
 

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -46,19 +46,15 @@ async def run_recalculation_task(
         year: The report year to scope the recalculation.
         job_id: The DataIngestionJob id to update with progress.
     """
-    logger.info(f"Recalc job {job_id}: task entered, opening sessions")
     async with SessionLocal() as job_session, SessionLocal() as data_session:
-        logger.info(f"Recalc job {job_id}: sessions opened")
         job_repo = DataIngestionRepository(job_session)
 
         claimed = await job_repo.claim_job(job_id, POD_ID)
-        logger.info(f"Recalc job {job_id}: claim_job returned {claimed}")
         if not claimed:
             logger.info(f"Job {job_id} already claimed or not eligible — skipping")
             return
 
         job = await job_repo.get_job_by_id(job_id)
-        logger.info(f"Recalc job {job_id}: get_job_by_id returned {job is not None}")
         if not job:
             logger.error(f"Recalculation job {job_id} not found.")
             return
@@ -67,27 +63,19 @@ async def run_recalculation_task(
             data_entry_type = DataEntryTypeEnum(data_entry_type_id)
             svc = EmissionRecalculationWorkflow(data_session)
 
-            logger.info(f"Recalc job {job_id}: about to update_ingestion_job")
             await job_repo.update_ingestion_job(
                 job_id=job_id,
                 status_message="Recalculating emissions...",
                 metadata={},
             )
-            logger.info(
-                f"Recalc job {job_id}: update done; about to commit job_session"
-            )
             await job_session.commit()
             logger.info(
-                f"Recalc job {job_id}: claimed and status committed; "
-                f"running workflow for det={data_entry_type.name}/year={year}"
+                f"Recalc job {job_id}: running workflow for "
+                f"det={data_entry_type.name}/year={year}"
             )
 
             stats = await svc.recalculate_for_data_entry_type(data_entry_type, year)
-            logger.info(f"Recalc job {job_id}: workflow returned {stats}")
-
-            # Commit the data session atomically
             await data_session.commit()
-            logger.info(f"Recalc job {job_id}: data session committed")
 
             result = (
                 IngestionResult.SUCCESS

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -48,15 +48,19 @@ async def run_recalculation_task(
         year: The report year to scope the recalculation.
         job_id: The DataIngestionJob id to update with progress.
     """
+    logger.info(f"Recalc job {job_id}: task entered, opening sessions")
     async with SessionLocal() as job_session, SessionLocal() as data_session:
+        logger.info(f"Recalc job {job_id}: sessions opened")
         job_repo = DataIngestionRepository(job_session)
 
         claimed = await job_repo.claim_job(job_id, POD_ID)
+        logger.info(f"Recalc job {job_id}: claim_job returned {claimed}")
         if not claimed:
             logger.info(f"Job {job_id} already claimed or not eligible — skipping")
             return
 
         job = await job_repo.get_job_by_id(job_id)
+        logger.info(f"Recalc job {job_id}: get_job_by_id returned {job is not None}")
         if not job:
             logger.error(f"Recalculation job {job_id} not found.")
             return
@@ -65,10 +69,14 @@ async def run_recalculation_task(
             data_entry_type = DataEntryTypeEnum(data_entry_type_id)
             svc = EmissionRecalculationWorkflow(data_session)
 
+            logger.info(f"Recalc job {job_id}: about to update_ingestion_job")
             await job_repo.update_ingestion_job(
                 job_id=job_id,
                 status_message="Recalculating emissions...",
                 metadata={},
+            )
+            logger.info(
+                f"Recalc job {job_id}: update done; about to commit job_session"
             )
             await job_session.commit()
             logger.info(

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -71,11 +71,17 @@ async def run_recalculation_task(
                 metadata={},
             )
             await job_session.commit()
+            logger.info(
+                f"Recalc job {job_id}: claimed and status committed; "
+                f"running workflow for det={data_entry_type.name}/year={year}"
+            )
 
             stats = await svc.recalculate_for_data_entry_type(data_entry_type, year)
+            logger.info(f"Recalc job {job_id}: workflow returned {stats}")
 
             # Commit the data session atomically
             await data_session.commit()
+            logger.info(f"Recalc job {job_id}: data session committed")
 
             result = (
                 IngestionResult.SUCCESS
@@ -90,7 +96,9 @@ async def run_recalculation_task(
                 result=result,
             )
             await job_session.commit()
-            logger.info(f"Recalculation job {job_id} finished: {stats}")
+            logger.info(
+                f"Recalc job {job_id}: FINISHED state committed (result={result.name})"
+            )
 
         except Exception as exc:
             logger.error(f"Recalculation job {job_id} failed: {exc}", exc_info=True)

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -5,8 +5,6 @@ Mirrors the dual-session pattern from ingestion_tasks.py:
 - data_session: single atomic commit at the end
 """
 
-import asyncio
-
 from app.core.logging import get_logger
 from app.db import SessionLocal
 from app.models.data_entry import DataEntryTypeEnum
@@ -119,29 +117,6 @@ async def run_recalculation_task(
                 result=IngestionResult.ERROR,
             )
             await job_session.commit()
-
-
-def run_recalculation(
-    module_type_id: int,
-    data_entry_type_id: int,
-    year: int,
-    job_id: int,
-) -> None:
-    """Sync wrapper for run_recalculation_task (FastAPI BackgroundTasks compatible).
-
-    Args:
-        module_type_id: The module type being recalculated.
-        data_entry_type_id: The data entry type to recalculate.
-        year: The report year.
-        job_id: Job id to update.
-    """
-    try:
-        asyncio.run(
-            run_recalculation_task(module_type_id, data_entry_type_id, year, job_id)
-        )
-    except Exception as exc:
-        logger.error(f"run_recalculation failed for job {job_id}: {exc}")
-        raise
 
 
 # ---------------------------------------------------------------------------
@@ -294,28 +269,3 @@ async def run_module_recalculation_task(
                 result=IngestionResult.ERROR,
             )
             await job_session.commit()
-
-
-def run_module_recalculation(
-    module_type_id: int,
-    data_entry_type_ids: list[int],
-    year: int,
-    job_id: int,
-) -> None:
-    """Sync wrapper for run_module_recalculation_task.
-
-    Args:
-        module_type_id: The module type being recalculated.
-        data_entry_type_ids: Data entry type IDs to process.
-        year: The report year.
-        job_id: Job id to update.
-    """
-    try:
-        asyncio.run(
-            run_module_recalculation_task(
-                module_type_id, data_entry_type_ids, year, job_id
-            )
-        )
-    except Exception as exc:
-        logger.error(f"run_module_recalculation failed for job {job_id}: {exc}")
-        raise

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -1,7 +1,7 @@
 """Background tasks for data ingestion."""
 
 import asyncio
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -169,20 +169,54 @@ async def _enqueue_stale_recalculations(
         logger.warning("Cannot enqueue recalculations without a year on the parent job")
         return
 
-    # Late import to avoid a circular import via app.workflows.
+    # Late imports to avoid circular imports.
+    from app.models.module_type import (
+        MODULE_TYPE_TO_DATA_ENTRY_TYPES,
+        ModuleTypeEnum,
+    )
     from app.tasks.emission_recalculation_tasks import run_recalculation_task
 
     repo = DataIngestionRepository(session)
-    rows = await repo.get_recalculation_status_by_year(year)
-    targets = [
-        r
-        for r in rows
-        if r["needs_recalculation"]
-        and (module_type_id is None or r["module_type_id"] == module_type_id)
-        and (
-            data_entry_type_id is None or r["data_entry_type_id"] == data_entry_type_id
-        )
-    ]
+
+    if data_entry_type_id is None and module_type_id is not None:
+        # Multi-type factor upload (e.g. equipments_factors.csv covers
+        # scientific + it + other under module=equipment_electric_consumption).
+        # The parent job has data_entry_type_id=NULL, which
+        # get_recalculation_status_by_year filters out — so we'd silently
+        # skip the recalc.  Expand to one target per det in the module
+        # instead.  We don't gate on needs_recalculation here: a fresh
+        # successful factor ingest just landed, every linked det is by
+        # definition stale.
+        try:
+            module = ModuleTypeEnum(module_type_id)
+        except ValueError:
+            logger.warning(
+                f"Unknown module_type_id={module_type_id}; skipping recalc fan-out"
+            )
+            return
+        dets = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(module, [])
+        # Same key shape as RecalculationStatusRow so the downstream loop
+        # can treat both branches uniformly.
+        targets: list[Any] = [
+            {
+                "module_type_id": module_type_id,
+                "data_entry_type_id": d.value,
+                "year": year,
+            }
+            for d in dets
+        ]
+    else:
+        rows = await repo.get_recalculation_status_by_year(year)
+        targets = [
+            r
+            for r in rows
+            if r["needs_recalculation"]
+            and (module_type_id is None or r["module_type_id"] == module_type_id)
+            and (
+                data_entry_type_id is None
+                or r["data_entry_type_id"] == data_entry_type_id
+            )
+        ]
 
     if not targets:
         logger.info(f"No stale (module, det) combos to recalculate for year={year}")

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -211,6 +211,12 @@ async def _enqueue_stale_recalculations(
         logger.info(f"No stale (module, det) combos to recalculate for year={year}")
         return
 
+    # Build all child jobs first, persist them in a single commit, then fan
+    # out the in-process tasks.  Per-iteration commits (the previous shape)
+    # multiplied roundtrips and gave intermediate visibility states for no
+    # benefit; the safety poller already rescues NOT_STARTED rows if this
+    # process dies between commit and fire_and_forget.
+    created_pairs: list[tuple[DataIngestionJob, Any]] = []
     for row in targets:
         new_job = DataIngestionJob(
             job_type="emission_recalc",
@@ -234,8 +240,11 @@ async def _enqueue_stale_recalculations(
                 }
             },
         )
-        created = await repo.create_ingestion_job(new_job)
-        await session.commit()
+        created_pairs.append((await repo.create_ingestion_job(new_job), row))
+
+    await session.commit()
+
+    for created, row in created_pairs:
         if created.id is None:
             logger.error(
                 "Failed to create child recalc job for "

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -2,10 +2,20 @@
 
 import asyncio
 from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
 from app.db import SessionLocal
-from app.models.data_ingestion import IngestionResult, IngestionState
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.services.data_ingestion.provider_factory import ProviderFactory
 from app.tasks._pod_id import POD_ID
@@ -78,6 +88,25 @@ async def run_sync_task(
             ingestion_result = result.get("data", {}).get(
                 "result", IngestionResult.SUCCESS
             )
+
+            # Plan 310B Part 4 — fan out emission recalculation jobs after a
+            # successful FACTORS sync.  Operators previously had to trigger
+            # this manually and forgot.  Children inherit the parent's
+            # pipeline_id so dashboards can group the chain.
+            if (
+                job.target_type == TargetType.FACTORS
+                and ingestion_result != IngestionResult.ERROR
+            ):
+                pipeline_id = job.pipeline_id or uuid4()
+                await _enqueue_stale_recalculations(
+                    job_session,
+                    parent_job_id=job.id,
+                    module_type_id=job.module_type_id,
+                    data_entry_type_id=job.data_entry_type_id,
+                    year=job.year,
+                    pipeline_id=pipeline_id,
+                )
+
             # Update final job status with the computed result
             await provider._update_job(
                 state=IngestionState.FINISHED,
@@ -110,3 +139,95 @@ def run_ingestion(provider_name: str, job_id: int, filters: dict):
         logger.error(f"Sync failed for job ID {job_id}: {str(e)}")
         # Error already logged and job status updated in run_sync_task
         raise  # propagate exception for Celery retry
+
+
+async def _enqueue_stale_recalculations(
+    session: AsyncSession,
+    *,
+    parent_job_id: Optional[int],
+    module_type_id: Optional[int],
+    data_entry_type_id: Optional[int],
+    year: Optional[int],
+    pipeline_id: UUID,
+) -> None:
+    """Fan out one ``emission_recalc`` job per stale ``(module, det)`` combo
+    after a successful factor ingest.
+
+    Filters ``get_recalculation_status_by_year`` by the parent job's scope
+    (module/det if set; otherwise all combos that need recalc).  Each child
+    inherits ``pipeline_id`` from the parent so dashboards can group runs.
+
+    Children are fired in-process via ``asyncio.create_task``.  If the pod
+    crashes between enqueue and dispatch, the safety poller (Plan 310A)
+    picks them up via ``state=NOT_STARTED AND run_after<=now()``.
+
+    This helper is intentionally local to ingestion_tasks.py — Plan C
+    generalises it as ``chain_job(parent, child)`` once the handler
+    registry lands.
+    """
+    if year is None:
+        logger.warning("Cannot enqueue recalculations without a year on the parent job")
+        return
+
+    # Late import to avoid a circular import via app.workflows.
+    from app.tasks.emission_recalculation_tasks import run_recalculation_task
+
+    repo = DataIngestionRepository(session)
+    rows = await repo.get_recalculation_status_by_year(year)
+    targets = [
+        r
+        for r in rows
+        if r["needs_recalculation"]
+        and (module_type_id is None or r["module_type_id"] == module_type_id)
+        and (
+            data_entry_type_id is None or r["data_entry_type_id"] == data_entry_type_id
+        )
+    ]
+
+    if not targets:
+        logger.info(f"No stale (module, det) combos to recalculate for year={year}")
+        return
+
+    for row in targets:
+        new_job = DataIngestionJob(
+            job_type="emission_recalc",
+            module_type_id=row["module_type_id"],
+            data_entry_type_id=row["data_entry_type_id"],
+            year=year,
+            ingestion_method=IngestionMethod.computed,
+            target_type=TargetType.DATA_ENTRIES,
+            entity_type=EntityType.MODULE_PER_YEAR,
+            state=IngestionState.NOT_STARTED,
+            pipeline_id=pipeline_id,
+            # run_after=None means runnable immediately; claim_job's WHERE
+            # treats NULL run_after as eligible.
+            run_after=None,
+            meta={
+                "config": {
+                    "year": year,
+                    "data_entry_type_id": row["data_entry_type_id"],
+                    "module_type_id": row["module_type_id"],
+                    "parent_job_id": parent_job_id,
+                }
+            },
+        )
+        created = await repo.create_ingestion_job(new_job)
+        await session.commit()
+        if created.id is None:
+            logger.error(
+                "Failed to create child recalc job for "
+                f"(module={row['module_type_id']}, det={row['data_entry_type_id']})"
+            )
+            continue
+        asyncio.create_task(
+            run_recalculation_task(
+                row["module_type_id"],
+                row["data_entry_type_id"],
+                year,
+                created.id,
+            )
+        )
+        logger.info(
+            f"Enqueued recalc job {created.id} for module={row['module_type_id']} "
+            f"det={row['data_entry_type_id']} year={year} pipeline={pipeline_id}"
+        )

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -96,14 +96,23 @@ async def run_sync_task(
                 job.target_type == TargetType.FACTORS
                 and ingestion_result != IngestionResult.ERROR
             ):
-                pipeline_id = job.pipeline_id or uuid4()
+                # Persist a fresh pipeline_id on the parent if it had
+                # none, so children genuinely inherit the same id.  The
+                # alternative — generating a new UUID locally only for
+                # the children — leaves the parent with NULL pipeline_id
+                # and an orphan group of children with a UUID nobody can
+                # correlate back.
+                if job.pipeline_id is None:
+                    job.pipeline_id = uuid4()
+                    job_session.add(job)
+                    await job_session.commit()
                 await _enqueue_stale_recalculations(
                     job_session,
                     parent_job_id=job.id,
                     module_type_id=job.module_type_id,
                     data_entry_type_id=job.data_entry_type_id,
                     year=job.year,
-                    pipeline_id=pipeline_id,
+                    pipeline_id=job.pipeline_id,
                 )
 
             # Update final job status with the computed result
@@ -167,13 +176,30 @@ async def _enqueue_stale_recalculations(
 
     repo = DataIngestionRepository(session)
 
-    if data_entry_type_id is None and module_type_id is not None:
+    if module_type_id is not None and data_entry_type_id is not None:
+        # Single-type factor upload — the parent job tells us exactly
+        # which (module, det) just changed.  We do NOT consult
+        # ``get_recalculation_status_by_year`` here because that helper
+        # filters on ``state=FINISHED`` and the parent job is still
+        # RUNNING at this point in the pipeline (the FINISHED stamp
+        # happens *after* fan-out, deliberately, so the fan-out commit
+        # gets included in the parent's atomic data_session).  Without
+        # this short-circuit, single-type uploads silently skipped
+        # recalc — the status query found no matching factor row.
+        targets: list[Any] = [
+            {
+                "module_type_id": module_type_id,
+                "data_entry_type_id": data_entry_type_id,
+                "year": year,
+            }
+        ]
+    elif data_entry_type_id is None and module_type_id is not None:
         # Multi-type factor upload (e.g. equipments_factors.csv covers
         # scientific + it + other under module=equipment_electric_consumption).
-        # The parent job has data_entry_type_id=NULL, which
-        # get_recalculation_status_by_year filters out — so we'd silently
-        # skip the recalc.  Expand to one target per det in the module
-        # instead.  We don't gate on needs_recalculation here: a fresh
+        # Same hazard as single-type — the status query would filter the
+        # parent out — but the resolution is different: expand to one
+        # target per det in the module via MODULE_TYPE_TO_DATA_ENTRY_TYPES.
+        # We don't gate on needs_recalculation here either: a fresh
         # successful factor ingest just landed, every linked det is by
         # definition stale.
         try:
@@ -184,9 +210,7 @@ async def _enqueue_stale_recalculations(
             )
             return
         dets = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(module, [])
-        # Same key shape as RecalculationStatusRow so the downstream loop
-        # can treat both branches uniformly.
-        targets: list[Any] = [
+        targets = [
             {
                 "module_type_id": module_type_id,
                 "data_entry_type_id": d.value,
@@ -195,17 +219,13 @@ async def _enqueue_stale_recalculations(
             for d in dets
         ]
     else:
+        # Both NULL — operator wants "anything stale this year".  This
+        # is the only branch that reads from
+        # ``get_recalculation_status_by_year`` (which filters on
+        # state=FINISHED).  Reachable only via admin-style triggers,
+        # not via a normal factor CSV upload.
         rows = await repo.get_recalculation_status_by_year(year)
-        targets = [
-            r
-            for r in rows
-            if r["needs_recalculation"]
-            and (module_type_id is None or r["module_type_id"] == module_type_id)
-            and (
-                data_entry_type_id is None
-                or r["data_entry_type_id"] == data_entry_type_id
-            )
-        ]
+        targets = [r for r in rows if r["needs_recalculation"]]
 
     if not targets:
         logger.info(f"No stale (module, det) combos to recalculate for year={year}")

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -174,6 +174,7 @@ async def _enqueue_stale_recalculations(
         MODULE_TYPE_TO_DATA_ENTRY_TYPES,
         ModuleTypeEnum,
     )
+    from app.tasks._background import fire_and_forget
     from app.tasks.emission_recalculation_tasks import run_recalculation_task
 
     repo = DataIngestionRepository(session)
@@ -253,13 +254,14 @@ async def _enqueue_stale_recalculations(
                 f"(module={row['module_type_id']}, det={row['data_entry_type_id']})"
             )
             continue
-        asyncio.create_task(
+        fire_and_forget(
             run_recalculation_task(
                 row["module_type_id"],
                 row["data_entry_type_id"],
                 year,
                 created.id,
-            )
+            ),
+            name=f"recalc-{created.id}",
         )
         logger.info(
             f"Enqueued recalc job {created.id} for module={row['module_type_id']} "

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -1,6 +1,5 @@
 """Background tasks for data ingestion."""
 
-import asyncio
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
@@ -129,18 +128,6 @@ async def run_sync_task(
             raise  # propagate exception
 
 
-# @celery_app.task(bind=True, max_retries=3, default_retry_delay=60)
-# add self to make it celery compatible
-def run_ingestion(provider_name: str, job_id: int, filters: dict):
-    """almost celery compatible sync wrapper for run_sync_task"""
-    try:
-        asyncio.run(run_sync_task(provider_name, job_id, filters))
-    except Exception as e:
-        logger.error(f"Sync failed for job ID {job_id}: {str(e)}")
-        # Error already logged and job status updated in run_sync_task
-        raise  # propagate exception for Celery retry
-
-
 async def _enqueue_stale_recalculations(
     session: AsyncSession,
     *,
@@ -157,9 +144,10 @@ async def _enqueue_stale_recalculations(
     (module/det if set; otherwise all combos that need recalc).  Each child
     inherits ``pipeline_id`` from the parent so dashboards can group runs.
 
-    Children are fired in-process via ``asyncio.create_task``.  If the pod
-    crashes between enqueue and dispatch, the safety poller (Plan 310A)
-    picks them up via ``state=NOT_STARTED AND run_after<=now()``.
+    Children are fired in-process via ``fire_and_forget`` so the Task is
+    held in a strong-ref set and isn't reaped by GC mid-execution.  If
+    the pod crashes between enqueue and dispatch, the safety poller
+    (Plan 310A) picks them up via ``state=NOT_STARTED AND run_after<=now()``.
 
     This helper is intentionally local to ingestion_tasks.py — Plan C
     generalises it as ``chain_job(parent, child)`` once the handler

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -151,4 +151,9 @@ async def run_sync_task_accred(
                 result=IngestionResult.ERROR,
             )
             await job_session.commit()
-            raise
+            # Do not re-raise: the endpoint schedules this task via
+            # ``fire_and_forget`` (no awaiter), so a re-raise would
+            # surface as "Task exception was never retrieved" warnings
+            # on every failure.  The job state + status_message already
+            # carry the error for operators / SSE consumers.
+            return

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -1,19 +1,28 @@
-"""Background tasks for unit synchronization with Accred API."""
+"""Background task for unit + principal-user synchronization with Accred API.
 
-import asyncio
+Plan 310B Part 5 — unit_sync is now a tracked DataIngestionJob (job_type=
+unit_sync, entity_type=GLOBAL_PER_YEAR).  The endpoint creates the job
+synchronously and returns its id; this task claims it via Plan 310A's
+``claim_job`` and updates ``status_message`` between steps so the SSE stream
+shows progress.
+"""
+
 from typing import Any, Dict
 
 from pydantic import BaseModel
 
 from app.core.logging import get_logger
 from app.db import SessionLocal
+from app.models.data_ingestion import IngestionResult, IngestionState
 from app.models.user import UserProvider
 from app.providers.role_provider import get_role_provider
 from app.providers.unit_provider import get_unit_provider
+from app.repositories.data_ingestion import DataIngestionRepository
 from app.schemas.carbon_report import CarbonReportCreate
 from app.services.carbon_report_service import CarbonReportService
 from app.services.unit_service import UnitService
 from app.services.user_service import UserService
+from app.tasks._pod_id import POD_ID
 
 logger = get_logger(__name__)
 
@@ -22,114 +31,124 @@ class SyncUnitRequest(BaseModel):
     target_year: int
 
 
-async def run_sync_task_accred(syncRequest: SyncUnitRequest) -> Dict[str, Any]:
+async def run_sync_task_accred(
+    sync_request: SyncUnitRequest,
+    job_id: int,
+) -> None:
+    """Run the Accred unit + principal-user sync as a tracked job.
+
+    Dual session — mirrors ``ingestion_tasks.run_sync_task``:
+
+    - ``job_session`` commits ``status_message`` updates immediately so the
+      SSE stream reflects progress.
+    - ``data_session`` writes units / users / carbon reports inside one
+      atomic transaction; rolled back as a unit on failure.
+
+    Claim via ``claim_job`` ensures pod safety (Plan 310A): if two pods race
+    on the same job_id, only one wins and the other returns silently.
     """
-    Background task to sync units and principal users from Accred API.
+    target_year = sync_request.target_year
 
-    This task:
-    1. Fetches all units from Accred API
-    2. Bulk upserts units into database
-    3. Fetches and upserts principal users
-    4. Commits changes
-    5. Create all carbon reports for all units (one per unit, using target_year)
-    6. All corresponding carbon_reports_modules are auto-created by service
+    async with SessionLocal() as job_session, SessionLocal() as data_session:
+        job_repo = DataIngestionRepository(job_session)
 
-    Args:
-        target_year: The year for carbon reports (required)
+        claimed = await job_repo.claim_job(job_id, POD_ID)
+        if not claimed:
+            logger.info(
+                f"Unit sync job {job_id} already claimed or not eligible — skipping"
+            )
+            return
 
-    Returns:
-        Dict with sync results including counts and status
-    """
-    target_year = syncRequest.target_year
+        try:
+            await job_repo.update_ingestion_job(
+                job_id=job_id,
+                status_message="Fetching units from Accred…",
+                metadata={},
+            )
+            await job_session.commit()
 
-    try:
-        logger.info("Starting unit sync from Accred API")
-
-        async with SessionLocal() as session:
-            carbon_reports_created = 0
-            # Get providers
-            provider = get_unit_provider(UserProvider.ACCRED)
+            unit_provider = get_unit_provider(UserProvider.ACCRED)
             role_provider = get_role_provider(UserProvider.ACCRED)
+            units_raw, principal_users_raw = await unit_provider.fetch_all_units()
 
-            # Fetch data from Accred API
-            units_raw, principal_users_raw = await provider.fetch_all_units()
-
-            # Map API responses to domain models
-            units = [provider.map_api_unit(unit) for unit in units_raw]
+            units = [unit_provider.map_api_unit(u) for u in units_raw]
             principal_users = [
-                role_provider.map_api_user(user) for user in principal_users_raw
+                role_provider.map_api_user(u) for u in principal_users_raw
             ]
 
-            logger.info(
-                f"Fetched {len(units)} units and "
-                f"{len(principal_users)} principal users from Accred API"
+            await job_repo.update_ingestion_job(
+                job_id=job_id,
+                status_message=(
+                    f"Upserting {len(units)} units and "
+                    f"{len(principal_users)} principal users…"
+                ),
+                metadata={},
             )
+            await job_session.commit()
 
-            unit_service = UnitService(session)
+            unit_service = UnitService(data_session)
             unit_upsert_result = await unit_service.bulk_upsert(units)
             units = unit_upsert_result.data
 
-            carbon_report_service = CarbonReportService(session)
-
-            user_service = UserService(session)
+            user_service = UserService(data_session)
             user_upsert_result = await user_service.bulk_upsert(principal_users)
             principal_users = user_upsert_result.data
 
-            try:
-                report_create_data = [
-                    CarbonReportCreate(year=target_year, unit_id=unit.id)
-                    for unit in units
-                    if unit.id is not None
-                ]
-                new_carbon_reports = await carbon_report_service.bulk_upsert(
-                    report_create_data
-                )
-                carbon_reports_created = len(new_carbon_reports)
+            await job_repo.update_ingestion_job(
+                job_id=job_id,
+                status_message=f"Creating carbon reports for year {target_year}…",
+                metadata={},
+            )
+            await job_session.commit()
 
-                logger.info(
-                    f"Upserted {carbon_reports_created} carbon reports "
-                    f"for {len(units)} units"
-                )
+            carbon_report_service = CarbonReportService(data_session)
+            report_create_data = [
+                CarbonReportCreate(year=target_year, unit_id=u.id)
+                for u in units
+                if u.id is not None
+            ]
+            new_carbon_reports = await carbon_report_service.bulk_upsert(
+                report_create_data
+            )
 
-                await carbon_report_service.ensure_modules_for_reports(
-                    new_carbon_reports
-                )
-                logger.info(
-                    f"Ensured modules for {len(new_carbon_reports)} carbon reports"
-                )
+            await job_repo.update_ingestion_job(
+                job_id=job_id,
+                status_message=(
+                    f"Ensuring modules for {len(new_carbon_reports)} carbon reports…"
+                ),
+                metadata={},
+            )
+            await job_session.commit()
 
-                await session.commit()
+            await carbon_report_service.ensure_modules_for_reports(new_carbon_reports)
+            await data_session.commit()
 
-            except Exception as e:
-                logger.error(f"Failed to create carbon reports: {e}", exc_info=True)
-                await session.rollback()
-                raise
-
-            result = {
-                "status": "success",
+            result_summary: Dict[str, Any] = {
                 "units_synced": len(units),
                 "users_synced": len(principal_users),
                 "unit_results": str(unit_upsert_result),
                 "user_results": str(user_upsert_result),
-                "carbon_reports_created": carbon_reports_created,
+                "carbon_reports_created": len(new_carbon_reports),
                 "carbon_report_year": target_year,
             }
-
-            logger.info(f"Unit sync completed successfully: {result}")
-            return result
-
-    except Exception as e:
-        logger.error(f"Unit sync from Accred API failed: {e}", exc_info=True)
-        return {"status": "error", "error": str(e)}
-
-
-# @celery_app.task(bind=True, max_retries=3, default_retry_delay=60)
-# add self to make it celery compatible
-def sync_units_from_accred_task(syncRequest: SyncUnitRequest):
-    """almost celery compatible sync wrapper for run_sync_task"""
-    try:
-        asyncio.run(run_sync_task_accred(syncRequest))
-    except Exception:
-        logger.error(f"Sync failed for sync request: {syncRequest}", exc_info=True)
-        # Error already logged and job status updated in run_sync_task
-        raise  # propagate exception for Celery retry
+            await job_repo.update_ingestion_job(
+                job_id=job_id,
+                status_message="Unit sync completed",
+                metadata=result_summary,
+                state=IngestionState.FINISHED,
+                result=IngestionResult.SUCCESS,
+            )
+            await job_session.commit()
+            logger.info(f"Unit sync job {job_id} completed: {result_summary}")
+        except Exception as exc:
+            logger.error(f"Unit sync job {job_id} failed: {exc}", exc_info=True)
+            await data_session.rollback()
+            await job_repo.update_ingestion_job(
+                job_id=job_id,
+                status_message=str(exc),
+                metadata={"error": str(exc)},
+                state=IngestionState.FINISHED,
+                result=IngestionResult.ERROR,
+            )
+            await job_session.commit()
+            raise

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -78,29 +78,49 @@ class EmissionRecalculationWorkflow:
         affected_module_ids: set[int] = set()
 
         for entry in entries:
+            # Plan 310B Part 6 — refresh primary_factor_id against current
+            # factors before computing.  Strategy A entries (equipment,
+            # purchases, …) need this so a CSV reupload that changes a
+            # factor's classification re-links the entry to the new
+            # factor row instead of dereferencing a stale FK.
+            #
+            # Gate: only run the refresh when the handler exposes a
+            # ``kind_field`` AND that field is actually present in
+            # ``entry.data``.  Strategy B handlers like
+            # professional_travel/plane have ``kind_field`` set but
+            # derive the value in ``pre_compute``, so it's not in
+            # ``entry.data`` — running the lookup with an empty kind
+            # would either clear ``primary_factor_id`` or raise
+            # ``MultipleResultsFound``, neither of which is right for
+            # those handlers.
+            #
+            # N+1 query per entry — acceptable for now; batched matching
+            # is on the Plan D follow-up list.
+            should_refresh = (
+                handler.kind_field is not None and handler.kind_field in entry.data
+            )
+            old_data = entry.data
             try:
-                # Plan 310B Part 6 — refresh primary_factor_id against current
-                # factors before computing.  Strategy A entries (equipment,
-                # purchases, …) need this so a CSV reupload that changes a
-                # factor's classification re-links the entry to the new
-                # factor row instead of dereferencing a stale FK.  Strategy B
-                # handlers' rematch is a no-op (they re-resolve at compute
-                # time anyway).  N+1 query per entry — acceptable for now;
-                # batched matching is on the Plan D follow-up list.
-                #
-                # primary_factor_id lives inside DataEntry.data (JSON column),
-                # not as a column on the table.  Reassign the dict so
-                # SQLAlchemy notices the change and persists it.
-                refreshed = await handler_svc.resolve_primary_factor_id(
-                    handler=handler,
-                    payload=dict(entry.data),
-                    data_entry_type_id=data_entry_type_id,
-                    year=year,
-                    existing_data=None,
-                )
-                new_factor_id = refreshed.get("primary_factor_id")
-                if new_factor_id != entry.data.get("primary_factor_id"):
-                    entry.data = {**entry.data, "primary_factor_id": new_factor_id}
+                if should_refresh:
+                    refreshed = await handler_svc.resolve_primary_factor_id(
+                        handler=handler,
+                        payload=dict(entry.data),
+                        data_entry_type_id=data_entry_type_id,
+                        year=year,
+                        existing_data=None,
+                    )
+                    new_factor_id = refreshed.get("primary_factor_id")
+                    if new_factor_id != entry.data.get("primary_factor_id"):
+                        # Tentative swap so DataEntryResponse + upsert
+                        # see the refreshed factor.  Rolled back below
+                        # if the upsert fails, so partial-failure runs
+                        # don't leave entry.data pointing at the new
+                        # factor while data_entry_emissions is still
+                        # computed against the old one.
+                        entry.data = {
+                            **entry.data,
+                            "primary_factor_id": new_factor_id,
+                        }
 
                 entry_response = DataEntryResponse.model_validate(entry)
                 await emission_svc.upsert_by_data_entry(entry_response)
@@ -108,6 +128,10 @@ class EmissionRecalculationWorkflow:
                 if entry.carbon_report_module_id is not None:
                     affected_module_ids.add(entry.carbon_report_module_id)
             except Exception as exc:
+                # Roll back the in-memory mutation so the outer
+                # data_session.commit() does not persist a stale link
+                # alongside an old emissions row.
+                entry.data = old_data
                 errors += 1
                 error_details.append(
                     {

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -9,9 +9,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntryTypeEnum
 from app.repositories.data_entry_repo import DataEntryRepository
-from app.schemas.data_entry import DataEntryResponse
+from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.services.module_handler_service import ModuleHandlerService
 
 logger = get_logger(__name__)
 
@@ -52,6 +53,8 @@ class EmissionRecalculationWorkflow:
 
         emission_svc = DataEntryEmissionService(self.session)
         module_svc = CarbonReportModuleService(self.session)
+        handler_svc = ModuleHandlerService(self.session)
+        handler = BaseModuleHandler.get_by_type(data_entry_type_id)
 
         recalculated = 0
         errors = 0
@@ -60,6 +63,29 @@ class EmissionRecalculationWorkflow:
 
         for entry in entries:
             try:
+                # Plan 310B Part 6 — refresh primary_factor_id against current
+                # factors before computing.  Strategy A entries (equipment,
+                # purchases, …) need this so a CSV reupload that changes a
+                # factor's classification re-links the entry to the new
+                # factor row instead of dereferencing a stale FK.  Strategy B
+                # handlers' rematch is a no-op (they re-resolve at compute
+                # time anyway).  N+1 query per entry — acceptable for now;
+                # batched matching is on the Plan D follow-up list.
+                #
+                # primary_factor_id lives inside DataEntry.data (JSON column),
+                # not as a column on the table.  Reassign the dict so
+                # SQLAlchemy notices the change and persists it.
+                refreshed = await handler_svc.resolve_primary_factor_id(
+                    handler=handler,
+                    payload=dict(entry.data),
+                    data_entry_type_id=data_entry_type_id,
+                    year=year,
+                    existing_data=None,
+                )
+                new_factor_id = refreshed.get("primary_factor_id")
+                if new_factor_id != entry.data.get("primary_factor_id"):
+                    entry.data = {**entry.data, "primary_factor_id": new_factor_id}
+
                 entry_response = DataEntryResponse.model_validate(entry)
                 await emission_svc.upsert_by_data_entry(entry_response)
                 recalculated += 1

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -50,6 +50,22 @@ class EmissionRecalculationWorkflow:
         """
         repo = DataEntryRepository(self.session)
         entries = await repo.list_by_data_entry_type_and_year(data_entry_type_id, year)
+        logger.info(
+            f"Recalc {data_entry_type_id.name}/{year}: "
+            f"{len(entries)} data entries to process"
+        )
+
+        # Early-exit: nothing to recalculate.  Keeps the recalc task off the
+        # handler / factor lookup paths entirely when the slice is empty,
+        # which is the dominant case right after a factor reupload for a
+        # det that has no data entries yet.
+        if not entries:
+            return {
+                "recalculated": 0,
+                "modules_refreshed": 0,
+                "errors": 0,
+                "error_details": [],
+            }
 
         emission_svc = DataEntryEmissionService(self.session)
         module_svc = CarbonReportModuleService(self.session)

--- a/backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py
@@ -1,0 +1,183 @@
+"""Integration test for ``GET /v1/factors/stale`` against a real Postgres.
+
+Plan 310B Part 3 — operators see factors not present in the latest CSV
+upload via this endpoint.  The endpoint round-trips through:
+
+- ``FactorRepository.list_stale_for_year`` (covered separately by
+  ``test_plan_310b_factor_pipeline_pg.py``)
+- ``StaleFactorResponse`` model conversion
+- FastAPI route + dependency injection wiring
+
+This test exists primarily to cover the HTTP route + response-model code
+in ``app/api/v1/factors.py`` that the repo-level tests don't touch.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+from app.repositories.factor_repo import FactorRepository
+from tests.integration.services.data_ingestion.test_plan_310b_factor_pipeline_pg import (  # noqa: E501
+    _make_factor,
+    _seed_factor_job,
+)
+
+
+async def _install_indexes(engine) -> None:
+    """Mirror migration b1f0a2c3d4e5's partial unique indexes — pg_dsn's
+    SQLModel.metadata.create_all doesn't run Alembic, so the indexes
+    aren't created automatically and ``upsert_factors`` would fail
+    inferring its conflict target."""
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
+                "ON factors (data_entry_type_id, year, emission_type_id, "
+                "(classification::text)) "
+                "WHERE year IS NOT NULL"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
+                "ON factors (data_entry_type_id, emission_type_id, "
+                "(classification::text)) "
+                "WHERE year IS NULL"
+            )
+        )
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+
+    yield {"factory": Sf, "engine": engine}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_get_stale_factors_returns_only_outdated_rows(pg_app):
+    """End-to-end: seed one stale + one fresh factor under different
+    is_current FACTORS jobs and verify the endpoint returns just the
+    stale one in StaleFactorResponse shape."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        old_job = _seed_factor_job()
+        old_job.is_current = False
+        latest_job = _seed_factor_job()
+        session.add_all([old_job, latest_job])
+        await session.commit()
+        assert old_job.id is not None and latest_job.id is not None
+        old_id: int = old_job.id
+        latest_id: int = latest_job.id
+
+        repo = FactorRepository(session)
+        await repo.upsert_factors(
+            [_make_factor({"kind": "food", "subkind": None})],
+            current_job_id=old_id,
+        )
+        await repo.upsert_factors(
+            [_make_factor({"kind": "waste", "subkind": None})],
+            current_job_id=latest_id,
+        )
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/factors/stale", params={"year": 2025})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 1, f"Expected exactly 1 stale row, got {body!r}"
+    row = body[0]
+    # Verify the StaleFactorResponse shape — fields the operator UI relies on.
+    assert row["classification"] == {"kind": "food", "subkind": None}
+    assert row["last_seen_job_id"] == old_id
+    assert row["year"] == 2025
+    assert row["data_entry_type_id"] == 1
+    assert row["emission_type_id"] == 10000
+    assert isinstance(row["id"], int) and row["id"] > 0
+
+
+@pytest.mark.asyncio
+async def test_get_stale_factors_returns_empty_list_with_no_factor_jobs(pg_app):
+    """No FACTORS jobs for the queried year → endpoint returns ``[]``,
+    not an error and not the full factor table.  Confirms the empty-map
+    short-circuit in ``list_stale_for_year`` propagates through the
+    HTTP response model."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        # Seed a non-current FACTORS job for a different year, just to prove
+        # we're filtering by year and not "any FACTORS job ever exists".
+        other_job = DataIngestionJob(
+            entity_type=EntityType.MODULE_PER_YEAR,
+            module_type_id=1,
+            data_entry_type_id=1,
+            year=2024,
+            target_type=TargetType.FACTORS,
+            ingestion_method=IngestionMethod.csv,
+            provider=UserProvider.DEFAULT,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            is_current=True,
+        )
+        session.add(other_job)
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/factors/stale", params={"year": 2025})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_emission_change_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_emission_change_pg.py
@@ -1,0 +1,170 @@
+"""End-to-end Postgres test for Plan 310B Part 6.
+
+The narrow recalc-fan-out test (test_plan_310b_recalc_fanout_pg.py)
+proves that recalc jobs are *enqueued* with the right scope.  This file
+goes one step further: it verifies that running the recalc workflow
+against a real factor → data-entry → emission graph actually
+**recomputes the emission** when the factor's values change.
+
+Failure-mode this guards against: the previous code path silently
+returned ("No stale combos to recalculate for year=2025") and emissions
+in the DB stayed at the old value despite a successful factor reupload.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.models.unit import Unit
+from app.schemas.data_entry import DataEntryResponse
+from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
+
+
+@pytest.mark.asyncio
+async def test_factor_reupload_recomputes_emission_in_db(pg_dsn):
+    """Equipment factor (it module, equipment_class=Laptop) seeded with
+    ef_kg_co2eq_per_kwh=0.1.  After computing the initial emission for a
+    matching data entry, change the factor's ef to 0.2 and run the recalc
+    workflow.  Verify on a **separate engine** (different connection pool
+    from the one that did the writes — proves cross-connection commit
+    visibility, the diagnostic the user lost when checking the dev DB)
+    that the persisted emission is exactly doubled.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    # ── 1. Seed the carbon-report graph + factor + data entry ──────────
+    async with Sf() as s:
+        unit = Unit(
+            institutional_code="TEST",
+            institutional_id="TEST-UNIT",
+            name="Test Unit",
+            level=1,
+        )
+        s.add(unit)
+        await s.commit()
+        unit_id = unit.id
+
+        report = CarbonReport(year=2025, unit_id=unit_id)
+        s.add(report)
+        await s.commit()
+        report_id = report.id
+
+        module = CarbonReportModule(
+            carbon_report_id=report_id,
+            module_type_id=ModuleTypeEnum.equipment_electric_consumption.value,
+        )
+        s.add(module)
+        await s.commit()
+        module_id = module.id
+
+        factor = Factor(
+            emission_type_id=EmissionType.equipment__it.value,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            classification={
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "year": 2025,
+            },
+            values={
+                "active_power_w": 100.0,
+                "standby_power_w": 10.0,
+                "ef_kg_co2eq_per_kwh": 0.1,
+            },
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        factor_id = factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            carbon_report_module_id=module_id,
+            data={
+                "primary_factor_id": factor_id,
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "active_usage_hours_per_week": 40.0,
+                "standby_usage_hours_per_week": 128.0,
+                "name": "Test Laptop",
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        entry_id = entry.id
+
+    # ── 2. Initial emission compute ────────────────────────────────────
+    async with Sf() as s:
+        entry = (
+            await s.execute(select(DataEntry).where(col(DataEntry.id) == entry_id))
+        ).scalar_one()
+        emission_svc = DataEntryEmissionService(s)
+        await emission_svc.upsert_by_data_entry(DataEntryResponse.model_validate(entry))
+        await s.commit()
+
+    async with Sf() as s:
+        initial_rows = (
+            (
+                await s.execute(
+                    select(DataEntryEmission).where(
+                        col(DataEntryEmission.data_entry_id) == entry_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        initial_total = sum((r.kg_co2eq or 0.0) for r in initial_rows)
+    assert initial_total > 0, "initial emission compute should produce a non-zero total"
+
+    # ── 3. Update the factor — same identity, double the ef ────────────
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kg_co2eq_per_kwh": 0.2}
+        await s.commit()
+
+    # ── 4. Run the recalc workflow ─────────────────────────────────────
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
+        await s.commit()
+
+    # ── 5. Verify on a SEPARATE engine ─────────────────────────────────
+    # This is the key assertion: a fresh connection pool reads the
+    # post-recalc state — proves the recompute committed and is visible
+    # across connections (i.e. another process / pgcli session sees it).
+    verify_engine = create_async_engine(pg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            new_rows = (
+                (
+                    await vs.execute(
+                        select(DataEntryEmission).where(
+                            col(DataEntryEmission.data_entry_id) == entry_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            new_total = sum((r.kg_co2eq or 0.0) for r in new_rows)
+    finally:
+        await verify_engine.dispose()
+        await engine.dispose()
+
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3), (
+        "Doubling ef_kg_co2eq_per_kwh should double the persisted emission. "
+        f"Initial={initial_total}, new={new_total}"
+    )

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
@@ -499,3 +499,66 @@ async def test_latest_factor_job_per_det_skips_both_nulls(pg_dsn):
         assert latest == {}
 
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_list_stale_filters_to_csv_ingestion_method(pg_dsn):
+    """Plan 310B fix (Copilot follow-up): ``list_stale_for_year`` must
+    only consider FACTORS jobs whose ``ingestion_method == csv``.
+
+    The bug it guards against: ``last_seen_job_id`` is ONLY stamped by
+    the CSV upsert path.  If a ``computed`` FACTORS job (factor recompute,
+    distinct from a CSV upload) becomes is_current later, its higher id
+    would shadow the latest CSV upload's id and make every CSV-stamped
+    factor look stale on ``/factors/stale``.
+
+    This test seeds a CSV factor job (id=N) plus a later computed factor
+    job (id=N+1) for the same (det, year) and verifies a factor stamped
+    by the CSV job is NOT reported as stale (because the computed job
+    is filtered out of the threshold map).
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        # CSV factor job — stamps last_seen_job_id on factors it writes.
+        csv_job = _seed_factor_job()
+        csv_job.is_current = False  # to allow second is_current row
+        # Later computed factor job — different ingestion_method, NOT a
+        # CSV upload, so it never stamps last_seen_job_id.
+        computed_job = _seed_factor_job()
+        computed_job.ingestion_method = IngestionMethod.computed
+        # Plan A's partial unique index on is_current allows only one
+        # is_current per (module, det, target, ingestion_method, year),
+        # so distinct ingestion_methods can both be is_current — that's
+        # exactly the production scenario this test guards.
+        session.add_all([csv_job, computed_job])
+        await session.commit()
+        assert csv_job.id is not None and computed_job.id is not None
+        csv_id: int = csv_job.id
+        computed_id: int = computed_job.id
+
+        # Sanity: computed job has a strictly greater id (would shadow
+        # the CSV job under a naive max(id) join).
+        assert computed_id > csv_id
+
+        repo = FactorRepository(session)
+        # Stamp the factor with the CSV job's id — production path.
+        await repo.upsert_factors(
+            [_make_factor({"kind": "food", "subkind": None})],
+            current_job_id=csv_id,
+        )
+        await session.commit()
+
+        # Without the ingestion_method filter, the latest threshold
+        # would be max(csv_id, computed_id) = computed_id, and the
+        # factor (last_seen=csv_id < computed_id) would appear stale.
+        # WITH the filter, only csv_id is considered → factor NOT stale.
+        stale = await repo.list_stale_for_year(2025)
+        assert stale == [], (
+            "computed FACTORS jobs must be excluded from the stale-"
+            "threshold; only csv jobs stamp last_seen_job_id"
+        )
+
+    await engine.dispose()

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
@@ -388,3 +388,114 @@ async def test_list_stale_for_year_handles_multi_type_factors_job(pg_dsn):
         assert stale[0].last_seen_job_id == old_id
 
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_list_stale_for_year_returns_empty_when_no_factor_job(pg_dsn):
+    """No is_current FACTORS job for the requested year → return [] rather
+    than treat every factor as stale.  Without this short-circuit, the
+    endpoint would noisily flag every existing factor on a year that never
+    had a CSV uploaded.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        # Seed a finished FACTORS job for 2024 (different year than the query)
+        # plus a factor row stamped against it.
+        other_year_job = _seed_factor_job()
+        other_year_job.year = 2024
+        session.add(other_year_job)
+        await session.commit()
+        assert other_year_job.id is not None
+
+        repo = FactorRepository(session)
+        await repo.upsert_factors(
+            [_make_factor({"kind": "food", "subkind": None}, year=2024)],
+            current_job_id=other_year_job.id,
+        )
+        await session.commit()
+
+        # Query for 2025 — no is_current FACTORS job exists for that year.
+        stale = await repo.list_stale_for_year(2025)
+        assert stale == []
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_latest_factor_job_per_det_skips_unknown_module(pg_dsn):
+    """A multi-type FACTORS job with a ``module_type_id`` that no longer
+    maps to a ``ModuleTypeEnum`` value (legacy enum cleanup, hand-edited
+    row, etc.) must be skipped silently rather than crash the stale
+    detection.  Defensive: lets operators view stale factors even when
+    one rogue job row would otherwise raise ValueError.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        # One job with a bogus module_type_id, marked is_current — used to
+        # exercise the ValueError branch in _latest_factor_job_per_det.
+        rogue = DataIngestionJob(
+            entity_type=EntityType.MODULE_PER_YEAR,
+            module_type_id=99999,  # not a valid ModuleTypeEnum
+            data_entry_type_id=None,
+            year=2025,
+            target_type=TargetType.FACTORS,
+            ingestion_method=IngestionMethod.csv,
+            provider=UserProvider.DEFAULT,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            is_current=True,
+        )
+        session.add(rogue)
+        await session.commit()
+
+        repo = FactorRepository(session)
+        # Should not raise.  No factors → returns empty map, list_stale
+        # returns [].
+        latest = await repo._latest_factor_job_per_det(2025)
+        assert latest == {}
+
+        stale = await repo.list_stale_for_year(2025)
+        assert stale == []
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_latest_factor_job_per_det_skips_both_nulls(pg_dsn):
+    """A FACTORS job with both ``module_type_id`` and ``data_entry_type_id``
+    NULL has no meaningful scope — it covers no factors, so it shouldn't
+    contribute to the stale-threshold map.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        # Both NULLs — degenerate but possible if someone POSTs a
+        # malformed sync request that bypasses validation.
+        unscoped = DataIngestionJob(
+            entity_type=EntityType.MODULE_PER_YEAR,
+            module_type_id=None,
+            data_entry_type_id=None,
+            year=2025,
+            target_type=TargetType.FACTORS,
+            ingestion_method=IngestionMethod.csv,
+            provider=UserProvider.DEFAULT,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            is_current=True,
+        )
+        session.add(unscoped)
+        await session.commit()
+
+        repo = FactorRepository(session)
+        latest = await repo._latest_factor_job_per_det(2025)
+        assert latest == {}
+
+    await engine.dispose()

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
@@ -1,0 +1,303 @@
+"""Real-Postgres tests for Plan 310B.
+
+These tests exercise behavior that SQLite cannot:
+
+- ``INSERT ... ON CONFLICT DO UPDATE`` against a partial unique index on
+  ``(data_entry_type_id, year, emission_type_id, classification::text)``
+  — keyed via JSONB so dict insertion order in Python is irrelevant.
+- ``last_seen_job_id`` cross-table query for stale-factor detection.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+
+The shared ``pg_dsn`` fixture builds the schema via
+``SQLModel.metadata.create_all`` and does **not** run Alembic migrations,
+so the Plan 310B partial unique indexes don't exist by default.  These
+tests create them inline to mirror the production schema.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.factor import Factor
+from app.models.user import UserProvider
+from app.repositories.factor_repo import FactorRepository
+
+
+async def _install_plan_310b_indexes(engine) -> None:
+    """Create the partial unique indexes that Plan 310B's migration adds.
+
+    ``pg_dsn`` builds tables via ``SQLModel.metadata.create_all``, which
+    doesn't know about the migration's bare DDL.  Mirror it here so
+    ``ON CONFLICT`` inference can find the index it needs to bind to.
+    """
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
+                "ON factors (data_entry_type_id, year, emission_type_id, "
+                "(classification::text)) "
+                "WHERE year IS NOT NULL"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
+                "ON factors (data_entry_type_id, emission_type_id, "
+                "(classification::text)) "
+                "WHERE year IS NULL"
+            )
+        )
+
+
+def _seed_factor_job() -> DataIngestionJob:
+    """A finished, current FACTORS job — referenced by ``last_seen_job_id``."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=1,
+        data_entry_type_id=1,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+
+
+def _make_factor(
+    classification: dict,
+    *,
+    data_entry_type_id: int = 1,
+    year: int | None = 2025,
+    values: dict | None = None,
+    emission_type_id: int = 10000,
+) -> Factor:
+    return Factor(
+        emission_type_id=emission_type_id,
+        data_entry_type_id=data_entry_type_id,
+        classification=classification,
+        values=values or {"kg_co2eq": 1.0},
+        year=year,
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_factors_inserts_new_row_with_last_seen_job_id(pg_dsn):
+    """First upsert: row gets a fresh id and last_seen_job_id stamped."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        job = _seed_factor_job()
+        session.add(job)
+        await session.commit()
+        assert job.id is not None
+        job_id: int = job.id
+
+        repo = FactorRepository(session)
+        affected = await repo.upsert_factors(
+            [_make_factor({"kind": "food", "subkind": None})],
+            current_job_id=job_id,
+        )
+        await session.commit()
+
+        assert affected == 1
+
+        # Verify the row landed and is stamped with the job id.
+        from sqlmodel import col, select
+
+        rows = (
+            (
+                await session.execute(
+                    select(Factor).where(col(Factor.data_entry_type_id) == 1)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].last_seen_job_id == job_id
+        assert rows[0].id is not None
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_upsert_factors_updates_existing_row_preserving_id(pg_dsn):
+    """Second upsert with same identity key: same id, values updated,
+    last_seen_job_id refreshed."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        # Two jobs for the same combo — only one can be is_current=True
+        # (existing partial unique index on the jobs table).
+        job1 = _seed_factor_job()
+        job1.is_current = False
+        job2 = _seed_factor_job()
+        session.add_all([job1, job2])
+        await session.commit()
+        assert job1.id is not None and job2.id is not None
+        job1_id: int = job1.id
+        job2_id: int = job2.id
+
+        repo = FactorRepository(session)
+        await repo.upsert_factors(
+            [
+                _make_factor(
+                    {"kind": "food", "subkind": None},
+                    values={"kg_co2eq": 100.0},
+                )
+            ],
+            current_job_id=job1_id,
+        )
+        await session.commit()
+
+        from sqlmodel import col, select
+
+        first = (
+            await session.execute(
+                select(Factor).where(col(Factor.data_entry_type_id) == 1)
+            )
+        ).scalar_one()
+        original_id = first.id
+
+        # Second upsert: same identity, new values.
+        await repo.upsert_factors(
+            [
+                _make_factor(
+                    {"kind": "food", "subkind": None},
+                    values={"kg_co2eq": 200.0},
+                )
+            ],
+            current_job_id=job2_id,
+        )
+        await session.commit()
+        # Drop the identity map so the verification select re-reads from DB
+        # rather than returning the cached row from the first select.
+        session.expire_all()
+
+        rows = (
+            (
+                await session.execute(
+                    select(Factor).where(col(Factor.data_entry_type_id) == 1)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1, "upsert must not insert a duplicate row"
+        assert rows[0].id == original_id, "factor id must be preserved"
+        assert rows[0].values == {"kg_co2eq": 200.0}
+        assert rows[0].last_seen_job_id == job2_id
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_upsert_factors_jsonb_key_order_resilience(pg_dsn):
+    """Two upserts with the same classification keys in different
+    insertion order resolve to one row (JSONB normalises key order).
+
+    This is the silent-duplicate-row footgun the JSON → JSONB migration
+    closes; without it, ``classification::text`` would differ between
+    ``{"a":1,"b":2}`` and ``{"b":2,"a":1}`` and the partial unique index
+    wouldn't trip.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        job = _seed_factor_job()
+        session.add(job)
+        await session.commit()
+        assert job.id is not None
+        job_id: int = job.id
+
+        repo = FactorRepository(session)
+        await repo.upsert_factors(
+            [_make_factor({"kind": "plane", "subkind": "long_haul"})],
+            current_job_id=job_id,
+        )
+        await session.commit()
+
+        # Same logical classification, different dict insertion order.
+        await repo.upsert_factors(
+            [_make_factor({"subkind": "long_haul", "kind": "plane"})],
+            current_job_id=job_id,
+        )
+        await session.commit()
+
+        from sqlmodel import col, select
+
+        rows = (
+            (
+                await session.execute(
+                    select(Factor).where(col(Factor.data_entry_type_id) == 1)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1, (
+            "JSONB normalisation should treat the two dicts as identical"
+        )
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_list_stale_for_year_returns_outdated_factors(pg_dsn):
+    """Factors whose ``last_seen_job_id`` predates the latest is_current
+    successful FACTORS job for their (det, year) combo are returned;
+    factors stamped with the latest job id are not."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        # Older finished factor job — not is_current.
+        old_job = _seed_factor_job()
+        old_job.is_current = False
+        # Newer is_current factor job — the "latest" reference.
+        latest_job = _seed_factor_job()
+        session.add_all([old_job, latest_job])
+        await session.commit()
+        assert old_job.id is not None and latest_job.id is not None
+        old_id: int = old_job.id
+        latest_id: int = latest_job.id
+
+        # Two factors: one stamped with old_id (stale), one with latest_id (fresh).
+        repo = FactorRepository(session)
+        await repo.upsert_factors(
+            [_make_factor({"kind": "food", "subkind": None})],
+            current_job_id=old_id,
+        )
+        await repo.upsert_factors(
+            [_make_factor({"kind": "waste", "subkind": None})],
+            current_job_id=latest_id,
+        )
+        await session.commit()
+
+        stale = await repo.list_stale_for_year(2025)
+        # Only the food factor is stale: its last_seen_job_id < latest_id.
+        # The waste factor was stamped with latest_id and is up to date.
+        assert len(stale) == 1
+        assert stale[0].classification == {"kind": "food", "subkind": None}
+        assert stale[0].last_seen_job_id == old_id
+
+    await engine.dispose()

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
@@ -301,3 +301,90 @@ async def test_list_stale_for_year_returns_outdated_factors(pg_dsn):
         assert stale[0].last_seen_job_id == old_id
 
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_list_stale_for_year_handles_multi_type_factors_job(pg_dsn):
+    """Regression: multi-type FACTORS jobs (``data_entry_type_id`` NULL,
+    ``module_type_id`` set — e.g. ``equipments_factors.csv`` covering
+    ``it`` + ``scientific`` under ``equipment_electric_consumption``) must
+    be expanded to the dets they cover when computing the stale-threshold.
+
+    Earlier shape: ``list_stale_for_year`` joined ``Factor.det = Job.det``,
+    so a multi-type job (``Job.det = NULL``) failed the equality and the
+    factor row was dropped from the result entirely.  Effect: any stale
+    factor written by a multi-type CSV ingest was silently invisible to
+    operators.
+    """
+    from app.models.data_entry import DataEntryTypeEnum
+    from app.models.module_type import ModuleTypeEnum
+
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_plan_310b_indexes(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    module_id = ModuleTypeEnum.equipment_electric_consumption.value
+    det_it = DataEntryTypeEnum.it.value
+    det_scientific = DataEntryTypeEnum.scientific.value
+
+    def _multi_type_job() -> DataIngestionJob:
+        """Job with det=NULL, module set — the shape produced by uploading
+        a multi-type CSV like ``equipments_factors.csv``."""
+        return DataIngestionJob(
+            entity_type=EntityType.MODULE_PER_YEAR,
+            module_type_id=module_id,
+            data_entry_type_id=None,
+            year=2025,
+            target_type=TargetType.FACTORS,
+            ingestion_method=IngestionMethod.csv,
+            provider=UserProvider.DEFAULT,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            is_current=False,
+        )
+
+    async with Sf() as session:
+        old_job = _multi_type_job()
+        latest_job = _multi_type_job()
+        latest_job.is_current = True
+        session.add_all([old_job, latest_job])
+        await session.commit()
+        assert old_job.id is not None and latest_job.id is not None
+        old_id: int = old_job.id
+        latest_id: int = latest_job.id
+
+        repo = FactorRepository(session)
+
+        # One stale factor (stamped by the old job) under det=it.
+        await repo.upsert_factors(
+            [
+                _make_factor(
+                    {"kind": "Laptop", "subkind": "Standard"},
+                    data_entry_type_id=det_it,
+                )
+            ],
+            current_job_id=old_id,
+        )
+        # One fresh factor (stamped by the latest job) under det=scientific.
+        # Different det proves the multi-type expansion covers the whole
+        # module, not just one of its dets.
+        await repo.upsert_factors(
+            [
+                _make_factor(
+                    {"kind": "Centrifugation", "subkind": "Ultra"},
+                    data_entry_type_id=det_scientific,
+                )
+            ],
+            current_job_id=latest_id,
+        )
+        await session.commit()
+
+        stale = await repo.list_stale_for_year(2025)
+        assert len(stale) == 1, (
+            "multi-type FACTORS jobs must expand to their covered dets "
+            "when resolving the stale-threshold"
+        )
+        assert stale[0].data_entry_type_id == det_it
+        assert stale[0].last_seen_job_id == old_id
+
+    await engine.dispose()

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
@@ -1,0 +1,424 @@
+"""End-to-end PG regression test for the #310B fire_and_forget cancellation bug.
+
+The bug: ``data_sync.py`` formerly handed the **sync** wrapper
+``run_ingestion`` to ``background_tasks.add_task``.  FastAPI runs sync
+background tasks in an anyio worker thread; ``run_ingestion`` did
+``asyncio.run(run_sync_task(...))`` which built a throwaway event loop
+in that thread.  Inside, ``_enqueue_stale_recalculations`` called
+``fire_and_forget(run_recalculation_task(...))`` — and the recalc Task
+was bound to the throwaway loop.  When ``asyncio.run`` exited and closed
+its loop, the recalc Task was cancelled silently, leaving the child
+``DataIngestionJob`` row stuck in ``state=RUNNING`` with empty
+``status_message``.
+
+Why no existing test caught it: every other test either calls internal
+functions directly on pytest's long-lived loop (which never reproduces
+the cancellation), or hits HTTP with the spawned task patched to a
+noop (so it never actually runs).  This test is the missing one — full
+chain ``HTTP → BackgroundTasks → run_sync_task → fire_and_forget →
+run_recalculation_task → DataEntryEmission updated``.
+
+Setup mirrors:
+- ``test_sync_units_endpoint_pg.py`` for the ``httpx.AsyncClient +
+  ASGITransport`` + ``app.dependency_overrides`` rig
+- ``test_plan_310b_emission_change_pg.py`` for the seed graph (Unit →
+  CarbonReport → CarbonReportModule → Factor → DataEntry → emission)
+- ``test_plan_310b_recalc_empty_entries_pg.py`` for the SessionLocal
+  monkeypatch trick that points the background-task code at the test
+  Postgres container
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.models.unit import Unit
+from app.schemas.data_entry import DataEntryResponse
+from app.services.data_entry_emission_service import DataEntryEmissionService
+
+POLL_TIMEOUT_SECONDS = 15.0
+POLL_INTERVAL_SECONDS = 0.1
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch, tmp_path):
+    """Wire the FastAPI app to the test Postgres + bypass auth + redirect
+    file storage to ``tmp_path``.
+
+    Three monkeypatches matter:
+    1. ``settings.FILES_STORAGE_PATH`` → tmp_path.  ``LocalFilesStore``
+       reads this lazily from ``make_files_store()``, which the factor
+       provider calls in its __init__.  Both the request-handler-side
+       provider and the run_sync_task-side provider pick up the new
+       path because we set this before the request is fired.
+    2. ``app.tasks.ingestion_tasks.SessionLocal`` → test sessionmaker.
+       ``run_sync_task`` opens its own job/data sessions via
+       ``app.db.SessionLocal``; that ``from app.db import SessionLocal``
+       happens at import time, so we have to rebind the name where it's
+       used, not at the source.
+    3. ``app.tasks.emission_recalculation_tasks.SessionLocal`` →
+       same reason, for the recalc child task.
+
+    The ``app.dependency_overrides`` for ``get_db`` covers the request
+    handler side; the SessionLocal monkeypatches cover the background
+    task side.  Without both, the background task would talk to the
+    production DB while the request handler talks to the test DB.
+    """
+    # The conftest's pg_dsn fixture returns a ``postgresql+asyncpg`` URL.
+    # asyncpg is strict about tz-aware vs tz-naive datetimes, which trips
+    # an unrelated latent issue in app.models.audit (``changed_at`` defaults
+    # to naive datetime.utcnow but audit_service writes tz-aware).  Production
+    # uses ``postgresql+psycopg`` which silently coerces.  Use the same
+    # driver here so the test isn't tripped by a model-side bug that's out
+    # of scope for #310B.
+    psycopg_dsn = pg_dsn.replace("+asyncpg", "+psycopg")
+    test_engine = create_async_engine(psycopg_dsn, future=True)
+    Sf = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    # The conftest's pg_dsn fixture runs ``SQLModel.metadata.create_all``
+    # which doesn't execute Alembic migrations.  ``factor_repo.upsert_factors``
+    # uses ``ON CONFLICT (..., (classification::text)) WHERE year IS NOT NULL``,
+    # which needs the partial unique indexes added by migration b1f0a2c3d4e5.
+    # Recreate them here so the upsert can land.
+    from sqlalchemy import text as sa_text
+
+    async with test_engine.begin() as conn:
+        await conn.execute(
+            sa_text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
+                "ON factors (data_entry_type_id, year, emission_type_id, "
+                "(classification::text)) WHERE year IS NOT NULL"
+            )
+        )
+        await conn.execute(
+            sa_text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
+                "ON factors (data_entry_type_id, emission_type_id, "
+                "(classification::text)) WHERE year IS NULL"
+            )
+        )
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-310B"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    # Patch where the name is *used*, not where it's defined: data_sync.py
+    # does ``from app.core.security import is_permitted`` at import time,
+    # which copies the reference into its own namespace.  Patching
+    # ``app.core.security.is_permitted`` alone leaves data_sync's copy
+    # bound to the original (denying-by-default) implementation.
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+    monkeypatch.setattr("app.api.v1.data_sync.is_permitted", _allow)
+
+    # Redirect file storage to tmp_path so the factor CSV we write below
+    # is what the LocalFilesStore reads.
+    monkeypatch.setattr(
+        "app.core.config.get_settings.cache_clear", lambda: None, raising=False
+    )
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "FILES_STORAGE_PATH", str(tmp_path))
+    # Disable LocalFilesStore Fernet encryption so the plaintext CSV
+    # we write below isn't treated as ciphertext on read.  In production
+    # FILES_ENCRYPTION_KEY is set and files are encrypted at rest;
+    # exercising that path is out of scope for the recalc-fan-out test.
+    monkeypatch.setattr(settings, "FILES_ENCRYPTION_KEY", "")
+    monkeypatch.setattr(settings, "FILES_ENCRYPTION_SALT", "")
+
+    # Point the background-task SessionLocal references at the test PG.
+    monkeypatch.setattr("app.tasks.ingestion_tasks.SessionLocal", Sf)
+    monkeypatch.setattr("app.tasks.emission_recalculation_tasks.SessionLocal", Sf)
+
+    yield {"factory": Sf, "dsn": pg_dsn, "tmp_path": tmp_path}
+
+    app.dependency_overrides.clear()
+    await test_engine.dispose()
+
+
+async def _wait_for_job(
+    Sf, job_id: int, *, timeout: float = POLL_TIMEOUT_SECONDS
+) -> DataIngestionJob:
+    """Plain ``while ... await asyncio.sleep`` polling.  Returns the row
+    once it reaches a terminal state, or raises ``AssertionError`` on
+    timeout — leaves the row state in the message so failures are
+    diagnosable from the assertion alone."""
+    deadline = time.monotonic() + timeout
+    last_state = None
+    while time.monotonic() < deadline:
+        async with Sf() as s:
+            row = (
+                await s.execute(
+                    select(DataIngestionJob).where(col(DataIngestionJob.id) == job_id)
+                )
+            ).scalar_one()
+            last_state = row.state
+            if row.state == IngestionState.FINISHED:
+                return row
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError(
+        f"Job {job_id} did not reach FINISHED within {timeout}s "
+        f"(last state seen: {last_state}). "
+        "If this asserts, the recalc Task was likely cancelled — re-check "
+        "data_sync.py for any sync wrapper passed to background_tasks.add_task."
+    )
+
+
+async def _wait_for_child_recalc_job(
+    Sf, parent_job_id: int, *, timeout: float = POLL_TIMEOUT_SECONDS
+) -> DataIngestionJob:
+    """Find the recalc child job spawned by ``_enqueue_stale_recalculations``
+    (matched by ``meta.config.parent_job_id``) and wait for it to reach
+    FINISHED."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        async with Sf() as s:
+            rows = (
+                (
+                    await s.execute(
+                        select(DataIngestionJob).where(
+                            col(DataIngestionJob.job_type) == "emission_recalc"
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for row in rows:
+                if (row.meta or {}).get("config", {}).get(
+                    "parent_job_id"
+                ) == parent_job_id:
+                    if row.state == IngestionState.FINISHED:
+                        return row
+                    break  # found the row but not done yet
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError(
+        f"Child recalc job for parent={parent_job_id} did not reach FINISHED "
+        f"within {timeout}s.  This is the exact symptom of the #310B bug — "
+        "check that data_sync.py uses async fns for background_tasks.add_task."
+    )
+
+
+@pytest.mark.asyncio
+async def test_factor_reupload_endpoint_recomputes_emission_via_recalc_task(
+    pg_app,
+):
+    """Full HTTP path → BackgroundTasks → run_sync_task → fire_and_forget
+    → run_recalculation_task → DataEntryEmission updated.
+
+    Seeds Factor v1 (ef=0.1) + DataEntry + initial emission, then POSTs
+    a factor v2 CSV (ef=0.2) to ``/v1/sync/dispatch``.  Polls both the
+    parent FACTORS job and the spawned child recalc job to FINISHED,
+    then re-reads emissions on a separate engine and asserts the value
+    doubled.
+    """
+    Sf = pg_app["factory"]
+    pg_dsn = pg_app["dsn"]
+    tmp_path: Path = pg_app["tmp_path"]
+
+    # ── 1. Seed the carbon-report graph + factor v1 + data entry ───────
+    async with Sf() as s:
+        unit = Unit(
+            institutional_code="TEST-310B",
+            institutional_id="TEST-UNIT-310B",
+            name="Test Unit 310B",
+            level=1,
+        )
+        s.add(unit)
+        await s.commit()
+
+        report = CarbonReport(year=2025, unit_id=unit.id)
+        s.add(report)
+        await s.commit()
+
+        module = CarbonReportModule(
+            carbon_report_id=report.id,
+            module_type_id=ModuleTypeEnum.equipment_electric_consumption.value,
+        )
+        s.add(module)
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.equipment__it.value,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            classification={
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "year": 2025,
+            },
+            values={
+                "active_power_w": 100.0,
+                "standby_power_w": 10.0,
+                "ef_kg_co2eq_per_kwh": 0.1,
+            },
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        factor_id = factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            carbon_report_module_id=module.id,
+            data={
+                "primary_factor_id": factor_id,
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "active_usage_hours_per_week": 40.0,
+                "standby_usage_hours_per_week": 128.0,
+                "name": "Test Laptop 310B",
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        entry_id = entry.id
+
+    # ── 2. Compute initial emission so the recalc has something to do ──
+    async with Sf() as s:
+        e = (
+            await s.execute(select(DataEntry).where(col(DataEntry.id) == entry_id))
+        ).scalar_one()
+        await DataEntryEmissionService(s).upsert_by_data_entry(
+            DataEntryResponse.model_validate(e)
+        )
+        await s.commit()
+
+    async with Sf() as s:
+        initial_total = sum(
+            (r.kg_co2eq or 0.0)
+            for r in (
+                (
+                    await s.execute(
+                        select(DataEntryEmission).where(
+                            col(DataEntryEmission.data_entry_id) == entry_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        )
+    assert initial_total > 0, (
+        "initial emission should be non-zero before the test exercises recalc"
+    )
+
+    # ── 3. Write factor v2 CSV (ef doubled) to the patched files dir ───
+    csv_dir = tmp_path / "tmp" / "test_310b"
+    csv_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = csv_dir / "factor_v2.csv"
+    csv_path.write_text(
+        "equipment_category,equipment_class,sub_class,active_power_w,"
+        "standby_power_w,active_usage_hours_per_week,"
+        "standby_usage_hours_per_week,ef_kg_co2eq_per_kwh\n"
+        "it,Laptop,Standard,100,10,40,128,0.2\n"
+    )
+    csv_relative = "tmp/test_310b/factor_v2.csv"
+
+    # ── 4. POST /v1/sync/dispatch ──────────────────────────────────────
+    # Single-type variant: parent job carries data_entry_type_id=it, so
+    # _enqueue_stale_recalculations enters the ELSE branch and queries
+    # get_recalculation_status_by_year, which returns a row needing
+    # recalculation (no prior recalc job + a fresh FACTORS job).
+    sync_request = {
+        "ingestion_method": IngestionMethod.csv.value,
+        "target_type": TargetType.FACTORS.value,
+        "year": 2025,
+        "file_path": csv_relative,
+        "config": {
+            "module_type_id": ModuleTypeEnum.equipment_electric_consumption.value,
+            "data_entry_type_id": DataEntryTypeEnum.it.value,
+        },
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/v1/sync/dispatch", json=sync_request)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    parent_job_id = body["job_id"]
+    assert parent_job_id and parent_job_id > 0
+
+    # ── 5. Poll parent factor job → FINISHED + SUCCESS ─────────────────
+    parent_row = await _wait_for_job(Sf, parent_job_id)
+    assert parent_row.result == IngestionResult.SUCCESS, (
+        f"parent factor job did not succeed: state={parent_row.state}, "
+        f"result={parent_row.result}, status_message={parent_row.status_message!r}"
+    )
+
+    # ── 6. Poll child recalc job → FINISHED ────────────────────────────
+    # If this asserts, the recalc Task was cancelled.  That's the bug.
+    child_row = await _wait_for_child_recalc_job(Sf, parent_job_id)
+    assert child_row.result == IngestionResult.SUCCESS, (
+        f"child recalc job did not succeed: state={child_row.state}, "
+        f"result={child_row.result}, status_message={child_row.status_message!r}"
+    )
+
+    # ── 7. Verify on a SEPARATE engine — emission doubled ──────────────
+    psycopg_dsn = pg_dsn.replace("+asyncpg", "+psycopg")
+    verify_engine = create_async_engine(psycopg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            new_total = sum(
+                (r.kg_co2eq or 0.0)
+                for r in (
+                    (
+                        await vs.execute(
+                            select(DataEntryEmission).where(
+                                col(DataEntryEmission.data_entry_id) == entry_id
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+            )
+    finally:
+        await verify_engine.dispose()
+
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3), (
+        "factor reupload should have doubled the emission "
+        f"(initial={initial_total}, new={new_total}).  If the values are "
+        "equal, the recalc Task was scheduled but never ran — i.e. the "
+        "#310B cancellation bug has been reintroduced."
+    )

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
@@ -277,13 +277,15 @@ async def test_factor_reupload_endpoint_recomputes_emission_via_recalc_task(
         s.add(module)
         await s.commit()
 
+        # ``year`` is stored on the dedicated column only — Plan 310B
+        # stops duplicating it inside ``classification``, so the seed
+        # matches the canonical year-less shape that re-uploads now write.
         factor = Factor(
             emission_type_id=EmissionType.equipment__it.value,
             data_entry_type_id=DataEntryTypeEnum.it.value,
             classification={
                 "equipment_class": "Laptop",
                 "sub_class": "Standard",
-                "year": 2025,
             },
             values={
                 "active_power_w": 100.0,

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_recalc_empty_entries_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_recalc_empty_entries_pg.py
@@ -1,0 +1,153 @@
+"""Plan 310B: emission_recalc must finish (FINISHED+SUCCESS) when there
+are zero matching DataEntry rows.
+
+Production failure observed by user: factors.csv uploaded for
+data_entry_type_id=40 (external_clouds) with NO data_entries in the DB
+left the recalc job stuck in ``state=RUNNING`` with no result and
+``locked_by`` still set.  The expected behaviour is a graceful
+"nothing to do" → FINISHED + SUCCESS, so the partial unique index
+allows the next factor reupload to claim a fresh recalc job.
+
+Two tests, both against real Postgres:
+
+- ``test_workflow_returns_zeros_with_no_entries`` — direct call to
+  ``EmissionRecalculationWorkflow.recalculate_for_data_entry_type``;
+  the workflow itself must not raise on an empty entries list.
+- ``test_run_recalculation_task_finishes_when_no_entries`` — the full
+  task path: claim_job → workflow → final state.  Asserts the row
+  lands FINISHED+SUCCESS on a separate engine (cross-connection).
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.module_type import ModuleTypeEnum
+from app.models.user import UserProvider
+from app.tasks.emission_recalculation_tasks import run_recalculation_task
+from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
+
+
+def _pending_recalc_job() -> DataIngestionJob:
+    """Mirrors what _enqueue_stale_recalculations would create for an
+    external_clouds (det=40) factor reupload."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=ModuleTypeEnum.external_cloud_and_ai.value,
+        data_entry_type_id=DataEntryTypeEnum.external_clouds.value,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.NOT_STARTED,
+        is_current=False,
+        job_type="emission_recalc",
+        meta={
+            "config": {
+                "year": 2025,
+                "data_entry_type_id": DataEntryTypeEnum.external_clouds.value,
+                "module_type_id": ModuleTypeEnum.external_cloud_and_ai.value,
+                "parent_job_id": None,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_returns_zeros_with_no_entries(pg_dsn):
+    """The workflow itself must not raise when there are no DataEntry
+    rows for the (det, year) slice — it returns zeroed stats."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        wf = EmissionRecalculationWorkflow(session)
+        stats = await wf.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.external_clouds, 2025
+        )
+
+    await engine.dispose()
+
+    assert stats == {
+        "recalculated": 0,
+        "modules_refreshed": 0,
+        "errors": 0,
+        "error_details": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_recalculation_task_finishes_when_no_entries(pg_dsn, monkeypatch):
+    """The full task path must transition the job to FINISHED+SUCCESS
+    when there are no matching entries — not leave it stuck in RUNNING.
+
+    Production observation: a factor reupload for det=40 with no
+    data_entries left the recalc job in RUNNING with no result, blocking
+    the next reupload from claiming.
+    """
+    # The task uses ``app.db.SessionLocal`` for both job and data sessions.
+    # Point it at the test container.
+    test_engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.tasks.emission_recalculation_tasks.SessionLocal", Sf)
+
+    # Seed the recalc job in NOT_STARTED so the task can claim it.
+    seed_engine = create_async_engine(pg_dsn, future=True)
+    SeedSf = async_sessionmaker(
+        seed_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with SeedSf() as s:
+        job = _pending_recalc_job()
+        s.add(job)
+        await s.commit()
+        assert job.id is not None
+        job_id: int = job.id
+    await seed_engine.dispose()
+
+    await run_recalculation_task(
+        module_type_id=ModuleTypeEnum.external_cloud_and_ai.value,
+        data_entry_type_id=DataEntryTypeEnum.external_clouds.value,
+        year=2025,
+        job_id=job_id,
+    )
+
+    # Verify on a separate engine — the row must be visible cross-
+    # connection in the terminal state.
+    verify_engine = create_async_engine(pg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            row = (
+                await vs.execute(
+                    select(DataIngestionJob).where(col(DataIngestionJob.id) == job_id)
+                )
+            ).scalar_one()
+    finally:
+        await verify_engine.dispose()
+        await test_engine.dispose()
+
+    assert row.state == IngestionState.FINISHED, (
+        f"Job stuck in {row.state} after no-entries recalc — production saw "
+        "this as a job that never released its lock"
+    )
+    assert row.result == IngestionResult.SUCCESS, (
+        f"Expected SUCCESS for empty-entries recalc, got result={row.result}"
+    )
+    # The lock should remain set (Plan 310A doesn't clear locked_by on
+    # finish) but the state transition is what unblocks the next reupload's
+    # claim — claim_job's Step 1 demotes ``is_current`` for siblings that
+    # are NOT RUNNING, then Step 2 atomically claims the new candidate.
+    assert row.locked_by is not None
+    assert row.attempts == 1

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_recalc_fanout_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_recalc_fanout_pg.py
@@ -1,0 +1,177 @@
+"""Real-Postgres tests for Plan 310B Part 4 — recalc fan-out after a
+multi-type factor ingest.
+
+Reproduces the production failure observed for equipments factor uploads:
+the CSV covers all three data-entry types under the equipment module
+(scientific, it, other), so the parent factor job is created with
+``data_entry_type_id = NULL``.  Without the multi-type branch in
+``_enqueue_stale_recalculations``, the fan-out finds zero stale combos
+because ``get_recalculation_status_by_year`` filters factor jobs with
+``data_entry_type_id IS NULL`` out of its result set.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.module_type import ModuleTypeEnum
+from app.models.user import UserProvider
+from app.tasks.ingestion_tasks import _enqueue_stale_recalculations
+
+
+def _multi_type_factor_job() -> DataIngestionJob:
+    """Mirrors the production case: a finished, current FACTORS job for
+    the equipments module with no specific data_entry_type set."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=ModuleTypeEnum.equipment_electric_consumption.value,
+        data_entry_type_id=None,  # multi-type CSV — det resolved per row
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enqueue_recalc_fans_out_when_factor_job_has_null_det(pg_dsn):
+    """Multi-type factor upload (det=NULL on the parent) must fan out one
+    recalc job per data_entry_type in the module.
+
+    Failing today: ``get_recalculation_status_by_year`` filters factor jobs
+    with ``data_entry_type_id IS NULL``, so the helper sees zero targets and
+    silently returns without creating any recalc jobs — leaving emissions
+    stale.  The expected behaviour is one ``emission_recalc`` job per det
+    in ``MODULE_TYPE_TO_DATA_ENTRY_TYPES[equipment_electric_consumption]``.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent = _multi_type_factor_job()
+        session.add(parent)
+        await session.commit()
+        assert parent.id is not None
+        parent_id: int = parent.id
+        module_type_id: int = parent.module_type_id  # type: ignore[assignment]
+
+    # Run the helper against a real PG session.
+    async with Sf() as session:
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=parent_id,
+            module_type_id=module_type_id,
+            data_entry_type_id=None,  # parent had no specific det
+            year=2025,
+            pipeline_id=uuid4(),
+        )
+
+    # Verify: one recalc job per det in the equipments module.
+    expected_dets = {
+        DataEntryTypeEnum.scientific.value,
+        DataEntryTypeEnum.it.value,
+        DataEntryTypeEnum.other.value,
+    }
+    async with Sf() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(DataIngestionJob).where(
+                        col(DataIngestionJob.target_type) == TargetType.DATA_ENTRIES,
+                        col(DataIngestionJob.ingestion_method)
+                        == IngestionMethod.computed,
+                        col(DataIngestionJob.module_type_id) == module_type_id,
+                        col(DataIngestionJob.year) == 2025,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        landed_dets = {r.data_entry_type_id for r in rows}
+        assert landed_dets == expected_dets, (
+            f"Expected one recalc per det {expected_dets}, got {landed_dets}"
+        )
+        # Each child references the parent in its meta config.
+        for r in rows:
+            assert r.job_type == "emission_recalc"
+            assert r.meta is not None
+            assert r.meta["config"]["parent_job_id"] == parent_id
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_recalc_specific_det_unchanged(pg_dsn):
+    """Parent factor job with a specific det still goes through the existing
+    ``get_recalculation_status_by_year`` path and creates exactly one recalc
+    job for that det."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent = _multi_type_factor_job()
+        parent.data_entry_type_id = DataEntryTypeEnum.it.value
+        session.add(parent)
+        await session.commit()
+        assert parent.id is not None
+        parent_id: int = parent.id
+        module_type_id: int = parent.module_type_id  # type: ignore[assignment]
+
+    async with Sf() as session:
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=parent_id,
+            module_type_id=module_type_id,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            year=2025,
+            pipeline_id=uuid4(),
+        )
+
+    async with Sf() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(DataIngestionJob).where(
+                        col(DataIngestionJob.target_type) == TargetType.DATA_ENTRIES,
+                        col(DataIngestionJob.ingestion_method)
+                        == IngestionMethod.computed,
+                        col(DataIngestionJob.module_type_id) == module_type_id,
+                        col(DataIngestionJob.year) == 2025,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Exactly one recalc job for det=it (Strategy A path through
+        # get_recalculation_status_by_year, which sees the parent job
+        # because it has a specific data_entry_type_id).
+        assert len(rows) == 1
+        assert rows[0].data_entry_type_id == DataEntryTypeEnum.it.value
+        assert rows[0].job_type == "emission_recalc"
+
+    await engine.dispose()
+
+
+# Silence the import-not-accessed warning for ``text`` (kept around in case
+# fixture extensions need raw DDL).
+_ = text

--- a/backend/tests/integration/services/data_ingestion/test_sync_units_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_units_endpoint_pg.py
@@ -1,0 +1,138 @@
+"""Integration test for POST /v1/sync/units against a real Postgres.
+
+Plan 310B Part 5 changed the endpoint from a fire-and-forget background
+task (``job_id=0``) to a tracked DataIngestionJob with
+``entity_type=GLOBAL_PER_YEAR`` and ``target_type=REFERENCE_DATA``.
+
+Production failure observed: ``invalid input value for enum
+target_type_enum: "REFERENCE_DATA"`` — the Postgres enum type was missing
+the ``REFERENCE_DATA`` label.  Migration ``c2d4e6f8a012`` adds it.
+
+This test exercises the full endpoint round-trip against PG:
+
+- POSTing ``{"target_year": 2025}`` returns 200 with a non-zero ``job_id``.
+- A ``DataIngestionJob`` row is committed to the DB with the expected
+  ``job_type='unit_sync'``, ``entity_type=GLOBAL_PER_YEAR``,
+  ``target_type=REFERENCE_DATA`` shape.
+- Verification reads the row on a **separate engine** so the assertion
+  only passes if the insert is committed and visible cross-connection.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionState,
+    TargetType,
+)
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+
+    yield {"factory": Sf, "dsn": pg_dsn}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_post_sync_units_creates_tracked_job(pg_app):
+    """POST /v1/sync/units commits a real DataIngestionJob and returns its
+    id; the row's enum-typed columns survive the round-trip (specifically
+    target_type=REFERENCE_DATA, the column that tripped production)."""
+    pg_dsn = pg_app["dsn"]
+
+    # Use httpx.AsyncClient + ASGITransport so the request runs on the same
+    # event loop as the pg_dsn fixture's async engine — TestClient spins up
+    # its own anyio portal, which would conflict with asyncpg connections
+    # bound to the test loop.
+    #
+    # Replace run_sync_task_accred with a noop coroutine so asyncio.create_task
+    # gets a real awaitable but the Accred fetch is skipped.  Patching
+    # asyncio.create_task directly would clobber it module-wide because
+    # ``data_sync.asyncio`` is the same module object as global asyncio.
+    accred_calls: list[tuple] = []
+
+    async def _noop_accred(sync_request, job_id):
+        accred_calls.append((sync_request.target_year, job_id))
+
+    with patch("app.api.v1.data_sync.run_sync_task_accred", _noop_accred):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post("/v1/sync/units", json={"target_year": 2025})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["state"] == IngestionState.NOT_STARTED.value
+    job_id = body["job_id"]
+    assert job_id and job_id > 0, (
+        f"Expected a non-zero job_id (Plan 310B replaced the placeholder 0), "
+        f"got {body!r}"
+    )
+
+    # The endpoint should have scheduled the noop Accred coroutine with the
+    # job_id it just created.
+    assert len(accred_calls) == 1
+    assert accred_calls[0] == (2025, job_id)
+
+    # Verify on a fresh engine — proves cross-connection commit visibility.
+    verify_engine = create_async_engine(pg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            row = (
+                await vs.execute(
+                    select(DataIngestionJob).where(col(DataIngestionJob.id) == job_id)
+                )
+            ).scalar_one()
+    finally:
+        await verify_engine.dispose()
+
+    assert row.job_type == "unit_sync"
+    assert row.entity_type == EntityType.GLOBAL_PER_YEAR
+    assert row.target_type == TargetType.REFERENCE_DATA
+    assert row.year == 2025
+    assert row.module_type_id is None
+    assert row.data_entry_type_id is None
+    assert row.state == IngestionState.NOT_STARTED
+    assert row.meta is not None
+    assert row.meta["config"]["target_year"] == 2025

--- a/backend/tests/unit/models/test_entity_type_ordinals.py
+++ b/backend/tests/unit/models/test_entity_type_ordinals.py
@@ -1,0 +1,35 @@
+"""Regression test pinning ``EntityType`` integer values.
+
+Enum integer values are part of the persisted ABI: every ingestion job
+serialises ``entity_type.value`` into ``DataIngestionJob.meta["config"]``
+and we round-trip via ``EntityType(value)`` to route to the right
+provider.  Inserting a new member at the front shifts the ordinals of
+the existing members, which silently mis-routes every historical row
+the next time it's read back.
+
+This test fails loudly if anyone reorders the enum without thinking
+about the persisted-state implications.  New members must be appended,
+not inserted in the middle.
+"""
+
+from app.models.data_ingestion import EntityType
+
+
+def test_entity_type_int_values_are_stable():
+    """Persisted ``meta["config"]["entity_type"]`` integers must keep
+    their meaning across deploys.  If you need to add a new member,
+    append it (not insert) — and update this test in lockstep so the
+    ABI change is explicit in code review."""
+    assert EntityType.MODULE_PER_YEAR.value == 1
+    assert EntityType.MODULE_UNIT_SPECIFIC.value == 2
+    assert EntityType.GLOBAL_PER_YEAR.value == 3
+
+
+def test_entity_type_round_trip_by_value():
+    """``EntityType(value)`` reconstructs the original member — the
+    operation that runs on every persisted job read.  Combined with
+    the ordinal pin above, this verifies historical rows containing
+    ``1`` and ``2`` still mean MODULE_PER_YEAR / MODULE_UNIT_SPECIFIC."""
+    assert EntityType(1) is EntityType.MODULE_PER_YEAR
+    assert EntityType(2) is EntityType.MODULE_UNIT_SPECIFIC
+    assert EntityType(3) is EntityType.GLOBAL_PER_YEAR

--- a/backend/tests/unit/services/data_ingestion/csv_providers/test_local_seed_upsert_batch.py
+++ b/backend/tests/unit/services/data_ingestion/csv_providers/test_local_seed_upsert_batch.py
@@ -1,0 +1,71 @@
+"""Regression test for ``LocalFactorCSVProvider._upsert_batch``.
+
+Plan 310B switched the production factor ingest from delete-and-insert
+to ``ON CONFLICT DO UPDATE``, which requires a ``job_id`` to stamp on
+``last_seen_job_id``.  Local seed scripts have no DataIngestionJob and
+therefore no ``job_id``, so once a seed CSV exceeds BATCH_SIZE the
+main batch loop would call ``_upsert_batch`` and crash with
+``ValueError("job_id is required for factor upsert")``.
+
+The fix overrides ``_upsert_batch`` on ``LocalFactorCSVProvider`` to
+keep the legacy ``bulk_create`` path.  This test pins that contract.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.data_ingestion.csv_providers.local_seed import (
+    LocalFactorCSVProvider,
+)
+
+
+@pytest.mark.asyncio
+async def test_local_factor_provider_upsert_batch_uses_legacy_bulk_create():
+    """``LocalFactorCSVProvider._upsert_batch`` must NOT raise the
+    "job_id is required" ValueError that the base class enforces.
+    Instead it routes the batch through ``_process_batch`` (which calls
+    ``factor_service.bulk_create``) so seed scripts can ingest factors
+    without a tracked DataIngestionJob.
+    """
+    provider = LocalFactorCSVProvider(
+        config={
+            "local_file_path": "/tmp/test.csv",
+            "module_type_id": 1,
+            "data_entry_type_id": 1,
+            "year": 2025,
+        },
+        data_session=MagicMock(),
+    )
+    # No set_job_id call — self.job_id stays None, the exact state that
+    # would crash the base-class _upsert_batch.
+    assert provider.job_id is None
+
+    factor_repo = MagicMock()
+    # If _upsert_batch falls through to the base implementation, it
+    # would call factor_repo.upsert_factors and raise on the missing
+    # job_id.  We assert the legacy path is taken instead.
+    factor_repo.upsert_factors = AsyncMock(
+        side_effect=AssertionError(
+            "Local seed must NOT call factor_repo.upsert_factors — "
+            "no job_id available, would raise ValueError"
+        )
+    )
+
+    batch = [MagicMock(), MagicMock(), MagicMock()]
+
+    # Patch _process_batch to confirm the legacy path runs without
+    # depending on FactorService internals.
+    with patch.object(
+        provider, "_process_batch", new_callable=AsyncMock
+    ) as mock_process:
+        reported = await provider._upsert_batch(batch, factor_repo)
+
+    # Legacy path was taken — exactly one call with the same batch.
+    mock_process.assert_awaited_once()
+    assert mock_process.await_args.args[0] is batch
+    # Reported count matches input length (no rowcount feedback in the
+    # bulk_create path, so the override returns len(batch)).
+    assert reported == 3
+    # The base-class ValueError sentinel was never tripped.
+    factor_repo.upsert_factors.assert_not_awaited()

--- a/backend/tests/unit/services/data_ingestion/test_background_tasks.py
+++ b/backend/tests/unit/services/data_ingestion/test_background_tasks.py
@@ -92,3 +92,60 @@ async def test_run_sync_task_job_not_found():
 
         # Should not raise
         await run_sync_task("FakeProviderClass", job_id=999)
+
+
+@pytest.mark.asyncio
+async def test_run_sync_task_provider_failure_marks_job_error_and_reraises():
+    """If ``provider.ingest`` raises, ``run_sync_task``'s except block must:
+    rollback the data session, stamp the job FINISHED+ERROR with the
+    exception text, then re-raise so the caller (BackgroundTasks /
+    fire_and_forget) sees the failure rather than swallowing it."""
+    fake_job = MagicMock()
+    fake_job.id = 123
+    fake_job.user = None
+    fake_job.meta = None
+    fake_job.target_type = None  # not FACTORS — skips fan-out branch
+
+    fake_provider = MagicMock()
+    fake_provider.set_job_id = AsyncMock()
+    fake_provider.ingest = AsyncMock(side_effect=RuntimeError("provider down"))
+    fake_provider._update_job = AsyncMock()
+
+    class FakeProviderClass:
+        def __new__(cls, *args, **kwargs):
+            return fake_provider
+
+    with (
+        patch("app.tasks.ingestion_tasks.SessionLocal") as mock_session_local,
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository") as mock_repo,
+        patch(
+            "app.tasks.ingestion_tasks.ProviderFactory.get_provider_class",
+            return_value=FakeProviderClass,
+        ),
+    ):
+        mock_job_session = MagicMock()
+        mock_job_session.commit = AsyncMock()
+        mock_job_session.rollback = AsyncMock()
+
+        mock_data_session = MagicMock()
+        mock_data_session.commit = AsyncMock()
+        mock_data_session.rollback = AsyncMock()
+
+        mock_session_local.return_value.__aenter__ = AsyncMock(
+            side_effect=[mock_job_session, mock_data_session]
+        )
+        mock_session_local.return_value.__aexit__ = AsyncMock(return_value=None)
+        mock_repo.return_value.claim_job = AsyncMock(return_value=True)
+        mock_repo.return_value.get_job_by_id = AsyncMock(return_value=fake_job)
+
+        with pytest.raises(RuntimeError, match="provider down"):
+            await run_sync_task("FakeProviderClass", job_id=123)
+
+    # Rollback path was exercised; job stamped FINISHED+ERROR with msg.
+    mock_data_session.rollback.assert_awaited_once()
+    update_call = fake_provider._update_job.call_args
+    assert update_call.kwargs["state"] == IngestionState.FINISHED
+    # IngestionResult lives on the model; we don't import it here, so check
+    # that the status_message echoes the exception text — sufficient to
+    # prove the except path ran end-to-end.
+    assert "provider down" in update_call.kwargs["status_message"]

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -379,3 +379,45 @@ def test_get_types_to_delete_configured_id_ignores_listed():
     result = provider._get_types_to_delete(listed)
 
     assert result == [DataEntryTypeEnum.scientific]
+
+
+@pytest.mark.asyncio
+async def test_upsert_batch_raises_when_job_id_missing():
+    """``_upsert_batch`` requires ``self.job_id`` so each row can be stamped
+    with ``last_seen_job_id``.  If the job_id was never set (e.g. the
+    seed-script path that bypasses DataIngestionJob creation), raise
+    eagerly rather than persist factors with a NULL pointer to "current
+    factor job."""
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv", "data_entry_type_id": 1},
+        data_session=MagicMock(),
+    )
+    # No set_job_id call → self.job_id stays None.
+    factor_repo = MagicMock()
+    factor_repo.upsert_factors = AsyncMock(return_value=0)
+
+    with pytest.raises(ValueError, match="job_id is required"):
+        await provider._upsert_batch([MagicMock()], factor_repo)
+
+    factor_repo.upsert_factors.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_batch_falls_back_to_batch_size_when_rowcount_negative():
+    """asyncpg returns rowcount=-1 for executemany ON CONFLICT statements
+    where it can't tally the result reliably.  ``_upsert_batch`` should
+    fall back to the input batch size so operator-visible stats don't
+    show a confusing -1."""
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv", "data_entry_type_id": 1},
+        data_session=MagicMock(),
+    )
+    await provider.set_job_id(42)
+
+    factor_repo = MagicMock()
+    factor_repo.upsert_factors = AsyncMock(return_value=-1)
+
+    batch = [MagicMock(), MagicMock(), MagicMock()]
+    reported = await provider._upsert_batch(batch, factor_repo)
+
+    assert reported == 3, "negative rowcount should fall back to len(batch)"

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -28,6 +28,7 @@ def _build_stats():
         "row_errors": [],
         "row_errors_count": 0,
         "factors_deleted": 0,
+        "factors_upserted": 0,
     }
 
 
@@ -286,6 +287,7 @@ async def test_finalize_and_commit_move_file_failure():
         factor_service=MagicMock(),
         stats=_build_stats(),
         setup_result={"processing_path": "processing/x", "filename": "x.csv"},
+        factor_repo=MagicMock(),
     )
     assert result["state"] == IngestionState.FINISHED
 

--- a/backend/tests/unit/services/data_ingestion/test_module_per_year_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_per_year_factor_csv_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import IngestionState
 from app.services.data_ingestion import csv_providers as csv_providers_module
 from app.services.data_ingestion.csv_providers.factors import (
     ModulePerYearFactorCSVProvider,
@@ -136,4 +137,8 @@ async def test_finalize_and_commit_routes_batch_through_upsert(monkeypatch):
     assert kwargs.get("current_job_id") == 42
     assert stats["factors_upserted"] == 3
     assert stats["factors_deleted"] == 0
-    assert result["state"].value == 3  # IngestionState.FINISHED
+    # Compare against the enum directly, not its int value — the int is
+    # part of the persisted ABI (we just had a Copilot incident over an
+    # EntityType renumber), so referring to it by name keeps the test
+    # readable AND avoids re-pinning ABI in two places.
+    assert result["state"] == IngestionState.FINISHED

--- a/backend/tests/unit/services/data_ingestion/test_module_per_year_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_per_year_factor_csv_provider.py
@@ -77,79 +77,63 @@ async def test_setup_handlers_and_context_multiple_types(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_csv_in_batches_deletes_existing_factors(monkeypatch):
-    """Test that existing factors are deleted before inserting new ones."""
-    from app.services.factor_service import FactorService
+async def test_finalize_and_commit_routes_batch_through_upsert(monkeypatch):
+    """Plan 310B Part 2: factor ingest upserts in place; never bulk-deletes.
 
-    # Create a properly mocked data session
+    Confirms ``_finalize_and_commit`` routes a non-empty batch through
+    ``factor_repo.upsert_factors`` stamped with the parent job_id, and
+    reports the result in ``stats['factors_upserted']``.
+    """
+    from app.models.factor import Factor
+
     mock_data_session = MagicMock()
     mock_data_session.flush = AsyncMock()
-    mock_data_session.commit = AsyncMock()  # likely also needed in _finalize_and_commit
-    mock_result = MagicMock()
-    mock_result.all = MagicMock(return_value=[])
-    mock_data_session.exec = MagicMock(return_value=mock_result)
 
     provider = ModulePerYearFactorCSVProvider(
         {
             "file_path": "tmp/test.csv",
             "data_entry_type_id": DataEntryTypeEnum.member.value,
             "year": 2024,
+            "job_id": 42,
         },
         data_session=mock_data_session,
     )
+    provider._files_store = MagicMock()
+    provider._files_store.move_file = AsyncMock(return_value=True)
 
-    # Mock the setup method
-    setup_result = {
-        "csv_text": "value\n100\n200",
-        "handlers": [_make_handler()],
-        "expected_columns": {"value"},
-        "required_columns": {"value"},
-        "processing_path": "processing/test.csv",
-        "filename": "test.csv",
-        "valid_entry_types": [DataEntryTypeEnum.member],
+    mock_factor_repo = MagicMock()
+    mock_factor_repo.upsert_factors = AsyncMock(return_value=3)
+
+    batch = [
+        Factor(
+            emission_type_id=10000,
+            data_entry_type_id=DataEntryTypeEnum.member.value,
+            classification={"kind": "food"},
+            values={"kg_co2eq_per_fte": 420},
+            year=2024,
+        )
+    ]
+    stats = {
+        "rows_processed": 1,
+        "rows_skipped": 0,
+        "batches_processed": 0,
+        "row_errors": [],
+        "row_errors_count": 0,
+        "factors_deleted": 0,
+        "factors_upserted": 0,
     }
 
-    async def mock_setup():
-        return setup_result
-
-    monkeypatch.setattr(provider, "_setup_and_validate", mock_setup)
-
-    # Create a mock FactorService
-    mock_factor_service = MagicMock(spec=FactorService)
-    mock_factor_service.count_by_data_entry_type_and_year = AsyncMock(return_value=5)
-    mock_factor_service.bulk_delete_by_data_entry_type = AsyncMock()
-    mock_factor_service.bulk_create = AsyncMock(return_value=[])
-
-    # Patch FactorService instantiation to return our mocked service
-    monkeypatch.setattr(
-        "app.services.data_ingestion.base_factor_csv_provider.FactorService",
-        MagicMock(return_value=mock_factor_service),
+    result = await provider._finalize_and_commit(
+        batch=batch,
+        factor_service=MagicMock(),
+        stats=stats,
+        setup_result={"processing_path": "processing/x", "filename": "x.csv"},
+        factor_repo=mock_factor_repo,
     )
 
-    async def mock_process_batch(batch, factor_service):
-        pass
-
-    monkeypatch.setattr(provider, "_process_batch", mock_process_batch)
-
-    # Mock file store operations
-    mock_files_store = MagicMock()
-    mock_files_store.move_file = AsyncMock(return_value=True)
-    mock_files_store.get_file = AsyncMock(return_value=(b"value\n100\n200", "text/csv"))
-    mock_files_store.file_exists = AsyncMock(return_value=True)
-
-    provider._files_store = mock_files_store
-
-    # Mock repo
-    mock_repo = MagicMock()
-    provider._repo = mock_repo
-
-    # Call process_csv_in_batches
-    result = await provider.process_csv_in_batches()
-
-    # Verify deletion was called
-    mock_factor_service.count_by_data_entry_type_and_year.assert_called_once()
-    mock_factor_service.bulk_delete_by_data_entry_type.assert_called_once()
-
-    # Verify stats include factors_deleted
-    assert "factors_deleted" in result["stats"]
-    assert result["stats"]["factors_deleted"] == 5
+    mock_factor_repo.upsert_factors.assert_awaited_once()
+    args, kwargs = mock_factor_repo.upsert_factors.call_args
+    assert kwargs.get("current_job_id") == 42
+    assert stats["factors_upserted"] == 3
+    assert stats["factors_deleted"] == 0
+    assert result["state"].value == 3  # IngestionState.FINISHED

--- a/backend/tests/unit/services/data_ingestion/test_unit_sync_tasks.py
+++ b/backend/tests/unit/services/data_ingestion/test_unit_sync_tasks.py
@@ -1,15 +1,22 @@
-"""Tests for unit sync tasks from Accred API."""
+"""Tests for unit sync tasks from Accred API.
+
+Plan 310B Part 5 — ``run_sync_task_accred`` now claims a tracked
+DataIngestionJob (entity_type=GLOBAL_PER_YEAR), updates ``status_message``
+between steps via the dual-session pattern, and finishes by stamping the
+job FINISHED+SUCCESS (or ERROR on failure).  These tests assert the new
+contract: that the job lifecycle transitions are emitted in order.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.data_ingestion import IngestionResult, IngestionState
 from app.tasks.unit_sync_tasks import SyncUnitRequest, run_sync_task_accred
 
 
 @pytest.fixture
 def mock_accred_units_raw():
-    """Mock raw units from Accred API."""
     return [
         {
             "id": "1",
@@ -32,205 +39,126 @@ def mock_accred_units_raw():
             "enddate": "0001-01-01T00:00:00Z",
             "ancestors": [],
         },
-        {
-            "id": "2",
-            "name": "Unit 2",
-            "labelfr": "Unité 2",
-            "labelen": "Unit 2",
-            "level": 1,
-            "parentid": None,
-            "pathcf": None,
-            "path": "Unit 2",
-            "cf": "2",
-            "responsible": {
-                "email": "user2@example.com",
-                "id": "101",
-                "name": "User 2",
-            },
-            "responsibleid": "101",
-            "unittypeid": 1,
-            "unittype": {"label": "Building"},
-            "enddate": "0001-01-01T00:00:00Z",
-            "ancestors": [],
-        },
     ]
 
 
 @pytest.fixture
 def mock_accred_principal_users_raw():
-    """Mock raw principal users from Accred API."""
-    return [
-        {"email": "user1@example.com", "id": "100", "name": "User 1"},
-        {"email": "user2@example.com", "id": "101", "name": "User 2"},
-    ]
+    return [{"email": "user1@example.com", "id": "100", "name": "User 1"}]
+
+
+def _patched_session_local():
+    """Build a MagicMock SessionLocal whose async-context-manager returns a
+    fresh mock session each call (job_session and data_session must be
+    distinct so call_count assertions stay meaningful)."""
+    session_local = MagicMock()
+
+    def _new_session(*_args, **_kwargs):
+        sess = MagicMock()
+        sess.commit = AsyncMock()
+        sess.rollback = AsyncMock()
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=sess)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        return ctx
+
+    session_local.side_effect = _new_session
+    return session_local
+
+
+def _common_provider_patches(units_raw, users_raw):
+    """Build the (unit_provider, role_provider) MagicMocks used by both tests."""
+    unit_provider = MagicMock()
+    unit_provider.fetch_all_units = AsyncMock(return_value=(units_raw, users_raw))
+    unit_provider.map_api_unit = MagicMock(
+        side_effect=lambda u: MagicMock(id=None, institutional_id=u["id"])
+    )
+    role_provider = MagicMock()
+    role_provider.map_api_user = MagicMock(
+        side_effect=lambda u: MagicMock(id=u["id"], email=u["email"])
+    )
+    return unit_provider, role_provider
 
 
 @pytest.mark.asyncio
-async def test_sync_units_creates_carbon_reports(
+async def test_run_sync_task_accred_claims_job_and_finishes(
     mock_accred_units_raw,
     mock_accred_principal_users_raw,
 ):
-    """Test that carbon reports are created for all units."""
-    mock_session = MagicMock()
-    mock_session.commit = AsyncMock()
-    mock_session.rollback = AsyncMock()
-
-    mock_unit_result = MagicMock()
-    mock_unit_result.data = [
-        MagicMock(id=1, institutional_id="1"),
-        MagicMock(id=2, institutional_id="2"),
-    ]
-
-    mock_user_result = MagicMock()
-    mock_user_result.data = [
-        MagicMock(id="100", email="user1@example.com"),
-        MagicMock(id="101", email="user2@example.com"),
-    ]
-
-    mock_reports = [
-        MagicMock(id=1, year=2024, unit_id=1),
-        MagicMock(id=2, year=2024, unit_id=2),
-    ]
-
-    mock_module_service = MagicMock()
-    mock_module_service.ensure_modules_for_reports = AsyncMock()
+    """Happy path: claim_job→RUNNING→…steps…→FINISHED+SUCCESS."""
+    unit_provider, role_provider = _common_provider_patches(
+        mock_accred_units_raw, mock_accred_principal_users_raw
+    )
+    repo = MagicMock()
+    repo.claim_job = AsyncMock(return_value=True)
+    repo.update_ingestion_job = AsyncMock()
 
     with (
-        patch("app.tasks.unit_sync_tasks.SessionLocal") as mock_session_local,
-        patch("app.tasks.unit_sync_tasks.get_unit_provider") as mock_get_unit_provider,
-        patch("app.tasks.unit_sync_tasks.get_role_provider") as mock_get_role_provider,
+        patch("app.tasks.unit_sync_tasks.SessionLocal", _patched_session_local()),
+        patch("app.tasks.unit_sync_tasks.DataIngestionRepository", return_value=repo),
+        patch(
+            "app.tasks.unit_sync_tasks.get_unit_provider", return_value=unit_provider
+        ),
+        patch(
+            "app.tasks.unit_sync_tasks.get_role_provider", return_value=role_provider
+        ),
+        patch("app.tasks.unit_sync_tasks.UnitService") as MockUnitService,
+        patch("app.tasks.unit_sync_tasks.UserService") as MockUserService,
+        patch("app.tasks.unit_sync_tasks.CarbonReportService") as MockCRService,
     ):
-        mock_provider = MagicMock()
-        mock_provider.fetch_all_units = AsyncMock(
-            return_value=(mock_accred_units_raw, mock_accred_principal_users_raw)
-        )
-        mock_provider.map_api_unit = MagicMock(
-            side_effect=lambda u: MagicMock(id=None, institutional_id=u["id"])
-        )
-        mock_get_unit_provider.return_value = mock_provider
+        unit_result = MagicMock()
+        unit_result.data = [MagicMock(id=1, institutional_id="1")]
+        user_result = MagicMock()
+        user_result.data = [MagicMock(id="100", email="user1@example.com")]
+        MockUnitService.return_value.bulk_upsert = AsyncMock(return_value=unit_result)
+        MockUserService.return_value.bulk_upsert = AsyncMock(return_value=user_result)
 
-        mock_role_provider = MagicMock()
-        mock_role_provider.map_api_user = MagicMock(
-            side_effect=lambda u: MagicMock(id=u["id"], email=u["email"])
-        )
-        mock_get_role_provider.return_value = mock_role_provider
+        cr_service = MagicMock()
+        reports = [MagicMock(id=1, year=2024, unit_id=1)]
+        cr_service.bulk_upsert = AsyncMock(return_value=reports)
+        cr_service.ensure_modules_for_reports = AsyncMock()
+        MockCRService.return_value = cr_service
 
-        mock_session_local.return_value.__aenter__.return_value = mock_session
-        mock_session_local.return_value.__aexit__.return_value = None
+        await run_sync_task_accred(SyncUnitRequest(target_year=2024), job_id=99)
 
-        with (
-            patch("app.tasks.unit_sync_tasks.UnitService") as MockUnitService,
-            patch("app.tasks.unit_sync_tasks.UserService") as MockUserService,
-            patch(
-                "app.tasks.unit_sync_tasks.CarbonReportService"
-            ) as MockCarbonReportService,
-        ):
-            MockUnitService.return_value.bulk_upsert = AsyncMock(
-                return_value=mock_unit_result
-            )
-            MockUserService.return_value.bulk_upsert = AsyncMock(
-                return_value=mock_user_result
-            )
-
-            mock_cr_service_instance = MagicMock()
-            mock_cr_service_instance.bulk_upsert = AsyncMock(return_value=mock_reports)
-            mock_cr_service_instance.module_service = mock_module_service
-            mock_cr_service_instance.ensure_modules_for_reports = AsyncMock()
-            MockCarbonReportService.return_value = mock_cr_service_instance
-
-            result = await run_sync_task_accred(SyncUnitRequest(target_year=2024))
-
-        assert result["status"] == "success"
-        assert result["units_synced"] == 2
-        assert result["users_synced"] == 2
-        assert result["carbon_reports_created"] == 2
-        assert result["carbon_report_year"] == 2024
-
-        mock_session.commit.assert_awaited_once()
-        mock_cr_service_instance.ensure_modules_for_reports.assert_awaited_once_with(
-            mock_reports
-        )
+    repo.claim_job.assert_awaited_once_with(99, mock_pod_id_arg(repo.claim_job))
+    final_call = repo.update_ingestion_job.call_args_list[-1]
+    assert final_call.kwargs["state"] == IngestionState.FINISHED
+    assert final_call.kwargs["result"] == IngestionResult.SUCCESS
+    cr_service.ensure_modules_for_reports.assert_awaited_once_with(reports)
 
 
 @pytest.mark.asyncio
-async def test_sync_units_upsert_existing_reports(
+async def test_run_sync_task_accred_claim_failed_returns_silently(
     mock_accred_units_raw,
     mock_accred_principal_users_raw,
 ):
-    """Test that existing carbon reports are upserted (bulk_upsert behavior)."""
-    mock_session = MagicMock()
-    mock_session.commit = AsyncMock()
-    mock_session.rollback = AsyncMock()
-
-    mock_unit_result = MagicMock()
-    mock_unit_result.data = [
-        MagicMock(id=1, institutional_id="1"),
-        MagicMock(id=2, institutional_id="2"),
-    ]
-
-    mock_user_result = MagicMock()
-    mock_user_result.data = [
-        MagicMock(id="100", email="user1@example.com"),
-        MagicMock(id="101", email="user2@example.com"),
-    ]
-
-    mock_reports = [
-        MagicMock(id=1, year=2024, unit_id=1),
-    ]
-
-    mock_module_service = MagicMock()
-    mock_module_service.ensure_modules_for_reports = AsyncMock()
+    """If claim_job returns False, the task returns without fetching anything."""
+    unit_provider, role_provider = _common_provider_patches(
+        mock_accred_units_raw, mock_accred_principal_users_raw
+    )
+    repo = MagicMock()
+    repo.claim_job = AsyncMock(return_value=False)
+    repo.update_ingestion_job = AsyncMock()
 
     with (
-        patch("app.tasks.unit_sync_tasks.SessionLocal") as mock_session_local,
-        patch("app.tasks.unit_sync_tasks.get_unit_provider") as mock_get_unit_provider,
-        patch("app.tasks.unit_sync_tasks.get_role_provider") as mock_get_role_provider,
+        patch("app.tasks.unit_sync_tasks.SessionLocal", _patched_session_local()),
+        patch("app.tasks.unit_sync_tasks.DataIngestionRepository", return_value=repo),
+        patch(
+            "app.tasks.unit_sync_tasks.get_unit_provider", return_value=unit_provider
+        ),
+        patch(
+            "app.tasks.unit_sync_tasks.get_role_provider", return_value=role_provider
+        ),
     ):
-        mock_provider = MagicMock()
-        mock_provider.fetch_all_units = AsyncMock(
-            return_value=(mock_accred_units_raw, mock_accred_principal_users_raw)
-        )
-        mock_provider.map_api_unit = MagicMock(
-            side_effect=lambda u: MagicMock(id=None, institutional_id=u["id"])
-        )
-        mock_get_unit_provider.return_value = mock_provider
+        await run_sync_task_accred(SyncUnitRequest(target_year=2024), job_id=99)
 
-        mock_role_provider = MagicMock()
-        mock_role_provider.map_api_user = MagicMock(
-            side_effect=lambda u: MagicMock(id=u["id"], email=u["email"])
-        )
-        mock_get_role_provider.return_value = mock_role_provider
+    repo.claim_job.assert_awaited_once()
+    repo.update_ingestion_job.assert_not_awaited()
+    unit_provider.fetch_all_units.assert_not_awaited()
 
-        mock_session_local.return_value.__aenter__.return_value = mock_session
-        mock_session_local.return_value.__aexit__.return_value = None
 
-        with (
-            patch("app.tasks.unit_sync_tasks.UnitService") as MockUnitService,
-            patch("app.tasks.unit_sync_tasks.UserService") as MockUserService,
-            patch(
-                "app.tasks.unit_sync_tasks.CarbonReportService"
-            ) as MockCarbonReportService,
-        ):
-            MockUnitService.return_value.bulk_upsert = AsyncMock(
-                return_value=mock_unit_result
-            )
-            MockUserService.return_value.bulk_upsert = AsyncMock(
-                return_value=mock_user_result
-            )
-
-            mock_cr_service_instance = MagicMock()
-            mock_cr_service_instance.bulk_upsert = AsyncMock(return_value=mock_reports)
-            mock_cr_service_instance.module_service = mock_module_service
-            mock_cr_service_instance.ensure_modules_for_reports = AsyncMock()
-            MockCarbonReportService.return_value = mock_cr_service_instance
-
-            result = await run_sync_task_accred(SyncUnitRequest(target_year=2024))
-
-        assert result["status"] == "success"
-        assert result["units_synced"] == 2
-        assert result["carbon_reports_created"] == 1
-
-        mock_cr_service_instance.bulk_upsert.assert_awaited_once()
-        mock_cr_service_instance.ensure_modules_for_reports.assert_awaited_once_with(
-            mock_reports
-        )
+def mock_pod_id_arg(claim_mock):
+    """Read the second positional arg passed to claim_job (POD_ID is module-
+    scoped so we just echo whatever was actually used)."""
+    return claim_mock.call_args.args[1]

--- a/backend/tests/unit/services/data_ingestion/test_unit_sync_tasks.py
+++ b/backend/tests/unit/services/data_ingestion/test_unit_sync_tasks.py
@@ -162,3 +162,44 @@ def mock_pod_id_arg(claim_mock):
     """Read the second positional arg passed to claim_job (POD_ID is module-
     scoped so we just echo whatever was actually used)."""
     return claim_mock.call_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_run_sync_task_accred_marks_job_error_when_provider_fails(
+    mock_accred_units_raw,
+    mock_accred_principal_users_raw,
+):
+    """Service raises mid-sync → except block runs: data_session rolled back,
+    job stamped FINISHED+ERROR with the exception message, exception
+    re-raised so the task's caller sees the failure."""
+    unit_provider, role_provider = _common_provider_patches(
+        mock_accred_units_raw, mock_accred_principal_users_raw
+    )
+    # Make fetch_all_units the failure point — an Accred outage is the
+    # most realistic trigger for the except branch.
+    unit_provider.fetch_all_units = AsyncMock(side_effect=RuntimeError("Accred down"))
+
+    repo = MagicMock()
+    repo.claim_job = AsyncMock(return_value=True)
+    repo.update_ingestion_job = AsyncMock()
+
+    with (
+        patch("app.tasks.unit_sync_tasks.SessionLocal", _patched_session_local()),
+        patch("app.tasks.unit_sync_tasks.DataIngestionRepository", return_value=repo),
+        patch(
+            "app.tasks.unit_sync_tasks.get_unit_provider", return_value=unit_provider
+        ),
+        patch(
+            "app.tasks.unit_sync_tasks.get_role_provider", return_value=role_provider
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="Accred down"):
+            await run_sync_task_accred(SyncUnitRequest(target_year=2024), job_id=99)
+
+    # The error path's final update should mark the job FINISHED+ERROR with
+    # the exception message in status_message — operators need to see why
+    # it failed without digging through logs.
+    final_call = repo.update_ingestion_job.call_args_list[-1]
+    assert final_call.kwargs["state"] == IngestionState.FINISHED
+    assert final_call.kwargs["result"] == IngestionResult.ERROR
+    assert "Accred down" in final_call.kwargs["status_message"]

--- a/backend/tests/unit/services/data_ingestion/test_unit_sync_tasks.py
+++ b/backend/tests/unit/services/data_ingestion/test_unit_sync_tasks.py
@@ -170,8 +170,14 @@ async def test_run_sync_task_accred_marks_job_error_when_provider_fails(
     mock_accred_principal_users_raw,
 ):
     """Service raises mid-sync → except block runs: data_session rolled back,
-    job stamped FINISHED+ERROR with the exception message, exception
-    re-raised so the task's caller sees the failure."""
+    job stamped FINISHED+ERROR with the exception message.
+
+    The task does NOT re-raise: the endpoint schedules it via
+    ``fire_and_forget`` (no awaiter), so re-raising would surface as
+    "Task exception was never retrieved" warnings.  Operators see the
+    error via the persisted job state + status_message; that's what
+    this test asserts.
+    """
     unit_provider, role_provider = _common_provider_patches(
         mock_accred_units_raw, mock_accred_principal_users_raw
     )
@@ -193,8 +199,10 @@ async def test_run_sync_task_accred_marks_job_error_when_provider_fails(
             "app.tasks.unit_sync_tasks.get_role_provider", return_value=role_provider
         ),
     ):
-        with pytest.raises(RuntimeError, match="Accred down"):
-            await run_sync_task_accred(SyncUnitRequest(target_year=2024), job_id=99)
+        # Must NOT raise — the task swallows the exception by design so
+        # fire_and_forget callers don't see "Task exception was never
+        # retrieved" warnings.
+        await run_sync_task_accred(SyncUnitRequest(target_year=2024), job_id=99)
 
     # The error path's final update should mark the job FINISHED+ERROR with
     # the exception message in status_message — operators need to see why

--- a/backend/tests/unit/tasks/test_background.py
+++ b/backend/tests/unit/tasks/test_background.py
@@ -1,0 +1,96 @@
+"""Tests for the fire_and_forget background-task helper.
+
+Guards the regression that left recalc jobs stuck in the DB:
+``asyncio.create_task(coro)`` returns a Task that asyncio's task tracker
+holds with only a weak reference; Python's GC could reap it before the
+loop scheduled its first step, so the task never logged anything and
+the backing DataIngestionJob row stayed in NOT_STARTED / RUNNING with
+no result.
+
+``fire_and_forget`` adds the task to a process-lifetime strong-ref set
+so it survives until completion.
+"""
+
+import asyncio
+import gc
+
+import pytest
+
+from app.tasks._background import _BACKGROUND_TASKS, fire_and_forget
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_runs_to_completion_after_caller_returns():
+    """The task must finish even after every named reference is dropped.
+
+    Bare ``asyncio.create_task`` would let the Task be garbage-collected
+    here; ``fire_and_forget`` keeps it in ``_BACKGROUND_TASKS`` until
+    completion.
+    """
+    finished = asyncio.Event()
+
+    async def _work():
+        # Yield once so we model the case where the loop hasn't started
+        # the task yet by the time the caller returns.
+        await asyncio.sleep(0)
+        finished.set()
+
+    def _schedule():
+        # Local-scope: the Task object is unreachable as soon as this
+        # function returns.  Without strong-ref tracking, GC could
+        # collect it before _work even starts.
+        fire_and_forget(_work(), name="test-work")
+
+    _schedule()
+    gc.collect()  # force the worst-case: try to reap before the task runs
+
+    await asyncio.wait_for(finished.wait(), timeout=1.0)
+    assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_removes_from_set_when_done():
+    """Once the task completes, the strong reference is released so the
+    set doesn't grow unboundedly across calls."""
+    started_size = len(_BACKGROUND_TASKS)
+
+    async def _work():
+        await asyncio.sleep(0)
+
+    task = fire_and_forget(_work())
+    assert task in _BACKGROUND_TASKS, "task should be tracked while running"
+
+    await task
+    # Done-callbacks may run on a later loop tick; yield to let them fire.
+    await asyncio.sleep(0)
+
+    assert task not in _BACKGROUND_TASKS, (
+        "task should be removed from the strong-ref set after completion"
+    )
+    assert len(_BACKGROUND_TASKS) == started_size
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_logs_unhandled_exception(caplog):
+    """When the coroutine raises, the done-callback logs the error so it
+    doesn't disappear silently."""
+
+    async def _boom():
+        raise RuntimeError("intentional test failure")
+
+    import logging
+
+    caplog.set_level(logging.ERROR, logger="app.tasks._background")
+    task = fire_and_forget(_boom(), name="boom-test")
+
+    # Give the loop a chance to run the task and the done-callback.
+    try:
+        await task
+    except RuntimeError:
+        pass
+    await asyncio.sleep(0)
+
+    assert any(
+        "boom-test" in record.message and "intentional test failure" in record.message
+        for record in caplog.records
+    ), f"expected error log; got {[r.message for r in caplog.records]!r}"

--- a/backend/tests/unit/tasks/test_background.py
+++ b/backend/tests/unit/tasks/test_background.py
@@ -94,3 +94,65 @@ async def test_fire_and_forget_logs_unhandled_exception(caplog):
         "boom-test" in record.message and "intentional test failure" in record.message
         for record in caplog.records
     ), f"expected error log; got {[r.message for r in caplog.records]!r}"
+
+
+def test_fire_and_forget_inside_asyncio_run_is_cancelled(caplog):
+    """Documents the FastAPI BackgroundTasks bug class (#310B regression).
+
+    When a sync function passed to ``background_tasks.add_task`` runs in
+    an anyio worker thread and does ``asyncio.run(coro)`` (which is what
+    the now-removed ``run_ingestion`` / ``run_recalculation`` /
+    ``run_module_recalculation`` sync wrappers did), every Task created
+    inside ``coro`` via ``asyncio.create_task`` / ``fire_and_forget`` is
+    bound to the throwaway loop and **cancelled the instant
+    ``asyncio.run`` closes the loop on exit**.
+
+    In production this left recalc jobs stuck in RUNNING with empty
+    ``status_message`` and no logs.  The fix is structural: pass async
+    functions to ``add_task`` directly, never sync wrappers that wrap
+    ``asyncio.run``.
+
+    This test pins two facts the production fix relies on:
+    1. The cancellation behaviour IS what we believe — if a future Python
+       changes ``asyncio.run`` to wait for orphan Tasks, our reasoning
+       (and the deleted sync wrappers' rationale) needs revisiting.
+    2. The ``WARNING``-level cancellation log in ``_on_done`` still fires
+       — that breadcrumb is what made this bug diagnosable in one log
+       line.  Keep it loud.
+    """
+    import logging
+
+    child_finished: list[bool] = []
+
+    async def _child():
+        # Long enough to outlive any plausible loop teardown; if we ever
+        # see this flag set, ``asyncio.run`` is no longer cancelling
+        # orphan Tasks and the test's premise is broken.
+        await asyncio.sleep(1.0)
+        child_finished.append(True)
+
+    async def _parent():
+        fire_and_forget(_child(), name="bug-310b-canary")
+        # Return immediately.  asyncio.run is about to close the loop —
+        # which would cancel _child unless something else is keeping it
+        # alive.  Our strong-ref set keeps _child alive through GC, but
+        # cannot save it from a closing loop.
+
+    caplog.set_level(logging.WARNING, logger="app.tasks._background")
+    asyncio.run(_parent())  # creates throwaway loop, runs _parent, closes loop
+
+    assert child_finished == [], (
+        "child Task survived asyncio.run loop close — Python's asyncio "
+        "may have changed cancellation semantics, or fire_and_forget has "
+        "started detaching tasks from the loop.  The premise behind "
+        "removing the sync wrappers (run_ingestion etc.) needs revisiting."
+    )
+
+    assert any(
+        "bug-310b-canary" in r.message and "cancelled" in r.message
+        for r in caplog.records
+    ), (
+        "expected cancellation WARNING from _on_done; got "
+        f"{[r.message for r in caplog.records]!r}.  If this fires only "
+        "as DEBUG/INFO, restore the WARNING level in _background._on_done."
+    )

--- a/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
+++ b/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
@@ -144,3 +144,67 @@ async def test_enqueue_stale_recalculations_noop_when_no_stale():
 
     repo.create_ingestion_job.assert_not_awaited()
     mock_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_recalculations_returns_when_year_is_none():
+    """If the parent factor job has no year, fan-out can't choose a recalc
+    scope — log a warning and return without consulting the repo."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_recalculation_status_by_year = AsyncMock()
+    repo.create_ingestion_job = AsyncMock()
+
+    with (
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
+        patch("app.tasks._background.fire_and_forget") as mock_create_task,
+    ):
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=42,
+            module_type_id=1,
+            data_entry_type_id=None,
+            year=None,
+            pipeline_id=uuid4(),
+        )
+
+    # Early-return path: nothing should be queried, nothing should be fired.
+    repo.get_recalculation_status_by_year.assert_not_awaited()
+    repo.create_ingestion_job.assert_not_awaited()
+    mock_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_recalculations_skips_unknown_module_type():
+    """Multi-type fan-out with an unknown ``module_type_id`` (e.g. an enum
+    value that no longer exists after a deletion) must skip rather than
+    raise — the parent factor job already finished; we don't want to take
+    the calling code down with a ValueError from MdoduleTypeEnum()."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_recalculation_status_by_year = AsyncMock(
+        side_effect=AssertionError(
+            "Unknown-module branch must short-circuit before consulting the repo"
+        )
+    )
+    repo.create_ingestion_job = AsyncMock()
+
+    with (
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
+        patch("app.tasks._background.fire_and_forget") as mock_create_task,
+    ):
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=42,
+            module_type_id=99999,  # not a valid ModuleTypeEnum value
+            data_entry_type_id=None,
+            year=2025,
+            pipeline_id=uuid4(),
+        )
+
+    repo.create_ingestion_job.assert_not_awaited()
+    mock_create_task.assert_not_called()

--- a/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
+++ b/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
@@ -208,3 +208,55 @@ async def test_enqueue_stale_recalculations_skips_unknown_module_type():
 
     repo.create_ingestion_job.assert_not_awaited()
     mock_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_recalculations_single_type_uses_parent_scope():
+    """Plan 310B fix (Copilot follow-up): single-type factor uploads
+    (parent has both module_type_id and data_entry_type_id set) MUST
+    NOT consult ``get_recalculation_status_by_year`` — that helper
+    filters on ``state=FINISHED`` but the parent factor job is still
+    RUNNING when the fan-out fires, so the query returns no row and
+    the recalc would silently skip.
+
+    Instead, the helper builds a single target directly from the
+    parent's (module, det) scope.  Pin that contract here.
+    """
+    session = MagicMock()
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    # If the helper consults this, the test fails — proves the
+    # short-circuit is in place.
+    repo.get_recalculation_status_by_year = AsyncMock(
+        side_effect=AssertionError(
+            "single-type fan-out must not consult get_recalculation_status_by_year"
+        )
+    )
+    repo.create_ingestion_job = AsyncMock(return_value=MagicMock(id=200))
+
+    pipeline = uuid4()
+
+    with (
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
+        patch("app.tasks._background.fire_and_forget") as mock_create_task,
+        patch("app.tasks.emission_recalculation_tasks.run_recalculation_task"),
+    ):
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=42,
+            module_type_id=5,  # single-type: both fields set
+            data_entry_type_id=11,
+            year=2025,
+            pipeline_id=pipeline,
+        )
+
+    # Exactly one child job — for the parent's (module, det) — fired.
+    assert repo.create_ingestion_job.await_count == 1
+    new_job = repo.create_ingestion_job.await_args.args[0]
+    assert new_job.module_type_id == 5
+    assert new_job.data_entry_type_id == 11
+    assert new_job.year == 2025
+    assert new_job.pipeline_id == pipeline
+    assert new_job.meta["config"]["parent_job_id"] == 42
+    assert mock_create_task.call_count == 1

--- a/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
+++ b/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
@@ -1,0 +1,144 @@
+"""Plan 310B Part 4 — auto-recalc fan-out at end of FACTORS sync."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.tasks.ingestion_tasks import _enqueue_stale_recalculations
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_recalculations_creates_one_job_per_target():
+    """Fans out one emission_recalc job per (module, det) flagged
+    needs_recalculation, scoped to the parent's module/det filter."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_recalculation_status_by_year = AsyncMock(
+        return_value=[
+            {
+                "module_type_id": 1,
+                "data_entry_type_id": 10,
+                "year": 2025,
+                "needs_recalculation": True,
+            },
+            {
+                "module_type_id": 1,
+                "data_entry_type_id": 11,
+                "year": 2025,
+                "needs_recalculation": True,
+            },
+            {
+                "module_type_id": 2,
+                "data_entry_type_id": 20,
+                "year": 2025,
+                "needs_recalculation": False,
+            },
+        ]
+    )
+    created_jobs = [MagicMock(id=100), MagicMock(id=101)]
+    repo.create_ingestion_job = AsyncMock(side_effect=created_jobs)
+
+    pipeline = uuid4()
+
+    with (
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
+        patch("app.tasks.ingestion_tasks.asyncio.create_task") as mock_create_task,
+        patch(
+            "app.tasks.emission_recalculation_tasks.run_recalculation_task"
+        ) as mock_runner,
+    ):
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=42,
+            module_type_id=None,  # no module filter — both stale combos hit
+            data_entry_type_id=None,
+            year=2025,
+            pipeline_id=pipeline,
+        )
+
+    # Two stale combos → two jobs created and two tasks scheduled.
+    assert repo.create_ingestion_job.await_count == 2
+    assert mock_create_task.call_count == 2
+    # Each created job inherited the parent pipeline_id.
+    for call in repo.create_ingestion_job.await_args_list:
+        new_job = call.args[0]
+        assert new_job.pipeline_id == pipeline
+        assert new_job.year == 2025
+        assert new_job.meta["config"]["parent_job_id"] == 42
+    # Sanity: the runner reference is what asyncio.create_task wraps.
+    assert mock_runner is not None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_recalculations_filters_by_parent_scope():
+    """When parent job has module_type_id set, only matching combos fan out."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_recalculation_status_by_year = AsyncMock(
+        return_value=[
+            {
+                "module_type_id": 1,
+                "data_entry_type_id": 10,
+                "year": 2025,
+                "needs_recalculation": True,
+            },
+            {
+                "module_type_id": 2,
+                "data_entry_type_id": 20,
+                "year": 2025,
+                "needs_recalculation": True,
+            },
+        ]
+    )
+    repo.create_ingestion_job = AsyncMock(return_value=MagicMock(id=100))
+
+    with (
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
+        patch("app.tasks.ingestion_tasks.asyncio.create_task"),
+        patch("app.tasks.emission_recalculation_tasks.run_recalculation_task"),
+    ):
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=42,
+            module_type_id=1,  # only module 1 → only the first row matches
+            data_entry_type_id=None,
+            year=2025,
+            pipeline_id=uuid4(),
+        )
+
+    assert repo.create_ingestion_job.await_count == 1
+    new_job = repo.create_ingestion_job.await_args.args[0]
+    assert new_job.module_type_id == 1
+    assert new_job.data_entry_type_id == 10
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_recalculations_noop_when_no_stale():
+    """No targets flagged → no jobs created, no tasks fired, no errors."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_recalculation_status_by_year = AsyncMock(return_value=[])
+    repo.create_ingestion_job = AsyncMock()
+
+    with (
+        patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
+        patch("app.tasks.ingestion_tasks.asyncio.create_task") as mock_create_task,
+    ):
+        await _enqueue_stale_recalculations(
+            session,
+            parent_job_id=42,
+            module_type_id=None,
+            data_entry_type_id=None,
+            year=2025,
+            pipeline_id=uuid4(),
+        )
+
+    repo.create_ingestion_job.assert_not_awaited()
+    mock_create_task.assert_not_called()

--- a/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
+++ b/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
@@ -73,27 +73,22 @@ async def test_enqueue_stale_recalculations_creates_one_job_per_target():
 
 
 @pytest.mark.asyncio
-async def test_enqueue_stale_recalculations_filters_by_parent_scope():
-    """When parent job has module_type_id set, only matching combos fan out."""
+async def test_enqueue_stale_recalculations_multitype_fans_out_per_module_det():
+    """Multi-type factor upload (parent has module set, det=NULL) fans out
+    one recalc per data_entry_type in MODULE_TYPE_TO_DATA_ENTRY_TYPES for
+    that module — bypassing get_recalculation_status_by_year, which filters
+    out factor jobs with data_entry_type_id IS NULL and would silently
+    drop the recalc.
+    """
     session = MagicMock()
     session.commit = AsyncMock()
 
     repo = MagicMock()
+    # Should not be consulted in the multi-type branch — fail loudly if it is.
     repo.get_recalculation_status_by_year = AsyncMock(
-        return_value=[
-            {
-                "module_type_id": 1,
-                "data_entry_type_id": 10,
-                "year": 2025,
-                "needs_recalculation": True,
-            },
-            {
-                "module_type_id": 2,
-                "data_entry_type_id": 20,
-                "year": 2025,
-                "needs_recalculation": True,
-            },
-        ]
+        side_effect=AssertionError(
+            "multi-type fan-out must not consult get_recalculation_status_by_year"
+        )
     )
     repo.create_ingestion_job = AsyncMock(return_value=MagicMock(id=100))
 
@@ -105,16 +100,23 @@ async def test_enqueue_stale_recalculations_filters_by_parent_scope():
         await _enqueue_stale_recalculations(
             session,
             parent_job_id=42,
-            module_type_id=1,  # only module 1 → only the first row matches
+            module_type_id=1,  # headcount → [member, student]
             data_entry_type_id=None,
             year=2025,
             pipeline_id=uuid4(),
         )
 
-    assert repo.create_ingestion_job.await_count == 1
-    new_job = repo.create_ingestion_job.await_args.args[0]
-    assert new_job.module_type_id == 1
-    assert new_job.data_entry_type_id == 10
+    # MODULE_TYPE_TO_DATA_ENTRY_TYPES[ModuleTypeEnum.headcount] is
+    # [member=1, student=2] — both should land.
+    assert repo.create_ingestion_job.await_count == 2
+    landed_dets = {
+        call.args[0].data_entry_type_id
+        for call in repo.create_ingestion_job.await_args_list
+    }
+    assert landed_dets == {1, 2}
+    for call in repo.create_ingestion_job.await_args_list:
+        assert call.args[0].module_type_id == 1
+        assert call.args[0].meta["config"]["parent_job_id"] == 42
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
+++ b/backend/tests/unit/tasks/test_plan_310b_auto_recalc.py
@@ -45,7 +45,7 @@ async def test_enqueue_stale_recalculations_creates_one_job_per_target():
 
     with (
         patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
-        patch("app.tasks.ingestion_tasks.asyncio.create_task") as mock_create_task,
+        patch("app.tasks._background.fire_and_forget") as mock_create_task,
         patch(
             "app.tasks.emission_recalculation_tasks.run_recalculation_task"
         ) as mock_runner,
@@ -68,7 +68,7 @@ async def test_enqueue_stale_recalculations_creates_one_job_per_target():
         assert new_job.pipeline_id == pipeline
         assert new_job.year == 2025
         assert new_job.meta["config"]["parent_job_id"] == 42
-    # Sanity: the runner reference is what asyncio.create_task wraps.
+    # Sanity: the runner reference is what fire_and_forget wraps.
     assert mock_runner is not None
 
 
@@ -94,7 +94,7 @@ async def test_enqueue_stale_recalculations_multitype_fans_out_per_module_det():
 
     with (
         patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
-        patch("app.tasks.ingestion_tasks.asyncio.create_task"),
+        patch("app.tasks._background.fire_and_forget"),
         patch("app.tasks.emission_recalculation_tasks.run_recalculation_task"),
     ):
         await _enqueue_stale_recalculations(
@@ -131,7 +131,7 @@ async def test_enqueue_stale_recalculations_noop_when_no_stale():
 
     with (
         patch("app.tasks.ingestion_tasks.DataIngestionRepository", return_value=repo),
-        patch("app.tasks.ingestion_tasks.asyncio.create_task") as mock_create_task,
+        patch("app.tasks._background.fire_and_forget") as mock_create_task,
     ):
         await _enqueue_stale_recalculations(
             session,

--- a/backend/tests/unit/tasks/test_poller_dispatch.py
+++ b/backend/tests/unit/tasks/test_poller_dispatch.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``app.tasks._poller.dispatch_job``.
+
+Pinning the dispatcher's job_type → handler routing.  Plan 310B Part 5
+added a ``unit_sync`` branch (Copilot follow-up): the endpoint creates
+NOT_STARTED unit_sync jobs and fires the task in-process, so if the pod
+crashes between the endpoint commit and the task's claim_job, the
+poller picks up the orphaned row and re-runs it via this dispatcher.
+Without the unit_sync branch the row would be stuck NOT_STARTED forever.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.data_ingestion import DataIngestionJob
+from app.tasks._poller import dispatch_job
+
+
+def _make_job(
+    job_id: int,
+    job_type: str,
+    *,
+    module_type_id: int | None = None,
+    data_entry_type_id: int | None = None,
+    year: int | None = None,
+    meta: dict | None = None,
+):
+    """Build a minimal mock DataIngestionJob.  ``spec=DataIngestionJob``
+    so attribute typos in the dispatcher are caught (would AttributeError
+    rather than silently return a Mock)."""
+    job = MagicMock(spec=DataIngestionJob)
+    job.id = job_id
+    job.job_type = job_type
+    job.module_type_id = module_type_id
+    job.data_entry_type_id = data_entry_type_id
+    job.year = year
+    job.meta = meta or {}
+    return job
+
+
+@pytest.mark.asyncio
+async def test_dispatch_job_routes_unit_sync_to_run_sync_task_accred():
+    """A NOT_STARTED unit_sync job picked up by the poller must be
+    routed to ``run_sync_task_accred``, with the target_year extracted
+    from ``meta["config"]["target_year"]`` (or job.year as fallback).
+
+    Before this branch existed, the dispatcher's else-clause logged
+    "Unknown job_type 'unit_sync' — skipping" and the row stayed
+    NOT_STARTED forever.
+    """
+    job = _make_job(
+        99,
+        "unit_sync",
+        year=2025,
+        meta={"config": {"target_year": 2025}},
+    )
+
+    with patch(
+        "app.tasks.unit_sync_tasks.run_sync_task_accred",
+        new_callable=AsyncMock,
+    ) as mock_run:
+        await dispatch_job(job, "test-pod")
+
+    # Routed exactly once, with the unwrapped SyncUnitRequest + job_id.
+    assert mock_run.await_count == 1
+    sync_request, kwargs = mock_run.await_args.args, mock_run.await_args.kwargs
+    assert sync_request[0].target_year == 2025
+    assert kwargs["job_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_dispatch_job_unit_sync_skips_when_year_missing():
+    """``unit_sync`` job without a target_year (corrupted meta or
+    bug at enqueue time) must be skipped with a warning, NOT raise."""
+    job = _make_job(
+        99,
+        "unit_sync",
+        year=None,
+        meta={"config": {}},
+    )
+
+    with patch(
+        "app.tasks.unit_sync_tasks.run_sync_task_accred",
+        new_callable=AsyncMock,
+    ) as mock_run:
+        await dispatch_job(job, "test-pod")
+
+    mock_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_job_unknown_job_type_skips_silently():
+    """Sanity check on the else-clause — unknown job_type doesn't
+    raise.  If a future refactor accidentally routes ``unit_sync`` here
+    again (i.e. removes the elif branch), the test_dispatch_job_routes
+    test above will catch it via the unrouted call to run_sync_task_accred.
+    """
+    job = _make_job(99, "totally_unknown_type")
+
+    # Should not raise.
+    await dispatch_job(job, "test-pod")

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -171,15 +171,18 @@ async def test_recalculate_empty_result():
 
 @pytest.mark.asyncio
 async def test_recalculate_rematches_primary_factor_id_when_changed():
-    """Plan 310B Part 6: when resolve_primary_factor_id returns a different
-    factor id than what's stored on entry.data, the workflow updates
-    entry.data['primary_factor_id'] before computing emissions.
+    """Plan 310B Part 6: Strategy A entries (kind_field present in
+    ``entry.data``) get their primary_factor_id refreshed when
+    resolve_primary_factor_id returns a different id, before the
+    emission recompute runs.
     """
     mock_session = MagicMock()
     svc = EmissionRecalculationWorkflow(mock_session)
 
     entry = _make_mock_entry(1, 10)
-    entry.data = {"primary_factor_id": 999}  # stale: points at the old factor
+    # Strategy A shape: kind_field's value is present on entry.data,
+    # so the rematch gate (``handler.kind_field in entry.data``) passes.
+    entry.data = {"primary_factor_id": 999, "equipment_class": "Laptop"}
 
     with (
         patch(
@@ -204,15 +207,17 @@ async def test_recalculate_rematches_primary_factor_id_when_changed():
         )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        # Strategy A handler: kind_field maps to a key in entry.data so
+        # the gate ``handler.kind_field in entry.data`` evaluates True.
+        strategy_a_handler = MagicMock()
+        strategy_a_handler.kind_field = "equipment_class"
+        mock_handler_cls.get_by_type.return_value = strategy_a_handler
         # New factor matches against current state — different id
         mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
             return_value={"primary_factor_id": 1234}
         )
 
-        result = await svc.recalculate_for_data_entry_type(
-            DataEntryTypeEnum.plane, 2025
-        )
+        result = await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
 
     assert result["recalculated"] == 1
     assert entry.data["primary_factor_id"] == 1234
@@ -315,3 +320,132 @@ async def test_recalculate_module_stats_called_once_per_module():
     assert result["recalculated"] == 3
     assert result["modules_refreshed"] == 2
     assert mock_module_cls.return_value.recompute_stats.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_recalculate_skips_rematch_for_strategy_b_handlers():
+    """Plan 310B Part 6 (Copilot follow-up): Strategy B handlers like
+    professional_travel/plane have ``kind_field`` set but derive the
+    kind value in ``pre_compute`` — it isn't on ``entry.data``.  Running
+    ``resolve_primary_factor_id`` against an empty kind would either
+    clear primary_factor_id or raise MultipleResultsFound.
+
+    The gate ``handler.kind_field in entry.data`` short-circuits the
+    refresh for these handlers; this test pins the contract.
+    """
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    # Strategy B shape: kind_field is "kind" but it's NOT in entry.data
+    # (would be derived in pre_compute).  Existing primary_factor_id
+    # must NOT be touched.
+    entry.data = {"primary_factor_id": 7, "from_location": "GVA"}
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.CarbonReportModuleService"
+        ) as mock_module_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
+    ):
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
+        mock_module_cls.return_value.recompute_stats = AsyncMock()
+        # Strategy B handler shape: kind_field set, but its value isn't
+        # present in entry.data (would be derived via pre_compute).
+        strategy_b_handler = MagicMock()
+        strategy_b_handler.kind_field = "kind"  # NOT a key on entry.data
+        mock_handler_cls.get_by_type.return_value = strategy_b_handler
+        # If the gate fails and the rematch runs, this would be the
+        # value swapped in.  We assert the rematch was NOT called.
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={"primary_factor_id": 9999}
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.plane, 2025
+        )
+
+    # Refresh skipped: resolver never called, primary_factor_id untouched.
+    mock_handler_svc_cls.return_value.resolve_primary_factor_id.assert_not_called()
+    assert entry.data["primary_factor_id"] == 7
+    assert result["recalculated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
+    """Plan 310B Part 6 (Copilot follow-up): if ``upsert_by_data_entry``
+    raises mid-loop, the in-memory ``entry.data`` mutation must be
+    rolled back so the outer ``data_session.commit()`` doesn't persist
+    a stale primary_factor_id alongside an old emissions row.
+    """
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    # Strategy A shape so the rematch fires.
+    entry.data = {"primary_factor_id": 7, "equipment_class": "Laptop"}
+    original_data = dict(entry.data)
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.CarbonReportModuleService"
+        ) as mock_module_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
+    ):
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        # The compute step raises — simulates a downstream failure between
+        # the rematch swap and the emissions-row write.
+        mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock(
+            side_effect=RuntimeError("compute blew up")
+        )
+        mock_module_cls.return_value.recompute_stats = AsyncMock()
+        strategy_a_handler = MagicMock()
+        strategy_a_handler.kind_field = "equipment_class"
+        mock_handler_cls.get_by_type.return_value = strategy_a_handler
+        # Resolver returns a different id — rematch tentatively swaps
+        # entry.data['primary_factor_id'] from 7 → 1234, then upsert fails.
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={"primary_factor_id": 1234}
+        )
+
+        result = await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
+
+    # Per-entry error counted — the workflow swallows per-entry exceptions
+    # so a single bad row doesn't abort the rest of the batch.
+    assert result["errors"] == 1
+    assert result["recalculated"] == 0
+    # Critical: entry.data was rolled back to its pre-rematch shape.
+    # Without the rollback, primary_factor_id would persist as 1234
+    # while data_entry_emissions still references 7 → silent corruption.
+    assert entry.data == original_data, (
+        "entry.data must be restored on per-entry failure"
+    )

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -14,6 +14,7 @@ def _make_mock_entry(entry_id: int, module_id: int) -> MagicMock:
     entry.id = entry_id
     entry.carbon_report_module_id = module_id
     entry.data_entry_type_id = DataEntryTypeEnum.plane
+    entry.data = {}  # primary_factor_id is read from / written to entry.data
     return entry
 
 
@@ -44,7 +45,17 @@ async def test_recalculate_all_success():
         patch(
             "app.workflows.emission_recalculation.DataEntryResponse"
         ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
     ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={}
+        )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -86,7 +97,17 @@ async def test_recalculate_partial_error():
         patch(
             "app.workflows.emission_recalculation.DataEntryResponse"
         ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
     ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={}
+        )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -131,6 +152,8 @@ async def test_recalculate_empty_result():
         ) as mock_repo_cls,
         patch("app.workflows.emission_recalculation.DataEntryEmissionService"),
         patch("app.workflows.emission_recalculation.CarbonReportModuleService"),
+        patch("app.workflows.emission_recalculation.BaseModuleHandler"),
+        patch("app.workflows.emission_recalculation.ModuleHandlerService"),
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[]
@@ -144,6 +167,100 @@ async def test_recalculate_empty_result():
     assert result["errors"] == 0
     assert result["modules_refreshed"] == 0
     assert result["error_details"] == []
+
+
+@pytest.mark.asyncio
+async def test_recalculate_rematches_primary_factor_id_when_changed():
+    """Plan 310B Part 6: when resolve_primary_factor_id returns a different
+    factor id than what's stored on entry.data, the workflow updates
+    entry.data['primary_factor_id'] before computing emissions.
+    """
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {"primary_factor_id": 999}  # stale: points at the old factor
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.CarbonReportModuleService"
+        ) as mock_module_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
+    ):
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
+        mock_module_cls.return_value.recompute_stats = AsyncMock()
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        # New factor matches against current state — different id
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={"primary_factor_id": 1234}
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.plane, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] == 1234
+
+
+@pytest.mark.asyncio
+async def test_recalculate_does_not_touch_entry_when_factor_unchanged():
+    """When resolve_primary_factor_id returns the same id, entry.data is
+    untouched (no churn).
+    """
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    original_data = {"primary_factor_id": 7, "extra": "preserved"}
+    entry.data = dict(original_data)
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.CarbonReportModuleService"
+        ) as mock_module_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
+    ):
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
+        mock_module_cls.return_value.recompute_stats = AsyncMock()
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={"primary_factor_id": 7}
+        )
+
+        await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+
+    assert entry.data == original_data
 
 
 @pytest.mark.asyncio
@@ -173,7 +290,17 @@ async def test_recalculate_module_stats_called_once_per_module():
         patch(
             "app.workflows.emission_recalculation.DataEntryResponse"
         ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
     ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={}
+        )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )

--- a/docs/implementation-plans/310-b-factor-pipeline.md
+++ b/docs/implementation-plans/310-b-factor-pipeline.md
@@ -305,6 +305,75 @@ directly (we are already in an async context).
 
 ---
 
+## Part 6 — Rematch on recalc (Strategy A only)
+
+### Why this is needed
+
+Parts 2–4 close most of the FK-stability problem: upsert-in-place preserves `factor.id` when a
+CSV re-uploads the same factor (same identity key) with new values. The recalc dereferences the
+stable FK and reads the new values. Correct.
+
+The hole is the **classification-change** case. The factor identity key includes
+`classification`, so a CSV reupload that changes a factor's classification (supplier renamed,
+vendor consolidated, sub-class added) does **not** update the existing row — it inserts a new
+factor row, and the old row stays as stale (`last_seen_job_id` < latest). Existing
+`DataEntry.primary_factor_id` continues to point at the stale row. The recalc job would then
+read stale values via the stale FK and emit wrong numbers, silently.
+
+This affects **Strategy A** entries only (equipment, purchases, process_emissions, etc. — see
+`data_entry_emission_service._fetch_factors`, line 296). Strategy B entries (headcount,
+travel, building) already re-match by classification at every recompute via
+`factor_service.get_by_classification`, so they pick up the new factor automatically.
+
+### Fix
+
+In `EmissionRecalculationWorkflow.recalculate_for_data_entry_type`, before computing emissions
+for each Strategy A data entry, re-resolve `primary_factor_id` against current factors. This
+treats stored `primary_factor_id` as a cache and matching as the truth — within Plan B's
+structure, no architectural reframe.
+
+The canonical matching function already exists:
+`ModuleHandlerService.resolve_primary_factor_id` (`module_handler_service.py:28`). Reuse it.
+
+```python
+# Inside EmissionRecalculationWorkflow, per data entry, before compute:
+handler = get_handler(data_entry.data_entry_type)
+if handler.kind_field is not None:           # Strategy A handlers expose kind_field
+    refreshed = await module_handler_service.resolve_primary_factor_id(
+        handler=handler,
+        payload=data_entry.data,             # has kind/subkind classification fields
+        data_entry_type_id=DataEntryTypeEnum(data_entry.data_entry_type),
+        year=year,
+        existing_data=None,
+    )
+    new_factor_id = refreshed.get("primary_factor_id")
+    if new_factor_id != data_entry.primary_factor_id:
+        data_entry.primary_factor_id = new_factor_id
+        # data_session.add not strictly needed if data_entry already attached;
+        # the dual-session pattern flushes on data_session.commit at end of task
+```
+
+After the loop, the existing `_fetch_factors` Strategy A path (`comp.factor_id = ...`) reads
+the refreshed FK and computes against the correct factor.
+
+### What this is **not**
+
+- Not a switch to derived-only (Option A): we still cache `primary_factor_id` for read-time
+  performance.
+- Not full invalidation-and-relink at ingest time: the rematch happens during recalc, where we
+  already iterate every affected entry. No extra query fan-out at ingest.
+- Not a JSONB-classification change: that is Part 1, separate concern.
+
+### Tests added (folded into the table below)
+
+- Factor reupload that **changes classification** of an existing factor → existing
+  Strategy A data_entries are re-linked to the new factor row; emissions reflect new values.
+- Factor reupload that **only changes values** (same identity key) → existing
+  `primary_factor_id` is unchanged (no churn), emissions reflect new values via stable FK.
+- Strategy B entry → no `primary_factor_id` mutation needed (already derived).
+
+---
+
 ## Tests
 
 | Test                                        | Assertion                                                                             |
@@ -320,6 +389,9 @@ directly (we are already in an async context).
 | `run_sync_task_accred` claim guard          | mock claim_job → False, asserts task returns without API calls                        |
 | `POST /sync/units`                          | returns real job_id (not 0); job is created, claimable                                |
 | `claim_job` with `module_type_id IS NULL`   | unsets previous GLOBAL_PER_YEAR is_current correctly                                  |
+| Recalc rematches on classification change   | Strategy A entries re-link to the new factor row; emissions use new values            |
+| Recalc no-op on values-only change          | `primary_factor_id` unchanged when identity key matches; emissions reflect new values |
+| Recalc Strategy B unaffected                | no `primary_factor_id` mutation; classification re-match happens in `_fetch_factors`  |
 
 ---
 

--- a/docs/implementation-plans/310-c-dag-handler-registry.md
+++ b/docs/implementation-plans/310-c-dag-handler-registry.md
@@ -458,3 +458,64 @@ multi-step run, not just the first.
 - `backend/app/api/v1/data_sync.py` — endpoints switch from per-task functions to `asyncio.create_task(run_job(id))`; new `GET /sync/pipelines/{id}`
 - `backend/app/models/data_ingestion.py` — `started_at`, `finished_at` columns
 - `backend/migrations/` — 1 migration (started_at, finished_at)
+
+---
+
+## Follow-ups rolled in from PR #976 review
+
+These were noted on PR #976 (Plan B) as "out-of-scope here, fits Plan C." None block
+Plan B's merge; flagged here so they aren't lost.
+
+### Permission gate on `GET /factors/stale`
+
+The stale-factor list endpoint added in Plan B (`backend/app/api/v1/factors.py`) currently
+requires only `Depends(get_current_user)` — any authenticated user can list which factors
+are out of sync with the latest CSV upload. Other operator endpoints in `data_sync.py`
+gate on `backoffice.data_management.view`. Tighten the dependency to match:
+
+```python
+current_user: User = Depends(
+    require_permission("backoffice.data_management", "view")
+),
+```
+
+This is a one-line change but pairs naturally with Plan C's broader cleanup of
+backoffice endpoints, so rolling it in here keeps the auth surface coherent.
+
+### Fan-out instrumentation on the parent factor job
+
+`_enqueue_stale_recalculations` (Plan B, in `ingestion_tasks.py`) returns silently when
+no recalc children get fired (e.g. `year is None`, or
+`MODULE_TYPE_TO_DATA_ENTRY_TYPES[module]` is empty). The parent FACTORS job still
+finishes with `result=SUCCESS` and a generic status message — operators have no in-band
+signal that "factor uploaded but no recalc cascade ran."
+
+When Plan C generalises this into `chain_job`, stamp the count of fired children into
+the parent's `extra_metadata`:
+
+```python
+fired_children = await chain_job(parent, ...)
+await update_ingestion_job(
+    parent.id,
+    extra_metadata={"children_fired": len(fired_children),
+                    "child_pipeline_id": str(pipeline_id)},
+)
+```
+
+Cheap, makes the chain auditable without parsing logs.
+
+### Stable ordering on `list_stale_for_year`
+
+`FactorRepository.list_stale_for_year` orders by `(data_entry_type_id, id)` after the
+PR #976 fix, but if Plan C reshapes the stale-factor surface (e.g. as part of
+`/sync/pipelines/{id}` rollup), preserve the deterministic ordering — operators
+diffing two reads back-to-back rely on it.
+
+### PG test fixture drift
+
+Plan B's PG tests inline `_install_plan_310b_indexes(engine)` to add the partial
+unique indexes that `SQLModel.metadata.create_all` doesn't know about. Once Plan C
+adds `started_at` / `finished_at` and the `pipeline_id` query, more migration-only
+DDL will accumulate. Promote the inline DDL into a shared `pg_dsn_with_310b` fixture
+in `conftest.py` so every PG-bound test gets the production schema without
+copy-pasting `CREATE UNIQUE INDEX` blocks.

--- a/docs/implementation-plans/310-d-pipeline-responsibility-split.md
+++ b/docs/implementation-plans/310-d-pipeline-responsibility-split.md
@@ -241,3 +241,44 @@ forward and back if a provider's chain-job semantics turn out to need adjustment
 - `frontend/src/pages/back-office/DataManagementPage.vue` and module cards — "Recalculating..." badge + pipeline SSE
 - `backend/app/core/config.py` — `BULK_PATH_PURE_ASYNC: bool = True` feature flag
 - `backend/migrations/` — `uq_aggregation_active` partial unique index
+
+---
+
+## Follow-ups rolled in from PR #976 review
+
+### Batch the rematch in `EmissionRecalculationWorkflow`
+
+Plan B added a per-entry rematch in `recalculate_for_data_entry_type`
+(`backend/app/workflows/emission_recalculation.py`):
+
+```python
+for entry in entries:
+    refreshed = await handler_svc.resolve_primary_factor_id(
+        handler=handler, payload=dict(entry.data),
+        data_entry_type_id=data_entry_type_id, year=year,
+        existing_data=None,
+    )
+    ...
+```
+
+This is **N+1**: one `resolve_primary_factor_id` call (and at least one factor query)
+per data entry. Acknowledged in code as Plan D scope. Concrete shape for the fix:
+
+1. Pull all factors for `(data_entry_type_id, year)` once, into a Python `dict` keyed
+   by classification tuple (using `handler.kind_field` / `subkind_field` to derive
+   the key).
+2. Replace `resolve_primary_factor_id` per-entry call with a Python lookup against
+   that dict.
+3. Fall back to the existing per-entry path only when the lookup misses (e.g. a
+   classification value the bulk-load query didn't see).
+
+For the largest existing module (purchases ~10k entries), this collapses ~10k DB
+roundtrips into one. Don't ship Plan D without this — the per-entry cost adds up
+once we move emission writes out of the ingest path and into recalc-only.
+
+### Two-pass partition in `FactorRepository.upsert_factors`
+
+Minor: the upsert splits its input into `with_year` / `no_year` via two list
+comprehensions. Single-pass with a defaultdict is cleaner and saves a list copy
+on 50k-row uploads. Pure refactor, no behavior change — fits Plan D's broader
+provider/repo audit.

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -100,6 +100,7 @@ erDiagram
     INTEGER data_entry_type_id "indexed"
     INTEGER emission_type_id "indexed"
     INTEGER id PK
+    INTEGER last_seen_job_id FK
     JSON values
     INTEGER year "indexed"
   }
@@ -161,6 +162,7 @@ erDiagram
   carbon_report_modules ||--}o data_entries : "carbon_report_module_id"
   carbon_reports ||--}o carbon_report_modules : "carbon_report_id"
   data_entries ||--}o data_entry_emissions : "data_entry_id"
+  data_ingestion_jobs ||--}o factors : "last_seen_job_id"
   factors ||--}o data_entry_emissions : "primary_factor_id"
   units ||--}o carbon_reports : "unit_id"
   units ||--}o unit_users : "unit_id"


### PR DESCRIPTION
## Summary

Implements [Plan 310B](../docs/implementation-plans/310-b-factor-pipeline.md) for the bulk-path (Path 2) data-ingestion pipeline. Six parts in one branch:

- **Factor identity stability** — `factors.classification` migrated to JSONB; partial unique index on `(det, year, emission_type, classification::text)`; `factor_repo.upsert_factors` uses `ON CONFLICT DO UPDATE` so re-uploads preserve `factor.id` and don't break `DataEntry.primary_factor_id` FKs.
- **Stale-factor visibility** — new `factors.last_seen_job_id` column + `GET /factors/stale` endpoint surfaces factors not present in the latest CSV without deleting them (deletion would re-introduce dangling FKs).
- **Auto-recalc fan-out** — `_enqueue_stale_recalculations` runs at the end of `run_sync_task` for FACTORS jobs, fans one `emission_recalc` job per stale `(module, det)` via `asyncio.create_task`, with the safety poller (Plan 310A) as crash recovery. Children inherit `pipeline_id`.
- **Unit-sync tracking** — `EntityType.GLOBAL_PER_YEAR` enum value; `POST /sync/units` now creates a tracked `DataIngestionJob` and returns the real `job_id` instead of `0`; `run_sync_task_accred` adopts the dual-session + `claim_job` pattern with SSE-visible status updates.
- **Rematch on recalc (Part 6, added during review)** — `EmissionRecalculationWorkflow` refreshes `primary_factor_id` for each entry against current factors before computing. Closes a hole the upsert-only path leaves: when a CSV reupload changes a factor's classification, upsert inserts a new row and existing entries would otherwise keep dereferencing the stale FK.

## Test plan

- [x] `rtk uv run pytest tests/unit tests/integration` — 1183 tests pass on this branch
- [x] Ran `tests/integration/services/data_ingestion/test_pod_safety_310a_pg.py` against a real Postgres
- [x] Applied migration `b1f0a2c3d4e5_plan_310b_factor_pipeline` against Postgres
- [x] PG follow-up tests added (`test_plan_310b_factor_pipeline_pg.py`): upsert insert / update-preserves-id / JSONB key-order resilience; `list_stale_for_year` returns the right rows
- [ ] Smoke test `POST /sync/factors/...` with a CSV: confirm factor IDs stay stable across reuploads and a successful run enqueues recalc jobs
- [ ] Smoke test `POST /sync/units`: confirm response carries a non-zero `job_id` and SSE shows the four `status_message` transitions

## Notes for reviewers

- Plan C and D depend on this; merging unblocks the next PR.
- `_enqueue_stale_recalculations` is intentionally local — Plan C will generalise it as `chain_job(parent, child)` once the handler registry lands.
- Rematch on recalc is acknowledged N+1; Plan D's per-job batching is the planned fix.
- `local_seed.py` keeps the legacy `bulk_create` path (`_finalize_and_commit` accepts `factor_repo` for signature compat but ignores it) — seed scripts assume an empty factor table.
- The new PG tests install the partial unique indexes inline because the shared `pg_dsn` fixture uses `SQLModel.metadata.create_all`, which doesn't run Alembic migrations. If we add more migration-only DDL later, consider promoting that into the fixture.