### PR TITLE
feat(#310c): add GET /sync/pipelines/{id} endpoint

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -103,15 +103,13 @@ class PipelineJobResponse(BaseModel):
     Plan 310C — surfaces the columns dashboards need to render the chain
     parent + fan-out children produced by ``_enqueue_stale_recalculations``.
 
-    TODO(310C Unit 1): once ``started_at`` / ``finished_at`` columns land
-    on ``data_ingestion_jobs`` (and a ``created_at`` if Unit 1 adds one),
-    extend this schema and the endpoint mapping below to return them so
-    the UI can show per-step durations.  Same for any other Unit-1-owned
-    timestamp columns — leaving them out here keeps this PR mergeable on
-    top of ``dev`` before Unit 1.
+    TODO(#1026): once ``started_at`` / ``finished_at`` columns land on
+    ``data_ingestion_jobs``, extend this schema and the endpoint mapping
+    below to return them so the UI can show per-step durations.  Leaving
+    them out here keeps this PR mergeable on top of ``dev`` before #1026.
     """
 
-    id: int
+    job_id: int
     job_type: Optional[str] = None
     state: Optional[IngestionState] = None
     result: Optional[IngestionResult] = None
@@ -667,7 +665,7 @@ async def get_pipeline_jobs(
         pipeline_id=pipeline_id,
         jobs=[
             PipelineJobResponse(
-                id=job.id,
+                job_id=job.id,
                 job_type=job.job_type,
                 state=job.state,
                 result=job.result,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -115,6 +115,7 @@ class PipelineJobResponse(BaseModel):
     job_type: Optional[str] = None
     state: Optional[IngestionState] = None
     result: Optional[IngestionResult] = None
+    target_type: Optional[TargetType] = None
     status_message: Optional[str] = None
     module_type_id: Optional[int] = None
     data_entry_type_id: Optional[int] = None
@@ -670,6 +671,7 @@ async def get_pipeline_jobs(
                 job_type=job.job_type,
                 state=job.state,
                 result=job.result,
+                target_type=job.target_type,
                 status_message=job.status_message,
                 module_type_id=job.module_type_id,
                 data_entry_type_id=job.data_entry_type_id,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from typing import Optional
+from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
@@ -94,6 +95,38 @@ class ModuleRecalculationStatus(BaseModel):
     year: int
     needs_recalculation: bool
     data_entry_types: list[RecalculationStatus]
+
+
+class PipelineJobResponse(BaseModel):
+    """Single ``DataIngestionJob`` row inside a multi-step pipeline run.
+
+    Plan 310C — surfaces the columns dashboards need to render the chain
+    parent + fan-out children produced by ``_enqueue_stale_recalculations``.
+
+    TODO(310C Unit 1): once ``started_at`` / ``finished_at`` columns land
+    on ``data_ingestion_jobs`` (and a ``created_at`` if Unit 1 adds one),
+    extend this schema and the endpoint mapping below to return them so
+    the UI can show per-step durations.  Same for any other Unit-1-owned
+    timestamp columns — leaving them out here keeps this PR mergeable on
+    top of ``dev`` before Unit 1.
+    """
+
+    id: int
+    job_type: Optional[str] = None
+    state: Optional[IngestionState] = None
+    result: Optional[IngestionResult] = None
+    status_message: Optional[str] = None
+    module_type_id: Optional[int] = None
+    data_entry_type_id: Optional[int] = None
+    year: Optional[int] = None
+
+
+class PipelineResponse(BaseModel):
+    """Wrapper for ``GET /sync/pipelines/{pipeline_id}`` — pipeline UUID
+    plus the ordered job list (parent first, then fan-out children)."""
+
+    pipeline_id: UUID
+    jobs: list[PipelineJobResponse]
 
 
 @router.post("/dispatch", response_model=SyncStatusResponse)
@@ -599,6 +632,53 @@ async def get_recalculation_status(
         )
         for module_id, dets in modules.items()
     ]
+
+
+@router.get("/pipelines/{pipeline_id}", response_model=PipelineResponse)
+async def get_pipeline_jobs(
+    pipeline_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
+) -> PipelineResponse:
+    """Return every job in a multi-step pipeline run, ordered by id.
+
+    **Required Permission**: ``backoffice.data_management.view``
+
+    Plan 310C — ``_enqueue_stale_recalculations`` (310B) stamps the same
+    ``pipeline_id`` on the parent FACTORS job and every fan-out
+    DATA_ENTRIES child it seeds.  The dashboard uses this endpoint to
+    render the whole chain, not just the parent.
+
+    Returns 404 when no jobs share the given ``pipeline_id`` — matches
+    the convention of other lookup endpoints in this module
+    (``cancel_job``, ``recover_job``).
+    """
+    jobs = await DataIngestionRepository(db).list_jobs_by_pipeline_id(pipeline_id)
+    if not jobs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No jobs found for pipeline_id {pipeline_id}",
+        )
+
+    return PipelineResponse(
+        pipeline_id=pipeline_id,
+        jobs=[
+            PipelineJobResponse(
+                id=job.id,
+                job_type=job.job_type,
+                state=job.state,
+                result=job.result,
+                status_message=job.status_message,
+                module_type_id=job.module_type_id,
+                data_entry_type_id=job.data_entry_type_id,
+                year=job.year,
+            )
+            for job in jobs
+            if job.id is not None
+        ],
+    )
 
 
 @router.post(

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -1,6 +1,7 @@
 import enum
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, TypedDict
+from uuid import UUID
 
 from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
@@ -124,6 +125,23 @@ class DataIngestionRepository:
     async def get_jobs_by_year(self, year: int) -> List[DataIngestionJob]:
         stmt = select(DataIngestionJob).where(DataIngestionJob.year == year)
         stmt = stmt.order_by(col(DataIngestionJob.id).desc())
+        exec_result = await self.session.execute(stmt)
+        return list(exec_result.scalars().all())
+
+    async def list_jobs_by_pipeline_id(
+        self, pipeline_id: UUID
+    ) -> List[DataIngestionJob]:
+        """Return every job that shares the given ``pipeline_id``.
+
+        Plan 310C — backs the ``GET /sync/pipelines/{pipeline_id}`` endpoint
+        so dashboards can render the whole multi-step run (parent + fan-out
+        children seeded by ``_enqueue_stale_recalculations``) in id order.
+        """
+        stmt = (
+            select(DataIngestionJob)
+            .where(DataIngestionJob.pipeline_id == pipeline_id)
+            .order_by(col(DataIngestionJob.id).asc())
+        )
         exec_result = await self.session.execute(stmt)
         return list(exec_result.scalars().all())
 

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
@@ -155,8 +155,7 @@ async def test_get_pipeline_returns_ordered_jobs(pg_app):
     jobs = body["jobs"]
     assert isinstance(jobs, list)
     assert [j["id"] for j in jobs] == expected_order, (
-        f"Expected ASC-id ordering {expected_order}, got "
-        f"{[j['id'] for j in jobs]!r}"
+        f"Expected ASC-id ordering {expected_order}, got {[j['id'] for j in jobs]!r}"
     )
 
     # Verify the parent shape — proves enum and Optional columns serialise.

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
@@ -154,8 +154,9 @@ async def test_get_pipeline_returns_ordered_jobs(pg_app):
     assert body["pipeline_id"] == str(pipeline_id)
     jobs = body["jobs"]
     assert isinstance(jobs, list)
-    assert [j["id"] for j in jobs] == expected_order, (
-        f"Expected ASC-id ordering {expected_order}, got {[j['id'] for j in jobs]!r}"
+    actual_ids = [j["job_id"] for j in jobs]
+    assert actual_ids == expected_order, (
+        f"Expected ASC-id ordering {expected_order}, got {actual_ids!r}"
     )
 
     # Verify the parent shape — proves enum and Optional columns serialise.

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
@@ -1,0 +1,270 @@
+"""Integration test for ``GET /v1/sync/pipelines/{pipeline_id}`` against PG.
+
+Plan 310C — surfaces every job in a multi-step pipeline (parent FACTORS
+job + the fan-out DATA_ENTRIES recalc children seeded by 310B's
+``_enqueue_stale_recalculations``) so the dashboard can render the chain.
+
+Why a real Postgres (not SQLite):
+
+- ``DataIngestionJob.pipeline_id`` is a native ``UUID`` column.  SQLite
+  doesn't enforce UUID typing — testing against PG verifies the round-trip
+  through asyncpg, the column type, and the FastAPI ``UUID`` path-param
+  parse all line up.
+- The endpoint exposes enum columns (``state``, ``result``,
+  ``target_type``).  The PG enum types must round-trip through the
+  response_model serialisation; SQLite stores them as plain strings and
+  hides any mismatch.
+
+Mirrors the auth / dependency-override pattern in
+``test_factors_stale_endpoint_pg.py`` (the canonical 310-series example).
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth.
+
+    ``is_permitted`` is monkeypatched to always-True so tests reach the
+    endpoint body.  The 403 test below deliberately bypasses this fixture
+    to exercise the real permission gate.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+
+    yield {"factory": Sf}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+def _make_parent_factor_job(pipeline_id) -> DataIngestionJob:
+    """FACTORS / FINISHED / SUCCESS — the chain head."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=1,
+        data_entry_type_id=1,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+        pipeline_id=pipeline_id,
+        job_type="factor_ingest",
+    )
+
+
+def _make_child_data_entries_job(
+    pipeline_id, *, data_entry_type_id: int
+) -> DataIngestionJob:
+    """DATA_ENTRIES recalc child — fan-out from the parent."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=1,
+        data_entry_type_id=data_entry_type_id,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+        pipeline_id=pipeline_id,
+        job_type="data_entry_recalc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_returns_ordered_jobs(pg_app):
+    """End-to-end: seed a parent + 2 children sharing a pipeline_id and
+    verify the endpoint returns all 3 jobs ordered by id ASC, with the
+    enum columns serialised to their integer values."""
+    Sf = pg_app["factory"]
+    pipeline_id = uuid4()
+
+    async with Sf() as session:
+        parent = _make_parent_factor_job(pipeline_id)
+        child_a = _make_child_data_entries_job(pipeline_id, data_entry_type_id=2)
+        child_b = _make_child_data_entries_job(pipeline_id, data_entry_type_id=3)
+        # Insert sequentially so ids are deterministic (parent first).
+        session.add(parent)
+        await session.flush()
+        session.add(child_a)
+        await session.flush()
+        session.add(child_b)
+        await session.commit()
+        assert parent.id is not None
+        assert child_a.id is not None
+        assert child_b.id is not None
+        expected_order = [parent.id, child_a.id, child_b.id]
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(f"/v1/sync/pipelines/{pipeline_id}")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pipeline_id"] == str(pipeline_id)
+    jobs = body["jobs"]
+    assert isinstance(jobs, list)
+    assert [j["id"] for j in jobs] == expected_order, (
+        f"Expected ASC-id ordering {expected_order}, got "
+        f"{[j['id'] for j in jobs]!r}"
+    )
+
+    # Verify the parent shape — proves enum and Optional columns serialise.
+    parent_row = jobs[0]
+    assert parent_row["job_type"] == "factor_ingest"
+    assert parent_row["state"] == IngestionState.FINISHED.value
+    assert parent_row["result"] == IngestionResult.SUCCESS.value
+    assert parent_row["module_type_id"] == 1
+    assert parent_row["data_entry_type_id"] == 1
+    assert parent_row["year"] == 2025
+
+    # And one child — different job_type, different data_entry_type_id.
+    child_row = jobs[1]
+    assert child_row["job_type"] == "data_entry_recalc"
+    assert child_row["data_entry_type_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_does_not_leak_jobs_from_other_pipelines(pg_app):
+    """Filtering bug regression — two unrelated pipelines should not
+    cross-contaminate.  Catches a ``SELECT *`` that forgot the WHERE
+    clause."""
+    Sf = pg_app["factory"]
+    target_pipeline = uuid4()
+    other_pipeline = uuid4()
+
+    async with Sf() as session:
+        ours = _make_parent_factor_job(target_pipeline)
+        theirs = _make_parent_factor_job(other_pipeline)
+        # Different combo so the partial unique is_current index doesn't trip.
+        theirs.module_type_id = 2
+        theirs.data_entry_type_id = 2
+        session.add_all([ours, theirs])
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(f"/v1/sync/pipelines/{target_pipeline}")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["jobs"]) == 1
+    assert body["jobs"][0]["module_type_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_unknown_uuid_returns_404(pg_app):
+    """No rows for the given pipeline_id → 404.  Matches the
+    ``cancel_job`` / ``recover_job`` not-found convention in this module
+    so the frontend can distinguish 'pipeline does not exist' from
+    'pipeline exists but is empty' (which is impossible by construction —
+    310B always seeds the parent)."""
+    unknown_pipeline = uuid4()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(f"/v1/sync/pipelines/{unknown_pipeline}")
+
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_returns_403_for_user_without_permission(
+    pg_dsn, monkeypatch
+):
+    """``GET /v1/sync/pipelines/{id}`` is gated behind
+    ``backoffice.data_management.view``.  Users without that permission
+    get HTTP 403.
+
+    Deliberately bypasses ``pg_app`` (which monkeypatches ``is_permitted``
+    to always-True) so the real permission check fires.  We still need to
+    override ``get_db`` and the auth dependencies so the route reaches the
+    permission gate."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _deny(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("app.core.security.is_permitted", _deny)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get(f"/v1/sync/pipelines/{uuid4()}")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+    assert resp.status_code == 403, resp.text

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
@@ -164,14 +164,17 @@ async def test_get_pipeline_returns_ordered_jobs(pg_app):
     assert parent_row["job_type"] == "factor_ingest"
     assert parent_row["state"] == IngestionState.FINISHED.value
     assert parent_row["result"] == IngestionResult.SUCCESS.value
+    assert parent_row["target_type"] == TargetType.FACTORS.value
     assert parent_row["module_type_id"] == 1
     assert parent_row["data_entry_type_id"] == 1
     assert parent_row["year"] == 2025
 
-    # And one child — different job_type, different data_entry_type_id.
+    # And one child — different job_type, different data_entry_type_id,
+    # different target_type (DATA_ENTRIES rather than parent's FACTORS).
     child_row = jobs[1]
     assert child_row["job_type"] == "data_entry_recalc"
     assert child_row["data_entry_type_id"] == 2
+    assert child_row["target_type"] == TargetType.DATA_ENTRIES.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Plan 310C Unit 7 — adds `GET /v1/sync/pipelines/{pipeline_id}` so the backoffice dashboard can render the full multi-step run (parent FACTORS job + fan-out DATA_ENTRIES recalc children seeded by 310B's `_enqueue_stale_recalculations`), not just the parent.

- `DataIngestionRepository.list_jobs_by_pipeline_id` — single `SELECT … ORDER BY id ASC` (parent first, then children).
- `GET /v1/sync/pipelines/{pipeline_id}` — gated on `backoffice.data_management.view` to match the other read-only sync endpoints (`get_jobs_by_year`, `get_recalculation_status`). Returns 404 when no jobs share the UUID, mirroring the `cancel_job` / `recover_job` not-found convention so the frontend can distinguish "pipeline does not exist" from any other empty state.
- `PipelineJobResponse` / `PipelineResponse` pydantic schemas — `id`, `job_type`, `state`, `result`, `status_message`, `module_type_id`, `data_entry_type_id`, `year`.

`started_at` / `finished_at` are intentionally omitted from the response shape — Unit 1 (a sibling worker) is adding those columns to `data_ingestion_jobs`, and a follow-up will extend `PipelineJobResponse` after both PRs merge. A `TODO` comment on the schema flags this.

## Test plan

- [x] `uv run pytest tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py -v` — 4 tests pass (ordered list, cross-pipeline isolation, 404 unknown UUID, 403 unprivileged user) against Docker-backed Postgres
- [x] `uv run pytest tests/unit/` — 1204 passed, no regressions
- [x] `uv run ruff check app/ tests/` — clean

Docker required for the new integration test. The pattern mirrors `test_factors_stale_endpoint_pg.py`.