### PR TITLE
docs(#860): C1 system-overview mermaid + condense

### DIFF
--- a/docs/src/architecture/02-system-overview.md
+++ b/docs/src/architecture/02-system-overview.md
@@ -1,336 +1,156 @@
-# System Overview Diagram
+---
+status: delivered
+last_updated: 2026-05-05
+summary: System-context and container view of co2-calculator.
+---
 
-- Interaction component Basic
+# System Overview
 
-```mermaid
-graph TB
-    User([User/Browser])
-    LB[EPFL Load Balancer]
+This page gives a C4-style **context** and **container** view of the
+co2-calculator. It answers: *who uses it, what it depends on, and which
+deployable units make it up.*
 
-    subgraph K8S["Kubernetes Cluster (XaaS Platform)"]
-        Ingress[Ingress Controller]
+For deeper detail, jump to:
 
-        subgraph Routes["Route Definitions"]
-            Root["/ → SPA"]
-            API["/api → Backend"]
-            Docs["/docs → API Docs"]
-            ITMgr["/it-manager → IT UI"]
-            TeamMgr["/team-manager → Team UI"]
-        end
+- [Subsystem Map](./03-subsystem-map.md) — internal component graph
+- [Data Flow](./10-data-flow.md) — request and upload sequences
+- [Tech Stack](./08-tech-stack.md) — frameworks and versions
+- [Deployment Topology](./11-deployment-topology.md) — Kubernetes layout
 
-        Frontend[Frontend Pods<br/>Vue 3 Applications]
-        Backend[Backend Pods<br/>FastAPI Services]
-        Workers[Worker Pods<br/>Celery + Redis]
-        Database[Database Layer<br/>PostgreSQL + PgBouncer]
-    end
+---
 
-    subgraph External["External Services"]
-        Auth[Microsoft Entra ID<br/>OAuth2/OIDC]
-        S3[EPFL S3 Storage]
-    end
+## System Context
 
-    User -->|HTTPS| LB
-    LB --> Ingress
-    Ingress --> Routes
-    Routes --> Frontend
-    Routes --> Backend
-
-    Frontend -->|API Calls| Backend
-    Backend <-->|Authentication| Auth
-    Backend -->|Read/Write| Database
-    Backend -->|Enqueue Tasks| Workers
-    Backend <-->|Files| S3
-
-    Workers -->|Read/Write| Database
-    Workers <-->|Files| S3
-
-    classDef external fill:#ffebee,stroke:#c62828,stroke-width:2px
-    classDef ingress fill:#e8eaf6,stroke:#3949ab,stroke-width:2px
-    classDef route fill:#fff9c4,stroke:#f57f17,stroke-width:2px
-    classDef frontend fill:#e1f5ff,stroke:#01579b,stroke-width:2px
-    classDef backend fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef workers fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
-    classDef database fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
-
-    class User,LB external
-    class Ingress ingress
-    class Root,API,Docs,ITMgr,TeamMgr route
-    class Frontend frontend
-    class Backend backend
-    class Workers workers
-    class Database database
-    class Auth,S3 external
-```
-
-- Interaction component detailed
+Actors and external dependencies surrounding the system.
 
 ```mermaid
-graph TB
-    User([User/Browser])
-    LB[EPFL Load Balancer]
+flowchart LR
+    User([EPFL User])
+    Admin([IT / Team Admin])
+    System["co2-calculator<br/>(SPA + API + Workers)"]
+    Entra[(Microsoft Entra ID<br/>OAuth2 / OIDC)]
+    S3[(EPFL S3<br/>Object Storage)]
+    Mail[[Notification Email]]
 
-    subgraph K8S["Kubernetes Cluster (XaaS Platform)"]
-        Ingress[Ingress Controller]
+    User -->|Browse, upload, view reports| System
+    Admin -->|Manage users, units, factors| System
+    System <-->|Authenticate| Entra
+    System <-->|Files and exports| S3
+    System -->|Status emails| Mail
 
-        subgraph Routes["Ingress Definitions"]
-            Root["/ - SPA Frontend"]
-            API["/api - Backend REST"]
-            Docs["/docs - Public API Docs"]
-            ITMgr["/it-manager - IT Interface"]
-            TeamMgr["/team-manager - Team Interface"]
-        end
-
-        subgraph Frontend["Frontend Pods"]
-            SPA[Vue 3 SPA]
-            ITApp[IT Manager App]
-            TeamApp[Team Manager App]
-        end
-
-        subgraph AppLayer["Application Layer"]
-            subgraph Backend["Backend Pods"]
-                FastAPI1[FastAPI Pod 1]
-                FastAPI2[FastAPI Pod 2]
-                APIAuth[Auth Middleware]
-            end
-
-            subgraph Workers["Worker Pods"]
-                Redis[Redis Queue]
-                Celery1[Celery Worker 1]
-                Celery2[Celery Worker 2]
-            end
-        end
-
-        subgraph DatabaseLayer["Database Layer"]
-            subgraph Pooling["Connection Pooling"]
-                PGBouncer1[PgBouncer Primary]
-                PGBouncer2[PgBouncer Secondary]
-            end
-
-            subgraph PostgreSQL["PostgreSQL Cluster"]
-                Primary[(PostgreSQL Primary<br/>Read/Write)]
-                Replica1[(PostgreSQL Replica 1<br/>Read Only)]
-                Replica2[(PostgreSQL Replica 2<br/>Read Only)]
-            end
-        end
-
-        subgraph Config["Config & Secrets"]
-            DBCreds[DB Credentials]
-            ConfigMaps[ConfigMaps]
-        end
-
-        subgraph Monitoring["Monitoring & Observability"]
-            Prometheus[Prometheus]
-            Grafana[Grafana]
-        end
-    end
-
-    subgraph External["External Services"]
-        EntraID[Microsoft Entra ID<br/>OAuth2/OpenID Connect]
-        S3[EPFL S3 Storage<br/>Object Storage]
-    end
-
-    User -->|HTTPS| LB
-    LB -->|Route Traffic| Ingress
-
-    Ingress -->|/* catch-all| Root
-    Ingress -->|/api/*| API
-    Ingress -->|/docs| Docs
-    Ingress -->|/it-manager/*| ITMgr
-    Ingress -->|/team-manager/*| TeamMgr
-
-    Root -->|Serve| SPA
-    ITMgr -->|Serve| ITApp
-    TeamMgr -->|Serve| TeamApp
-
-    API -->|Forward| FastAPI1
-    API -->|Forward| FastAPI2
-    Docs -->|Swagger UI| FastAPI1
-
-    SPA -->|API Calls| FastAPI1
-    ITApp -->|API Calls| FastAPI1
-    TeamApp -->|API Calls| FastAPI2
-
-    FastAPI1 -->|Authenticate| APIAuth
-    FastAPI2 -->|Authenticate| APIAuth
-    APIAuth <-->|OAuth2/OIDC| EntraID
-
-    FastAPI1 -->|Enqueue Jobs| Redis
-    FastAPI2 -->|Enqueue Jobs| Redis
-
-    FastAPI1 -->|Read/Write Queries| PGBouncer1
-    FastAPI2 -->|Read/Write Queries| PGBouncer1
-
-    Redis -->|Distribute| Celery1
-    Redis -->|Distribute| Celery2
-
-    Celery1 -->|Read/Write Queries| PGBouncer2
-    Celery2 -->|Read/Write Queries| PGBouncer2
-
-    FastAPI1 <-->|Store/Retrieve Files| S3
-    FastAPI2 <-->|Store/Retrieve Files| S3
-    Celery1 <-->|Read/Write Files| S3
-    Celery2 <-->|Read/Write Files| S3
-
-    PGBouncer1 -->|Writes| Primary
-    PGBouncer1 -->|Reads| Replica1
-    PGBouncer1 -->|Reads| Replica2
-
-    PGBouncer2 -->|Writes| Primary
-    PGBouncer2 -->|Reads| Replica1
-    PGBouncer2 -->|Reads| Replica2
-
-    Primary -.->|Replication| Replica1
-    Primary -.->|Replication| Replica2
-
-    DBCreds --> FastAPI1
-    DBCreds --> FastAPI2
-    DBCreds --> Celery1
-    DBCreds --> Celery2
-    DBCreds --> PGBouncer1
-    DBCreds --> PGBouncer2
-
-    ConfigMaps --> FastAPI1
-    ConfigMaps --> FastAPI2
-
-    Prometheus --> FastAPI1
-    Prometheus --> FastAPI2
-    Prometheus --> PGBouncer1
-    Prometheus --> PGBouncer2
-    Grafana --> Prometheus
-
-    classDef external fill:#ffebee,stroke:#c62828,stroke-width:2px
-    classDef ingress fill:#e8eaf6,stroke:#3949ab,stroke-width:2px
-    classDef frontend fill:#e1f5ff,stroke:#01579b,stroke-width:2px
-    classDef backend fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef workers fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
-    classDef database fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
-    classDef config fill:#fce4ec,stroke:#880e4f,stroke-width:2px
-    classDef route fill:#fff9c4,stroke:#f57f17,stroke-width:2px
-
-    class User,LB external
-    class Ingress ingress
-    class Root,API,Docs,ITMgr,TeamMgr route
-    class SPA,ITApp,TeamApp frontend
-    class FastAPI1,FastAPI2,APIAuth backend
-    class Redis,Celery1,Celery2 workers
-    class PGBouncer1,PGBouncer2,Primary,Replica1,Replica2 database
-    class DBCreds,ConfigMaps,Prometheus,Grafana config
-    class EntraID,S3 external
+    classDef system fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef ext fill:#ffebee,stroke:#c62828,stroke-width:2px
+    class System system
+    class Entra,S3,Mail ext
 ```
 
-- Interaction component less detailed
+**Boundaries.** The system owns its data (PostgreSQL) and queues
+(Redis). Identity is delegated to Entra ID. File blobs live in EPFL S3.
+Everything else is internal.
+
+---
+
+## Containers
+
+Deployable units inside the Kubernetes cluster and their main
+collaborators.
 
 ```mermaid
-graph TB
-    Frontend["Frontend Layer<br/>Vue 3 + Quasar"]
-    Backend["Backend Layer<br/>FastAPI"]
-    Workers["Workers Layer<br/>Celery + Redis"]
-    Database["Database Layer<br/>PostgreSQL"]
-    Storage["Storage Layer<br/>EPFL S3"]
-    Infra["Infrastructure Layer<br/>Kubernetes on XaaS"]
+flowchart TB
+    Browser([Browser])
 
-    Frontend <-->|REST API| Backend
-    Backend <-->|Enqueue Tasks| Workers
-    Backend <-->|Read/Write| Database
-    Backend <-->|Upload/Download| Storage
-    Workers -->|Read/Write Files| Storage
-    Workers -->|Store Results| Database
-    Infra -.->|Hosts| Frontend
-    Infra -.->|Hosts| Backend
-    Infra -.->|Hosts| Workers
-    Infra -.->|Manages| Database
-    Infra -.->|Manages| Storage
+    subgraph Edge["Edge"]
+        Ingress[nginx-ingress<br/>TLS via cert-manager]
+    end
 
-    classDef frontend fill:#e1f5ff,stroke:#01579b,stroke-width:2px
-    classDef backend fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef workers fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
-    classDef database fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
-    classDef storage fill:#fff9c4,stroke:#f57f17,stroke-width:2px
-    classDef infra fill:#fce4ec,stroke:#880e4f,stroke-width:2px
+    subgraph K8s["Kubernetes (EPFL XaaS)"]
+        FE["Frontend<br/>Vue 3 + Quasar (Nginx)"]
+        BE["Backend API<br/>FastAPI + Uvicorn"]
+        WK["Workers<br/>Celery"]
+        Redis[(Redis<br/>queue + cache)]
+        PG[(PostgreSQL<br/>via PgBouncer)]
+    end
 
-    class Frontend frontend
-    class Backend backend
-    class Workers workers
-    class Database database
-    class Storage storage
-    class Infra infra
+    Entra[(Entra ID)]
+    S3[(EPFL S3)]
+
+    Browser -->|HTTPS| Ingress
+    Ingress -->|/| FE
+    Ingress -->|/api| BE
+    FE -->|REST / JSON| BE
+    BE <-->|OIDC| Entra
+    BE -->|SQLAlchemy async| PG
+    BE -->|enqueue| Redis
+    BE <-->|presigned URLs| S3
+    Redis -->|dispatch| WK
+    WK -->|results| PG
+    WK <-->|files| S3
+
+    classDef fe fill:#e1f5ff,stroke:#01579b,stroke-width:2px
+    classDef be fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef wk fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
+    classDef data fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
+    classDef ext fill:#ffebee,stroke:#c62828,stroke-width:2px
+    classDef edge fill:#e8eaf6,stroke:#3949ab,stroke-width:2px
+
+    class FE fe
+    class BE be
+    class WK wk
+    class Redis,PG data
+    class Entra,S3 ext
+    class Ingress edge
 ```
 
-- Overview of database query system
+### Container responsibilities
+
+| Container       | Role                                                     |
+| --------------- | -------------------------------------------------------- |
+| **Frontend**    | Static SPA bundle, Quasar UI, calls Backend over REST.   |
+| **Backend API** | Auth, business logic, persistence, presigned-URL broker. |
+| **Workers**     | CPU-bound jobs: factor recalc, CSV ingest, exports.      |
+| **Redis**       | Celery broker + short-lived caches.                      |
+| **PostgreSQL**  | System of record, accessed via PgBouncer.                |
+
+Stack and versions live in [Tech Stack](./08-tech-stack.md).
+
+---
+
+## Request Lifecycle (high level)
 
 ```mermaid
-flowchart TD
-    subgraph K8s Cluster
-        A[FastAPI Pods] -->|Read/Write Queries| B[PgBouncer Primary/Secondary]
-        B -->|Writes| C[(PostgreSQL Primary)]
-        B -->|Reads| D[(PostgreSQL Replica 1)]
-        B -->|Reads| E[(PostgreSQL Replica 2)]
-    end
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant FE as Frontend
+    participant BE as Backend
+    participant Q as Redis
+    participant W as Worker
+    participant DB as PostgreSQL
 
-    subgraph Config & Secrets
-        F[DB Credentials & ConfigMaps] --> A
-        F --> B
-    end
-
-    subgraph Monitoring & Observability
-        G[Prometheus / Grafana] --> A
-        G --> B
-    end
+    U->>FE: Action (e.g. upload CSV)
+    FE->>BE: REST + JWT
+    BE->>DB: Persist metadata
+    BE->>Q: Enqueue job
+    BE-->>FE: 202 + job id
+    Q->>W: Dispatch
+    W->>DB: Write results
+    FE->>BE: Poll status
+    BE->>DB: Read status
+    BE-->>FE: Result / progress
 ```
 
-- Dataflow
+Detailed sequences (uploads, exports, auth) are in
+[Data Flow](./10-data-flow.md) and [Auth Flow](./04-auth-flow.md).
 
-```mermaid
-graph TB
-    User([User])
-    FE[Frontend]
-    BE[Backend API]
-    Queue[Redis Queue]
-    Worker[Celery Workers]
-    Process[Process]
-    DB[(PostgreSQL)]
-    S3[(S3 Storage)]
+---
 
-    User -->|1. Upload File| FE
-    FE -->|2. POST Request| BE
-    BE -->|3. Store File| S3
-    BE -->|4. Create Task| Queue
-    BE -->|5. Save Metadata| DB
-    Queue -->|6. Dispatch| Worker
-    Worker -->|7. Fetch File| S3
-    Worker -->|8. Process| Process
-    Process -->|8.a result |Worker
-    Worker -->|9. Store Results| DB
-    Worker -->|10. Save Output| S3
-    BE -->|11. Response| FE
-    FE -->|12. Display| User
+## Cross-cutting
 
-    classDef userStyle fill:#e0e0e0,stroke:#424242,stroke-width:2px
-    classDef frontendStyle fill:#e1f5ff,stroke:#01579b,stroke-width:2px
-    classDef backendStyle fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef workerStyle fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
-    classDef dataStyle fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
-    classDef storageStyle fill:#fff9c4,stroke:#f57f17,stroke-width:2px
-    classDef ProcessStyle fill:#ffeeff,stroke:#f13f4a,stroke-width:2px
-
-    class User userStyle
-    class FE frontendStyle
-    class BE backendStyle
-    class Queue,Worker workerStyle
-    class DB dataStyle
-    class S3 storageStyle
-    class Process ProcessStyle
-```
-
-The system consists of several interconnected layers that work together to provide the complete functionality. The diagram above shows the high-level components and their interactions.
-
-## High-Level Components
-
-1. **Frontend Layer** - User interface implemented with Vue 3 and Quasar
-2. **Backend Layer** - RESTful API implemented with FastAPI
-3. **Workers Layer** - Asynchronous processing with Celery and Redis
-4. **Database Layer** - Data persistence with PostgreSQL
-5. **Storage Layer** - Object storage for file uploads
-6. **Infrastructure Layer** - Hosting and operational components
-
-For detailed information about each component, see the Component Breakdown section below and the specific documentation in the corresponding folders under `docs/`.
+- **Identity.** JWT issued after Entra ID OIDC handshake — see
+  [Auth Flow](./04-auth-flow.md).
+- **Observability.** Prometheus scrapes Backend + PgBouncer; Grafana
+  dashboards in cluster.
+- **Config.** ConfigMaps + Secrets per environment — see
+  [Environments](./05-environments.md).
+- **Scaling.** Stateless API + workers scale via HPA — see
+  [Scalability](./12-scalability.md).

--- a/docs/src/architecture/02-system-overview.md
+++ b/docs/src/architecture/02-system-overview.md
@@ -27,26 +27,24 @@ Actors and external dependencies surrounding the system.
 flowchart LR
     User([EPFL User])
     Admin([IT / Team Admin])
-    System["co2-calculator<br/>(SPA + API + Workers)"]
+    System["co2-calculator<br/>(SPA + API)"]
     Entra[(Microsoft Entra ID<br/>OAuth2 / OIDC)]
     S3[(EPFL S3<br/>Object Storage)]
-    Mail[[Notification Email]]
 
     User -->|Browse, upload, view reports| System
     Admin -->|Manage users, units, factors| System
     System <-->|Authenticate| Entra
     System <-->|Files and exports| S3
-    System -->|Status emails| Mail
 
     classDef system fill:#fff3e0,stroke:#e65100,stroke-width:2px
     classDef ext fill:#ffebee,stroke:#c62828,stroke-width:2px
     class System system
-    class Entra,S3,Mail ext
+    class Entra,S3 ext
 ```
 
-**Boundaries.** The system owns its data (PostgreSQL) and queues
-(Redis). Identity is delegated to Entra ID. File blobs live in EPFL S3.
-Everything else is internal.
+**Boundaries.** The system owns its data (PostgreSQL, which also stores
+the background-job queue table). Identity is delegated to Entra ID. File
+blobs live in EPFL S3. Everything else is internal.
 
 ---
 
@@ -65,9 +63,7 @@ flowchart TB
 
     subgraph K8s["Kubernetes (EPFL XaaS)"]
         FE["Frontend<br/>Vue 3 + Quasar (Nginx)"]
-        BE["Backend API<br/>FastAPI + Uvicorn"]
-        WK["Workers<br/>Celery"]
-        Redis[(Redis<br/>queue + cache)]
+        BE["Backend API<br/>FastAPI + Uvicorn<br/>(in-process background tasks)"]
         PG[(PostgreSQL<br/>via PgBouncer)]
     end
 
@@ -77,39 +73,32 @@ flowchart TB
     Browser -->|HTTPS| Ingress
     Ingress -->|/| FE
     Ingress -->|/api| BE
-    FE -->|REST / JSON| BE
+    FE -->|REST / JSON<br/>auth cookies| BE
     BE <-->|OIDC| Entra
     BE -->|SQLAlchemy async| PG
-    BE -->|enqueue| Redis
-    BE <-->|presigned URLs| S3
-    Redis -->|dispatch| WK
-    WK -->|results| PG
-    WK <-->|files| S3
+    BE <-->|read/write blobs| S3
 
     classDef fe fill:#e1f5ff,stroke:#01579b,stroke-width:2px
     classDef be fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef wk fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
     classDef data fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
     classDef ext fill:#ffebee,stroke:#c62828,stroke-width:2px
     classDef edge fill:#e8eaf6,stroke:#3949ab,stroke-width:2px
 
     class FE fe
     class BE be
-    class WK wk
-    class Redis,PG data
+    class PG data
     class Entra,S3 ext
     class Ingress edge
 ```
 
 ### Container responsibilities
 
-| Container       | Role                                                     |
-| --------------- | -------------------------------------------------------- |
-| **Frontend**    | Static SPA bundle, Quasar UI, calls Backend over REST.   |
-| **Backend API** | Auth, business logic, persistence, presigned-URL broker. |
-| **Workers**     | CPU-bound jobs: factor recalc, CSV ingest, exports.      |
-| **Redis**       | Celery broker + short-lived caches.                      |
-| **PostgreSQL**  | System of record, accessed via PgBouncer.                |
+| Container           | Role                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Frontend**        | Static SPA bundle, Quasar UI, calls Backend over REST with HTTP-only auth cookies.                                  |
+| **Backend API**     | Auth, business logic, persistence, file uploads via `/files/temp-upload`.                                           |
+| **Background tasks**| In-process FastAPI `BackgroundTasks` chained via `asyncio.create_task`; 10s safety-net poller. See ADR-010.         |
+| **PostgreSQL**      | System of record (also holds the background-job queue table), accessed via PgBouncer.                               |
 
 Stack and versions live in [Tech Stack](./08-tech-stack.md).
 
@@ -123,18 +112,15 @@ sequenceDiagram
     actor U as User
     participant FE as Frontend
     participant BE as Backend
-    participant Q as Redis
-    participant W as Worker
     participant DB as PostgreSQL
 
     U->>FE: Action (e.g. upload CSV)
-    FE->>BE: REST + JWT
-    BE->>DB: Persist metadata
-    BE->>Q: Enqueue job
+    FE->>BE: REST + auth cookie
+    BE->>DB: Persist metadata + claim job
     BE-->>FE: 202 + job id
-    Q->>W: Dispatch
-    W->>DB: Write results
-    FE->>BE: Poll status
+    Note over BE: asyncio.create_task chain
+    BE->>DB: Write results
+    FE->>BE: Poll status (or SSE)
     BE->>DB: Read status
     BE-->>FE: Result / progress
 ```
@@ -146,11 +132,12 @@ Detailed sequences (uploads, exports, auth) are in
 
 ## Cross-cutting
 
-- **Identity.** JWT issued after Entra ID OIDC handshake — see
+- **Identity.** Entra ID OIDC handshake exchanged for HTTP-only
+  `auth_token` / `refresh_token` cookies — see
   [Auth Flow](./04-auth-flow.md).
 - **Observability.** Prometheus scrapes Backend + PgBouncer; Grafana
   dashboards in cluster.
 - **Config.** ConfigMaps + Secrets per environment — see
   [Environments](./05-environments.md).
-- **Scaling.** Stateless API + workers scale via HPA — see
-  [Scalability](./12-scalability.md).
+- **Scaling.** Stateless API (and its in-process tasks) scales via HPA —
+  see [Scalability](./12-scalability.md).


### PR DESCRIPTION
## Summary

- Rewrites `docs/src/architecture/02-system-overview.md` around C4-style **system context** and **container** mermaid diagrams plus a high-level request-lifecycle sequence.
- Drops 5 overlapping/duplicated diagrams that re-stated content owned by `03-subsystem-map.md` and `10-data-flow.md`; replaces with 3 focused views and explicit cross-links.
- Adds frontmatter (`status: delivered`, `last_updated: 2026-05-05`, summary).
- 336 -> 156 lines (well under the 180-line target).

## Test plan

- [x] `mkdocs build --strict` exits 0
- [x] All 3 mermaid blocks rendered (verified in built HTML)
- [x] Cross-links target existing sibling docs (subsystem-map, data-flow, tech-stack, deployment-topology, auth-flow, environments, scalability)
- [x] No content duplication with `01-purpose-scope.md`, `03-subsystem-map.md`, `08-tech-stack.md`