### PR TITLE
fix(#310c): gate /factors/stale on backoffice.data_management.view

### DIFF
--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
+from app.core.security import require_permission
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.user import User
 from app.repositories.factor_repo import FactorRepository
@@ -29,7 +30,9 @@ class StaleFactorResponse(BaseModel):
 async def list_stale_factors(
     year: int = Query(..., description="Report year to scope the query"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
 ) -> list[StaleFactorResponse]:
     """Return factors not present in the latest successful FACTORS ingest.
 
@@ -40,6 +43,8 @@ async def list_stale_factors(
     ``primary_factor_id`` (this is a JSON value, not a real FK column);
     this endpoint surfaces them so the UI can warn that linked data
     entries are using outdated factors.
+
+    **Required Permission**: ``backoffice.data_management.view``
     """
     rows = await FactorRepository(db).list_stale_for_year(year)
     responses: list[StaleFactorResponse] = []

--- a/backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py
@@ -148,6 +148,70 @@ async def test_get_stale_factors_returns_only_outdated_rows(pg_app):
 
 
 @pytest.mark.asyncio
+async def test_stale_endpoint_returns_403_for_user_without_permission(
+    pg_dsn, monkeypatch
+):
+    """Plan 310C Unit 2 — ``GET /v1/factors/stale`` is gated behind
+    ``backoffice.data_management.view``.  Users without that permission
+    get HTTP 403, not the stale-factor list.
+
+    This test deliberately bypasses ``pg_app`` (which monkeypatches
+    ``is_permitted`` to always return True) so the real permission
+    check fires.  We still need to override ``get_db`` and the
+    auth dependencies so the route reaches the permission gate."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _deny(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("app.core.security.is_permitted", _deny)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/v1/factors/stale", params={"year": 2025})
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_stale_endpoint_returns_200_for_permitted_user(pg_app):
+    """Plan 310C Unit 2 — happy path of the permission gate.  When
+    ``is_permitted`` returns True (via ``pg_app``'s monkeypatch), the
+    endpoint reaches the repository and returns the StaleFactorResponse
+    list shape — even when there's nothing to report."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/factors/stale", params={"year": 2025})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
 async def test_get_stale_factors_returns_empty_list_with_no_factor_jobs(pg_app):
     """No FACTORS jobs for the queried year → endpoint returns ``[]``,
     not an error and not the full factor table.  Confirms the empty-map


### PR DESCRIPTION
## Summary

Plan 310C Unit 2 — closes a privilege gap on `GET /v1/factors/stale`.

The endpoint was using `Depends(get_current_user)`, which let any
authenticated user read the operator-facing list of factors missing from
the latest CSV upload. This PR replaces it with
`Depends(require_permission("backoffice.data_management", "view"))`,
matching the gate already in place on the sibling `/sync/jobs/by-status`,
`/sync/jobs/year/{year}`, `/sync/jobs/year/{year}/latest`, and
`/sync/recalculation-status` endpoints in `app/api/v1/data_sync.py`.

The other endpoints in `factors.py` (`/{data_entry_type}/class-subclass-map`
and `/{data_entry_type_id}/classes/{kind}/values`) are out of scope for
this fix; they keep their existing `get_current_user` dependency.

## Changes

- `backend/app/api/v1/factors.py` — import `require_permission` from
  `app.core.security`, swap the `/stale` dependency, document the
  required permission in the route docstring.
- `backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py`
  — two new integration tests covering the gate end-to-end against
  Postgres:
  - `test_stale_endpoint_returns_403_for_user_without_permission`:
    deliberately bypasses `pg_app`'s blanket `is_permitted` monkeypatch
    so the real permission check fires and asserts HTTP 403.
  - `test_stale_endpoint_returns_200_for_permitted_user`: happy path
    via the existing fixture; confirms the gate doesn't block authorized
    users and the empty-list response shape is preserved.

## Test plan

- [x] `rtk uv run ruff check app/ tests/` — clean
- [x] `rtk uv run pytest tests/unit/` — 1204 passed
- [x] `rtk uv run pytest tests/integration/services/data_ingestion/` — 47
      passed (Docker-backed Postgres available locally; the new tests
      run on the existing `pg_dsn` fixture)
- [x] All 4 tests in `test_factors_stale_endpoint_pg.py` pass, including
      the two new permission-gate tests