### PR TITLE
refactor(#310d): single-pass partition in upsert_factors

### DIFF
--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -102,8 +102,13 @@ class FactorRepository:
         if not factors:
             return 0
 
-        with_year = [f for f in factors if f.year is not None]
-        no_year = [f for f in factors if f.year is None]
+        with_year: List[Factor] = []
+        no_year: List[Factor] = []
+        for f in factors:
+            if f.year is not None:
+                with_year.append(f)
+            else:
+                no_year.append(f)
 
         affected = 0
         if with_year:


### PR DESCRIPTION
## Summary

- Replace two list comprehensions over `factors` (one filtering `year is not None`, one filtering `year is None`) with a single `for` loop that appends to pre-allocated `with_year` / `no_year` lists.
- One iteration over the input instead of two. Behavior identical — same partitions, same order, same downstream `_upsert_subset` calls.
- Pure refactor, no API or schema change.

This is Unit 4 of Plan 310-D (`docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`, "Two-pass partition in `FactorRepository.upsert_factors`" section).

## Test plan

- [x] `uv run pytest tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py -v` — 9/9 pass (covers `upsert_factors` insert + update + JSONB key-order paths)
- [x] `uv run pytest tests/unit/` — 1204/1204 pass
- [x] `uv run ruff check app/ tests/` — clean
- [x] No new tests required: existing 310-B integration tests exercise both partitions.