### PR TITLE
docs(#860): B0 wire auto-index infrastructure

### DIFF
--- a/docs/gen_indexes.py
+++ b/docs/gen_indexes.py
@@ -1,0 +1,142 @@
+"""Auto-index generator hook for MkDocs.
+
+Walks documentation sections and emits virtual `INDEX.md` files via
+`mkdocs_gen_files`. Implementation-plans index is grouped by frontmatter
+`status` (delivered / in-progress / abandoned); other sections get an
+alphabetical TOC. Files lacking frontmatter fall under "Uncategorized" so
+`mkdocs build --strict` keeps passing before sibling backfill lands.
+
+Frontmatter schema (all optional)::
+
+    ---
+    status: delivered | in-progress | abandoned
+    issue: 310-b
+    title: Human-readable title
+    last_updated: 2026-05-05
+    summary: One-line description.
+    ---
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import mkdocs_gen_files
+
+try:
+    import frontmatter as _frontmatter
+
+    def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+        post = _frontmatter.loads(text)
+        return dict(post.metadata), post.content
+except ImportError:  # minimal fallback parser
+    _FM_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n(.*)\Z", re.DOTALL)
+
+    def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+        match = _FM_RE.match(text)
+        if not match:
+            return {}, text
+        meta: dict[str, Any] = {}
+        for line in match.group(1).splitlines():
+            if ":" not in line or line.lstrip().startswith("#"):
+                continue
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip().strip("\"'")
+        return meta, match.group(2)
+
+
+# Repo root resolves from this script's location: docs/gen_indexes.py -> repo
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_SRC = REPO_ROOT / "docs" / "src"
+PLANS_DIR = REPO_ROOT / "docs" / "implementation-plans"
+PLANS_GH_URL = (
+    "https://github.com/epfl-enac/co2-calculator/blob/main/docs/implementation-plans"
+)
+
+STATUS_ORDER = ("delivered", "in-progress", "abandoned", "uncategorized")
+STATUS_LABEL = {
+    "delivered": "Delivered",
+    "in-progress": "In progress",
+    "abandoned": "Abandoned",
+    "uncategorized": "Uncategorized",
+}
+
+
+def _title_from(meta: dict[str, Any], body: str, fallback: str) -> str:
+    if meta.get("title"):
+        return str(meta["title"])
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return fallback
+
+
+def _section_index(section: str) -> None:
+    """Emit alphabetical TOC for a section under docs_dir."""
+    section_dir = DOCS_SRC / section
+    if not section_dir.is_dir():
+        return
+    rows = []
+    for md in sorted(section_dir.glob("*.md")):
+        if md.name.lower() in {"index.md", "index_.md"}:
+            continue
+        meta, body = _parse_frontmatter(md.read_text(encoding="utf-8"))
+        title = _title_from(meta, body, md.stem)
+        rows.append(f"- [{title}]({md.name})")
+    lines = [f"# {section.replace('-', ' ').title()} index", ""]
+    lines.extend(rows or ["_No pages yet._"])
+    with mkdocs_gen_files.open(f"{section}/INDEX.md", "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def _plans_index() -> None:
+    """Emit grouped index for implementation-plans (lives outside docs_dir)."""
+    if not PLANS_DIR.is_dir():
+        return
+    groups: dict[str, list[dict[str, Any]]] = {key: [] for key in STATUS_ORDER}
+    for md in sorted(PLANS_DIR.glob("*.md")):
+        meta, body = _parse_frontmatter(md.read_text(encoding="utf-8"))
+        status = str(meta.get("status", "")).strip().lower() or "uncategorized"
+        if status not in groups:
+            status = "uncategorized"
+        groups[status].append(
+            {
+                "title": _title_from(meta, body, md.stem),
+                "issue": meta.get("issue", ""),
+                "last_updated": meta.get("last_updated", ""),
+                "summary": meta.get("summary", ""),
+                "filename": md.name,
+            }
+        )
+
+    lines = [
+        "# Implementation plans",
+        "",
+        f"Plans live in `docs/implementation-plans/` (outside `docs_dir`); links point to GitHub. {sum(len(v) for v in groups.values())} total.",
+        "",
+    ]
+    for key in STATUS_ORDER:
+        entries = groups[key]
+        if not entries:
+            continue
+        lines.append(f"## {STATUS_LABEL[key]} ({len(entries)})")
+        lines.append("")
+        lines.append("| Title | Issue | Last updated | Summary |")
+        lines.append("| --- | --- | --- | --- |")
+        for e in entries:
+            link = f"[{e['title']}]({PLANS_GH_URL}/{e['filename']})"
+            summary = str(e["summary"]).replace("|", "\\|")
+            lines.append(
+                f"| {link} | {e['issue']} | {e['last_updated']} | {summary} |"
+            )
+        lines.append("")
+
+    with mkdocs_gen_files.open("implementation-plans/INDEX.md", "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+for _section in ("architecture", "backend", "frontend"):
+    _section_index(_section)
+_plans_index()

--- a/docs/gen_indexes.py
+++ b/docs/gen_indexes.py
@@ -51,9 +51,28 @@ except ImportError:  # minimal fallback parser
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_SRC = REPO_ROOT / "docs" / "src"
 PLANS_DIR = REPO_ROOT / "docs" / "src" / "implementation-plans"
-PLANS_GH_URL = (
-    "https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans"
-)
+
+# Filename for generated section/plan indexes. Differs from `index.md` by more
+# than case so it does not collide with hand-authored `index.md` files on
+# case-insensitive filesystems (macOS/Windows).
+GENERATED_INDEX_NAME = "_index.md"
+
+
+def _plans_gh_url() -> str:
+    """Derive the GitHub blob URL for implementation-plans from MkDocs config.
+
+    Reads `repo_url` from the active MkDocs config (via `mkdocs_gen_files`),
+    so fork builds and renamed remotes link correctly. Falls back to the
+    upstream repo if config isn't available (e.g. running outside a build).
+    """
+    fallback = "https://github.com/epfl-enac/co2-calculator"
+    try:
+        repo_url = str(
+            mkdocs_gen_files.FilesEditor.current().config.repo_url or fallback
+        )
+    except Exception:  # pragma: no cover - non-build invocation
+        repo_url = fallback
+    return f"{repo_url.rstrip('/')}/blob/main/docs/src/implementation-plans"
 
 STATUS_ORDER = ("delivered", "in-progress", "abandoned", "uncategorized")
 STATUS_LABEL = {
@@ -79,15 +98,16 @@ def _section_index(section: str) -> None:
     if not section_dir.is_dir():
         return
     rows = []
+    skip_names = {"index.md", "index_.md", GENERATED_INDEX_NAME.lower()}
     for md in sorted(section_dir.glob("*.md")):
-        if md.name.lower() in {"index.md", "index_.md"}:
+        if md.name.lower() in skip_names:
             continue
         meta, body = _parse_frontmatter(md.read_text(encoding="utf-8"))
         title = _title_from(meta, body, md.stem)
         rows.append(f"- [{title}]({md.name})")
     lines = [f"# {section.replace('-', ' ').title()} index", ""]
     lines.extend(rows or ["_No pages yet._"])
-    with mkdocs_gen_files.open(f"{section}/INDEX.md", "w") as f:
+    with mkdocs_gen_files.open(f"{section}/{GENERATED_INDEX_NAME}", "w") as f:
         f.write("\n".join(lines) + "\n")
 
 
@@ -111,6 +131,7 @@ def _plans_index() -> None:
             }
         )
 
+    plans_gh_url = _plans_gh_url()
     lines = [
         "# Implementation plans",
         "",
@@ -126,14 +147,16 @@ def _plans_index() -> None:
         lines.append("| Title | Issue | Last updated | Summary |")
         lines.append("| --- | --- | --- | --- |")
         for e in entries:
-            link = f"[{e['title']}]({PLANS_GH_URL}/{e['filename']})"
+            link = f"[{e['title']}]({plans_gh_url}/{e['filename']})"
             summary = str(e["summary"]).replace("|", "\\|")
             lines.append(
                 f"| {link} | {e['issue']} | {e['last_updated']} | {summary} |"
             )
         lines.append("")
 
-    with mkdocs_gen_files.open("implementation-plans/INDEX.md", "w") as f:
+    with mkdocs_gen_files.open(
+        f"implementation-plans/{GENERATED_INDEX_NAME}", "w"
+    ) as f:
         f.write("\n".join(lines) + "\n")
 
 

--- a/docs/gen_indexes.py
+++ b/docs/gen_indexes.py
@@ -50,9 +50,9 @@ except ImportError:  # minimal fallback parser
 # Repo root resolves from this script's location: docs/gen_indexes.py -> repo
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_SRC = REPO_ROOT / "docs" / "src"
-PLANS_DIR = REPO_ROOT / "docs" / "implementation-plans"
+PLANS_DIR = REPO_ROOT / "docs" / "src" / "implementation-plans"
 PLANS_GH_URL = (
-    "https://github.com/epfl-enac/co2-calculator/blob/main/docs/implementation-plans"
+    "https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans"
 )
 
 STATUS_ORDER = ("delivered", "in-progress", "abandoned", "uncategorized")
@@ -92,7 +92,7 @@ def _section_index(section: str) -> None:
 
 
 def _plans_index() -> None:
-    """Emit grouped index for implementation-plans (lives outside docs_dir)."""
+    """Emit grouped index for implementation-plans (lives under docs_dir/src)."""
     if not PLANS_DIR.is_dir():
         return
     groups: dict[str, list[dict[str, Any]]] = {key: [] for key in STATUS_ORDER}
@@ -114,7 +114,7 @@ def _plans_index() -> None:
     lines = [
         "# Implementation plans",
         "",
-        f"Plans live in `docs/implementation-plans/` (outside `docs_dir`); links point to GitHub. {sum(len(v) for v in groups.values())} total.",
+        f"Plans live in `docs/src/implementation-plans/`; links point to GitHub. {sum(len(v) for v in groups.values())} total.",
         "",
     ]
     for key in STATUS_ORDER:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -121,15 +121,34 @@ plugins:
   #     enabled_if_env: ENABLE_PDF_EXPORT
   #     # custom_styles: styles/pdf-custom.css
   #     verbose: false
-  - git-authors
+  - awesome-pages
+  - gen-files:
+      scripts:
+        - gen_indexes.py
+  - literate-nav
+  - git-authors:
+      # Auto-generated INDEX.md files live in a temp dir from gen-files
+      # and have no git history. Don't escalate that to a build error.
+      strict: false
+      fallback_to_empty: true
   - git-revision-date-localized:
       fallback_to_build_date: true
       locale: en
       timezone: Europe/Zurich
+      strict: false
   - minify:
       minify_html: true
       minify_css: true
       minify_js: true
+
+# Auto-generated section indexes are intentionally excluded from `nav:`;
+# whitelist them so `mkdocs build --strict` keeps passing.
+not_in_nav: |
+  /architecture/INDEX.md
+  /backend/INDEX.md
+  /frontend/INDEX.md
+  /implementation-plans/INDEX.md
+  /contributing/auto-index.md
 
 copyright: >
   2025 EPFL — GPL-3.0 License. Built with MkDocs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -143,11 +143,13 @@ plugins:
 
 # Auto-generated section indexes are intentionally excluded from `nav:`;
 # whitelist them so `mkdocs build --strict` keeps passing.
+# Filename `_index.md` (not `INDEX.md`) avoids case-insensitive collisions
+# with hand-authored `index.md` pages on macOS/Windows filesystems.
 not_in_nav: |
-  /architecture/INDEX.md
-  /backend/INDEX.md
-  /frontend/INDEX.md
-  /implementation-plans/INDEX.md
+  /architecture/_index.md
+  /backend/_index.md
+  /frontend/_index.md
+  /implementation-plans/_index.md
   /contributing/auto-index.md
 
 copyright: >

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -7,10 +7,14 @@ requires-python = ">=3.12.7"
 dependencies = [
     "brotli>=1.2.0",
     "mkdocs>=1.6.1",
+    "mkdocs-awesome-pages-plugin>=2.9.3",
+    "mkdocs-gen-files>=0.5.0",
     "mkdocs-git-authors-plugin>=0.10.0",
     "mkdocs-git-revision-date-localized-plugin>=1.4.7",
+    "mkdocs-literate-nav>=0.6.1",
     "mkdocs-material>=9.6.22",
     "mkdocs-material-extensions>=1.3.1",
     "mkdocs-minify-plugin>=0.8.0",
     "mkdocs-with-pdf>=0.9.3",
+    "python-frontmatter>=1.1.0",
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# Plugin pins for the auto-index pipeline (issue #860 / B0).
+# Existing core deps are managed via pyproject.toml + uv.lock.
+mkdocs-gen-files>=0.5.0
+mkdocs-literate-nav>=0.6.1
+mkdocs-awesome-pages-plugin>=2.9.3
+python-frontmatter>=1.1.0

--- a/docs/src/.pages
+++ b/docs/src/.pages
@@ -1,0 +1,16 @@
+# Awesome-pages skeleton (issue #860 / B0).
+# B3 owns the explicit `nav:` block in mkdocs.yml — keep this file
+# metadata-only until that lands. Once `nav:` is removed, replace this
+# stub with the section ordering below to drive layout from `.pages`:
+#
+# nav:
+#   - index.md
+#   - architecture
+#   - architecture-decision-records
+#   - backend
+#   - frontend
+#   - database
+#   - infra
+#   - implementation-plans
+#   - user-docs
+title: EPFL Project Technical Docs

--- a/docs/src/contributing/auto-index.md
+++ b/docs/src/contributing/auto-index.md
@@ -1,0 +1,41 @@
+# Auto-index frontmatter
+
+Section indexes (`architecture/`, `backend/`, `frontend/`, `implementation-plans/`)
+are generated at build time by `docs/gen_indexes.py` (run via the
+`mkdocs-gen-files` plugin). Add YAML frontmatter to any plan or page so it
+appears in the right group with rich metadata.
+
+## Schema
+
+```yaml
+---
+status: delivered  # delivered | in-progress | abandoned
+issue: 310-b
+last_updated: 2026-05-05
+summary: One-line description.
+---
+```
+
+All keys are optional. Files missing `status` land under **Uncategorized**;
+files missing `title` fall back to the first `# H1` heading, then the
+filename stem.
+
+## Trigger a rebuild
+
+Local preview:
+
+```bash
+cd docs
+uv run mkdocs serve
+```
+
+The `gen-files` plugin re-runs on every reload. CI builds invoke
+`uv run mkdocs build --strict` — `--strict` promotes warnings to errors,
+so missing frontmatter must still produce a valid page (the script
+guarantees this by emitting an "Uncategorized" group).
+
+## Where output lands
+
+Each `INDEX.md` is virtual (written via `mkdocs_gen_files.open()`), so
+it never appears on disk. Run `mkdocs build` and open
+`site/<section>/INDEX.html` to inspect output.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -9,24 +9,32 @@ source = { virtual = "." }
 dependencies = [
     { name = "brotli" },
     { name = "mkdocs" },
+    { name = "mkdocs-awesome-pages-plugin" },
+    { name = "mkdocs-gen-files" },
     { name = "mkdocs-git-authors-plugin" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
+    { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
     { name = "mkdocs-material-extensions" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocs-with-pdf" },
+    { name = "python-frontmatter" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-awesome-pages-plugin", specifier = ">=2.9.3" },
+    { name = "mkdocs-gen-files", specifier = ">=0.5.0" },
     { name = "mkdocs-git-authors-plugin", specifier = ">=0.10.0" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
+    { name = "mkdocs-literate-nav", specifier = ">=0.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.22" },
     { name = "mkdocs-material-extensions", specifier = ">=1.3.1" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "mkdocs-with-pdf", specifier = ">=0.9.3" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
 ]
 
 [[package]]
@@ -63,6 +71,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
 ]
 
 [[package]]
@@ -521,6 +538,33 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-awesome-pages-plugin"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "natsort" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/e8/6ae9c18d8174a5d74ce4ade7a7f4c350955063968bc41ff1e5833cff4a2b/mkdocs_awesome_pages_plugin-2.10.1.tar.gz", hash = "sha256:cda2cb88c937ada81a4785225f20ef77ce532762f4500120b67a1433c1cdbb2f", size = 16303, upload-time = "2024-12-22T21:13:49.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/61/19fc1e9c579dbfd4e8a402748f1d63cab7aabe8f8d91eb0235e45b32d040/mkdocs_awesome_pages_plugin-2.10.1-py3-none-any.whl", hash = "sha256:c6939dbea37383fc3cf8c0a4e892144ec3d2f8a585e16fdc966b34e7c97042a7", size = 15118, upload-time = "2024-12-22T21:13:46.945Z" },
+]
+
+[[package]]
+name = "mkdocs-gen-files"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "properdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/43/428f312149c161cae557eecd35f3c4a82b867998b1d47fb29fdfe927be26/mkdocs_gen_files-0.6.1.tar.gz", hash = "sha256:57d7ff2229e23d077e46d14a33db6d37c8823f6ce1a503c874c1764a71679763", size = 8746, upload-time = "2026-03-16T23:26:09.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/1b/3075eb67fe66e19db059f0a25744c4e56978a309603a20e1d3353d545b5e/mkdocs_gen_files-0.6.1-py3-none-any.whl", hash = "sha256:b3182bfc6219e35b8d26658cb988368659d5d023aac30c2a819247558fc12189", size = 8282, upload-time = "2026-03-16T23:26:08.292Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -559,6 +603,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f8/a17ec39a4fc314d40cc96afdc1d401e393ebd4f42309d454cc940a2cf38a/mkdocs_git_revision_date_localized_plugin-1.4.7.tar.gz", hash = "sha256:10a49eff1e1c3cb766e054b9d8360c904ce4fe8c33ac3f6cc083ac6459c91953", size = 450473, upload-time = "2025-05-28T18:26:20.697Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/b6/106fcc15287e7228658fbd0ad9e8b0d775becced0a089cc39984641f4a0f/mkdocs_git_revision_date_localized_plugin-1.4.7-py3-none-any.whl", hash = "sha256:056c0a90242409148f1dc94d5c9d2c25b5b8ddd8de45489fa38f7fa7ccad2bc4", size = 25382, upload-time = "2025-05-28T18:26:18.907Z" },
+]
+
+[[package]]
+name = "mkdocs-literate-nav"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "properdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/af/dd3776a7a713f798f79bec7eb9c661d5cfb83ddc17d9a3667595e53e1559/mkdocs_literate_nav-0.6.3.tar.gz", hash = "sha256:edbaca22343f861fe4e34aac47d55a0c9955c640dbf02eea99fe631e914cf9ee", size = 17526, upload-time = "2026-03-16T23:26:50.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/2c/bcf1ae903975ad6f169abb05c1eb0f94395478364deb89270cf034081b29/mkdocs_literate_nav-0.6.3-py3-none-any.whl", hash = "sha256:2c421561280fa9184f88cbf399bebbd4cc17ee507e978a31ce11fd6f3aabf233", size = 13355, upload-time = "2026-03-16T23:26:49.562Z" },
 ]
 
 [[package]]
@@ -620,6 +677,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/64/e73be18183e5c37125288eb5b42e96206c1d75244c889e255bd8b9538e3c/mkdocs-with-pdf-0.9.3.tar.gz", hash = "sha256:bda3375d7040d1b8871da17c6d71ea736bdca6c669608f28ed62771031d2e0c6", size = 40510, upload-time = "2021-07-03T02:04:41.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/e6/985cb55066445eb6372a74ab500ca2b415f049560642d55dd566877d25cf/mkdocs_with_pdf-0.9.3-py3-none-any.whl", hash = "sha256:002d76417b5cc584effdfdb6ec8d073266a308a85680c430562e97f00b886e49", size = 46227, upload-time = "2021-07-03T02:04:39.429Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
 ]
 
 [[package]]
@@ -728,6 +794,29 @@ wheels = [
 ]
 
 [[package]]
+name = "properdocs"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/29/f27a4e1eddf72ed3db6e47818fbafe6debbf09fd7051f9c1a007239b46ef/properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e", size = 276141, upload-time = "2026-03-20T20:07:48.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd", size = 225406, upload-time = "2026-03-20T20:07:46.875Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -786,6 +875,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
 ]
 
 [[package]]
@@ -961,6 +1062,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires the per-section auto-index pipeline that the rest of the #860 docs-refresh batch depends on.

- Adds three MkDocs plugins: `awesome-pages`, `gen-files` (script: `gen_indexes.py`), `literate-nav`.
- New `docs/gen_indexes.py` walks `docs/src/{architecture,backend,frontend}` plus `docs/implementation-plans/` and emits virtual `INDEX.md` files. Plans are grouped by YAML frontmatter `status` (`delivered` / `in-progress` / `abandoned`); files without frontmatter fall under **Uncategorized** so `--strict` keeps passing before B4's frontmatter backfill lands.
- Whitelists generated pages via top-level `not_in_nav` (the explicit `nav:` block is owned by B3, so this branch leaves it untouched).
- Pins the new plugins in `docs/pyproject.toml` and a new `docs/requirements.txt`.
- Documents the schema and rebuild flow in `docs/src/contributing/auto-index.md`.
- Adds a metadata-only `docs/src/.pages` stub (B3 will replace it with the section ordering when the explicit `nav:` block is removed).

Independence from sibling B4 confirmed: build is green with zero plan frontmatter today (all 67 plans land under "Uncategorized").

## Test plan

- [x] `python -m venv /tmp/mkenv-b0 && /tmp/mkenv-b0/bin/pip install mkdocs mkdocs-material mkdocs-mermaid2-plugin mkdocs-gen-files mkdocs-literate-nav mkdocs-awesome-pages-plugin python-frontmatter mkdocs-git-authors-plugin mkdocs-git-revision-date-localized-plugin mkdocs-minify-plugin`
- [x] `cd docs && /tmp/mkenv-b0/bin/mkdocs build --strict --site-dir /tmp/mkdocs-b0` -> exit 0
- [x] `/tmp/mkdocs-b0/implementation-plans/INDEX.html` exists (36 KB, 67 rows under Uncategorized)
- [x] `/tmp/mkdocs-b0/{architecture,backend,frontend}/INDEX.html` and `/tmp/mkdocs-b0/contributing/auto-index.html` exist
- [x] Spot-checked grouping by temporarily adding `status: in-progress` frontmatter to one plan; group counts went 1 in-progress + 66 uncategorized as expected.