### PR TITLE
docs(#860): C3 frontend-overview mermaid + condense

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,6 +80,8 @@ nav:
 
   - Frontend:
       - Overview: frontend/01-overview.md
+      - Component Tree: frontend/01-overview/components.md
+      - Persona Flows: frontend/01-overview/personas.md
       - Design Tokens: frontend/02-design-tokens.md
 
   - Backend:

--- a/docs/src/frontend/01-overview.md
+++ b/docs/src/frontend/01-overview.md
@@ -1,683 +1,75 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Frontend architecture and persona flows.
+---
+
 # Frontend Overview
 
-The frontend is a Single Page Application (SPA) built with Vue 3 and Quasar Framework. This overview provides setup instructions, implementation details, and references to system-wide architecture documentation.
+A Vue 3 + Quasar Single Page Application served from `frontend/`. This page is
+the landing point: jump to the detail page that matches your task.
 
-For system architecture and technology decisions, see:
-
-- [Component Breakdown](../architecture/09-component-breakdown.md) - Frontend layer architecture
-- [Tech Stack](../architecture/08-tech-stack.md) - Technology selection rationale
-- [Auth Flow](../architecture/04-auth-flow.md) - Authentication implementation
-- [ADR-002 Frontend Framework](../architecture-decision-records/002-frontend-framework.md) - Why Vue 3 + Quasar
-
----
+- [Component tree](01-overview/components.md) — pages, layouts, atomic design
+  primitives, stores, routing.
+- [Persona flows](01-overview/personas.md) — state diagrams for the data-entry
+  user and the back-office user.
+- [Design tokens](02-design-tokens.md) — SCSS tokens and theming.
 
 ## Quick Start
 
-### Prerequisites
-
-- Node.js 18+ (LTS recommended)
-- npm, yarn, or pnpm package manager
-- Modern web browser (Chrome, Firefox, Safari, Edge)
-
-### Installation
-
 ```bash
-# Clone repository (if not already done)
-git clone https://github.com/EPFL-ENAC/co2-calculator.git
-cd co2-calculator/frontend
-
-# Install dependencies
+cd frontend
 npm install
-# or
-yarn install
-
-# Copy environment file
-cp .env.example .env
-# Edit .env with your backend API URL
+cp .env.example .env       # set VITE_API_BASE_URL
+npm run dev                # http://localhost:5173
+npm run build              # output in dist/spa/
 ```
 
-### Development Server
+`VITE_` is the only prefix Vite exposes to the client. Quasar config lives in
+`quasar.config.js` (build targets, plugins, dev-server proxy).
+
+## Project Layout
+
+```text
+frontend/src/
+  api/         ky http client + endpoint constants
+  boot/        Quasar boot files (i18n, plugins)
+  components/  atoms / molecules / organisms / audit / charts / layout
+  layouts/     MainLayout.vue
+  pages/       app/, back-office/, system/  (one route = one page)
+  router/      routes.ts, guards/
+  stores/      Pinia stores (auth, modules, workspace, factors, …)
+  i18n/        en, fr locale files
+  css/         tokens and Quasar theme overrides
+```
+
+## Testing
+
+Playwright covers both component and end-to-end suites; there is no Vitest
+unit suite. Storybook interaction tests catch visual regressions.
 
 ```bash
-# Start development server with hot reload
-npm run dev
-# or
-quasar dev
-
-# Application will be available at http://localhost:5173
+npm run test-ct            # Playwright component tests
+npm run test:e2e           # Playwright integration tests
+npm run storybook:test     # Storybook test-runner
+npm run lint               # ESLint
 ```
 
-### Build for Production
-
-```bash
-# Build production bundle
-npm run build
-# or
-quasar build
-
-# Output in dist/spa/ directory
-```
-
----
-
-## Project Structure
-
-```
-frontend/
-├── src/
-│   ├── assets/          # Static assets (images, fonts)
-│   ├── components/      # Reusable Vue components
-│   ├── composables/     # Vue composition functions
-│   ├── layouts/         # Layout components (header, footer, sidebar)
-│   ├── pages/           # Route page components
-│   ├── router/          # Vue Router configuration
-│   ├── stores/          # Pinia state management stores
-│   ├── i18n/            # Internationalization (i18n) translations
-│   ├── boot/            # Quasar boot files (plugins, etc.)
-│   ├── css/             # Global styles, SCSS tokens
-│   ├── App.vue          # Root application component
-│   └── main.ts          # Application entry point
-├── public/              # Static public files
-├── index.html           # HTML template
-├── quasar.config.js     # Quasar framework configuration
-├── package.json         # Dependencies and scripts
-└── tsconfig.json        # TypeScript configuration
-```
-
-### Key Directories
-
-- **components/**: Organized by feature (labs/, reports/, admin/, shared/)
-- **pages/**: One component per route (LabsPage.vue, DashboardPage.vue)
-- **stores/**: Pinia stores for state management (authStore, labsStore)
-- **router/**: Route definitions with guards for authentication
-- **i18n/**: Language files (en.json, fr.json, de.json)
-
----
-
-## Architecture Patterns
-
-### Component Hierarchy
-
-```
-App.vue
-└── MainLayout.vue
-    ├── HeaderNav.vue
-    ├── SidebarMenu.vue
-    └── <router-view> (page components)
-        ├── LabsPage.vue
-        │   └── LabCard.vue
-        ├── LabDetailPage.vue
-        │   ├── LabOverview.vue
-        │   ├── DataImportPanel.vue
-        │   └── ResultsChart.vue
-        └── AdminPage.vue
-```
-
-**Pattern**: Presentational components (UI) + Container components (logic)
-
-### State Management (Pinia)
-
-```typescript
-// stores/labsStore.ts
-export const useLabsStore = defineStore("labs", {
-  state: () => ({
-    labs: [],
-    currentLab: null,
-    loading: false,
-  }),
-  actions: {
-    async fetchLabs() {
-      /* API call */
-    },
-    async createLab(data) {
-      /* API call */
-    },
-  },
-  getters: {
-    labsByDate: (state) => state.labs.sort(/*...*/),
-  },
-});
-```
-
-**Stores**: `authStore`, `labsStore`, `importsStore`, `reportsStore`, `adminStore`
-
-### Routing
-
-```javascript
-// router/routes.ts
-const routes = [
-  {
-    path: "/",
-    component: MainLayout,
-    meta: { requiresAuth: true },
-    children: [
-      { path: "labs", component: LabsPage },
-      { path: "labs/:id", component: LabDetailPage },
-      { path: "reports", component: ReportsPage },
-      { path: "admin", component: AdminPage, meta: { requiresRole: "admin" } },
-    ],
-  },
-];
-```
-
-**Route Guards**: Authentication and role-based access control implemented in `router/index.ts`
-
----
-
-## Development Workflow
-
-### Running Development Server
-
-```bash
-# Start with hot module replacement
-npm run dev
-
-# Start with specific port
-quasar dev --port 8080
-
-# Start with HTTPS (for OIDC testing)
-quasar dev --https
-```
-
-### Code Quality
-
-```bash
-# Lint code (ESLint)
-npm run lint
-
-# Format code (Prettier)
-npm run format
-
-# Type checking (TypeScript)
-npm run type-check
-```
-
-### Testing
-
-```bash
-# Run unit tests (Vitest): NOT IMPLEMENTED
-npm run test:unit
-
-# Run component tests (Playwright)
-npm run test-ct
-
-# Run E2E tests (Playwright)
-npm run test:e2e
-
-# Generate coverage report: NOT IMPLEMENTED
-npm run test:coverage
-```
-
----
-
-## Configuration
-
-### Environment Variables
-
-Create `.env` file in `frontend/` directory:
-
-```env
-# Backend API
-VITE_API_BASE_URL=http://localhost:8000/api/v1
-
-# Feature Flags
-VITE_ENABLE_ANALYTICS=false
-VITE_ENABLE_DEBUG_PANEL=true
-```
-
-**Note**: `VITE_` prefix is required for Vite to expose variables to the client.
-
-### Quasar Configuration
-
-Edit `quasar.config.js` for:
-
-- Build options (target browsers, bundle splitting)
-- Quasar plugins (Notify, Dialog, Loading)
-- Dev server proxy (API calls to backend)
-- CSS preprocessor options
-
----
+CI runs `test-ct`, `test:e2e`, and `storybook:test-ci` (boots Storybook, then
+runs the test-runner against it).
 
 ## Authentication & Authorization
 
-### Authentication Flow
-
-1. User clicks "Login" → Redirect to Microsoft Entra ID (OIDC)
-2. User authenticates with EPFL credentials
-3. Redirect back to `/auth/callback` with authorization code
-4. Frontend exchanges code for JWT token
-5. Store token in memory (authStore) + localStorage (refresh token)
-6. Include token in all API requests: `Authorization: Bearer <token>`
-
-**Implementation**: `oidc-client-ts` library in `boot/oidc.ts`
-
-**Detailed Flow**: See [Auth Flow Across Layers](../architecture/04-auth-flow.md)
-
-### Route Protection
-
-```javascript
-// router/index.ts
-router.beforeEach((to, from, next) => {
-  const authStore = useAuthStore();
-
-  if (to.meta.requiresAuth && !authStore.isAuthenticated) {
-    next({ name: "Login" });
-  } else if (to.meta.requiresRole && !authStore.hasRole(to.meta.requiresRole)) {
-    next({ name: "Forbidden" });
-  } else {
-    next();
-  }
-});
-```
-
----
-
-## Internationalization (i18n)
-
-### Language Support
-
-- **English** (en) - Default
-- **French** (fr) - Primary for EPFL users
-- **German** (de) - Additional support
-
-### Translation Files
-
-```
-src/i18n/
-├── en.json
-├── fr.json
-└── de.json
-```
-
-### Contributing translation
-
-1. Create a feature branch from `main`
-   ![Screenshot](img/branch.png)
-   ![Screenshot](img/new_branch.png)
-   ![Screenshot](img/translation_branch_name.png)
-
-2. Make your changes to the translation files
-   ![Screenshot](img/translation_modify.png)
-
-3. Commit with a conventional commit message (e.g., `feat(i18n): add dashboard translations`)
-   ![Screenshot](img/translation_commit.png)
-   ![Screenshot](img/translation_commit_message.png)
-
-4. Push your branch and open a pull request
-   ![Screenshot](img/translation_pull_request.png)
-
-5. Ensure CI checks pass
-   ![Screenshot](img/translation_checks.png)
-
-### Contributing translation
-
-1. Create a feature branch from `main`
-   ![Screenshot](img/branch.png)
-   ![Screenshot](img/new_branch.png)
-   ![Screenshot](img/translation_branch_name.png)
-
-2. Make your changes to the translation files
-   ![Screenshot](img/translation_modify.png)
-
-3. Commit with a conventional commit message (e.g., `feat(i18n): add dashboard translations`)
-   ![Screenshot](img/translation_commit.png)
-   ![Screenshot](img/translation_commit_message.png)
-
-4. Push your branch and open a pull request
-   ![Screenshot](img/translation_pull_request.png)
-
-5. Ensure CI checks pass
-   ![Screenshot](img/translation_checks.png)
-
-### Usage in Components
-
-```vue
-<template>
-  <h1>{{ $t("labs.title") }}</h1>
-  <p>{{ $t("labs.description", { count: labsCount }) }}</p>
-</template>
-
-<script setup>
-import { useI18n } from "vue-i18n";
-
-const { t, locale } = useI18n();
-
-// Programmatic usage
-const message = t("common.success");
-locale.value = "fr"; // Switch language
-</script>
-```
-
-**Library**: `vue-i18n` integration with Quasar
-
----
-
-## UI Component System
-
-### Quasar Components
-
-Leverage Quasar's extensive component library:
-
-- **Forms**: QInput, QSelect, QDate, QFile
-- **Data Display**: QTable, QCard, QList, QTree
-- **Navigation**: QTabs, QDrawer, QBreadcrumbs
-- **Feedback**: QDialog, QNotify, QLoading, QTooltip
-
-**Documentation**: [Quasar Components](https://quasar.dev/vue-components/)
-
-### Custom Components
-
-Organized by feature in `components/`:
-
-```
-components/
-├── labs/
-│   ├── LabCard.vue
-│   ├── LabForm.vue
-│   └── LabFilters.vue
-├── reports/
-│   ├── ReportChart.vue (eCharts integration)
-│   └── ReportExport.vue
-├── shared/
-│   ├── LoadingSpinner.vue
-│   ├── ErrorBoundary.vue
-│   └── ConfirmDialog.vue
-└── admin/
-    ├── UserManagement.vue
-    └── FactorEditor.vue
-```
-
-### Styling
-
-- **SCSS Tokens**: Design system tokens in `css/tokens/` (generated from Figma)
-- **Global Styles**: `css/quasar.variables.scss` (Quasar theme customization)
-- **Component Styles**: Scoped `<style lang="scss" scoped>`
-- **Utility Classes**: Quasar's responsive classes (`.q-pa-md`, `.col-xs-12`)
-
----
-
-## API Integration
-
-### HTTP Client
-
-```typescript
-// boot/axios.ts
-import axios from "axios";
-
-const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 10000,
-});
-
-// Request interceptor (add auth token)
-api.interceptors.request.use((config) => {
-  const authStore = useAuthStore();
-  if (authStore.token) {
-    config.headers.Authorization = `Bearer ${authStore.token}`;
-  }
-  return config;
-});
-
-// Response interceptor (handle errors)
-api.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      // Redirect to login
-      authStore.logout();
-    }
-    return Promise.reject(error);
-  },
-);
-```
-
-### API Service Layer
-
-```typescript
-// services/labsService.ts
-export const labsService = {
-  async fetchLabs() {
-    const { data } = await api.get("/labs");
-    return data;
-  },
-
-  async createLab(labData) {
-    const { data } = await api.post("/labs", labData);
-    return data;
-  },
-
-  async importCSV(labId, file) {
-    const formData = new FormData();
-    formData.append("file", file);
-    const { data } = await api.post(`/labs/${labId}/imports`, formData);
-    return data;
-  },
-};
-```
-
-**Pattern**: Services abstract API calls from components/stores
-
----
-
-## Data Visualization
-
-### eCharts Integration
-
-```vue
-<template>
-  <div ref="chartRef" style="width: 100%; height: 400px;"></div>
-</template>
-
-<script setup>
-import { ref, onMounted, watch } from "vue";
-import * as echarts from "echarts";
-
-const chartRef = ref(null);
-let chartInstance = null;
-
-onMounted(() => {
-  chartInstance = echarts.init(chartRef.value);
-  updateChart();
-});
-
-const updateChart = () => {
-  const option = {
-    title: { text: "CO2 Emissions by Category" },
-    xAxis: { type: "category", data: ["Travel", "Equipment", "Energy"] },
-    yAxis: { type: "value" },
-    series: [{ data: [120, 200, 150], type: "bar" }],
-  };
-  chartInstance.setOption(option);
-};
-
-watch(() => props.data, updateChart);
-</script>
-```
-
-**Charts**: Bar charts, line charts, pie charts, treemaps for emissions breakdown
-
----
-
-## Performance Optimization
-
-### Code Splitting
-
-```javascript
-// router/routes.ts
-const routes = [
-  {
-    path: "/admin",
-    component: () => import("pages/AdminPage.vue"), // Lazy load
-  },
-];
-```
-
-### Bundle Optimization
-
-```javascript
-// quasar.config.js
-build: {
-  vueRouterMode: 'history',
-  vitePlugins: [
-    ['vite-plugin-compression', { algorithm: 'gzip' }]
-  ],
-  rollupOptions: {
-    output: {
-      manualChunks: {
-        'vendor-vue': ['vue', 'vue-router', 'pinia'],
-        'vendor-quasar': ['quasar'],
-        'vendor-charts': ['echarts']
-      }
-    }
-  }
-}
-```
-
-### Image Optimization
-
-- Use WebP format for images
-- Lazy load images with `v-lazy` directive
-- Responsive images with `<picture>` element
-
-See [Scalability Strategy](../architecture/12-scalability.md) for system-wide performance.
-
----
-
-## Troubleshooting
-
-### Development Server Issues
-
-```bash
-# Clear node_modules and reinstall
-rm -rf node_modules package-lock.json
-npm install
-
-# Clear Vite cache
-rm -rf .quasar node_modules/.vite
-npm run dev
-```
-
-### OIDC Authentication Issues
-
-- Check redirect URI matches OIDC provider configuration
-- Verify client ID and tenant ID are correct
-- Ensure HTTPS is enabled for production (OIDC requirement)
-- Check browser console for CORS errors
-
-### API Connection Issues
-
-```javascript
-// Check proxy configuration in quasar.config.js
-devServer: {
-  proxy: {
-    '/api': {
-      target: 'http://localhost:8000',
-      changeOrigin: true
-    }
-  }
-}
-```
-
-### Build Errors
-
-```bash
-# Type check for errors
-npm run type-check
-
-# Check for ESLint errors
-npm run lint
-
-# Check Quasar configuration
-quasar info
-```
-
----
-
-## Production Deployment
-
-### Build Process
-
-```bash
-# Production build
-npm run build
-
-# Output: dist/spa/
-# - index.html
-# - assets/ (JS, CSS, images)
-```
-
-### Nginx Configuration
-
-```nginx
-server {
-  listen 80;
-  server_name co2calculator.epfl.ch;
-
-  root /usr/share/nginx/html;
-  index index.html;
-
-  # SPA fallback
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
-  # Cache static assets
-  location /assets/ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-  }
-
-  # Security headers
-  add_header X-Frame-Options "SAMEORIGIN";
-  add_header X-Content-Type-Options "nosniff";
-  add_header X-XSS-Protection "1; mode=block";
-}
-```
-
-### Docker Build
-
-```dockerfile
-# Multi-stage build
-FROM node:18-alpine AS builder
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-
-FROM nginx:alpine
-COPY --from=builder /app/dist/spa /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
-```
-
-For deployment architecture, see:
-
-- [Deployment Topology](../architecture/11-deployment-topology.md) - Kubernetes setup
-- [CI/CD Pipeline](../architecture/06-cicd-pipeline.md) - Automated deployment
-- [Environments](../architecture/05-environments.md) - Environment configuration
-
----
-
-## Additional Resources
-
-### Architecture Documentation
-
-- [System Overview](../architecture/02-system-overview.md) - Full system diagram
-- [Component Breakdown](../architecture/09-component-breakdown.md) - Frontend layer details
-- [Data Flow](../architecture/10-data-flow.md) - Data movement patterns
-
-### External Documentation
-
-- [Vue 3 Documentation](https://vuejs.org/)
-- [Quasar Framework](https://quasar.dev/)
-- [Pinia Documentation](https://pinia.vuejs.org/)
-- [Vue Router Documentation](https://router.vuejs.org/)
-- [Vue I18n Documentation](https://vue-i18n.intlify.dev/)
-- [eCharts Documentation](https://echarts.apache.org/)
-
----
-
-**Last Updated**: November 11, 2025  
-**Readable in**: ~10 minutes
+`LoginPage` redirects to `API_LOGIN_URL` (Microsoft Entra ID via backend);
+`auth/me` populates the `auth` Pinia store with `roles_raw` and
+`permissions`. Guards in `router/guards/` enforce access:
+`requirePermission`, `requireModuleEditPermission`, `validateUnitGuard`,
+`redirectToWorkspaceIfSelectedGuard`. See
+[Auth Flow Across Layers](../architecture/04-auth-flow.md) for the full path.
+
+## Further Reading
+
+- [Component Breakdown](../architecture/09-component-breakdown.md)
+- [ADR-002 Frontend Framework](../architecture-decision-records/002-frontend-framework.md)
+- [Deployment Topology](../architecture/11-deployment-topology.md) — Nginx +
+  Docker production setup (centralized there).

--- a/docs/src/frontend/01-overview.md
+++ b/docs/src/frontend/01-overview.md
@@ -21,7 +21,7 @@ the landing point: jump to the detail page that matches your task.
 cd frontend
 npm install
 cp .env.example .env       # set VITE_API_BASE_URL
-npm run dev                # http://localhost:5173
+npm run dev                # http://localhost:9000
 npm run build              # output in dist/spa/
 ```
 
@@ -55,8 +55,9 @@ npm run storybook:test     # Storybook test-runner
 npm run lint               # ESLint
 ```
 
-CI runs `test-ct`, `test:e2e`, and `storybook:test-ci` (boots Storybook, then
-runs the test-runner against it).
+CI runs `test-ct` and `test:e2e` (see `.github/workflows/test.yml`). The
+Storybook test-runner is not yet wired into CI; run `npm run storybook:test`
+locally to exercise it.
 
 ## Authentication & Authorization
 

--- a/docs/src/frontend/01-overview/components.md
+++ b/docs/src/frontend/01-overview/components.md
@@ -1,0 +1,116 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Frontend component tree and module organization.
+---
+
+# Component Tree
+
+The frontend follows a loose Atomic Design split (`atoms/molecules/organisms`)
+under `frontend/src/components/`, plus feature folders (`audit/`, `charts/`,
+`layout/`). Pages live in `frontend/src/pages/` grouped by audience: `app/`
+(end users), `back-office/` (admins), `system/` (superadmin).
+
+## Top-Level Tree
+
+```mermaid
+graph TD
+    App[App.vue] --> Layout[layouts/MainLayout.vue]
+    Layout --> Router{router-view}
+
+    Router --> AppPages[pages/app/]
+    Router --> BackOffice[pages/back-office/]
+    Router --> System[pages/system/]
+    Router --> Errors[ErrorNotFound / ErrorUnauthorized]
+
+    AppPages --> LoginPage
+    AppPages --> WorkspaceSetupPage
+    AppPages --> WorkspacePage --> HomePage
+    WorkspacePage --> ModulePage
+    WorkspacePage --> ModuleResultsPage
+    WorkspacePage --> ResultsPage
+    WorkspacePage --> SimulationsPage
+    WorkspacePage --> AddSimulationPage
+    WorkspacePage --> EditSimulationPage
+    WorkspacePage --> DocumentationPage
+
+    BackOffice --> UserManagementPage
+    BackOffice --> DataManagementPage
+    BackOffice --> ReportingPage
+    BackOffice --> UITextsEditingPage
+    BackOffice --> DocumentationEditingPage
+    System --> LogsPage
+```
+
+`WorkspacePage` is the workspace shell: it owns the unit/year context and
+renders the module-scoped children.
+
+## Component Layers
+
+```mermaid
+graph LR
+    Pages[pages/*] --> Organisms
+    Pages --> Layout[components/layout]
+    Organisms[components/organisms] --> Molecules
+    Organisms --> Audit[components/audit]
+    Organisms --> Charts[components/charts]
+    Molecules[components/molecules] --> Atoms
+    Atoms[components/atoms] --> Quasar[Quasar primitives]
+    Charts --> ECharts[vue-echarts]
+
+    Pages -.uses.-> Stores[(Pinia stores)]
+    Organisms -.uses.-> Stores
+    Stores -.calls.-> Api[api/ ky http client]
+```
+
+- **atoms/** — `CO2Container`, `CO2DestinationInput`, `Co2LanguageSelector`,
+  `ModuleIcon`. Single-purpose, story-covered.
+- **molecules/** — `BigNumber`, `ChartContainer`, `Co2TimelineItem`,
+  `HeadCountBarChart`, `NoteDialog`.
+- **organisms/** — feature subfolders: `backoffice/`, `data-management/`,
+  `layout/`, `login/`, `module/`, `workspace-selector/`, plus large composed
+  views like `AdditionalCategoriesSection.vue` and `ItFocusSection.vue`.
+- **audit/** — back-office audit log UI: `AuditDetailDrawer`,
+  `AuditFilterBar`, `AuditPagination`, `AuditSearchBar`, `AuditStatCards`,
+  `AuditTable`.
+
+## Pinia Stores
+
+State lives in `frontend/src/stores/`. The active stores are:
+
+| Store                       | Purpose                                              |
+| --------------------------- | ---------------------------------------------------- |
+| `auth`                      | Current user, `roles_raw`, `permissions`, login/out  |
+| `workspace`                 | Selected unit + year; drives most of the app shell   |
+| `modules`                   | Module config and per-module activity data           |
+| `factors`                   | Emission factors loaded from the backend             |
+| `unitFilters`               | Unit picker filtering and search                     |
+| `yearConfig`                | Year-scoped configuration (open/closed years, etc.)  |
+| `building_rooms`            | Room metadata for equipment module                   |
+| `files`                     | Upload state for CSV imports                         |
+| `backoffice`                | Back-office shell state                              |
+| `backofficeDataManagement`  | Factor / unit / activity admin                       |
+| `colorblind`                | Accessibility palette toggle                         |
+
+## Routing & Guards
+
+Defined in `frontend/src/router/routes.ts`. All authenticated routes nest
+under `/:language(en|fr)/`; the workspace routes nest further under
+`/:unit/:year/`. Three guards from `router/guards/`:
+
+- `requirePermission(resource, action)` — back-office and system pages.
+- `requireModuleEditPermission()` — module data-entry pages.
+- `validateUnitGuard`, `redirectToWorkspaceIfSelectedGuard` — workspace.
+
+## API Layer
+
+`frontend/src/api/` wraps [ky](https://github.com/sindresorhus/ky) with
+endpoint constants and an auth-aware fetch wrapper. Components do not call
+`fetch` directly: they go through stores, which call the api layer. Errors
+bubble back to UI as Quasar `Notify` toasts.
+
+## Charts and Visualization
+
+`components/charts/` plus `vue-echarts` (declarative ECharts). Use
+`ChartContainer.vue` for sizing and reactive resize. See
+`HeadCountBarChart.vue` for a worked example.

--- a/docs/src/frontend/01-overview/personas.md
+++ b/docs/src/frontend/01-overview/personas.md
@@ -1,0 +1,125 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Frontend persona flows for data-entry and back-office users.
+---
+
+# Persona Flows
+
+Two primary personas drive the frontend. Both authenticate against Microsoft
+Entra ID via the backend, then diverge based on permissions returned from
+`auth/me`.
+
+## Data-Entry User
+
+Lab member who enters activity data for the unit they belong to and reviews
+the resulting emissions.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Login
+    Login: LoginPage redirects to API_LOGIN_URL
+    Login --> WorkspaceSetup: auth/me succeeds
+    Login --> Unauthorized: no view permission
+
+    WorkspaceSetup: WorkspaceSetupPage (pick unit + year)
+    WorkspaceSetup --> Home: workspace selected
+
+    Home: HomePage (module overview)
+    Home --> ModuleEntry: open a module
+    Home --> ConsolidatedResults: open Results
+    Home --> Simulations: open Simulations
+
+    ModuleEntry: ModulePage (requireModuleEditPermission)
+    ModuleEntry --> ModuleEntry: edit activity rows
+    ModuleEntry --> ModuleResults: review module
+    ModuleResults: ModuleResultsPage
+    ModuleResults --> Home: back to overview
+    ModuleResults --> ConsolidatedResults: open Results
+
+    ConsolidatedResults: ResultsPage (all modules)
+    ConsolidatedResults --> Home
+
+    Simulations --> AddSimulation: create
+    Simulations --> EditSimulation: edit existing
+    AddSimulation --> Simulations: save
+    EditSimulation --> Simulations: save
+
+    Home --> Logout
+    Logout --> [*]
+```
+
+Key gates:
+
+- `validateUnitGuard` rejects unknown units in the URL.
+- `requireModuleEditPermission()` blocks read-only users from `ModulePage`
+  while still letting them open `ModuleResultsPage` and `ResultsPage`.
+- The `workspace` Pinia store holds the selected `(unit, year)` and survives
+  page reloads via `pinia-plugin-persistedstate`.
+
+## Back-Office User
+
+Admin who curates emission factors, manages users, edits documentation, and
+audits the system. Access is gated by `backoffice.users` permissions
+(scoped per affiliation — see issue #459).
+
+```mermaid
+stateDiagram-v2
+    [*] --> Login
+    Login --> BackOfficeShell: backoffice.users:view
+    Login --> Unauthorized: missing permission
+
+    BackOfficeShell: /back-office (redirects to Reporting)
+
+    BackOfficeShell --> Reporting
+    BackOfficeShell --> DataManagement: requires edit
+    BackOfficeShell --> UserManagement: requires edit
+    BackOfficeShell --> UITextsEditing
+    BackOfficeShell --> DocEditing
+    BackOfficeShell --> Logs: system.users:edit
+
+    Reporting: ReportingPage (generate / monitor reports)
+
+    DataManagement: DataManagementPage
+    DataManagement --> ImportFactors: upload CSV
+    ImportFactors --> ValidateFactors: backend validates
+    ValidateFactors --> DataManagement: success
+    ValidateFactors --> DataManagement: errors shown
+
+    UserManagement: UserManagementPage (assign roles)
+
+    UITextsEditing: UITextsEditingPage (i18n via GitHub PR)
+    DocEditing: DocumentationEditingPage (docs via GitHub PR)
+
+    Logs: LogsPage + components/audit/*
+    Logs --> Logs: filter, paginate, drill down
+
+    BackOfficeShell --> Logout
+    Logout --> [*]
+```
+
+Key gates:
+
+- Every back-office route uses `requirePermission('backoffice.users', …)`.
+- `LogsPage` requires `system.users:edit` (superadmin).
+- The audit drawer (`AuditDetailDrawer.vue`) reads from
+  `components/audit/*` and the `backofficeDataManagement` store.
+- `UITextsEditingPage` and `DocumentationEditingPage` write changes by
+  opening pull requests on the docs / i18n repo — no direct file writes
+  from the browser.
+
+## Where Things Live
+
+| Concern                 | Code path                                                |
+| ----------------------- | -------------------------------------------------------- |
+| Login                   | `pages/app/LoginPage.vue`, `stores/auth.ts`              |
+| Workspace selection     | `pages/app/WorkspaceSetupPage.vue`, `stores/workspace.ts`|
+| Module data entry       | `pages/app/ModulePage.vue`, `components/organisms/module`|
+| Results                 | `pages/app/ResultsPage.vue` (consolidated)               |
+| Back-office data        | `pages/back-office/DataManagementPage.vue`               |
+| Audit                   | `pages/system/LogsPage.vue`, `components/audit/`         |
+| Route guards            | `frontend/src/router/guards/`                            |
+
+For the underlying request/response model, see
+[Auth Flow Across Layers](../../architecture/04-auth-flow.md) and
+[Data Flow](../../architecture/10-data-flow.md).

--- a/docs/src/frontend/01-overview/personas.md
+++ b/docs/src/frontend/01-overview/personas.md
@@ -100,8 +100,9 @@ stateDiagram-v2
 
 Key gates:
 
-- Every back-office route uses `requirePermission('backoffice.users', …)`.
-- `LogsPage` requires `system.users:edit` (superadmin).
+- Most back-office routes use `requirePermission('backoffice.users', …)`;
+  the audit logs route is the exception (`LogsPage` uses
+  `system.users:edit`, see `frontend/src/router/routes.ts:265-278`).
 - The audit drawer (`AuditDetailDrawer.vue`) reads from
   `components/audit/*` and the `backofficeDataManagement` store.
 - `UITextsEditingPage` and `DocumentationEditingPage` write changes by


### PR DESCRIPTION
## Summary

- Replace 683-line `docs/src/frontend/01-overview.md` with a 75-line landing page plus two detail pages: `01-overview/components.md` (mermaid component tree + atomic-design layers, Pinia stores, routing, API layer) and `01-overview/personas.md` (mermaid state diagrams for data-entry and back-office users).
- Replace fictional component names (LabsPage / LabCard / AdminPage) with the real ones from `frontend/src/pages/` and `frontend/src/components/`. Persona flows match the actual `router/guards/` (`requirePermission`, `requireModuleEditPermission`, `validateUnitGuard`).
- Drop content already covered elsewhere (Nginx config, Dockerfile, Quasar build options, duplicated translation contribution block) and link to `architecture/11-deployment-topology.md`. Update `docs/mkdocs.yml` nav to expose the two new sub-pages under Frontend.

## Test plan

- [x] `mkdocs build --strict` exits 0 with `mkdocs-material`, `mkdocs-mermaid2-plugin`, `mkdocs-git-authors-plugin`, `mkdocs-git-revision-date-localized-plugin`, `mkdocs-minify-plugin` installed.
- [x] Landing page is 75 lines; `components.md` 116 lines; `personas.md` 125 lines (each respects 10-Minute Rule for its sections).
- [x] `#authentication--authorization` anchor preserved so cross-doc links from `architecture/04-auth-flow.md` and `architecture/13-cross-cutting-concerns.md` keep working.
- [ ] Visual smoke test (mermaid renders) on a deployed branch preview.