### PR TITLE
feat: add PDF print of result page charts

### DIFF
--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTreeMapChart.vue';
 import EmissionTypeBreakdownChart from 'src/components/charts/results/EmissionTypeBreakdownChart.vue';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 import {
   MODULE_TO_CATEGORIES,
   CHART_CATEGORY_COLOR_SCALES,
@@ -32,6 +33,7 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const isPrintMode = usePrintMode();
 
 // Modules that can appear as tabs (exclude headcount — no treemap chart)
 // Same left-to-right order as the bar chart (mirrors backend MODULE_BREAKDOWN_ORDER)
@@ -202,7 +204,7 @@ const emissionTypeInfoKey = computed(() =>
 
 <template>
   <q-card flat bordered class="q-pa-xl">
-    <div class="flex justify-between items-center q-mb-md">
+    <div v-if="!isPrintMode" class="flex justify-between items-center q-mb-md">
       <span class="text-h5 text-weight-medium">{{
         $t('results_treemap_title')
       }}</span>
@@ -259,7 +261,7 @@ const emissionTypeInfoKey = computed(() =>
     </div>
 
     <!-- Module tab buttons -->
-    <div class="flex flex-wrap q-gutter-sm q-mb-md">
+    <div v-if="!isPrintMode" class="flex flex-wrap q-gutter-sm q-mb-md">
       <q-btn
         v-for="mod in availableModules"
         :key="mod"

--- a/frontend/src/components/charts/EvolutionOverTimeChart.vue
+++ b/frontend/src/components/charts/EvolutionOverTimeChart.vue
@@ -15,8 +15,10 @@ import TooltipEcharts from './results/TooltipEcharts.vue';
 import { useEchartsTooltip } from './results/useEchartsTooltip';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 
 const { t } = useI18n();
+const isPrintMode = usePrintMode();
 
 use([
   CanvasRenderer,
@@ -125,34 +127,37 @@ const chartOption = computed((): EChartsOption => {
       top: '10%',
       containLabel: true,
     },
-    tooltip: {
-      trigger: 'axis',
-      formatter: (params: unknown) => {
-        const arr = Array.isArray(params) ? params : [];
-        if (!arr.length) {
-          emitTooltip(null);
-          return '';
-        }
-        const title =
-          arr[0].axisValue != null ? String(arr[0].axisValue) : undefined;
-        emitTooltip({
-          title,
-          rows: arr.map(
-            (item: {
-              seriesName?: string;
-              value?: number;
-              color?: string;
-            }) => ({
-              label: item.seriesName ?? '',
-              value: item.value != null ? item.value.toFixed(0) : '-',
-              color: item.color ?? '#888',
-            }),
-          ),
-        });
-        return '';
-      },
-    },
+    tooltip: isPrintMode.value
+      ? { show: false }
+      : {
+          trigger: 'axis',
+          formatter: (params: unknown) => {
+            const arr = Array.isArray(params) ? params : [];
+            if (!arr.length) {
+              emitTooltip(null);
+              return '';
+            }
+            const title =
+              arr[0].axisValue != null ? String(arr[0].axisValue) : undefined;
+            emitTooltip({
+              title,
+              rows: arr.map(
+                (item: {
+                  seriesName?: string;
+                  value?: number;
+                  color?: string;
+                }) => ({
+                  label: item.seriesName ?? '',
+                  value: item.value != null ? item.value.toFixed(0) : '-',
+                  color: item.color ?? '#888',
+                }),
+              ),
+            });
+            return '';
+          },
+        },
     legend: {
+      show: !isPrintMode.value,
       data: [t('plane', 'plane'), t('train', 'train')],
       top: 0,
       left: 'center',

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -16,6 +16,7 @@ import TooltipEcharts from './results/TooltipEcharts.vue';
 import { useEchartsTooltip } from './results/useEchartsTooltip';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 
 import type { EmissionTreemapCategory } from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
@@ -23,6 +24,7 @@ import { formatTonnesForChart } from 'src/utils/number';
 const { t } = useI18n();
 const moduleStore = useModuleStore();
 const workspaceStore = useWorkspaceStore();
+const isPrintMode = usePrintMode();
 
 const LABEL_KEY_MAP: Record<string, string> = {
   // process_emissions
@@ -163,31 +165,33 @@ const chartOption = computed((): EChartsOption => {
 
   return {
     animation: false,
-    tooltip: {
-      trigger: 'item',
-      formatter: (params: unknown) => {
-        const p = params as {
-          seriesName?: string;
-          color?: string;
-          data?: { value: number; originalValue: number };
-        };
-        const val = p.data?.originalValue ?? 0;
-        if (val <= 0) {
-          emitTooltip(null);
-          return '';
-        }
-        emitTooltip({
-          rows: [
-            {
-              label: p.seriesName ?? '',
-              value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
-              color: p.color ?? '#888',
-            },
-          ],
-        });
-        return '';
-      },
-    },
+    tooltip: isPrintMode.value
+      ? { show: false }
+      : {
+          trigger: 'item',
+          formatter: (params: unknown) => {
+            const p = params as {
+              seriesName?: string;
+              color?: string;
+              data?: { value: number; originalValue: number };
+            };
+            const val = p.data?.originalValue ?? 0;
+            if (val <= 0) {
+              emitTooltip(null);
+              return '';
+            }
+            emitTooltip({
+              rows: [
+                {
+                  label: p.seriesName ?? '',
+                  value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+                  color: p.color ?? '#888',
+                },
+              ],
+            });
+            return '';
+          },
+        },
     legend: { show: false },
     grid: {
       left: 0,
@@ -277,7 +281,7 @@ const babyBlueScheme = computed(() => {
 <template>
   <div class="flex justify-between items-center q-mb-xs">
     <q-card-section
-      v-if="legendData.length > 0"
+      v-if="!isPrintMode && legendData.length > 0"
       class="legend-container q-pa-none"
     >
       <div class="flex flex-wrap" style="gap: 15px">
@@ -296,7 +300,7 @@ const babyBlueScheme = computed(() => {
     </q-card-section>
 
     <q-btn
-      v-if="showEvolutionDialog"
+      v-if="!isPrintMode && showEvolutionDialog"
       color="primary"
       unelevated
       no-caps
@@ -322,7 +326,9 @@ const babyBlueScheme = computed(() => {
       class="chart"
       autoresize
       :option="chartOption"
-      :style="{ height: height ?? '200px' }"
+      :style="{
+        height: isPrintMode ? (height ?? '80px') : (height ?? '200px'),
+      }"
       @vue:mounted="onChartReady"
     />
     <Teleport to="body">

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -31,6 +31,7 @@ use([
 ]);
 
 import { formatTonnesForChart } from 'src/utils/number';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 
 const props = defineProps<{
   perPersonBreakdown?: Record<string, number> | null;
@@ -42,12 +43,12 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const isPrintMode = usePrintMode();
 const toggleAdditionalData = ref(false);
 const effectiveToggle = computed(
   () => props.viewAdditionalData ?? toggleAdditionalData.value,
 );
 
-// ✅ TOOLTIP COMPOSABLE
 const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
 
 const chartRef = ref<InstanceType<typeof VChart>>();
@@ -129,15 +130,14 @@ const datasetSource = computed(() => {
 
 const additionalSeriesData = computed(() => {
   if (!effectiveToggle.value) return [];
+  const encodeFor = (cat: string, val: string) =>
+    isPrintMode.value ? { x: val, y: cat } : { x: cat, y: val };
   return [
     {
       name: t('charts-commuting-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'commuting',
-      },
+      encode: encodeFor('category', 'commuting'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.commuting,
       },
@@ -149,10 +149,7 @@ const additionalSeriesData = computed(() => {
       name: t('charts-food-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'food',
-      },
+      encode: encodeFor('category', 'food'),
       itemStyle: {
         color: colors.value.mint.darker,
       },
@@ -164,10 +161,7 @@ const additionalSeriesData = computed(() => {
       name: t('charts-waste-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'waste',
-      },
+      encode: encodeFor('category', 'waste'),
       itemStyle: {
         color: colors.value.periwinkle.darker,
       },
@@ -179,10 +173,7 @@ const additionalSeriesData = computed(() => {
       name: t('charts-embodied-energy-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'embodied_energy',
-      },
+      encode: encodeFor('category', 'embodied_energy'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.embodied_energy,
       },
@@ -194,15 +185,20 @@ const additionalSeriesData = computed(() => {
 });
 
 const chartOption = computed((): EChartsOption => {
+  const encodeFor = (categoryAxis: string, valueAxis: string) =>
+    isPrintMode.value
+      ? { x: valueAxis, y: categoryAxis }
+      : { x: categoryAxis, y: valueAxis };
+
+  const barMaxWidth = isPrintMode.value ? 40 : undefined;
+
   const seriesArray = [
     {
       name: t('charts-process-emissions-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'process_emissions',
-      },
+      barMaxWidth,
+      encode: encodeFor('category', 'process_emissions'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.process_emissions,
       },
@@ -214,10 +210,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('charts-buildings-energy-combustion-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'buildings_energy_combustion',
-      },
+      encode: encodeFor('category', 'buildings_energy_combustion'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.buildings_energy_combustion,
       },
@@ -229,10 +222,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('charts-buildings-room-category'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'buildings_room',
-      },
+      encode: encodeFor('category', 'buildings_room'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.buildings_room,
       },
@@ -244,10 +234,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('equipment-electric-consumption'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'equipment',
-      },
+      encode: encodeFor('category', 'equipment'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.equipment,
       },
@@ -259,10 +246,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('external-cloud-and-ai'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'external_cloud_and_ai',
-      },
+      encode: encodeFor('category', 'external_cloud_and_ai'),
       itemStyle: {
         color: CHART_CATEGORY_COLOR_SCHEMES.value.external_cloud_and_ai,
       },
@@ -274,10 +258,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('professional-travel'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'professional_travel',
-      },
+      encode: encodeFor('category', 'professional_travel'),
       itemStyle: {
         color: colors.value.babyBlue.darker,
       },
@@ -289,10 +270,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('purchase'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'purchases',
-      },
+      encode: encodeFor('category', 'purchases'),
       itemStyle: {
         color: colors.value.lightGreen.darker,
       },
@@ -304,10 +282,7 @@ const chartOption = computed((): EChartsOption => {
       name: t('research-facilities'),
       type: 'bar' as const,
       stack: 'total',
-      encode: {
-        x: 'category',
-        y: 'research_facilities',
-      },
+      encode: encodeFor('category', 'research_facilities'),
       itemStyle: {
         color: colors.value.paleYellowGreen.darker,
       },
@@ -321,10 +296,7 @@ const chartOption = computed((): EChartsOption => {
             name: t('charts-objective-tick'),
             type: 'bar' as const,
             stack: 'total',
-            encode: {
-              x: 'category',
-              y: 'objective2030',
-            },
+            encode: encodeFor('category', 'objective2030'),
             itemStyle: {
               color: colors.value.skyBlue.darker,
             },
@@ -338,99 +310,96 @@ const chartOption = computed((): EChartsOption => {
   ];
 
   return {
-    tooltip: {
-      trigger: 'axis',
-      axisPointer: {
-        type: 'shadow',
-      },
-      formatter: (params: unknown) => {
-        const arr = Array.isArray(params) ? params : params ? [params] : [];
-        if (!arr.length) {
-          emitTooltip(null);
-          return '';
-        }
+    tooltip: isPrintMode.value
+      ? { show: false }
+      : {
+          trigger: 'axis',
+          axisPointer: {
+            type: 'shadow',
+          },
+          formatter: (params: unknown) => {
+            const arr = Array.isArray(params) ? params : params ? [params] : [];
+            if (!arr.length) {
+              emitTooltip(null);
+              return '';
+            }
 
-        const firstParam = arr[0] as Record<string, unknown>;
-        const data = firstParam.data as Record<string, unknown> | undefined;
-        const title = String(firstParam.axisValue ?? firstParam.name ?? '');
+            const firstParam = arr[0] as Record<string, unknown>;
+            const data = firstParam.data as Record<string, unknown> | undefined;
+            const title = String(firstParam.axisValue ?? firstParam.name ?? '');
 
-        const rows: TooltipRow[] = [];
+            const rows: TooltipRow[] = [];
 
-        for (const param of [...arr].reverse()) {
-          const p = param as Record<string, unknown>;
-          const series = seriesArray.find((s) => s.name === p.seriesName);
-          const key = series?.encode.y;
-          const dataValue = Number(data?.[key]) || 0;
-          if (dataValue > 0 && series) {
-            rows.push({
-              label: series.name,
-              value: formatTonnesForChart(dataValue),
-              color: (series.itemStyle?.color as string) ?? '#888',
-            });
-          }
-        }
+            for (const param of [...arr].reverse()) {
+              const p = param as Record<string, unknown>;
+              const series = seriesArray.find((s) => s.name === p.seriesName);
+              const key = series?.encode.y;
+              const dataValue = Number(data?.[key]) || 0;
+              if (dataValue > 0 && series) {
+                rows.push({
+                  label: series.name,
+                  value: formatTonnesForChart(dataValue),
+                  color: (series.itemStyle?.color as string) ?? '#888',
+                });
+              }
+            }
 
-        const state: TooltipState = { title, rows };
-        emitTooltip(state);
-        return '';
-      },
-    },
-
-    grid: {
-      left: '5%',
-      right: '4%',
-      top: 80,
-      bottom: '0%',
-      containLabel: true,
-    },
-
-    xAxis: {
-      type: 'category',
-      axisLabel: {
-        interval: 0,
-        rotate: 45,
-        fontSize: 11,
-      },
-    },
-
-    yAxis: {
-      type: 'value',
-      name: t('tco2eq'),
-      nameLocation: 'middle',
-      nameGap: 40,
-      nameRotate: 90,
-      nameTextStyle: {
-        fontSize: 11,
-        fontWeight: 'bold',
-      },
-      axisLabel: {
-        formatter: '{value}',
-      },
-    },
-
-    graphic: [
-      {
-        type: 'rect',
-        left: '46px',
-        top: '15px',
-        shape: {
-          width: 500,
-          height: 300,
+            const state: TooltipState = { title, rows };
+            emitTooltip(state);
+            return '';
+          },
         },
-        style: {
-          fill: new graphic.LinearGradient(0, 0, 0, 1, [
-            {
-              offset: 0,
-              color: 'rgba(240,240,240,0.9)',
-            },
-            {
-              offset: 1,
-              color: 'rgba(240,240,240,0.1)',
-            },
-          ]),
+
+    grid: isPrintMode.value
+      ? { left: '10%', right: '4%', top: 10, bottom: 30, containLabel: true }
+      : { left: '5%', right: '4%', top: 80, bottom: '0%', containLabel: true },
+
+    xAxis: isPrintMode.value
+      ? {
+          type: 'value',
+          name: t('tco2eq'),
+          nameLocation: 'middle' as const,
+          nameGap: 30,
+          nameTextStyle: { fontSize: 11, fontWeight: 'bold' as const },
+          axisLabel: { formatter: '{value}' },
+        }
+      : {
+          type: 'category',
+          axisLabel: { interval: 0, rotate: 45, fontSize: 11 },
         },
-      },
-    ],
+
+    yAxis: isPrintMode.value
+      ? {
+          type: 'category',
+          axisLabel: { fontSize: 11 },
+          axisTick: { alignWithLabel: true },
+        }
+      : {
+          type: 'value',
+          name: t('tco2eq'),
+          nameLocation: 'middle' as const,
+          nameGap: 40,
+          nameRotate: 90,
+          nameTextStyle: { fontSize: 11, fontWeight: 'bold' as const },
+          axisLabel: { formatter: '{value}' },
+        },
+
+    graphic: isPrintMode.value
+      ? []
+      : [
+          {
+            type: 'rect',
+            left: '46px',
+            top: '15px',
+            shape: { width: 500, height: 500 },
+            style: {
+              fill: new graphic.LinearGradient(0, 0, 0, 1, [
+                { offset: 0, color: 'rgba(240,240,240,0.9)' },
+                { offset: 1, color: 'rgba(240,240,240,0.1)' },
+              ]),
+            },
+          },
+        ],
 
     dataset: {
       dimensions: [
@@ -508,8 +477,15 @@ const downloadCSV = () => {
 </script>
 
 <template>
-  <q-card flat class="container container--pa-none full-width">
-    <q-card-section class="flex justify-between items-center">
+  <q-card
+    flat
+    class="container container--pa-none full-width"
+    :class="{ 'container--print': isPrintMode }"
+  >
+    <q-card-section
+      class="flex justify-between items-center"
+      :class="{ 'q-pb-none': isPrintMode }"
+    >
       <div>
         <span class="text-body1 text-weight-medium q-ml-sm q-mb-none">
           {{
@@ -518,7 +494,7 @@ const downloadCSV = () => {
         </span>
       </div>
 
-      <div class="flex items-center no-wrap q-gutter-sm">
+      <div v-if="!isPrintMode" class="flex items-center no-wrap q-gutter-sm">
         <q-btn
           v-if="headcountValidated"
           unelevated
@@ -560,7 +536,7 @@ const downloadCSV = () => {
       <q-card-section class="chart-container flex justify-center items-center">
         <v-chart
           ref="chartRef"
-          class="chart"
+          :class="['chart', { 'chart--print': isPrintMode }]"
           autoresize
           :option="chartOption"
           @vue:mounted="onChartReady"
@@ -602,8 +578,13 @@ const downloadCSV = () => {
 }
 
 .chart {
-  width: 200px;
-  min-height: 500px;
+  width: 100%;
+  min-height: 420px;
+}
+
+.chart--print {
+  min-height: unset;
+  height: 120px !important;
 }
 
 .validation-placeholder {

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -184,15 +184,15 @@ const additionalSeriesData = computed(() => {
   ];
 });
 
-const chartOption = computed((): EChartsOption => {
-  const encodeFor = (categoryAxis: string, valueAxis: string) =>
-    isPrintMode.value
-      ? { x: valueAxis, y: categoryAxis }
-      : { x: categoryAxis, y: valueAxis };
+function encodeFor(categoryAxis: string, valueAxis: string) {
+  return isPrintMode.value
+    ? { x: valueAxis, y: categoryAxis }
+    : { x: categoryAxis, y: valueAxis };
+}
 
+const seriesArray = computed(() => {
   const barMaxWidth = isPrintMode.value ? 40 : undefined;
-
-  const seriesArray = [
+  return [
     {
       name: t('charts-process-emissions-category'),
       type: 'bar' as const,
@@ -308,99 +308,124 @@ const chartOption = computed((): EChartsOption => {
       : []),
     ...additionalSeriesData.value,
   ];
+});
+
+const chartTooltipOption = computed(() => {
+  if (isPrintMode.value) return { show: false };
+
+  function tooltipFormatter(params: unknown): string {
+    const arr = Array.isArray(params) ? params : params ? [params] : [];
+    if (!arr.length) {
+      emitTooltip(null);
+      return '';
+    }
+
+    const firstParam = arr[0] as Record<string, unknown>;
+    const data = firstParam.data as Record<string, unknown> | undefined;
+    const title = String(firstParam.axisValue ?? firstParam.name ?? '');
+
+    const rows: TooltipRow[] = [];
+
+    for (const param of [...arr].reverse()) {
+      const p = param as Record<string, unknown>;
+      const series = seriesArray.value.find((s) => s.name === p.seriesName);
+      const key = series?.encode.y;
+      const dataValue = Number(data?.[key]) || 0;
+      if (dataValue > 0 && series) {
+        rows.push({
+          label: series.name,
+          value: formatTonnesForChart(dataValue),
+          color: (series.itemStyle?.color as string) ?? '#888',
+        });
+      }
+    }
+
+    const state: TooltipState = { title, rows };
+    emitTooltip(state);
+    return '';
+  }
 
   return {
-    tooltip: isPrintMode.value
-      ? { show: false }
-      : {
-          trigger: 'axis',
-          axisPointer: {
-            type: 'shadow',
-          },
-          formatter: (params: unknown) => {
-            const arr = Array.isArray(params) ? params : params ? [params] : [];
-            if (!arr.length) {
-              emitTooltip(null);
-              return '';
-            }
+    trigger: 'axis' as const,
+    axisPointer: { type: 'shadow' as const },
+    formatter: tooltipFormatter,
+  };
+});
 
-            const firstParam = arr[0] as Record<string, unknown>;
-            const data = firstParam.data as Record<string, unknown> | undefined;
-            const title = String(firstParam.axisValue ?? firstParam.name ?? '');
+const chartGridOption = computed(() => {
+  if (isPrintMode.value) {
+    return {
+      left: '10%',
+      right: '4%',
+      top: 10,
+      bottom: 30,
+      containLabel: true,
+    };
+  }
+  return { left: '5%', right: '4%', top: 80, bottom: '0%', containLabel: true };
+});
 
-            const rows: TooltipRow[] = [];
+const chartXAxisOption = computed(() => {
+  if (isPrintMode.value) {
+    return {
+      type: 'value' as const,
+      name: t('tco2eq'),
+      nameLocation: 'middle' as const,
+      nameGap: 30,
+      nameTextStyle: { fontSize: 11, fontWeight: 'bold' as const },
+      axisLabel: { formatter: '{value}' },
+    };
+  }
+  return {
+    type: 'category' as const,
+    axisLabel: { interval: 0, rotate: 45, fontSize: 11 },
+  };
+});
 
-            for (const param of [...arr].reverse()) {
-              const p = param as Record<string, unknown>;
-              const series = seriesArray.find((s) => s.name === p.seriesName);
-              const key = series?.encode.y;
-              const dataValue = Number(data?.[key]) || 0;
-              if (dataValue > 0 && series) {
-                rows.push({
-                  label: series.name,
-                  value: formatTonnesForChart(dataValue),
-                  color: (series.itemStyle?.color as string) ?? '#888',
-                });
-              }
-            }
+const chartYAxisOption = computed(() => {
+  if (isPrintMode.value) {
+    return {
+      type: 'category' as const,
+      axisLabel: { fontSize: 11 },
+      axisTick: { alignWithLabel: true },
+    };
+  }
+  return {
+    type: 'value' as const,
+    name: t('tco2eq'),
+    nameLocation: 'middle' as const,
+    nameGap: 40,
+    nameRotate: 90,
+    nameTextStyle: { fontSize: 11, fontWeight: 'bold' as const },
+    axisLabel: { formatter: '{value}' },
+  };
+});
 
-            const state: TooltipState = { title, rows };
-            emitTooltip(state);
-            return '';
-          },
-        },
+const chartGraphicOption = computed(() => {
+  if (isPrintMode.value) return [];
+  return [
+    {
+      type: 'rect',
+      left: '46px',
+      top: '15px',
+      shape: { width: 500, height: 500 },
+      style: {
+        fill: new graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: 'rgba(240,240,240,0.9)' },
+          { offset: 1, color: 'rgba(240,240,240,0.1)' },
+        ]),
+      },
+    },
+  ];
+});
 
-    grid: isPrintMode.value
-      ? { left: '10%', right: '4%', top: 10, bottom: 30, containLabel: true }
-      : { left: '5%', right: '4%', top: 80, bottom: '0%', containLabel: true },
-
-    xAxis: isPrintMode.value
-      ? {
-          type: 'value',
-          name: t('tco2eq'),
-          nameLocation: 'middle' as const,
-          nameGap: 30,
-          nameTextStyle: { fontSize: 11, fontWeight: 'bold' as const },
-          axisLabel: { formatter: '{value}' },
-        }
-      : {
-          type: 'category',
-          axisLabel: { interval: 0, rotate: 45, fontSize: 11 },
-        },
-
-    yAxis: isPrintMode.value
-      ? {
-          type: 'category',
-          axisLabel: { fontSize: 11 },
-          axisTick: { alignWithLabel: true },
-        }
-      : {
-          type: 'value',
-          name: t('tco2eq'),
-          nameLocation: 'middle' as const,
-          nameGap: 40,
-          nameRotate: 90,
-          nameTextStyle: { fontSize: 11, fontWeight: 'bold' as const },
-          axisLabel: { formatter: '{value}' },
-        },
-
-    graphic: isPrintMode.value
-      ? []
-      : [
-          {
-            type: 'rect',
-            left: '46px',
-            top: '15px',
-            shape: { width: 500, height: 500 },
-            style: {
-              fill: new graphic.LinearGradient(0, 0, 0, 1, [
-                { offset: 0, color: 'rgba(240,240,240,0.9)' },
-                { offset: 1, color: 'rgba(240,240,240,0.1)' },
-              ]),
-            },
-          },
-        ],
-
+const chartOption = computed((): EChartsOption => {
+  return {
+    tooltip: chartTooltipOption.value,
+    grid: chartGridOption.value,
+    xAxis: chartXAxisOption.value,
+    yAxis: chartYAxisOption.value,
+    graphic: chartGraphicOption.value,
     dataset: {
       dimensions: [
         'category',
@@ -420,7 +445,7 @@ const chartOption = computed((): EChartsOption => {
       ],
       source: datasetSource.value as Array<Record<string, unknown>>,
     },
-    series: seriesArray as echarts.SeriesOption[],
+    series: seriesArray.value as echarts.SeriesOption[],
   };
 });
 

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -35,6 +35,7 @@ import {
   normalizeParentKey,
 } from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 
 const CATEGORY_LABEL_MAP: Record<string, string> = RESULTS_CATEGORY_LABEL_KEYS;
 
@@ -101,9 +102,11 @@ export interface TopClassBreakdownItem {
 const props = defineProps<{
   categoryRows: EmissionBreakdownCategoryRow[];
   topClassBreakdown?: TopClassBreakdownItem[];
+  printMode?: boolean;
 }>();
 
 const { t } = useI18n();
+const isPrintMode = usePrintMode();
 
 const categoryKeyPrefixes = Object.keys(CATEGORY_LABEL_MAP);
 
@@ -364,34 +367,37 @@ const chartOption = computed((): EChartsOption => {
 
   return {
     animation: false,
-    tooltip: {
-      trigger: 'item',
-      formatter: (params: unknown) => {
-        const p = params as {
-          seriesName?: string;
-          color?: string;
-          seriesIndex?: number;
-          data?: Record<string, unknown>;
-        };
-        const dimKey = segmentKeys[p.seriesIndex ?? 0];
-        const row = p.data;
-        const val = row && dimKey !== undefined ? Number(row[dimKey]) || 0 : 0;
-        if (val <= 0) {
-          emitTooltip(null);
-          return '';
-        }
-        emitTooltip({
-          rows: [
-            {
-              label: p.seriesName ?? '',
-              value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
-              color: p.color ?? '#888',
-            },
-          ],
-        });
-        return '';
-      },
-    },
+    tooltip: isPrintMode.value
+      ? { show: false }
+      : {
+          trigger: 'item',
+          formatter: (params: unknown) => {
+            const p = params as {
+              seriesName?: string;
+              color?: string;
+              seriesIndex?: number;
+              data?: Record<string, unknown>;
+            };
+            const dimKey = segmentKeys[p.seriesIndex ?? 0];
+            const row = p.data;
+            const val =
+              row && dimKey !== undefined ? Number(row[dimKey]) || 0 : 0;
+            if (val <= 0) {
+              emitTooltip(null);
+              return '';
+            }
+            emitTooltip({
+              rows: [
+                {
+                  label: p.seriesName ?? '',
+                  value: `${formatTonnesForChart(val)}${t('results_units_tonnes')}`,
+                  color: p.color ?? '#888',
+                },
+              ],
+            });
+            return '';
+          },
+        },
     legend: { show: false },
     grid: {
       left: '3%',
@@ -427,7 +433,8 @@ const chartOption = computed((): EChartsOption => {
 
 const chartHeight = computed(() => {
   const barCount = chartData.value.bars.length;
-  return Math.max(200, barCount * 60 + 60);
+  const natural = Math.max(200, barCount * 60 + 60);
+  return isPrintMode.value ? Math.min(natural, 500) : natural;
 });
 
 const chartRef = ref<InstanceType<typeof VChart>>();

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -33,6 +33,7 @@ use([
 ]);
 
 import type { EmissionBreakdownResponse } from 'src/stores/modules';
+import type { TooltipRow } from 'src/types/chartTooltip';
 import { formatTonnesForChart } from 'src/utils/number';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
 
@@ -1080,17 +1081,18 @@ const chartOption = computed((): EChartsOption => {
 
           formatter: (params: unknown) => {
             const arr = Array.isArray(params) ? params : params ? [params] : [];
-            if (!arr.length) return '';
-            const p = arr[0] as {
+            if (!arr.length) {
+              emitTooltip(null);
+              return '';
+            }
+
+            const firstParam = arr[0] as {
               data?: Record<string, unknown>;
               axisValue?: string;
               name?: string;
-              seriesName?: string;
-              marker?: string;
-              value?: number | number[];
             };
-            const data = p.data;
-            const name = p.axisValue || p.name || '';
+            const data = firstParam.data;
+            const name = firstParam.axisValue || firstParam.name || '';
             const isValidated = validatedLabels.value.has(name);
 
             if (!isValidated) {
@@ -1099,18 +1101,25 @@ const chartOption = computed((): EChartsOption => {
                 : additionalBuildingsLabels.value.has(name)
                   ? t('buildings')
                   : name;
-              return `<strong>${name}</strong><br/><span style="color:#aaa">${t('results_validate_module_title', { module: moduleName })}</span>`;
+              emitTooltip({
+                title: name,
+                rows: [],
+                footer: t('results_validate_module_title', {
+                  module: moduleName,
+                }),
+                tone: 'muted',
+              });
+              return '';
             }
 
+            const rows: TooltipRow[] = [];
             let total = 0;
-            let tooltip = `<strong>${name}</strong><br/>`;
 
-            arr.reverse().forEach((param: unknown) => {
+            for (const param of [...arr].reverse()) {
               const p = param as {
                 seriesName?: string;
                 seriesIndex?: number;
-                marker?: string;
-                value?: number | number[];
+                color?: string;
                 data?: Record<string, unknown>;
               };
               const series =
@@ -1119,17 +1128,28 @@ const chartOption = computed((): EChartsOption => {
                   : seriesArray.find((s) => s.name === p.seriesName);
               const key = series?.encode.y;
 
-              if (!data || !key) return;
+              if (!data || !key) continue;
               const dataValue = Number(data[key]) || 0;
               if (dataValue > 0) {
-                tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
+                rows.push({
+                  label: series?.name ?? p.seriesName ?? '',
+                  value: formatTonnesForChart(dataValue),
+                  color:
+                    (series?.itemStyle?.color as string) ?? p.color ?? '#888',
+                });
                 total += dataValue;
               }
+            }
+
+            emitTooltip({
+              title: name,
+              rows,
+              separatorRow: {
+                label: t('total'),
+                value: formatTonnesForChart(total),
+              },
             });
-
-            const totalDisplay = formatTonnesForChart(total);
-
-            return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;
+            return '';
           },
         },
 
@@ -1227,7 +1247,7 @@ const chartOption = computed((): EChartsOption => {
 
 const chartRef = ref<InstanceType<typeof VChart>>();
 
-const { tooltip, style, attach } = useEchartsTooltip();
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
 
 const onChartReady = async () => {
   await nextTick();

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -21,7 +21,6 @@ import {
 import VChart from 'vue-echarts';
 import TooltipEcharts from './TooltipEcharts.vue';
 import { useEchartsTooltip } from './useEchartsTooltip';
-import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
 
 use([
   CanvasRenderer,
@@ -35,6 +34,7 @@ use([
 
 import type { EmissionBreakdownResponse } from 'src/stores/modules';
 import { formatTonnesForChart } from 'src/utils/number';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 
 const props = defineProps<{
   breakdownData?: EmissionBreakdownResponse | null;
@@ -43,6 +43,7 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const isPrintMode = usePrintMode();
 const toggleAdditionalData = ref(false);
 const effectiveToggle = computed(
   () => props.viewAdditionalData ?? toggleAdditionalData.value,
@@ -162,7 +163,7 @@ function recalculateScopeRects() {
             id: 'sr1',
             left: s1.left,
             top: '15px',
-            shape: { width: s1.width, height: 300 },
+            shape: { width: s1.width, height: isPrintMode.value ? 200 : 300 },
             style: {
               fill: new graphic.LinearGradient(0, 0, 0, 1, [
                 { offset: 0, color: 'rgba(248,248,248,0.9)' },
@@ -192,7 +193,7 @@ function recalculateScopeRects() {
             id: 'sr2',
             left: s2.left,
             top: '15px',
-            shape: { width: s2.width, height: 300 },
+            shape: { width: s2.width, height: isPrintMode.value ? 200 : 300 },
             style: {
               fill: new graphic.LinearGradient(0, 0, 0, 1, [
                 { offset: 0, color: 'rgba(240,240,240,0.9)' },
@@ -222,7 +223,7 @@ function recalculateScopeRects() {
             id: 'sr3',
             left: s3.left,
             top: '15px',
-            shape: { width: s3.width, height: 300 },
+            shape: { width: s3.width, height: isPrintMode.value ? 200 : 300 },
             style: {
               fill: new graphic.LinearGradient(0, 0, 0, 1, [
                 { offset: 0, color: 'rgba(229,229,229,0.9)' },
@@ -264,7 +265,10 @@ function recalculateScopeRects() {
             id: 'sadd',
             left: dividerX,
             top: '15px',
-            shape: { width: additionalRect?.width ?? 200, height: 300 },
+            shape: {
+              width: additionalRect?.width ?? 200,
+              height: isPrintMode ? 200 : 300,
+            },
             style: {
               fill: new graphic.LinearGradient(0, 0, 0, 1, [
                 { offset: 0, color: 'rgba(215,215,215,0.9)' },
@@ -290,7 +294,7 @@ function recalculateScopeRects() {
             id: 'sdiv',
             left: dividerX,
             top: '0px',
-            shape: { width: 1, height: 420 },
+            shape: { width: 1, height: isPrintMode ? 200 : 420 },
             style: {
               fill: new graphic.LinearGradient(0, 0, 0, 1, [
                 { offset: 0, color: 'rgba(0,0,0,1)' },
@@ -1066,83 +1070,68 @@ const chartOption = computed((): EChartsOption => {
 
   return {
     animation: false,
-    tooltip: {
-      trigger: 'axis',
-      axisPointer: {
-        type: 'shadow',
-      },
+    tooltip: isPrintMode.value
+      ? { show: false }
+      : {
+          trigger: 'axis',
+          axisPointer: {
+            type: 'shadow',
+          },
 
-      formatter: (params: unknown) => {
-        const arr = Array.isArray(params) ? params : params ? [params] : [];
-        if (!arr.length) {
-          emitTooltip(null);
-          return '';
-        }
-        const first = arr[0] as {
-          data?: Record<string, unknown>;
-          axisValue?: string;
-          name?: string;
-        };
-        const data = first.data;
-        const name = String(first.axisValue || first.name || '');
-        const isValidated = validatedLabels.value.has(name);
+          formatter: (params: unknown) => {
+            const arr = Array.isArray(params) ? params : params ? [params] : [];
+            if (!arr.length) return '';
+            const p = arr[0] as {
+              data?: Record<string, unknown>;
+              axisValue?: string;
+              name?: string;
+              seriesName?: string;
+              marker?: string;
+              value?: number | number[];
+            };
+            const data = p.data;
+            const name = p.axisValue || p.name || '';
+            const isValidated = validatedLabels.value.has(name);
 
-        if (!isValidated) {
-          const moduleName = additionalHeadcountLabels.value.has(name)
-            ? t('headcount')
-            : additionalBuildingsLabels.value.has(name)
-              ? t('buildings')
-              : name;
-          emitTooltip({
-            title: name,
-            rows: [],
-            tone: 'muted',
-            footer: t('results_validate_module_title', { module: moduleName }),
-          });
-          return '';
-        }
+            if (!isValidated) {
+              const moduleName = additionalHeadcountLabels.value.has(name)
+                ? t('headcount')
+                : additionalBuildingsLabels.value.has(name)
+                  ? t('buildings')
+                  : name;
+              return `<strong>${name}</strong><br/><span style="color:#aaa">${t('results_validate_module_title', { module: moduleName })}</span>`;
+            }
 
-        const rows: TooltipRow[] = [];
-        let total = 0;
+            let total = 0;
+            let tooltip = `<strong>${name}</strong><br/>`;
 
-        for (const param of [...arr].reverse()) {
-          const p = param as {
-            seriesName?: string;
-            seriesIndex?: number;
-          };
-          const series =
-            typeof p.seriesIndex === 'number'
-              ? seriesArray[p.seriesIndex]
-              : seriesArray.find((s) => s.name === p.seriesName);
-          const key = series?.encode.y;
-          if (!data || !key) continue;
-          const dataValue = Number(data[key]) || 0;
-          if (dataValue > 0) {
-            rows.push({
-              label: series?.name ?? String(p.seriesName ?? ''),
-              value: formatTonnesForChart(dataValue),
-              color: (series?.itemStyle?.color as string) ?? '#888',
-            });
-            total += dataValue;
-          }
-        }
+            arr.reverse().forEach((param: unknown) => {
+              const p = param as {
+                seriesName?: string;
+                seriesIndex?: number;
+                marker?: string;
+                value?: number | number[];
+                data?: Record<string, unknown>;
+              };
+              const series =
+                typeof p.seriesIndex === 'number'
+                  ? seriesArray[p.seriesIndex]
+                  : seriesArray.find((s) => s.name === p.seriesName);
+              const key = series?.encode.y;
 
-        const state: TooltipState = {
-          title: name,
-          rows,
-          ...(rows.length > 1
-            ? {
-                separatorRow: {
-                  label: t('results_objectives_total'),
-                  value: formatTonnesForChart(total),
-                },
+              if (!data || !key) return;
+              const dataValue = Number(data[key]) || 0;
+              if (dataValue > 0) {
+                tooltip += `${p.marker || ''} ${series?.name || p.seriesName || ''}: <strong>${formatTonnesForChart(dataValue)} </strong><br/>`;
+                total += dataValue;
               }
-            : {}),
-        };
-        emitTooltip(state);
-        return '';
-      },
-    },
+            });
+
+            const totalDisplay = formatTonnesForChart(total);
+
+            return `${tooltip}<hr style="margin: 4px 0"/>Total: <strong>${totalDisplay}</strong>`;
+          },
+        },
 
     grid: {
       left: '5%',
@@ -1238,7 +1227,7 @@ const chartOption = computed((): EChartsOption => {
 
 const chartRef = ref<InstanceType<typeof VChart>>();
 
-const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+const { tooltip, style, attach } = useEchartsTooltip();
 
 const onChartReady = async () => {
   await nextTick();
@@ -1317,6 +1306,7 @@ const downloadCSV = () => {
     <q-card-section class="flex justify-between items-center">
       <div class="flex items-center no-wrap">
         <q-icon
+          v-if="!isPrintMode"
           name="o_info"
           size="xs"
           color="primary"
@@ -1366,7 +1356,7 @@ const downloadCSV = () => {
         </span>
       </div>
 
-      <div class="flex items-center no-wrap q-gutter-sm">
+      <div v-if="!isPrintMode" class="flex items-center no-wrap q-gutter-sm">
         <q-btn
           unelevated
           no-caps
@@ -1404,7 +1394,7 @@ const downloadCSV = () => {
     >
       <v-chart
         ref="chartRef"
-        class="chart"
+        :class="['chart', { 'chart--print': isPrintMode }]"
         autoresize
         :option="chartOption"
         @rendered="recalculateScopeRects"
@@ -1434,12 +1424,16 @@ const downloadCSV = () => {
 
 .chart {
   width: 100%;
-  min-height: 500px;
+  min-height: 320px;
+}
+
+.chart--print {
+  min-height: 320px;
 }
 
 @media (max-width: 1320px) {
-  .chart {
-    width: 95%;
+  .chart:not(.chart--print) {
+    width: 100%;
   }
 }
 </style>

--- a/frontend/src/components/molecules/BigNumber.vue
+++ b/frontend/src/components/molecules/BigNumber.vue
@@ -12,6 +12,7 @@ const props = withDefaults(
     comparisonHighlight?: string;
     color?: string;
     tooltipPlacement?: 'title' | 'comparison';
+    printMode?: boolean;
   }>(),
   {
     bordered: true,
@@ -21,6 +22,7 @@ const props = withDefaults(
     comparisonHighlight: undefined,
     color: undefined,
     tooltipPlacement: 'title',
+    printMode: false,
   },
 );
 
@@ -56,11 +58,16 @@ const comparisonParts = computed(() => {
   <q-card
     flat
     :bordered="bordered"
-    :class="['container', 'container--pa-none', 'big-number']"
+    :class="[
+      'container',
+      'container--pa-none',
+      'big-number',
+      { 'big-number--print': printMode },
+    ]"
   >
     <q-card-section class="flex items-center q-mb-xs">
       <q-icon
-        v-if="$slots.tooltip && tooltipPlacement === 'title'"
+        v-if="$slots.tooltip && tooltipPlacement === 'title' && !printMode"
         name="o_info"
         size="xs"
         color="primary"
@@ -98,7 +105,9 @@ const comparisonParts = computed(() => {
         style="width: 50%"
       >
         <q-icon
-          v-if="$slots.tooltip && tooltipPlacement === 'comparison'"
+          v-if="
+            $slots.tooltip && tooltipPlacement === 'comparison' && !printMode
+          "
           name="o_info"
           size="xs"
           color="primary"
@@ -140,5 +149,36 @@ const comparisonParts = computed(() => {
   align-self: flex-end;
   white-space: normal;
   overflow-wrap: anywhere;
+}
+
+@media print {
+  .big-number.q-card--bordered {
+    outline: 1px solid rgba(0, 0, 0, 0.2) !important;
+    border-radius: 4px !important;
+  }
+}
+
+.big-number--print {
+  :deep(.q-card-section) {
+    padding: 8px 10px 4px;
+  }
+
+  .big-number__value :deep(.text-h1) {
+    font-size: 1.4rem !important;
+    line-height: 1.2 !important;
+  }
+
+  .text-body1 {
+    font-size: 0.75rem !important;
+    line-height: 1.2 !important;
+  }
+
+  .text-body2 {
+    font-size: 0.7rem !important;
+  }
+
+  .text-caption {
+    font-size: 0.65rem !important;
+  }
 }
 </style>

--- a/frontend/src/components/organisms/AdditionalCategoriesSection.vue
+++ b/frontend/src/components/organisms/AdditionalCategoriesSection.vue
@@ -43,6 +43,7 @@ const props = defineProps<{
   embodiedEnergyByCategory?: EmbodiedEnergyCategoryEntry[];
   headcountValidated?: boolean;
   buildingsValidated?: boolean;
+  printMode?: boolean;
 }>();
 
 const { t, te } = useI18n();
@@ -69,6 +70,11 @@ onMounted(() => {
     chartVisibilityObserver?.disconnect();
     chartVisibilityObserver = null;
   };
+
+  if (props.printMode) {
+    activateCharts();
+    return;
+  }
 
   if (!el) {
     activateCharts();
@@ -106,7 +112,7 @@ onBeforeUnmount(() => {
 });
 
 watch(chartsInView, async (v) => {
-  if (!v) return;
+  if (!v || props.printMode) return;
   await nextTick();
   for (const r of [
     commutingCO2Ref,
@@ -371,11 +377,15 @@ const embodiedEnergyLegend = computed(() =>
   <div>
     <div>
       <q-card flat>
-        <div ref="additionalGridRef" class="additional-grid">
+        <div
+          ref="additionalGridRef"
+          class="additional-grid"
+          :class="{ 'additional-grid--print': printMode }"
+        >
           <!-- ═══ HEADCOUNT SECTION ═══ -->
           <!-- Headcount not validated: full-width placeholder -->
           <div
-            v-if="!headcountValidated"
+            v-if="!headcountValidated && !printMode"
             class="additional-col additional-placeholder additional-placeholder--wide"
           >
             <div class="placeholder-content">
@@ -391,7 +401,7 @@ const embodiedEnergyLegend = computed(() =>
 
           <!-- Headcount validated but no data: placeholder -->
           <div
-            v-else-if="headcountHasNoData"
+            v-else-if="headcountHasNoData && !printMode"
             class="additional-col additional-placeholder additional-placeholder--wide"
           >
             <div class="placeholder-content">
@@ -418,7 +428,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
               </div>
               <q-separator class="q-my-lg" />
-              <div>
+              <div class="total-cell">
                 <div class="total-value items-center">
                   <div
                     class="text-h1 text-weight-medium"
@@ -500,7 +510,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
               </div>
               <q-separator class="q-my-lg" />
-              <div>
+              <div class="total-cell">
                 <div class="total-value items-center">
                   <div
                     class="text-h1 text-weight-medium"
@@ -569,7 +579,12 @@ const embodiedEnergyLegend = computed(() =>
               <div class="q-pt-xl q-px-lg additional-header">
                 <div class="text-h5 text-weight-medium text-center">
                   {{ $t('charts-waste-category') }}
-                  <q-icon name="o_info" size="xs" class="q-ml-xs text-primary">
+                  <q-icon
+                    v-if="!printMode"
+                    name="o_info"
+                    size="xs"
+                    class="q-ml-xs text-primary"
+                  >
                     <q-tooltip class="text-body2 text-black">
                       {{ $t('results_additional_waste_tooltip') }}
                     </q-tooltip>
@@ -580,7 +595,7 @@ const embodiedEnergyLegend = computed(() =>
                 </div>
               </div>
               <q-separator class="q-my-lg" />
-              <div>
+              <div class="total-cell">
                 <div class="total-value items-center">
                   <div
                     class="text-h1 text-weight-medium"
@@ -648,7 +663,7 @@ const embodiedEnergyLegend = computed(() =>
           <!-- BUILDINGS SECTION  -->
           <!-- Buildings not validated: placeholder -->
           <div
-            v-if="!buildingsValidated"
+            v-if="!buildingsValidated && !printMode"
             class="additional-col additional-placeholder"
           >
             <div class="placeholder-content">
@@ -664,7 +679,7 @@ const embodiedEnergyLegend = computed(() =>
 
           <!-- Buildings validated but no data: placeholder -->
           <div
-            v-else-if="embodiedEnergyTotal <= 0"
+            v-else-if="embodiedEnergyTotal <= 0 && !printMode"
             class="additional-col additional-placeholder"
           >
             <div class="placeholder-content">
@@ -683,7 +698,12 @@ const embodiedEnergyLegend = computed(() =>
             <div class="q-pt-xl q-px-lg additional-header">
               <div class="text-h5 text-weight-medium text-center">
                 {{ $t('charts-embodied-energy-category') }}
-                <q-icon name="o_info" size="xs" class="q-ml-xs text-primary">
+                <q-icon
+                  v-if="!printMode"
+                  name="o_info"
+                  size="xs"
+                  class="q-ml-xs text-primary"
+                >
                   <q-tooltip class="text-body2 text-black">
                     {{ $t('results_additional_embodied_energy_tooltip') }}
                   </q-tooltip>
@@ -694,7 +714,7 @@ const embodiedEnergyLegend = computed(() =>
               </div>
             </div>
             <q-separator class="q-my-lg" />
-            <div>
+            <div class="total-cell">
               <div class="total-value items-center">
                 <div
                   class="text-h1 text-weight-medium"
@@ -753,7 +773,7 @@ const embodiedEnergyLegend = computed(() =>
         </div>
       </q-card>
     </div>
-    <Teleport to="body">
+    <Teleport v-if="!printMode" to="body">
       <tooltip-echarts
         v-if="tooltip.visible"
         :tooltip-state="tooltip.data"
@@ -769,6 +789,100 @@ const embodiedEnergyLegend = computed(() =>
   flex-direction: column;
   overflow: hidden;
   width: 100%;
+}
+
+.additional-grid--print {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+
+  .additional-col {
+    min-height: unset;
+    max-width: unset;
+  }
+
+  .additional-col:not(:last-child) {
+    border-right: 1px solid rgba(0, 0, 0, 0.12);
+    border-bottom: none;
+  }
+
+  .additional-header {
+    height: 120px;
+    overflow: hidden;
+    padding: 6px 8px 0 !important;
+  }
+
+  .total-cell {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  :deep(.q-separator) {
+    margin: 4px 0 !important;
+  }
+
+  :deep(.q-pt-xl) {
+    padding-top: 6px !important;
+  }
+
+  :deep(.q-pb-xl) {
+    padding-bottom: 6px !important;
+  }
+
+  :deep(.q-my-lg) {
+    margin: 4px 0 !important;
+  }
+
+  :deep(.q-mt-md) {
+    margin-top: 4px !important;
+  }
+
+  :deep(.q-mb-xs) {
+    margin-bottom: 2px !important;
+  }
+
+  :deep(.q-pt-md) {
+    padding-top: 4px !important;
+  }
+
+  :deep(.q-pb-md) {
+    padding-bottom: 4px !important;
+  }
+
+  :deep(.q-px-md) {
+    padding-left: 4px !important;
+    padding-right: 4px !important;
+  }
+
+  :deep(.q-px-lg) {
+    padding-left: 6px !important;
+    padding-right: 6px !important;
+  }
+
+  .legend-dot {
+    width: 10px;
+    height: 10px;
+  }
+
+  :deep(.text-caption) {
+    font-size: 0.65rem !important;
+    line-height: 1.25 !important;
+  }
+
+  :deep(.text-overline) {
+    font-size: 0.65rem !important;
+    line-height: 1.25 !important;
+  }
+
+  :deep(.text-h1) {
+    font-size: 1.4rem !important;
+    line-height: 1.2 !important;
+  }
+
+  .chart {
+    height: 140px !important;
+  }
 }
 
 @media (min-width: 1024px) {

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -28,11 +28,13 @@ const props = withDefaults(
     co2PerKmKg?: number;
     /** Carbon report year (Results page selected year). */
     year?: number;
+    printMode?: boolean;
   }>(),
   {
     loading: false,
     co2PerKmKg: 0,
     year: undefined,
+    printMode: false,
   },
 );
 
@@ -383,24 +385,31 @@ const barChartOption = computed<EChartsOption>(() => {
 
 <template>
   <div>
-    <div class="q-pt-xl q-px-lg">
-      <h2 class="text-h2 text-weight-medium">
-        {{ $t('it-title') }}
-      </h2>
-      <span class="text-body1 text-secondary">{{
-        $t('it-subtitle', { year: year ?? '' })
-      }}</span>
-    </div>
-
-    <q-separator class="q-mt-xl" />
+    <template v-if="!printMode">
+      <div class="q-pt-xl q-px-lg">
+        <h2 class="text-h2 text-weight-medium">
+          {{ $t('it-title') }}
+        </h2>
+        <span class="text-body1 text-secondary">{{
+          $t('it-subtitle', { year: year ?? '' })
+        }}</span>
+      </div>
+      <q-separator class="q-mt-xl" />
+    </template>
 
     <!-- Summary numbers -->
-    <q-card v-if="data" flat class="grid-2-col q-mt-lg q-mb-lg q-px-lg">
+    <q-card
+      v-if="data"
+      flat
+      class="grid-2-col q-mt-lg q-mb-lg"
+      :class="{ 'q-px-lg': !printMode }"
+    >
       <BigNumber
         :title="$t('it-focus-total')"
         :number="`${formatTonnesCO2(displayTotalItTonnes)}`"
         comparison=""
         color="accent"
+        :print-mode="printMode"
       >
       </BigNumber>
       <BigNumber
@@ -413,14 +422,15 @@ const barChartOption = computed<EChartsOption>(() => {
         :comparison="$t('it-focus-share-of-total-hint')"
         hide-unit
         color="accent"
+        :print-mode="printMode"
       />
     </q-card>
 
     <template v-if="!loading && data">
-      <q-separator class="q-mt-xl" />
+      <q-separator v-if="!printMode" class="q-mt-xl" />
       <!-- Stacked horizontal bar chart - one bar per IT category, segments = top items -->
 
-      <q-card v-if="hasData" flat class="q-mb-lg q-pa-lg q-mx-lg">
+      <q-card v-if="hasData" flat :bordered="printMode" class="q-mb-lg q-px-lg">
         <div
           class="flex items-center no-wrap text-h5 text-weight-medium q-my-xl"
         >

--- a/frontend/src/components/organisms/ReportPage.vue
+++ b/frontend/src/components/organisms/ReportPage.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page" :class="{ 'page--first': isFirst }">
+    <header v-if="title || pageNumber != null" class="page__header">
+      <div class="page__title">
+        <q-img src="/epfl-logo.svg" :alt="$t('logo_alt')" width="75px" />
+        <span class="q-ml-md text-h5 text-weight-medium">{{
+          $t('calculator_title')
+        }}</span>
+      </div>
+      <div class="page__number">
+        <span v-if="pageNumber != null">{{ pageNumber }}</span>
+      </div>
+    </header>
+
+    <div class="page__content">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title?: string;
+  pageNumber?: number;
+  isFirst?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  title: undefined,
+  pageNumber: undefined,
+  isFirst: false,
+});
+</script>
+
+<style scoped lang="scss">
+.page {
+  width: 210mm;
+  height: 297mm;
+  overflow: hidden;
+  padding: 10mm;
+  background: white;
+  color: black;
+  box-sizing: border-box;
+  margin: 12px 0;
+
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 5mm;
+}
+
+.page__title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.page__number {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.page__content {
+  flex: 1;
+  min-height: 0;
+}
+
+.page--first .page__header {
+  margin-bottom: 10mm;
+}
+
+@media print {
+  .page {
+    margin: 0;
+    page-break-after: always;
+    break-after: page;
+  }
+}
+</style>

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -70,7 +70,7 @@
             </div>
           </div>
         </div>
-      </div>
+      </template>
       <div
         v-if="carbonFootprintSubtitle"
         class="text-body2 text-secondary q-px-lg q-mx-sm q-mt-xs"

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -13,50 +13,61 @@
       </span>
     </template>
     <template v-else>
-      <div class="flex w-full items-center justify-between q-mx-lg">
-        <div class="text-body1 text-weight-medium q-ml-sm q-mb-none text-black">
-          {{ carbonFootprintTitle }}
-        </div>
-        <div class="flex items-center no-wrap q-gutter-xs">
-          <q-btn
-            v-if="emissionTypeInfoKey && moduleChartView === 'type'"
-            flat
-            round
-            dense
-            icon="info_outline"
-            size="sm"
-            class="text-grey-7"
-            :aria-label="t('emission-type-breakdown-info-aria')"
+      <template v-if="!isPrintMode">
+        <div class="flex w-full items-center justify-between q-mx-lg">
+          <div
+            class="text-body1 text-weight-medium q-ml-sm q-mb-none text-black"
           >
-            <q-tooltip
-              anchor="bottom right"
-              self="top right"
-              :offset="[0, 8]"
-              max-width="320px"
-              class="text-body2"
+            {{ carbonFootprintTitle }}
+          </div>
+          <div
+            v-if="showControls"
+            class="flex items-center no-wrap q-gutter-xs"
+          >
+            <q-btn
+              v-if="emissionTypeInfoKey && moduleChartView === 'type'"
+              flat
+              round
+              dense
+              icon="info_outline"
+              size="sm"
+              class="text-grey-7"
+              :aria-label="t('emission-type-breakdown-info-aria')"
             >
-              {{ t(emissionTypeInfoKey) }}
-            </q-tooltip>
-          </q-btn>
-          <div class="chart-view-toggle">
-            <q-btn
-              unelevated
-              dense
-              :style="moduleChartView === 'type' ? activeButtonStyle : {}"
-              :class="moduleChartView !== 'type' ? 'toggle-inactive' : ''"
-              icon="stacked_bar_chart"
-              size="sm"
-              @click="moduleChartView = 'type'"
-            />
-            <q-btn
-              unelevated
-              dense
-              :style="moduleChartView === 'breakdown' ? activeButtonStyle : {}"
-              :class="moduleChartView !== 'breakdown' ? 'toggle-inactive' : ''"
-              icon="grid_view"
-              size="sm"
-              @click="moduleChartView = 'breakdown'"
-            />
+              <q-tooltip
+                anchor="bottom right"
+                self="top right"
+                :offset="[0, 8]"
+                max-width="320px"
+                class="text-body2"
+              >
+                {{ t(emissionTypeInfoKey) }}
+              </q-tooltip>
+            </q-btn>
+            <div class="chart-view-toggle">
+              <q-btn
+                unelevated
+                dense
+                :style="moduleChartView === 'type' ? activeButtonStyle : {}"
+                :class="moduleChartView !== 'type' ? 'toggle-inactive' : ''"
+                icon="stacked_bar_chart"
+                size="sm"
+                @click="moduleChartView = 'type'"
+              />
+              <q-btn
+                unelevated
+                dense
+                :style="
+                  moduleChartView === 'breakdown' ? activeButtonStyle : {}
+                "
+                :class="
+                  moduleChartView !== 'breakdown' ? 'toggle-inactive' : ''
+                "
+                icon="grid_view"
+                size="sm"
+                @click="moduleChartView = 'breakdown'"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -76,6 +87,7 @@
             :show-evolution-dialog="
               type === MODULES.ProfessionalTravel && showEvolutionChart
             "
+            :print-mode="printMode"
           />
           <span v-else class="text-body2 text-secondary">
             {{ $t('no-chart-data') }}
@@ -87,6 +99,7 @@
             :key="type"
             :category-rows="moduleCategoryRows"
             :top-class-breakdown="topClassBreakdownData"
+            :print-mode="printMode"
           />
 
           <span v-else class="text-body2 text-secondary">
@@ -108,6 +121,7 @@ import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTr
 import EmissionTypeBreakdownChart from 'src/components/charts/results/EmissionTypeBreakdownChart.vue';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { usePrintMode } from 'src/composables/print/usePrintMode';
 import {
   buildModuleTreemapData,
   CATEGORY_CHART_KEYS,
@@ -122,11 +136,28 @@ import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakd
 const props = defineProps<{
   type: Module;
   showEvolutionChart?: boolean;
+  forcedView?: 'breakdown' | 'type';
+  showControls?: boolean;
+  printMode?: boolean;
 }>();
 
 const { t, te } = useI18n();
 
-const moduleChartView = ref<'breakdown' | 'type'>('type');
+const moduleChartView = ref<'breakdown' | 'type'>(props.forcedView ?? 'type');
+
+const isPrintMode = usePrintMode();
+const showControls = computed(() => {
+  if (isPrintMode.value) return false;
+  return props.showControls !== false && !props.forcedView;
+});
+
+watch(
+  () => props.forcedView,
+  (v) => {
+    if (!v) return;
+    moduleChartView.value = v;
+  },
+);
 
 const emissionTypeInfoKey = computed(() =>
   getEmissionTypeBreakdownInfoKey(props.type),

--- a/frontend/src/components/organisms/print/ResultsPrintModulePage.vue
+++ b/frontend/src/components/organisms/print/ResultsPrintModulePage.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import BigNumber from 'src/components/molecules/BigNumber.vue';
+import ModuleCharts from 'src/components/organisms/module/ModuleCharts.vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import type { ModuleResult } from 'src/api/modules';
+import type { ModuleConfig } from 'src/constant/moduleConfig';
+import { MODULES, type Module } from 'src/constant/modules';
+
+interface Props {
+  module: Module;
+  pageNumber: number;
+  moduleResult: ModuleResult | undefined;
+  moduleConfig: ModuleConfig | undefined;
+  totalFte: number | null | undefined;
+  hasCo2PerKmKg: boolean;
+  co2PerKmKg: number;
+  currentYear: number;
+}
+
+const props = defineProps<Props>();
+
+const { t, te } = useI18n();
+
+const FORMAT_INTEGER = {
+  options: { minimumFractionDigits: 0, maximumFractionDigits: 0 },
+};
+const FORMAT_CO2_PER_KM = {
+  options: { minimumFractionDigits: 2, maximumFractionDigits: 2 },
+};
+
+const percentChangeFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+  signDisplay: 'always',
+});
+
+function formatPercentChange(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return percentChangeFormatter.format(value / 100);
+}
+
+function getTotalModuleCarbonFootprintTitle(): string {
+  const specificKey = `results_total_module_carbon_footprint_${props.module}`;
+  if (te(specificKey)) return t(specificKey);
+  return t('results_total_module_carbon_footprint', {
+    module: t(props.module),
+  });
+}
+</script>
+
+<template>
+  <ReportPage :title="$t(module)" :page-number="pageNumber">
+    <h2 class="text-h5 q-mt-none report-h2">
+      {{ $t(module) }}
+    </h2>
+    <div class="text-body2 text-secondary report-subtitle">
+      {{ $t('results_subtitle', { year: currentYear }) }}
+    </div>
+
+    <div class="q-mt-md">
+      <template v-if="moduleResult">
+        <div class="grid-3-col grid-compact q-mt-md">
+          <BigNumber
+            :title="getTotalModuleCarbonFootprintTitle()"
+            :number="
+              moduleConfig?.totalFormatter(moduleResult.total_tonnes_co2eq)
+            "
+            :comparison="
+              hasCo2PerKmKg
+                ? $t('results_equivalent_to_car', {
+                    km: $nOrDash(
+                      moduleResult.equivalent_car_km,
+                      FORMAT_INTEGER,
+                    ),
+                    value: `${$nOrDash(co2PerKmKg, FORMAT_CO2_PER_KM)}`,
+                  })
+                : undefined
+            "
+            :comparison-highlight="`${$nOrDash(moduleResult.equivalent_car_km, FORMAT_INTEGER)}km`"
+            color="negative"
+            :print-mode="true"
+          />
+
+          <BigNumber
+            :title="
+              $t('results_module_carbon_footprint', { module: $t(module) })
+            "
+            :number="
+              formatPercentChange(moduleResult.year_comparison_percentage)
+            "
+            :unit="
+              $t('results_compared_to', { year: (currentYear - 1).toString() })
+            "
+            :color="
+              moduleResult.year_comparison_percentage == null
+                ? undefined
+                : moduleResult.year_comparison_percentage < 0
+                  ? 'positive'
+                  : 'negative'
+            "
+            :comparison="
+              $t('results_compared_to_value_of', {
+                value: `${moduleConfig?.totalFormatter(
+                  moduleResult.previous_year_total_tonnes_co2eq,
+                )}${$t('results_units_tonnes')}`,
+              })
+            "
+            :comparison-highlight="`${moduleConfig?.totalFormatter(
+              moduleResult.previous_year_total_tonnes_co2eq,
+            )}${$t('results_units_tonnes')}`"
+            :print-mode="true"
+          />
+
+          <BigNumber
+            :title="
+              totalFte == null
+                ? $t('results_carbon_footprint_per_FTE_no_headcount')
+                : $t('results_carbon_footprint_per_fte', {
+                    FTE: $nOrDash(totalFte, {
+                      options: { maximumFractionDigits: 1 },
+                    }),
+                  })
+            "
+            :number="
+              moduleConfig?.totalFormatter(moduleResult.tonnes_co2eq_per_fte)
+            "
+            :comparison="
+              $t('results_paris_agreement_value', {
+                value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
+              })
+            "
+            :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
+            color="negative"
+            :print-mode="true"
+          >
+            <template #tooltip>{{
+              $t('results_paris_agreement_tooltip')
+            }}</template>
+          </BigNumber>
+        </div>
+      </template>
+
+      <q-card flat bordered class="q-pa-lg q-mt-md print-avoid-break">
+        <div class="text-body1 text-weight-medium q-ml-sm q-mb-none">
+          {{
+            $t('results_module_chart_emission_types', { module: $t(module) })
+          }}
+        </div>
+        <ModuleCharts
+          :type="module"
+          :show-evolution-chart="module === MODULES.ProfessionalTravel"
+          forced-view="type"
+          :show-controls="false"
+        />
+      </q-card>
+
+      <q-card flat bordered class="q-pa-lg q-mt-md print-avoid-break">
+        <div class="text-body1 text-weight-medium q-ml-sm q-mb-none">
+          {{ $t('results_module_chart_breakdown', { module: $t(module) }) }}
+        </div>
+        <ModuleCharts
+          :type="module"
+          :show-evolution-chart="module === MODULES.ProfessionalTravel"
+          forced-view="breakdown"
+          :show-controls="false"
+        />
+      </q-card>
+    </div>
+  </ReportPage>
+</template>
+
+<style scoped lang="scss">
+.grid-3-col {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.grid-compact {
+  gap: 10px;
+}
+
+.report-h2 {
+  letter-spacing: -0.01em;
+}
+
+.report-subtitle {
+  line-height: 1.35;
+}
+
+.print-avoid-break {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+@media (min-width: 1024px) {
+  .grid-3-col {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media print {
+  .grid-3-col {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+</style>

--- a/frontend/src/composables/print/usePrintMode.ts
+++ b/frontend/src/composables/print/usePrintMode.ts
@@ -1,0 +1,12 @@
+import { computed, inject, provide, type ComputedRef } from 'vue';
+
+const PRINT_MODE_KEY: unique symbol = Symbol('printMode');
+
+export function providePrintMode(enabled: boolean): void {
+  provide(PRINT_MODE_KEY, enabled);
+}
+
+export function usePrintMode(): ComputedRef<boolean> {
+  const injected = inject<boolean | null>(PRINT_MODE_KEY, null);
+  return computed(() => injected === true);
+}

--- a/frontend/src/composables/print/useResultsPrintData.ts
+++ b/frontend/src/composables/print/useResultsPrintData.ts
@@ -1,0 +1,261 @@
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import {
+  getResultsSummary,
+  type ResultsSummary,
+  type ModuleResult,
+} from 'src/api/modules';
+import { MODULES, MODULES_LIST, type Module } from 'src/constant/modules';
+import { IT_FOCUS_SOURCE_MODULES } from 'src/constant/itFocus';
+import { getModuleTypeId, MODULE_STATES } from 'src/constant/moduleStates';
+import { useModuleStore, useTimelineStore } from 'src/stores/modules';
+import { useWorkspaceStore } from 'src/stores/workspace';
+
+export function useResultsPrintData() {
+  const route = useRoute();
+  const workspaceStore = useWorkspaceStore();
+  const timelineStore = useTimelineStore();
+  const moduleStore = useModuleStore();
+
+  const unitParam = computed(() => String(route.params.unit ?? ''));
+  const yearParam = computed(() =>
+    parseInt(String(route.params.year ?? '0'), 10),
+  );
+
+  const resultsSummary = ref<ResultsSummary | null>(null);
+  const resultsSummaryLoading = ref(true);
+
+  const currentYear = computed(
+    () => yearParam.value || new Date().getFullYear(),
+  );
+
+  const hideResearchFacilities = computed(
+    () => String(route.query.hideResearchFacilities ?? '0') === '1',
+  );
+  const hideAdditionalData = computed(
+    () => String(route.query.hideAdditionalData ?? '0') === '1',
+  );
+  const viewAdditionalData = computed(() => !hideAdditionalData.value);
+
+  const excludedModules = computed(() => {
+    const ids: number[] = [];
+    if (hideResearchFacilities.value) {
+      const id = getModuleTypeId(MODULES.ResearchFacilities);
+      if (id !== undefined) ids.push(id);
+    }
+    return ids;
+  });
+
+  const co2PerKmKg = computed(() => resultsSummary.value?.co2_per_km_kg ?? 0);
+  const hasCo2PerKmKg = computed(() => co2PerKmKg.value > 0);
+
+  const perPersonBreakdown = computed(
+    () => moduleStore.state.emissionBreakdown?.per_person_breakdown ?? null,
+  );
+  const validatedCategories = computed(
+    () => moduleStore.state.emissionBreakdown?.validated_categories ?? null,
+  );
+  const headcountValidatedForPerPerson = computed(
+    () => validatedCategories.value?.includes('commuting') ?? false,
+  );
+
+  const isModuleValidated = (module: string) =>
+    timelineStore.itemStates[module as Module] === MODULE_STATES.Validated;
+
+  const validatedModulesForPrint = computed(() =>
+    MODULES_LIST.filter((m) => {
+      if (m === MODULES.Headcount) return false;
+      if (hideResearchFacilities.value && m === MODULES.ResearchFacilities)
+        return false;
+      return isModuleValidated(m);
+    }),
+  );
+
+  const modulesConfig = ref<Record<
+    string,
+    import('src/constant/moduleConfig').ModuleConfig
+  > | null>(null);
+
+  const loadModulesConfig = async () => {
+    if (!modulesConfig.value) {
+      const { MODULES_CONFIG } = await import('src/constant/module-config');
+      modulesConfig.value = MODULES_CONFIG;
+    }
+  };
+
+  const getModuleConfig = (module: string) => modulesConfig.value?.[module];
+
+  const getModuleResult = (module: string): ModuleResult | undefined => {
+    if (!resultsSummary.value) return undefined;
+    const typeId = getModuleTypeId(module as Module);
+    return resultsSummary.value.module_results.find(
+      (m) => m.module_type_id === typeId,
+    );
+  };
+
+  const additionalBreakdown = computed(
+    () => moduleStore.state.emissionBreakdown?.additional_breakdown ?? [],
+  );
+  const commutingRow = computed(
+    () =>
+      additionalBreakdown.value.find((r) => r.category_key === 'commuting') ??
+      null,
+  );
+  const foodRow = computed(
+    () =>
+      additionalBreakdown.value.find((r) => r.category_key === 'food') ?? null,
+  );
+  const wasteRow = computed(
+    () =>
+      additionalBreakdown.value.find((r) => r.category_key === 'waste') ?? null,
+  );
+  const embodiedEnergyRow = computed(
+    () =>
+      additionalBreakdown.value.find(
+        (r) => r.category_key === 'embodied_energy',
+      ) ?? null,
+  );
+  const embodiedEnergyByCategory = computed(
+    () =>
+      moduleStore.state.emissionBreakdown?.embodied_energy_by_category ?? [],
+  );
+
+  const validatedAdditionalTonnes = computed(() => {
+    const validated = new Set(
+      moduleStore.state.emissionBreakdown?.validated_categories ?? [],
+    );
+    return additionalBreakdown.value.reduce((sum, row) => {
+      if (!validated.has(row.category_key)) return sum;
+      const catTotal = row.emissions.reduce((categorySum, emission) => {
+        return (
+          categorySum +
+          (typeof emission.value === 'number' ? emission.value : 0)
+        );
+      }, 0);
+      return sum + catTotal;
+    }, 0);
+  });
+
+  const adjustedTotalTonnes = computed(() => {
+    const raw = resultsSummary.value?.unit_totals.total_tonnes_co2eq;
+    if (raw == null) return null;
+    return viewAdditionalData.value
+      ? raw
+      : raw - validatedAdditionalTonnes.value;
+  });
+
+  const adjustedTonnesPerFte = computed(() => {
+    const fte = resultsSummary.value?.unit_totals.total_fte;
+    if (adjustedTotalTonnes.value == null || !fte || fte <= 0) return null;
+    return adjustedTotalTonnes.value / fte;
+  });
+
+  const additionalChartsValidated = computed(() => {
+    const breakdown = moduleStore.state.emissionBreakdown;
+    if (!breakdown) return false;
+    return breakdown.headcount_validated || breakdown.buildings_validated;
+  });
+
+  const showItFocusSection = computed(() =>
+    IT_FOCUS_SOURCE_MODULES.some(
+      (m) => timelineStore.itemStates[m] === MODULE_STATES.Validated,
+    ),
+  );
+
+  const modulePagesStart = 2;
+  const itPageNumber = computed(
+    () => modulePagesStart + validatedModulesForPrint.value.length,
+  );
+  const additionalPageNumber = computed(
+    () => itPageNumber.value + (showItFocusSection.value ? 1 : 0),
+  );
+
+  async function initWorkspaceFromRoute() {
+    workspaceStore.setSelectedParams({
+      unit: unitParam.value,
+      year: yearParam.value,
+    });
+
+    await workspaceStore.getUnits();
+
+    const routeUnit = String(workspaceStore.selectedParams?.unit || '');
+    const unitIdFromRoute = routeUnit.split('-')[0];
+    const validUnit = workspaceStore.units.find(
+      (unit) =>
+        unit.id === parseInt(unitIdFromRoute, 10) || unit.name === routeUnit,
+    );
+
+    if (!validUnit) {
+      workspaceStore.setUnit(null);
+      workspaceStore.setYear(null);
+      return null;
+    }
+
+    workspaceStore.setUnit(validUnit);
+    workspaceStore.setYear(workspaceStore.selectedParams?.year || null);
+
+    await workspaceStore.selectCarbonReportForYear(
+      workspaceStore.selectedUnit.id,
+      workspaceStore.selectedYear,
+    );
+
+    const carbonReportId = workspaceStore.selectedCarbonReport?.id ?? null;
+    if (carbonReportId) {
+      await timelineStore.fetchModuleStates(carbonReportId);
+    }
+
+    return carbonReportId;
+  }
+
+  async function fetchAllData(carbonReportId: number) {
+    try {
+      resultsSummaryLoading.value = true;
+      resultsSummary.value = await getResultsSummary(
+        carbonReportId,
+        excludedModules.value,
+      );
+    } catch {
+      resultsSummary.value = null;
+    } finally {
+      resultsSummaryLoading.value = false;
+    }
+
+    await moduleStore.getEmissionBreakdown(
+      carbonReportId,
+      excludedModules.value,
+    );
+    await moduleStore.getItBreakdown(carbonReportId, excludedModules.value);
+  }
+
+  return {
+    resultsSummary,
+    resultsSummaryLoading,
+    currentYear,
+    viewAdditionalData,
+    co2PerKmKg,
+    hasCo2PerKmKg,
+    perPersonBreakdown,
+    validatedCategories,
+    headcountValidatedForPerPerson,
+    validatedModulesForPrint,
+    getModuleResult,
+    getModuleConfig,
+    additionalBreakdown,
+    commutingRow,
+    foodRow,
+    wasteRow,
+    embodiedEnergyRow,
+    embodiedEnergyByCategory,
+    adjustedTotalTonnes,
+    adjustedTonnesPerFte,
+    additionalChartsValidated,
+    showItFocusSection,
+    modulePagesStart,
+    itPageNumber,
+    additionalPageNumber,
+    initWorkspaceFromRoute,
+    fetchAllData,
+    loadModulesConfig,
+  };
+}

--- a/frontend/src/css/03-layout/_grid.scss
+++ b/frontend/src/css/03-layout/_grid.scss
@@ -28,7 +28,7 @@ $breakpoint-desktop: 1320px;
   grid-template-columns: repeat(1, 1fr);
   gap: 16px;
 
-  @media (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-tablet), print {
     grid-template-columns: repeat(2, 1fr);
   }
 }
@@ -38,7 +38,7 @@ $breakpoint-desktop: 1320px;
   grid-template-columns: repeat(1, 1fr);
   gap: 16px;
 
-  @media (min-width: $breakpoint-desktop) {
+  @media (min-width: $breakpoint-desktop), print {
     grid-template-columns: repeat(3, 1fr);
   }
 }

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -7,6 +7,22 @@ export default {
     en: 'Download as PDF',
     fr: 'Télécharger en PDF',
   },
+  results_print: {
+    en: 'Print',
+    fr: 'Imprimer',
+  },
+  results_loading: {
+    en: 'Loading…',
+    fr: 'Chargement…',
+  },
+  results_module_chart_emission_types: {
+    en: '{module} — Emission types',
+    fr: "{module} — Types d'émissions",
+  },
+  results_module_chart_breakdown: {
+    en: '{module} — Breakdown',
+    fr: '{module} — Répartition',
+  },
   results_colorblind_mode: {
     en: 'Colorblind mode',
     fr: 'Mode daltonien',
@@ -66,6 +82,10 @@ export default {
   results_title: {
     en: 'Results',
     fr: 'Résultats',
+  },
+  results_print_title: {
+    en: 'Total results',
+    fr: 'Résultats totaux',
   },
   results_subtitle: {
     en: 'Annual carbon footprint {year}',

--- a/frontend/src/layouts/PrintLayout.vue
+++ b/frontend/src/layouts/PrintLayout.vue
@@ -1,0 +1,36 @@
+<template>
+  <q-layout view="lHh Lpr lFf" class="print-layout">
+    <q-page-container>
+      <router-view />
+    </q-page-container>
+  </q-layout>
+</template>
+
+<script setup lang="ts">
+import { providePrintMode } from 'src/composables/print/usePrintMode';
+
+providePrintMode(true);
+</script>
+
+<style>
+@page {
+  size: A4 portrait;
+  margin: 0;
+}
+
+body {
+  background: white;
+}
+
+@media print {
+  body {
+    background: white !important;
+  }
+}
+</style>
+
+<style scoped>
+.print-layout {
+  background: white;
+}
+</style>

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -28,6 +28,7 @@ import { MODULE_STATES, getModuleTypeId } from 'src/constant/moduleStates';
 import { useI18n } from 'vue-i18n';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import ReductionObjectiveChart from 'src/components/charts/results/ReductionObjectiveChart.vue';
+import { useRoute, useRouter } from 'vue-router';
 
 const yearConfigStore = useYearConfigStore();
 
@@ -138,6 +139,8 @@ const workspaceStore = useWorkspaceStore();
 const timelineStore = useTimelineStore();
 const moduleStore = useModuleStore();
 const colorblindStore = useColorblindStore();
+const router = useRouter();
+const route = useRoute();
 const colorblindMode = computed({
   get: () => colorblindStore.enabled,
   set: (v: boolean) => colorblindStore.setEnabled(v),
@@ -343,8 +346,19 @@ const loadModulesConfig = async () => {
 const getModuleConfig = (module: string) => modulesConfig.value?.[module];
 
 const downloadPDF = () => {
-  // Open browser print dialog where user can save as PDF
-  window.print();
+  const resolved = router.resolve({
+    name: 'results-print',
+    params: {
+      language: String(route.params.language ?? 'en'),
+      unit: workspaceStore.selectedParams?.unit ?? route.params.unit,
+      year: String(currentYear.value),
+    },
+    query: {
+      hideResearchFacilities: hideResearchFacilities.value ? '1' : '0',
+      hideAdditionalData: hideAdditionalData.value ? '1' : '0',
+    },
+  });
+  window.open(resolved.href, '_blank');
 };
 
 const getUncertainty = (

--- a/frontend/src/pages/app/ResultsPrintPage.vue
+++ b/frontend/src/pages/app/ResultsPrintPage.vue
@@ -1,0 +1,448 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import BigNumber from 'src/components/molecules/BigNumber.vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import AdditionalCategoriesSection from 'src/components/organisms/AdditionalCategoriesSection.vue';
+import ItFocusSection from 'src/components/organisms/ItFocusSection.vue';
+import ResultsPrintModulePage from 'src/components/organisms/print/ResultsPrintModulePage.vue';
+import { useResultsPrintData } from 'src/composables/print/useResultsPrintData';
+import { useModuleStore } from 'src/stores/modules';
+
+const {
+  resultsSummary,
+  resultsSummaryLoading,
+  currentYear,
+  viewAdditionalData,
+  co2PerKmKg,
+  hasCo2PerKmKg,
+  perPersonBreakdown,
+  validatedCategories,
+  headcountValidatedForPerPerson,
+  validatedModulesForPrint,
+  getModuleResult,
+  getModuleConfig,
+  additionalBreakdown,
+  commutingRow,
+  foodRow,
+  wasteRow,
+  embodiedEnergyRow,
+  embodiedEnergyByCategory,
+  adjustedTotalTonnes,
+  adjustedTonnesPerFte,
+  additionalChartsValidated,
+  showItFocusSection,
+  modulePagesStart,
+  itPageNumber,
+  additionalPageNumber,
+  initWorkspaceFromRoute,
+  fetchAllData,
+  loadModulesConfig,
+} = useResultsPrintData();
+
+const moduleStore = useModuleStore();
+
+const percentChangeFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+  signDisplay: 'always',
+});
+
+function formatPercentChange(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return percentChangeFormatter.format(value / 100);
+}
+
+function printReport() {
+  window.print();
+}
+
+onMounted(async () => {
+  const carbonReportId = await initWorkspaceFromRoute();
+  if (!carbonReportId) return;
+
+  await loadModulesConfig();
+  await fetchAllData(carbonReportId);
+});
+</script>
+
+<template>
+  <div class="bg-grey-2 print-report">
+    <q-toolbar class="bg-ac text-primary q-py-sm toolbar print-hide">
+      <q-space />
+      <q-btn
+        color="accent"
+        icon="o_print"
+        size="md"
+        class="text-weight-medium"
+        :label="$t('results_print')"
+        @click="printReport"
+      />
+    </q-toolbar>
+
+    <div
+      v-if="resultsSummary && !resultsSummaryLoading"
+      class="report-container"
+    >
+      <ReportPage
+        :title="$t('results_print_title')"
+        :page-number="1"
+        :is-first="true"
+      >
+        <h2 class="text-h5 q-mt-none report-h2">
+          {{ $t('results_print_title') }}
+        </h2>
+        <div class="text-body2 text-secondary report-subtitle">
+          {{ $t('results_subtitle', { year: currentYear }) }}
+        </div>
+
+        <div class="grid-3-col q-mt-lg">
+          <BigNumber
+            :title="$t('results_total_unit_carbon_footprint')"
+            :number="
+              $nOrDash(adjustedTotalTonnes, {
+                options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+              })
+            "
+            tooltip-placement="comparison"
+            :comparison="
+              hasCo2PerKmKg
+                ? $t('results_equivalent_to_car', {
+                    km: $nOrDash(resultsSummary.unit_totals.equivalent_car_km, {
+                      options: {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      },
+                    }),
+                    value: `${$nOrDash(co2PerKmKg, {
+                      options: {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      },
+                    })}`,
+                  })
+                : undefined
+            "
+            :comparison-highlight="`${$nOrDash(
+              resultsSummary.unit_totals.equivalent_car_km,
+              {
+                options: {
+                  minimumFractionDigits: 1,
+                  maximumFractionDigits: 1,
+                },
+              },
+            )}km`"
+            color="negative"
+            :print-mode="true"
+          >
+            <template v-if="hasCo2PerKmKg" #tooltip>{{
+              $t('results_total_unit_carbon_footprint_tooltip', {
+                value: $nOrDash(co2PerKmKg, {
+                  options: {
+                    minimumFractionDigits: 1,
+                    maximumFractionDigits: 1,
+                  },
+                }),
+                unit: $t('results_kg_co2eq_per_km'),
+              })
+            }}</template>
+          </BigNumber>
+
+          <BigNumber
+            :title="$t('results_unit_carbon_footprint')"
+            :number="
+              formatPercentChange(
+                resultsSummary.unit_totals.year_comparison_percentage,
+              )
+            "
+            :unit="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? $t('results_no_comparison_year_available')
+                : $t('results_compared_to', {
+                    year: (currentYear - 1).toString(),
+                  })
+            "
+            :color="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? undefined
+                : resultsSummary.unit_totals.year_comparison_percentage < 0
+                  ? 'positive'
+                  : 'negative'
+            "
+            :comparison="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? undefined
+                : $t('results_compared_to_value_of', {
+                    value: `${$nOrDash(
+                      resultsSummary.unit_totals
+                        .previous_year_total_tonnes_co2eq,
+                      {
+                        options: {
+                          minimumFractionDigits: 1,
+                          maximumFractionDigits: 1,
+                        },
+                      },
+                    )}${$t('results_units_tonnes')}`,
+                  })
+            "
+            :comparison-highlight="
+              resultsSummary.unit_totals.year_comparison_percentage == null
+                ? undefined
+                : `${$nOrDash(
+                    resultsSummary.unit_totals.previous_year_total_tonnes_co2eq,
+                    {
+                      options: {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      },
+                    },
+                  )}${$t('results_units_tonnes')}`
+            "
+            :print-mode="true"
+          />
+
+          <BigNumber
+            :title="
+              resultsSummary.unit_totals.total_fte == null
+                ? $t('results_carbon_footprint_per_FTE_no_headcount')
+                : $t('results_carbon_footprint_per_fte', {
+                    FTE: $nOrDash(resultsSummary.unit_totals.total_fte, {
+                      options: { maximumFractionDigits: 1 },
+                    }),
+                  })
+            "
+            :number="
+              $nOrDash(adjustedTonnesPerFte, {
+                options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+              })
+            "
+            :comparison="
+              $t('results_paris_agreement_value', {
+                value: `${$nOrDash(2)}${$t('results_units_tonnes')}`,
+              })
+            "
+            :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
+            color="negative"
+            :print-mode="true"
+          >
+            <template #tooltip>{{
+              $t('results_paris_agreement_tooltip')
+            }}</template>
+          </BigNumber>
+        </div>
+
+        <section class="q-mt-md">
+          <ModuleCarbonFootprintChart
+            :breakdown-data="moduleStore.state.emissionBreakdown"
+            :view-additional-data="viewAdditionalData"
+            :print-mode="true"
+          />
+        </section>
+        <section class="q-mt-md">
+          <CarbonFootPrintPerPersonChart
+            :per-person-breakdown="perPersonBreakdown"
+            :validated-categories="validatedCategories"
+            :headcount-validated="headcountValidatedForPerPerson"
+            :view-additional-data="viewAdditionalData"
+            :print-mode="true"
+          />
+        </section>
+      </ReportPage>
+
+      <ResultsPrintModulePage
+        v-for="(module, idx) in validatedModulesForPrint"
+        :key="module"
+        :module="module"
+        :page-number="idx + modulePagesStart"
+        :module-result="getModuleResult(module)"
+        :module-config="getModuleConfig(module)"
+        :total-fte="resultsSummary.unit_totals.total_fte"
+        :has-co2-per-km-kg="hasCo2PerKmKg"
+        :co2-per-km-kg="co2PerKmKg"
+        :current-year="currentYear"
+      />
+
+      <ReportPage
+        v-if="showItFocusSection"
+        :title="$t('it-focus-title')"
+        :page-number="itPageNumber"
+      >
+        <h2 class="text-h5 q-mt-none">
+          {{ $t('it-focus-title') }}
+        </h2>
+        <div class="text-body2 text-secondary q-mb-md">
+          {{ $t('it-focus-subtitle') }}
+        </div>
+
+        <ItFocusSection
+          :data="moduleStore.state.itBreakdown"
+          :loading="moduleStore.state.loadingItBreakdown"
+          :co2-per-km-kg="co2PerKmKg"
+          :year="currentYear"
+          :print-mode="true"
+        />
+      </ReportPage>
+
+      <ReportPage
+        v-if="
+          viewAdditionalData &&
+          additionalBreakdown.length > 0 &&
+          additionalChartsValidated
+        "
+        :title="$t('results_additional_title')"
+        :page-number="additionalPageNumber"
+      >
+        <h2 class="text-h5 q-mt-none">
+          {{ $t('results_additional_title') }}
+        </h2>
+        <div class="text-body2 text-secondary">
+          {{ $t('results_additional_subtitle') }}
+        </div>
+        <q-card flat bordered class="q-mt-md print-avoid-break">
+          <AdditionalCategoriesSection
+            :commuting-row="commutingRow"
+            :food-row="foodRow"
+            :waste-row="wasteRow"
+            :embodied-energy-row="embodiedEnergyRow"
+            :embodied-energy-by-category="embodiedEnergyByCategory"
+            :headcount-validated="
+              moduleStore.state.emissionBreakdown?.headcount_validated ?? false
+            "
+            :buildings-validated="
+              moduleStore.state.emissionBreakdown?.buildings_validated ?? false
+            "
+            :print-mode="true"
+          />
+        </q-card>
+      </ReportPage>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.report-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 0;
+  color: black !important;
+}
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid var(--half-muted-color);
+  z-index: 1000;
+}
+
+.module-page-header {
+  margin-bottom: 0px;
+}
+
+.grid-3-col {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.report-h2 {
+  letter-spacing: -0.01em;
+}
+
+.report-subtitle {
+  line-height: 1.35;
+}
+
+.print-card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  padding: 12px 12px 10px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.03);
+}
+
+.print-card--chart {
+  padding: 10px 10px 8px;
+}
+
+.print-card__eyebrow {
+  letter-spacing: 0.08em;
+}
+
+.print-avoid-break {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+@media (min-width: 1024px) {
+  .grid-3-col {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media print {
+  .print-hide,
+  .q-header,
+  .q-footer,
+  .q-drawer {
+    display: none !important;
+  }
+
+  .grid-3-col {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .bg-grey-3 {
+    background: white !important;
+  }
+
+  .report-container {
+    display: block !important;
+    width: 100% !important;
+    padding: 0 !important;
+  }
+
+  .print-report :deep(.q-card),
+  .print-report :deep(.q-card-section) {
+    box-shadow: none !important;
+  }
+
+  .print-report :deep(.big-number--print.q-card--bordered) {
+    border: none !important;
+  }
+
+  .module-page-header {
+    margin-bottom: 10px;
+  }
+
+  .module-charts-stack {
+    gap: 12px;
+  }
+
+  /* Reduce Quasar spacing inside embedded chart cards for print */
+  .print-card :deep(.q-pa-xl) {
+    padding: 12px !important;
+  }
+
+  .print-card :deep(.q-mx-lg) {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  .print-card :deep(.q-my-lg) {
+    margin-top: 10px !important;
+    margin-bottom: 10px !important;
+  }
+
+  .print-card :deep(.q-separator) {
+    margin: 10px 0 !important;
+  }
+
+  :deep(a) {
+    color: var(--title-color) !important;
+    text-decoration: underline !important;
+  }
+}
+</style>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -38,6 +38,23 @@ export function isBackOfficeRoute(route: RouteLocationNormalized): boolean {
 }
 
 const routes: RouteRecordRaw[] = [
+  // Print preview — own layout so no header/sidebar appears
+  {
+    path: `/:language(${LANGUAGE_PATTERN})/:unit(${UNIT_PATTERN})/:year(${YEAR_PATTERN})/results/print`,
+    component: () => import('layouts/PrintLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: 'results-print',
+        component: () => import('pages/app/ResultsPrintPage.vue'),
+        meta: {
+          requiresAuth: true,
+          note: 'Results – Print/PDF preview (no chrome)',
+          breadcrumb: false,
+        },
+      },
+    ],
+  },
   {
     path: '/',
     component: () => import('layouts/MainLayout.vue'),


### PR DESCRIPTION
## What does this change?
Adds a dedicated print/PDF preview page for the Results section. Clicking "Download as PDF" now opens a clean, A4-formatted report in a new browser tab — free of the app header, sidebar, and navigation — then triggers the browser's native print dialog automatically.

## Why is this needed?
The previous implementation called `window.print()` directly on the Results page, which printed the entire app UI including chrome elements, producing an unusable PDF output. This replaces that with a properly paginated, colour-accurate report.

## Type of change
- [x] ✨ New feature
- [x] 🎨 Design/UI improvement


## Related issues
- Closes #836