### PR TITLE
feat: apply default current on purchase and external cloud data entries creation

### DIFF
--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -73,7 +73,7 @@ class ExternalCloudHandlerCreate(DataEntryCreate):
     service_type: str
     provider: str
     spent_amount: float
-    currency: Optional[str] = "eur"
+    currency: Optional[str] = None
     note: Optional[str] = None
 
     @model_validator(mode="before")
@@ -101,10 +101,11 @@ class ExternalCloudHandlerCreate(DataEntryCreate):
     def validate_currency(cls, v: Optional[str]) -> str:
         if v is None:
             return "eur"
+        normalized_v = v.strip().lower()
         valid_currencies = ["chf", "eur", "usd"]
-        if v.lower() not in valid_currencies:
+        if normalized_v not in valid_currencies:
             raise ValueError(f"Currency must be one of: {valid_currencies}")
-        return v
+        return normalized_v
 
 
 class ExternalAIHandlerCreate(DataEntryCreate):
@@ -155,10 +156,11 @@ class ExternalCloudHandlerUpdate(DataEntryUpdate):
     def validate_currency(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v
+        normalized_v = v.strip().lower()
         valid_currencies = ["chf", "eur", "usd"]
-        if v.lower() not in valid_currencies:
+        if normalized_v not in valid_currencies:
             raise ValueError(f"Currency must be one of: {valid_currencies}")
-        return v
+        return normalized_v
 
 
 class ExternalAIHandlerUpdate(DataEntryUpdate):

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import ValidationInfo, field_validator
+from pydantic import ValidationInfo, field_validator, model_validator
 from sqlalchemy import case
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -73,8 +73,21 @@ class ExternalCloudHandlerCreate(DataEntryCreate):
     service_type: str
     provider: str
     spent_amount: float
-    currency: Optional[str] = None
+    currency: Optional[str] = "eur"
     note: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_default_currency(cls, data: Any) -> Any:
+        """Ensure default currency is applied when input has null or empty currency."""
+        if isinstance(data, dict):
+            currency = data.get("currency")
+            # Apply default when currency is None, empty string, or whitespace-only
+            if currency is None or (
+                isinstance(currency, str) and currency.strip() == ""
+            ):
+                data["currency"] = "eur"
+        return data
 
     @field_validator("spent_amount", mode="after")
     @classmethod
@@ -85,9 +98,9 @@ class ExternalCloudHandlerCreate(DataEntryCreate):
 
     @field_validator("currency", mode="after")
     @classmethod
-    def validate_currency(cls, v: Optional[str]) -> Optional[str]:
+    def validate_currency(cls, v: Optional[str]) -> str:
         if v is None:
-            return v
+            return "eur"
         valid_currencies = ["chf", "eur", "usd"]
         if v.lower() not in valid_currencies:
             raise ValueError(f"Currency must be one of: {valid_currencies}")

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
@@ -52,11 +52,24 @@ class PurchaseHandlerCreate(DataEntryCreate):
     supplier: Optional[str] = None
     quantity: Optional[float] = None
     total_spent_amount: float
-    currency: Optional[str] = None
+    currency: Optional[str] = "chf"
     purchase_institutional_code: Optional[str] = None
     purchase_institutional_description: Optional[str] = None
     purchase_additional_code: Optional[str] = None
     note: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_default_currency(cls, data: Any) -> Any:
+        """Ensure default currency is applied when input has null or empty currency."""
+        if isinstance(data, dict):
+            currency = data.get("currency")
+            # Apply default when currency is None, empty string, or whitespace-only
+            if currency is None or (
+                isinstance(currency, str) and currency.strip() == ""
+            ):
+                data["currency"] = "chf"
+        return data
 
     @field_validator("quantity", mode="after")
     @classmethod
@@ -81,6 +94,16 @@ class PurchaseHandlerCreate(DataEntryCreate):
             raise ValueError(
                 "Purchase institutional code must be at least 1 character long"
             )
+        return v
+
+    @field_validator("currency", mode="after")
+    @classmethod
+    def validate_currency(cls, v: Optional[str]) -> str:
+        if v is None:
+            return "chf"
+        valid_currencies = ["chf", "eur", "usd"]
+        if v.lower() not in valid_currencies:
+            raise ValueError(f"Currency must be one of: {valid_currencies}")
         return v
 
 
@@ -112,7 +135,7 @@ class PurchaseHandlerUpdate(DataEntryUpdate):
 
     @field_validator("quantity", mode="after")
     @classmethod
-    def validate_quantity(cls, v: Optional[int]) -> Optional[int]:
+    def validate_quantity(cls, v: Optional[float]) -> Optional[float]:
         if v is None:
             return v
         if v < 0:
@@ -126,6 +149,16 @@ class PurchaseHandlerUpdate(DataEntryUpdate):
             return v
         if v < 0:
             raise ValueError("Total spend amount must be non-negative")
+        return v
+
+    @field_validator("currency", mode="after")
+    @classmethod
+    def validate_currency(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        valid_currencies = ["chf", "eur", "usd"]
+        if v.lower() not in valid_currencies:
+            raise ValueError(f"Currency must be one of: {valid_currencies}")
         return v
 
 

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -52,7 +52,7 @@ class PurchaseHandlerCreate(DataEntryCreate):
     supplier: Optional[str] = None
     quantity: Optional[float] = None
     total_spent_amount: float
-    currency: Optional[str] = "chf"
+    currency: Optional[str] = None
     purchase_institutional_code: Optional[str] = None
     purchase_institutional_description: Optional[str] = None
     purchase_additional_code: Optional[str] = None
@@ -101,10 +101,11 @@ class PurchaseHandlerCreate(DataEntryCreate):
     def validate_currency(cls, v: Optional[str]) -> str:
         if v is None:
             return "chf"
+        normalized_v = v.strip().lower()
         valid_currencies = ["chf", "eur", "usd"]
-        if v.lower() not in valid_currencies:
+        if normalized_v not in valid_currencies:
             raise ValueError(f"Currency must be one of: {valid_currencies}")
-        return v
+        return normalized_v
 
 
 class PurchaseAdditionalHandlerCreate(DataEntryCreate):
@@ -156,10 +157,11 @@ class PurchaseHandlerUpdate(DataEntryUpdate):
     def validate_currency(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v
+        normalized_v = v.strip().lower()
         valid_currencies = ["chf", "eur", "usd"]
-        if v.lower() not in valid_currencies:
+        if normalized_v not in valid_currencies:
             raise ValueError(f"Currency must be one of: {valid_currencies}")
-        return v
+        return normalized_v
 
 
 class PurchaseAdditionalHandlerUpdate(DataEntryUpdate):


### PR DESCRIPTION
## What does this change?

Data entries contain the default currency.

## Why is this needed?

1. Default currency was not visible in data reports
2. Protect from default currency changes

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #982

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
