### PR TITLE
docs(#860): point agent rules at docs/src/implementation-plans/

### DIFF
--- a/.github/instructions/branch-completion.agent.md
+++ b/.github/instructions/branch-completion.agent.md
@@ -72,7 +72,7 @@ git diff backup-<branch-name> --stat
 git diff backup-<branch-name>
 
 # Find implementation plans
-find docs/implementation-plans -name "<issue-number>-*.md" -type f
+find docs/src/implementation-plans -name "<issue-number>-*.md" -type f
 ```
 
 Read implementation plans to understand:

--- a/.github/instructions/branch-completion.prompt.md
+++ b/.github/instructions/branch-completion.prompt.md
@@ -102,10 +102,12 @@ git diff backup-<branch-name>
 
 ```bash
 # Search for implementation plan with matching issue number
-find docs/implementation-plans -name "<issue-number>-*.md" -type f
+find docs/src/implementation-plans -name "<issue-number>-*.md" -type f
 ```
 
-**Example**: For branch `feat/243-backoffice-data-management`, search for `docs/implementation-plans/243-*.md`
+**Example**: For branch `feat/243-backoffice-data-management`, search for `docs/src/implementation-plans/243-*.md`
+
+> **Note (2026-05-05):** Plans moved from `docs/implementation-plans/` to `docs/src/implementation-plans/` so they sit inside MkDocs' `docs_dir` and can be navigated from the docs site.
 
 **Read the implementation plan** to extract:
 


### PR DESCRIPTION
## Summary

- Update `find docs/implementation-plans` invocations in `branch-completion.agent.md` and `branch-completion.prompt.md` to `docs/src/implementation-plans`, so future agents look in the location B4 (PR #1014) is moving plans into.
- Update the example path in `branch-completion.prompt.md` from `docs/implementation-plans/243-*.md` to `docs/src/implementation-plans/243-*.md`.
- Add a dated note in `branch-completion.prompt.md` recording the move from `docs/implementation-plans/` to `docs/src/implementation-plans/` (inside MkDocs `docs_dir`).

Pure text edits to instruction files; independent of B4's branch landing.

## Test plan

- [x] `grep -rn 'docs/implementation-plans' --include='*.md' --include='*.instructions.md' --include='AGENTS.md' --include='CLAUDE.md' --include='*.txt' | grep -v 'docs/src/implementation-plans' | grep -v '.github/workflows'` returns no rows.
- [x] Spot-checked both touched files; surrounding context preserved.

Relates-to #860