### PR TITLE
docs(#860): B1 ADR refresh + 5 new ADRs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,9 +74,14 @@ nav:
       - ADR-004 Database Selection: architecture-decision-records/004-database-selection.md
       - ADR-005 Authorization Strategy: architecture-decision-records/005-authorization-strategy.md
       - ADR-010 Background Job Processing: architecture-decision-records/010-background-job-processing.md
+      - ADR-011 Factor Classification JSONB: architecture-decision-records/011-factor-classification-jsonb.md
       - ADR-012 JWT Authentication: architecture-decision-records/012-jwt-authentication-strategy.md
       - ADR-013 Object Storage: architecture-decision-records/013-object-storage-strategy.md
       - ADR-014 Security Checklist: architecture-decision-records/014-security-checklist.md
+      - ADR-015 Atomic Job Claiming: architecture-decision-records/015-claim-job-atomic-state-is-current.md
+      - ADR-016 Two-Path Pipeline: architecture-decision-records/016-pipeline-two-path-principle.md
+      - ADR-017 /me Async Role Sync: architecture-decision-records/017-me-endpoint-async-role-sync.md
+      - ADR-018 Factor CSV Idempotency: architecture-decision-records/018-factor-csv-delete-before-insert.md
 
   - Frontend:
       - Overview: frontend/01-overview.md

--- a/docs/src/architecture-decision-records/010-background-job-processing.md
+++ b/docs/src/architecture-decision-records/010-background-job-processing.md
@@ -9,7 +9,7 @@ summary: In-process asyncio.create_task chained jobs with a 10s safety-net polle
 **Status**: Accepted
 **Date**: 2026-05-05 (supersedes 2025-11-10 "Planned")
 **Deciders**: Development Team
-**Related**: [ADR-004: Database Selection](./004-database-selection.md); plan `docs/implementation-plans/310-overview.md`
+**Related**: [ADR-004: Database Selection](./004-database-selection.md); plan `docs/src/implementation-plans/310-overview.md`
 
 ## Context
 
@@ -44,7 +44,7 @@ backed by a **10-second safety-net poller** in every web pod.
 registry (`run_job(job_id)`) keeps the dispatch boundary clean: a
 future Deployment can host the runner without rewriting handlers.
 
-See `docs/implementation-plans/310-overview.md` for the full
+See `docs/src/implementation-plans/310-overview.md` for the full
 rationale and the four-plan roadmap (310-a through 310-d).
 
 ## Consequences
@@ -73,6 +73,6 @@ rationale and the four-plan roadmap (310-a through 310-d).
 
 ## References
 
-- `docs/implementation-plans/310-overview.md`
-- `docs/implementation-plans/310-a-pod-safety.md`
+- `docs/src/implementation-plans/310-overview.md`
+- `docs/src/implementation-plans/310-a-pod-safety.md`
 - [ADR-015: claim_job atomic claim](./015-claim-job-atomic-state-is-current.md)

--- a/docs/src/architecture-decision-records/010-background-job-processing.md
+++ b/docs/src/architecture-decision-records/010-background-job-processing.md
@@ -1,106 +1,78 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: In-process asyncio.create_task chained jobs with a 10s safety-net poller; defer Celery until data-volume thresholds.
+---
+
 # ADR-010: Background Job Processing
 
-**Status**: Planned  
-**Date**: 2025-11-10  
-**Deciders**: Development Team  
-**Related**: [Tech Stack](../architecture/08-tech-stack.md#backend-stack), [ADR-004: Database Selection](./004-database-selection.md)
+**Status**: Accepted
+**Date**: 2026-05-05 (supersedes 2025-11-10 "Planned")
+**Deciders**: Development Team
+**Related**: [ADR-004: Database Selection](./004-database-selection.md); plan `docs/implementation-plans/310-overview.md`
 
 ## Context
 
-We needed a solution for handling background tasks and asynchronous processing in our system that would:
+Path 2 (bulk operator) workflows — CSV ingest, factor sync, emission
+recalculation, unit sync — must run asynchronously across multi-pod
+deployments. Earlier drafts assumed Celery + Redis, but the data
+volume never demanded a dedicated worker fleet. Meanwhile, ad-hoc
+FastAPI `BackgroundTasks` exposed pod-collision races, untracked
+`unit_sync` jobs, and stuck `RUNNING` rows after pod crashes.
 
-- Support distributed task execution across multiple workers
-- Integrate well with our Python-based backend
-- Provide reliable task queuing and execution
-- Offer monitoring and management capabilities
-- Scale horizontally to handle varying workloads
-- Handle task retries and failure scenarios gracefully
+We needed a model that runs reliably in-process today yet stays
+swappable when throughput justifies isolated workers.
 
 ## Decision
 
-We will use **Celery with Redis** as our distributed task queue system for background job processing (preferred approach, pending final evaluation).
+Use **in-process `asyncio.create_task`** to chain pipeline steps,
+backed by a **10-second safety-net poller** in every web pod.
 
-**Note**: This decision is planned but not yet implemented. Alternatives like Dramatiq, Huey, and FastAPI BackgroundTasks will be evaluated during implementation.
+1. **Fast path**: a successful job handler calls
+   `asyncio.create_task(run_job(next_job_id))` to fire the next step
+   in milliseconds.
+2. **Safety net**: each pod polls every 10s for orphan jobs
+   (`state=NOT_STARTED AND run_after<=now() AND locked_by IS NULL`)
+   using `FOR UPDATE SKIP LOCKED`, recovering chains broken by pod
+   crashes.
+3. **Atomic claim**: `claim_job` flips `state=RUNNING` and
+   `is_current=TRUE` in a single transaction, guarded by the partial
+   unique index on `(state, is_current)`. Pod collisions lose the
+   UPDATE, not the data.
 
-## Rationale
+**Celery + Redis is deferred**, not rejected. Plan C's handler
+registry (`run_job(job_id)`) keeps the dispatch boundary clean: a
+future Deployment can host the runner without rewriting handlers.
 
-Celery provides a robust solution for our background processing needs:
-
-1. **Python Native**: First-class support for Python with excellent integration
-2. **Multiple Broker Support**: Works with Redis, RabbitMQ, and other message brokers
-3. **Distributed Execution**: Tasks can be executed across multiple worker nodes
-4. **Flexible Routing**: Advanced routing capabilities for different task types
-5. **Monitoring Tools**: Built-in monitoring and management tools (Flower)
-6. **Retry Mechanisms**: Configurable retry policies with exponential backoff
-7. **Large Community**: Extensive documentation and community support
-
-Redis was chosen as the message broker because:
-
-- Simple setup and operation
-- Excellent performance for our expected workload
-- Persistence options for task durability
-- Pub/Sub capabilities for real-time features
-
-Compared to alternatives:
-
-- **RQ**: Simpler but less feature-rich, sufficient for basic needs
-- **Dramatiq**: Modern alternative with better API, good performance
-- **Huey**: Lightweight Redis-based queue, simpler than Celery
-- **FastAPI BackgroundTasks**: Built-in but limited to single-process, no persistence
-- Custom solutions would require significant development effort
-- Other queue systems (like RabbitMQ) are more complex to operate
+See `docs/implementation-plans/310-overview.md` for the full
+rationale and the four-plan roadmap (310-a through 310-d).
 
 ## Consequences
 
-### Positive
+**Positive**:
 
-- Reliable distributed task processing
-- Horizontal scalability for background jobs
-- Built-in monitoring and management (Flower)
-- Flexible task scheduling options
-- Graceful handling of failures and retries
-- Large community and ecosystem
+- Zero new infrastructure (no Redis broker, no worker fleet).
+- Sub-second chain latency on the happy path.
+- Crash recovery within 10s without operator intervention.
+- Atomic `claim_job` eliminates the duplicate-write race (ADR-015).
+- Handler registry keeps the migration path to Celery cheap.
 
-### Negative
+**Negative**:
 
-- Additional infrastructure component (Redis) required
-- Learning curve for team members unfamiliar with Celery
-- Potential for increased complexity in debugging distributed tasks
-- Need for proper monitoring and alerting setup
-- Operational overhead compared to simpler solutions
+- Job CPU shares the web pod's event loop. Bulk recalcs can affect
+  request p95 — monitored, not yet observed.
+- Poller adds ~1 SELECT/pod/10s; trivial today, audit at scale.
+- No job-level resource isolation (memory caps, priority queues).
 
-### Neutral
+**Re-evaluate Celery when** any of:
 
-- Decision deferred until implementation phase
-- Will evaluate simpler alternatives (Dramatiq, Huey) based on actual requirements
-- FastAPI BackgroundTasks may be sufficient for MVP phase
-
-## Implementation Details
-
-Our Celery implementation will include:
-
-1. **Task Organization**:
-   - Separate modules for different task types
-   - Consistent naming conventions for tasks
-   - Clear separation between task definitions and business logic
-
-2. **Worker Configuration**:
-   - Dedicated worker processes for different task priorities
-   - Proper resource allocation and limits
-   - Supervision and auto-restart mechanisms
-
-3. **Monitoring**:
-   - Flower for real-time monitoring
-   - Custom metrics for task performance
-   - Alerting for failed tasks and queue backlogs
-
-4. **Error Handling**:
-   - Comprehensive logging for task execution
-   - Configurable retry policies
-   - Dead letter queue for repeatedly failing tasks
+- p95 web latency rises during ingestion.
+- Job throughput exceeds ~100 jobs/minute.
+- Recalcs need >4 GB RAM per worker.
+- Sub-second chain latency required (10s poll becomes the floor).
 
 ## References
 
-- [Celery Documentation](https://docs.celeryproject.org/)
-- [Redis Documentation](https://redis.io/documentation)
-- [Flower Monitoring Tool](https://flower.readthedocs.io/)
+- `docs/implementation-plans/310-overview.md`
+- `docs/implementation-plans/310-a-pod-safety.md`
+- [ADR-015: claim_job atomic claim](./015-claim-job-atomic-state-is-current.md)

--- a/docs/src/architecture-decision-records/011-factor-classification-jsonb.md
+++ b/docs/src/architecture-decision-records/011-factor-classification-jsonb.md
@@ -1,0 +1,80 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Migrate factors.classification from JSON to JSONB so cast-to-text is deterministic and the unique index actually deduplicates.
+---
+
+# ADR-011: Store `factors.classification` as JSONB
+
+**Status**: Accepted
+**Date**: 2026-05-05
+**Deciders**: Backend Team
+**Related**: [ADR-004: Database Selection](./004-database-selection.md); plan `docs/implementation-plans/310-b-factor-pipeline.md`
+
+## Context
+
+`factors.classification` was declared `Column(JSON)` to hold a small
+free-form dict (e.g. `{"fuel": "diesel", "vehicle": "lorry"}`). Plan
+310-b introduces a unique factor identity:
+
+```
+(data_entry_type_id, year, emission_type_id, classification)
+```
+
+enforced by a partial unique index on `(classification::text)`.
+PostgreSQL `JSON` preserves the original text, so `::text` reflects
+whatever order Python's `json.dumps` produced. A second caller that
+writes `{"vehicle": "lorry", "fuel": "diesel"}` would be a different
+`::text` value, defeating the index and silently inserting a
+duplicate row.
+
+## Decision
+
+Migrate the column to **PostgreSQL JSONB** and the SQLAlchemy model
+to `Column(JSONB)` from `sqlalchemy.dialects.postgresql`.
+
+```sql
+ALTER TABLE factors
+  ALTER COLUMN classification TYPE JSONB USING classification::JSONB;
+```
+
+JSONB normalizes keys alphabetically at write time, so
+`classification::text` is deterministic regardless of insertion
+order. The partial unique indexes introduced by 310-b
+(`uq_factor_identity` and `uq_factor_identity_no_year`) now actually
+enforce identity.
+
+Read paths return the same Python `dict`, so application code is
+unchanged.
+
+## Consequences
+
+**Positive**:
+
+- The unique index is a real constraint, not a coincidence. Silent
+  duplicate-factor rows are eliminated.
+- `ON CONFLICT DO UPDATE` upserts (310-b Part 2) preserve
+  `factor.id`, keeping `DataEntry.primary_factor_id` FKs alive
+  across CSV re-uploads (Strategy A entries).
+- JSONB permits GIN indexes if classification queries grow.
+
+**Negative**:
+
+- One-time PostgreSQL-only migration; SQLite dev databases keep
+  `JSON` (no behavioral difference for tests, the index is
+  Postgres-scoped).
+- Whitespace and key-order changes to the source CSV no longer
+  produce different rows — operators must rely on values, not
+  serialization, to express intent (the desirable outcome).
+
+**Migration path**:
+
+- Rolled out in the 310-b PR alongside the unique indexes and the
+  `factor_repo.upsert_factors` code path.
+- No backfill needed — JSONB normalizes existing rows on cast.
+
+## References
+
+- `docs/implementation-plans/310-b-factor-pipeline.md`
+- `docs/implementation-plans/310-overview.md`
+- [PostgreSQL JSON Types](https://www.postgresql.org/docs/current/datatype-json.html)

--- a/docs/src/architecture-decision-records/011-factor-classification-jsonb.md
+++ b/docs/src/architecture-decision-records/011-factor-classification-jsonb.md
@@ -9,7 +9,7 @@ summary: Migrate factors.classification from JSON to JSONB so cast-to-text is de
 **Status**: Accepted
 **Date**: 2026-05-05
 **Deciders**: Backend Team
-**Related**: [ADR-004: Database Selection](./004-database-selection.md); plan `docs/implementation-plans/310-b-factor-pipeline.md`
+**Related**: [ADR-004: Database Selection](./004-database-selection.md); plan `docs/src/implementation-plans/310-b-factor-pipeline.md`
 
 ## Context
 
@@ -75,6 +75,6 @@ unchanged.
 
 ## References
 
-- `docs/implementation-plans/310-b-factor-pipeline.md`
-- `docs/implementation-plans/310-overview.md`
+- `docs/src/implementation-plans/310-b-factor-pipeline.md`
+- `docs/src/implementation-plans/310-overview.md`
 - [PostgreSQL JSON Types](https://www.postgresql.org/docs/current/datatype-json.html)

--- a/docs/src/architecture-decision-records/015-claim-job-atomic-state-is-current.md
+++ b/docs/src/architecture-decision-records/015-claim-job-atomic-state-is-current.md
@@ -9,7 +9,7 @@ summary: claim_job sets state=RUNNING and is_current=TRUE atomically, letting th
 **Status**: Accepted
 **Date**: 2026-05-05
 **Deciders**: Backend Team
-**Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/implementation-plans/310-a-pod-safety.md`
+**Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/src/implementation-plans/310-a-pod-safety.md`
 
 ## Context
 
@@ -73,6 +73,6 @@ returns `True`. SQLite is not a substitute for this test.
 
 ## References
 
-- `docs/implementation-plans/310-a-pod-safety.md`
-- `docs/implementation-plans/310-overview.md`
+- `docs/src/implementation-plans/310-a-pod-safety.md`
+- `docs/src/implementation-plans/310-overview.md`
 - [ADR-010: Background Job Processing](./010-background-job-processing.md)

--- a/docs/src/architecture-decision-records/015-claim-job-atomic-state-is-current.md
+++ b/docs/src/architecture-decision-records/015-claim-job-atomic-state-is-current.md
@@ -1,0 +1,78 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: claim_job sets state=RUNNING and is_current=TRUE atomically, letting the partial unique index reject the second pod.
+---
+
+# ADR-015: Atomic `claim_job` on `state` + `is_current`
+
+**Status**: Accepted
+**Date**: 2026-05-05
+**Deciders**: Backend Team
+**Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/implementation-plans/310-a-pod-safety.md`
+
+## Context
+
+The legacy job lifecycle created a row at
+`state=NOT_STARTED, is_current=FALSE`, then the background task set
+`is_current=TRUE` only after starting. The partial unique index
+`ix_data_ingestion_jobs_is_current_unique` therefore protected
+nothing during the gap. Two concurrent operator clicks, or two pods
+handling the same trigger, both ran the same job and double-wrote
+`carbon_reports`.
+
+## Decision
+
+`claim_job(job_id, pod_id)` performs the claim in **one DB
+transaction with two statements**:
+
+1. `UPDATE` to unset `is_current` on any previous current row for the
+   same `(module_type_id, data_entry_type_id, target_type,
+   ingestion_method, year)` combo.
+2. `UPDATE` the target row to
+   `state=RUNNING, is_current=TRUE, locked_by=POD_ID,
+   locked_at=NOW(), attempts=attempts+1`,
+   gated by `WHERE id=:id AND state=NOT_STARTED AND
+   attempts<max_attempts`.
+
+Two pods racing this transaction both attempt step 2. Step 1 in pod
+B's transaction tries to flip the same `is_current=TRUE` row that
+pod A just set, but the partial unique index trips before commit.
+Pod B's transaction rolls back; `claim_job` returns `False`.
+
+Returns:
+
+- `True`  — caller owns the job, must run it.
+- `False` — another pod won, or the job is no longer eligible
+  (`state != NOT_STARTED`, `attempts >= max_attempts`).
+
+## Consequences
+
+**Positive**:
+
+- Pod collisions on the bulk path are eliminated by the database,
+  not by application-level locks.
+- Combined with the 10s safety-net poller (ADR-010), crashed claims
+  recover automatically: the next poller re-claims the row once
+  `locked_by` clears (handled by the recovery path in 310-a).
+- Backbone for `attempts`/`max_attempts` retry semantics — each
+  re-claim increments `attempts`, capping retry storms.
+
+**Negative**:
+
+- Caller must check the `bool` return and skip silently on `False`.
+  Forgetting this re-introduces double-execution; covered by
+  integration tests in 310-a.
+- The partial unique index must be present before deploying this
+  code path. Migration ordering matters — the column add and index
+  creation ship in the same Alembic revision as `claim_job`.
+
+**Tested under contention** with a real PostgreSQL fixture that
+fires two concurrent `claim_job` calls and asserts exactly one
+returns `True`. SQLite is not a substitute for this test.
+
+## References
+
+- `docs/implementation-plans/310-a-pod-safety.md`
+- `docs/implementation-plans/310-overview.md`
+- [ADR-010: Background Job Processing](./010-background-job-processing.md)

--- a/docs/src/architecture-decision-records/016-pipeline-two-path-principle.md
+++ b/docs/src/architecture-decision-records/016-pipeline-two-path-principle.md
@@ -1,0 +1,88 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Path 1 (interactive UI) writes inline; Path 2 (bulk operator) chains async jobs. Each table has one writer per path.
+---
+
+# ADR-016: Two-Path Pipeline Principle (Interactive vs Bulk)
+
+**Status**: Accepted
+**Date**: 2026-05-05
+**Deciders**: Backend Team
+**Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/implementation-plans/310-d-pipeline-responsibility-split.md`
+
+## Context
+
+The CO2 calculator serves two user paths with fundamentally
+different latency expectations:
+
+- **Path 1 — Interactive UI**: standard and principal users edit
+  modules through `POST/PATCH/DELETE /v1/carbon_reports/...`. Users
+  expect instant visual feedback (<200ms typical).
+- **Path 2 — Bulk operator**: principal users and backoffice métier
+  upload CSVs, sync factors, sync units. Operators expect minutes,
+  not milliseconds; SSE streams progress.
+
+Earlier code mixed both paths through the same write functions.
+Bulk CSV ingest computed emissions inside the ingest transaction;
+factor recalculation also wrote `data_entry_emissions`; both called
+`recompute_stats` writing `carbon_reports`. Two concurrent bulk
+pipelines for different modules raced on the same tables.
+
+## Decision
+
+Codify a **two-path principle** with distinct write strategies per
+path:
+
+| Path                  | Trigger                          | Write strategy        |
+| --------------------- | -------------------------------- | --------------------- |
+| 1 — Interactive UI    | UI module edit endpoints         | Inline, synchronous   |
+| 2 — Bulk operator     | `/sync/dispatch`, `/sync/...`    | Async chained jobs    |
+
+Each table has **exactly one writer per path**:
+
+| Table                  | Path 2 writer                    | Path 1 writer (unchanged)    |
+| ---------------------- | -------------------------------- | ---------------------------- |
+| `data_entries`         | `csv_ingest` / `api_ingest` jobs | `CarbonReportModuleWorkflow` |
+| `data_entry_emissions` | `emission_recalc` job            | `CarbonReportModuleWorkflow` |
+| `carbon_reports.stats` | `aggregation` job                | `CarbonReportModuleWorkflow` |
+
+Path 2 chain (per module):
+
+```
+csv_ingest  →  emission_recalc  →  aggregation
+```
+
+Aggregation jobs dedupe per `(module_type_id, year)` so N parallel
+recalcs collapse to one stats refresh.
+
+Path 1 keeps inline writes. Single-row request scope serializes its
+writes naturally; this is a deliberate UX choice, not a violation.
+
+See `docs/implementation-plans/310-d-pipeline-responsibility-split.md`.
+
+## Consequences
+
+**Positive**:
+
+- Bulk-path race conditions on `data_entry_emissions` and
+  `carbon_reports.stats` are eliminated by ownership, not locking.
+- Long-running emission compute no longer holds ingest transaction
+  locks; ingest commits fast and chains the recalc.
+- Frontend UX explicit: per-module "Recalculating..." badge while
+  Path 2 chains run.
+
+**Negative**:
+
+- Two write paths to maintain. Tests must cover both.
+- New contributors must learn which path their change belongs to;
+  the rule "is the user staring at a spinner?" decides — yes is
+  Path 1, no is Path 2.
+
+**Future work**: batched ingest (1k–5k rows) is deferred until
+Path 2's job-split lands and lock duration becomes the bottleneck.
+
+## References
+
+- `docs/implementation-plans/310-d-pipeline-responsibility-split.md`
+- `docs/implementation-plans/310-overview.md`

--- a/docs/src/architecture-decision-records/016-pipeline-two-path-principle.md
+++ b/docs/src/architecture-decision-records/016-pipeline-two-path-principle.md
@@ -1,12 +1,12 @@
 ---
-status: delivered
+status: partially-delivered
 last_updated: 2026-05-05
-summary: Path 1 (interactive UI) writes inline; Path 2 (bulk operator) chains async jobs. Each table has one writer per path.
+summary: Path 1 (interactive UI) writes inline; Path 2 (bulk operator) chains async jobs. Single-writer-per-path is the target; today emissions/stats writers are split between the dispatch chain and legacy inline calls.
 ---
 
 # ADR-016: Two-Path Pipeline Principle (Interactive vs Bulk)
 
-**Status**: Accepted
+**Status**: Accepted (principle); ownership split partially implemented — see "Current state" below
 **Date**: 2026-05-05
 **Deciders**: Backend Team
 **Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`
@@ -39,15 +39,16 @@ path:
 | 1 — Interactive UI    | UI module edit endpoints         | Inline, synchronous   |
 | 2 — Bulk operator     | `/sync/dispatch`, `/sync/...`    | Async chained jobs    |
 
-Each table has **exactly one writer per path**:
+Each table should have **exactly one writer per path**. The target
+ownership map:
 
-| Table                  | Path 2 writer                    | Path 1 writer (unchanged)    |
+| Table                  | Path 2 writer (target)           | Path 1 writer (unchanged)    |
 | ---------------------- | -------------------------------- | ---------------------------- |
 | `data_entries`         | `csv_ingest` / `api_ingest` jobs | `CarbonReportModuleWorkflow` |
 | `data_entry_emissions` | `emission_recalc` job            | `CarbonReportModuleWorkflow` |
 | `carbon_reports.stats` | `aggregation` job                | `CarbonReportModuleWorkflow` |
 
-Path 2 chain (per module):
+Path 2 chain (per module), once fully delivered:
 
 ```
 csv_ingest  →  emission_recalc  →  aggregation
@@ -60,6 +61,28 @@ Path 1 keeps inline writes. Single-row request scope serializes its
 writes naturally; this is a deliberate UX choice, not a violation.
 
 See `docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`.
+
+### Current state
+
+The single-writer split is **partially delivered**. The dispatch path
+chains `csv_ingest → emission_recalc`, but stats recomputation is not
+yet a dedicated `aggregation` job — it is still called inline:
+
+- `backend/app/workflows/emission_recalculation.py:150` —
+  `module_svc.recompute_stats(module_id)` runs at the end of the
+  recalc workflow.
+- `backend/app/services/data_ingestion/base_csv_provider.py:1082` —
+  bulk CSV ingest invokes `_recompute_module_stats()` inline before
+  the recalc chain takes over.
+
+`TargetType` does not yet expose an `AGGREGATION` value, and no
+aggregation worker exists. Until plan 310-d lands the dedicated
+aggregation job and removes the inline `recompute_stats` calls, the
+`carbon_reports.stats` row of the table above describes intent, not
+the live writer set. Treat the table as the architectural goal; the
+in-tree behavior for stats is **mixed: extracted in the dispatch path
+where applicable, still inline in the legacy ingest and recalc
+paths**.
 
 ## Consequences
 

--- a/docs/src/architecture-decision-records/016-pipeline-two-path-principle.md
+++ b/docs/src/architecture-decision-records/016-pipeline-two-path-principle.md
@@ -9,7 +9,7 @@ summary: Path 1 (interactive UI) writes inline; Path 2 (bulk operator) chains as
 **Status**: Accepted
 **Date**: 2026-05-05
 **Deciders**: Backend Team
-**Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/implementation-plans/310-d-pipeline-responsibility-split.md`
+**Related**: [ADR-010: Background Job Processing](./010-background-job-processing.md); plan `docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`
 
 ## Context
 
@@ -59,7 +59,7 @@ recalcs collapse to one stats refresh.
 Path 1 keeps inline writes. Single-row request scope serializes its
 writes naturally; this is a deliberate UX choice, not a violation.
 
-See `docs/implementation-plans/310-d-pipeline-responsibility-split.md`.
+See `docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`.
 
 ## Consequences
 
@@ -84,5 +84,5 @@ Path 2's job-split lands and lock duration becomes the bottleneck.
 
 ## References
 
-- `docs/implementation-plans/310-d-pipeline-responsibility-split.md`
-- `docs/implementation-plans/310-overview.md`
+- `docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`
+- `docs/src/implementation-plans/310-overview.md`

--- a/docs/src/architecture-decision-records/017-me-endpoint-async-role-sync.md
+++ b/docs/src/architecture-decision-records/017-me-endpoint-async-role-sync.md
@@ -1,0 +1,76 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: /me is a pure DB read; /refresh triggers async role sync with 15-minute TTL eventual consistency.
+---
+
+# ADR-017: `/me` is a Pure DB Read; `/refresh` Triggers Async Role Sync
+
+**Status**: Accepted
+**Date**: 2026-05-05
+**Deciders**: Backend Team, Auth Lead
+**Related**: [ADR-005: Authorization Strategy](./005-authorization-strategy.md), [ADR-012: JWT Authentication](./012-jwt-authentication-strategy.md); plan `docs/implementation-plans/334-me-performance-optimization.md`; `docs/role-sync-architecture.md`
+
+## Context
+
+`/me` previously fetched the user, then synchronously called the
+external role provider (Accred) to refresh roles before returning.
+Latency averaged ~1000ms per call, every call. Frontends polled
+`/me` aggressively, multiplying load on Accred and on our request
+threads. A single Accred outage stalled every authenticated page.
+
+We needed `/me` to be cheap enough that the frontend could call it
+freely, while keeping role data fresh enough for authorization
+decisions that already use the database row, not the JWT claims.
+
+## Decision
+
+Split the responsibilities:
+
+- **`/me`** validates the JWT, reads the user row (with cached
+  roles), and returns. **No external calls.** Target latency ~8ms.
+- **`/refresh`** validates the JWT, reads the user row, and triggers
+  background role sync via FastAPI `BackgroundTasks`. Returns
+  immediately with the currently cached roles.
+
+Background `RoleSyncService`:
+
+- Runs only if `last_roles_sync_at` is older than 15 minutes (TTL),
+  preventing sync storms.
+- Fetches fresh roles from the configured provider.
+- Diffs against cached roles; writes only on change; updates
+  `last_roles_sync_at` on success.
+- Failures are logged but never block the response.
+
+Authorization always reads `User.roles` from the database, so the
+guarantee is **eventual consistency within 15 minutes**, not
+strict freshness. Operators can force a sync by hitting `/refresh`.
+
+See `docs/implementation-plans/334-me-performance-optimization.md`
+and `docs/role-sync-architecture.md`.
+
+## Consequences
+
+**Positive**:
+
+- `/me` p95 dropped from ~1000ms to ~8ms.
+- Accred outages no longer cascade into authenticated routes.
+- External API call rate dropped from "per request" to "per 15 min
+  per active user".
+- Frontends can poll `/me` freely (used for tab focus, route
+  guards, etc.).
+
+**Negative**:
+
+- Role changes on the provider are visible after up to 15 minutes
+  unless the user (or admin) hits `/refresh`.
+- A new `last_roles_sync_at` column and the `RoleSyncService` add
+  surface area; covered by unit tests in `334`'s Task 2.
+- Background errors are silent to the caller (logged only); we
+  accept this in exchange for endpoint reliability.
+
+## References
+
+- `docs/implementation-plans/334-me-performance-optimization.md`
+- `docs/role-sync-architecture.md`
+- [ADR-005: Authorization Strategy](./005-authorization-strategy.md)

--- a/docs/src/architecture-decision-records/017-me-endpoint-async-role-sync.md
+++ b/docs/src/architecture-decision-records/017-me-endpoint-async-role-sync.md
@@ -9,7 +9,7 @@ summary: /me is a pure DB read; /refresh triggers async role sync with 15-minute
 **Status**: Accepted
 **Date**: 2026-05-05
 **Deciders**: Backend Team, Auth Lead
-**Related**: [ADR-005: Authorization Strategy](./005-authorization-strategy.md), [ADR-012: JWT Authentication](./012-jwt-authentication-strategy.md); plan `docs/implementation-plans/334-me-performance-optimization.md`; `docs/role-sync-architecture.md`
+**Related**: [ADR-005: Authorization Strategy](./005-authorization-strategy.md), [ADR-012: JWT Authentication](./012-jwt-authentication-strategy.md); plan `docs/src/implementation-plans/334-me-performance-optimization.md`; `docs/role-sync-architecture.md`
 
 ## Context
 
@@ -46,7 +46,7 @@ Authorization always reads `User.roles` from the database, so the
 guarantee is **eventual consistency within 15 minutes**, not
 strict freshness. Operators can force a sync by hitting `/refresh`.
 
-See `docs/implementation-plans/334-me-performance-optimization.md`
+See `docs/src/implementation-plans/334-me-performance-optimization.md`
 and `docs/role-sync-architecture.md`.
 
 ## Consequences
@@ -71,6 +71,6 @@ and `docs/role-sync-architecture.md`.
 
 ## References
 
-- `docs/implementation-plans/334-me-performance-optimization.md`
+- `docs/src/implementation-plans/334-me-performance-optimization.md`
 - `docs/role-sync-architecture.md`
 - [ADR-005: Authorization Strategy](./005-authorization-strategy.md)

--- a/docs/src/architecture-decision-records/018-factor-csv-delete-before-insert.md
+++ b/docs/src/architecture-decision-records/018-factor-csv-delete-before-insert.md
@@ -9,7 +9,7 @@ summary: Factor CSV uploads delete then re-insert scoped by (data_entry_type_id,
 **Status**: Accepted
 **Date**: 2026-05-05
 **Deciders**: Backend Team
-**Related**: [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md); plan `docs/implementation-plans/243-data-management-full-data-flow.md`
+**Related**: [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md); plan `docs/src/implementation-plans/243-data-management-full-data-flow.md`
 
 ## Context
 
@@ -55,7 +55,7 @@ Combined with 310-b's `last_seen_job_id` stamping and JSONB
 classification (ADR-011), this gives operators predictable
 re-upload semantics without leaking duplicate rows.
 
-See `docs/implementation-plans/243-data-management-full-data-flow.md`.
+See `docs/src/implementation-plans/243-data-management-full-data-flow.md`.
 
 ## Consequences
 
@@ -82,6 +82,6 @@ operator UX accommodates "stale factor" badges.
 
 ## References
 
-- `docs/implementation-plans/243-data-management-full-data-flow.md`
-- `docs/implementation-plans/310-b-factor-pipeline.md`
+- `docs/src/implementation-plans/243-data-management-full-data-flow.md`
+- `docs/src/implementation-plans/310-b-factor-pipeline.md`
 - [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md)

--- a/docs/src/architecture-decision-records/018-factor-csv-delete-before-insert.md
+++ b/docs/src/architecture-decision-records/018-factor-csv-delete-before-insert.md
@@ -1,0 +1,87 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Factor CSV uploads delete then re-insert scoped by (data_entry_type_id, year) for idempotent reuploads.
+---
+
+# ADR-018: Factor CSV Idempotency via Delete-Before-Insert
+
+**Status**: Accepted
+**Date**: 2026-05-05
+**Deciders**: Backend Team
+**Related**: [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md); plan `docs/implementation-plans/243-data-management-full-data-flow.md`
+
+## Context
+
+Factor CSV uploads previously **appended** rows. Re-uploading the
+same file (a routine operator action — fix a typo, re-run a
+validation) duplicated every factor. Operators had no clean
+"reset" path short of manual SQL.
+
+The 310-b factor pipeline introduces upsert-in-place keyed on
+`(data_entry_type_id, year, emission_type_id, classification)` and
+preserves `factor.id` across uploads — that solves the FK-orphan
+problem. But we still need a clear idempotency contract for the
+**delete-the-rest** semantics: factors that were in the previous
+CSV but not in the new one should disappear (or be marked stale).
+
+## Decision
+
+CSV factor providers run **delete-before-insert** scoped to the
+`(data_entry_type_id, year)` of the upload, before processing
+batches:
+
+```python
+if self.data_entry_type_id and self.year:
+    existing = await factor_service.count_by_data_entry_type_and_year(
+        data_entry_type_id=int(self.data_entry_type_id),
+        year=self.year,
+    )
+    await factor_service.bulk_delete_by_data_entry_type(
+        data_entry_type_id=int(self.data_entry_type_id),
+        year=self.year,
+    )
+    stats["factors_deleted"] = existing
+```
+
+The repository methods
+`list_id_by_data_entry_type_and_year` and
+`count_by_data_entry_type_and_year` provide the audit numbers.
+`bulk_delete_by_data_entry_type` accepts an optional `year`; with
+`year=None` it deletes all rows for the type (backward compatible).
+The deletion count is recorded in job metadata for the audit trail.
+
+Combined with 310-b's `last_seen_job_id` stamping and JSONB
+classification (ADR-011), this gives operators predictable
+re-upload semantics without leaking duplicate rows.
+
+See `docs/implementation-plans/243-data-management-full-data-flow.md`.
+
+## Consequences
+
+**Positive**:
+
+- Same CSV uploaded twice yields the same row count.
+- Operators have a clear mental model: the upload **is** the new
+  truth for that `(type, year)`.
+- Audit log captures `factors_deleted` per upload.
+
+**Negative**:
+
+- Deletion happens before insertion, so a partial-failure window
+  exists where the table is empty for that scope. Mitigated by
+  running inside the ingest transaction; a rollback restores the
+  previous rows.
+- Factors omitted from a re-upload are gone. Operators relying on
+  partial CSVs to "patch" must understand this — the public docs
+  flag it explicitly.
+
+**Future direction**: 310-b's upsert-in-place + `last_seen_job_id`
+allows a softer "mark stale, keep FKs" mode for production once the
+operator UX accommodates "stale factor" badges.
+
+## References
+
+- `docs/implementation-plans/243-data-management-full-data-flow.md`
+- `docs/implementation-plans/310-b-factor-pipeline.md`
+- [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md)

--- a/docs/src/architecture-decision-records/018-factor-csv-delete-before-insert.md
+++ b/docs/src/architecture-decision-records/018-factor-csv-delete-before-insert.md
@@ -1,15 +1,15 @@
 ---
 status: delivered
 last_updated: 2026-05-05
-summary: Factor CSV uploads delete then re-insert scoped by (data_entry_type_id, year) for idempotent reuploads.
+summary: Production factor CSV uploads use upsert-in-place keyed on (data_entry_type_id, year, emission_type_id, classification) with last_seen_job_id stamping; delete-before-insert is the local-dev seed pattern only.
 ---
 
-# ADR-018: Factor CSV Idempotency via Delete-Before-Insert
+# ADR-018: Factor CSV Idempotency — Upsert in Production, Delete-Before-Insert in Local Seeds
 
 **Status**: Accepted
 **Date**: 2026-05-05
 **Deciders**: Backend Team
-**Related**: [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md); plan `docs/src/implementation-plans/243-data-management-full-data-flow.md`
+**Related**: [ADR-011: Factor Classification JSONB](./011-factor-classification-jsonb.md); plan `docs/src/implementation-plans/243-data-management-full-data-flow.md`; plan `docs/src/implementation-plans/310-b-factor-pipeline.md`
 
 ## Context
 
@@ -18,18 +18,51 @@ same file (a routine operator action — fix a typo, re-run a
 validation) duplicated every factor. Operators had no clean
 "reset" path short of manual SQL.
 
-The 310-b factor pipeline introduces upsert-in-place keyed on
-`(data_entry_type_id, year, emission_type_id, classification)` and
-preserves `factor.id` across uploads — that solves the FK-orphan
-problem. But we still need a clear idempotency contract for the
-**delete-the-rest** semantics: factors that were in the previous
-CSV but not in the new one should disappear (or be marked stale).
+Two ingest contexts have different constraints:
+
+- **Production CSV upload** (`POST /sync/factors/...`) runs against
+  a populated database with FK references from existing data
+  entries. Wholesale `DELETE` would either orphan FKs or cascade
+  through downstream tables. It also runs as a tracked
+  `DataIngestionJob` with a `job_id` for audit.
+- **Local seed scripts** (`LocalFactorCSVProvider`) run against an
+  empty or scratch database during `make seed-data` / dev bootstrap.
+  No FK risk, no `DataIngestionJob` to stamp.
+
+Both need idempotent re-runs, but the production path needs FK
+preservation that delete-before-insert cannot offer.
 
 ## Decision
 
-CSV factor providers run **delete-before-insert** scoped to the
-`(data_entry_type_id, year)` of the upload, before processing
-batches:
+Two complementary strategies, selected by the provider class.
+
+### Production: upsert keyed on the factor identity tuple
+
+Production CSV ingest runs through
+`BaseFactorCSVProvider._upsert_batch` →
+`FactorRepo.upsert_factors(batch, current_job_id=self.job_id)`
+(`backend/app/services/data_ingestion/base_factor_csv_provider.py:201,477`).
+Each row is keyed on
+`(data_entry_type_id, year, emission_type_id, classification)`
+(the JSONB identity introduced by ADR-011). On match, the existing
+`factor.id` is preserved and the row is updated in place; on miss,
+a new row is inserted. Every row touched by the upload has its
+`last_seen_job_id` stamped to the current job.
+
+"Delete-the-rest" semantics is achieved by **stale-row detection**,
+not physical delete: factors whose `last_seen_job_id` predates the
+latest job for `(data_entry_type_id, year)` are surfaced via the
+stale-factor query and can be reviewed / marked / removed by
+operators with FK-aware tooling.
+
+### Local seeds: delete-before-insert scoped to (type, year)
+
+`LocalFactorCSVProvider`
+(`backend/app/services/data_ingestion/csv_providers/local_seed.py`)
+overrides `_upsert_batch` to stay on the legacy `bulk_create` path
+because seed runs have no `DataIngestionJob` and therefore no
+`job_id` to stamp. Before inserting, it deletes existing rows
+scoped to `(data_entry_type_id, year)`:
 
 ```python
 if self.data_entry_type_id and self.year:
@@ -44,41 +77,45 @@ if self.data_entry_type_id and self.year:
     stats["factors_deleted"] = existing
 ```
 
-The repository methods
-`list_id_by_data_entry_type_and_year` and
-`count_by_data_entry_type_and_year` provide the audit numbers.
-`bulk_delete_by_data_entry_type` accepts an optional `year`; with
-`year=None` it deletes all rows for the type (backward compatible).
-The deletion count is recorded in job metadata for the audit trail.
+This is safe in seed context because the database is fresh and no
+FK pressure exists. `FactorStatsDict.factors_deleted` is explicitly
+documented as "set by local-seed delete-and-insert path; 0 in
+upsert path" — the field's value at runtime tells you which
+strategy ran.
 
-Combined with 310-b's `last_seen_job_id` stamping and JSONB
-classification (ADR-011), this gives operators predictable
-re-upload semantics without leaking duplicate rows.
-
-See `docs/src/implementation-plans/243-data-management-full-data-flow.md`.
+See `docs/src/implementation-plans/243-data-management-full-data-flow.md`
+and `docs/src/implementation-plans/310-b-factor-pipeline.md`.
 
 ## Consequences
 
 **Positive**:
 
-- Same CSV uploaded twice yields the same row count.
-- Operators have a clear mental model: the upload **is** the new
-  truth for that `(type, year)`.
-- Audit log captures `factors_deleted` per upload.
+- Production uploads preserve `factor.id` across re-uploads, so
+  existing FK references in `data_entry_emissions` keep working.
+- Same CSV re-uploaded twice yields the same logical row set in
+  both contexts (idempotent).
+- `last_seen_job_id` gives operators a queryable stale-factor list
+  without committing to a destructive delete.
+- Audit log captures `factors_deleted` (seeds) or `affected`
+  (production upsert count) per upload.
 
 **Negative**:
 
-- Deletion happens before insertion, so a partial-failure window
-  exists where the table is empty for that scope. Mitigated by
-  running inside the ingest transaction; a rollback restores the
-  previous rows.
-- Factors omitted from a re-upload are gone. Operators relying on
-  partial CSVs to "patch" must understand this — the public docs
-  flag it explicitly.
+- Two code paths — `_upsert_batch` for production,
+  `bulk_create` + scoped delete for seeds — must both be tested.
+  Production paths must never silently fall through to the seed
+  branch (asserted by the `job_id` requirement in the base
+  `_upsert_batch`).
+- Stale-row cleanup in production is operator-driven, not
+  automatic. The doc surface (operator runbook) must call out the
+  stale-factor query and the recommended cadence.
+- Seed-only behavior: factors omitted from a re-seeded CSV are
+  gone. Seed scripts must remain authoritative for the `(type,
+  year)` they touch.
 
-**Future direction**: 310-b's upsert-in-place + `last_seen_job_id`
-allows a softer "mark stale, keep FKs" mode for production once the
-operator UX accommodates "stale factor" badges.
+**Future direction**: surface the stale-factor list in the
+operator UI (badges, bulk-archive action) so production cleanup
+moves out of SQL and into the same UX as upload.
 
 ## References
 

--- a/docs/src/architecture-decision-records/index.md
+++ b/docs/src/architecture-decision-records/index.md
@@ -45,14 +45,14 @@ understand why certain choices were made.
 | [ADR-010](./010-background-job-processing.md) | In-process asyncio + 10s safety-net poller   | ✅ Accepted | No new infra; Celery deferred            |
 | [ADR-013](./013-object-storage-strategy.md)   | Local filesystem, S3 optional                | 📋 Planned  | Zero-config dev, scalable prod           |
 | [ADR-015](./015-claim-job-atomic-state-is-current.md) | Atomic claim_job on (state, is_current)      | ✅ Accepted | Closes pod-collision race                |
-| [ADR-016](./016-pipeline-two-path-principle.md)       | Two-path principle (interactive vs bulk)     | ✅ Accepted | One writer per table per path            |
+| [ADR-016](./016-pipeline-two-path-principle.md)       | Two-path principle (interactive vs bulk)     | ✅ Accepted (principle); ownership split partially delivered | Single-writer-per-path is the target; stats today still inline in legacy paths |
 
 ### Data Pipeline
 
 | ADR                                                       | Decision                                | Status      | Key Rationale                          |
 | --------------------------------------------------------- | --------------------------------------- | ----------- | -------------------------------------- |
 | [ADR-011](./011-factor-classification-jsonb.md)           | factors.classification → JSONB          | ✅ Accepted | Deterministic key order, real uniqueness |
-| [ADR-018](./018-factor-csv-delete-before-insert.md)       | Factor CSV delete-before-insert         | ✅ Accepted | Idempotent re-uploads scoped by (det,year) |
+| [ADR-018](./018-factor-csv-delete-before-insert.md)       | Factor CSV idempotency (upsert in prod, delete-before-insert in seeds) | ✅ Accepted | Production: upsert + last_seen_job_id; seeds: scoped delete-before-insert |
 
 ### Auth & Identity
 

--- a/docs/src/architecture-decision-records/index.md
+++ b/docs/src/architecture-decision-records/index.md
@@ -40,10 +40,25 @@ understand why certain choices were made.
 
 ### Infrastructure & Operations
 
-| ADR                                           | Decision                      | Status     | Key Rationale                  |
-| --------------------------------------------- | ----------------------------- | ---------- | ------------------------------ |
-| [ADR-010](./010-background-job-processing.md) | Background Jobs               | 📋 Planned | Celery + Redis preferred       |
-| [ADR-013](./013-object-storage-strategy.md)   | Local filesystem, S3 optional | 📋 Planned | Zero-config dev, scalable prod |
+| ADR                                           | Decision                                     | Status      | Key Rationale                            |
+| --------------------------------------------- | -------------------------------------------- | ----------- | ---------------------------------------- |
+| [ADR-010](./010-background-job-processing.md) | In-process asyncio + 10s safety-net poller   | ✅ Accepted | No new infra; Celery deferred            |
+| [ADR-013](./013-object-storage-strategy.md)   | Local filesystem, S3 optional                | 📋 Planned  | Zero-config dev, scalable prod           |
+| [ADR-015](./015-claim-job-atomic-state-is-current.md) | Atomic claim_job on (state, is_current)      | ✅ Accepted | Closes pod-collision race                |
+| [ADR-016](./016-pipeline-two-path-principle.md)       | Two-path principle (interactive vs bulk)     | ✅ Accepted | One writer per table per path            |
+
+### Data Pipeline
+
+| ADR                                                       | Decision                                | Status      | Key Rationale                          |
+| --------------------------------------------------------- | --------------------------------------- | ----------- | -------------------------------------- |
+| [ADR-011](./011-factor-classification-jsonb.md)           | factors.classification → JSONB          | ✅ Accepted | Deterministic key order, real uniqueness |
+| [ADR-018](./018-factor-csv-delete-before-insert.md)       | Factor CSV delete-before-insert         | ✅ Accepted | Idempotent re-uploads scoped by (det,year) |
+
+### Auth & Identity
+
+| ADR                                                   | Decision                              | Status      | Key Rationale                          |
+| ----------------------------------------------------- | ------------------------------------- | ----------- | -------------------------------------- |
+| [ADR-017](./017-me-endpoint-async-role-sync.md)       | /me pure DB read; /refresh async sync | ✅ Accepted | ~8ms /me; eventual 15-min consistency  |
 
 ## Planned Decisions
 
@@ -51,7 +66,7 @@ understand why certain choices were made.
 | --- | ------------------- | ---------- | ------------------------------------------ |
 | 008 | Observability Stack | 📋 Planned | Prometheus + Grafana + OpenTelemetry       |
 | 009 | Caching Strategy    | 📋 Planned | Redis for emissions factors, rate limiting |
-| 011 | OIDC Integration    | 📋 Planned | MS Entra ID for EPFL SSO                   |
+| 019 | OIDC Integration    | 📋 Planned | MS Entra ID for EPFL SSO                   |
 
 ## Rejected Alternatives
 
@@ -97,4 +112,4 @@ small refactorings.
 
 ---
 
-**Last Updated**: November 11, 2025
+**Last Updated**: 2026-05-05


### PR DESCRIPTION
## Summary

- Refresh ADR-010 (Background Job Processing) from Planned/Celery to Accepted: in-process `asyncio.create_task` chained jobs + 10s safety-net poller. Celery deferred until volume thresholds.
- Surface five architectural decisions previously buried in `docs/implementation-plans/`:
  - ADR-011 factors.classification → JSONB (cites 310-b)
  - ADR-015 atomic claim_job on (state, is_current) (cites 310-a)
  - ADR-016 two-path pipeline principle (cites 310-d)
  - ADR-017 /me pure DB read; /refresh async role sync (cites 334 + role-sync-architecture)
  - ADR-018 factor CSV delete-before-insert idempotency (cites 243)
- Index updated with new sections (Data Pipeline, Auth & Identity), ADR-010 status flipped to Accepted, OIDC slot moved from 011 to 019.
- Each ADR carries YAML frontmatter (status: delivered, last_updated: 2026-05-05, summary).

Note: ADR slots 012/013/014 were already taken by JWT/Object Storage/Security Checklist, so two-path/me/csv-delete were assigned to 016/017/018; 011 and 015 (per task spec) were free.

## Test plan

- [x] `mkdocs build --strict` exits 0 (validated locally with mkdocs-material + git-authors + git-revision-date-localized + minify plugins)
- [ ] Reviewer skim each ADR for accuracy against cited plan
- [ ] Visual check of index landing page in deployed docs preview