### PR TITLE
docs(#860): B5 LLM-agent guide + glossary

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -45,6 +45,8 @@ markdown_extensions:
 docs_dir: src
 nav:
   - Home: index.md
+  - LLM Agent Guide: llm-agent-guide.md
+  - Glossary: glossary.md
   - Architecture:
       - Overview: architecture/index.md
       - Purpose & Scope: architecture/01-purpose-scope.md

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -55,7 +55,8 @@ per-request work for a single user. Path 2 is bulk operator workflows
 
 **Recalc** — Re-running emission computations after a factor change or
 classification fix. Triggered automatically when factor pipelines deliver
-new versions. See plan 310b.
+new versions. See
+[`310-b-factor-pipeline.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans/310-b-factor-pipeline.md).
 
 **`/refresh`** — Endpoint that triggers a background role sync from
 Entra/Accred and returns immediately. Pair with `/me` to read the result.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -40,7 +40,7 @@ kg CO2-eq. Versioned by year and scope; ingested via the factor pipeline.
 **Factor pipeline** — Bulk import and normalization workflow that ingests
 CSV factor sources into canonical factor tables and triggers
 recalculation. See
-[`310-b-factor-pipeline.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/implementation-plans/310-b-factor-pipeline.md).
+[`310-b-factor-pipeline.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans/310-b-factor-pipeline.md).
 
 **GHG Protocol** — The Greenhouse Gas Protocol, the international
 emissions accounting standard. Defines Scope 1, 2, and 3.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -1,0 +1,74 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Alphabetical glossary of project-specific terms used across the co2-calculator codebase and docs.
+---
+
+# Glossary
+
+Project-specific terms. For industry-wide acronyms (REST, JWT, OIDC), see
+the relevant ADR or external reference.
+
+**Activity** — A unit of measured work that emits CO2 (a flight, a kWh of
+lab power, a kg of purchased material). Multiplied by an emission factor.
+
+**ADR (Architecture Decision Record)** — A dated record of one accepted
+architectural decision. See
+[`architecture-decision-records/`](./architecture-decision-records/index.md).
+
+**Affiliation** — A user's link to one or more EPFL units, sourced from
+Accred. Scopes what backoffice users may view or edit (issue #459).
+
+**Backoffice** — The administrative surface: user management, factor
+management, audit, ingestion. Permissions live under `backoffice.*`. See
+[`backend/07-DEVELOPER-GUIDE-PERMISSIONS.md`](./backend/07-DEVELOPER-GUIDE-PERMISSIONS.md).
+
+**`claim_job`** — Atomic SQL operation that flips a job from
+`NOT_STARTED` to `RUNNING` and sets `is_current=TRUE` in one transaction.
+Pod-collision losers lose the UPDATE, not the data. See ADR-010, ADR-015.
+
+**CRD (Customer Requirements Document)** — The mandate spec at
+[`architecture/spec.md`](./architecture/spec.md). Top of the
+source-of-truth hierarchy.
+
+**Data-entry user** — Role that submits activity data for a unit. Distinct
+from validators and backoffice operators. See ADR-005.
+
+**Emission factor** — Coefficient mapping an activity quantity to
+kg CO2-eq. Versioned by year and scope; ingested via the factor pipeline.
+
+**Factor pipeline** — Bulk import and normalization workflow that ingests
+CSV factor sources into canonical factor tables and triggers
+recalculation. See
+[`310-b-factor-pipeline.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/implementation-plans/310-b-factor-pipeline.md).
+
+**GHG Protocol** — The Greenhouse Gas Protocol, the international
+emissions accounting standard. Defines Scope 1, 2, and 3.
+
+**`/me`** — `GET /api/v1/auth/me`. Returns the cached user profile, roles,
+and computed permissions in ~8 ms. Does not trigger role sync. See
+[`role-sync-architecture.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/role-sync-architecture.md).
+
+**Path 1 vs Path 2** — Operational paths in the bulk-job model. Path 1 is
+per-request work for a single user. Path 2 is bulk operator workflows
+(CSV ingest, factor sync, recalc). See ADR-010.
+
+**Recalc** — Re-running emission computations after a factor change or
+classification fix. Triggered automatically when factor pipelines deliver
+new versions. See plan 310b.
+
+**`/refresh`** — Endpoint that triggers a background role sync from
+Entra/Accred and returns immediately. Pair with `/me` to read the result.
+See [`role-sync-architecture.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/role-sync-architecture.md).
+
+**Role sync** — Background process that reconciles a user's roles and
+affiliations from the upstream identity provider into the local DB.
+Tracked via `last_roles_sync_at`. See ADR-012.
+
+**Scope 1 / 2 / 3** — GHG Protocol categories. Scope 1: direct emissions
+(on-site combustion). Scope 2: purchased energy. Scope 3: all other
+indirect emissions (travel, purchases, services).
+
+**Validator** — Role that approves submitted data before it counts toward
+published totals. Sits between data-entry users and backoffice operators
+in the permission hierarchy. See ADR-005.

--- a/docs/src/llm-agent-guide.md
+++ b/docs/src/llm-agent-guide.md
@@ -19,7 +19,7 @@ Read top-down. Lower tiers refine higher tiers, never override them.
 2. **ADRs** — [`architecture-decision-records/`](./architecture-decision-records/index.md).
    Accepted architectural decisions with explicit `Status`. An accepted ADR
    binds; a superseded ADR is history only.
-3. **Implementation plans** — [`docs/implementation-plans/`](https://github.com/epfl-enac/co2-calculator/tree/main/docs/implementation-plans).
+3. **Implementation plans** — [`docs/src/implementation-plans/`](https://github.com/epfl-enac/co2-calculator/tree/main/docs/src/implementation-plans).
    Issue-scoped detail. Filter by frontmatter `status` (see below) before
    trusting.
 4. **Code** — ground truth. If docs and code disagree, code wins. File an
@@ -53,7 +53,7 @@ status as suspect, and verify against code.
 | Auth flow / token lifecycle     | [`backend/05-REQUEST_FLOW.md`](./backend/05-REQUEST_FLOW.md), ADR-012, ADR-013                                                |
 | Permission model                | [`backend/06-PERMISSION-SYSTEM.md`](./backend/06-PERMISSION-SYSTEM.md), ADR-005                                               |
 | Adding a permission             | [`backend/07-DEVELOPER-GUIDE-PERMISSIONS.md`](./backend/07-DEVELOPER-GUIDE-PERMISSIONS.md)                                    |
-| Background jobs / poller        | ADR-010, [`310-overview.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/implementation-plans/310-overview.md) |
+| Background jobs / poller        | ADR-010, [`310-overview.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans/310-overview.md) |
 | CI/CD                           | [`architecture/cicd-workflows.md`](./architecture/cicd-workflows.md)                                                          |
 | Role sync (`/me` vs `/refresh`) | [`role-sync-architecture.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/role-sync-architecture.md)           |
 | Glossary of project terms       | [`glossary.md`](./glossary.md)                                                                                                |

--- a/docs/src/llm-agent-guide.md
+++ b/docs/src/llm-agent-guide.md
@@ -65,7 +65,8 @@ status as suspect, and verify against code.
   safety-net poller. Cite the current ADR-010, not historical chatter.
 - **`fire_and_forget` cancels with the request.** FastAPI `BackgroundTasks`
   must be handed async functions directly; sync wrappers that call
-  `asyncio.run` cancel any tasks they spawn. See plan 310b.
+  `asyncio.run` cancel any tasks they spawn. See
+  [`310-b-factor-pipeline.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans/310-b-factor-pipeline.md).
 - **`backoffice.*` permissions only apply server-side.** Frontend gates
   use the same path but read from `/auth/me`; do not gate UI on raw roles.
 - **Plans named `*-copilot-feedback-*` are review threads, not plans.** They

--- a/docs/src/llm-agent-guide.md
+++ b/docs/src/llm-agent-guide.md
@@ -1,0 +1,74 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Orientation guide for LLM agents dropped into the co2-calculator repo — where to read, what to trust, what is stale.
+---
+
+# LLM Agent Guide
+
+You are an LLM agent that has just been dropped into this repo. Read this
+page first. It tells you which document wins when sources disagree, how to
+read frontmatter on plans, and where to look for common questions.
+
+## Source-of-truth hierarchy
+
+Read top-down. Lower tiers refine higher tiers, never override them.
+
+1. **CRD** — [`architecture/spec.md`](./architecture/spec.md). Scope, mandate,
+   acceptance criteria. If a feature is not in the CRD, it is out of scope.
+2. **ADRs** — [`architecture-decision-records/`](./architecture-decision-records/index.md).
+   Accepted architectural decisions with explicit `Status`. An accepted ADR
+   binds; a superseded ADR is history only.
+3. **Implementation plans** — [`docs/implementation-plans/`](https://github.com/epfl-enac/co2-calculator/tree/main/docs/implementation-plans).
+   Issue-scoped detail. Filter by frontmatter `status` (see below) before
+   trusting.
+4. **Code** — ground truth. If docs and code disagree, code wins. File an
+   issue tagged `docs` and link the offending file.
+
+## Frontmatter conventions on plans
+
+Every plan and ADR carries:
+
+```
+---
+status: draft | accepted | delivered | superseded
+issue: 310b               # GitHub issue or sub-issue id
+last_updated: 2026-05-05
+summary: one-line abstract
+---
+```
+
+- `draft` — speculative; do not cite as a decision.
+- `accepted` — agreed approach; implementation may be partial.
+- `delivered` — shipped; matches main-branch code at `last_updated`.
+- `superseded` — retained for history; check the linked successor.
+
+Treat any plan older than ~6 months without a `delivered` or `superseded`
+status as suspect, and verify against code.
+
+## Where to find X
+
+| Question                        | Start here                                                                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Auth flow / token lifecycle     | [`backend/05-REQUEST_FLOW.md`](./backend/05-REQUEST_FLOW.md), ADR-012, ADR-013                                                |
+| Permission model                | [`backend/06-PERMISSION-SYSTEM.md`](./backend/06-PERMISSION-SYSTEM.md), ADR-005                                               |
+| Adding a permission             | [`backend/07-DEVELOPER-GUIDE-PERMISSIONS.md`](./backend/07-DEVELOPER-GUIDE-PERMISSIONS.md)                                    |
+| Background jobs / poller        | ADR-010, [`310-overview.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/implementation-plans/310-overview.md) |
+| CI/CD                           | [`architecture/cicd-workflows.md`](./architecture/cicd-workflows.md)                                                          |
+| Role sync (`/me` vs `/refresh`) | [`role-sync-architecture.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/role-sync-architecture.md)           |
+| Glossary of project terms       | [`glossary.md`](./glossary.md)                                                                                                |
+
+## Common pitfalls
+
+- **ADR-010 is not Celery.** Earlier drafts proposed Celery + Redis; the
+  accepted decision is in-process `asyncio.create_task` plus a 10-second
+  safety-net poller. Cite the current ADR-010, not historical chatter.
+- **`fire_and_forget` cancels with the request.** FastAPI `BackgroundTasks`
+  must be handed async functions directly; sync wrappers that call
+  `asyncio.run` cancel any tasks they spawn. See plan 310b.
+- **`backoffice.*` permissions only apply server-side.** Frontend gates
+  use the same path but read from `/auth/me`; do not gate UI on raw roles.
+- **Plans named `*-copilot-feedback-*` are review threads, not plans.** They
+  capture bot feedback for a PR; they do not represent the design.
+- **`status: draft` plans land in the repo.** Presence in the tree does not
+  imply acceptance — check frontmatter.


### PR DESCRIPTION
## Summary

- Add `docs/src/llm-agent-guide.md` — orientation for an LLM agent dropped into the repo: source-of-truth hierarchy (CRD > ADR > plan > code), frontmatter conventions, common-question routing, and known stale spots (e.g. ADR-010 is in-process asyncio, not Celery).
- Add `docs/src/glossary.md` — 17 project-specific terms (Activity, Emission factor, Scope 1/2/3, GHG protocol, CRD, ADR, Affiliation, Backoffice, Data-entry user, Validator, Path 1/2, `claim_job`, Factor pipeline, Recalc, `/me`, `/refresh`, Role sync) cross-linked to canonical docs.
- Register both files in `docs/mkdocs.yml` nav alongside Home.

Both files carry `status: delivered` / `last_updated: 2026-05-05` frontmatter and respect the 80-line / 600-word budget.

## Test plan

- [x] `mkdocs build --strict` exits 0 against a clean `origin/main` checkout with the new files applied — verified locally; no warnings on the new files.
- [ ] Re-confirm in CI (`deploy-mkdocs.yml`).