### PR TITLE
fix(#310a): poller auto-recovers stuck RUNNING jobs (kube safety net)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -314,10 +314,20 @@ class Settings(BaseSettings):
         ),
     )
 
-    # Background job safety (Plan 310A)
+    # Background job safety (Plan 310A + auto-recovery sweep, PR #998)
     STALE_JOB_TIMEOUT_MINUTES: int = Field(
-        default=30,
-        description="Minutes before a RUNNING job is considered stale",
+        default=60,
+        description=(
+            "Minutes before a RUNNING job is considered stale.  Doubles as "
+            "the auto-recovery sweep's threshold: jobs whose ``locked_at`` "
+            "is older than this are reset to NOT_STARTED (or marked "
+            "FINISHED+ERROR if attempts >= max_attempts).  Until the worker "
+            "heartbeats ``locked_at`` (planned in 310C), set this *above* "
+            "the longest plausible job runtime — otherwise the sweep will "
+            "preempt a still-working pod and trigger duplicate processing.  "
+            "60 min gives ample headroom for current ingest/recalc loads; "
+            "raise if a specific job type is expected to run longer."
+        ),
     )
     RUN_BACKGROUND_POLLER: bool = Field(
         default=True,

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -223,6 +223,81 @@ class DataIngestionRepository:
         await self.session.commit()
         return True
 
+    async def sweep_stuck_running_jobs(
+        self, stale_timeout_minutes: int
+    ) -> tuple[int, int]:
+        """Auto-recovery sweep for jobs stuck in RUNNING after a pod crash.
+
+        The poller calls this once per tick.  Jobs whose ``locked_at`` is
+        older than the stale window are split into two buckets:
+
+        - **Recoverable** (``attempts < max_attempts``) — reset to
+          NOT_STARTED so the next poll cycle can re-dispatch them.  Unlike
+          ``recover_job`` (the manual API path, which resets ``attempts=0``
+          on operator intent), this preserves ``attempts`` so a genuinely
+          broken job that crashes every claim can't loop forever — once
+          ``attempts`` reaches ``max_attempts`` the next sweep abandons it.
+
+        - **Abandoned** (``attempts >= max_attempts``) — moved to
+          ``state=FINISHED, result=ERROR`` with a diagnostic
+          ``status_message``.  Operators see the failure on the dashboard
+          instead of a silently-stuck row.
+
+        Returns ``(recovered_count, abandoned_count)``.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=stale_timeout_minutes)
+        stale_filter = and_(
+            col(DataIngestionJob.state) == IngestionState.RUNNING,
+            or_(
+                col(DataIngestionJob.locked_at).is_(None),
+                col(DataIngestionJob.locked_at) < cutoff,
+            ),
+        )
+
+        # Bucket 1: still has retries left → unlock and let claim_job pick
+        # it up next cycle.  Preserve ``attempts`` so claim_job's
+        # ``attempts < max_attempts`` guard caps the retry count.
+        recovered = await self.session.execute(
+            update(DataIngestionJob)
+            .where(
+                stale_filter,
+                col(DataIngestionJob.attempts) < col(DataIngestionJob.max_attempts),
+            )
+            .values(
+                state=IngestionState.NOT_STARTED,
+                locked_by=None,
+                locked_at=None,
+                is_current=False,
+                run_after=None,
+            )
+            .returning(col(DataIngestionJob.id))
+        )
+        recovered_ids = list(recovered.scalars().all())
+
+        # Bucket 2: out of retries → mark FINISHED+ERROR loud and clear.
+        abandoned = await self.session.execute(
+            update(DataIngestionJob)
+            .where(
+                stale_filter,
+                col(DataIngestionJob.attempts) >= col(DataIngestionJob.max_attempts),
+            )
+            .values(
+                state=IngestionState.FINISHED,
+                result=IngestionResult.ERROR,
+                status_message=(
+                    "Auto-recovery: pod-crash sweep found this job RUNNING past "
+                    "the stale-timeout window with attempts >= max_attempts.  "
+                    "Marking FINISHED+ERROR.  If the underlying issue is fixed, "
+                    "create a new job — this row's attempts counter is exhausted."
+                ),
+            )
+            .returning(col(DataIngestionJob.id))
+        )
+        abandoned_ids = list(abandoned.scalars().all())
+
+        await self.session.commit()
+        return len(recovered_ids), len(abandoned_ids)
+
     async def recover_job(
         self, job_id: int, stale_timeout_minutes: int
     ) -> Optional[DataIngestionJob]:

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -244,6 +244,20 @@ class DataIngestionRepository:
           instead of a silently-stuck row.
 
         Returns ``(recovered_count, abandoned_count)``.
+
+        ⚠️ **No heartbeat (yet)**: ``locked_at`` is set ONCE by
+        ``claim_job`` and never refreshed during execution, so any
+        legitimately long-running job whose runtime exceeds
+        ``stale_timeout_minutes`` will be falsely classified as stale.
+        That triggers duplicate processing — the sweep recovers the row,
+        another pod claims and re-runs it, while the original pod is
+        still working toward its commit.  Mitigation today: set
+        ``STALE_JOB_TIMEOUT_MINUTES`` *above* the longest plausible job
+        runtime (default 60 min, raise if needed).  Plan 310C wires a
+        per-job heartbeat into the generic ``run_job`` runner; until
+        then, this method shares the same long-running-job hazard as the
+        manual ``recover_job`` path — the sweep just exercises it more
+        often.
         """
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=stale_timeout_minutes)
         stale_filter = and_(

--- a/backend/app/tasks/_poller.py
+++ b/backend/app/tasks/_poller.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.db import SessionLocal
 from app.models.data_ingestion import DataIngestionJob
@@ -98,11 +99,42 @@ async def dispatch_job(job: DataIngestionJob, pod_id: str) -> None:
 
 
 async def poll_pending_jobs() -> None:
-    """Pick up jobs that were created but never scheduled (e.g. crashed pod)."""
+    """Pick up jobs that were created but never scheduled (e.g. crashed pod).
+
+    Two sweeps per iteration:
+
+    1. ``sweep_stuck_running_jobs`` — auto-recovery for jobs stuck in
+       RUNNING past the stale-timeout window (a pod crashed mid-execution).
+       Recoverable rows go back to NOT_STARTED; rows out of retries are
+       moved to FINISHED+ERROR so operators see them.  Without this, the
+       only way to recover from a pod crash was the manual
+       ``POST /sync/jobs/{id}/recover`` endpoint and the 30-min stale
+       window.
+
+    2. The original NOT_STARTED dispatch sweep.
+    """
+    settings = get_settings()
     while True:
         try:
             async with SessionLocal() as session:
                 repo = DataIngestionRepository(session)
+
+                # Sweep 1: pod-crash auto-recovery.
+                recovered, abandoned = await repo.sweep_stuck_running_jobs(
+                    settings.STALE_JOB_TIMEOUT_MINUTES
+                )
+                if recovered:
+                    logger.warning(
+                        f"Poller: auto-recovered {recovered} stuck RUNNING job(s) "
+                        "(state→NOT_STARTED, attempts preserved for max-retry guard)"
+                    )
+                if abandoned:
+                    logger.error(
+                        f"Poller: abandoned {abandoned} stuck RUNNING job(s) — "
+                        "exhausted max_attempts retries, marked FINISHED+ERROR"
+                    )
+
+                # Sweep 2: dispatch NOT_STARTED jobs (existing Plan 310A behaviour).
                 stmt = repo._pending_jobs_query(10)
                 jobs = (await session.execute(stmt)).scalars().all()
                 for job in jobs:

--- a/backend/tests/integration/services/data_ingestion/test_pod_safety_310a.py
+++ b/backend/tests/integration/services/data_ingestion/test_pod_safety_310a.py
@@ -270,6 +270,185 @@ async def test_recover_job_none_id(db_session: AsyncSession):
 
 
 # ======================================================================
+# sweep_stuck_running_jobs tests (poller's pod-crash auto-recovery)
+# ======================================================================
+#
+# Difference from ``recover_job``: the sweep PRESERVES ``attempts`` so
+# claim_job's max-retry guard caps an infinitely-crashing job, and it
+# ABANDONS jobs whose attempts have hit max (state=FINISHED+ERROR) so
+# operators see them.  ``recover_job`` (the manual API path) intentionally
+# resets attempts to 0 — operator override of the cap.
+
+
+@pytest.mark.asyncio
+async def test_sweep_recovers_stuck_running_with_retries_left(
+    db_session: AsyncSession,
+):
+    """attempts < max → reset to NOT_STARTED but PRESERVE attempts.
+
+    Locks are cleared so claim_job can pick it up next cycle, but
+    attempts is intact so a job that crashes every time can't loop
+    forever — claim_job's ``attempts < max_attempts`` guard caps it.
+    """
+    stale_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+    job = _make_job(
+        state=IngestionState.RUNNING,
+        locked_by="pod-crashed-1",
+        locked_at=stale_time,
+        attempts=1,
+        max_attempts=3,
+        is_current=True,
+    )
+    db_session.add(job)
+    await db_session.flush()
+    job_id = job.id
+
+    repo = DataIngestionRepository(db_session)
+    recovered, abandoned = await repo.sweep_stuck_running_jobs(stale_timeout_minutes=30)
+    assert (recovered, abandoned) == (1, 0)
+
+    refreshed = await repo.get_job_by_id(job_id)
+    assert refreshed is not None
+    assert refreshed.state == IngestionState.NOT_STARTED
+    assert refreshed.locked_by is None
+    assert refreshed.locked_at is None
+    assert refreshed.is_current is False
+    assert refreshed.run_after is None
+    # attempts is preserved — that's the whole difference vs recover_job
+    assert refreshed.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_abandons_stuck_running_at_max_attempts(
+    db_session: AsyncSession,
+):
+    """attempts >= max → mark FINISHED+ERROR with diagnostic message.
+
+    Without this branch, a job whose handler crashes every claim would
+    sit RUNNING forever after attempts hits max — claim_job won't
+    re-pick it up (``attempts < max_attempts`` is false), and the
+    recoverable branch above won't fire either (same gate).  So we
+    mark it terminally failed; operators see it and can investigate.
+    """
+    stale_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+    job = _make_job(
+        state=IngestionState.RUNNING,
+        locked_by="pod-crashed-final",
+        locked_at=stale_time,
+        attempts=3,
+        max_attempts=3,
+        is_current=True,
+    )
+    db_session.add(job)
+    await db_session.flush()
+    job_id = job.id
+
+    repo = DataIngestionRepository(db_session)
+    recovered, abandoned = await repo.sweep_stuck_running_jobs(stale_timeout_minutes=30)
+    assert (recovered, abandoned) == (0, 1)
+
+    refreshed = await repo.get_job_by_id(job_id)
+    assert refreshed is not None
+    assert refreshed.state == IngestionState.FINISHED
+    assert refreshed.result == IngestionResult.ERROR
+    assert "Auto-recovery" in (refreshed.status_message or "")
+    assert "max_attempts" in (refreshed.status_message or "")
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_running_within_stale_window(db_session: AsyncSession):
+    """Jobs whose locked_at is within the stale window are presumed alive."""
+    recent_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+    job = _make_job(
+        state=IngestionState.RUNNING,
+        locked_by="pod-alive",
+        locked_at=recent_time,
+        attempts=1,
+    )
+    db_session.add(job)
+    await db_session.flush()
+
+    repo = DataIngestionRepository(db_session)
+    recovered, abandoned = await repo.sweep_stuck_running_jobs(stale_timeout_minutes=30)
+    assert (recovered, abandoned) == (0, 0)
+
+    refreshed = await repo.get_job_by_id(job.id)
+    assert refreshed is not None
+    assert refreshed.state == IngestionState.RUNNING  # untouched
+
+
+@pytest.mark.asyncio
+async def test_sweep_recovers_running_with_null_locked_at(db_session: AsyncSession):
+    """RUNNING with NULL locked_at = a clearly-broken row (claim_job
+    always sets locked_at on success).  Treat as stale and recover."""
+    job = _make_job(
+        state=IngestionState.RUNNING,
+        locked_by="pod-mystery",
+        locked_at=None,
+        attempts=1,
+        max_attempts=3,
+    )
+    db_session.add(job)
+    await db_session.flush()
+
+    repo = DataIngestionRepository(db_session)
+    recovered, abandoned = await repo.sweep_stuck_running_jobs(stale_timeout_minutes=30)
+    assert (recovered, abandoned) == (1, 0)
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_touch_not_started(db_session: AsyncSession):
+    """NOT_STARTED is the dispatch sweep's domain — auto-recovery only
+    cares about RUNNING."""
+    job = _make_job(state=IngestionState.NOT_STARTED, attempts=0)
+    db_session.add(job)
+    await db_session.flush()
+
+    repo = DataIngestionRepository(db_session)
+    recovered, abandoned = await repo.sweep_stuck_running_jobs(stale_timeout_minutes=30)
+    assert (recovered, abandoned) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_sweep_handles_mixed_population(db_session: AsyncSession):
+    """One sweep call handles multiple rows in different buckets without
+    interference — recoverable, abandoned, alive, and not-started all
+    coexist; only the first two are touched."""
+    stale = datetime.now(timezone.utc) - timedelta(minutes=60)
+    fresh = datetime.now(timezone.utc) - timedelta(minutes=5)
+    db_session.add_all(
+        [
+            _make_job(
+                state=IngestionState.RUNNING,
+                locked_at=stale,
+                attempts=1,
+                max_attempts=3,
+                module_type_id=1,
+            ),
+            _make_job(
+                state=IngestionState.RUNNING,
+                locked_at=stale,
+                attempts=3,
+                max_attempts=3,
+                module_type_id=2,
+            ),
+            _make_job(
+                state=IngestionState.RUNNING,
+                locked_at=fresh,
+                attempts=1,
+                module_type_id=3,
+            ),
+            _make_job(state=IngestionState.NOT_STARTED, module_type_id=4),
+        ]
+    )
+    await db_session.flush()
+
+    repo = DataIngestionRepository(db_session)
+    recovered, abandoned = await repo.sweep_stuck_running_jobs(stale_timeout_minutes=30)
+    assert (recovered, abandoned) == (1, 1)
+
+
+# ======================================================================
 # run_sync_task claim guard tests
 # ======================================================================
 

--- a/docs/implementation-plans/310-c-dag-handler-registry.md
+++ b/docs/implementation-plans/310-c-dag-handler-registry.md
@@ -157,6 +157,58 @@ The legacy `run_ingestion`, `run_recalculation`, `run_module_recalculation`,
 `sync_units_from_accred_task` sync wrappers are removed once their handler bodies are
 registered. This is a follow-up cleanup commit within the same PR.
 
+### Pod-crash safety net: heartbeat + preemption check (rolled in from PR #998 review)
+
+PR #998 added an auto-recovery sweep to the safety poller (jobs stuck in RUNNING past
+`STALE_JOB_TIMEOUT_MINUTES` get reset to NOT_STARTED or marked FINISHED+ERROR). The
+review on that PR flagged a real concurrency hazard that lives until the runner
+heartbeats: any job whose runtime exceeds the stale-timeout window is falsely
+classified as stuck — the sweep recovers the row, another pod re-claims, and now two
+pods are processing the same job. PR #998's mitigation is operational: bump
+`STALE_JOB_TIMEOUT_MINUTES` to 60 min and document the caveat. The proper fix lives
+here, in `run_job`, in two parts:
+
+**1. Heartbeat the active worker.** Add a column or repurpose `locked_at`:
+
+```python
+# repo helper
+async def heartbeat(self, job_id: int) -> None:
+    await self.session.execute(
+        update(DataIngestionJob)
+        .where(col(DataIngestionJob.id) == job_id,
+               col(DataIngestionJob.locked_by) == POD_ID,  # only OUR job
+               col(DataIngestionJob.state) == IngestionState.RUNNING)
+        .values(locked_at=func.now())
+    )
+    await self.session.commit()
+```
+
+Inside `run_job`, spawn a per-job heartbeat task that wakes every
+`STALE_JOB_TIMEOUT_MINUTES / 4` (default: every 15 min for a 60 min timeout) and
+calls `heartbeat(job_id)` until the handler returns. Wrap with `try/finally` so the
+heartbeat task is reliably cancelled even if the handler raises. The auto-recovery
+sweep then becomes safe regardless of how long the worker takes — what it actually
+detects is "no heartbeat for >`STALE_JOB_TIMEOUT_MINUTES`," i.e. real pod death.
+
+**2. Worker-side preemption check.** Defence-in-depth for the brief window before
+the first heartbeat fires, and for any future regression in heartbeat scheduling.
+Inside `run_job`, before each `data_session.commit()`:
+
+```python
+current = await repo.get_job_by_id(job_id)
+if current is None or current.locked_by != POD_ID:
+    logger.warning(
+        f"Job {job_id} was preempted (locked_by={current and current.locked_by!r}); "
+        "rolling back our work and exiting"
+    )
+    await data_session.rollback()
+    return  # do NOT update job state — the new owner will
+```
+
+Together these eliminate the duplicate-processing risk that PR #998's sweep adds.
+With the heartbeat, `STALE_JOB_TIMEOUT_MINUTES` can be tightened back down (10–15 min)
+to bound recovery latency on real crashes.
+
 ---
 
 ## DAG chaining via `chain_job` helper


### PR DESCRIPTION
## Summary

- Plan 310A's safety poller only dispatches NOT_STARTED jobs. Jobs claimed but whose pod crashed mid-execution sit in RUNNING with stale \`locked_at\` until an operator hits \`POST /sync/jobs/{id}/recover\` — a real burden in kube setups with rolling restarts.
- This PR adds a sweep that runs once per poller tick, **before** the dispatch sweep. For each RUNNING job whose \`locked_at\` is older than \`STALE_JOB_TIMEOUT_MINUTES\`:
  - \`attempts < max_attempts\` → reset to \`NOT_STARTED\` but **preserve** \`attempts\`. This is the key difference vs \`recover_job\` (manual API path resets to 0): \`claim_job\`'s \`attempts < max_attempts\` guard caps a genuinely-broken job that crashes every claim.
  - \`attempts >= max_attempts\` → mark \`FINISHED + ERROR\` with a clear \`status_message\`. Without this branch, an exhausted-retry job sits RUNNING forever (claim_job won't re-pick it up; the recoverable branch won't fire either). Operators see the failure on the dashboard.

## Why on \`dev\`, not \`main\`

\`main\` doesn't have Plan 310A's \`recover_job\`/\`claim_job\`/\`STALE_JOB_TIMEOUT_MINUTES\` foundation yet — those live on \`dev\` (and its descendants \`feat/310b-factor-pipeline\`, \`feat/310c-…\`, etc.). Targeting \`dev\` keeps this aligned with the rest of the 310 stack.

## Plan C compatibility

Plan 310C will rewrite the poller's body to call a generic \`run_job(jid)\` dispatcher (replaces 310A's broken \`dispatch_job\` that reads \`meta[\"provider_name\"]\`). This sweep slots in cleanly because it's **additive** to the existing dispatch sweep — 310C's rewrite preserves both passes and just changes the second one.

## Test plan

- [x] \`uv run pytest tests/integration/services/data_ingestion/test_pod_safety_310a.py -v -k sweep\` — 6 new sweep tests pass
- [x] \`uv run pytest tests/unit/ tests/integration/services/data_ingestion/test_pod_safety_310a.py\` — 1201 tests pass, no regressions in 310A coverage
- [ ] (operator gut check on staging once merged) Kill a pod mid-job and confirm the next poll tick auto-recovers the row instead of leaving it stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)