### PR TITLE
perf(#310d): batch rematch in EmissionRecalculationWorkflow

### DIFF
--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -9,6 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntryTypeEnum
 from app.repositories.data_entry_repo import DataEntryRepository
+from app.repositories.factor_repo import FactorRepository
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.data_entry_emission_service import DataEntryEmissionService
@@ -70,7 +71,43 @@ class EmissionRecalculationWorkflow:
         emission_svc = DataEntryEmissionService(self.session)
         module_svc = CarbonReportModuleService(self.session)
         handler_svc = ModuleHandlerService(self.session)
+        factor_repo = FactorRepository(self.session)
         handler = BaseModuleHandler.get_by_type(data_entry_type_id)
+
+        # Plan 310D — batch the rematch.  Pre-load all factors for
+        # (data_entry_type_id, year) once into a dict keyed by
+        # (kind, subkind), turning what was N+1 SQL roundtrips into one
+        # bulk SELECT plus Python lookups.  Skipped when the handler has
+        # no ``kind_field`` because there is nothing to rematch on.
+        #
+        # Lookup-key matches ``ModuleHandlerService.resolve_primary_factor_id``:
+        # both read ``classification[kind_field]`` and (when defined)
+        # ``classification[subkind_field]``, normalising "" → None for
+        # subkind.  Dict misses fall back to the per-entry resolver,
+        # which itself does a kind-only fallback when the exact
+        # (kind, subkind) row is absent.
+        factor_lookup: dict[tuple[str, str | None], int] = {}
+        if handler.kind_field is not None:
+            kind_field = handler.kind_field
+            subkind_field = handler.subkind_field
+            factors = await factor_repo.list_by_data_entry_type(
+                data_entry_type_id, year
+            )
+            for factor in factors:
+                if factor.id is None:
+                    continue
+                classification = factor.classification or {}
+                kind_value = classification.get(kind_field)
+                if kind_value is None or kind_value == "":
+                    continue
+                subkind_value: str | None = None
+                if subkind_field:
+                    raw = classification.get(subkind_field)
+                    subkind_value = raw if raw else None
+                # First writer wins on duplicate keys; ``get_by_classification``
+                # uses ``one_or_none`` which raises on duplicates anyway, so
+                # callers don't depend on ordering when the index is consistent.
+                factor_lookup.setdefault((kind_value, subkind_value), factor.id)
 
         recalculated = 0
         errors = 0
@@ -94,22 +131,36 @@ class EmissionRecalculationWorkflow:
             # ``MultipleResultsFound``, neither of which is right for
             # those handlers.
             #
-            # N+1 query per entry — acceptable for now; batched matching
-            # is on the Plan D follow-up list.
+            # Plan 310D — bulk-prefetched ``factor_lookup`` collapses
+            # the per-entry SELECT into a Python dict lookup; the
+            # per-entry ``resolve_primary_factor_id`` path remains as
+            # a fallback for dict misses (kind value the bulk query
+            # didn't see, e.g. a stale entry whose classification no
+            # longer appears in the current factor set).
             should_refresh = (
                 handler.kind_field is not None and handler.kind_field in entry.data
             )
             old_data = entry.data
             try:
                 if should_refresh:
-                    refreshed = await handler_svc.resolve_primary_factor_id(
-                        handler=handler,
-                        payload=dict(entry.data),
-                        data_entry_type_id=data_entry_type_id,
-                        year=year,
-                        existing_data=None,
+                    new_factor_id = self._lookup_factor_id(
+                        entry_data=entry.data,
+                        kind_field=handler.kind_field,
+                        subkind_field=handler.subkind_field,
+                        factor_lookup=factor_lookup,
                     )
-                    new_factor_id = refreshed.get("primary_factor_id")
+                    if new_factor_id is None:
+                        # Dict miss — fall back to the per-entry resolver
+                        # (which can fall through kind-only when subkind
+                        # doesn't match an exact factor row).
+                        refreshed = await handler_svc.resolve_primary_factor_id(
+                            handler=handler,
+                            payload=dict(entry.data),
+                            data_entry_type_id=data_entry_type_id,
+                            year=year,
+                            existing_data=None,
+                        )
+                        new_factor_id = refreshed.get("primary_factor_id")
                     if new_factor_id != entry.data.get("primary_factor_id"):
                         # Tentative swap so DataEntryResponse + upsert
                         # see the refreshed factor.  Rolled back below
@@ -169,3 +220,29 @@ class EmissionRecalculationWorkflow:
             "errors": errors,
             "error_details": error_details,
         }
+
+    @staticmethod
+    def _lookup_factor_id(
+        entry_data: dict,
+        kind_field: str,
+        subkind_field: str | None,
+        factor_lookup: dict[tuple[str, str | None], int],
+    ) -> int | None:
+        """Resolve ``primary_factor_id`` from the bulk-prefetched lookup.
+
+        Returns ``None`` on miss so the caller can fall back to the
+        per-entry resolver (which itself does kind-only fallback when
+        the exact ``(kind, subkind)`` row is absent).
+
+        Mirrors the key-derivation done in
+        ``ModuleHandlerService.resolve_primary_factor_id``: subkind
+        normalises empty string → None, kind reads as-is.
+        """
+        kind = entry_data.get(kind_field)
+        if kind is None or kind == "":
+            return None
+        subkind: str | None = None
+        if subkind_field:
+            raw = entry_data.get(subkind_field)
+            subkind = raw if raw else None
+        return factor_lookup.get((kind, subkind))

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -13,7 +13,6 @@ from app.repositories.factor_repo import FactorRepository
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.data_entry_emission_service import DataEntryEmissionService
-from app.services.module_handler_service import ModuleHandlerService
 
 logger = get_logger(__name__)
 
@@ -70,7 +69,6 @@ class EmissionRecalculationWorkflow:
 
         emission_svc = DataEntryEmissionService(self.session)
         module_svc = CarbonReportModuleService(self.session)
-        handler_svc = ModuleHandlerService(self.session)
         factor_repo = FactorRepository(self.session)
         handler = BaseModuleHandler.get_by_type(data_entry_type_id)
 
@@ -140,17 +138,20 @@ class EmissionRecalculationWorkflow:
             # ``MultipleResultsFound``, neither of which is right for
             # those handlers.
             #
-            # Plan 310D — bulk-prefetched ``factor_lookup`` collapses
-            # the per-entry SELECT into a Python dict lookup; the
-            # per-entry ``resolve_primary_factor_id`` path remains as
-            # a fallback for dict misses (kind value the bulk query
-            # didn't see, e.g. a stale entry whose classification no
-            # longer appears in the current factor set).
-            # Bind ``kind_field`` to a local up-front so the type-narrowing
-            # ``is not None`` check below directly proves it to mypy at the
-            # ``_lookup_factor_id`` call site (signature requires ``str``).
-            # Avoids an ``assert`` in production, which bandit B101 flags
-            # because asserts are stripped under ``python -O``.
+            # Plan 310D — bulk-prefetched ``factor_lookup`` is the
+            # single source of truth for the rematch.  ``_lookup_factor_id``
+            # mirrors the full kind→subkind→kind-only fallback chain
+            # in-memory, so a miss here means "factor truly dropped from
+            # the current CSV" — no DB fallback.  Per the strict-drop
+            # contract, we clear ``primary_factor_id`` and let the
+            # downstream upsert recompute ``kg_co2eq`` as None, which the
+            # dashboard surfaces as a missing-factor signal to operators.
+            #
+            # Bind ``kind_field`` to a local up-front so the
+            # type-narrowing ``is not None`` check below proves it to
+            # mypy at the ``_lookup_factor_id`` call site.  Avoids an
+            # ``assert`` (bandit B101) because asserts are stripped under
+            # ``python -O``.
             kind_field = handler.kind_field
             old_data = entry.data
             try:
@@ -161,25 +162,14 @@ class EmissionRecalculationWorkflow:
                         subkind_field=handler.subkind_field,
                         factor_lookup=factor_lookup,
                     )
-                    if new_factor_id is None:
-                        # Dict miss — fall back to the per-entry resolver
-                        # (which can fall through kind-only when subkind
-                        # doesn't match an exact factor row).
-                        refreshed = await handler_svc.resolve_primary_factor_id(
-                            handler=handler,
-                            payload=dict(entry.data),
-                            data_entry_type_id=data_entry_type_id,
-                            year=year,
-                            existing_data=None,
-                        )
-                        new_factor_id = refreshed.get("primary_factor_id")
                     if new_factor_id != entry.data.get("primary_factor_id"):
                         # Tentative swap so DataEntryResponse + upsert
-                        # see the refreshed factor.  Rolled back below
-                        # if the upsert fails, so partial-failure runs
-                        # don't leave entry.data pointing at the new
-                        # factor while data_entry_emissions is still
-                        # computed against the old one.
+                        # see the refreshed factor (or ``None`` on a
+                        # drop).  Rolled back below if the upsert fails,
+                        # so partial-failure runs don't leave entry.data
+                        # pointing at the new factor while
+                        # data_entry_emissions is still computed against
+                        # the old one.
                         entry.data = {
                             **entry.data,
                             "primary_factor_id": new_factor_id,
@@ -242,9 +232,19 @@ class EmissionRecalculationWorkflow:
     ) -> int | None:
         """Resolve ``primary_factor_id`` from the bulk-prefetched lookup.
 
-        Returns ``None`` on miss so the caller can fall back to the
-        per-entry resolver (which itself does kind-only fallback when
-        the exact ``(kind, subkind)`` row is absent).
+        Mirrors the kind→subkind→kind-only fallback chain that
+        ``ModuleHandlerService.resolve_primary_factor_id`` runs in DB,
+        but entirely in-memory:
+
+        1. Exact ``(kind, subkind)`` match.
+        2. Kind-only ``(kind, None)`` fallback — only succeeds if a
+           factor with no subkind was prefetched (subkind=NULL row).
+
+        Returns ``None`` on overall miss.  Per Plan 310-D's strict
+        rematch contract, the caller treats a None as "factor dropped"
+        and clears the entry's ``primary_factor_id`` so the recomputed
+        emission is ``None`` (operator surfaces it as missing-factor
+        rather than silently substituting via a per-entry DB roundtrip).
 
         Mirrors the key-derivation done in
         ``ModuleHandlerService.resolve_primary_factor_id``: subkind
@@ -257,4 +257,12 @@ class EmissionRecalculationWorkflow:
         if subkind_field:
             raw = entry_data.get(subkind_field)
             subkind = raw if raw else None
-        return factor_lookup.get((kind, subkind))
+        # Exact match first.
+        factor_id = factor_lookup.get((kind, subkind))
+        if factor_id is not None:
+            return factor_id
+        # Kind-only fallback — only worth trying when subkind was set;
+        # otherwise the lookup above already tried (kind, None).
+        if subkind is not None:
+            return factor_lookup.get((kind, None))
+        return None

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -91,9 +91,9 @@ class EmissionRecalculationWorkflow:
         # ``kind_field`` OR when no entry actually carries that key in
         # ``entry.data``.  Strategy B handlers (e.g.
         # professional_travel/plane) declare ``kind_field`` but derive
-        # the value in ``pre_compute`` — every entry would fail
-        # ``should_refresh`` below, so prefetching factors here would be
-        # a wasted SELECT per recalc slice.
+        # the value in ``pre_compute`` — every entry would fail the
+        # per-entry refresh gate below, so prefetching factors here
+        # would be a wasted SELECT per recalc slice.
         if handler.kind_field is not None and any(
             handler.kind_field in e.data for e in entries
         ):
@@ -146,19 +146,18 @@ class EmissionRecalculationWorkflow:
             # a fallback for dict misses (kind value the bulk query
             # didn't see, e.g. a stale entry whose classification no
             # longer appears in the current factor set).
-            should_refresh = (
-                handler.kind_field is not None and handler.kind_field in entry.data
-            )
+            # Bind ``kind_field`` to a local up-front so the type-narrowing
+            # ``is not None`` check below directly proves it to mypy at the
+            # ``_lookup_factor_id`` call site (signature requires ``str``).
+            # Avoids an ``assert`` in production, which bandit B101 flags
+            # because asserts are stripped under ``python -O``.
+            kind_field = handler.kind_field
             old_data = entry.data
             try:
-                if should_refresh:
-                    # ``should_refresh`` is True iff ``handler.kind_field is not
-                    # None``; bind to a local non-Optional so ``_lookup_factor_id``
-                    # type-checks against its ``kind_field: str`` signature.
-                    assert handler.kind_field is not None
+                if kind_field is not None and kind_field in entry.data:
                     new_factor_id = self._lookup_factor_id(
                         entry_data=entry.data,
-                        kind_field=handler.kind_field,
+                        kind_field=kind_field,
                         subkind_field=handler.subkind_field,
                         factor_lookup=factor_lookup,
                     )

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -147,18 +147,22 @@ class EmissionRecalculationWorkflow:
             # downstream upsert recompute ``kg_co2eq`` as None, which the
             # dashboard surfaces as a missing-factor signal to operators.
             #
-            # Bind ``kind_field`` to a local up-front so the
-            # type-narrowing ``is not None`` check below proves it to
-            # mypy at the ``_lookup_factor_id`` call site.  Avoids an
-            # ``assert`` (bandit B101) because asserts are stripped under
-            # ``python -O``.
-            kind_field = handler.kind_field
+            # Bind to a local with an explicit ``Optional[str]`` annotation
+            # so the ``is not None`` check below narrows it to ``str`` at
+            # the ``_lookup_factor_id`` call site.  The name differs from
+            # ``kind_field`` used in the prefetch block above to avoid a
+            # mypy scope-collision (the prefetch binding lives inside an
+            # ``if handler.kind_field is not None`` block, so mypy infers
+            # the narrower ``str`` and then refuses the wider re-bind here).
+            # Also avoids an ``assert`` (bandit B101 — asserts are stripped
+            # under ``python -O``).
+            entry_kind_field: str | None = handler.kind_field
             old_data = entry.data
             try:
-                if kind_field is not None and kind_field in entry.data:
+                if entry_kind_field is not None and entry_kind_field in entry.data:
                     new_factor_id = self._lookup_factor_id(
                         entry_data=entry.data,
-                        kind_field=kind_field,
+                        kind_field=entry_kind_field,
                         subkind_field=handler.subkind_field,
                         factor_lookup=factor_lookup,
                     )

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -87,7 +87,16 @@ class EmissionRecalculationWorkflow:
         # which itself does a kind-only fallback when the exact
         # (kind, subkind) row is absent.
         factor_lookup: dict[tuple[str, str | None], int] = {}
-        if handler.kind_field is not None:
+        # Skip the bulk SELECT entirely when the handler has no
+        # ``kind_field`` OR when no entry actually carries that key in
+        # ``entry.data``.  Strategy B handlers (e.g.
+        # professional_travel/plane) declare ``kind_field`` but derive
+        # the value in ``pre_compute`` — every entry would fail
+        # ``should_refresh`` below, so prefetching factors here would be
+        # a wasted SELECT per recalc slice.
+        if handler.kind_field is not None and any(
+            handler.kind_field in e.data for e in entries
+        ):
             kind_field = handler.kind_field
             subkind_field = handler.subkind_field
             factors = await factor_repo.list_by_data_entry_type(
@@ -143,6 +152,10 @@ class EmissionRecalculationWorkflow:
             old_data = entry.data
             try:
                 if should_refresh:
+                    # ``should_refresh`` is True iff ``handler.kind_field is not
+                    # None``; bind to a local non-Optional so ``_lookup_factor_id``
+                    # type-checks against its ``kind_field: str`` signature.
+                    assert handler.kind_field is not None
                     new_factor_id = self._lookup_factor_id(
                         entry_data=entry.data,
                         kind_field=handler.kind_field,

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -51,14 +51,8 @@ async def test_recalculate_all_success():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_handler_cls.get_by_type.return_value = MagicMock()
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={}
-        )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -109,14 +103,8 @@ async def test_recalculate_partial_error():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_handler_cls.get_by_type.return_value = MagicMock()
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={}
-        )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -165,7 +153,6 @@ async def test_recalculate_empty_result():
         patch("app.workflows.emission_recalculation.DataEntryEmissionService"),
         patch("app.workflows.emission_recalculation.CarbonReportModuleService"),
         patch("app.workflows.emission_recalculation.BaseModuleHandler"),
-        patch("app.workflows.emission_recalculation.ModuleHandlerService"),
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[]
@@ -213,15 +200,16 @@ async def test_recalculate_rematches_primary_factor_id_when_changed():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
         )
+        # Bulk dict has the new factor for kind=Laptop with id=1234.
+        new_factor = MagicMock()
+        new_factor.id = 1234
+        new_factor.classification = {"equipment_class": "Laptop"}
         mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
-            return_value=[]
+            return_value=[new_factor]
         )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
@@ -231,10 +219,6 @@ async def test_recalculate_rematches_primary_factor_id_when_changed():
         strategy_a_handler.kind_field = "equipment_class"
         strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
-        # Bulk lookup is empty → fallback resolver runs and returns 1234
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={"primary_factor_id": 1234}
-        )
 
         result = await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
 
@@ -271,9 +255,6 @@ async def test_recalculate_does_not_touch_entry_when_factor_unchanged():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
@@ -283,10 +264,9 @@ async def test_recalculate_does_not_touch_entry_when_factor_unchanged():
         )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
+        # Handler with no kind_field (MagicMock attr is not in entry.data
+        # so the rematch gate fails) — entry.data stays untouched.
         mock_handler_cls.get_by_type.return_value = MagicMock()
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={"primary_factor_id": 7}
-        )
 
         await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
 
@@ -326,14 +306,8 @@ async def test_recalculate_module_stats_called_once_per_module():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_handler_cls.get_by_type.return_value = MagicMock()
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={}
-        )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -390,9 +364,6 @@ async def test_recalculate_skips_rematch_for_strategy_b_handlers():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
@@ -408,18 +379,14 @@ async def test_recalculate_skips_rematch_for_strategy_b_handlers():
         strategy_b_handler.kind_field = "kind"  # NOT a key on entry.data
         strategy_b_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_b_handler
-        # If the gate fails and the rematch runs, this would be the
-        # value swapped in.  We assert the rematch was NOT called.
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={"primary_factor_id": 9999}
-        )
 
         result = await svc.recalculate_for_data_entry_type(
             DataEntryTypeEnum.plane, 2025
         )
 
-    # Refresh skipped: resolver never called, primary_factor_id untouched.
-    mock_handler_svc_cls.return_value.resolve_primary_factor_id.assert_not_called()
+    # Refresh skipped: primary_factor_id untouched.  (The per-entry DB
+    # resolver fallback was removed in Plan 310-D's strict-drop refactor;
+    # the gate above is now the only thing keeping Strategy B safe.)
     assert entry.data["primary_factor_id"] == 7
     assert result["recalculated"] == 1
     # Plan 310D Copilot follow-up: the bulk-prefetch SELECT must also be
@@ -461,15 +428,18 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
         )
+        # Bulk dict has the new factor with id 1234 — rematch tentatively
+        # swaps entry.data['primary_factor_id'] from 7 → 1234, then upsert
+        # fails so the rollback restores the original.
+        new_factor = MagicMock()
+        new_factor.id = 1234
+        new_factor.classification = {"equipment_class": "Laptop"}
         mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
-            return_value=[]
+            return_value=[new_factor]
         )
         # The compute step raises — simulates a downstream failure between
         # the rematch swap and the emissions-row write.
@@ -481,11 +451,6 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
         strategy_a_handler.kind_field = "equipment_class"
         strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
-        # Resolver returns a different id — rematch tentatively swaps
-        # entry.data['primary_factor_id'] from 7 → 1234, then upsert fails.
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={"primary_factor_id": 1234}
-        )
 
         result = await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
 
@@ -509,15 +474,13 @@ async def test_recalculate_uses_single_factor_bulk_fetch():
 
     Three Strategy A entries:
     - Two share kind ``Laptop`` → both hit the bulk dict.
-    - One has kind ``Server`` not in the bulk dict → falls back to the
-      per-entry resolver.
+    - One has kind ``Server`` not in the bulk dict → strict-drop:
+      ``primary_factor_id`` is cleared to ``None`` (no DB fallback).
 
     Asserts:
     - ``factor_repo.list_by_data_entry_type`` is called EXACTLY ONCE.
-    - ``handler_svc.resolve_primary_factor_id`` is called only for the
-      missed entry (1 call, not 3).
-    - Dict-hit entries get the bulk-loaded factor id; the missed entry
-      gets the resolver's returned id.
+    - Dict-hit entries get the bulk-loaded factor id.
+    - Dict-miss entry has ``primary_factor_id`` cleared to ``None``.
     """
     mock_session = MagicMock()
     svc = EmissionRecalculationWorkflow(mock_session)
@@ -552,9 +515,6 @@ async def test_recalculate_uses_single_factor_bulk_fetch():
         patch(
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
-        patch(
-            "app.workflows.emission_recalculation.ModuleHandlerService"
-        ) as mock_handler_svc_cls,
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
@@ -568,10 +528,6 @@ async def test_recalculate_uses_single_factor_bulk_fetch():
         strategy_a_handler.kind_field = "equipment_class"
         strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
-        # Fallback resolver — only the Server entry should reach it.
-        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
-            return_value={"primary_factor_id": 9999}
-        )
 
         await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
 
@@ -579,13 +535,72 @@ async def test_recalculate_uses_single_factor_bulk_fetch():
     bulk_call = mock_factor_repo_cls.return_value.list_by_data_entry_type
     assert bulk_call.await_count == 1
 
-    # Dict-hit entries take the fast path; resolver is invoked only for
-    # the miss (Server kind not present in the bulk-loaded factor set).
-    resolver = mock_handler_svc_cls.return_value.resolve_primary_factor_id
-    assert resolver.await_count == 1
-
-    # Bulk-hit entries linked to the bulk factor; miss linked to the
-    # resolver's returned id.
+    # Bulk-hit entries linked to the bulk factor; miss has its
+    # primary_factor_id cleared to None (strict-drop, Plan 310-D).
     assert laptop_a.data["primary_factor_id"] == 4242
     assert laptop_b.data["primary_factor_id"] == 4242
-    assert server.data["primary_factor_id"] == 9999
+    assert server.data["primary_factor_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_recalculate_kind_only_fallback_in_dict():
+    """Plan 310-D Copilot follow-up: in-memory kind→subkind→kind-only fallback.
+
+    When an entry has a non-empty subkind but the current factor set has
+    only a kind-only row (subkind=NULL), the in-memory dict lookup must
+    fall through ``(kind, None)`` rather than missing and clearing the
+    factor link.  This used to cost a per-entry DB roundtrip via the
+    resolver fallback; now it's an O(1) dict lookup.
+    """
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    # Entry asks for (Laptop, Premium); current factors only have
+    # (Laptop, NULL) — kind-only fallback should hit it.
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 0,
+        "equipment_class": "Laptop",
+        "sub_class": "Premium",
+    }
+    kind_only_factor = MagicMock()
+    kind_only_factor.id = 555
+    # No sub_class → registers as (Laptop, None) in the bulk dict.
+    kind_only_factor.classification = {"equipment_class": "Laptop"}
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.CarbonReportModuleService"
+        ) as mock_module_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[kind_only_factor]
+        )
+        mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
+        mock_module_cls.return_value.recompute_stats = AsyncMock()
+        handler = MagicMock()
+        handler.kind_field = "equipment_class"
+        handler.subkind_field = "sub_class"
+        mock_handler_cls.get_by_type.return_value = handler
+
+        await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
+
+    # Kind-only fallback hit — primary_factor_id resolved to 555 from
+    # the (Laptop, None) bulk-dict entry, NOT cleared and NOT a DB call.
+    assert entry.data["primary_factor_id"] == 555

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -37,6 +37,9 @@ async def test_recalculate_all_success():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -58,6 +61,9 @@ async def test_recalculate_all_success():
         )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
         )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
@@ -89,6 +95,9 @@ async def test_recalculate_partial_error():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -110,6 +119,9 @@ async def test_recalculate_partial_error():
         )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
         )
 
         # model_validate returns a mock with .id matching the entry
@@ -189,6 +201,9 @@ async def test_recalculate_rematches_primary_factor_id_when_changed():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -205,14 +220,18 @@ async def test_recalculate_rematches_primary_factor_id_when_changed():
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
         )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
         # Strategy A handler: kind_field maps to a key in entry.data so
         # the gate ``handler.kind_field in entry.data`` evaluates True.
         strategy_a_handler = MagicMock()
         strategy_a_handler.kind_field = "equipment_class"
+        strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
-        # New factor matches against current state — different id
+        # Bulk lookup is empty → fallback resolver runs and returns 1234
         mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
             return_value={"primary_factor_id": 1234}
         )
@@ -240,6 +259,9 @@ async def test_recalculate_does_not_touch_entry_when_factor_unchanged():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -255,6 +277,9 @@ async def test_recalculate_does_not_touch_entry_when_factor_unchanged():
     ):
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
         )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
@@ -287,6 +312,9 @@ async def test_recalculate_module_stats_called_once_per_module():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -308,6 +336,9 @@ async def test_recalculate_module_stats_called_once_per_module():
         )
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
         )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
@@ -347,6 +378,9 @@ async def test_recalculate_skips_rematch_for_strategy_b_handlers():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -363,12 +397,16 @@ async def test_recalculate_skips_rematch_for_strategy_b_handlers():
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
         )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
         mock_module_cls.return_value.recompute_stats = AsyncMock()
         # Strategy B handler shape: kind_field set, but its value isn't
         # present in entry.data (would be derived via pre_compute).
         strategy_b_handler = MagicMock()
         strategy_b_handler.kind_field = "kind"  # NOT a key on entry.data
+        strategy_b_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_b_handler
         # If the gate fails and the rematch runs, this would be the
         # value swapped in.  We assert the rematch was NOT called.
@@ -406,6 +444,9 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
             "app.workflows.emission_recalculation.DataEntryRepository"
         ) as mock_repo_cls,
         patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
             "app.workflows.emission_recalculation.DataEntryEmissionService"
         ) as mock_emission_cls,
         patch(
@@ -422,6 +463,9 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=[entry]
         )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
         # The compute step raises — simulates a downstream failure between
         # the rematch swap and the emissions-row write.
         mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock(
@@ -430,6 +474,7 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
         mock_module_cls.return_value.recompute_stats = AsyncMock()
         strategy_a_handler = MagicMock()
         strategy_a_handler.kind_field = "equipment_class"
+        strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
         # Resolver returns a different id — rematch tentatively swaps
         # entry.data['primary_factor_id'] from 7 → 1234, then upsert fails.
@@ -449,3 +494,93 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
     assert entry.data == original_data, (
         "entry.data must be restored on per-entry failure"
     )
+
+
+@pytest.mark.asyncio
+async def test_recalculate_uses_single_factor_bulk_fetch():
+    """Plan 310D: the workflow pulls all factors for
+    ``(data_entry_type_id, year)`` in a SINGLE call before the per-entry
+    loop, then resolves ``primary_factor_id`` via Python dict lookup.
+
+    Three Strategy A entries:
+    - Two share kind ``Laptop`` → both hit the bulk dict.
+    - One has kind ``Server`` not in the bulk dict → falls back to the
+      per-entry resolver.
+
+    Asserts:
+    - ``factor_repo.list_by_data_entry_type`` is called EXACTLY ONCE.
+    - ``handler_svc.resolve_primary_factor_id`` is called only for the
+      missed entry (1 call, not 3).
+    - Dict-hit entries get the bulk-loaded factor id; the missed entry
+      gets the resolver's returned id.
+    """
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    laptop_a = _make_mock_entry(1, 10)
+    laptop_a.data = {"primary_factor_id": 0, "equipment_class": "Laptop"}
+    laptop_b = _make_mock_entry(2, 10)
+    laptop_b.data = {"primary_factor_id": 0, "equipment_class": "Laptop"}
+    server = _make_mock_entry(3, 10)
+    server.data = {"primary_factor_id": 0, "equipment_class": "Server"}
+    entries = [laptop_a, laptop_b, server]
+
+    # Bulk-loaded factor: matches kind=Laptop only.
+    laptop_factor = MagicMock()
+    laptop_factor.id = 4242
+    laptop_factor.classification = {"equipment_class": "Laptop"}
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.CarbonReportModuleService"
+        ) as mock_module_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+        patch(
+            "app.workflows.emission_recalculation.ModuleHandlerService"
+        ) as mock_handler_svc_cls,
+    ):
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[laptop_factor]
+        )
+        mock_emission_cls.return_value.upsert_by_data_entry = AsyncMock()
+        mock_module_cls.return_value.recompute_stats = AsyncMock()
+        strategy_a_handler = MagicMock()
+        strategy_a_handler.kind_field = "equipment_class"
+        strategy_a_handler.subkind_field = None
+        mock_handler_cls.get_by_type.return_value = strategy_a_handler
+        # Fallback resolver — only the Server entry should reach it.
+        mock_handler_svc_cls.return_value.resolve_primary_factor_id = AsyncMock(
+            return_value={"primary_factor_id": 9999}
+        )
+
+        await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
+
+    # Single bulk SELECT, regardless of entry count.
+    bulk_call = mock_factor_repo_cls.return_value.list_by_data_entry_type
+    assert bulk_call.await_count == 1
+
+    # Dict-hit entries take the fast path; resolver is invoked only for
+    # the miss (Server kind not present in the bulk-loaded factor set).
+    resolver = mock_handler_svc_cls.return_value.resolve_primary_factor_id
+    assert resolver.await_count == 1
+
+    # Bulk-hit entries linked to the bulk factor; miss linked to the
+    # resolver's returned id.
+    assert laptop_a.data["primary_factor_id"] == 4242
+    assert laptop_b.data["primary_factor_id"] == 4242
+    assert server.data["primary_factor_id"] == 9999

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -422,6 +422,11 @@ async def test_recalculate_skips_rematch_for_strategy_b_handlers():
     mock_handler_svc_cls.return_value.resolve_primary_factor_id.assert_not_called()
     assert entry.data["primary_factor_id"] == 7
     assert result["recalculated"] == 1
+    # Plan 310D Copilot follow-up: the bulk-prefetch SELECT must also be
+    # skipped for Strategy B slices.  Without this gate every Strategy B
+    # recalc paid for an extra ``list_by_data_entry_type`` query that
+    # was guaranteed to feed zero useful lookups.
+    mock_factor_repo_cls.return_value.list_by_data_entry_type.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Replaces the per-entry \`handler_svc.resolve_primary_factor_id()\` call inside \`recalculate_for_data_entry_type\` with a single bulk fetch + in-memory dict lookup keyed by classification tuple.

- **Before**: N+1 — one DB roundtrip per entry (~10k for purchases).
- **After**: 1 SELECT, dict lookup per entry. Per-entry handler call kept as a fallback for dict misses (rare classification values, Strategy-B handlers where \`kind_field\` is not in \`entry.data\`).

Preserves the \`entry.data\` rollback semantics added in 310-B — the tentative-swap-before-upsert / restore-on-exception pattern is unchanged.

Plan 310-D follow-up \"Batch the rematch\" — explicitly scoped here because moving emission writes out of the ingest path (Tier 2 work) makes recalc-only the hot path.

## Files

- \`backend/app/workflows/emission_recalculation.py\` — bulk fetch helper + dict lookup; preserves all existing branches and rollback paths.
- \`backend/tests/unit/workflows/test_emission_recalculation.py\` — adds \`test_recalculate_uses_single_factor_bulk_fetch\` asserting the bulk fetch fires once and the per-entry resolver is called only on dict miss.

## Test plan

- [x] \`rtk uv run pytest tests/unit/workflows/test_emission_recalculation.py -v\` — 9/9 pass (incl. 310-B's rollback + Strategy-B gate tests, plus the new bulk-fetch test).
- [x] \`rtk uv run pytest tests/integration/services/data_ingestion/test_plan_310b_factor_pipeline_pg.py -v\` — 9/9 pass (Docker available).
- [x] \`rtk uv run ruff check app/ tests/\` — clean.

## Notes

Part of a Tier-1 batch landing parallelizable surface of Plans 310-C/D. Sibling PRs: #1019, #1020, #1021, #1022, #1023, #1026.