### PR TITLE
feat(#310c): add started_at/finished_at observability columns

### DIFF
--- a/backend/alembic/versions/2026_05_05_1000-d3e5f7a9b1c4_add_started_finished_at.py
+++ b/backend/alembic/versions/2026_05_05_1000-d3e5f7a9b1c4_add_started_finished_at.py
@@ -2,7 +2,7 @@
 """add started_at / finished_at to data_ingestion_jobs
 
 Revision ID: d3e5f7a9b1c4
-Revises: c2d4e6f8a012, 3f8147b5e516
+Revises: 3f8147b5e516
 Create Date: 2026-05-05 10:00:00.000000
 
 Plan 310-C observability columns.  Adds two nullable timestamps that, with
@@ -21,11 +21,11 @@ Both columns are nullable to avoid a backfill — pre-existing rows simply
 lack timing data, which the dashboard query (see plan 310-c) treats as
 "unknown" via ``WHERE finished_at IS NOT NULL`` filters.
 
-This migration also serves as a merge for the two pre-existing heads
-(``c2d4e6f8a012`` from the 310-B factor pipeline branch and
-``3f8147b5e516`` from the search-locations branch).  Carrying DDL on a
-merge is standard Alembic and avoids a no-op merge file ahead of this
-one.
+Chains off the single dev head ``3f8147b5e516`` (search-locations).
+Earlier drafts of this migration carried a multi-revision merge to
+bridge two pre-existing heads, but ``dev`` linearised its chain
+(``3f8147b5e516``'s parent is now ``c2d4e6f8a012``), so a single
+parent is correct.
 """
 
 from typing import Sequence, Union
@@ -43,10 +43,7 @@ __all__ = [
 
 
 revision: str = "d3e5f7a9b1c4"  # noqa: F841
-down_revision: Union[str, Sequence[str], None] = (  # noqa: F841
-    "c2d4e6f8a012",
-    "3f8147b5e516",
-)
+down_revision: Union[str, Sequence[str], None] = "3f8147b5e516"  # noqa: F841
 branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
 depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
 

--- a/backend/alembic/versions/2026_05_05_1000-d3e5f7a9b1c4_add_started_finished_at.py
+++ b/backend/alembic/versions/2026_05_05_1000-d3e5f7a9b1c4_add_started_finished_at.py
@@ -1,0 +1,69 @@
+# codeql[py/unused-global-variable]
+"""add started_at / finished_at to data_ingestion_jobs
+
+Revision ID: d3e5f7a9b1c4
+Revises: c2d4e6f8a012, 3f8147b5e516
+Create Date: 2026-05-05 10:00:00.000000
+
+Plan 310-C observability columns.  Adds two nullable timestamps that, with
+``locked_at`` (Plan 310-A), distinguish per-attempt timing from total
+wall-clock duration:
+
+- ``started_at`` is set ONCE on the first claim and stays put across
+  retries.  Used to compute ``finished_at - started_at`` as true total
+  duration regardless of how many attempts a job needed.
+- ``finished_at`` is set when the job reaches ``state=FINISHED``.
+
+``locked_at`` (already present) updates on every claim and is per-attempt;
+it answers "is this lock stale?" not "how long did the job take?".
+
+Both columns are nullable to avoid a backfill — pre-existing rows simply
+lack timing data, which the dashboard query (see plan 310-c) treats as
+"unknown" via ``WHERE finished_at IS NOT NULL`` filters.
+
+This migration also serves as a merge for the two pre-existing heads
+(``c2d4e6f8a012`` from the 310-B factor pipeline branch and
+``3f8147b5e516`` from the search-locations branch).  Carrying DDL on a
+merge is standard Alembic and avoids a no-op merge file ahead of this
+one.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "d3e5f7a9b1c4"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = (  # noqa: F841
+    "c2d4e6f8a012",
+    "3f8147b5e516",
+)
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "data_ingestion_jobs",
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "data_ingestion_jobs",
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("data_ingestion_jobs", "finished_at")
+    op.drop_column("data_ingestion_jobs", "started_at")

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -260,6 +260,22 @@ class DataIngestionJob(DataIngestionJobBase, table=True):
         description="Timestamp of the most recent successful claim",
     )
 
+    # Observability (Plan 310C)
+    started_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(SADateTime(timezone=True)),
+        description=(
+            "Timestamp of the FIRST successful claim — stays put across retries "
+            "(unlike locked_at, which updates every claim).  Combined with "
+            "finished_at gives true total wall-clock duration."
+        ),
+    )
+    finished_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(SADateTime(timezone=True)),
+        description="Timestamp the job reached state=FINISHED",
+    )
+
     # Retry scaffolding (Plan 310A)
     attempts: int = Field(
         default=0,

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -69,23 +69,20 @@ class DataIngestionRepository:
         completed_at: Optional[datetime] = None,
         state: Optional[IngestionState] = None,
         result: Optional[IngestionResult] = None,
-        finished_at: bool = False,
     ) -> Optional[DataIngestionJob]:
         """Update ingestion job with legacy status_code and new state/result.
 
         Args:
             job_id: Job ID to update
             status_message: Status message
-            status_code: Legacy status code (for backward compatibility)
             metadata: Metadata to merge
             completed_at: Optional completed timestamp written into ``meta``
                 (legacy JSON field; pre-dates the ``finished_at`` column).
-            state: New state value (optional, for new code)
+            state: New state value (optional, for new code).  When this
+                transitions the row to ``FINISHED`` and ``finished_at`` is
+                still NULL, the column is auto-stamped (idempotent — a
+                later update keeps the original timestamp).
             result: New result value (optional, for new code)
-            finished_at: When True, also stamp the top-level ``finished_at``
-                column with ``func.now()`` (Plan 310C observability).  Kept
-                opt-in so existing callers that drove only ``meta`` JSON
-                aren't forced to migrate in lockstep.
         """
         stmt = select(DataIngestionJob).where(DataIngestionJob.id == job_id)
         exec_result = await self.session.execute(stmt)
@@ -101,10 +98,11 @@ class DataIngestionRepository:
                 result_job.state = state
             if result is not None:
                 result_job.result = result
-            if finished_at:
-                # ORM-level assignment of a SQL function expression so the
-                # value is rendered server-side (matches set_started_at and
-                # claim_job's locked_at).
+            if state == IngestionState.FINISHED and result_job.finished_at is None:
+                # Auto-stamp on the FIRST transition to FINISHED.  IS NULL
+                # guard makes it idempotent — re-running update on an
+                # already-FINISHED row leaves the original timestamp intact.
+                # Server-side ``func.now()`` matches claim_job's locked_at.
                 result_job.finished_at = func.now()
 
             merged_meta = {
@@ -259,6 +257,15 @@ class DataIngestionRepository:
                     .values(
                         locked_by=pod_id,
                         locked_at=func.now(),
+                        # Stamp ``started_at`` atomically with the RUNNING
+                        # transition so a crash between this commit and the
+                        # runner doing work cannot leave the column NULL.
+                        # ``coalesce`` preserves the original timestamp on
+                        # retry-claim — ``finished_at - started_at`` then
+                        # measures total wall-clock duration across retries.
+                        started_at=func.coalesce(
+                            col(DataIngestionJob.started_at), func.now()
+                        ),
                         state=IngestionState.RUNNING,
                         is_current=True,
                         attempts=col(DataIngestionJob.attempts) + 1,
@@ -350,6 +357,9 @@ class DataIngestionRepository:
             .values(
                 state=IngestionState.FINISHED,
                 result=IngestionResult.ERROR,
+                # Terminal transition — stamp finished_at so the dashboard
+                # query sees auto-abandoned rows alongside normal completions.
+                finished_at=func.now(),
                 status_message=(
                     "Auto-recovery: pod-crash sweep found this job RUNNING past "
                     "the stale-timeout window with attempts >= max_attempts.  "
@@ -541,6 +551,10 @@ class DataIngestionRepository:
         job.state = IngestionState.FINISHED
         job.result = IngestionResult.ERROR
         job.status_message = "Cancelled by user"
+        # Terminal transition — stamp finished_at so observability queries
+        # see cancelled rows alongside success/error completions.
+        if job.finished_at is None:
+            job.finished_at = func.now()
         job.is_current = False
         merged_meta = {
             **self.sanitize_for_json(job.meta or {}),

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -69,6 +69,7 @@ class DataIngestionRepository:
         completed_at: Optional[datetime] = None,
         state: Optional[IngestionState] = None,
         result: Optional[IngestionResult] = None,
+        finished_at: bool = False,
     ) -> Optional[DataIngestionJob]:
         """Update ingestion job with legacy status_code and new state/result.
 
@@ -77,9 +78,14 @@ class DataIngestionRepository:
             status_message: Status message
             status_code: Legacy status code (for backward compatibility)
             metadata: Metadata to merge
-            completed_at: Optional completed timestamp
+            completed_at: Optional completed timestamp written into ``meta``
+                (legacy JSON field; pre-dates the ``finished_at`` column).
             state: New state value (optional, for new code)
             result: New result value (optional, for new code)
+            finished_at: When True, also stamp the top-level ``finished_at``
+                column with ``func.now()`` (Plan 310C observability).  Kept
+                opt-in so existing callers that drove only ``meta`` JSON
+                aren't forced to migrate in lockstep.
         """
         stmt = select(DataIngestionJob).where(DataIngestionJob.id == job_id)
         exec_result = await self.session.execute(stmt)
@@ -95,6 +101,11 @@ class DataIngestionRepository:
                 result_job.state = state
             if result is not None:
                 result_job.result = result
+            if finished_at:
+                # ORM-level assignment of a SQL function expression so the
+                # value is rendered server-side (matches set_started_at and
+                # claim_job's locked_at).
+                result_job.finished_at = func.now()
 
             merged_meta = {
                 **self.sanitize_for_json(result_job.meta or {}),
@@ -113,6 +124,29 @@ class DataIngestionRepository:
             await self.session.flush()
             await self.session.refresh(result_job)
         return result_job
+
+    async def set_started_at(self, job_id: int) -> None:
+        """Stamp ``started_at`` on the FIRST successful claim only.
+
+        Idempotent via the ``started_at IS NULL`` guard — retries (every
+        subsequent claim_job after the original pod crashed and the safety
+        sweep recovered the row) call this again but the UPDATE matches no
+        row, leaving the original timestamp intact.  This is the property
+        that lets ``finished_at - started_at`` measure total wall-clock
+        duration across retries; ``locked_at`` (refreshed on every claim)
+        answers a different question.
+
+        Does not commit — leaves transaction control to the caller (the
+        ``run_job`` runner in Plan 310C), matching ``update_ingestion_job``.
+        """
+        await self.session.execute(
+            update(DataIngestionJob)
+            .where(
+                col(DataIngestionJob.id) == job_id,
+                col(DataIngestionJob.started_at).is_(None),
+            )
+            .values(started_at=func.now())
+        )
 
     async def get_job_by_id(self, job_id: int) -> Optional[DataIngestionJob]:
         stmt = select(DataIngestionJob).where(DataIngestionJob.id == job_id)

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -70,7 +70,10 @@ class DataIngestionRepository:
         state: Optional[IngestionState] = None,
         result: Optional[IngestionResult] = None,
     ) -> Optional[DataIngestionJob]:
-        """Update ingestion job with legacy status_code and new state/result.
+        """Update ingestion job's status_message, state, result, and metadata.
+
+        ``state == FINISHED`` also auto-stamps the top-level ``finished_at``
+        column when it is still NULL (see the ``state`` arg below).
 
         Args:
             job_id: Job ID to update

--- a/backend/tests/integration/services/data_ingestion/test_observability_columns_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_observability_columns_pg.py
@@ -40,12 +40,13 @@ def _make_pending_job() -> DataIngestionJob:
 
 @pytest.mark.asyncio
 async def test_started_at_idempotent_then_finished_at_set(pg_dsn):
-    """End-to-end on PG: first set_started_at fires, retry no-ops, finished_at fires.
+    """End-to-end on PG: set_started_at + finished_at auto-stamp on FINISHED.
 
     Mirrors the runner's lifecycle: claim → set_started_at; retry → claim
     again → set_started_at again (no-op); on completion →
-    update_ingestion_job(finished_at=True).  Both observability columns
-    end populated and ``started_at`` is unchanged across the retry call.
+    update_ingestion_job(state=FINISHED) auto-stamps finished_at.  Both
+    observability columns end populated and ``started_at`` is unchanged
+    across the retry call.
     """
     engine = create_async_engine(pg_dsn, future=True)
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -89,14 +90,15 @@ async def test_started_at_idempotent_then_finished_at_set(pg_dsn):
                 "total-duration metric."
             )
 
-            # Completion — finished_at column gets stamped.
+            # Completion — finished_at column auto-stamps on the FINISHED
+            # transition (no opt-in flag; the timestamp is derived from
+            # the lifecycle state itself).
             await repo.update_ingestion_job(
                 job_id,
                 status_message="ok",
                 metadata={},
                 state=IngestionState.FINISHED,
                 result=IngestionResult.SUCCESS,
-                finished_at=True,
             )
             await session.commit()
 

--- a/backend/tests/integration/services/data_ingestion/test_observability_columns_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_observability_columns_pg.py
@@ -1,0 +1,116 @@
+"""Postgres tests for Plan 310C observability columns.
+
+Exercises the ``set_started_at`` + ``finished_at`` repo helpers against a
+real Postgres so we cover ``func.now()`` resolving server-side and the
+TIMESTAMPTZ column type.  SQLite covers the WHERE-guard semantics; this
+covers production-shape SQL.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+from app.repositories.data_ingestion import DataIngestionRepository
+
+
+def _make_pending_job() -> DataIngestionJob:
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=1,
+        data_entry_type_id=10,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.NOT_STARTED,
+        is_current=False,
+        meta={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_started_at_idempotent_then_finished_at_set(pg_dsn):
+    """End-to-end on PG: first set_started_at fires, retry no-ops, finished_at fires.
+
+    Mirrors the runner's lifecycle: claim → set_started_at; retry → claim
+    again → set_started_at again (no-op); on completion →
+    update_ingestion_job(finished_at=True).  Both observability columns
+    end populated and ``started_at`` is unchanged across the retry call.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            repo = DataIngestionRepository(session)
+
+            job = _make_pending_job()
+            session.add(job)
+            await session.commit()
+            assert job.id is not None
+            job_id: int = job.id
+
+            # First "claim" — stamps started_at.
+            await repo.set_started_at(job_id)
+            await session.commit()
+
+            after_first = (
+                await session.execute(
+                    select(DataIngestionJob).where(DataIngestionJob.id == job_id)
+                )
+            ).scalar_one()
+            await session.refresh(after_first)
+            first_started_at = after_first.started_at
+            assert first_started_at is not None
+            assert after_first.finished_at is None
+
+            # Retry — set_started_at must no-op via the IS NULL guard.
+            await repo.set_started_at(job_id)
+            await session.commit()
+
+            after_retry = (
+                await session.execute(
+                    select(DataIngestionJob).where(DataIngestionJob.id == job_id)
+                )
+            ).scalar_one()
+            await session.refresh(after_retry)
+            assert after_retry.started_at == first_started_at, (
+                "started_at must stay byte-equal across retries — the IS NULL "
+                "guard is what makes finished_at - started_at a valid "
+                "total-duration metric."
+            )
+
+            # Completion — finished_at column gets stamped.
+            await repo.update_ingestion_job(
+                job_id,
+                status_message="ok",
+                metadata={},
+                state=IngestionState.FINISHED,
+                result=IngestionResult.SUCCESS,
+                finished_at=True,
+            )
+            await session.commit()
+
+            final = (
+                await session.execute(
+                    select(DataIngestionJob).where(DataIngestionJob.id == job_id)
+                )
+            ).scalar_one()
+            await session.refresh(final)
+
+            assert final.started_at == first_started_at
+            assert final.finished_at is not None
+            assert final.finished_at >= final.started_at
+            assert final.state == IngestionState.FINISHED
+            assert final.result == IngestionResult.SUCCESS
+    finally:
+        await engine.dispose()

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1,6 +1,13 @@
-"""Unit tests for DataIngestionRepository.get_recalculation_status_by_year."""
+"""Unit tests for DataIngestionRepository.
+
+Covers:
+- ``get_recalculation_status_by_year`` (Plan 310B)
+- ``set_started_at`` and ``update_ingestion_job(finished_at=True)``
+  (Plan 310C observability columns)
+"""
 
 import pytest
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.data_ingestion import (
@@ -375,3 +382,155 @@ async def test_get_recalculation_status_wrong_year_excluded(
     rows = await repo.get_recalculation_status_by_year(2025)
 
     assert rows == []
+
+
+# ======================================================================
+# Plan 310C observability columns: set_started_at + finished_at flag
+# ======================================================================
+
+
+def _make_pending_job() -> DataIngestionJob:
+    """Minimal NOT_STARTED job — observability columns default to NULL.
+
+    Distinct from ``_make_job`` above: that helper's required arguments
+    (``state``, ``result``, ``target_type``, ...) are tuned for the
+    recalculation-status query, where every test row is FINISHED.  Here we
+    need NOT_STARTED rows with sensible defaults for everything else, so a
+    parameter-free constructor is clearer than defaulting six args of
+    ``_make_job``.
+    """
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=1,
+        data_entry_type_id=10,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.NOT_STARTED,
+        is_current=False,
+        meta={},
+    )
+
+
+async def _reload_job(db_session: AsyncSession, job_id: int) -> DataIngestionJob:
+    """Re-SELECT the job after expiring the identity map.
+
+    ``set_started_at`` and the ``finished_at=True`` branch issue raw
+    UPDATEs that bypass the ORM, so any session-attached instance keeps
+    stale attribute values until we expire and re-fetch.
+    """
+    db_session.expire_all()
+    return (
+        await db_session.execute(
+            select(DataIngestionJob).where(DataIngestionJob.id == job_id)
+        )
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_set_started_at_first_call_populates_column(
+    db_session: AsyncSession,
+):
+    """First ``set_started_at`` flips the column from NULL to a timestamp."""
+    repo = DataIngestionRepository(db_session)
+    job = _make_pending_job()
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+    assert job.started_at is None
+
+    await repo.set_started_at(job.id)
+    await db_session.commit()
+
+    refreshed = await _reload_job(db_session, job.id)
+    assert refreshed.started_at is not None
+
+
+@pytest.mark.asyncio
+async def test_set_started_at_second_call_is_noop(
+    db_session: AsyncSession,
+):
+    """Second ``set_started_at`` leaves the original timestamp byte-equal.
+
+    Verifies the ``started_at IS NULL`` guard — the property we rely on
+    when retries call this method again, since ``finished_at - started_at``
+    is supposed to span ALL attempts, not just the most recent one.
+    """
+    repo = DataIngestionRepository(db_session)
+    job = _make_pending_job()
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+
+    await repo.set_started_at(job.id)
+    await db_session.commit()
+    first_value = (await _reload_job(db_session, job.id)).started_at
+    assert first_value is not None
+
+    await repo.set_started_at(job.id)
+    await db_session.commit()
+    second_value = (await _reload_job(db_session, job.id)).started_at
+
+    # Byte-equal, not "earlier-or-equal": SQLite's second-precision clock
+    # can make back-to-back UPDATEs produce identical timestamps, which
+    # would silently pass an inequality assertion for the wrong reason.
+    assert second_value == first_value
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_job_finished_at_flag_sets_column(
+    db_session: AsyncSession,
+):
+    """``finished_at=True`` stamps the top-level column on the FINISHED transition."""
+    repo = DataIngestionRepository(db_session)
+    job = _make_pending_job()
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+    assert job.finished_at is None
+
+    await repo.update_ingestion_job(
+        job.id,
+        status_message="ok",
+        metadata={},
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        finished_at=True,
+    )
+    await db_session.commit()
+
+    refreshed = await _reload_job(db_session, job.id)
+    assert refreshed.finished_at is not None
+    assert refreshed.state == IngestionState.FINISHED
+    assert refreshed.result == IngestionResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_job_without_flag_leaves_finished_at_null(
+    db_session: AsyncSession,
+):
+    """Without the flag, ``finished_at`` stays NULL even on FINISHED transitions.
+
+    Backward-compat guarantee for existing callers that drive only the
+    legacy ``meta["completed_at"]`` JSON field — they continue to work
+    unchanged and the new column stays opt-in.
+    """
+    repo = DataIngestionRepository(db_session)
+    job = _make_pending_job()
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+
+    await repo.update_ingestion_job(
+        job.id,
+        status_message="ok",
+        metadata={},
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+    )
+    await db_session.commit()
+
+    refreshed = await _reload_job(db_session, job.id)
+    assert refreshed.finished_at is None
+    assert refreshed.state == IngestionState.FINISHED

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -2,8 +2,8 @@
 
 Covers:
 - ``get_recalculation_status_by_year`` (Plan 310B)
-- ``set_started_at`` and ``update_ingestion_job(finished_at=True)``
-  (Plan 310C observability columns)
+- ``set_started_at`` plus state-driven ``finished_at`` auto-stamping in
+  ``update_ingestion_job``, ``cancel_job`` (Plan 310C observability columns)
 """
 
 import pytest
@@ -479,10 +479,15 @@ async def test_set_started_at_second_call_is_noop(
 
 
 @pytest.mark.asyncio
-async def test_update_ingestion_job_finished_at_flag_sets_column(
+async def test_update_ingestion_job_auto_stamps_finished_at_on_finished_state(
     db_session: AsyncSession,
 ):
-    """``finished_at=True`` stamps the top-level column on the FINISHED transition."""
+    """Transitioning to FINISHED auto-stamps ``finished_at``.
+
+    No opt-in flag: the timestamp is derived from the lifecycle state
+    transition itself, not a parameter the caller may forget.  This is
+    the contract the dashboard's duration query depends on.
+    """
     repo = DataIngestionRepository(db_session)
     job = _make_pending_job()
     db_session.add(job)
@@ -496,7 +501,6 @@ async def test_update_ingestion_job_finished_at_flag_sets_column(
         metadata={},
         state=IngestionState.FINISHED,
         result=IngestionResult.SUCCESS,
-        finished_at=True,
     )
     await db_session.commit()
 
@@ -507,14 +511,44 @@ async def test_update_ingestion_job_finished_at_flag_sets_column(
 
 
 @pytest.mark.asyncio
-async def test_update_ingestion_job_without_flag_leaves_finished_at_null(
+async def test_update_ingestion_job_to_running_does_not_stamp_finished_at(
     db_session: AsyncSession,
 ):
-    """Without the flag, ``finished_at`` stays NULL even on FINISHED transitions.
+    """Non-terminal transitions never stamp ``finished_at``.
 
-    Backward-compat guarantee for existing callers that drive only the
-    legacy ``meta["completed_at"]`` JSON field — they continue to work
-    unchanged and the new column stays opt-in.
+    Closes the original ``finished_at: bool`` flag's loophole — callers
+    can no longer accidentally persist a terminal timestamp on a
+    RUNNING/QUEUED job.  Only the transition to FINISHED triggers the
+    stamp.
+    """
+    repo = DataIngestionRepository(db_session)
+    job = _make_pending_job()
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+
+    await repo.update_ingestion_job(
+        job.id,
+        status_message="working",
+        metadata={},
+        state=IngestionState.RUNNING,
+    )
+    await db_session.commit()
+
+    refreshed = await _reload_job(db_session, job.id)
+    assert refreshed.finished_at is None
+    assert refreshed.state == IngestionState.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_job_finished_at_idempotent_on_repeat_calls(
+    db_session: AsyncSession,
+):
+    """Re-running update on an already-FINISHED row preserves the original timestamp.
+
+    The IS NULL guard (``result_job.finished_at is None``) makes the
+    auto-stamp idempotent so retry-update paths can't drift the recorded
+    completion time.
     """
     repo = DataIngestionRepository(db_session)
     job = _make_pending_job()
@@ -530,7 +564,44 @@ async def test_update_ingestion_job_without_flag_leaves_finished_at_null(
         result=IngestionResult.SUCCESS,
     )
     await db_session.commit()
+    first_value = (await _reload_job(db_session, job.id)).finished_at
+    assert first_value is not None
 
+    await repo.update_ingestion_job(
+        job.id,
+        status_message="updated note",
+        metadata={"extra": "info"},
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+    )
+    await db_session.commit()
+    second_value = (await _reload_job(db_session, job.id)).finished_at
+
+    assert second_value == first_value
+
+
+@pytest.mark.asyncio
+async def test_cancel_job_stamps_finished_at(db_session: AsyncSession):
+    """``cancel_job`` is a terminal transition — must populate ``finished_at``.
+
+    Without this, observability queries that filter on ``finished_at IS
+    NOT NULL`` silently miss cancelled jobs even though they are
+    lifecycle-FINISHED.
+    """
+    repo = DataIngestionRepository(db_session)
+    job = _make_pending_job()
+    job.state = IngestionState.RUNNING
+    job.is_current = True
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+    assert job.finished_at is None
+
+    cancelled = await repo.cancel_job(job.id)
+    await db_session.commit()
+
+    assert cancelled is not None
     refreshed = await _reload_job(db_session, job.id)
-    assert refreshed.finished_at is None
     assert refreshed.state == IngestionState.FINISHED
+    assert refreshed.result == IngestionResult.ERROR
+    assert refreshed.finished_at is not None


### PR DESCRIPTION
## Summary

Adds two nullable timestamps to \`data_ingestion_jobs\` for true wall-clock duration tracking, distinct from the per-attempt \`locked_at\` column from Plan 310-A.

- \`started_at\` is set on the **first** claim only (idempotent guard \`WHERE started_at IS NULL\`), so it survives retries.
- \`finished_at\` is set when state transitions to \`FINISHED\`.

Together they answer \"how long did this job take total?\" — \`locked_at\` answers \"is the current attempt's lock stale?\".

Plan 310-C \"Observability\" section. The runner that actually calls these helpers lands in Tier 2; this PR is greenfield infrastructure.

## Files

- \`backend/alembic/versions/2026_05_05_1000-d3e5f7a9b1c4_add_started_finished_at.py\` (new) — multi-revision: \`Revises: c2d4e6f8a012, 3f8147b5e516\` (merges 310-A and 310-B heads).
- \`backend/app/models/data_ingestion.py\` — adds \`started_at\` / \`finished_at\` to \`DataIngestionJob\` SQLModel.
- \`backend/app/repositories/data_ingestion.py\` — adds \`set_started_at(job_id)\` (idempotent), extends \`update_ingestion_job\` with \`finished_at: bool = False\` flag.
- \`backend/tests/unit/repositories/test_data_ingestion_repo.py\` — 4 new tests for the helpers.
- \`backend/tests/integration/services/data_ingestion/test_observability_columns_pg.py\` (new) — PG round-trip test for both columns.

## Test plan

- [x] \`rtk uv run alembic heads\` — single head \`d3e5f7a9b1c4\` (chain merges cleanly)
- [x] \`rtk uv run pytest tests/unit/repositories/test_data_ingestion_repo.py\` — 13/13 pass (incl. 4 new)
- [x] \`rtk uv run pytest tests/integration/services/data_ingestion/test_observability_columns_pg.py\` — 1/1 pass (Docker available)
- [x] \`rtk uv run ruff check app/ tests/\` — clean

## Notes

Part of a Tier-1 batch landing parallelizable surface of Plans 310-C/D. Sibling PRs: #1019 (Unit 4), #1020 (Unit 6), #1021 (Unit 2), #1022 (Unit 3), #1023 (Unit 7). After this lands, PR #1023's \`PipelineJobResponse\` schema can include \`started_at\`/\`finished_at\` (currently has a \`TODO(310C Unit 1)\` comment).