### PR TITLE
chore(#310c): consolidate _install_plan_310b_indexes into shared fixture

### DIFF
--- a/backend/tests/integration/services/data_ingestion/conftest.py
+++ b/backend/tests/integration/services/data_ingestion/conftest.py
@@ -13,6 +13,7 @@ import docker
 import docker.errors
 import pytest
 import pytest_asyncio
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -122,3 +123,50 @@ async def pg_session(pg_dsn):
     async with factory() as session:
         yield session
     await engine.dispose()
+
+
+async def _install_plan_310b_indexes(engine) -> None:
+    """Create the partial unique indexes that Plan 310B's migration adds.
+
+    ``pg_dsn`` builds tables via ``SQLModel.metadata.create_all``, which
+    doesn't know about the migration's bare DDL.  Mirror it here so
+    ``ON CONFLICT`` inference can find the index it needs to bind to.
+    """
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
+                "ON factors (data_entry_type_id, year, emission_type_id, "
+                "(classification::text)) "
+                "WHERE year IS NOT NULL"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
+                "ON factors (data_entry_type_id, emission_type_id, "
+                "(classification::text)) "
+                "WHERE year IS NULL"
+            )
+        )
+
+
+@pytest_asyncio.fixture(scope="function")
+async def pg_dsn_with_310b(pg_dsn):
+    """``pg_dsn`` plus Plan 310B's migration-only partial unique indexes.
+
+    ``pg_dsn`` builds tables via ``SQLModel.metadata.create_all``, which
+    doesn't run Alembic and therefore never creates the
+    ``uq_factor_identity`` / ``uq_factor_identity_no_year`` partial unique
+    indexes that ``factor_repo.upsert_factors`` needs to bind its
+    ``ON CONFLICT`` clause.  Tests that exercise the upsert path (or any
+    code reachable from it) should depend on this fixture instead of the
+    bare ``pg_dsn`` so the production schema is mirrored without
+    copy-pasting the DDL into each test file.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    try:
+        await _install_plan_310b_indexes(engine)
+    finally:
+        await engine.dispose()
+    yield pg_dsn

--- a/backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import pytest_asyncio
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -42,35 +41,15 @@ from tests.integration.services.data_ingestion.test_plan_310b_factor_pipeline_pg
 )
 
 
-async def _install_indexes(engine) -> None:
-    """Mirror migration b1f0a2c3d4e5's partial unique indexes — pg_dsn's
-    SQLModel.metadata.create_all doesn't run Alembic, so the indexes
-    aren't created automatically and ``upsert_factors`` would fail
-    inferring its conflict target."""
-    async with engine.begin() as conn:
-        await conn.execute(
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
-                "ON factors (data_entry_type_id, year, emission_type_id, "
-                "(classification::text)) "
-                "WHERE year IS NOT NULL"
-            )
-        )
-        await conn.execute(
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
-                "ON factors (data_entry_type_id, emission_type_id, "
-                "(classification::text)) "
-                "WHERE year IS NULL"
-            )
-        )
-
-
 @pytest_asyncio.fixture
-async def pg_app(pg_dsn, monkeypatch):
-    """Wire the FastAPI app to the test Postgres + bypass auth."""
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_indexes(engine)
+async def pg_app(pg_dsn_with_310b, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth.
+
+    Depends on ``pg_dsn_with_310b`` (in conftest) so the Plan 310B
+    partial unique indexes are present — ``upsert_factors`` needs them
+    to bind ``ON CONFLICT``.
+    """
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async def override_get_db():

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py
@@ -9,14 +9,13 @@ These tests exercise behavior that SQLite cannot:
 
 Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
 
-The shared ``pg_dsn`` fixture builds the schema via
-``SQLModel.metadata.create_all`` and does **not** run Alembic migrations,
-so the Plan 310B partial unique indexes don't exist by default.  These
-tests create them inline to mirror the production schema.
+The shared ``pg_dsn_with_310b`` fixture (in ``conftest.py``) layers the
+Plan 310B migration's partial unique indexes on top of the
+``SQLModel.metadata.create_all`` schema produced by ``pg_dsn``, so the
+upsert path's ``ON CONFLICT`` inference has a target index to bind to.
 """
 
 import pytest
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -31,32 +30,6 @@ from app.models.data_ingestion import (
 from app.models.factor import Factor
 from app.models.user import UserProvider
 from app.repositories.factor_repo import FactorRepository
-
-
-async def _install_plan_310b_indexes(engine) -> None:
-    """Create the partial unique indexes that Plan 310B's migration adds.
-
-    ``pg_dsn`` builds tables via ``SQLModel.metadata.create_all``, which
-    doesn't know about the migration's bare DDL.  Mirror it here so
-    ``ON CONFLICT`` inference can find the index it needs to bind to.
-    """
-    async with engine.begin() as conn:
-        await conn.execute(
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
-                "ON factors (data_entry_type_id, year, emission_type_id, "
-                "(classification::text)) "
-                "WHERE year IS NOT NULL"
-            )
-        )
-        await conn.execute(
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
-                "ON factors (data_entry_type_id, emission_type_id, "
-                "(classification::text)) "
-                "WHERE year IS NULL"
-            )
-        )
 
 
 def _seed_factor_job() -> DataIngestionJob:
@@ -93,10 +66,9 @@ def _make_factor(
 
 
 @pytest.mark.asyncio
-async def test_upsert_factors_inserts_new_row_with_last_seen_job_id(pg_dsn):
+async def test_upsert_factors_inserts_new_row_with_last_seen_job_id(pg_dsn_with_310b):
     """First upsert: row gets a fresh id and last_seen_job_id stamped."""
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -135,11 +107,10 @@ async def test_upsert_factors_inserts_new_row_with_last_seen_job_id(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_upsert_factors_updates_existing_row_preserving_id(pg_dsn):
+async def test_upsert_factors_updates_existing_row_preserving_id(pg_dsn_with_310b):
     """Second upsert with same identity key: same id, values updated,
     last_seen_job_id refreshed."""
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -208,7 +179,7 @@ async def test_upsert_factors_updates_existing_row_preserving_id(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_upsert_factors_jsonb_key_order_resilience(pg_dsn):
+async def test_upsert_factors_jsonb_key_order_resilience(pg_dsn_with_310b):
     """Two upserts with the same classification keys in different
     insertion order resolve to one row (JSONB normalises key order).
 
@@ -217,8 +188,7 @@ async def test_upsert_factors_jsonb_key_order_resilience(pg_dsn):
     ``{"a":1,"b":2}`` and ``{"b":2,"a":1}`` and the partial unique index
     wouldn't trip.
     """
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -261,12 +231,11 @@ async def test_upsert_factors_jsonb_key_order_resilience(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_list_stale_for_year_returns_outdated_factors(pg_dsn):
+async def test_list_stale_for_year_returns_outdated_factors(pg_dsn_with_310b):
     """Factors whose ``last_seen_job_id`` predates the latest is_current
     successful FACTORS job for their (det, year) combo are returned;
     factors stamped with the latest job id are not."""
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -304,7 +273,7 @@ async def test_list_stale_for_year_returns_outdated_factors(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_list_stale_for_year_handles_multi_type_factors_job(pg_dsn):
+async def test_list_stale_for_year_handles_multi_type_factors_job(pg_dsn_with_310b):
     """Regression: multi-type FACTORS jobs (``data_entry_type_id`` NULL,
     ``module_type_id`` set — e.g. ``equipments_factors.csv`` covering
     ``it`` + ``scientific`` under ``equipment_electric_consumption``) must
@@ -319,8 +288,7 @@ async def test_list_stale_for_year_handles_multi_type_factors_job(pg_dsn):
     from app.models.data_entry import DataEntryTypeEnum
     from app.models.module_type import ModuleTypeEnum
 
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     module_id = ModuleTypeEnum.equipment_electric_consumption.value
@@ -391,14 +359,13 @@ async def test_list_stale_for_year_handles_multi_type_factors_job(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_list_stale_for_year_returns_empty_when_no_factor_job(pg_dsn):
+async def test_list_stale_for_year_returns_empty_when_no_factor_job(pg_dsn_with_310b):
     """No is_current FACTORS job for the requested year → return [] rather
     than treat every factor as stale.  Without this short-circuit, the
     endpoint would noisily flag every existing factor on a year that never
     had a CSV uploaded.
     """
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -425,15 +392,14 @@ async def test_list_stale_for_year_returns_empty_when_no_factor_job(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_latest_factor_job_per_det_skips_unknown_module(pg_dsn):
+async def test_latest_factor_job_per_det_skips_unknown_module(pg_dsn_with_310b):
     """A multi-type FACTORS job with a ``module_type_id`` that no longer
     maps to a ``ModuleTypeEnum`` value (legacy enum cleanup, hand-edited
     row, etc.) must be skipped silently rather than crash the stale
     detection.  Defensive: lets operators view stale factors even when
     one rogue job row would otherwise raise ValueError.
     """
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -467,13 +433,12 @@ async def test_latest_factor_job_per_det_skips_unknown_module(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_latest_factor_job_per_det_skips_both_nulls(pg_dsn):
+async def test_latest_factor_job_per_det_skips_both_nulls(pg_dsn_with_310b):
     """A FACTORS job with both ``module_type_id`` and ``data_entry_type_id``
     NULL has no meaningful scope — it covers no factors, so it shouldn't
     contribute to the stale-threshold map.
     """
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:
@@ -502,7 +467,7 @@ async def test_latest_factor_job_per_det_skips_both_nulls(pg_dsn):
 
 
 @pytest.mark.asyncio
-async def test_list_stale_filters_to_csv_ingestion_method(pg_dsn):
+async def test_list_stale_filters_to_csv_ingestion_method(pg_dsn_with_310b):
     """Plan 310B fix (Copilot follow-up): ``list_stale_for_year`` must
     only consider FACTORS jobs whose ``ingestion_method == csv``.
 
@@ -517,8 +482,7 @@ async def test_list_stale_filters_to_csv_ingestion_method(pg_dsn):
     by the CSV job is NOT reported as stale (because the computed job
     is filtered out of the threshold map).
     """
-    engine = create_async_engine(pg_dsn, future=True)
-    await _install_plan_310b_indexes(engine)
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as session:

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
@@ -66,7 +66,7 @@ POLL_INTERVAL_SECONDS = 0.1
 
 
 @pytest_asyncio.fixture
-async def pg_app(pg_dsn, monkeypatch, tmp_path):
+async def pg_app(pg_dsn_with_310b, monkeypatch, tmp_path):
     """Wire the FastAPI app to the test Postgres + bypass auth + redirect
     file storage to ``tmp_path``.
 
@@ -88,40 +88,21 @@ async def pg_app(pg_dsn, monkeypatch, tmp_path):
     handler side; the SessionLocal monkeypatches cover the background
     task side.  Without both, the background task would talk to the
     production DB while the request handler talks to the test DB.
+
+    Depends on ``pg_dsn_with_310b`` (in conftest) so the partial unique
+    indexes Plan 310B's migration adds are present — ``upsert_factors``
+    needs them to bind ``ON CONFLICT``.
     """
-    # The conftest's pg_dsn fixture returns a ``postgresql+asyncpg`` URL.
-    # asyncpg is strict about tz-aware vs tz-naive datetimes, which trips
-    # an unrelated latent issue in app.models.audit (``changed_at`` defaults
-    # to naive datetime.utcnow but audit_service writes tz-aware).  Production
-    # uses ``postgresql+psycopg`` which silently coerces.  Use the same
-    # driver here so the test isn't tripped by a model-side bug that's out
-    # of scope for #310B.
-    psycopg_dsn = pg_dsn.replace("+asyncpg", "+psycopg")
+    # ``pg_dsn_with_310b`` returns a ``postgresql+asyncpg`` URL.  asyncpg
+    # is strict about tz-aware vs tz-naive datetimes, which trips an
+    # unrelated latent issue in app.models.audit (``changed_at`` defaults
+    # to naive datetime.utcnow but audit_service writes tz-aware).
+    # Production uses ``postgresql+psycopg`` which silently coerces.  Use
+    # the same driver here so the test isn't tripped by a model-side bug
+    # that's out of scope for #310B.
+    psycopg_dsn = pg_dsn_with_310b.replace("+asyncpg", "+psycopg")
     test_engine = create_async_engine(psycopg_dsn, future=True)
     Sf = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
-
-    # The conftest's pg_dsn fixture runs ``SQLModel.metadata.create_all``
-    # which doesn't execute Alembic migrations.  ``factor_repo.upsert_factors``
-    # uses ``ON CONFLICT (..., (classification::text)) WHERE year IS NOT NULL``,
-    # which needs the partial unique indexes added by migration b1f0a2c3d4e5.
-    # Recreate them here so the upsert can land.
-    from sqlalchemy import text as sa_text
-
-    async with test_engine.begin() as conn:
-        await conn.execute(
-            sa_text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity "
-                "ON factors (data_entry_type_id, year, emission_type_id, "
-                "(classification::text)) WHERE year IS NOT NULL"
-            )
-        )
-        await conn.execute(
-            sa_text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_factor_identity_no_year "
-                "ON factors (data_entry_type_id, emission_type_id, "
-                "(classification::text)) WHERE year IS NULL"
-            )
-        )
 
     async def override_get_db():
         async with Sf() as session:
@@ -169,7 +150,7 @@ async def pg_app(pg_dsn, monkeypatch, tmp_path):
     monkeypatch.setattr("app.tasks.ingestion_tasks.SessionLocal", Sf)
     monkeypatch.setattr("app.tasks.emission_recalculation_tasks.SessionLocal", Sf)
 
-    yield {"factory": Sf, "dsn": pg_dsn, "tmp_path": tmp_path}
+    yield {"factory": Sf, "dsn": pg_dsn_with_310b, "tmp_path": tmp_path}
 
     app.dependency_overrides.clear()
     await test_engine.dispose()


### PR DESCRIPTION
## Summary

Folds the 9+ inline calls to \`_install_plan_310b_indexes\` into a single \`pg_dsn_with_310b\` fixture in \`tests/integration/services/data_ingestion/conftest.py\`.

Tests that need the partial unique indexes (which \`SQLModel.metadata.create_all\` does not generate because they are partial-WHERE) now request \`pg_dsn_with_310b\` instead of \`pg_dsn\` and skip the per-test DDL block.

Plan 310-C \"PG test fixture drift\" follow-up — see docs/implementation-plans/310-c-dag-handler-registry.md.

## Files

- \`backend/tests/integration/services/data_ingestion/conftest.py\` — adds \`pg_dsn_with_310b\` fixture + helper
- \`backend/tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py\` — uses fixture, drops inline DDL (-9 inline call sites)
- \`backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py\` — uses fixture
- \`backend/tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py\` — uses fixture
- (note: \`test_sync_units_endpoint_pg.py\` did not actually call the helper — verified, no change needed there)

Test-only refactor; no production code touched. Net: 92 insertions / 120 deletions.

## Test plan

- [x] \`rtk uv run ruff check tests/integration/services/data_ingestion/\` — clean
- [x] \`rtk uv run pytest tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py tests/integration/services/data_ingestion/test_factors_stale_endpoint_pg.py tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py tests/integration/services/data_ingestion/test_sync_units_endpoint_pg.py\` — 13 passed

## Notes

This PR is part of a Tier-1 batch landing the parallelizable surface of Plans 310-C/D. Sibling: #1019 (Unit 4), #1020 (Unit 6), #1021 (Unit 2). May need a trivial rebase against #1021 if both touch \`test_factors_stale_endpoint_pg.py\` at the same lines — should resolve cleanly since changes are line-disjoint (Unit 2 adds 403/200 tests; Unit 3 changes the fixture parameter name).