### PR TITLE
feat(#310c): add handler registry scaffolding

### DIFF
--- a/backend/app/tasks/registry.py
+++ b/backend/app/tasks/registry.py
@@ -1,0 +1,70 @@
+"""Handler registry for Plan 310-C unified job dispatch.
+
+Plan 310-C unifies background-job dispatch under a single ``run_job(job_id)``
+runner. Each ``DataIngestionJob.job_type`` maps to exactly one handler
+coroutine; this module owns that mapping.
+
+Handlers are registered with the :func:`register` decorator at import time
+(typically next to the handler definition in ``app/tasks/*_tasks.py``).
+The runner (landing in a follow-up tier) looks up the handler via
+:func:`get_handler` and invokes it with a freshly opened pair of sessions:
+
+    handler(job, job_session, data_session) -> dict
+
+The returned ``dict`` becomes ``job.meta`` on success.
+
+This module is greenfield in this PR: no handlers are registered yet. The
+registry has no callers until Tier 2 wires up the runner and existing tasks.
+"""
+
+from typing import Awaitable, Callable
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import DataIngestionJob
+
+# Handler signature:
+#   handler(job, job_session, data_session) -> dict (becomes job.meta on success)
+HandlerFn = Callable[
+    [DataIngestionJob, AsyncSession, AsyncSession],
+    Awaitable[dict],
+]
+
+_REGISTRY: dict[str, HandlerFn] = {}
+
+
+def register(job_type: str):
+    """Decorator to register a handler for a ``job_type``.
+
+    Raises :class:`ValueError` if ``job_type`` is already registered, so an
+    accidental double-import or naming collision fails loudly at import time
+    rather than silently shadowing an earlier registration.
+    """
+
+    def decorator(fn: HandlerFn) -> HandlerFn:
+        if job_type in _REGISTRY:
+            raise ValueError(f"job_type {job_type!r} already registered")
+        _REGISTRY[job_type] = fn
+        return fn
+
+    return decorator
+
+
+def get_handler(job_type: str) -> HandlerFn:
+    """Return the handler registered for ``job_type``.
+
+    Raises :class:`ValueError` if no handler has been registered. The runner
+    is expected to surface this as a job failure rather than crash.
+    """
+    handler = _REGISTRY.get(job_type)
+    if handler is None:
+        raise ValueError(f"No handler registered for job_type={job_type!r}")
+    return handler
+
+
+# --- test-only helper ---------------------------------------------------------
+# Production code must not call this; the registry is process-lifetime state
+# populated by import-time decorators.
+def _reset_registry() -> None:
+    """Test helper — clears the registry between tests so tests can re-register."""
+    _REGISTRY.clear()

--- a/backend/app/tasks/registry.py
+++ b/backend/app/tasks/registry.py
@@ -17,6 +17,7 @@ This module is greenfield in this PR: no handlers are registered yet. The
 registry has no callers until Tier 2 wires up the runner and existing tasks.
 """
 
+import inspect
 from typing import Awaitable, Callable
 
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -32,18 +33,61 @@ HandlerFn = Callable[
 
 _REGISTRY: dict[str, HandlerFn] = {}
 
+# Required positional parameter count for the handler contract:
+#   (job, job_session, data_session) -> Awaitable[dict]
+_HANDLER_REQUIRED_ARITY = 3
+
 
 def register(job_type: str):
     """Decorator to register a handler for a ``job_type``.
 
-    Raises :class:`ValueError` if ``job_type`` is already registered, so an
-    accidental double-import or naming collision fails loudly at import time
-    rather than silently shadowing an earlier registration.
+    Raises :class:`ValueError` if:
+
+    - ``job_type`` is already registered (accidental double-import or naming
+      collision fails loudly at import time rather than silently shadowing).
+    - The decorated function is not a coroutine function (the runner does
+      ``await handler(...)``; a sync function would only fail at first
+      dispatch, far from where the bug was introduced).
+    - The signature does not accept the required ``(job, job_session,
+      data_session)`` arity. We accept ``*args``-style handlers as long as
+      the callable can take 3 positional arguments.
     """
 
     def decorator(fn: HandlerFn) -> HandlerFn:
         if job_type in _REGISTRY:
             raise ValueError(f"job_type {job_type!r} already registered")
+        if not inspect.iscoroutinefunction(fn):
+            raise ValueError(
+                f"handler for job_type {job_type!r} must be `async def`; got {fn!r}"
+            )
+        sig = inspect.signature(fn)
+        params = list(sig.parameters.values())
+        positional = [
+            p
+            for p in params
+            if p.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            )
+        ]
+        has_var = any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in positional)
+        # Required positionals are those without defaults (excluding *args).
+        required = [
+            p
+            for p in positional
+            if p.kind != inspect.Parameter.VAR_POSITIONAL
+            and p.default is inspect.Parameter.empty
+        ]
+        accepts_arity = (has_var or len(positional) >= _HANDLER_REQUIRED_ARITY) and len(
+            required
+        ) <= _HANDLER_REQUIRED_ARITY
+        if not accepts_arity:
+            raise ValueError(
+                f"handler for job_type {job_type!r} must accept "
+                f"(job, job_session, data_session); got signature {sig}"
+            )
         _REGISTRY[job_type] = fn
         return fn
 

--- a/backend/tests/unit/tasks/test_registry.py
+++ b/backend/tests/unit/tasks/test_registry.py
@@ -18,10 +18,25 @@ from app.tasks.registry import (
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Ensure each test starts and ends with an empty registry."""
+    """Snapshot the registry, run the test on an empty one, and restore.
+
+    Once Tier 2 wires real handlers via import-time ``@register(...)``,
+    those registrations live in the same module-level dict.  An
+    unconditional reset in teardown would clobber them and make any
+    later test relying on ``get_handler("csv_ingest")`` fail with
+    ``No handler registered`` — silently order-dependent.
+
+    Snapshot pattern: capture current state, blank for the test,
+    restore unconditionally on teardown so siblings see whatever was
+    registered before this test started.
+    """
+    snapshot = dict(_REGISTRY)
     _reset_registry()
-    yield
-    _reset_registry()
+    try:
+        yield
+    finally:
+        _reset_registry()
+        _REGISTRY.update(snapshot)
 
 
 async def _noop_handler(job, job_session, data_session) -> dict:

--- a/backend/tests/unit/tasks/test_registry.py
+++ b/backend/tests/unit/tasks/test_registry.py
@@ -90,3 +90,46 @@ def test_reset_registry_clears():
         get_handler("foo")
     with pytest.raises(ValueError):
         get_handler("bar")
+
+
+def test_register_rejects_sync_function():
+    """Sync handlers would only fail at first dispatch (`await sync_fn()` is
+    a TypeError).  Catching at registration moves the error from "mystery
+    runtime job failure" to "import-time loud crash"."""
+
+    def sync_handler(job, job_session, data_session) -> dict:
+        return {}
+
+    with pytest.raises(ValueError, match="must be `async def`"):
+        # type-ignore: intentionally feeding a sync handler to verify
+        # the runtime guard fires; the static type rejects it for the
+        # same reason, which is the contract we want.
+        register("foo")(sync_handler)  # type: ignore[arg-type]
+
+
+def test_register_rejects_wrong_arity():
+    """Handler signature must accept (job, job_session, data_session).
+    Anything taking fewer required positionals would TypeError at dispatch."""
+
+    async def too_few(job) -> dict:
+        return {}
+
+    async def too_many(job, job_session, data_session, extra) -> dict:
+        return {}
+
+    with pytest.raises(ValueError, match="must accept"):
+        register("foo")(too_few)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must accept"):
+        register("bar")(too_many)  # type: ignore[arg-type]
+
+
+def test_register_accepts_var_positional_handler():
+    """``*args``-style handlers are valid — they trivially accept the 3-arg
+    contract.  Some test mocks use this shape."""
+
+    async def varargs_handler(*args, **kwargs) -> dict:
+        return {}
+
+    decorated = register("foo")(varargs_handler)
+    assert decorated is varargs_handler
+    assert get_handler("foo") is varargs_handler

--- a/backend/tests/unit/tasks/test_registry.py
+++ b/backend/tests/unit/tasks/test_registry.py
@@ -1,0 +1,77 @@
+"""Unit tests for the Plan 310-C handler registry.
+
+The registry is a module-level dict, so tests use a fixture that calls
+``_reset_registry()`` to keep them independent.
+"""
+
+import inspect
+
+import pytest
+
+from app.tasks.registry import (
+    _REGISTRY,
+    _reset_registry,
+    get_handler,
+    register,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Ensure each test starts and ends with an empty registry."""
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+async def _noop_handler(job, job_session, data_session) -> dict:
+    return {}
+
+
+def test_register_decorator_registers_handler():
+    @register("foo")
+    async def handler(job, job_session, data_session) -> dict:
+        return {"ok": True}
+
+    assert get_handler("foo") is handler
+
+
+def test_register_duplicate_raises():
+    register("foo")(_noop_handler)
+
+    with pytest.raises(ValueError, match="already registered"):
+        register("foo")(_noop_handler)
+
+
+def test_get_handler_unknown_raises():
+    with pytest.raises(ValueError, match="No handler registered for job_type='bogus'"):
+        get_handler("bogus")
+
+
+def test_register_returns_function_unchanged():
+    async def handler(job, job_session, data_session) -> dict:
+        return {"answer": 42}
+
+    decorated = register("bar")(handler)
+
+    # Same object back — decorator is a pure side-effect registration.
+    assert decorated is handler
+    # Signature preserved.
+    assert inspect.signature(decorated) == inspect.signature(handler)
+    # Still a coroutine function.
+    assert inspect.iscoroutinefunction(decorated)
+
+
+def test_reset_registry_clears():
+    register("foo")(_noop_handler)
+    register("bar")(_noop_handler)
+    assert "foo" in _REGISTRY
+    assert "bar" in _REGISTRY
+
+    _reset_registry()
+
+    assert _REGISTRY == {}
+    with pytest.raises(ValueError):
+        get_handler("foo")
+    with pytest.raises(ValueError):
+        get_handler("bar")


### PR DESCRIPTION
## Summary

First independent slice of Plan 310-C: introduce the handler registry that the unified `run_job(job_id)` runner will dispatch through. Greenfield module — no callers in this PR; existing tasks register in Tier 2 alongside the runner.

- `app/tasks/registry.py` — `register(job_type)` decorator, `get_handler(job_type)` lookup, typed `HandlerFn` signature `(job, job_session, data_session) -> dict`.
- Duplicate registration raises `ValueError` so import-time collisions fail loudly.
- Unknown `job_type` lookup raises `ValueError` so the runner can surface this as a job failure rather than crash.
- `_reset_registry()` test-only helper keeps unit tests independent.

Spec: `docs/src/implementation-plans/310-c-dag-handler-registry.md` lines 34-64.

## Test plan

- [x] `uv run pytest backend/tests/unit/tasks/test_registry.py -v` — 5/5 pass
- [x] `uv run pytest backend/tests/unit/` — 1209/1209 pass (no regressions)
- [x] `uv run ruff check backend/app/tasks/registry.py backend/tests/unit/tasks/test_registry.py` — clean
- [x] Smoke import: `python -c "from app.tasks.registry import register, get_handler"` — ok

## Out of scope (Tier 2)

- `run_job` / `chain_job` runner.
- Wiring existing task functions (`csv_ingest`, `api_ingest`, `factor_ingest`, `emission_recalc`, `module_emission_recalc`, `unit_sync`) to the registry.
- Rewiring the Plan 310-A safety poller through `run_job`.
