### PR TITLE
docs(#860): document CSV seed formats from code (A3-redo)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Permission System: backend/06-PERMISSION-SYSTEM.md
       - "Developer Guide: Permissions": backend/07-DEVELOPER-GUIDE-PERMISSIONS.md
       - Location Search: backend/09-LOCATION-SEARCH.md
+      - CSV seed formats: backend/csv-seed-formats.md
 
   - Database:
       - Overview: database/01-overview.md

--- a/docs/src/backend/csv-seed-formats.md
+++ b/docs/src/backend/csv-seed-formats.md
@@ -1,0 +1,248 @@
+---
+status: delivered
+last_updated: 2026-05-05
+summary: Reference for CSV seed-data formats supported by the data_ingestion service.
+---
+
+# CSV seed formats
+
+## Why this exists
+
+The backend ingests CSV files from operator uploads, integration-test fixtures,
+and (historically) seed scripts. Each upload routes through a CSV provider in
+`backend/app/services/data_ingestion/csv_providers/`. This page lists the
+supported formats, their column schemas, and idempotency rules — so a developer
+or LLM agent extending ingestion knows what to produce, parse, or assert against.
+
+For the database entities these CSVs feed, see [Database ERD](../database/erd.md).
+
+## Provider overview
+
+```mermaid
+flowchart LR
+    CSV[CSV file] --> PF[ProviderFactory]
+    PF -->|MODULE_PER_YEAR + DATA_ENTRIES| MPY[ModulePerYearCSVProvider]
+    PF -->|MODULE_UNIT_SPECIFIC + DATA_ENTRIES| MUS[ModuleUnitSpecificCSVProvider]
+    PF -->|FACTORS| FAC[ModulePerYearFactorCSVProvider]
+    PF -->|REDUCTION_OBJECTIVES| RED[ModulePerYearReductionObjectivesApiProvider]
+    PF -->|REFERENCE_DATA| REF[ModulePerYearReferenceDataApiProvider]
+    MPY --> DE[(data_entries)]
+    MUS --> DE
+    FAC --> FT[(factors)]
+    RED --> YC[(year_configuration.config)]
+```
+
+Routing keys live in `backend/app/services/data_ingestion/provider_factory.py`.
+
+## Common conventions
+
+All CSV providers share these defaults (see `base_csv_provider.py:716` and
+the `csv.DictReader` calls in each provider):
+
+- **Encoding:** UTF-8 with optional BOM (`utf-8-sig`).
+- **Delimiter:** comma. Quote character: double quote.
+- **Header row:** required; column order is free.
+- **Extra columns:** silently ignored.
+- **Empty file:** rejected with `Wrong CSV format or encoding: CSV file is empty`.
+- **Source paths:** must start with `tmp/`, `uploads/`, or `temporary/`
+  (`base_csv_provider.py::_validate_file_path`).
+
+## Module-per-year CSV (data entries)
+
+- **Provider:** `ModulePerYearCSVProvider`
+- **Path:** `backend/app/services/data_ingestion/csv_providers/module_per_year.py`
+- **Target entity:** `data_entries` (one row per CSV row).
+- **Used for:** headcount, professional travel, buildings, purchases, research
+  facilities, etc.
+
+### Required and expected columns
+
+The only column required by the provider for every row is
+`unit_institutional_id` (`module_per_year.py:109`). Remaining columns are
+derived from the active `BaseModuleHandler` subclasses' `create_dto.model_fields`
+(see `_get_expected_columns_from_handlers` in `base_csv_provider.py:79`).
+
+| Column | Type | Required | Description |
+|---|---|---|---|
+| `unit_institutional_id` | string | yes | Unit code; resolves to `units.institutional_id`. |
+| handler-specific fields | varies | varies | Defined by the matching `BaseModuleHandler.create_dto`. |
+| `note` | string | no | Free-form annotation kept on the data entry. |
+
+For the headcount-member handler the columns are
+`unit_institutional_id, name, position_title, position_category,
+user_institutional_id, fte, note` (verified against
+`tests/integration/data_ingestion/fixtures/valid_module_per_year.csv`).
+
+### Idempotency
+
+Delete-then-insert per affected module: rows previously inserted with
+`source = CSV_MODULE_PER_YEAR` are removed before the new batch is loaded
+(`base_csv_provider.py::_delete_existing_entries_for_module_per_year`,
+implementation plan `docs/implementation-plans/220-csv-upload-implementation-summary.md`).
+Manual user entries (`source = USER_MANUAL`) are never touched.
+
+### Example
+
+```csv
+unit_institutional_id,name,position_title,position_category,user_institutional_id,fte,note
+UNIT001,John Doe,Professor,professor,UID001,1.0,
+UNIT002,Jane Smith,Post-doctoral researcher,postdoctoral_assistant,UID002,0.5,
+```
+
+## Module-unit-specific CSV (data entries)
+
+- **Provider:** `ModuleUnitSpecificCSVProvider`
+- **Path:** `backend/app/services/data_ingestion/csv_providers/module_unit_specific.py`
+- **Target entity:** `data_entries` for one specific `carbon_report_module_id`.
+- **Used for:** equipment, external AI, external clouds, and other
+  unit-scoped uploads.
+
+### Required and expected columns
+
+The provider requires a single `data_entry_type_id` in the upload config and
+loads one handler. Required columns come from the handler's
+`create_dto.model_fields` filtered by `is_required()`
+(`base_csv_provider.py::_get_required_columns_from_handler`). The CSV does
+**not** include `unit_institutional_id` — the unit is fixed by
+`carbon_report_module_id` from the API request.
+
+For the equipment handler the columns are
+`name, equipment_class, sub_class, active_usage_hours_per_week,
+standby_usage_hours_per_week, note` (verified against
+`backend/app/modules/equipment_electric_consumption/schemas.py::EquipmentHandlerCreate`).
+
+### Validation rules
+
+- `active_usage_hours_per_week + standby_usage_hours_per_week <= 168`
+  (`EquipmentModuleHandler.pre_compute`).
+- Other handlers attach their own `field_validator`s to the create DTO.
+
+### Idempotency
+
+**Append-only.** No prior rows are deleted (verified at
+`base_csv_provider.py:478` and confirmed in
+`docs/implementation-plans/220-csv-upload-implementation-summary.md`).
+
+### Example
+
+```csv
+name,equipment_class,sub_class,active_usage_hours_per_week,standby_usage_hours_per_week,note
+Thermostat Numerique,Agitator / Incubator,CO2 incubators,12,150,Test equipment
+ECRAN EIZO FLEXSCAN,Monitors,,8,160,
+```
+
+## Factors CSV
+
+- **Provider:** `ModulePerYearFactorCSVProvider`
+- **Path:** `backend/app/services/data_ingestion/csv_providers/factors.py`
+- **Target entity:** `factors`.
+- **Config inputs:** `module_type_id`, optional `data_entry_type_id`, `year`.
+
+### Columns
+
+Columns vary per `BaseFactorHandler` subclass. The expected set is
+`create_dto.model_fields - FACTOR_META_FIELDS`, where the meta-fields excluded
+from CSVs are `id, classification, values, emission_type_id,
+data_entry_type_id, year` (`backend/app/schemas/factor.py:11`). To find the
+columns for a given factor type, read its `*FactorCreate` class in
+`backend/app/modules/<module>/schemas.py`.
+
+Example — `TravelPlaneFactorHandler` (verified at
+`backend/app/modules/professional_travel/schemas.py:407`):
+
+| Column | Type | Required | Description |
+|---|---|---|---|
+| `category` | enum | yes | `very_short_haul`, `short_haul`, `medium_haul`, or `long_haul`. |
+| `ef_kg_co2eq_per_km` | float | yes | Emission factor; must be `>= 0`. |
+| `rfi_adjustment` | float | yes | Radiative-forcing index multiplier. |
+| `class_adjustement` | float | yes | Cabin-class multiplier (note: legacy spelling). |
+| `min_distance` | float | yes | Lower bound of the distance band (km). |
+| `max_distance` | float | yes | Upper bound of the distance band (km). |
+
+### Idempotency
+
+Delete-then-insert by `(data_entry_type_id, year)`
+(`base_factor_csv_provider.py:189-205`). All existing factor rows for that
+combination are removed before the new batch is inserted.
+
+### Example
+
+```csv
+category,ef_kg_co2eq_per_km,rfi_adjustment,class_adjustement,min_distance,max_distance
+very_short_haul,0.258,1.0,1.0,0,500
+short_haul,0.156,2.0,1.0,500,1500
+medium_haul,0.131,2.0,1.2,1500,3500
+long_haul,0.151,2.0,1.4,3500,20000
+```
+
+## Reduction-objective CSV
+
+- **Provider:** `ModulePerYearReductionObjectivesApiProvider`
+- **Path:** `backend/app/services/data_ingestion/csv_providers/reduction_objectives.py`
+- **Target entity:** `year_configuration.config.reduction_objectives.<key>`
+  (single JSON blob per category, not row-per-row).
+- **Selector:** `reduction_objective_type_id` in the upload config picks one of
+  three sub-formats (`backend/app/schemas/year_configuration.py:114`).
+
+### Sub-formats
+
+| `reduction_objective_type_id` | `config_key` | Required columns |
+|---|---|---|
+| `0` (FOOTPRINT) | `institutional_footprint` | `year, category, co2` |
+| `1` (POPULATION) | `population_projections` | `year, pop` |
+| `2` (SCENARIOS) | `unit_scenarios` | `scenario, year, reduction_percentage` |
+
+Validation rules (`schemas/year_configuration.py:43-89`):
+
+- `co2 >= 0`, `pop >= 0`, `0.0 <= reduction_percentage <= 1.0`.
+
+### Idempotency
+
+The whole validated row set is written as a JSON list under
+`year_configuration.config.reduction_objectives.<config_key>`, replacing the
+previous value for that key.
+
+### Example (FOOTPRINT)
+
+```csv
+year,category,co2
+2024,energy,1234.5
+2024,food,567.8
+2024,travel,890.1
+```
+
+## Reference-data CSV
+
+- **Provider:** `ModulePerYearReferenceDataApiProvider`
+- **Path:** `backend/app/services/data_ingestion/csv_providers/reference_data.py`
+- **Status:** Setup currently returns `{}`; column schema and validation rules
+  are **TBD**. Do not rely on this format until the provider is fleshed out.
+  Track work against the file above.
+
+## Where fixtures live
+
+Integration-test CSV fixtures (the ground truth for shape and edge cases) sit
+under `backend/tests/integration/data_ingestion/fixtures/`. The fixture
+README in that directory documents valid examples, missing-column failures,
+extra-column tolerance, and empty-file handling.
+
+Note: an older comment in that README points to `backend/seed_data/` for
+production CSVs. That directory does not exist on `main` today; treat the
+fixtures dir as the canonical reference.
+
+## How to add a new format
+
+1. Subclass `BaseCSVProvider`, `BaseFactorCSVProvider`, or
+   `BaseReductionObjectiveCSVProvider` and implement the abstract hooks
+   (`_setup_handlers_and_factors` / `_setup_handlers_and_context` /
+   `_resolve_handler`).
+2. Register the provider in `ProviderFactory.PROVIDERS` (or
+   `COMPUTED_FACTOR_PROVIDERS`) in
+   `backend/app/services/data_ingestion/provider_factory.py` under the right
+   `(module_type, ingestion_method, target_type, entity_type)` key.
+3. Add a fixture CSV under
+   `backend/tests/integration/data_ingestion/fixtures/` and document its
+   shape in the fixtures README.
+4. Add an integration test under
+   `backend/tests/integration/data_ingestion/` that exercises happy-path,
+   missing-column, and idempotency scenarios.

--- a/docs/src/backend/csv-seed-formats.md
+++ b/docs/src/backend/csv-seed-formats.md
@@ -36,16 +36,28 @@ Routing keys live in `backend/app/services/data_ingestion/provider_factory.py`.
 
 ## Common conventions
 
-All CSV providers share these defaults (see `base_csv_provider.py:716` and
-the `csv.DictReader` calls in each provider):
+CSV providers share many — but not all — defaults. The list below splits them
+into truly-shared behaviour and per-provider differences.
 
-- **Encoding:** UTF-8 with optional BOM (`utf-8-sig`).
+### Shared by all providers
+
 - **Delimiter:** comma. Quote character: double quote.
 - **Header row:** required; column order is free.
 - **Extra columns:** silently ignored.
-- **Empty file:** rejected with `Wrong CSV format or encoding: CSV file is empty`.
+- **Empty file:** rejected with `CSV file is empty`
+  (`base_csv_provider.py:244`, `base_factor_csv_provider.py:300`,
+  `base_reduction_objective_csv_provider.py:320`). The data-entry path wraps
+  this message with the prefix described below; the factor and
+  reduction-objective paths raise a bare `ValueError`.
 - **Source paths:** must start with `tmp/`, `uploads/`, or `temporary/`
   (`base_csv_provider.py::_validate_file_path`).
+
+### Per-provider differences
+
+| Aspect | `BaseCSVProvider` (data entries) | `BaseFactorCSVProvider` (factors, reference data) | `BaseReductionObjectiveCSVProvider` |
+|---|---|---|---|
+| Encoding | `utf-8-sig` (BOM tolerated) — `base_csv_provider.py:746` | plain `utf-8` (no BOM tolerance) — `base_factor_csv_provider.py:272` | `utf-8-sig` (BOM tolerated) — `base_reduction_objective_csv_provider.py:279` |
+| Header-validation error wrapping | `Wrong CSV format or encoding: <message>` (`base_csv_provider.py:768`) | bare `ValueError` (`base_factor_csv_provider.py::_validate_csv_headers`) | bare `ValueError` (`base_reduction_objective_csv_provider.py::_validate_csv_headers`) |
 
 ## Module-per-year CSV (data entries)
 
@@ -58,7 +70,7 @@ the `csv.DictReader` calls in each provider):
 ### Required and expected columns
 
 The only column required by the provider for every row is
-`unit_institutional_id` (`module_per_year.py:109`). Remaining columns are
+`unit_institutional_id` (`module_per_year.py:111`). Remaining columns are
 derived from the active `BaseModuleHandler` subclasses' `create_dto.model_fields`
 (see `_get_expected_columns_from_handlers` in `base_csv_provider.py:79`).
 
@@ -71,7 +83,7 @@ derived from the active `BaseModuleHandler` subclasses' `create_dto.model_fields
 For the headcount-member handler the columns are
 `unit_institutional_id, name, position_title, position_category,
 user_institutional_id, fte, note` (verified against
-`tests/integration/data_ingestion/fixtures/valid_module_per_year.csv`).
+`backend/tests/integration/data_ingestion/fixtures/valid_module_per_year.csv`).
 
 ### Idempotency
 
@@ -119,9 +131,11 @@ standby_usage_hours_per_week, note` (verified against
 
 ### Idempotency
 
-**Append-only.** No prior rows are deleted (verified at
-`base_csv_provider.py:478` and confirmed in
-`docs/implementation-plans/220-csv-upload-implementation-summary.md`).
+**Append-only.** No prior rows are deleted: the deletion call is gated by an
+`if self.entity_type == EntityType.MODULE_PER_YEAR` guard
+(`base_csv_provider.py:568`), so `MODULE_UNIT_SPECIFIC` never enters the
+`_delete_existing_entries_for_module_per_year` branch. Confirmed in
+`docs/implementation-plans/220-csv-upload-implementation-summary.md`.
 
 ### Example
 
@@ -148,7 +162,7 @@ columns for a given factor type, read its `*FactorCreate` class in
 `backend/app/modules/<module>/schemas.py`.
 
 Example — `TravelPlaneFactorHandler` (verified at
-`backend/app/modules/professional_travel/schemas.py:407`):
+`backend/app/modules/professional_travel/schemas.py:412`):
 
 | Column | Type | Required | Description |
 |---|---|---|---|
@@ -162,8 +176,14 @@ Example — `TravelPlaneFactorHandler` (verified at
 ### Idempotency
 
 Delete-then-insert by `(data_entry_type_id, year)`
-(`base_factor_csv_provider.py:189-205`). All existing factor rows for that
-combination are removed before the new batch is inserted.
+(`base_factor_csv_provider.py:173-191`). All existing factor rows for that
+combination are removed via `factor_service.bulk_delete_by_data_entry_type`
+before the new batch is inserted via `factor_service.bulk_create`. The set of
+types deleted is computed by `_get_types_to_delete`
+(`base_factor_csv_provider.py:572-582`); subclasses (notably
+`LocalFactorCSVProvider` in `csv_providers/local_seed.py`) override that hook
+to scope deletion to specific data-entry types when a single CSV covers only
+part of a module's types.
 
 ### Example
 
@@ -182,7 +202,7 @@ long_haul,0.151,2.0,1.4,3500,20000
 - **Target entity:** `year_configuration.config.reduction_objectives.<key>`
   (single JSON blob per category, not row-per-row).
 - **Selector:** `reduction_objective_type_id` in the upload config picks one of
-  three sub-formats (`backend/app/schemas/year_configuration.py:114`).
+  three sub-formats (`backend/app/schemas/year_configuration.py:119`).
 
 ### Sub-formats
 
@@ -192,7 +212,7 @@ long_haul,0.151,2.0,1.4,3500,20000
 | `1` (POPULATION) | `population_projections` | `year, pop` |
 | `2` (SCENARIOS) | `unit_scenarios` | `scenario, year, reduction_percentage` |
 
-Validation rules (`schemas/year_configuration.py:43-89`):
+Validation rules (`backend/app/schemas/year_configuration.py:43-94`):
 
 - `co2 >= 0`, `pop >= 0`, `0.0 <= reduction_percentage <= 1.0`.
 


### PR DESCRIPTION
## Summary

- Add `docs/src/backend/csv-seed-formats.md`: a from-code reference for the five CSV providers in `backend/app/services/data_ingestion/csv_providers/` (module-per-year, module-unit-specific, factors, reduction-objectives, reference-data).
- Cover encoding, delimiter, header expectations, idempotency rules, column tables, validation rules, and one verified worked example per format.
- Wire the page into the Backend nav in `docs/mkdocs.yml`.

## Context

This is the A3-redo of issue #860. The original A3 unit stopped because the source `backend/seed_data/CSV_FORMATS.md` does not exist on `main`. This PR writes the documentation directly from the provider source code and the integration-test fixtures (the canonical ground truth), citing line numbers and avoiding fabrication. Reference Data is honestly flagged as TBD because its provider returns an empty setup today.

## Test plan

- [x] `mkdocs build --strict` exits 0 (verified locally with full plugin set: mkdocs-material, git-authors, git-revision-date-localized, minify, pymdown-extensions). No new warnings introduced by this page.
- [x] Every column claim cross-checked against the relevant provider / handler / fixture (line numbers cited inline in the doc).
- [x] Cross-link to `../database/erd.md` resolves under `--strict`.