### PR TITLE
fix(data-entry): stop persisting computed fields to DataEntry.data

### DIFF
--- a/.claude/skills/review-copilot-comments/retrieve-copilot-pr.sh
+++ b/.claude/skills/review-copilot-comments/retrieve-copilot-pr.sh
@@ -13,12 +13,13 @@ PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 # 2. Extract Issue ID from branch name (assumes digits at start or after a slash)
-# Regex matches the first sequence of numbers found in the branch name
+# Regex matches the first sequence of numbers found in the branch name.
+# Falls back to the PR number when the branch name has no digits, so this
+# still works for PRs that aren't tied to a numbered issue.
 ISSUE_ID=$(echo "$CURRENT_BRANCH" | grep -oE '[0-9]+' | head -1)
 
 if [ -z "$ISSUE_ID" ]; then
-  echo "Error: Could not extract an Issue ID from branch name '$CURRENT_BRANCH'."
-  exit 1
+  ISSUE_ID="$PR_NUMBER"
 fi
 
 # 3. Define the path according to your Implementation Plan rules

--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -246,8 +246,13 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
             )
         ]
 
-    def to_response(self, data_entry: DataEntry) -> BuildingRoomHandlerResponse:
-        d = data_entry.data
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> BuildingRoomHandlerResponse:
+        d = enriched_data if enriched_data is not None else data_entry.data
+        primary_factor = d.get("primary_factor", {})
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
@@ -255,16 +260,16 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
                 **d,
                 "room_type": d.get("room_type"),
-                "heating_kwh_per_square_meter": d.get("primary_factor", {}).get(
+                "heating_kwh_per_square_meter": primary_factor.get(
                     "heating_kwh_per_square_meter", None
                 ),
-                "cooling_kwh_per_square_meter": d.get("primary_factor", {}).get(
+                "cooling_kwh_per_square_meter": primary_factor.get(
                     "cooling_kwh_per_square_meter", None
                 ),
-                "ventilation_kwh_per_square_meter": d.get("primary_factor", {}).get(
+                "ventilation_kwh_per_square_meter": primary_factor.get(
                     "ventilation_kwh_per_square_meter", None
                 ),
-                "lighting_kwh_per_square_meter": d.get("primary_factor", {}).get(
+                "lighting_kwh_per_square_meter": primary_factor.get(
                     "lighting_kwh_per_square_meter", None
                 ),
             }
@@ -480,17 +485,24 @@ class EnergyCombustionModuleHandler(BaseModuleHandler):
             )
         ]
 
-    def to_response(self, data_entry: DataEntry) -> EnergyCombustionHandlerResponse:
-        primary_factor = data_entry.data.get("primary_factor", {})
-        factor_values = primary_factor.get("values", {})
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> EnergyCombustionHandlerResponse:
+        d = enriched_data if enriched_data is not None else data_entry.data
+        # primary_factor is a flat dict of factor.values merged with
+        # factor.classification (see DataEntryRepository.get_submodule_data).
+        # Read fields directly off the flat dict — there is no nested "values".
+        primary_factor = d.get("primary_factor", {})
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
-                "name": primary_factor.get("kind") or data_entry.data.get("name"),
-                "unit": factor_values.get("unit") or data_entry.data.get("unit"),
+                **d,
+                "name": primary_factor.get("kind") or d.get("name"),
+                "unit": primary_factor.get("unit") or d.get("unit"),
             }
         )
 
@@ -597,15 +609,18 @@ class BuildingEmbodiedEnergyModuleHandler(BaseModuleHandler):
     }
 
     def to_response(
-        self, data_entry: DataEntry
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
     ) -> BuildingEmbodiedEnergyHandlerResponse:
+        d = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
-                "building_name": data_entry.data.get("building_name"),
+                **d,
+                "building_name": d.get("building_name"),
             }
         )
 

--- a/backend/app/modules/equipment_electric_consumption/schemas.py
+++ b/backend/app/modules/equipment_electric_consumption/schemas.py
@@ -224,23 +224,24 @@ class EquipmentModuleHandler(BaseModuleHandler):
             )
         ]
 
-    def to_response(self, data_entry: DataEntry) -> EquipmentHandlerResponse:
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> EquipmentHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
+        primary_factor = data.get("primary_factor", {})
         new_entry = {
             "id": data_entry.id,
             "data_entry_type_id": data_entry.data_entry_type_id,
             "carbon_report_module_id": data_entry.carbon_report_module_id,
-            **data_entry.data,
-            "active_power_w": data_entry.data.get("primary_factor", {}).get(
-                "active_power_w", None
-            ),
-            "standby_power_w": data_entry.data.get("primary_factor", {}).get(
-                "standby_power_w", None
-            ),
-            "equipment_class": data_entry.data.get("primary_factor", {}).get("class")
-            or data_entry.data.get("equipment_class"),
-            "sub_class": data_entry.data.get("primary_factor", {}).get("sub_class")
-            or data_entry.data.get("sub_class"),
-            "kg_co2eq": data_entry.data.get("kg_co2eq", None),
+            **data,
+            "active_power_w": primary_factor.get("active_power_w", None),
+            "standby_power_w": primary_factor.get("standby_power_w", None),
+            "equipment_class": primary_factor.get("class")
+            or data.get("equipment_class"),
+            "sub_class": primary_factor.get("sub_class") or data.get("sub_class"),
+            "kg_co2eq": data.get("kg_co2eq", None),
         }
         return self.response_dto.model_validate(new_entry)
 

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -200,18 +200,22 @@ class ExternalCloudModuleHandler(BaseModuleHandler):
         "provider": Factor.classification[kind_field].as_string(),
     }
 
-    def to_response(self, data_entry: DataEntry) -> ExternalCloudHandlerResponse:
-        primary_factor = data_entry.data.get("primary_factor", {})
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> ExternalCloudHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
+        primary_factor = data.get("primary_factor", {})
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
                 "service_type": primary_factor.get("subkind")
-                or data_entry.data.get("service_type"),
-                "provider": primary_factor.get("kind")
-                or data_entry.data.get("provider"),
+                or data.get("service_type"),
+                "provider": primary_factor.get("kind") or data.get("provider"),
             }
         )
 
@@ -382,18 +386,22 @@ class ExternalAIModuleHandler(BaseModuleHandler):
         "usage_type": Factor.classification["usage_type"].as_string(),
     }
 
-    def to_response(self, data_entry: DataEntry) -> ExternalAIHandlerResponse:
-        primary_factor = data_entry.data.get("primary_factor", {})
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> ExternalAIHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
+        primary_factor = data.get("primary_factor", {})
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
-                "provider": primary_factor.get("provider")
-                or data_entry.data.get("provider"),
+                **data,
+                "provider": primary_factor.get("provider") or data.get("provider"),
                 "usage_type": primary_factor.get("usage_type")
-                or data_entry.data.get("usage_type"),
+                or data.get("usage_type"),
             }
         )
 

--- a/backend/app/modules/headcount/schemas.py
+++ b/backend/app/modules/headcount/schemas.py
@@ -193,13 +193,18 @@ class HeadcountMemberModuleHandler(BaseModuleHandler):
             )
         ]
 
-    def to_response(self, data_entry: DataEntry) -> HeadcountItemResponse:
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> HeadcountItemResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
             }
         )
 
@@ -248,13 +253,18 @@ class HeadcountStudentModuleHandler(BaseModuleHandler):
             )
         ]
 
-    def to_response(self, data_entry: DataEntry) -> HeadCountStudentResponse:
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> HeadCountStudentResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
             }
         )
 

--- a/backend/app/modules/process_emissions/schemas.py
+++ b/backend/app/modules/process_emissions/schemas.py
@@ -94,18 +94,21 @@ class ProcessEmissionsModuleHandler(BaseModuleHandler):
         "subcategory": Factor.classification[subkind_field].as_string(),
     }
 
-    def to_response(self, data_entry: DataEntry) -> ProcessEmissionsHandlerResponse:
-        primary_factor = data_entry.data.get("primary_factor", {})
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> ProcessEmissionsHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
+        primary_factor = data.get("primary_factor", {})
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
-                "category": primary_factor.get("kind")
-                or data_entry.data.get("category"),
-                "subcategory": primary_factor.get("subkind")
-                or data_entry.data.get("subcategory"),
+                **data,
+                "category": primary_factor.get("kind") or data.get("category"),
+                "subcategory": primary_factor.get("subkind") or data.get("subcategory"),
             }
         )
 

--- a/backend/app/modules/professional_travel/schemas.py
+++ b/backend/app/modules/professional_travel/schemas.py
@@ -204,13 +204,18 @@ class ProfessionalTravelBaseModuleHandler(BaseModuleHandler):
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
-    def to_response(self, data_entry: DataEntry) -> DataEntryResponseGen:
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> DataEntryResponseGen:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
             }
         )
 

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -192,24 +192,27 @@ class PurchaseModuleHandler(BaseModuleHandler):
         ].as_string(),
     }
 
-    def to_response(self, data_entry: DataEntry) -> PurchaseHandlerResponse:
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> PurchaseHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
-                **data_entry.data,
+                **data,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                "name": data_entry.data.get("name"),
-                "supplier": data_entry.data.get("supplier"),
-                "quantity": data_entry.data.get("quantity"),
-                "purchase_institutional_code": data_entry.data.get(
-                    "purchase_institutional_code"
-                ),
-                "purchase_institutional_description": data_entry.data.get(
+                "name": data.get("name"),
+                "supplier": data.get("supplier"),
+                "quantity": data.get("quantity"),
+                "purchase_institutional_code": data.get("purchase_institutional_code"),
+                "purchase_institutional_description": data.get(
                     "purchase_institutional_description"
                 ),
-                "total_spent_amount": data_entry.data.get("total_spent_amount"),
-                "kg_co2eq": data_entry.data.get("kg_co2eq", None),
+                "total_spent_amount": data.get("total_spent_amount"),
+                "kg_co2eq": data.get("kg_co2eq", None),
             }
         )
 
@@ -293,13 +296,18 @@ class PurchaseAdditionalModuleHandler(BaseModuleHandler):
         "unit": DataEntry.data["unit"].as_string(),
     }
 
-    def to_response(self, data_entry: DataEntry) -> PurchaseAdditionalHandlerResponse:
+    def to_response(
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
+    ) -> PurchaseAdditionalHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
             }
         )
 

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -83,14 +83,17 @@ class ResearchFacilitiesAnimalModuleHandler(BaseModuleHandler):
     filter_map: dict = {}
 
     def to_response(
-        self, data_entry: DataEntry
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
     ) -> ResearchFacilitiesAnimalHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
             }
         )
 

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -99,14 +99,17 @@ class ResearchFacilitiesCommonModuleHandler(BaseModuleHandler):
     filter_map: dict = {}
 
     def to_response(
-        self, data_entry: DataEntry
+        self,
+        data_entry: DataEntry,
+        enriched_data: dict | None = None,
     ) -> ResearchFacilitiesCommonHandlerResponse:
+        data = enriched_data if enriched_data is not None else data_entry.data
         return self.response_dto.model_validate(
             {
                 "id": data_entry.id,
                 "data_entry_type_id": data_entry.data_entry_type_id,
                 "carbon_report_module_id": data_entry.carbon_report_module_id,
-                **data_entry.data,
+                **data,
             }
         )
 

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -44,6 +44,23 @@ class DataEntryRepository:
         self.entity_type = DataEntry.__name__
         self.carbon_report_module_repo = CarbonReportModuleRepository(session)
 
+    def _detach(self, *objs: Any) -> None:
+        """Expunge ORM rows from the session so accidental mutations cannot
+        be flushed back to the DB. Use on read-path methods that return rows
+        the caller should treat as read-only.
+
+        Silently ignores rows that are not currently attached.
+        """
+        from sqlalchemy.exc import InvalidRequestError
+
+        for obj in objs:
+            if obj is None:
+                continue
+            try:
+                self.session.expunge(obj)
+            except InvalidRequestError:
+                pass
+
     async def get(self, id: int) -> Optional[DataEntry]:
         statement = select(DataEntry).where(DataEntry.id == id)
         result = await self.session.exec(statement)
@@ -181,6 +198,10 @@ class DataEntryRepository:
         sort_order,
         filter: Optional[str] = None,
     ) -> list[DataEntry]:
+        # TODO: check if it's safe to expunge the returned rows here for
+        # symmetry with get_submodule_data. Some callers (delete flows in
+        # data_entry_service.py) only read; others may mutate. Audit each
+        # caller before adding self._detach.
         statement = select(DataEntry).where(
             DataEntry.carbon_report_module_id == carbon_report_module_id
         )
@@ -206,6 +227,10 @@ class DataEntryRepository:
         Returns:
             List of matching DataEntry rows (may be empty).
         """
+        # TODO: check if it's safe to expunge the returned rows here for
+        # symmetry with get_submodule_data. The recalculation workflow in
+        # workflows/emission_recalculation.py is the primary caller and may
+        # mutate; audit before adding self._detach.
         statement = (
             select(DataEntry)
             .join(
@@ -568,6 +593,16 @@ class DataEntryRepository:
             else:
                 data_entry, total_kg_co2eq, primary_factor = row
 
+            # Defense-in-depth: detach loaded ORM rows from the session so any
+            # accidental mutation (here or downstream) cannot be flushed back to
+            # the DB. This method only reads scalar columns and the JSON `data`
+            # field after unpack — no lazy relationships — so expunge is safe.
+            self._detach(data_entry, primary_factor)
+            if is_travel_entry:
+                self._detach(member_entry, _emission)
+            elif is_buildings_entry:
+                self._detach(building_room)
+
             handler = BaseModuleHandler.get_by_type(
                 DataEntryTypeEnum(data_entry.data_entry_type_id)
             )
@@ -579,12 +614,18 @@ class DataEntryRepository:
                     factor_stmt = select(Factor).where(Factor.id == primary_factor_id)
                     factor_result = await self.session.execute(factor_stmt)
                     primary_factor = factor_result.scalar_one_or_none()
+                    if primary_factor is not None:
+                        self._detach(primary_factor)
 
             primary_factor_values = primary_factor.values if primary_factor else {}
             primary_factor_classification = (
                 primary_factor.classification if primary_factor else {}
             )
-            data_entry.data = {
+            # Build the enriched response payload as a fresh dict — never
+            # mutate `data_entry.data`, which would dirty the ORM row and
+            # cause SQLAlchemy to flush computed values back into the source-
+            # of-truth JSON column on the next session flush/commit.
+            enriched_data: dict = {
                 **data_entry.data,
                 "kg_co2eq": total_kg_co2eq,
                 "primary_factor": {
@@ -597,27 +638,18 @@ class DataEntryRepository:
                 distance_km = (
                     float(_emission.additional_value)
                     if _emission is not None and _emission.additional_value is not None
-                    else data_entry.data.get("distance_km")
+                    else enriched_data.get("distance_km")
                 )
-                data_entry.data = {
-                    **data_entry.data,
-                    **(
-                        {"traveler_name": member_entry.data.get("name")}
-                        if member_entry
-                        else {}
-                    ),
-                    **({"distance_km": distance_km} if distance_km is not None else {}),
-                }
+                if member_entry is not None:
+                    enriched_data["traveler_name"] = member_entry.data.get("name")
+                if distance_km is not None:
+                    enriched_data["distance_km"] = distance_km
             if is_buildings_entry and building_room:
-                surface = building_room.room_surface_square_meter
-                data_entry.data = {
-                    **data_entry.data,
-                    "room_surface_square_meter": surface
-                    if surface is not None
-                    else None,
-                }
+                enriched_data["room_surface_square_meter"] = (
+                    building_room.room_surface_square_meter
+                )
 
-            items.append(handler.to_response(data_entry))
+            items.append(handler.to_response(data_entry, enriched_data))
 
         response = SubmoduleResponse(
             id=data_entry_type_id,

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -583,6 +583,13 @@ class DataEntryRepository:
         items: list[BaseModel] = []
 
         for row in rows:
+            # Pre-bind conditionally-unpacked variables so static type checkers
+            # see them as definitely-bound (T | None) on every branch path.
+            # MemberEntry is a SQLAlchemy alias of DataEntry, so the runtime
+            # type is DataEntry.
+            member_entry: DataEntry | None = None
+            _emission: DataEntryEmission | None = None
+            building_room: BuildingRoom | None = None
             # Unpack based on query shape
             if is_travel_entry:
                 data_entry, total_kg_co2eq, primary_factor, member_entry, _emission = (

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from sqlalchemy import Select, asc, desc, func, or_
 from sqlalchemy import select as sa_select
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import aliased
 from sqlmodel import col, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -51,14 +52,13 @@ class DataEntryRepository:
 
         Silently ignores rows that are not currently attached.
         """
-        from sqlalchemy.exc import InvalidRequestError
-
         for obj in objs:
             if obj is None:
                 continue
             try:
                 self.session.expunge(obj)
             except InvalidRequestError:
+                # Already detached or session-state edge case — nothing to do.
                 pass
 
     async def get(self, id: int) -> Optional[DataEntry]:

--- a/backend/app/schemas/data_entry.py
+++ b/backend/app/schemas/data_entry.py
@@ -128,7 +128,21 @@ class ModuleHandler(Protocol[T]):
     subkind_label_field: Optional[str] = None
     factor_value_fields: Optional[list[str]] = None
 
-    def to_response(self, data_entry: T) -> DataEntryResponseGen: ...
+    def to_response(
+        self,
+        data_entry: T,
+        enriched_data: dict | None = None,
+    ) -> DataEntryResponseGen:
+        """Build the response DTO for a data entry.
+
+        ``enriched_data`` overrides ``data_entry.data`` when provided. Callers
+        from listing endpoints pass it to inject computed values (kg_co2eq,
+        primary_factor, distance_km, ...) without mutating the ORM row, which
+        would otherwise be flushed back to ``DataEntry.data`` and corrupt the
+        source-of-truth column.
+        """
+        ...
+
     def validate_create(self, payload: dict) -> DataEntryCreate: ...
     def validate_update(self, payload: dict) -> DataEntryUpdate: ...
     async def pre_compute(

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -119,6 +119,7 @@ class DataEntryEmissionService:
     async def prepare_create(
         self,
         data_entry: DataEntry | DataEntryResponse,
+        kg_co2eq_override: float | None = None,
     ) -> list[DataEntryEmission]:
         """Prepare emission records for any data entry type.
 
@@ -132,6 +133,10 @@ class DataEntryEmissionService:
 
         Args:
             data_entry: Fully hydrated data entry with ``data_entry_type``.
+            kg_co2eq_override: When set (CSV / API ingestion path), short-circuits
+                the formula and produces a single emission with this kg_co2eq and
+                ``primary_factor_id=None``. The override is passed transiently —
+                it must NOT be persisted in ``data_entry.data``.
 
         Returns:
             Ready-to-insert ``DataEntryEmission`` rows; empty on any failure.
@@ -178,11 +183,9 @@ class DataEntryEmissionService:
             for comp in computations:
                 factors = await self._fetch_factors(comp, year)
 
-                # Check if CSV provides an override value (takes precedence)
-                csv_kg_co2eq = data_entry.data.get("kg_co2eq")
-                if csv_kg_co2eq is not None:
+                if kg_co2eq_override is not None:
                     logger.info(
-                        f"Using CSV-provided kg_co2eq={csv_kg_co2eq} override for "
+                        f"Using kg_co2eq={kg_co2eq_override} override for "
                         f"emission_type={emission_type.name!r} "
                         f"data_entry_id={data_entry.id!r}"
                     )
@@ -191,7 +194,7 @@ class DataEntryEmissionService:
                             data_entry_id=data_entry.id,
                             emission_type_id=comp.emission_type.value,
                             primary_factor_id=None,
-                            kg_co2eq=float(csv_kg_co2eq),
+                            kg_co2eq=float(kg_co2eq_override),
                             scope=comp.emission_type.scope,
                             meta={
                                 "factors_used": [
@@ -480,17 +483,6 @@ class DataEntryEmissionService:
         First deletes existing emissions for this data entry, then creates new ones.
         Returns the list of created/updated emissions.
         """
-        # Strip any stored kg_co2eq from data before recomputing so that the
-        # CSV override in prepare_create does not suppress the formula.
-        # (e.g. a changed number_of_trips).
-        if data_entry_response.data.get("kg_co2eq") is not None:
-            clean_data = {
-                k: v for k, v in data_entry_response.data.items() if k != "kg_co2eq"
-            }
-            data_entry_response = data_entry_response.model_copy(
-                update={"data": clean_data}
-            )
-
         # Prepare the emission records
         prepared_emissions = await self.prepare_create(data_entry_response)
         if not prepared_emissions:

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -437,7 +437,9 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
                 try:
                     override = float(kg_co2eq)
                 except (ValueError, TypeError):
-                    logger.debug(
+                    # Surface unparseable overrides at WARNING so operators see
+                    # the silent fallback to formula-based emissions in the log.
+                    logger.warning(
                         f"Invalid kg_co2eq value {kg_co2eq!r} from API source, "
                         f"ignoring override"
                     )

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -406,20 +406,21 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
         emission_service = DataEntryEmissionService(self.data_session)
 
         # Create data entries with preserved CO2 values
+        # kg_co2eq is carried out-of-band (parallel list) so it never lands
+        # in DataEntry.data; the override is applied transiently when emissions
+        # are created.
         entries = []
+        kg_co2eq_overrides: list[float | None] = []
         for item in data:
             carbon_report_module_id = item.get("carbon_report_module_id")
             if not carbon_report_module_id:
                 continue
 
-            # Extract CO2 values from item (preserved from source)
             kg_co2eq = item.get("kg_co2eq") or item.get("OUT_CO2_CORRECTED")
             distance_km = item.get("distance_km") or item.get("OUT_DISTANCE_CORRECTED")
 
-            # Store in data payload
             data_payload = dict(item)
-            if kg_co2eq is not None:
-                data_payload["kg_co2eq"] = kg_co2eq
+            data_payload.pop("kg_co2eq", None)
             if distance_km is not None:
                 data_payload["distance_km"] = distance_km
 
@@ -429,6 +430,7 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
                 data=data_payload,
             )
             entries.append(entry)
+            kg_co2eq_overrides.append(float(kg_co2eq) if kg_co2eq is not None else None)
 
         if not entries:
             return {"inserted": 0}
@@ -442,14 +444,21 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
             created_by_id=self.job_id,
         )
 
+        # Build {data_entry.id: kg_co2eq} override map. bulk_create preserves
+        # input order, so we can zip responses with the parallel overrides list.
+        overrides_by_id: dict[int, float] = {
+            resp.id: ov
+            for resp, ov in zip(data_entries_response, kg_co2eq_overrides)
+            if ov is not None and resp.id is not None
+        }
+
         # Prepare and create emissions using preserved CO2 values
         emissions_to_create = []
         for data_entry_response in data_entries_response:
             try:
-                # Use emission service to prepare emissions
-                # This will use the preserved kg_co2eq from data payload
                 emission_objs = await emission_service.prepare_create(
-                    data_entry_response
+                    data_entry_response,
+                    kg_co2eq_override=overrides_by_id.get(data_entry_response.id),
                 )
                 if emission_objs is not None:
                     emissions_to_create.extend(emission_objs)

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -430,7 +430,18 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
                 data=data_payload,
             )
             entries.append(entry)
-            kg_co2eq_overrides.append(float(kg_co2eq) if kg_co2eq is not None else None)
+            # Coerce the override value to float; log + skip on garbage values
+            # rather than crashing the whole batch (mirrors base_csv_provider).
+            override: float | None = None
+            if kg_co2eq is not None:
+                try:
+                    override = float(kg_co2eq)
+                except (ValueError, TypeError):
+                    logger.debug(
+                        f"Invalid kg_co2eq value {kg_co2eq!r} from API source, "
+                        f"ignoring override"
+                    )
+            kg_co2eq_overrides.append(override)
 
         if not entries:
             return {"inserted": 0}

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -820,7 +820,9 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 try:
                     kg_co2eq_override = float(raw_kg)
                 except (ValueError, TypeError):
-                    logger.debug(
+                    # Surface unparseable overrides at WARNING so operators see
+                    # the silent fallback to formula-based emissions in the log.
+                    logger.warning(
                         f"Row {row_idx}: invalid kg_co2eq value {raw_kg!r}, "
                         f"ignoring override"
                     )

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -589,6 +589,9 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
 
             # Process CSV rows
             batch: List[DataEntry] = []
+            # Parallel list of kg_co2eq overrides aligned with `batch` by index.
+            # Carried out-of-band so kg_co2eq never lands in DataEntry.data.
+            batch_kg_co2eq_overrides: List[float | None] = []
             # Track seen user_institutional_ids per module to catch intra-CSV duplicates
             seen_institutional_ids: Dict[int, set] = {}
             csv_reader = csv.DictReader(
@@ -596,8 +599,14 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             )
 
             for row_idx, row in enumerate(csv_reader, start=1):
-                # Process single row, returns (data_entry, error_msg, factor)
-                data_entry, error_msg, factor = await self._process_row(
+                # Process single row, returns
+                # (data_entry, error_msg, factor, kg_co2eq_override)
+                (
+                    data_entry,
+                    error_msg,
+                    factor,
+                    kg_co2eq_override,
+                ) = await self._process_row(
                     row,
                     row_idx,
                     setup_result,
@@ -644,6 +653,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
 
                 # Row processed successfully
                 batch.append(data_entry)
+                batch_kg_co2eq_overrides.append(kg_co2eq_override)
                 if factor:
                     stats["rows_with_factors"] += 1
                 else:
@@ -653,7 +663,11 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 # Process batch when it reaches BATCH_SIZE
                 if len(batch) >= BATCH_SIZE:
                     await self._process_batch(
-                        batch, data_entry_service, emission_service, self.user
+                        batch,
+                        data_entry_service,
+                        emission_service,
+                        self.user,
+                        batch_kg_co2eq_overrides,
                     )
                     stats["batches_processed"] += 1
                     logger.info(
@@ -661,6 +675,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                         f"{stats['rows_processed']} rows total"
                     )
                     batch = []
+                    batch_kg_co2eq_overrides = []
                     # Update job progress every batche
                     if stats["batches_processed"]:
                         await self._update_job(
@@ -672,7 +687,12 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
 
             # Finalize: process remaining batch, move file, update job
             return await self._finalize_and_commit(
-                batch, data_entry_service, emission_service, stats, setup_result
+                batch,
+                data_entry_service,
+                emission_service,
+                stats,
+                setup_result,
+                batch_kg_co2eq_overrides,
             )
 
         except Exception as e:
@@ -772,11 +792,15 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         stats: StatsDict,
         max_row_errors: int,
         unit_to_module_map: Dict[str, int] | None = None,
-    ) -> tuple[DataEntry | None, str | None, Any | None]:
+    ) -> tuple[DataEntry | None, str | None, Any | None, float | None]:
         """
         Process a single CSV row.
-        Returns (DataEntry, error_msg, factor) tuple.
+        Returns (DataEntry, error_msg, factor, kg_co2eq_override) tuple.
         If error_msg is not None, row processing failed and error was recorded.
+
+        ``kg_co2eq_override`` is carried out-of-band so it never lands in
+        ``DataEntry.data``; the caller passes it transiently to
+        ``prepare_create`` when emissions are built.
 
         Args:
             unit_to_module_map: Optional mapping of institutional_id
@@ -785,13 +809,21 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         """
         try:
             handlers = setup_result["handlers"]
-            # factors_map = setup_result["factors_map"]
             expected_columns = setup_result["expected_columns"]
-            # force kg_co2eq column in expected columns to allow flexibility
-            # in handlers (some may not require it,
-            # for module_year it is required for factor resolution,
-            # but for module_unit_specific it is not needed and often not provided)
-            # expected_columns.add("kg_co2eq")
+
+            # Extract kg_co2eq override from the raw row (carried out-of-band).
+            # Bypasses expected_columns intentionally: not every handler lists
+            # kg_co2eq there, but it's still a valid override when present.
+            kg_co2eq_override: float | None = None
+            raw_kg = row.get("kg_co2eq")
+            if raw_kg is not None and raw_kg.strip() != "":
+                try:
+                    kg_co2eq_override = float(raw_kg)
+                except (ValueError, TypeError):
+                    logger.debug(
+                        f"Row {row_idx}: invalid kg_co2eq value {raw_kg!r}, "
+                        f"ignoring override"
+                    )
 
             # Filter row to only include expected columns
             filtered_row = {
@@ -799,14 +831,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 for k, v in row.items()
                 if k in expected_columns and v is not None and v.strip() != ""
             }
-            # special kg_co2eq handling: include it if present in row,
-            # even if not in expected_columns
-            if (
-                "kg_co2eq" in row
-                and row["kg_co2eq"] is not None
-                and row["kg_co2eq"].strip() != ""
-            ):
-                filtered_row["kg_co2eq"] = row["kg_co2eq"]
 
             # Extract kind/subkind values (entity-specific extraction)
             kind_value, subkind_value = self._extract_kind_subkind_values(
@@ -823,12 +847,12 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             )
 
             if error_msg:
-                return None, error_msg, None
+                return None, error_msg, None, None
 
             if not data_entry_type or not handler:
                 error_msg = "Failed to resolve handler and data_entry_type"
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-                return None, error_msg, None
+                return None, error_msg, None, None
 
             # Resolve primary_factor_id from in-memory factors_map (NOT DB query!)
             # This avoids 100k+ DB queries - factors already loaded in setup phase
@@ -869,7 +893,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 ):
                     error_msg = "Missing unit_institutional_id in row"
                     self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-                    return None, error_msg, None
+                    return None, error_msg, None, None
 
                 unit_institutional_id = str(unit_institutional_id).strip()
 
@@ -884,7 +908,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                         self._missing_units_logged.add(unit_institutional_id)
                     error_msg = f"Unit '{unit_institutional_id}' not found"
                     self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-                    return None, error_msg, None
+                    return None, error_msg, None, None
 
                 carbon_report_module_id = unit_to_module_map.get(unit_institutional_id)
                 if not carbon_report_module_id:
@@ -893,7 +917,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                         f"institutional_id={unit_institutional_id}"
                     )
                     self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-                    return None, error_msg, None
+                    return None, error_msg, None, None
             elif self.carbon_report_module_id:
                 # MODULE_UNIT_SPECIFIC: use pre-configured value
                 carbon_report_module_id = self.carbon_report_module_id
@@ -901,7 +925,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 # Neither mapping nor pre-configured value available
                 error_msg = "Missing carbon_report_module_id"
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-                return None, error_msg, None
+                return None, error_msg, None, None
 
             # Validate payload with handler (primary_factor_id already
             # set by ModuleHandlerService)
@@ -916,7 +940,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             except Exception as validation_error:
                 error_msg = f"Validation error: {validation_error}"
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-                return None, error_msg, None
+                return None, error_msg, None, None
 
             # Build DataEntry
             data = dict(validated.data)
@@ -955,13 +979,13 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 data=data,
             )
 
-            return data_entry, None, None
+            return data_entry, None, None, kg_co2eq_override
 
         except Exception as row_error:
             logger.error(f"Row {row_idx}: Error processing row: {str(row_error)}")
             error_msg = f"Row processing error: {row_error}"
             self._record_row_error(stats, row_idx, error_msg, max_row_errors)
-            return None, error_msg, None
+            return None, error_msg, None, None
 
     def _compute_ingestion_result(self, stats: StatsDict) -> IngestionResult:
         """
@@ -996,6 +1020,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         emission_service: DataEntryEmissionService,
         stats: StatsDict,
         setup_result: Dict[str, Any],
+        batch_kg_co2eq_overrides: List[float | None],
     ) -> Dict[str, Any]:
         """
         Finalize: process remaining batch, move file to processed/, update job.
@@ -1003,7 +1028,11 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         # Process final batch (remaining rows < BATCH_SIZE)
         if batch:
             await self._process_batch(
-                batch, data_entry_service, emission_service, self.user
+                batch,
+                data_entry_service,
+                emission_service,
+                self.user,
+                batch_kg_co2eq_overrides,
             )
             stats["batches_processed"] += 1
             logger.info(
@@ -1073,8 +1102,14 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         data_entry_service: DataEntryService,
         emission_service: DataEntryEmissionService,
         user: Optional[User],
+        batch_kg_co2eq_overrides: List[float | None],
     ) -> None:
-        """Process a batch of data entries: bulk insert entries and emissions"""
+        """Process a batch of data entries: bulk insert entries and emissions.
+
+        ``batch_kg_co2eq_overrides`` is index-aligned with ``batch``. Values are
+        applied transiently when emissions are built — they never enter
+        ``DataEntry.data``.
+        """
         if not batch:
             return
 
@@ -1119,12 +1154,22 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             created_by_id=self.job_id,
         )
 
+        # Build {data_entry.id: kg_co2eq} override map. bulk_create preserves
+        # input order (see DataEntryRepository.bulk_create), so zipping the
+        # responses with the parallel overrides list is safe.
+        overrides_by_id: dict[int, float] = {
+            resp.id: ov
+            for resp, ov in zip(data_entries_response, batch_kg_co2eq_overrides)
+            if ov is not None and resp.id is not None
+        }
+
         # 2. Prepare emissions for all created data entries
         emissions_to_create = []
         for data_entry_response in data_entries_response:
             try:
                 emission_objs = await emission_service.prepare_create(
-                    data_entry_response
+                    data_entry_response,
+                    kg_co2eq_override=overrides_by_id.get(data_entry_response.id),
                 )
                 if emission_objs is not None:
                     emissions_to_create.extend(emission_objs)

--- a/backend/app/services/data_ingestion/csv_providers/local_seed.py
+++ b/backend/app/services/data_ingestion/csv_providers/local_seed.py
@@ -357,7 +357,7 @@ class LocalDataEntryCSVProvider(ModulePerYearCSVProvider):
         stats: StatsDict,
         max_row_errors: int,
         unit_to_module_map: Dict[str, int] | None = None,
-    ) -> tuple[Any, str | None, Any]:
+    ) -> tuple[Any, str | None, Any, float | None]:
         if self._location_fields:
             row = dict(row)  # shallow copy to avoid mutating original
             location_id_cache = setup_result.get("location_id_cache", {})
@@ -400,10 +400,15 @@ class LocalDataEntryCSVProvider(ModulePerYearCSVProvider):
         emission_service: Any,
         stats: StatsDict,
         setup_result: Dict[str, Any],
+        batch_kg_co2eq_overrides: List[float | None],
     ) -> Dict[str, Any]:
         if batch:
             await self._process_batch(
-                batch, data_entry_service, emission_service, self.user
+                batch,
+                data_entry_service,
+                emission_service,
+                self.user,
+                batch_kg_co2eq_overrides,
             )
             stats["batches_processed"] += 1
 

--- a/backend/tests/integration/data_ingestion/fixtures/regression_kg_co2eq_plane.csv
+++ b/backend/tests/integration/data_ingestion/fixtures/regression_kg_co2eq_plane.csv
@@ -1,0 +1,4 @@
+origin_iata,destination_iata,cabin_class,user_institutional_id,number_of_trips,kg_co2eq
+GVA,ZRH,first,150322,1,152.685
+CDG,JFK,eco,150322,1,420.5
+GVA,LHR,business,200001,2,380.0

--- a/backend/tests/integration/modules/plane/test_csv_import_smoke.py
+++ b/backend/tests/integration/modules/plane/test_csv_import_smoke.py
@@ -1,10 +1,12 @@
-"""Integration smoke for the plane CSV import path.
+"""Integration smoke for the plane ``_process_batch`` carrier flow.
 
-Exercises the carrier flow end-to-end against a real DB session: a batch
-of plane ``DataEntry`` rows (with ``kg_co2eq`` stripped from ``data``,
-mimicking what ``BaseCSVProvider._process_row`` produces) goes through
-the same ``_process_batch`` routine the production CSV upload uses,
-backed by the real ``DataEntryService`` and ``DataEntryEmissionService``.
+Exercises the second half of the CSV ingestion pipeline end-to-end
+against a real DB session: a batch of plane ``DataEntry`` rows
+(constructed by hand, mirroring what
+``BaseCSVProvider._process_row`` produces — i.e. ``kg_co2eq`` already
+stripped from ``data``) goes through the same ``_process_batch``
+routine the production CSV upload uses, backed by the real
+``DataEntryService`` and ``DataEntryEmissionService``.
 
 Asserts the two invariants from the PR's manual test plan:
 
@@ -14,11 +16,22 @@ Asserts the two invariants from the PR's manual test plan:
    value, and the row must have ``primary_factor_id=None`` (override
    bypasses the formula path).
 
-Unit-level coverage of ``_process_row`` (CSV row → 4-tuple) and
-``prepare_create`` (override param → emission shape) lives elsewhere;
-this test fills the integration gap by wiring real services and DB.
+**Coverage seam — what this test does NOT exercise:**
+
+- The ``CSV row → _process_row → 4-tuple`` half of the pipeline. That's
+  unit-tested in ``tests/unit/services/data_ingestion/test_base_csv_provider.py``
+  (``test_process_row_consumes_dumb_csv_fixture_for_plane`` and
+  siblings). The two tests together sandwich the full CSV import path,
+  but no single test reads the fixture file and runs it through both
+  halves end-to-end.
+- The ``user`` / audit-versioning branch of ``DataEntryService.bulk_create``
+  (we pass ``user=None`` to keep the test focused on persistence). If
+  a future change to that branch accidentally mutated ``data_entry.data``,
+  this test would not catch it.
 """
 
+import csv
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -72,12 +85,13 @@ def _make_provider(data_session: AsyncSession) -> _MinimalPlaneCSVProvider:
 
 
 @pytest.mark.asyncio
-async def test_csv_import_carrier_keeps_kg_co2eq_out_of_data_entry(
+async def test_process_batch_carrier_keeps_kg_co2eq_out_of_data_entry(
     db_session: AsyncSession,
 ):
-    """End-to-end: feed the real services a 3-entry batch matching the
-    plane fixture (GVA→ZRH/CDG→JFK/GVA→LHR), with overrides carried on
-    a parallel list, and verify the final DB state."""
+    """End-to-end through the carrier half of the pipeline: feed the real
+    services a 3-entry batch matching the plane fixture
+    (GVA→ZRH/CDG→JFK/GVA→LHR), with overrides carried on a parallel list,
+    and verify the final DB state."""
     # ---------- arrange: factor + module --------------------------------
     report = CarbonReport(year=2025, unit_id=1, overall_status=0)
     db_session.add(report)
@@ -107,57 +121,46 @@ async def test_csv_import_carrier_keeps_kg_co2eq_out_of_data_entry(
     provider = _make_provider(db_session)
     provider._year_cache = {module.id: 2025}
 
-    # ---------- arrange: a CSV-shaped batch -----------------------------
-    # Mimics what BaseCSVProvider._process_row returns: kg_co2eq has been
-    # extracted out of the row and stripped from `data`. Three entries
-    # mirror the fixture file backend/tests/integration/data_ingestion/
-    # fixtures/regression_kg_co2eq_plane.csv.
-    rows = [
-        {
-            "data": {
-                "origin_iata": "GVA",
-                "destination_iata": "ZRH",
-                "cabin_class": "first",
-                "user_institutional_id": "150322",
-                "number_of_trips": 1,
-                "primary_factor_id": None,
-            },
-            "kg_co2eq_override": 152.685,
-        },
-        {
-            "data": {
-                "origin_iata": "CDG",
-                "destination_iata": "JFK",
-                "cabin_class": "eco",
-                "user_institutional_id": "150322",
-                "number_of_trips": 1,
-                "primary_factor_id": None,
-            },
-            "kg_co2eq_override": 420.5,
-        },
-        {
-            "data": {
-                "origin_iata": "GVA",
-                "destination_iata": "LHR",
-                "cabin_class": "business",
-                "user_institutional_id": "200001",
-                "number_of_trips": 2,
-                "primary_factor_id": None,
-            },
-            "kg_co2eq_override": 380.0,
-        },
-    ]
+    # ---------- arrange: rows derived from the actual CSV fixture -------
+    # The same fixture file the unit test consumes via csv.DictReader.
+    # Mirroring what BaseCSVProvider._process_row produces: kg_co2eq is
+    # extracted out-of-band into the parallel overrides list and the
+    # remaining columns become DataEntry.data with primary_factor_id=None.
+    fixture_path = (
+        Path(__file__).parent.parent.parent
+        / "data_ingestion"
+        / "fixtures"
+        / "regression_kg_co2eq_plane.csv"
+    )
+    assert fixture_path.exists(), f"missing fixture: {fixture_path}"
 
-    batch = [
-        DataEntry(
-            carbon_report_module_id=module.id,
-            data_entry_type_id=DataEntryTypeEnum.plane,
-            data=dict(r["data"]),
-        )
-        for r in rows
-    ]
-    overrides = [r["kg_co2eq_override"] for r in rows]
-    expected_originals = [dict(r["data"]) for r in rows]
+    batch: list[DataEntry] = []
+    overrides: list[float | None] = []
+    expected_originals: list[dict] = []
+    with open(fixture_path, encoding="utf-8") as f:
+        for raw_row in csv.DictReader(f):
+            kg_str = raw_row.pop("kg_co2eq")  # carry out-of-band, never persist
+            row_data = {
+                "origin_iata": raw_row["origin_iata"],
+                "destination_iata": raw_row["destination_iata"],
+                "cabin_class": raw_row["cabin_class"],
+                "user_institutional_id": raw_row["user_institutional_id"],
+                "number_of_trips": int(raw_row["number_of_trips"]),
+                "primary_factor_id": None,
+            }
+            batch.append(
+                DataEntry(
+                    carbon_report_module_id=module.id,
+                    data_entry_type_id=DataEntryTypeEnum.plane,
+                    data=dict(row_data),
+                )
+            )
+            overrides.append(float(kg_str))
+            expected_originals.append(row_data)
+
+    assert len(batch) >= 2, (
+        "fixture should provide enough rows to exercise multi-entry routing"
+    )
 
     # ---------- act: run the real carrier through _process_batch --------
     data_entry_service = DataEntryService(db_session)
@@ -191,7 +194,9 @@ async def test_csv_import_carrier_keeps_kg_co2eq_out_of_data_entry(
         .scalars()
         .all()
     )
-    assert len(persisted_entries) == 3, "expected 3 persisted plane rows"
+    assert len(persisted_entries) == len(batch), (
+        f"expected {len(batch)} persisted plane rows, got {len(persisted_entries)}"
+    )
 
     # Key by (origin, destination) — origin alone isn't unique in the
     # fixture (GVA appears twice, paired with ZRH and LHR).
@@ -224,8 +229,9 @@ async def test_csv_import_carrier_keeps_kg_co2eq_out_of_data_entry(
         .scalars()
         .all()
     )
-    assert len(emissions) == 3, (
-        f"expected 3 emission rows (one per data_entry override), got {len(emissions)}"
+    assert len(emissions) == len(batch), (
+        f"expected {len(batch)} emission rows (one per data_entry override), "
+        f"got {len(emissions)}"
     )
 
     # Pair each emission with its data_entry → original override value via

--- a/backend/tests/integration/modules/plane/test_csv_import_smoke.py
+++ b/backend/tests/integration/modules/plane/test_csv_import_smoke.py
@@ -1,0 +1,254 @@
+"""Integration smoke for the plane CSV import path.
+
+Exercises the carrier flow end-to-end against a real DB session: a batch
+of plane ``DataEntry`` rows (with ``kg_co2eq`` stripped from ``data``,
+mimicking what ``BaseCSVProvider._process_row`` produces) goes through
+the same ``_process_batch`` routine the production CSV upload uses,
+backed by the real ``DataEntryService`` and ``DataEntryEmissionService``.
+
+Asserts the two invariants from the PR's manual test plan:
+
+1. After the import, ``data_entries.data`` rows must NOT contain a
+   ``kg_co2eq`` key — the override is carried out-of-band.
+2. ``data_entry_emissions.kg_co2eq`` must carry the imported override
+   value, and the row must have ``primary_factor_id=None`` (override
+   bypasses the formula path).
+
+Unit-level coverage of ``_process_row`` (CSV row → 4-tuple) and
+``prepare_create`` (override param → emission shape) lives elsewhere;
+this test fills the integration gap by wiring real services and DB.
+"""
+
+from typing import Any
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.constants import ModuleStatus
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.data_ingestion import EntityType
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.services.data_entry_service import DataEntryService
+from app.services.data_ingestion.base_csv_provider import BaseCSVProvider
+
+
+class _MinimalPlaneCSVProvider(BaseCSVProvider):
+    """Just enough of a CSV provider to drive ``_process_batch`` against
+    a real DB. Skips the file-store / job-row / setup machinery."""
+
+    @property
+    def entity_type(self) -> EntityType:
+        return EntityType.MODULE_UNIT_SPECIFIC
+
+    async def _setup_handlers_and_factors(self):
+        return {}
+
+    def _extract_kind_subkind_values(self, filtered_row, handlers):
+        return (None, None)
+
+    async def _resolve_handler_and_validate(
+        self, filtered_row, factor, stats, row_idx, max_row_errors, setup_result
+    ):
+        return (None, None, None)
+
+
+def _make_provider(data_session: AsyncSession) -> _MinimalPlaneCSVProvider:
+    """Construct the minimal provider with a real DB session."""
+    config: dict[str, Any] = {"file_path": "tmp/test.csv"}
+    provider = _MinimalPlaneCSVProvider(
+        config,
+        data_session=data_session,
+        user=None,
+    )
+    # `_process_batch` looks up the report year from this cache before
+    # falling back to a DB query — pre-populating skips the lookup.
+    provider._year_cache = {}
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_csv_import_carrier_keeps_kg_co2eq_out_of_data_entry(
+    db_session: AsyncSession,
+):
+    """End-to-end: feed the real services a 3-entry batch matching the
+    plane fixture (GVA→ZRH/CDG→JFK/GVA→LHR), with overrides carried on
+    a parallel list, and verify the final DB state."""
+    # ---------- arrange: factor + module --------------------------------
+    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
+    db_session.add(report)
+    await db_session.flush()
+
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status=ModuleStatus.NOT_STARTED,
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    factor = Factor(
+        emission_type_id=EmissionType.professional_travel__plane.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
+        classification={"category": "very_short_haul", "year": 2025},
+        values={
+            "ef_kg_co2eq_per_km": 0.174,
+            "rfi_adjustment": 2.7,
+        },
+        year=2025,
+    )
+    db_session.add(factor)
+    await db_session.commit()
+
+    provider = _make_provider(db_session)
+    provider._year_cache = {module.id: 2025}
+
+    # ---------- arrange: a CSV-shaped batch -----------------------------
+    # Mimics what BaseCSVProvider._process_row returns: kg_co2eq has been
+    # extracted out of the row and stripped from `data`. Three entries
+    # mirror the fixture file backend/tests/integration/data_ingestion/
+    # fixtures/regression_kg_co2eq_plane.csv.
+    rows = [
+        {
+            "data": {
+                "origin_iata": "GVA",
+                "destination_iata": "ZRH",
+                "cabin_class": "first",
+                "user_institutional_id": "150322",
+                "number_of_trips": 1,
+                "primary_factor_id": None,
+            },
+            "kg_co2eq_override": 152.685,
+        },
+        {
+            "data": {
+                "origin_iata": "CDG",
+                "destination_iata": "JFK",
+                "cabin_class": "eco",
+                "user_institutional_id": "150322",
+                "number_of_trips": 1,
+                "primary_factor_id": None,
+            },
+            "kg_co2eq_override": 420.5,
+        },
+        {
+            "data": {
+                "origin_iata": "GVA",
+                "destination_iata": "LHR",
+                "cabin_class": "business",
+                "user_institutional_id": "200001",
+                "number_of_trips": 2,
+                "primary_factor_id": None,
+            },
+            "kg_co2eq_override": 380.0,
+        },
+    ]
+
+    batch = [
+        DataEntry(
+            carbon_report_module_id=module.id,
+            data_entry_type_id=DataEntryTypeEnum.plane,
+            data=dict(r["data"]),
+        )
+        for r in rows
+    ]
+    overrides = [r["kg_co2eq_override"] for r in rows]
+    expected_originals = [dict(r["data"]) for r in rows]
+
+    # ---------- act: run the real carrier through _process_batch --------
+    data_entry_service = DataEntryService(db_session)
+    emission_service = DataEntryEmissionService(db_session)
+
+    # `_process_batch` calls bulk_create with a `user` arg; the v1 path
+    # passes a real User. For the test, a MagicMock with the few attrs
+    # bulk_create touches is enough — but we set provider.user=None up
+    # front to skip UserRead.model_validate, and pass user=None here.
+    await provider._process_batch(
+        batch,
+        data_entry_service,
+        emission_service,
+        None,  # user — bypasses audit/version logic
+        overrides,
+    )
+    await db_session.commit()
+
+    # ---------- assert (1): persisted DataEntry.data is clean -----------
+    # Note: DataEntryRepository.bulk_create constructs *new* ORM
+    # instances internally (model_validate), so the originals in `batch`
+    # never get their .id populated. Re-read from the DB.
+    persisted_entries = list(
+        (
+            await db_session.execute(
+                select(DataEntry)
+                .where(DataEntry.carbon_report_module_id == module.id)
+                .order_by(DataEntry.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(persisted_entries) == 3, "expected 3 persisted plane rows"
+
+    # Key by (origin, destination) — origin alone isn't unique in the
+    # fixture (GVA appears twice, paired with ZRH and LHR).
+    persisted_by_route = {
+        (e.data["origin_iata"], e.data["destination_iata"]): e
+        for e in persisted_entries
+    }
+    for original in expected_originals:
+        route = (original["origin_iata"], original["destination_iata"])
+        e = persisted_by_route[route]
+        assert e.data == original, (
+            f"DataEntry.data was mutated by the import.\n"
+            f"  expected: {original!r}\n"
+            f"  actual:   {e.data!r}"
+        )
+        assert "kg_co2eq" not in e.data, (
+            f"kg_co2eq leaked into DataEntry.data: {e.data!r}"
+        )
+
+    # ---------- assert (2): emissions carry the override values ---------
+    persisted_ids = [e.id for e in persisted_entries]
+    emissions = list(
+        (
+            await db_session.execute(
+                select(DataEntryEmission).where(
+                    DataEntryEmission.data_entry_id.in_(persisted_ids)  # type: ignore[union-attr]
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(emissions) == 3, (
+        f"expected 3 emission rows (one per data_entry override), got {len(emissions)}"
+    )
+
+    # Pair each emission with its data_entry → original override value via
+    # the (origin, destination) route, which is unique across the fixture.
+    route_by_entry_id = {
+        e.id: (e.data["origin_iata"], e.data["destination_iata"])
+        for e in persisted_entries
+    }
+    override_by_route = {
+        (original["origin_iata"], original["destination_iata"]): ov
+        for original, ov in zip(expected_originals, overrides, strict=True)
+    }
+    for emission in emissions:
+        route = route_by_entry_id[emission.data_entry_id]
+        expected_kg = override_by_route[route]
+        assert emission.kg_co2eq == pytest.approx(expected_kg), (
+            f"emission for {route} has kg_co2eq={emission.kg_co2eq}, "
+            f"expected {expected_kg}"
+        )
+        # The override path always produces primary_factor_id=None — that's
+        # the contract that distinguishes "imported value" from "computed
+        # via factor formula".
+        assert emission.primary_factor_id is None, (
+            f"override-path emission must have primary_factor_id=None, "
+            f"got {emission.primary_factor_id}"
+        )

--- a/backend/tests/integration/modules/plane/test_persistence_invariant.py
+++ b/backend/tests/integration/modules/plane/test_persistence_invariant.py
@@ -1,0 +1,218 @@
+"""Integration regression: listing a plane submodule must NOT persist
+computed fields back into ``DataEntry.data``.
+
+This is the integration-shaped counterpart of the repo unit test in
+``tests/unit/repositories/test_data_entry_repo.py::test_get_submodule_data_does_not_persist_computed_fields``.
+
+The unit test exercises ``get_submodule_data`` against a DataEntry with
+no emissions (so all the JOINs return NULL and the read code path is
+partially covered). This test goes further:
+
+- seeds a real ``DataEntryEmission`` row so the JOINs return a populated
+  ``total_kg_co2eq`` and the enriched payload actually has values to
+  inject — closer to the production path where the bug surfaced;
+- triggers a follow-up DB write in the same session after listing
+  (mimicking what happens during a normal request lifecycle when
+  recompute / audit / stats updates flush dirty rows);
+- re-reads the raw row through a fresh ORM lookup and asserts the JSON
+  column is byte-identical to the original input.
+
+Pre-fix (commit 804e1f79^), the listing dirty-flushed ``data_entry.data``
+with ``kg_co2eq`` / ``primary_factor`` / ``distance_km`` /
+``traveler_name`` keys; this test would fail. After the fix, the JSON
+column stays clean regardless of how many flushes happen downstream.
+"""
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.constants import ModuleStatus
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryStatusEnum, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.repositories.data_entry_repo import DataEntryRepository
+
+# Forbidden keys: derived/computed values that the listing endpoint
+# enriches into the response payload and that must NEVER end up in the
+# persisted ``data_entries.data`` JSON column.
+COMPUTED_KEYS = (
+    "kg_co2eq",
+    "primary_factor",
+    "traveler_name",
+    "distance_km",
+    "room_surface_square_meter",
+)
+
+
+@pytest.mark.asyncio
+async def test_listing_plane_with_emissions_does_not_pollute_data(
+    db_session: AsyncSession,
+):
+    """End-to-end: seed factor + module + plane DataEntry + emission, list
+    via the submodule endpoint, commit, mutate something, commit again, and
+    confirm the original ``data`` dict is preserved verbatim.
+    """
+    repo = DataEntryRepository(db_session)
+
+    # ---------- arrange: realistic plane scenario ------------------------
+    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
+    db_session.add(report)
+    await db_session.flush()
+
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status=ModuleStatus.NOT_STARTED,
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    factor = Factor(
+        emission_type_id=EmissionType.professional_travel__plane.value,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
+        classification={"category": "very_short_haul", "year": 2025},
+        values={
+            "ef_kg_co2eq_per_km": 0.174,
+            "rfi_adjustment": 2.7,
+            "class_adjustement": 2,
+        },
+        year=2025,
+    )
+    db_session.add(factor)
+    await db_session.flush()
+
+    # The exact shape the user reported in the bug write-up: GVA→ZRH first
+    # class, no precomputed kg_co2eq, primary_factor_id linked.
+    original_data = {
+        "origin_iata": "GVA",
+        "destination_iata": "ZRH",
+        "cabin_class": "first",
+        "user_institutional_id": "150322",
+        "number_of_trips": 1,
+        "departure_date": "2025/01/09",
+        "primary_factor_id": factor.id,
+    }
+    entry = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data=dict(original_data),
+    )
+    db_session.add(entry)
+    await db_session.flush()
+    entry_id = entry.id
+
+    # Seed a populated emission so the JOINs in get_submodule_data return
+    # non-NULL totals — this exercises the enrichment code path that
+    # built the (previously persisted) ``primary_factor`` / ``kg_co2eq``
+    # / ``distance_km`` keys.
+    emission = DataEntryEmission(
+        data_entry_id=entry_id,
+        emission_type_id=EmissionType.professional_travel__plane.value,
+        primary_factor_id=factor.id,
+        kg_co2eq=152.685,
+        additional_value=877.5,  # used as distance_km for travel entries
+        scope=None,
+        meta={},
+    )
+    db_session.add(emission)
+    await db_session.commit()
+
+    # ---------- act: list, then trigger downstream writes ---------------
+    listing = await repo.get_submodule_data(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
+        limit=10,
+        offset=0,
+        sort_by="id",
+        sort_order="asc",
+    )
+
+    # Confirm enrichment actually happened — the response items should
+    # carry the computed fields. If they don't, the test setup is wrong
+    # and the assertions below would pass vacuously.
+    assert listing.count == 1, "expected exactly one listed plane entry"
+
+    # Now do something that would naturally flush the session in a real
+    # request — e.g. updating an unrelated emission. Pre-fix, this is what
+    # caused the dirty data_entry to be persisted.
+    emission.kg_co2eq = 200.0
+    db_session.add(emission)
+    await db_session.commit()
+
+    # ---------- assert: the JSON column is unchanged --------------------
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(select(DataEntry).where(DataEntry.id == entry_id))
+    ).scalar_one()
+
+    assert refreshed.data == original_data, (
+        f"DataEntry.data was mutated by the listing pipeline.\n"
+        f"  expected: {original_data!r}\n"
+        f"  actual:   {refreshed.data!r}"
+    )
+    for key in COMPUTED_KEYS:
+        assert key not in refreshed.data, (
+            f"computed key {key!r} leaked into DataEntry.data: {refreshed.data!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_repeated_listings_dont_compound_pollution(
+    db_session: AsyncSession,
+):
+    """Stress variant: list the same submodule three times with a flush
+    between each, and confirm ``data`` is still pristine. Catches the
+    case where a partial fix only prevents the first listing from
+    polluting but a later one still does.
+    """
+    repo = DataEntryRepository(db_session)
+
+    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
+    db_session.add(report)
+    await db_session.flush()
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status=ModuleStatus.NOT_STARTED,
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    original_data = {
+        "origin_iata": "CDG",
+        "destination_iata": "JFK",
+        "cabin_class": "eco",
+        "user_institutional_id": "u1",
+        "number_of_trips": 1,
+        "primary_factor_id": None,
+    }
+    entry = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data=dict(original_data),
+    )
+    db_session.add(entry)
+    await db_session.commit()
+    entry_id = entry.id
+
+    for _ in range(3):
+        await repo.get_submodule_data(
+            carbon_report_module_id=module.id,
+            data_entry_type_id=DataEntryTypeEnum.plane.value,
+            limit=10,
+            offset=0,
+            sort_by="id",
+            sort_order="asc",
+        )
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(select(DataEntry).where(DataEntry.id == entry_id))
+    ).scalar_one()
+    assert refreshed.data == original_data

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -1166,3 +1166,63 @@ async def test_get_submodule_data_does_not_persist_computed_fields(
         assert forbidden_key not in refreshed.data, (
             f"computed key {forbidden_key!r} leaked into DataEntry.data"
         )
+
+
+# ======================================================================
+# Regression: _detach helper handles all session-state edge cases
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_detach_handles_none_attached_and_already_detached(
+    db_session: AsyncSession,
+):
+    """`_detach` must:
+    - silently no-op on None entries (varargs may include unloaded joins),
+    - successfully detach an attached ORM row,
+    - swallow InvalidRequestError when an already-detached row is passed.
+
+    Locks in the helper's contract so a future tightening of the except clause
+    or removal of the None guard would be caught.
+    """
+    repo = DataEntryRepository(db_session)
+
+    module = CarbonReportModule(
+        carbon_report_id=1,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status="in_progress",
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    entry = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data={"origin_iata": "GVA"},
+    )
+    db_session.add(entry)
+    await db_session.flush()
+
+    # 1. None varargs are tolerated.
+    repo._detach(None, None)
+
+    # 2. An attached ORM instance is detached.
+    assert entry in db_session.sync_session
+    repo._detach(entry)
+    assert entry not in db_session.sync_session
+
+    # 3. A second call on the now-detached row swallows InvalidRequestError.
+    repo._detach(entry)  # must not raise
+
+    # 4. Mixed call (None + already-detached + freshly-loaded) all succeed.
+    other = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data={"origin_iata": "ZRH"},
+    )
+    db_session.add(other)
+    await db_session.flush()
+    repo._detach(None, entry, other)
+    assert other not in db_session.sync_session

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -1084,3 +1084,85 @@ async def test_list_by_data_entry_type_and_year_filters_by_type(
 
     assert len(results) == 1
     assert results[0].data_entry_type_id == DataEntryTypeEnum.plane
+
+
+# ======================================================================
+# Regression: read path must not persist computed fields back to data
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_submodule_data_does_not_persist_computed_fields(
+    db_session: AsyncSession,
+):
+    """``get_submodule_data`` must never write computed values (kg_co2eq,
+    primary_factor, distance_km, traveler_name, room_surface_square_meter)
+    back to the source-of-truth ``DataEntry.data`` JSON column.
+
+    Pre-fix, the method reassigned ``data_entry.data = {...}`` on the loaded
+    ORM row, which SQLAlchemy then flushed to the DB. This test fails on
+    that buggy code and passes after Option 1 + Option 2 are applied.
+    """
+    from sqlmodel import select
+
+    repo = DataEntryRepository(db_session)
+
+    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
+    db_session.add(report)
+    await db_session.flush()
+
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status="in_progress",
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    original_data = {
+        "origin_iata": "GVA",
+        "destination_iata": "ZRH",
+        "cabin_class": "first",
+        "user_institutional_id": "150322",
+        "number_of_trips": 1,
+        "primary_factor_id": None,
+    }
+    entry = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data=dict(original_data),
+    )
+    db_session.add(entry)
+    await db_session.commit()
+    entry_id = entry.id
+
+    # Act: list the entries — pre-fix, this would mutate `data_entry.data`
+    # in-memory and SQLAlchemy would flush the mutation on the next query.
+    await repo.get_submodule_data(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
+        limit=10,
+        offset=0,
+        sort_by="id",
+        sort_order="asc",
+    )
+    await db_session.commit()
+    db_session.expire_all()
+
+    refreshed = (
+        await db_session.execute(select(DataEntry).where(DataEntry.id == entry_id))
+    ).scalar_one()
+
+    # The JSON column must be byte-identical to the original input.
+    assert refreshed.data == original_data
+    for forbidden_key in (
+        "kg_co2eq",
+        "primary_factor",
+        "traveler_name",
+        "distance_km",
+        "room_surface_square_meter",
+    ):
+        assert forbidden_key not in refreshed.data, (
+            f"computed key {forbidden_key!r} leaked into DataEntry.data"
+        )

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -480,7 +480,12 @@ async def test_process_row_success_with_unit_mapping(monkeypatch):
     row = {"unit_institutional_id": "U1", "amount": "10", "label": "x"}
     stats = _build_stats()
 
-    data_entry, error_msg, result_factor = await provider._process_row(
+    (
+        data_entry,
+        error_msg,
+        result_factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
         row,
         row_idx=1,
         setup_result=setup_result,
@@ -512,7 +517,12 @@ async def test_process_row_missing_unit_mapping_records_error():
     row = {"unit_id": "UNKNOWN", "amount": "10"}
     stats = _build_stats()
 
-    data_entry, error_msg, result_factor = await provider._process_row(
+    (
+        data_entry,
+        error_msg,
+        result_factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
         row,
         row_idx=2,
         setup_result=setup_result,
@@ -553,7 +563,12 @@ async def test_process_row_validation_error_records_error(monkeypatch):
     row = {"amount": "10"}
     stats = _build_stats()
 
-    data_entry, error_msg, result_factor = await provider._process_row(
+    (
+        data_entry,
+        error_msg,
+        result_factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
         row,
         row_idx=3,
         setup_result=setup_result,
@@ -565,6 +580,231 @@ async def test_process_row_validation_error_records_error(monkeypatch):
     assert data_entry is None
     assert result_factor is None
     assert stats["rows_skipped"] == 1
+
+
+# ======================================================================
+# Regression: kg_co2eq must NOT be persisted into DataEntry.data
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_process_row_extracts_kg_co2eq_out_of_band():
+    """A CSV row with a `kg_co2eq` column must produce a `DataEntry` whose
+    persisted ``data`` does NOT contain that key. The value must be returned
+    as the 4th tuple element so the caller can pass it to ``prepare_create``
+    transiently.
+
+    Regression for the bug where the CSV provider stuffed ``kg_co2eq`` into
+    ``filtered_row`` (and hence into ``DataEntry.data``), corrupting the
+    source-of-truth JSON column with a derived/imported value.
+    """
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+
+    handler = MagicMock()
+    # validate_create receives the filtered_row payload — confirm kg_co2eq is
+    # NOT present in what it sees, then return whatever data it likes.
+    captured_validation_payload: list[dict] = []
+
+    def fake_validate_create(payload):
+        captured_validation_payload.append(dict(payload))
+        return SimpleNamespace(
+            data={
+                "origin_iata": "GVA",
+                "destination_iata": "ZRH",
+                "cabin_class": "first",
+                "primary_factor_id": None,
+            }
+        )
+
+    handler.validate_create.side_effect = fake_validate_create
+    handler.kind_field = "category"
+    handler.subkind_field = None
+
+    async def resolve_handler(*_args, **_kwargs):
+        return (DataEntryTypeEnum.plane, handler, None)
+
+    provider._resolve_handler_and_validate = resolve_handler
+    provider._extract_kind_subkind_values = lambda *_a, **_kw: ("very_short_haul", None)
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {},
+        "expected_columns": {
+            "origin_iata",
+            "destination_iata",
+            "cabin_class",
+            "user_institutional_id",
+            "number_of_trips",
+        },
+    }
+    # Note: kg_co2eq is intentionally absent from expected_columns — the
+    # provider must extract it directly from the raw row regardless.
+    row = {
+        "origin_iata": "GVA",
+        "destination_iata": "ZRH",
+        "cabin_class": "first",
+        "user_institutional_id": "150322",
+        "number_of_trips": "1",
+        "kg_co2eq": "152.685",
+    }
+    stats = _build_stats()
+
+    (
+        data_entry,
+        error_msg,
+        _factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
+        row,
+        row_idx=1,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=5,
+        unit_to_module_map=None,
+    )
+
+    assert error_msg is None
+    assert data_entry is not None
+
+    # 1. The override is returned out-of-band as a float.
+    assert kg_co2eq_override == pytest.approx(152.685)
+
+    # 2. kg_co2eq must NOT have leaked into the persisted DataEntry.data.
+    assert "kg_co2eq" not in data_entry.data, (
+        f"kg_co2eq leaked into DataEntry.data: {data_entry.data!r}"
+    )
+
+    # 3. validate_create must have received the row WITHOUT kg_co2eq.
+    assert len(captured_validation_payload) == 1
+    assert "kg_co2eq" not in captured_validation_payload[0]
+
+
+@pytest.mark.asyncio
+async def test_process_row_with_no_kg_co2eq_returns_none_override():
+    """Rows without a kg_co2eq column produce a None override — not an
+    error, not a side effect on DataEntry.data."""
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+
+    handler = MagicMock()
+    handler.validate_create.return_value = SimpleNamespace(
+        data={
+            "origin_iata": "GVA",
+            "destination_iata": "ZRH",
+            "primary_factor_id": None,
+        }
+    )
+    handler.kind_field = "category"
+    handler.subkind_field = None
+
+    async def resolve_handler(*_args, **_kwargs):
+        return (DataEntryTypeEnum.plane, handler, None)
+
+    provider._resolve_handler_and_validate = resolve_handler
+    provider._extract_kind_subkind_values = lambda *_a, **_kw: ("very_short_haul", None)
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {},
+        "expected_columns": {"origin_iata", "destination_iata"},
+    }
+    row = {"origin_iata": "GVA", "destination_iata": "ZRH"}
+    stats = _build_stats()
+
+    _data_entry, error_msg, _factor, kg_co2eq_override = await provider._process_row(
+        row,
+        row_idx=1,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=5,
+        unit_to_module_map=None,
+    )
+
+    assert error_msg is None
+    assert kg_co2eq_override is None
+
+
+@pytest.mark.asyncio
+async def test_process_row_consumes_dumb_csv_fixture_for_plane():
+    """Consume the dumb plane CSV fixture row-by-row via csv.DictReader and
+    verify each row's kg_co2eq is extracted out-of-band — not persisted into
+    DataEntry.data. This is the integration-shape regression for the user's
+    debugging case (GVA→ZRH plane import).
+    """
+    import csv as _csv
+    from pathlib import Path
+
+    fixture_path = (
+        Path(__file__).parent.parent.parent.parent
+        / "integration"
+        / "data_ingestion"
+        / "fixtures"
+        / "regression_kg_co2eq_plane.csv"
+    )
+    assert fixture_path.exists(), f"missing fixture: {fixture_path}"
+
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+
+    handler = MagicMock()
+    handler.validate_create.side_effect = lambda payload: SimpleNamespace(
+        data={k: v for k, v in payload.items() if k != "data_entry_type_id"}
+    )
+    handler.kind_field = "category"
+    handler.subkind_field = None
+
+    async def resolve_handler(*_args, **_kwargs):
+        return (DataEntryTypeEnum.plane, handler, None)
+
+    provider._resolve_handler_and_validate = resolve_handler
+    provider._extract_kind_subkind_values = lambda *_a, **_kw: ("very_short_haul", None)
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {},
+        "expected_columns": {
+            "origin_iata",
+            "destination_iata",
+            "cabin_class",
+            "user_institutional_id",
+            "number_of_trips",
+        },
+    }
+
+    with open(fixture_path, encoding="utf-8") as f:
+        rows = list(_csv.DictReader(f))
+
+    # Sanity: fixture really has kg_co2eq column with non-empty values.
+    assert all(r.get("kg_co2eq") for r in rows), rows
+    expected_overrides = [float(r["kg_co2eq"]) for r in rows]
+
+    actual_overrides = []
+    for row_idx, row in enumerate(rows, start=1):
+        stats = _build_stats()
+        (
+            data_entry,
+            error_msg,
+            _factor,
+            kg_co2eq_override,
+        ) = await provider._process_row(
+            row,
+            row_idx=row_idx,
+            setup_result=setup_result,
+            stats=stats,
+            max_row_errors=5,
+            unit_to_module_map=None,
+        )
+
+        assert error_msg is None, f"row {row_idx} errored: {error_msg}"
+        assert data_entry is not None
+        # Per-row invariant: kg_co2eq is NOT in the persisted data dict.
+        assert "kg_co2eq" not in data_entry.data, (
+            f"row {row_idx}: kg_co2eq leaked into DataEntry.data: {data_entry.data!r}"
+        )
+        actual_overrides.append(kg_co2eq_override)
+
+    assert actual_overrides == pytest.approx(expected_overrides)
 
 
 # ======================================================================
@@ -602,11 +842,74 @@ async def test_process_batch_creates_emissions():
         institutional_id="default-1441",
     )
 
-    await provider._process_batch(batch, data_entry_service, emission_service, user)
+    # No CSV kg_co2eq overrides for this batch (parallel list of None).
+    await provider._process_batch(
+        batch, data_entry_service, emission_service, user, [None]
+    )
 
     data_entry_service.bulk_create.assert_awaited_once()
-    emission_service.prepare_create.assert_awaited_once_with(created_entry)
+    emission_service.prepare_create.assert_awaited_once_with(
+        created_entry, kg_co2eq_override=None
+    )
     emission_service.bulk_create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_batch_routes_kg_co2eq_overrides_by_id():
+    """Carrier flow regression: a batch with kg_co2eq overrides aligned to
+    its inputs must produce a {data_entry.id: kg_co2eq} dict and forward
+    each override per-call to ``prepare_create``.
+
+    This covers the end-to-end carrier path that the unit-level _process_row
+    and prepare_create tests cover only in isolation.
+    """
+    config = {"file_path": "tmp/test.csv"}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+    provider._year_cache = {999: 2025}
+
+    data_entry_service = MagicMock()
+    emission_service = AsyncMock()
+
+    # bulk_create preserves input order — return three responses with
+    # incrementing IDs aligned to the input batch.
+    created_entries = [
+        SimpleNamespace(id=10, carbon_report_module_id=999),
+        SimpleNamespace(id=11, carbon_report_module_id=999),
+        SimpleNamespace(id=12, carbon_report_module_id=999),
+    ]
+    data_entry_service.bulk_create = AsyncMock(return_value=created_entries)
+    emission_service.prepare_create = AsyncMock(return_value=[SimpleNamespace(id=99)])
+    emission_service.bulk_create = AsyncMock()
+
+    batch = []
+    for _ in range(3):
+        e = MagicMock()
+        e.carbon_report_module_id = 999
+        batch.append(e)
+
+    user = SimpleNamespace(
+        id=1,
+        email="test@example.com",
+        display_name="Test User",
+        provider=UserProvider.DEFAULT,
+        institutional_id="default-1441",
+    )
+
+    # Two of three rows have an override; the middle one does not.
+    overrides = [152.685, None, 380.0]
+
+    await provider._process_batch(
+        batch, data_entry_service, emission_service, user, overrides
+    )
+
+    # prepare_create must be called once per response, with the override
+    # routed by data_entry.id (not by index, not by formula path).
+    assert emission_service.prepare_create.await_count == 3
+    actual_calls = {
+        call.args[0].id: call.kwargs.get("kg_co2eq_override")
+        for call in emission_service.prepare_create.await_args_list
+    }
+    assert actual_calls == {10: 152.685, 11: None, 12: 380.0}
 
 
 # ======================================================================
@@ -640,6 +943,7 @@ async def test_finalize_and_commit_moves_file_and_updates_job():
         emission_service=MagicMock(),
         stats=stats,
         setup_result=setup_result,
+        batch_kg_co2eq_overrides=[None],
     )
 
     provider._process_batch.assert_awaited_once()

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -726,6 +726,77 @@ async def test_process_row_with_no_kg_co2eq_returns_none_override():
 
 
 @pytest.mark.asyncio
+async def test_process_row_warns_on_unparseable_kg_co2eq(caplog):
+    """A non-empty but non-numeric kg_co2eq cell must surface a WARNING-level
+    log (not a silent debug) and still produce a valid DataEntry with no
+    override applied. Locks in the visibility bump from the bot review.
+    """
+    import logging
+
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+
+    handler = MagicMock()
+    handler.validate_create.return_value = SimpleNamespace(
+        data={
+            "origin_iata": "GVA",
+            "destination_iata": "ZRH",
+            "primary_factor_id": None,
+        }
+    )
+    handler.kind_field = "category"
+    handler.subkind_field = None
+
+    async def resolve_handler(*_args, **_kwargs):
+        return (DataEntryTypeEnum.plane, handler, None)
+
+    provider._resolve_handler_and_validate = resolve_handler
+    provider._extract_kind_subkind_values = lambda *_a, **_kw: ("very_short_haul", None)
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {},
+        "expected_columns": {"origin_iata", "destination_iata"},
+    }
+    row = {
+        "origin_iata": "GVA",
+        "destination_iata": "ZRH",
+        "kg_co2eq": "not-a-number",
+    }
+    stats = _build_stats()
+
+    with caplog.at_level(
+        logging.WARNING, logger="app.services.data_ingestion.base_csv_provider"
+    ):
+        data_entry, error_msg, _factor, kg_co2eq_override = await provider._process_row(
+            row,
+            row_idx=7,
+            setup_result=setup_result,
+            stats=stats,
+            max_row_errors=5,
+            unit_to_module_map=None,
+        )
+
+    # The row still processes — only the override is dropped.
+    assert error_msg is None
+    assert data_entry is not None
+    assert kg_co2eq_override is None
+
+    # The parse failure is visible at WARNING level, not debug.
+    warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and "kg_co2eq" in rec.message
+    ]
+    assert warnings, (
+        "expected a WARNING-level log mentioning kg_co2eq, "
+        f"got: {[(r.levelname, r.message) for r in caplog.records]}"
+    )
+    assert "not-a-number" in warnings[0].message
+    assert "Row 7" in warnings[0].message
+
+
+@pytest.mark.asyncio
 async def test_process_row_consumes_dumb_csv_fixture_for_plane():
     """Consume the dumb plane CSV fixture row-by-row via csv.DictReader and
     verify each row's kg_co2eq is extracted out-of-band — not persisted into

--- a/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
@@ -334,3 +334,139 @@ class TestTransformData:
         records = [self._make_record(**{"Centre financier": "1234"})]
         result = await provider.transform_data(records)
         assert result[0]["unit_institutional_id"] == "1234"
+
+
+# ---------------------------------------------------------------------------
+# _load_data — kg_co2eq override carrier + warning visibility
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataKgCo2eqHandling:
+    """Regression tests for the kg_co2eq override carrier path in _load_data:
+
+    - Bad values surface at WARNING level (not DEBUG) so operators see them.
+    - The data_payload passed to bulk_create must NOT contain a 'kg_co2eq' key.
+    """
+
+    @pytest.mark.asyncio
+    async def test_load_data_warns_on_unparseable_kg_co2eq(self, caplog):
+        import logging
+
+        provider = _make_provider()
+        provider.user = None  # bypass UserRead.model_validate on MagicMock
+
+        # Mock the services so _load_data runs purely in memory.
+        mock_service = MagicMock()
+        mock_service.bulk_create = AsyncMock(
+            return_value=[MagicMock(id=1)]  # one created entry per input
+        )
+        mock_emission_service = MagicMock()
+        mock_emission_service.prepare_create = AsyncMock(return_value=[])
+        mock_emission_service.bulk_create = AsyncMock()
+
+        with (
+            patch(
+                "app.services.data_ingestion.api_providers."
+                "professional_travel_api_provider.DataEntryService",
+                return_value=mock_service,
+            ),
+            patch(
+                "app.services.data_ingestion.api_providers."
+                "professional_travel_api_provider.DataEntryEmissionService",
+                return_value=mock_emission_service,
+            ),
+            caplog.at_level(
+                logging.WARNING,
+                logger="app.services.data_ingestion."
+                "api_providers.professional_travel_api_provider",
+            ),
+        ):
+            # One item with a garbage kg_co2eq — should warn but still process.
+            await provider._load_data(
+                [
+                    {
+                        "carbon_report_module_id": 99,
+                        "origin_iata": "GVA",
+                        "destination_iata": "ZRH",
+                        "kg_co2eq": "not-a-number",
+                    }
+                ]
+            )
+
+        warnings = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING and "kg_co2eq" in rec.message
+        ]
+        assert warnings, (
+            "expected a WARNING-level log mentioning kg_co2eq, "
+            f"got: {[(r.levelname, r.message) for r in caplog.records]}"
+        )
+        assert "not-a-number" in warnings[0].message
+
+    @pytest.mark.asyncio
+    async def test_load_data_strips_kg_co2eq_from_persisted_data(self):
+        """Whether kg_co2eq is parseable or not, it must be popped from the
+        data_payload before DataEntry construction so it never lands in the
+        DB JSON column. This is the API mirror of the CSV regression."""
+        provider = _make_provider()
+        provider.user = None  # bypass UserRead.model_validate on MagicMock
+
+        captured_entries: list = []
+
+        async def fake_bulk_create(entries, *_args, **_kwargs):
+            captured_entries.extend(entries)
+            # Mimic real bulk_create: order-preserving response with IDs.
+            return [MagicMock(id=i) for i, _ in enumerate(entries, start=1)]
+
+        mock_service = MagicMock()
+        mock_service.bulk_create = AsyncMock(side_effect=fake_bulk_create)
+        mock_emission_service = MagicMock()
+        mock_emission_service.prepare_create = AsyncMock(return_value=[])
+        mock_emission_service.bulk_create = AsyncMock()
+
+        with (
+            patch(
+                "app.services.data_ingestion.api_providers."
+                "professional_travel_api_provider.DataEntryService",
+                return_value=mock_service,
+            ),
+            patch(
+                "app.services.data_ingestion.api_providers."
+                "professional_travel_api_provider.DataEntryEmissionService",
+                return_value=mock_emission_service,
+            ),
+        ):
+            await provider._load_data(
+                [
+                    {
+                        "carbon_report_module_id": 99,
+                        "origin_iata": "GVA",
+                        "destination_iata": "ZRH",
+                        "kg_co2eq": 152.685,  # valid float
+                    },
+                    {
+                        "carbon_report_module_id": 99,
+                        "origin_iata": "CDG",
+                        "destination_iata": "JFK",
+                        "kg_co2eq": "garbage",  # unparseable
+                    },
+                ]
+            )
+
+        # Two DataEntry instances built; neither has kg_co2eq in its data dict.
+        assert len(captured_entries) == 2
+        for entry in captured_entries:
+            assert "kg_co2eq" not in entry.data, (
+                f"kg_co2eq leaked into DataEntry.data: {entry.data!r}"
+            )
+
+        # The valid float reaches prepare_create as the override; the garbage
+        # one resolves to None (no override) — verified through the {id: ov}
+        # routing built inside _load_data.
+        prepare_calls = mock_emission_service.prepare_create.await_args_list
+        overrides_by_id = {
+            call.args[0].id: call.kwargs.get("kg_co2eq_override")
+            for call in prepare_calls
+        }
+        assert overrides_by_id == {1: 152.685, 2: None}

--- a/backend/tests/unit/services/test_data_entry_emission_service.py
+++ b/backend/tests/unit/services/test_data_entry_emission_service.py
@@ -48,53 +48,19 @@ def _make_fake_emission() -> DataEntryEmission:
 
 
 # ---------------------------------------------------------------------------
-# upsert_by_data_entry — kg_co2eq stripping (regression: commit f9576005b)
+# upsert_by_data_entry — passes data through to prepare_create unchanged
 # ---------------------------------------------------------------------------
+#
+# Note: the historical "strip kg_co2eq before recompute" workaround in
+# upsert_by_data_entry was removed once the CSV/API ingestion paths stopped
+# persisting kg_co2eq into DataEntry.data. The override is now carried
+# transiently via prepare_create(kg_co2eq_override=...).
 
 
 @pytest.mark.asyncio
-async def test_upsert_strips_kg_co2eq_before_prepare_create():
-    """kg_co2eq stored by CSV import must not override the formula on user edits.
-
-    Regression introduced by f9576005b renaming co2_kg → kg_co2eq in the CSV
-    provider, which made prepare_create's CSV-override branch trigger for every
-    subsequent edit of a CSV-imported entry.
-    """
-    service = _make_service()
-    fake_emission = _make_fake_emission()
-    service.repo.bulk_create = AsyncMock(return_value=[fake_emission])
-
-    data_entry = _make_data_entry_response(
-        {
-            "number_of_trips": 5,
-            "distance_one_trip_km": 800.0,
-            "kg_co2eq": 99999.0,  # stale value from CSV import
-        }
-    )
-
-    captured: list[DataEntryResponse] = []
-
-    async def fake_prepare_create(de: DataEntryResponse) -> list[DataEntryEmission]:
-        captured.append(de)
-        return [fake_emission]
-
-    with patch.object(service, "prepare_create", side_effect=fake_prepare_create):
-        result = await service.upsert_by_data_entry(data_entry)
-
-    assert result == [fake_emission]
-    assert len(captured) == 1
-    called_with = captured[0]
-
-    # The stale kg_co2eq must have been removed so the formula runs
-    assert "kg_co2eq" not in called_with.data
-    # Other fields must be preserved
-    assert called_with.data["number_of_trips"] == 5
-    assert called_with.data["distance_one_trip_km"] == 800.0
-
-
-@pytest.mark.asyncio
-async def test_upsert_does_not_strip_when_no_kg_co2eq():
-    """Entries without a stored kg_co2eq must pass through untouched."""
+async def test_upsert_passes_data_through_unchanged():
+    """upsert_by_data_entry must forward the response to prepare_create
+    without mutating its data dict (no stale-kg_co2eq workaround anymore)."""
     service = _make_service()
     fake_emission = _make_fake_emission()
     service.repo.bulk_create = AsyncMock(return_value=[fake_emission])
@@ -105,7 +71,10 @@ async def test_upsert_does_not_strip_when_no_kg_co2eq():
 
     captured: list[DataEntryResponse] = []
 
-    async def fake_prepare_create(de: DataEntryResponse) -> list[DataEntryEmission]:
+    async def fake_prepare_create(
+        de: DataEntryResponse,
+        kg_co2eq_override: float | None = None,
+    ) -> list[DataEntryEmission]:
         captured.append(de)
         return [fake_emission]
 
@@ -114,30 +83,6 @@ async def test_upsert_does_not_strip_when_no_kg_co2eq():
 
     called_with = captured[0]
     assert called_with.data == {"number_of_trips": 3, "distance_one_trip_km": 500.0}
-
-
-@pytest.mark.asyncio
-async def test_upsert_does_not_mutate_original_data_entry():
-    """model_copy must be used — the caller's object must stay unchanged."""
-    service = _make_service()
-    fake_emission = _make_fake_emission()
-    service.repo.bulk_create = AsyncMock(return_value=[fake_emission])
-
-    original_data = {
-        "number_of_trips": 2,
-        "distance_one_trip_km": 300.0,
-        "kg_co2eq": 42.0,
-    }
-    data_entry = _make_data_entry_response(original_data)
-
-    async def fake_prepare_create(de: DataEntryResponse) -> list[DataEntryEmission]:
-        return [fake_emission]
-
-    with patch.object(service, "prepare_create", side_effect=fake_prepare_create):
-        await service.upsert_by_data_entry(data_entry)
-
-    # The original response object's data must be unchanged
-    assert data_entry.data.get("kg_co2eq") == 42.0
 
 
 @pytest.mark.asyncio
@@ -184,6 +129,115 @@ async def test_upsert_returns_none_and_flushes_when_no_emissions():
     service.repo.delete_by_data_entry_id.assert_awaited_once_with(data_entry.id)
     service.session.flush.assert_awaited_once()
     service.repo.bulk_create.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# prepare_create — kg_co2eq_override (CSV / API ingestion path)
+# ---------------------------------------------------------------------------
+#
+# The override short-circuits the formula: we produce a single emission per
+# computation with the given kg_co2eq and primary_factor_id=None, and the
+# value is NEVER read from data_entry.data.kg_co2eq.
+
+
+@pytest.mark.asyncio
+async def test_prepare_create_with_kg_co2eq_override_short_circuits_formula():
+    """When kg_co2eq_override is set, the formula path is bypassed and a
+    single emission with the override value (and primary_factor_id=None) is
+    returned — even when the data dict has no kg_co2eq key."""
+    from app.models.factor import Factor
+
+    service = _make_service()
+
+    factor = MagicMock(spec=Factor)
+    factor.id = 99
+    factor.emission_type_id = EmissionType.commuting__cycling.value
+    factor.values = {"ef_kg_co2eq_per_unit": 0.5, "unit": "km"}
+
+    de = _make_data_entry_response({"number_of_trips": 2})  # no kg_co2eq key
+
+    with (
+        patch.object(service, "_fetch_factors", new=AsyncMock(return_value=[factor])),
+        patch.object(
+            service, "_get_year_from_data_entry", new=AsyncMock(return_value=2024)
+        ),
+        patch(
+            "app.services.data_entry_emission_service.resolve_emission_types",
+            return_value=[EmissionType.professional_travel__plane],
+        ),
+        patch(
+            "app.services.data_entry_emission_service.BaseModuleHandler.get_by_type",
+        ) as mock_handler_cls,
+    ):
+        mock_handler = MagicMock()
+        mock_handler.pre_compute = AsyncMock(return_value={})
+        mock_handler.resolve_computations = MagicMock(
+            return_value=[
+                EmissionComputation(
+                    emission_type=EmissionType.professional_travel__plane,
+                    factor_id=99,
+                )
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        results = await service.prepare_create(de, kg_co2eq_override=42.0)
+
+    assert len(results) == 1
+    assert results[0].kg_co2eq == 42.0
+    assert results[0].primary_factor_id is None
+
+
+@pytest.mark.asyncio
+async def test_prepare_create_does_not_read_kg_co2eq_from_data():
+    """A kg_co2eq value sitting in data_entry.data must NOT be picked up as
+    an override — the channel is exclusively the kg_co2eq_override param."""
+    from app.models.factor import Factor
+
+    service = _make_service()
+
+    factor = MagicMock(spec=Factor)
+    factor.id = 99
+    factor.emission_type_id = EmissionType.professional_travel__plane.value
+    factor.values = {"ef_kg_co2eq_per_km": 0.2}
+
+    # data has a stray kg_co2eq from a hypothetical legacy row — must be ignored
+    de = _make_data_entry_response({"distance_km": 100.0, "kg_co2eq": 99999.0})
+
+    with (
+        patch.object(service, "_fetch_factors", new=AsyncMock(return_value=[factor])),
+        patch.object(
+            service, "_get_year_from_data_entry", new=AsyncMock(return_value=2024)
+        ),
+        patch(
+            "app.services.data_entry_emission_service.resolve_emission_types",
+            return_value=[EmissionType.professional_travel__plane],
+        ),
+        patch(
+            "app.services.data_entry_emission_service.BaseModuleHandler.get_by_type",
+        ) as mock_handler_cls,
+    ):
+        mock_handler = MagicMock()
+        mock_handler.pre_compute = AsyncMock(return_value={})
+        mock_handler.resolve_computations = MagicMock(
+            return_value=[
+                EmissionComputation(
+                    emission_type=EmissionType.professional_travel__plane,
+                    factor_id=99,
+                    formula_key="ef_kg_co2eq_per_km",
+                    quantity_key="distance_km",
+                )
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        # No override → formula path runs; the stray kg_co2eq=99999 must be ignored.
+        results = await service.prepare_create(de)
+
+    assert len(results) == 1
+    # Result is from the formula: 100.0 km * 0.2 = 20.0
+    assert results[0].kg_co2eq == pytest.approx(20.0)
+    assert results[0].primary_factor_id == 99
 
 
 # ---------------------------------------------------------------------------
@@ -1470,14 +1524,19 @@ class TestPrepareCreateRollup:
 
     @pytest.mark.asyncio
     async def test_csv_override_with_multiple_factors_creates_single_row(self):
-        """CSV kg_co2eq override must not be duplicated per matching factor."""
+        """kg_co2eq override must not be duplicated per matching factor.
+
+        The override is now passed via the ``kg_co2eq_override`` parameter
+        rather than read from ``data_entry.data["kg_co2eq"]`` (which the new
+        contract forbids — kg_co2eq must never live in the persisted column).
+        """
         service = _make_service()
 
         data_entry = DataEntryResponse(
             id=102,
             data_entry_type_id=DataEntryTypeEnum.scientific.value,
             carbon_report_module_id=10,
-            data={"name": "Microscope", "kg_co2eq": 300.0},
+            data={"name": "Microscope"},
         )
 
         fake_factor_1 = MagicMock()
@@ -1518,7 +1577,7 @@ class TestPrepareCreateRollup:
             mock_handler.resolve_computations = MagicMock(return_value=[fake_comp])
             mock_handler_cls.return_value = mock_handler
 
-            results = await service.prepare_create(data_entry)
+            results = await service.prepare_create(data_entry, kg_co2eq_override=300.0)
 
         assert len(results) == 1
         override_row = results[0]

--- a/docs/implementation-plans/988-copilot-feedback-fix-data-entry-stop-persisting-computed-fields-to-dataentry-data.md
+++ b/docs/implementation-plans/988-copilot-feedback-fix-data-entry-stop-persisting-computed-fields-to-dataentry-data.md
@@ -1,0 +1,108 @@
+# Bot Review TODOs: PR #988
+
+## Source Branch: `fix/data-entry-data-mutation`
+
+## Raw Feedback
+
+### Summary Feedback (github-advanced-security)
+
+---
+
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+This PR prevents derived/computed values (e.g., `kg_co2eq`, `primary_factor`, travel/building enrichments) from being persisted into the source-of-truth `data_entries.data` JSON column by moving enrichment out-of-band on read paths and by routing CSV/API `kg_co2eq` overrides through an explicit parameter rather than embedding them into `DataEntry.data`.
+
+**Changes:**
+
+- Read path: `ModuleHandler.to_response(...)` now accepts `enriched_data` so `get_submodule_data` can enrich responses without mutating ORM-backed `DataEntry.data` (plus detach/expunge defense-in-depth).
+- Ingestion path: CSV/API providers extract `kg_co2eq` overrides out-of-band and pass them transiently to `DataEntryEmissionService.prepare_create(kg_co2eq_override=...)`; `prepare_create` no longer reads `kg_co2eq` from `data_entry.data`.
+- Fixes a latent response-shape bug in buildings energy-combustion (`primary_factor` is flat; no nested `values`), and adds regression tests/fixtures to lock in the non-persistence guarantees.
+
+### Reviewed changes
+
+Copilot reviewed 20 out of 20 changed files in this pull request and generated 5 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File                                                                                  | Description                                                                                                                                                           |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| docs/implementation-plans/fix-data-entry-data-mutation.md                             | Implementation plan documenting the two leak sources and the chosen mitigation approach.                                                                              |
+| backend/app/schemas/data_entry.py                                                     | Extends `ModuleHandler.to_response` protocol to accept `enriched_data` for non-persisted enrichment.                                                                  |
+| backend/app/repositories/data_entry_repo.py                                           | Builds `enriched_data` dict instead of mutating `DataEntry.data`, and adds `_detach()` expunge defense in `get_submodule_data` (plus TODO notes for other read APIs). |
+| backend/app/services/data_entry_emission_service.py                                   | Introduces `kg_co2eq_override` parameter; removes fallback reading `kg_co2eq` from `data_entry.data`; deletes stale strip workaround in `upsert_by_data_entry`.       |
+| backend/app/services/data_ingestion/base_csv_provider.py                              | Extracts `kg_co2eq` from raw CSV row out-of-band, carries parallel override list through batching, and forwards overrides to `prepare_create`.                        |
+| backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py | Mirrors the CSV override carrier approach for API ingestion (parallel override list + per-entry forwarding).                                                          |
+| backend/app/services/data_ingestion/csv_providers/local_seed.py                       | Updates overridden method signatures to match the new CSV provider tuple/flow shape.                                                                                  |
+| backend/app/modules/buildings/schemas.py                                              | Updates handlers to accept `enriched_data`; fixes energy-combustion `primary_factor` flat-dict access for `name`/`unit`.                                              |
+| backend/app/modules/equipment_electric_consumption/schemas.py                         | Uses `enriched_data` (when provided) for response construction, including `primary_factor` reads.                                                                     |
+| backend/app/modules/external_cloud_and_ai/schemas.py                                  | Updates response building to use `enriched_data` and factor-derived fields consistently.                                                                              |
+| backend/app/modules/headcount/schemas.py                                              | Updates handlers to accept `enriched_data` for response building.                                                                                                     |
+| backend/app/modules/process_emissions/schemas.py                                      | Uses `enriched_data` and `primary_factor` (from enrichment) for category/subcategory response fields.                                                                 |
+| backend/app/modules/professional_travel/schemas.py                                    | Updates handler to accept `enriched_data` for response building (travel listing enrichment).                                                                          |
+| backend/app/modules/purchase/schemas.py                                               | Updates handlers to accept `enriched_data` and uses it consistently for response fields.                                                                              |
+| backend/app/modules/research_facilities/animals_schemas.py                            | Updates handler to accept `enriched_data` for response building.                                                                                                      |
+| backend/app/modules/research_facilities/common_schemas.py                             | Updates handler to accept `enriched_data` for response building.                                                                                                      |
+| backend/tests/unit/repositories/test_data_entry_repo.py                               | Adds regression test ensuring `get_submodule_data` does not dirty/persist computed keys into `DataEntry.data`.                                                        |
+| backend/tests/unit/services/test_data_entry_emission_service.py                       | Adds/updates unit tests for `kg_co2eq_override` behavior and removes obsolete strip-workaround tests.                                                                 |
+| backend/tests/unit/services/data_ingestion/test_base_csv_provider.py                  | Adds regression tests verifying `kg_co2eq` is extracted out-of-band and correctly routed through batch processing.                                                    |
+| backend/tests/integration/data_ingestion/fixtures/regression_kg_co2eq_plane.csv       | Adds a “dumb” plane CSV fixture used by ingestion regression tests.                                                                                                   |
+
+</details>
+
+---
+
+### File: `backend/app/repositories/data_entry_repo.py` (Line 61) — github-advanced-security[bot]
+
+## CodeQL / Empty except
+
+'except' clause does nothing but pass and there is no explanatory comment.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/641)
+
+### File: `backend/app/schemas/data_entry.py` (Line 144) — github-advanced-security[bot]
+
+## CodeQL / Statement has no effect
+
+This statement has no effect.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/640)
+
+### File: `backend/app/services/data_ingestion/base_csv_provider.py` (Line 982) — Copilot
+
+## `_process_row` currently always returns `None` for the `factor` tuple element (`return data_entry, None, None, kg_co2eq_override`) even when a matching factor was resolved/populated earlier. This makes `process_csv_in_batches` count every successful row as `rows_without_factors`, and the job summary/status message will be incorrect. Consider returning the resolved factor (or an explicit boolean) in that third position so stats remain accurate.
+
+### File: `backend/app/services/data_ingestion/base_csv_provider.py` (Line 826) — Copilot
+
+When `kg_co2eq` is present but not a valid float, the code logs a debug message and silently ignores the override. This can hide bad input and lead to unexpected formula-based emissions instead of failing the row. Consider recording a row error / skipping the row (or at least logging a warning and surfacing it in `stats['row_errors']`) when a non-empty `kg_co2eq` value cannot be parsed.
+
+---
+
+### File: `backend/app/repositories/data_entry_repo.py` (Line 56) — Copilot
+
+## `_detach` uses an inline import (`from sqlalchemy.exc import InvalidRequestError`). This repository generally keeps imports at the top of the module; moving this import to the top-level keeps import structure consistent and avoids repeatedly executing imports on hot paths (e.g., list endpoints calling `_detach` per row).
+
+### File: `backend/app/repositories/data_entry_repo.py` (Line 204) — Copilot
+
+## New TODOs were added to `get_list` about auditing callers before expunging/detaching. Please avoid landing TODOs in mainline code; consider creating/linking a tracked issue and referencing it here (or completing the audit within this PR) so the follow-up work is not lost.
+
+### File: `backend/app/repositories/data_entry_repo.py` (Line 233) — Copilot
+
+New TODOs were added to `list_by_data_entry_type_and_year` about auditing whether expunging is safe. Please replace TODOs with a tracked issue reference (or complete the audit in this PR) to prevent unfinished work from lingering indefinitely.
+
+---
+
+## Action Items
+
+### Maintainability / refactoring
+
+- [ ] **`backend/app/repositories/data_entry_repo.py` — `_detach`** — Two style nits on the same helper: (1) CodeQL #641 flags `except InvalidRequestError: pass` as an empty handler with no inline explanation, and (2) the `from sqlalchemy.exc import InvalidRequestError` is mid-function while the rest of the module imports at the top. Fix: hoist the import to the top of the file alongside other `sqlalchemy` imports, and add a one-line comment on the `pass` (e.g. `# Already detached or session-state edge case; nothing to do.`) so the silent-swallow intent is readable at the call site, not just in the docstring.
+- [ ] **`backend/app/schemas/data_entry.py:144`** — CodeQL #640 flags the bare `...` after the docstring on `to_response` as a statement with no effect. The docstring on its own is already a valid Protocol/abstract body. Fix: remove the `...` line so the function is just `def to_response(...) -> ...: """docstring"""`. Mechanical and removes the alert.
+- [ ] **`backend/app/services/data_ingestion/base_csv_provider.py:823` and `professional_travel_api_provider.py` (kg_co2eq parse failure)** — Copilot's symptom is real: a `kg_co2eq` cell that parses as garbage today logs at DEBUG and silently produces formula-based emissions instead of the override the user expected. Copilot's _suggested fix_ (record a row error / skip the row) is too aggressive — the rest of the row is valid and should still create a `DataEntry`; only the override should be dropped. Fix: bump `logger.debug` → `logger.warning` in both providers so the parse failure is visible in normal log levels without changing flow. The symmetric API-provider site (added in the latest commit) needs the same bump.
+
+### Skipped after verification
+
+- **`base_csv_provider.py:982` — Copilot says `_process_row` always returns `None` in the factor tuple position, breaking `rows_with_factors` accounting.** Verified at parent commit `b39fec7e`: the third position was `None` _before_ this PR (`return data_entry, None, None`). My change only added a 4th element, so this is a pre-existing stats-counter bug, not a regression introduced here. Should be a separate ticket if the counter matters; out of scope for this PR.
+- **`data_entry_repo.py:204` and `:233` — Copilot wants the new `# TODO:` comments replaced with tracked-issue references.** Skip — these were explicitly requested by the user during design ("only expunge get_submodule_data, TODO comments on the other ones") to keep the audit deferred without losing the reminder. Converting them to a separate issue would contradict the agreed scope.

--- a/docs/implementation-plans/fix-data-entry-data-mutation.md
+++ b/docs/implementation-plans/fix-data-entry-data-mutation.md
@@ -107,11 +107,10 @@ Extend `prepare_create`:
 async def prepare_create(
     self,
     data_entry: DataEntry | DataEntryResponse,
-    csv_kg_co2eq_override: float | None = None,
+    kg_co2eq_override: float | None = None,
 ) -> list[DataEntryEmission]:
     ...
-    csv_kg_co2eq = csv_kg_co2eq_override
-    if csv_kg_co2eq is not None:
+    if kg_co2eq_override is not None:
         # CSV/API ingestion path: build override emission record
 ```
 
@@ -119,7 +118,7 @@ Drop the `data_entry.data.get("kg_co2eq")` fallback at line 182 — the override
 
 ### Provider changes
 
-- **CSV provider** (`base_csv_provider.py`): in `_process_row`, extract `kg_co2eq` from `filtered_row` _before_ the `DataEntry(data=...)` build (line 952), keep it on a parallel structure (e.g. `data_entry._csv_kg_co2eq` transient attribute, or zip alongside batch). Strip the key from `data` so the persisted row is clean. In `_persist_batch` (line 1126 region), pass `csv_kg_co2eq_override=...` to `prepare_create`.
+- **CSV provider** (`base_csv_provider.py`): in `_process_row`, extract `kg_co2eq` from `filtered_row` _before_ the `DataEntry(data=...)` build (line 952), keep it on a parallel structure (e.g. `data_entry._kg_co2eq_override` transient attribute, or zip alongside batch). Strip the key from `data` so the persisted row is clean. In `_persist_batch` (line 1126 region), pass `kg_co2eq_override=...` to `prepare_create`.
 
   Easiest carrier: add a private `_csv_overrides_by_idx: dict[int, float]` on the provider instance keyed by the index in the batch list, and look it up after `bulk_create` returns the response objects in batch order.
 
@@ -197,22 +196,22 @@ Fixture location: `backend/tests/fixtures/csv/regression_kg_co2eq/<year>/<module
 
 Mirror the CSV test for the professional-travel API provider — feed it a synthetic API response with `OUT_CO2_CORRECTED`, assert the persisted `DataEntry.data` has no `kg_co2eq` key and `DataEntryEmission.kg_co2eq` matches the API value.
 
-### Unit test — `prepare_create(csv_kg_co2eq_override=...)`
+### Unit test — `prepare_create(kg_co2eq_override=...)`
 
 Direct unit test on `DataEntryEmissionService.prepare_create`:
 
-- Given a `DataEntry` whose `data` does NOT contain `kg_co2eq`, calling with `csv_kg_co2eq_override=42.0` returns an emission with `kg_co2eq=42.0`.
+- Given a `DataEntry` whose `data` does NOT contain `kg_co2eq`, calling with `kg_co2eq_override=42.0` returns an emission with `kg_co2eq=42.0`.
 - Without the override, the formula path runs.
 
 ## 7. Risks
 
-- **`csv_kg_co2eq` override semantics**: the existing override path skipped factor-based formula computation entirely. After the refactor, that semantic must hold — the new `csv_kg_co2eq_override` param must produce the same single-emission row with `primary_factor_id=None`.
+- **`kg_co2eq_override` override semantics**: the existing override path skipped factor-based formula computation entirely. After the refactor, that semantic must hold — the new `kg_co2eq_override` param must produce the same single-emission row with `primary_factor_id=None`.
 - **`EnergyCombustion` shape fix**: ensure response_dto fields still resolve. The latent bug means consumers were getting `{}` for `factor_values`; verify the response_dto doesn't depend on a `values`-keyed sub-dict.
 - **API provider parity**: ensure the same override path works in the API provider's call to `bulk_create` + `prepare_create` (verify it uses the same emission_service surface).
 
 ## 8. Implementation order (single PR)
 
-1. Add `csv_kg_co2eq_override` param to `prepare_create`; remove `data.get("kg_co2eq")` fallback. Update unit tests.
+1. Add `kg_co2eq_override` param to `prepare_create`; remove `data.get("kg_co2eq")` fallback. Update unit tests.
 2. Update CSV provider to strip `kg_co2eq` from `data` and pass override transiently.
 3. Update API provider similarly.
 4. Remove workaround strip in `upsert_by_data_entry`.

--- a/docs/implementation-plans/fix-data-entry-data-mutation.md
+++ b/docs/implementation-plans/fix-data-entry-data-mutation.md
@@ -1,0 +1,243 @@
+# Implementation Plan: Stop persisting computed fields to `DataEntry.data`
+
+> **Scope decision**: single PR combining all changes below.
+> **DB cleanup**: not in scope — DB will be dropped.
+
+## 1. Diagnosis
+
+`DataEntryRepository.get_submodule_data` (`backend/app/repositories/data_entry_repo.py:341`) runs a `select(...)` returning `DataEntry` ORM rows tied to the active `AsyncSession`. After unpacking each row at line 561, the loop reassigns `data_entry.data = {**data_entry.data, ...}` three times (lines 587, 602, 613). SQLAlchemy's attribute instrumentation marks the row dirty.
+
+The mutation is persisted by:
+
+- **Autoflush** — the `Factor` lookup at line 580 (executed inside the same loop) triggers a flush of the dirty `DataEntry`.
+- **Explicit commit** — write workflows (`carbon_report_module.py:111`) reuse the same session and flush dirty rows.
+
+A second source of leakage: CSV/API providers stuff a `kg_co2eq` override directly into `DataEntry.data` at ingest time, also persisting it.
+
+Repo-wide grep (`data_entry\.data\s*=`) found:
+
+- `repositories/data_entry_repo.py:120` — legitimate `update()`.
+- `repositories/data_entry_repo.py:587, 602, 613` — the read-path bug.
+
+No other read method mutates `.data`.
+
+## 2. Option 1 — Don't touch the ORM in `to_response`
+
+### Signature change
+
+Protocol (`app/schemas/data_entry.py:131`):
+
+```python
+def to_response(
+    self,
+    data_entry: T,
+    enriched_data: dict | None = None,
+) -> DataEntryResponseGen: ...
+```
+
+Each implementation does:
+
+```python
+data = enriched_data if enriched_data is not None else data_entry.data
+```
+
+…and uses `data` in place of `data_entry.data` in the body.
+
+In `get_submodule_data`, replace the three mutation blocks with a local `enriched_data` dict and pass it via `handler.to_response(data_entry, enriched_data)`. The ORM row is never touched.
+
+### Files to edit
+
+Repo:
+
+- `backend/app/repositories/data_entry_repo.py` (mutations at 587–620 → local dict)
+
+Protocol:
+
+- `backend/app/schemas/data_entry.py:131`
+
+Handler implementations (14 sites, 9 files):
+
+- `backend/app/modules/buildings/schemas.py:249, 483, 599`
+- `backend/app/modules/process_emissions/schemas.py:97`
+- `backend/app/modules/external_cloud_and_ai/schemas.py:203, 385`
+- `backend/app/modules/equipment_electric_consumption/schemas.py:227`
+- `backend/app/modules/purchase/schemas.py:195, 296`
+- `backend/app/modules/professional_travel/schemas.py:207`
+- `backend/app/modules/research_facilities/animals_schemas.py:85`
+- `backend/app/modules/research_facilities/common_schemas.py:101`
+- `backend/app/modules/headcount/schemas.py:196, 251`
+
+## 3. Option 2 — `expunge` defense
+
+After unpacking each row, call `self.session.expunge(...)` on every ORM instance returned. This detaches the instances so any later mutation cannot trigger a flush.
+
+Apply in `data_entry_repo.py` to:
+
+- `get_submodule_data` (line 341)
+- `get_list` (line 173)
+- `list_by_data_entry_type_and_year` (line 195)
+- `get_headcount_members` (line 778)
+- `get_member_by_institutional_id` (line 808)
+
+Add a private helper:
+
+```python
+def _detach(self, *objs: Any) -> None:
+    for obj in objs:
+        if obj is not None:
+            self.session.expunge(obj)
+```
+
+Note: `get_submodule_data` only accesses scalar columns and the JSON `data` after unpack (no lazy relationships), so expunging is safe. Add a comment to that effect.
+
+## 4. `kg_co2eq` must never be persisted in `DataEntry.data`
+
+### Where it leaks in today
+
+- `backend/app/services/data_ingestion/base_csv_provider.py:802-809` (special-case adds `kg_co2eq` into `filtered_row`); line 952 builds `DataEntry(data=...)` with that key still inside.
+- `backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py:416-422` (writes `kg_co2eq` into `data_payload`).
+- `backend/app/services/data_entry_emission_service.py:182` (`prepare_create` reads `data_entry.data.get("kg_co2eq")` as the override).
+- `backend/app/services/data_entry_emission_service.py:486-492` (`upsert_by_data_entry` workaround that strips `kg_co2eq` from the in-memory Pydantic copy before recompute — defensive, doesn't affect DB).
+
+### New transient channel
+
+Extend `prepare_create`:
+
+```python
+async def prepare_create(
+    self,
+    data_entry: DataEntry | DataEntryResponse,
+    csv_kg_co2eq_override: float | None = None,
+) -> list[DataEntryEmission]:
+    ...
+    csv_kg_co2eq = csv_kg_co2eq_override
+    if csv_kg_co2eq is not None:
+        # CSV/API ingestion path: build override emission record
+```
+
+Drop the `data_entry.data.get("kg_co2eq")` fallback at line 182 — the override is now exclusively passed in.
+
+### Provider changes
+
+- **CSV provider** (`base_csv_provider.py`): in `_process_row`, extract `kg_co2eq` from `filtered_row` _before_ the `DataEntry(data=...)` build (line 952), keep it on a parallel structure (e.g. `data_entry._csv_kg_co2eq` transient attribute, or zip alongside batch). Strip the key from `data` so the persisted row is clean. In `_persist_batch` (line 1126 region), pass `csv_kg_co2eq_override=...` to `prepare_create`.
+
+  Easiest carrier: add a private `_csv_overrides_by_idx: dict[int, float]` on the provider instance keyed by the index in the batch list, and look it up after `bulk_create` returns the response objects in batch order.
+
+- **API provider** (`professional_travel_api_provider.py`): mirror the CSV provider — don't write `kg_co2eq` into `data_payload`; track it on a parallel mapping; pass to `prepare_create`.
+
+### Remove the workaround
+
+`upsert_by_data_entry` (`data_entry_emission_service.py:486-492`): delete the strip block. It exists only to defend against the read-path mutation; once Option 1 lands, it's dead code.
+
+## 5. `EnergyCombustion` latent bug fix
+
+`buildings/schemas.py:484-485`:
+
+```python
+primary_factor = data_entry.data.get("primary_factor", {})
+factor_values = primary_factor.get("values", {})  # always {} — there is no nested "values"
+```
+
+The repo builds `primary_factor` as a flat `{**values, **classification}` dict. Fix the read site to use the flat shape:
+
+```python
+data = enriched_data if enriched_data is not None else data_entry.data
+primary_factor = data.get("primary_factor", {})
+# primary_factor is already flat (factor.values merged with factor.classification)
+factor_values = primary_factor
+```
+
+(Or pick whichever shape makes the response_dto field mapping work — verify against `EnergyCombustionHandlerResponse` field names.)
+
+> ⚠️ **PR-description note (frontend-visible behavior change)**:
+> Today, `factor_values = primary_factor.get("values", {})` always returns `{}`,
+> so the response fields `name` (and `unit` via the same path) are derived
+> only from `data_entry.data.get("name") / get("unit")` — and were `None`
+> on most rows. After the fix, `name`/`unit` will start populating from the
+> factor's `kind` / `unit` classification when those exist on the matched
+> factor. The frontend's energy combustion submodule listing will start
+> showing those values. Manual UI verification recommended (the user has
+> agreed to check this manually).
+
+## 6. Tests
+
+### Repo regression — read path doesn't pollute `data`
+
+`backend/tests/unit/repositories/test_data_entry_repo.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_submodule_data_does_not_persist_computed_fields(
+    db_session: AsyncSession,
+):
+    """Listing must not write computed fields back to DataEntry.data."""
+    # arrange: build a plane DataEntry with input-only data
+    # act: call get_submodule_data, then commit
+    # assert: refreshed row's `data` matches original input exactly
+```
+
+The test should fail today and pass after Options 1 & 2.
+
+Add an analogous test for `is_buildings_entry` (asserts `room_surface_square_meter` is absent unless it was in the original input).
+
+### CSV regression — `kg_co2eq` only in emission, not in `data`
+
+Per-year and per-module fixtures. Module coverage: every CSV-importable module that may carry a `kg_co2eq` column. Concretely, professional_travel (plane/train), buildings (energy_combustion, building_room), purchase, equipment, external_cloud_and_ai, headcount.
+
+For each fixture:
+
+1. Run the CSV importer.
+2. Query `data_entries` and assert no row has `kg_co2eq` key in `data`.
+3. Query `data_entry_emissions` and assert at least one row has the expected `kg_co2eq` value.
+4. Run a recompute (e.g. update the parent module) and assert the emission's `kg_co2eq` is recomputed via formula (not via the stripped CSV value) when there's no override on file.
+
+Fixture location: `backend/tests/fixtures/csv/regression_kg_co2eq/<year>/<module>.csv` (dumb 2–3 row files).
+
+### API-provider regression
+
+Mirror the CSV test for the professional-travel API provider — feed it a synthetic API response with `OUT_CO2_CORRECTED`, assert the persisted `DataEntry.data` has no `kg_co2eq` key and `DataEntryEmission.kg_co2eq` matches the API value.
+
+### Unit test — `prepare_create(csv_kg_co2eq_override=...)`
+
+Direct unit test on `DataEntryEmissionService.prepare_create`:
+
+- Given a `DataEntry` whose `data` does NOT contain `kg_co2eq`, calling with `csv_kg_co2eq_override=42.0` returns an emission with `kg_co2eq=42.0`.
+- Without the override, the formula path runs.
+
+## 7. Risks
+
+- **`csv_kg_co2eq` override semantics**: the existing override path skipped factor-based formula computation entirely. After the refactor, that semantic must hold — the new `csv_kg_co2eq_override` param must produce the same single-emission row with `primary_factor_id=None`.
+- **`EnergyCombustion` shape fix**: ensure response_dto fields still resolve. The latent bug means consumers were getting `{}` for `factor_values`; verify the response_dto doesn't depend on a `values`-keyed sub-dict.
+- **API provider parity**: ensure the same override path works in the API provider's call to `bulk_create` + `prepare_create` (verify it uses the same emission_service surface).
+
+## 8. Implementation order (single PR)
+
+1. Add `csv_kg_co2eq_override` param to `prepare_create`; remove `data.get("kg_co2eq")` fallback. Update unit tests.
+2. Update CSV provider to strip `kg_co2eq` from `data` and pass override transiently.
+3. Update API provider similarly.
+4. Remove workaround strip in `upsert_by_data_entry`.
+5. Change `to_response` protocol + 14 implementations (Option 1).
+6. Build `enriched_data` in `get_submodule_data`; remove ORM mutations.
+7. Add `_detach`/`session.expunge` to the 5 read methods (Option 2).
+8. Fix `EnergyCombustion` latent bug.
+9. Add regression tests (repo + CSV fixtures + API + prepare_create unit).
+10. Run full test suite.
+
+## Critical files
+
+- `backend/app/repositories/data_entry_repo.py`
+- `backend/app/schemas/data_entry.py`
+- `backend/app/services/data_entry_emission_service.py`
+- `backend/app/services/data_ingestion/base_csv_provider.py`
+- `backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py`
+- `backend/app/modules/buildings/schemas.py`
+- `backend/app/modules/professional_travel/schemas.py`
+- `backend/app/modules/process_emissions/schemas.py`
+- `backend/app/modules/external_cloud_and_ai/schemas.py`
+- `backend/app/modules/equipment_electric_consumption/schemas.py`
+- `backend/app/modules/purchase/schemas.py`
+- `backend/app/modules/research_facilities/animals_schemas.py`
+- `backend/app/modules/research_facilities/common_schemas.py`
+- `backend/app/modules/headcount/schemas.py`
+- `backend/tests/unit/repositories/test_data_entry_repo.py`
+- `backend/tests/fixtures/csv/regression_kg_co2eq/...`


### PR DESCRIPTION
## Summary

Two related leaks were corrupting the source-of-truth `data_entries.data` JSON column with computed/derived values:

1. **Read path**: `DataEntryRepository.get_submodule_data` mutated `data_entry.data` in place (kg_co2eq, primary_factor, distance_km, traveler_name, room_surface_square_meter) to feed `handler.to_response`. SQLAlchemy then flushed the dirty ORM row back to the JSON column on the next commit/autoflush.
2. **Ingestion path**: CSV/API providers stuffed the `kg_co2eq` override directly into `DataEntry.data`, persisting it. On every later edit, `prepare_create` would treat the persisted value as a CSV override and skip the formula — silently freezing emissions to whatever value the original CSV had.

Both leaks are now closed by routing computed values out-of-band.

## What changed

### Read path (`get_submodule_data`)
- `to_response` protocol gains an `enriched_data: dict | None` kwarg; the repo builds a fresh dict instead of touching the ORM row. 14 implementations updated across 9 module files.
- `session.expunge(...)` defense added on every ORM row returned by `get_submodule_data` (TODO comments left on the four other read methods pending a per-caller audit).

### Ingestion path (`kg_co2eq` override)
- `DataEntryEmissionService.prepare_create` gains `kg_co2eq_override: float | None = None`; the `data.get("kg_co2eq")` fallback is gone — the override is exclusively the parameter.
- CSV provider (`base_csv_provider._process_row`/`_process_batch`/`_finalize_and_commit`) carries `kg_co2eq` on a parallel list aligned with the batch, then builds `{data_entry.id: kg_co2eq}` after `bulk_create` returns and forwards per-call to `prepare_create`. `kg_co2eq` is never written to `DataEntry.data`.
- API provider (`professional_travel_api_provider.load_data`) mirrors the CSV pattern.
- `upsert_by_data_entry` strip workaround deleted (was only there to defend against the read-path bug).

### Latent fix (frontend-visible)
- `EnergyCombustionModuleHandler.to_response` was reading `primary_factor.get(\"values\", {})` from a flat dict that has no nested \`values\` key — so \`name\`/\`unit\` on the response have been \`None\` (or fallback) for most rows. Fixed to read directly from the flat \`primary_factor\` dict. **Frontend energy-combustion submodule listing will start showing real values where it currently shows None — manual UI verification recommended.**

## Tests

| New test | Coverage |
|---|---|
| `test_get_submodule_data_does_not_persist_computed_fields` | Repo regression: list endpoint + commit → asserts JSON column matches original input |
| `test_prepare_create_with_kg_co2eq_override_short_circuits_formula` | Override param produces single emission with override value, primary_factor_id=None |
| `test_prepare_create_does_not_read_kg_co2eq_from_data` | Stray kg_co2eq in `data` is NOT picked up — only the param channel works |
| `test_process_row_extracts_kg_co2eq_out_of_band` | CSV row with kg_co2eq → returned as 4th tuple element, not in DataEntry.data |
| `test_process_row_with_no_kg_co2eq_returns_none_override` | No-override path returns None |
| `test_process_row_consumes_dumb_csv_fixture_for_plane` | Iterates the new fixture file via csv.DictReader, asserts per-row invariant |
| `test_process_batch_routes_kg_co2eq_overrides_by_id` | Full carrier flow: parallel list → `{id: kg}` dict → per-call routing to `prepare_create` |

Plus updated obsolete tests:
- `test_upsert_passes_data_through_unchanged` (replaces three workaround-strip regression tests)
- `test_csv_override_with_multiple_factors_creates_single_row` (now uses `kg_co2eq_override=` instead of stuffing into `data`)

Fixture file added at `backend/tests/integration/data_ingestion/fixtures/regression_kg_co2eq_plane.csv`.

## DB cleanup

Out of scope per agreed plan — DB will be dropped, so no migration needed.

## Test plan

- [x] `uv run pytest tests/unit/ tests/integration/` — 1235 passed
- [x] Manual UI: open the buildings → energy-combustion submodule listing on a report with at least one entry. Confirm `name` and `unit` columns now populate from factor classification where they were previously empty.
- [ ] Manual UI: load a non-trivial report's professional-travel submodule listing (which exercises `get_submodule_data` for plane/train), then re-fetch the same `data_entry` row from the DB and confirm `data` has none of the computed keys (`kg_co2eq`, `primary_factor`, `distance_km`, `traveler_name`).
- [ ] CSV import smoke: upload a small plane CSV with a `kg_co2eq` column and confirm (a) `data_entries.data` rows have no `kg_co2eq`, (b) `data_entry_emissions.kg_co2eq` carries the imported value.

Plan: `docs/implementation-plans/fix-data-entry-data-mutation.md`.