### PR TITLE
fix(ingestion): require year for MODULE_UNIT_SPECIFIC CSV uploads

### DIFF
--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -867,13 +867,15 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 # providers (_setup_handlers_and_factors for
                 # MODULE_UNIT_SPECIFIC, _resolve_module_per_year_modules for
                 # MODULE_PER_YEAR) raise before any row reaches this method,
-                # so reaching this branch with year unset would mean a future
-                # caller bypassed setup. Re-raise loudly rather than fall back
-                # to a sentinel year that silently misses every factor lookup.
-                if self.year is None:
+                # so reaching this branch with a falsy year would mean a
+                # future caller bypassed setup. Use the same `not self.year`
+                # check the setup-time guard uses so both layers reject the
+                # same set of values (None and 0); a stricter `is None` check
+                # would let `year=0` rebuild the `:0:` silent-miss key.
+                if not self.year:
                     raise ValueError(
-                        "year must be set before processing rows; "
-                        "setup-time guard was bypassed"
+                        "year must be set (and non-zero) before processing "
+                        "rows; setup-time guard was bypassed"
                     )
                 year_value = self.year
                 # Build lookup key same way as load_factors_map does

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -863,7 +863,19 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 kind_value, subkind_value = self._extract_kind_subkind_values(
                     filtered_row, handlers
                 )
-                year_value = self.year or 0
+                # Defense in depth: setup-time guards in the entity-specific
+                # providers (_setup_handlers_and_factors for
+                # MODULE_UNIT_SPECIFIC, _resolve_module_per_year_modules for
+                # MODULE_PER_YEAR) raise before any row reaches this method,
+                # so reaching this branch with year unset would mean a future
+                # caller bypassed setup. Re-raise loudly rather than fall back
+                # to a sentinel year that silently misses every factor lookup.
+                if self.year is None:
+                    raise ValueError(
+                        "year must be set before processing rows; "
+                        "setup-time guard was bypassed"
+                    )
+                year_value = self.year
                 # Build lookup key same way as load_factors_map does
                 key_full = (
                     f"{data_entry_type.value}:"

--- a/backend/app/services/data_ingestion/csv_providers/module_unit_specific.py
+++ b/backend/app/services/data_ingestion/csv_providers/module_unit_specific.py
@@ -36,6 +36,14 @@ class ModuleUnitSpecificCSVProvider(BaseCSVProvider):
         - Loads factors for that specific data_entry_type
         - Returns required_columns (strict validation)
         """
+        # Year is required: factor lookups during row processing key on
+        # `{type}:{year}:{kind}:{subkind}`, so a missing year would silently
+        # miss every factor and import rows with primary_factor_id=None.
+        # Symmetric to the MODULE_PER_YEAR guard in
+        # base_csv_provider.py::_resolve_module_per_year_modules.
+        if not self.year:
+            raise ValueError("year is required for MODULE_UNIT_SPECIFIC entity type")
+
         configured_data_entry_type_id = self.config.get("data_entry_type_id")
 
         if configured_data_entry_type_id is None:

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -502,6 +502,71 @@ async def test_process_row_success_with_unit_mapping(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_process_row_rejects_falsy_year_after_setup_bypass():
+    """Defense-in-depth row-level guard must reject ``year=0`` the same way
+    ``_setup_handlers_and_factors`` does.
+
+    Regression for the asymmetry caught in the PR review: the row-level
+    check originally used ``if self.year is None`` while the setup-time
+    check uses ``if not self.year``, so a caller that bypassed setup with
+    ``year=0`` would slip past the backstop and rebuild the
+    ``{type}:0:...`` silent-miss key — exactly the bug this PR is meant to
+    close. Both layers now use the same falsy check.
+    """
+    config = {"file_path": "tmp/test.csv", "year": 2025}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+    # Simulate a future caller that bypassed setup and left year unset/zero.
+    # The setup-time guard would have raised; the row-level guard must too.
+    provider.year = 0
+
+    handler = MagicMock()
+    handler.kind_field = "kind"
+    handler.subkind_field = None
+
+    async def resolve_handler(*_args, **_kwargs):
+        return (DataEntryTypeEnum.student, handler, None)
+
+    provider._resolve_handler_and_validate = resolve_handler
+    provider._extract_kind_subkind_values = lambda filtered_row, handlers: (
+        "x",
+        None,
+    )
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {"unused_key": SimpleNamespace(id=1)},
+        "expected_columns": {"unit_institutional_id"},
+    }
+    row = {"unit_institutional_id": "U1"}
+    stats = _build_stats()
+
+    # The row-level ValueError is caught by `_process_row`'s broad
+    # try/except (same path every row-validation failure takes) and
+    # recorded as a per-row error. The desired outcome is "this row is
+    # rejected" — not "process_csv_in_batches aborts" — so assert the
+    # per-row error path, not a propagated exception.
+    (
+        data_entry,
+        error_msg,
+        result_factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
+        row,
+        row_idx=1,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=5,
+        unit_to_module_map={"U1": 123},
+    )
+
+    assert data_entry is None
+    assert error_msg is not None and "year must be set" in error_msg
+    assert kg_co2eq_override is None
+    assert stats["rows_skipped"] == 1
+    assert stats["row_errors_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_process_row_missing_unit_mapping_records_error():
     """Test _process_row records error when unit mapping is missing."""
     config = {"file_path": "tmp/test.csv"}

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -445,7 +445,7 @@ def _build_stats() -> StatsDict:
 @pytest.mark.asyncio
 async def test_process_row_success_with_unit_mapping(monkeypatch):
     """Test _process_row builds data entry when mapping is present."""
-    config = {"file_path": "tmp/test.csv"}
+    config = {"file_path": "tmp/test.csv", "year": 2025}
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
     handler = MagicMock()
@@ -598,7 +598,7 @@ async def test_process_row_extracts_kg_co2eq_out_of_band():
     ``filtered_row`` (and hence into ``DataEntry.data``), corrupting the
     source-of-truth JSON column with a derived/imported value.
     """
-    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42, "year": 2025}
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
     handler = MagicMock()
@@ -684,7 +684,7 @@ async def test_process_row_extracts_kg_co2eq_out_of_band():
 async def test_process_row_with_no_kg_co2eq_returns_none_override():
     """Rows without a kg_co2eq column produce a None override — not an
     error, not a side effect on DataEntry.data."""
-    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42, "year": 2025}
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
     handler = MagicMock()
@@ -733,7 +733,7 @@ async def test_process_row_warns_on_unparseable_kg_co2eq(caplog):
     """
     import logging
 
-    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42, "year": 2025}
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
     handler = MagicMock()
@@ -815,7 +815,7 @@ async def test_process_row_consumes_dumb_csv_fixture_for_plane():
     )
     assert fixture_path.exists(), f"missing fixture: {fixture_path}"
 
-    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42}
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 42, "year": 2025}
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
     handler = MagicMock()

--- a/backend/tests/unit/services/data_ingestion/test_module_unit_specific_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_unit_specific_csv_provider.py
@@ -30,6 +30,7 @@ async def test_setup_handlers_and_factors_single_type(monkeypatch):
         {
             "file_path": "tmp/test.csv",
             "data_entry_type_id": DataEntryTypeEnum.member.value,
+            "year": 2025,
         },
         data_session=MagicMock(),
     )
@@ -66,6 +67,51 @@ async def test_setup_handlers_and_factors_single_type(monkeypatch):
     assert "factors_map" in setup
     assert "factor_id_to_factor" in setup
     assert setup["factor_id_to_factor"] == {42: mock_factor}
+
+
+@pytest.mark.asyncio
+async def test_setup_handlers_and_factors_raises_when_year_missing():
+    """Regression: a CSV upload that arrives without ``year`` in the
+    payload must fail loudly at setup time rather than silently importing
+    every row with primary_factor_id=None.
+
+    The factor lookup keys on ``{type}:{year}:{kind}:{subkind}``, so a
+    missing year produces a ``{type}:0:...`` key that never matches any
+    real factor — the kind of silent miscompile this guard is meant to
+    prevent. See base_csv_provider.py::_process_row, which now also has
+    a defensive ``if self.year is None: raise`` so that even if a future
+    caller bypasses setup the row loop refuses to fall back to a sentinel.
+    """
+    provider = ModuleUnitSpecificCSVProvider(
+        {
+            "file_path": "tmp/test.csv",
+            "data_entry_type_id": DataEntryTypeEnum.member.value,
+            # year deliberately omitted — mimics a frontend payload that
+            # forgets to include it (the bug the guard catches).
+        },
+        data_session=MagicMock(),
+    )
+
+    with pytest.raises(ValueError, match="year is required"):
+        await provider._setup_handlers_and_factors()
+
+
+@pytest.mark.asyncio
+async def test_setup_handlers_and_factors_raises_when_year_is_zero():
+    """Sibling regression: ``year=0`` is also invalid. The guard uses
+    ``if not self.year`` (matching the MODULE_PER_YEAR sibling's pattern)
+    so falsy years are rejected the same as ``None``."""
+    provider = ModuleUnitSpecificCSVProvider(
+        {
+            "file_path": "tmp/test.csv",
+            "data_entry_type_id": DataEntryTypeEnum.member.value,
+            "year": 0,
+        },
+        data_session=MagicMock(),
+    )
+
+    with pytest.raises(ValueError, match="year is required"):
+        await provider._setup_handlers_and_factors()
 
 
 def test_extract_kind_subkind_values_from_handler():
@@ -303,6 +349,7 @@ async def test_setup_returns_empty_factor_id_map_with_no_factors(monkeypatch):
         {
             "file_path": "tmp/test.csv",
             "data_entry_type_id": DataEntryTypeEnum.member.value,
+            "year": 2025,
         },
         data_session=MagicMock(),
     )
@@ -334,6 +381,7 @@ async def test_setup_returns_multiple_factors_in_id_map(monkeypatch):
         {
             "file_path": "tmp/test.csv",
             "data_entry_type_id": DataEntryTypeEnum.member.value,
+            "year": 2025,
         },
         data_session=MagicMock(),
     )
@@ -371,6 +419,7 @@ async def test_setup_skips_factors_without_id(monkeypatch):
         {
             "file_path": "tmp/test.csv",
             "data_entry_type_id": DataEntryTypeEnum.member.value,
+            "year": 2025,
         },
         data_session=MagicMock(),
     )
@@ -494,6 +543,7 @@ async def test_all_data_entry_types_return_factor_id_to_factor(monkeypatch):
             {
                 "file_path": "tmp/test.csv",
                 "data_entry_type_id": entry_type.value,
+                "year": 2025,
             },
             data_session=MagicMock(),
         )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7339,13 +7339,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -524,6 +524,7 @@ const onFilesUploaded = async (filePaths: string[]) => {
       moduleStore.state.data?.carbon_report_module_id;
     const jobId = await dataManagementStore.initiateSync({
       module_type_id: moduleTypeId,
+      year: Number(props.year),
       provider_type: 'csv',
       target_type: TargetType.DATA_ENTRIES,
       file_path: filePath,

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -123,7 +123,7 @@ export enum IngestionResult {
 
 export type InitiateSyncParams = {
   module_type_id: number;
-  year?: number;
+  year: number;
   provider_type: 'csv' | 'api';
   target_type?: TargetType;
   filters?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

- A missing `year` in CSV upload payloads silently miscompiled emissions: `BaseCSVProvider._process_row` fell back to `self.year or 0` when building the factor lookup key (`{type}:{year}:{kind}:{subkind}`), which never matched any real factor — every row imported with `primary_factor_id=None` and the module fell back to formula-path with no factor link. No error, no log, just wrong numbers.
- Adds the symmetric setup-time guard for **MODULE_UNIT_SPECIFIC** (the variant that lacked one — `MODULE_PER_YEAR` already raised in `_resolve_module_per_year_modules`), replaces the silent `or 0` fallback with a defense-in-depth `if … raise ValueError`, and updates the frontend `ModuleTable.vue` upload payload (`onFilesUploaded`) to include `year` — the omitting caller in production.
- Regression tests assert the new `ValueError` both when `year` is missing **and** when it is `0` (matching the falsy-check in the guard).

## Why this was MODULE_UNIT_SPECIFIC only

| Site | Pre-existing year handling |
| --- | --- |
| `base_csv_provider.py:340` (MODULE_PER_YEAR) | ✅ `raise ValueError(...)` |
| `professional_travel_api_provider.py:740` | ✅ `raise ValueError(...)` |
| `factor_update_provider.py:119` | ✅ `raise ValueError(...)` |
| `base_factor_csv_provider.py:247` + `local_seed.py:90` | ✅ raise / explicit None handling |
| **`base_csv_provider.py:866`** (MODULE_UNIT_SPECIFIC `_process_row`) | ❌ `or 0` — silent miscompile |

A repo-wide sweep confirmed this was the only `.year or 0` site in the backend.

## Test plan

- [x] `uv run pytest` — 1244 passing
- [x] New regression: `test_setup_handlers_and_factors_raises_when_year_missing`
- [x] New regression: `test_setup_handlers_and_factors_raises_when_year_is_zero`
- [ ] Manual: upload a CSV via the module table without selecting a year — should now 400 cleanly (frontend now sends `year`, so this is an API-level safety net)
- [ ] Manual: confirm a normal CSV upload (with `year` selected in the UI) still imports correctly and `primary_factor_id` is populated on the resulting emissions

## Related

- Independent of #988 (which is about *persisting computed fields* — different concern, different file area).