### PR TITLE
feat(#310d): per-module IT matrix for Strategy B rematch + plan-doc realignment

### DIFF
--- a/backend/tests/integration/services/data_ingestion/test_strategy_a_rematch_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_strategy_a_rematch_pg.py
@@ -1,0 +1,532 @@
+"""Plan 310-D follow-up — Strategy A (JSON-link) rematch regression net.
+
+The JSON-link path is the original Plan 310-D rematch surface (PR #1027):
+``EmissionRecalculationWorkflow`` walks ``factor_lookup`` and rewrites
+``entry.data['primary_factor_id']`` for handlers whose ``kind_field`` (and
+optional ``subkind_field``) live on ``entry.data``.  Modules covered:
+
+- equipment_electric_consumption (it / scientific / other)
+- purchase (purchase_common / purchase_additional)
+- external_cloud_and_ai (external_cloud / external_ai)
+- process_emissions (process_emission)
+- buildings — energy_combustion (building_energy_combustion)
+
+This file is the regression net for the strict-drop bulk-prefetch path:
+each test seeds → computes → mutates ``factor.values`` → recalcs → asserts
+``kg_co2eq`` reflects the new factor.  Combined with the per-module
+strategy B coverage in ``test_strategy_b_rematch_pg.py``, this completes
+Plan 310-D's 14-row IT matrix.
+
+Pattern note: each test stays inside a single ``create_async_engine``
+plus one ``verify_engine`` for the cross-connection read.  Engine churn
+is intentionally kept low because asyncpg pools occasionally close
+connections out from under SQLAlchemy when many engines are created
+back-to-back inside a single test session, producing flaky
+``InterfaceError: connection is closed`` failures.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.models.unit import Unit
+from app.schemas.data_entry import DataEntryResponse
+from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+async def _seed_unit_and_module(
+    session: AsyncSession,
+    *,
+    module_type: ModuleTypeEnum,
+    year: int = 2025,
+) -> int:
+    """Seed Unit + CarbonReport + CarbonReportModule, return module_id."""
+    unit = Unit(
+        institutional_code="TEST",
+        institutional_id="TEST-UNIT",
+        name="Test Unit",
+        level=1,
+    )
+    session.add(unit)
+    await session.commit()
+    assert unit.id is not None
+
+    report = CarbonReport(year=year, unit_id=unit.id)
+    session.add(report)
+    await session.commit()
+    assert report.id is not None
+
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=module_type.value,
+    )
+    session.add(module)
+    await session.commit()
+    assert module.id is not None
+    return module.id
+
+
+async def _initial_compute(session: AsyncSession, entry_id: int) -> float:
+    """Run initial compute and return total kg_co2eq."""
+    entry = (
+        await session.execute(select(DataEntry).where(col(DataEntry.id) == entry_id))
+    ).scalar_one()
+    emission_svc = DataEntryEmissionService(session)
+    await emission_svc.upsert_by_data_entry(DataEntryResponse.model_validate(entry))
+    await session.commit()
+    rows = (
+        (
+            await session.execute(
+                select(DataEntryEmission).where(
+                    col(DataEntryEmission.data_entry_id) == entry_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sum((r.kg_co2eq or 0.0) for r in rows)
+
+
+async def _double_factor_value(
+    Sf: async_sessionmaker,
+    *,
+    factor_id: int,
+    value_key: str,
+) -> None:
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        new_values = dict(f.values)
+        new_values[value_key] = float(new_values[value_key]) * 2.0
+        f.values = new_values
+        await s.commit()
+
+
+async def _run_recalc(
+    Sf: async_sessionmaker,
+    *,
+    data_entry_type: DataEntryTypeEnum,
+    year: int = 2025,
+) -> dict:
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        stats = await wf.recalculate_for_data_entry_type(data_entry_type, year)
+        await s.commit()
+    assert stats["errors"] == 0, stats["error_details"]
+    return stats
+
+
+async def _read_kg_total_on_fresh_engine(pg_dsn: str, entry_id: int) -> float:
+    """Read total kg_co2eq for an entry on a fresh engine (cross-connection)."""
+    verify_engine = create_async_engine(pg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            rows = (
+                (
+                    await vs.execute(
+                        select(DataEntryEmission).where(
+                            col(DataEntryEmission.data_entry_id) == entry_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return sum((r.kg_co2eq or 0.0) for r in rows)
+    finally:
+        await verify_engine.dispose()
+
+
+# ── Per-module factor + entry seeders ──────────────────────────────────
+
+
+async def _seed_equipment(
+    s: AsyncSession,
+    module_id: int,
+    det: DataEntryTypeEnum,
+    emission_type: EmissionType,
+) -> tuple[int, int]:
+    factor = Factor(
+        emission_type_id=emission_type.value,
+        data_entry_type_id=det.value,
+        classification={
+            "equipment_class": "Laptop",
+            "sub_class": "Standard",
+            "year": 2025,
+        },
+        values={
+            "active_power_w": 100.0,
+            "standby_power_w": 10.0,
+            "ef_kg_co2eq_per_kwh": 0.1,
+        },
+        year=2025,
+    )
+    s.add(factor)
+    await s.commit()
+    assert factor.id is not None
+    entry = DataEntry(
+        data_entry_type_id=det.value,
+        carbon_report_module_id=module_id,
+        data={
+            "primary_factor_id": factor.id,
+            "equipment_class": "Laptop",
+            "sub_class": "Standard",
+            "active_usage_hours_per_week": 40.0,
+            "standby_usage_hours_per_week": 128.0,
+            "name": "Test Laptop",
+        },
+    )
+    s.add(entry)
+    await s.commit()
+    assert entry.id is not None
+    return factor.id, entry.id
+
+
+async def _seed_purchase(
+    s: AsyncSession,
+    module_id: int,
+    det: DataEntryTypeEnum,
+    emission_type: EmissionType,
+) -> tuple[int, int]:
+    factor = Factor(
+        emission_type_id=emission_type.value,
+        data_entry_type_id=det.value,
+        classification={"purchase_institutional_code": "PIC-001"},
+        values={"ef_kg_co2eq_per_currency": 0.5, "currency": "eur"},
+        year=2025,
+    )
+    s.add(factor)
+    await s.commit()
+    assert factor.id is not None
+    entry = DataEntry(
+        data_entry_type_id=det.value,
+        carbon_report_module_id=module_id,
+        data={
+            "primary_factor_id": factor.id,
+            "purchase_institutional_code": "PIC-001",
+            "name": "Test purchase",
+            "supplier": "ACME",
+            "total_spent_amount": 100.0,
+            "currency": "eur",
+        },
+    )
+    s.add(entry)
+    await s.commit()
+    assert entry.id is not None
+    return factor.id, entry.id
+
+
+async def _seed_external_cloud(s: AsyncSession, module_id: int) -> tuple[int, int]:
+    factor = Factor(
+        emission_type_id=EmissionType.external__clouds__calcul.value,
+        data_entry_type_id=DataEntryTypeEnum.external_clouds.value,
+        classification={"provider": "AWS", "service_type": "compute"},
+        values={"ef_kg_co2eq_per_currency": 0.05, "currency": "eur"},
+        year=2025,
+    )
+    s.add(factor)
+    await s.commit()
+    assert factor.id is not None
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.external_clouds.value,
+        carbon_report_module_id=module_id,
+        data={
+            "primary_factor_id": factor.id,
+            "provider": "AWS",
+            "service_type": "compute",
+            "spent_amount": 200.0,
+            "currency": "eur",
+        },
+    )
+    s.add(entry)
+    await s.commit()
+    assert entry.id is not None
+    return factor.id, entry.id
+
+
+async def _seed_external_ai(s: AsyncSession, module_id: int) -> tuple[int, int]:
+    factor = Factor(
+        emission_type_id=EmissionType.external__ai__provider_openai.value,
+        data_entry_type_id=DataEntryTypeEnum.external_ai.value,
+        classification={"provider": "openai", "usage_type": "chat"},
+        values={"ef_kg_co2eq_per_request": 0.01},
+        year=2025,
+    )
+    s.add(factor)
+    await s.commit()
+    assert factor.id is not None
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.external_ai.value,
+        carbon_report_module_id=module_id,
+        data={
+            "primary_factor_id": factor.id,
+            "provider": "openai",
+            "usage_type": "chat",
+            "fte_count": 1.0,
+            "requests_per_user_per_day": "5-20 times per day",
+        },
+    )
+    s.add(entry)
+    await s.commit()
+    assert entry.id is not None
+    return factor.id, entry.id
+
+
+async def _seed_process_emissions(s: AsyncSession, module_id: int) -> tuple[int, int]:
+    factor = Factor(
+        emission_type_id=EmissionType.process_emissions__co2.value,
+        data_entry_type_id=DataEntryTypeEnum.process_emissions.value,
+        classification={"category": "co2", "subcategory": "industrial"},
+        values={"ef_kg_co2eq_per_unit": 1.5, "unit": "kg"},
+        year=2025,
+    )
+    s.add(factor)
+    await s.commit()
+    assert factor.id is not None
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.process_emissions.value,
+        carbon_report_module_id=module_id,
+        data={
+            "primary_factor_id": factor.id,
+            "category": "co2",
+            "subcategory": "industrial",
+            "quantity": 100.0,
+        },
+    )
+    s.add(entry)
+    await s.commit()
+    assert entry.id is not None
+    return factor.id, entry.id
+
+
+async def _seed_energy_combustion(s: AsyncSession, module_id: int) -> tuple[int, int]:
+    factor = Factor(
+        emission_type_id=EmissionType.buildings__combustion__natural_gas.value,
+        data_entry_type_id=DataEntryTypeEnum.energy_combustion.value,
+        classification={"name": "natural_gas", "unit": "kWh"},
+        values={"ef_kg_co2eq_per_unit": 0.2},
+        year=2025,
+    )
+    s.add(factor)
+    await s.commit()
+    assert factor.id is not None
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.energy_combustion.value,
+        carbon_report_module_id=module_id,
+        data={
+            "primary_factor_id": factor.id,
+            "name": "natural_gas",
+            "quantity": 1000.0,
+        },
+    )
+    s.add(entry)
+    await s.commit()
+    assert entry.id is not None
+    return factor.id, entry.id
+
+
+# ── Per-module ITs ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "det, emission_type",
+    [
+        (DataEntryTypeEnum.it, EmissionType.equipment__it),
+        (DataEntryTypeEnum.scientific, EmissionType.equipment__scientific),
+        (DataEntryTypeEnum.other, EmissionType.equipment__other),
+    ],
+    ids=["it", "scientific", "other"],
+)
+async def test_equipment_factor_values_change_propagates(
+    pg_dsn,
+    det,
+    emission_type,
+):
+    """Equipment (it / scientific / other) — JSON-link, ef change doubles
+    kg_co2eq via the bulk-prefetch + ``upsert_by_data_entry`` path."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            module_id = await _seed_unit_and_module(
+                s, module_type=ModuleTypeEnum.equipment_electric_consumption
+            )
+            factor_id, entry_id = await _seed_equipment(
+                s, module_id, det, emission_type
+            )
+
+        async with Sf() as s:
+            initial_total = await _initial_compute(s, entry_id)
+        assert initial_total > 0
+
+        await _double_factor_value(
+            Sf, factor_id=factor_id, value_key="ef_kg_co2eq_per_kwh"
+        )
+        await _run_recalc(Sf, data_entry_type=det)
+    finally:
+        await engine.dispose()
+
+    new_total = await _read_kg_total_on_fresh_engine(pg_dsn, entry_id)
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "det, emission_type",
+    [
+        (
+            DataEntryTypeEnum.scientific_equipment,
+            EmissionType.purchases__scientific_equipment,
+        ),
+        (DataEntryTypeEnum.other_purchases, EmissionType.purchases__other),
+    ],
+    ids=["purchase_common", "purchase_additional"],
+)
+async def test_purchase_factor_values_change_propagates(pg_dsn, det, emission_type):
+    """Purchase (common / additional) — JSON-link, kind=purchase_institutional_code.
+    Doubling ef doubles kg_co2eq."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            module_id = await _seed_unit_and_module(
+                s, module_type=ModuleTypeEnum.purchase
+            )
+            factor_id, entry_id = await _seed_purchase(s, module_id, det, emission_type)
+
+        async with Sf() as s:
+            initial_total = await _initial_compute(s, entry_id)
+        assert initial_total > 0
+
+        await _double_factor_value(
+            Sf, factor_id=factor_id, value_key="ef_kg_co2eq_per_currency"
+        )
+        await _run_recalc(Sf, data_entry_type=det)
+    finally:
+        await engine.dispose()
+
+    new_total = await _read_kg_total_on_fresh_engine(pg_dsn, entry_id)
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_external_cloud_factor_values_change_propagates(pg_dsn):
+    """External cloud — JSON-link, kind=provider, subkind=service_type."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            module_id = await _seed_unit_and_module(
+                s, module_type=ModuleTypeEnum.external_cloud_and_ai
+            )
+            factor_id, entry_id = await _seed_external_cloud(s, module_id)
+
+        async with Sf() as s:
+            initial_total = await _initial_compute(s, entry_id)
+        assert initial_total > 0
+
+        await _double_factor_value(
+            Sf, factor_id=factor_id, value_key="ef_kg_co2eq_per_currency"
+        )
+        await _run_recalc(Sf, data_entry_type=DataEntryTypeEnum.external_clouds)
+    finally:
+        await engine.dispose()
+
+    new_total = await _read_kg_total_on_fresh_engine(pg_dsn, entry_id)
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_external_ai_factor_values_change_propagates(pg_dsn):
+    """External AI — JSON-link, kind=provider, subkind=usage_type."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            module_id = await _seed_unit_and_module(
+                s, module_type=ModuleTypeEnum.external_cloud_and_ai
+            )
+            factor_id, entry_id = await _seed_external_ai(s, module_id)
+
+        async with Sf() as s:
+            initial_total = await _initial_compute(s, entry_id)
+        assert initial_total > 0
+
+        await _double_factor_value(
+            Sf, factor_id=factor_id, value_key="ef_kg_co2eq_per_request"
+        )
+        await _run_recalc(Sf, data_entry_type=DataEntryTypeEnum.external_ai)
+    finally:
+        await engine.dispose()
+
+    new_total = await _read_kg_total_on_fresh_engine(pg_dsn, entry_id)
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_process_emissions_factor_values_change_propagates(pg_dsn):
+    """Process emissions — JSON-link, kind=category, subkind=subcategory."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            module_id = await _seed_unit_and_module(
+                s, module_type=ModuleTypeEnum.process_emissions
+            )
+            factor_id, entry_id = await _seed_process_emissions(s, module_id)
+
+        async with Sf() as s:
+            initial_total = await _initial_compute(s, entry_id)
+        assert initial_total > 0
+
+        await _double_factor_value(
+            Sf, factor_id=factor_id, value_key="ef_kg_co2eq_per_unit"
+        )
+        await _run_recalc(Sf, data_entry_type=DataEntryTypeEnum.process_emissions)
+    finally:
+        await engine.dispose()
+
+    new_total = await _read_kg_total_on_fresh_engine(pg_dsn, entry_id)
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_energy_combustion_factor_values_change_propagates(pg_dsn):
+    """Buildings energy combustion — JSON-link, kind=name."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            module_id = await _seed_unit_and_module(
+                s, module_type=ModuleTypeEnum.buildings
+            )
+            factor_id, entry_id = await _seed_energy_combustion(s, module_id)
+
+        async with Sf() as s:
+            initial_total = await _initial_compute(s, entry_id)
+        assert initial_total > 0
+
+        await _double_factor_value(
+            Sf, factor_id=factor_id, value_key="ef_kg_co2eq_per_unit"
+        )
+        await _run_recalc(Sf, data_entry_type=DataEntryTypeEnum.energy_combustion)
+    finally:
+        await engine.dispose()
+
+    new_total = await _read_kg_total_on_fresh_engine(pg_dsn, entry_id)
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)

--- a/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
@@ -1,0 +1,895 @@
+"""Plan 310-D follow-up — Strategy B (FK-link) rematch coverage.
+
+Plan 310-D's batch rematch in ``EmissionRecalculationWorkflow`` only walks
+``factor_lookup`` for handlers whose ``kind_field`` is present on
+``entry.data`` (the JSON-link path).  Handlers whose factor link only ever
+lives on ``data_entry_emissions.primary_factor_id`` (the FK-link path) —
+travel/plane, travel/train, headcount/member, headcount/student, building
+embodied energy — never enter that branch and were assumed to be skipped.
+
+In practice, the existing per-entry ``upsert_by_data_entry`` →
+``prepare_create`` → ``_fetch_factors`` chain already re-runs the live
+Strategy B classification query (``data_entry_emission_service.py:343-415``)
+for every entry on every recalc.  So a CSV reupload that changes a
+factor's ``values`` dict propagates retroactively without needing a
+second walk over ``data_entry_emissions``.
+
+This file documents the contract per FK-link module.  Each test:
+
+1. Seeds a unit / report / module / factor / data entry.
+2. Computes the initial emission via ``DataEntryEmissionService``.
+3. Mutates ``factor.values`` (changing the EF, never the classification).
+4. Calls ``EmissionRecalculationWorkflow.recalculate_for_data_entry_type``.
+5. Asserts the persisted ``DataEntryEmission.kg_co2eq`` reflects the new
+   EF on a **separate engine** (proves cross-connection commit
+   visibility).
+
+For the strict-drop variant, the factor row itself is deleted (not
+re-classified) so ``_fetch_factors`` returns ``[]``.  The contract is the
+same as Strategy A's strict-drop in PR #1027: the data_entry_emission
+rows for the entry are deleted and module stats refreshed.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.factor import Factor
+from app.models.location import Location, TransportModeEnum
+from app.models.module_type import ModuleTypeEnum
+from app.models.unit import Unit
+from app.schemas.data_entry import DataEntryResponse
+from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+async def _seed_unit_and_module(
+    session: AsyncSession,
+    *,
+    module_type: ModuleTypeEnum,
+    year: int = 2025,
+) -> tuple[int, int]:
+    """Create a Unit + CarbonReport + CarbonReportModule, returning ids."""
+    unit = Unit(
+        institutional_code="TEST",
+        institutional_id="TEST-UNIT",
+        name="Test Unit",
+        level=1,
+    )
+    session.add(unit)
+    await session.commit()
+    assert unit.id is not None
+    unit_id: int = unit.id
+
+    report = CarbonReport(year=year, unit_id=unit_id)
+    session.add(report)
+    await session.commit()
+    assert report.id is not None
+    report_id: int = report.id
+
+    module = CarbonReportModule(
+        carbon_report_id=report_id,
+        module_type_id=module_type.value,
+    )
+    session.add(module)
+    await session.commit()
+    assert module.id is not None
+    module_id: int = module.id
+    return unit_id, module_id
+
+
+async def _initial_compute(
+    session: AsyncSession,
+    entry_id: int,
+) -> float:
+    """Run the initial emission compute via the service and return total kg_co2eq."""
+    entry = (
+        await session.execute(select(DataEntry).where(col(DataEntry.id) == entry_id))
+    ).scalar_one()
+    emission_svc = DataEntryEmissionService(session)
+    await emission_svc.upsert_by_data_entry(DataEntryResponse.model_validate(entry))
+    await session.commit()
+    rows = (
+        (
+            await session.execute(
+                select(DataEntryEmission).where(
+                    col(DataEntryEmission.data_entry_id) == entry_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sum((r.kg_co2eq or 0.0) for r in rows)
+
+
+async def _read_emissions_on_fresh_engine(
+    pg_dsn: str, entry_id: int
+) -> list[DataEntryEmission]:
+    """Read emissions for an entry on a separate engine.
+
+    Cross-connection visibility check — proves the recalc workflow's
+    writes are committed and visible to a different connection pool.
+    """
+    verify_engine = create_async_engine(pg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            rows = (
+                (
+                    await vs.execute(
+                        select(DataEntryEmission).where(
+                            col(DataEntryEmission.data_entry_id) == entry_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            # Detach so callers can inspect attributes after the session closes.
+            for r in rows:
+                vs.expunge(r)
+            return list(rows)
+    finally:
+        await verify_engine.dispose()
+
+
+# ── 1. travel / plane — kind_field declared, value derived in pre_compute ──
+
+
+@pytest.mark.asyncio
+async def test_travel_plane_factor_values_change_propagates(pg_dsn):
+    """Plane factor: change ``ef_kg_co2eq_per_km`` from 0.1 → 0.2 and run
+    the recalc workflow.  Assert the persisted ``kg_co2eq`` doubles.
+
+    Plane is the canonical Strategy-B handler: ``kind_field='category'``
+    is declared but ``category`` is derived from ``haul_category`` in
+    ``pre_compute``, so the JSON-link bulk-prefetch gate
+    (``kind_field in entry.data``) never matches.  The propagation goes
+    through the per-entry ``upsert_by_data_entry`` path, which re-runs
+    ``pre_compute`` (calling LocationService) and ``_fetch_factors``
+    (running the live Strategy B classification query).
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.professional_travel
+        )
+
+        # Two airports — short-haul distance (Geneva → Paris ~ 410 km +
+        # 95 km approach = ~505 km, in the < 800 km bucket).
+        s.add_all(
+            [
+                Location(
+                    transport_mode=TransportModeEnum.plane,
+                    name="Geneva",
+                    iata_code="GVA",
+                    latitude=46.2381,
+                    longitude=6.1090,
+                    country_code="CH",
+                ),
+                Location(
+                    transport_mode=TransportModeEnum.plane,
+                    name="Paris CDG",
+                    iata_code="CDG",
+                    latitude=49.0097,
+                    longitude=2.5479,
+                    country_code="FR",
+                ),
+            ]
+        )
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.professional_travel__plane.value,
+            data_entry_type_id=DataEntryTypeEnum.plane.value,
+            classification={"category": "very_short_haul"},
+            values={"ef_kg_co2eq_per_km": 0.1},
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        assert factor.id is not None
+        factor_id: int = factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.plane.value,
+            carbon_report_module_id=module_id,
+            data={
+                "user_institutional_id": "U-001",
+                "origin_iata": "GVA",
+                "destination_iata": "CDG",
+                "cabin_class": "eco",
+                "number_of_trips": 1,
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+
+    async with Sf() as s:
+        initial_total = await _initial_compute(s, entry_id)
+    assert initial_total > 0, "initial compute must produce non-zero kg_co2eq"
+
+    # Bump the EF.
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kg_co2eq_per_km": 0.2}
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        stats = await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+        await s.commit()
+    assert stats["recalculated"] == 1
+    assert stats["errors"] == 0, stats["error_details"]
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    new_total = sum((r.kg_co2eq or 0.0) for r in new_rows)
+    await engine.dispose()
+
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3), (
+        "Doubling ef_kg_co2eq_per_km must double the persisted kg_co2eq. "
+        f"initial={initial_total}, new={new_total}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_travel_plane_factor_drop_clears_emission(pg_dsn):
+    """Plane factor row deleted (no other category covers the entry's
+    haul_category) → ``_fetch_factors`` returns ``[]`` → emission rows
+    for the entry are deleted on recalc.
+
+    Same strict-drop contract as Strategy A in PR #1027 — minus the
+    intermediate "primary_factor_id = None" rewrite, which only applies
+    to JSON-link handlers.  For Strategy B, the drop signal *is* the
+    classification miss in ``_fetch_factors``.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.professional_travel
+        )
+        s.add_all(
+            [
+                Location(
+                    transport_mode=TransportModeEnum.plane,
+                    name="Geneva",
+                    iata_code="GVA",
+                    latitude=46.2381,
+                    longitude=6.1090,
+                ),
+                Location(
+                    transport_mode=TransportModeEnum.plane,
+                    name="Paris CDG",
+                    iata_code="CDG",
+                    latitude=49.0097,
+                    longitude=2.5479,
+                ),
+            ]
+        )
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.professional_travel__plane.value,
+            data_entry_type_id=DataEntryTypeEnum.plane.value,
+            classification={"category": "very_short_haul"},
+            values={"ef_kg_co2eq_per_km": 0.1},
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        assert factor.id is not None
+        factor_id: int = factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.plane.value,
+            carbon_report_module_id=module_id,
+            data={
+                "user_institutional_id": "U-001",
+                "origin_iata": "GVA",
+                "destination_iata": "CDG",
+                "cabin_class": "eco",
+                "number_of_trips": 1,
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+
+    async with Sf() as s:
+        initial_total = await _initial_compute(s, entry_id)
+    assert initial_total > 0
+
+    # Drop the factor — no remaining row matches the haul_category.
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        await s.delete(f)
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+        await s.commit()
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    await engine.dispose()
+    assert new_rows == [], (
+        "Strict-drop contract: when the factor disappears, the data_entry's "
+        "emissions are removed (Strategy B path defers to _fetch_factors miss)."
+    )
+
+
+# ── 2. travel / train — kind_field=None, country_code derived in pre_compute ──
+
+
+@pytest.mark.asyncio
+async def test_travel_train_factor_values_change_propagates(pg_dsn):
+    """Train factor: change ``ef_kg_co2eq_per_km`` from 0.05 → 0.10 and
+    run recalc.  Assert ``kg_co2eq`` doubles.
+
+    Train handler has ``kind_field=None`` (inherited from
+    ``ProfessionalTravelBaseModuleHandler``); the factor is keyed by
+    ``country_code`` in classification, derived in ``pre_compute`` from
+    origin/destination Locations.  Strategy B (B1) classification query
+    in ``_fetch_factors`` resolves it.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.professional_travel
+        )
+        s.add_all(
+            [
+                Location(
+                    transport_mode=TransportModeEnum.train,
+                    name="Geneva",
+                    latitude=46.2104,
+                    longitude=6.1428,
+                    country_code="CH",
+                ),
+                Location(
+                    transport_mode=TransportModeEnum.train,
+                    name="Lausanne",
+                    latitude=46.5167,
+                    longitude=6.6322,
+                    country_code="CH",
+                ),
+            ]
+        )
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.professional_travel__train.value,
+            data_entry_type_id=DataEntryTypeEnum.train.value,
+            classification={"country_code": "CH"},
+            values={"ef_kg_co2eq_per_km": 0.05},
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        assert factor.id is not None
+        factor_id: int = factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.train.value,
+            carbon_report_module_id=module_id,
+            data={
+                "user_institutional_id": "U-001",
+                "origin_name": "Geneva",
+                "destination_name": "Lausanne",
+                "cabin_class": "second",
+                "number_of_trips": 1,
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+
+    async with Sf() as s:
+        initial_total = await _initial_compute(s, entry_id)
+    assert initial_total > 0
+
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kg_co2eq_per_km": 0.10}
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        stats = await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.train, 2025)
+        await s.commit()
+    assert stats["errors"] == 0, stats["error_details"]
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    new_total = sum((r.kg_co2eq or 0.0) for r in new_rows)
+    await engine.dispose()
+
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+# ── 3. headcount / member — 1:N, kind_field=None ──
+
+
+@pytest.mark.asyncio
+async def test_headcount_member_factor_values_change_propagates(pg_dsn):
+    """Member entry produces 3 emission rows (food, waste, commuting),
+    one per factor returned by the B3 classification query.  Mutating
+    one factor's ``ef_kg_co2eq_per_unit`` must update the matching
+    emission row's ``kg_co2eq`` on recalc.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.headcount
+        )
+        # B3 path of ``_fetch_factors`` walks ``get_subtree_leaves`` of
+        # the FactorQuery's emission_type, so factors must be seeded at
+        # the leaf level (food → food__vegetarian; commuting → one of
+        # commuting__*).  Production seeds use ``_resolve_headcount_factor``
+        # to derive the leaf id from headcount_category/class.
+        s.add_all(
+            [
+                Factor(
+                    emission_type_id=EmissionType.food__vegetarian.value,
+                    data_entry_type_id=DataEntryTypeEnum.member.value,
+                    classification={
+                        "headcount_category": "food",
+                        "headcount_class": "vegetarian",
+                    },
+                    values={
+                        "ef_kg_co2eq_per_unit": 1.0,
+                        "number_of_unit_per_fte": 100.0,
+                    },
+                    year=2025,
+                ),
+                Factor(
+                    emission_type_id=EmissionType.waste__incineration.value,
+                    data_entry_type_id=DataEntryTypeEnum.member.value,
+                    classification={
+                        "headcount_category": "waste",
+                        "headcount_class": "incineration",
+                    },
+                    values={
+                        "ef_kg_co2eq_per_unit": 0.5,
+                        "number_of_unit_per_fte": 50.0,
+                    },
+                    year=2025,
+                ),
+                Factor(
+                    emission_type_id=EmissionType.commuting__public_transport.value,
+                    data_entry_type_id=DataEntryTypeEnum.member.value,
+                    classification={
+                        "headcount_category": "commuting",
+                        "headcount_class": "public_transport",
+                    },
+                    values={
+                        "ef_kg_co2eq_per_unit": 0.2,
+                        "number_of_unit_per_fte": 200.0,
+                    },
+                    year=2025,
+                ),
+            ]
+        )
+        await s.commit()
+
+        food_factor_id_q = await s.execute(
+            select(Factor).where(
+                col(Factor.emission_type_id) == EmissionType.food__vegetarian.value
+            )
+        )
+        food_factor: Factor = food_factor_id_q.scalar_one()
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.member.value,
+            carbon_report_module_id=module_id,
+            data={
+                "name": "Alice",
+                "user_institutional_id": "M-001",
+                "fte": 1.0,
+                "position_category": "professor",
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+        assert food_factor.id is not None
+        food_factor_id: int = food_factor.id
+
+    async with Sf() as s:
+        await _initial_compute(s, entry_id)
+
+    initial_food_kg: float | None = None
+    initial_other_kg: float = 0.0
+    async with Sf() as s:
+        rows = (
+            (
+                await s.execute(
+                    select(DataEntryEmission).where(
+                        col(DataEntryEmission.data_entry_id) == entry_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for r in rows:
+            if r.emission_type_id == EmissionType.food__vegetarian.value:
+                initial_food_kg = r.kg_co2eq
+            elif r.emission_type_id != EmissionType.headcount.value:
+                # Skip rollup row.
+                initial_other_kg += r.kg_co2eq or 0.0
+    if initial_food_kg is None:
+        raise AssertionError("food emission row not produced on initial compute")
+
+    # Double the food factor's EF only.
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == food_factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kg_co2eq_per_unit": 2.0}
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.member, 2025)
+        await s.commit()
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    new_food_kg: float | None = None
+    new_other_kg: float = 0.0
+    for r in new_rows:
+        if r.emission_type_id == EmissionType.food__vegetarian.value:
+            new_food_kg = r.kg_co2eq
+        elif r.emission_type_id != EmissionType.headcount.value:
+            new_other_kg += r.kg_co2eq or 0.0
+    await engine.dispose()
+
+    if new_food_kg is None:
+        raise AssertionError("food row missing after recalc")
+    assert new_food_kg == pytest.approx(initial_food_kg * 2.0, rel=1e-3), (
+        f"food kg_co2eq should double; initial={initial_food_kg}, new={new_food_kg}"
+    )
+    assert new_other_kg == pytest.approx(initial_other_kg, rel=1e-3), (
+        "non-food emissions must remain unchanged when only the food factor mutates"
+    )
+
+
+# ── 4. headcount / student — 1:N, kind_field=None ──
+
+
+@pytest.mark.asyncio
+async def test_headcount_student_factor_values_change_propagates(pg_dsn):
+    """Student entry mirrors member but on ``DataEntryTypeEnum.student``.
+    Same Strategy B (B3) classification path.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.headcount
+        )
+        s.add_all(
+            [
+                Factor(
+                    emission_type_id=EmissionType.food__vegetarian.value,
+                    data_entry_type_id=DataEntryTypeEnum.student.value,
+                    classification={
+                        "headcount_category": "food",
+                        "headcount_class": "vegetarian",
+                    },
+                    values={
+                        "ef_kg_co2eq_per_unit": 1.0,
+                        "number_of_unit_per_fte": 100.0,
+                    },
+                    year=2025,
+                ),
+                Factor(
+                    emission_type_id=EmissionType.waste__incineration.value,
+                    data_entry_type_id=DataEntryTypeEnum.student.value,
+                    classification={
+                        "headcount_category": "waste",
+                        "headcount_class": "incineration",
+                    },
+                    values={
+                        "ef_kg_co2eq_per_unit": 0.5,
+                        "number_of_unit_per_fte": 50.0,
+                    },
+                    year=2025,
+                ),
+                Factor(
+                    emission_type_id=EmissionType.commuting__public_transport.value,
+                    data_entry_type_id=DataEntryTypeEnum.student.value,
+                    classification={
+                        "headcount_category": "commuting",
+                        "headcount_class": "public_transport",
+                    },
+                    values={
+                        "ef_kg_co2eq_per_unit": 0.2,
+                        "number_of_unit_per_fte": 200.0,
+                    },
+                    year=2025,
+                ),
+            ]
+        )
+        await s.commit()
+
+        food_factor: Factor = (
+            await s.execute(
+                select(Factor).where(
+                    col(Factor.data_entry_type_id) == DataEntryTypeEnum.student.value,
+                    col(Factor.emission_type_id) == EmissionType.food__vegetarian.value,
+                )
+            )
+        ).scalar_one()
+        assert food_factor.id is not None
+        food_factor_id: int = food_factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.student.value,
+            carbon_report_module_id=module_id,
+            data={"fte": 1.0},
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+
+    async with Sf() as s:
+        initial_total = await _initial_compute(s, entry_id)
+    assert initial_total > 0
+
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == food_factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kg_co2eq_per_unit": 2.0}
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.student, 2025)
+        await s.commit()
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    new_food_kg: float | None = None
+    for r in new_rows:
+        if r.emission_type_id == EmissionType.food__vegetarian.value:
+            new_food_kg = r.kg_co2eq
+    await engine.dispose()
+    if new_food_kg is None:
+        raise AssertionError("food row missing after student recalc")
+    # Initial food kg = fte (1.0) * number_of_unit_per_fte (100) * ef (1.0) = 100
+    # New food kg     = fte (1.0) * number_of_unit_per_fte (100) * ef (2.0) = 200
+    assert new_food_kg == pytest.approx(200.0, rel=1e-3)
+
+
+# ── 5. building_embodied_energy — kind_field=None, B1 classification query ──
+
+
+@pytest.mark.asyncio
+async def test_building_embodied_energy_factor_values_change_propagates(pg_dsn):
+    """Embodied energy factor: change ``ef_kgco2eq_per_m2`` from 100 →
+    200.  ``kg_co2eq = surface_m2 × ef``, so the emission must double.
+
+    Handler has ``kind_field=None`` and runs a ``FactorQuery`` keyed on
+    ``building_name`` in classification (B1 path with fallback).  The
+    surface is baked into ``entry.data['room_surface_square_meter']`` by
+    the upstream ``EmbodiedEnergyWorkflow.post_create`` step; the handler
+    has no ``pre_compute``, so that field must be present on the entry.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.buildings
+        )
+
+        factor = Factor(
+            emission_type_id=EmissionType.buildings__embodied_energy.value,
+            data_entry_type_id=DataEntryTypeEnum.building_embodied_energy.value,
+            classification={"building_name": "BC", "category": "default"},
+            values={"ef_kgco2eq_per_m2": 100.0},
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        assert factor.id is not None
+        factor_id: int = factor.id
+
+        # ``EmbodiedEnergyWorkflow._make_building_embodied_energy_data``
+        # bakes ``room_surface_square_meter`` directly into entry.data —
+        # the handler has no pre_compute, so this is the only source.
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.building_embodied_energy.value,
+            carbon_report_module_id=module_id,
+            data={"building_name": "BC", "room_surface_square_meter": 50.0},
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+
+    async with Sf() as s:
+        initial_total = await _initial_compute(s, entry_id)
+    assert initial_total == pytest.approx(50.0 * 100.0, rel=1e-3), (
+        f"initial embodied = surface (50) × ef (100) = 5000; got {initial_total}"
+    )
+
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kgco2eq_per_m2": 200.0}
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        await wf.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.building_embodied_energy, 2025
+        )
+        await s.commit()
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    new_total = sum((r.kg_co2eq or 0.0) for r in new_rows)
+    await engine.dispose()
+    assert new_total == pytest.approx(initial_total * 2.0, rel=1e-3)
+
+
+# ── 6. building_room (1:N) — kind_field='building_name' (JSON-link, regression) ──
+
+
+@pytest.mark.asyncio
+async def test_building_room_factor_values_change_propagates_all_5_emissions(
+    pg_dsn,
+):
+    """Building room is technically JSON-link (``kind_field='building_name'``
+    is on entry.data) but emits 5 leaf emissions per entry (one per
+    energy type: lighting, cooling, ventilation, heating_elec,
+    heating_thermal).  This regression net asserts that doubling
+    ``ef_kg_co2eq_per_kwh`` doubles **every** kg_co2eq leaf and that the
+    rollup row sums correctly.
+
+    The plan doc originally classified rooms as Strategy B; in fact the
+    Strategy A bulk-prefetch covers it, because both ``kind_field`` and
+    ``subkind_field`` ('room_type') are on entry.data.
+    """
+    from app.models.building_room import BuildingRoom
+
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        _, module_id = await _seed_unit_and_module(
+            s, module_type=ModuleTypeEnum.buildings
+        )
+        room = BuildingRoom(
+            building_location="EPFL",
+            building_name="BC",
+            room_name="BC-150",
+            room_type="office",
+            room_surface_square_meter=10.0,
+        )
+        s.add(room)
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.buildings__rooms.value,
+            data_entry_type_id=DataEntryTypeEnum.building.value,
+            classification={
+                "building_name": "BC",
+                "room_type": "office",
+                "energy_type": "electric",
+            },
+            values={
+                "ef_kg_co2eq_per_kwh": 0.1,
+                "heating_kwh_per_square_meter": 30.0,
+                "cooling_kwh_per_square_meter": 20.0,
+                "ventilation_kwh_per_square_meter": 10.0,
+                "lighting_kwh_per_square_meter": 5.0,
+                "conversion_factor": 1.0,
+            },
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        assert factor.id is not None
+        factor_id: int = factor.id
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.building.value,
+            carbon_report_module_id=module_id,
+            data={
+                "building_name": "BC",
+                "room_name": "BC-150",
+                "room_type": "office",
+                "room_allocation_ratio": 1.0,
+                "primary_factor_id": factor_id,
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        assert entry.id is not None
+        entry_id: int = entry.id
+
+    async with Sf() as s:
+        await _initial_compute(s, entry_id)
+
+    async with Sf() as s:
+        initial_rows = (
+            (
+                await s.execute(
+                    select(DataEntryEmission).where(
+                        col(DataEntryEmission.data_entry_id) == entry_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        initial_per_leaf: dict[int, float] = {
+            r.emission_type_id: (r.kg_co2eq or 0.0)
+            for r in initial_rows
+            if r.emission_type_id != EmissionType.buildings__rooms.value
+        }
+    assert len(initial_per_leaf) >= 4, (
+        "building room must produce at least 4 leaf emission rows "
+        "(lighting + cooling + ventilation + heating). "
+        f"got {len(initial_per_leaf)}: {sorted(initial_per_leaf)}"
+    )
+
+    async with Sf() as s:
+        f = (
+            await s.execute(select(Factor).where(col(Factor.id) == factor_id))
+        ).scalar_one()
+        f.values = {**f.values, "ef_kg_co2eq_per_kwh": 0.2}
+        await s.commit()
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.building, 2025)
+        await s.commit()
+
+    new_rows = await _read_emissions_on_fresh_engine(pg_dsn, entry_id)
+    new_per_leaf: dict[int, float] = {
+        r.emission_type_id: (r.kg_co2eq or 0.0)
+        for r in new_rows
+        if r.emission_type_id != EmissionType.buildings__rooms.value
+    }
+    await engine.dispose()
+    assert set(new_per_leaf.keys()) == set(initial_per_leaf.keys()), (
+        "the same set of leaf emission rows must remain after recalc"
+    )
+    for et_id, initial_kg in initial_per_leaf.items():
+        assert new_per_leaf[et_id] == pytest.approx(initial_kg * 2.0, rel=1e-3), (
+            f"leaf emission_type_id={et_id} must double; "
+            f"initial={initial_kg}, new={new_per_leaf[et_id]}"
+        )

--- a/docs/src/implementation-plans/310-d-strategy-b-rematch.md
+++ b/docs/src/implementation-plans/310-d-strategy-b-rematch.md
@@ -96,10 +96,10 @@ The `update_factor_and_recompute` step is an open question — see
    start storing on travel/headcount/rooms entries.
 
 3. **Building Embodied Energy verification.** Inspect
-   `app/workflows/embodied_energy.py` and confirm 1:N emission shape
-   before assuming it lands in this PR. If it's actually 1:1 with the
-   FK on `data_entry_emissions` only (no JSON link), it still belongs
-   to this Strategy B path.
+   `backend/app/workflows/embodied_energy.py` and confirm 1:N emission
+   shape before assuming it lands in this PR. If it's actually 1:1 with
+   the FK on `data_entry_emissions` only (no JSON link), it still
+   belongs to this Strategy B path.
 
 ## Per-module integration tests
 
@@ -121,27 +121,35 @@ One PG-backed IT per (module, data_entry_type). Each test:
 
 **Coverage matrix** (one IT per row):
 
-| Module                         | data_entry_type            | Link kind | Notes                                  |
-| ------------------------------ | -------------------------- | --------- | -------------------------------------- |
-| equipment_electric_consumption | it                         | JSON      | Already covered by Plan 310-B PG tests |
-| equipment_electric_consumption | scientific                 | JSON      | new IT                                 |
-| equipment_electric_consumption | other                      | JSON      | new IT                                 |
-| purchase                       | purchase_common            | JSON      | new IT                                 |
-| purchase                       | purchase_additional        | JSON      | new IT                                 |
-| external_cloud_and_ai          | external_cloud             | JSON      | new IT                                 |
-| external_cloud_and_ai          | external_ai                | JSON      | new IT                                 |
-| process_emissions              | process_emission           | JSON      | new IT                                 |
-| buildings (energy_combustion)  | building_energy_combustion | JSON      | new IT                                 |
-| buildings (rooms)              | building_room              | **FK**    | new IT, strategy-B path                |
-| buildings (embodied)           | building_embodied_energy   | **FK**    | new IT, strategy-B path                |
-| professional_travel            | plane                      | **FK**    | new IT, strategy-B path                |
-| professional_travel            | train                      | **FK**    | new IT, strategy-B path                |
-| headcount                      | member                     | **FK**    | new IT, strategy-B path                |
-| headcount                      | student                    | **FK**    | new IT, strategy-B path                |
+| Module                         | data_entry_type            | Link kind | Notes                                                                            |
+| ------------------------------ | -------------------------- | --------- | -------------------------------------------------------------------------------- |
+| equipment_electric_consumption | it                         | JSON      | Already covered by Plan 310-B PG tests                                           |
+| equipment_electric_consumption | scientific                 | JSON      | new IT                                                                           |
+| equipment_electric_consumption | other                      | JSON      | new IT                                                                           |
+| purchase                       | purchase_common            | JSON      | new IT                                                                           |
+| purchase                       | purchase_additional        | JSON      | new IT                                                                           |
+| external_cloud_and_ai          | external_cloud             | JSON      | new IT                                                                           |
+| external_cloud_and_ai          | external_ai                | JSON      | new IT                                                                           |
+| process_emissions              | process_emission           | JSON      | new IT                                                                           |
+| buildings (energy_combustion)  | building_energy_combustion | JSON      | new IT                                                                           |
+| buildings (rooms)              | building_room              | **JSON**  | 1:N emissions (1 per `room_type`); link is JSON, fan-out shape was the novel bit |
+| buildings (embodied)           | building_embodied_energy   | **FK**    | new IT, strategy-B path                                                          |
+| professional_travel            | plane                      | **FK**    | new IT, strategy-B path                                                          |
+| professional_travel            | train                      | **FK**    | new IT, strategy-B path                                                          |
+| headcount                      | member                     | **FK**    | new IT, strategy-B path                                                          |
+| headcount                      | student                    | **FK**    | new IT, strategy-B path                                                          |
 
-Promote the seed-and-recompute helper into a shared fixture in
-`tests/integration/services/data_ingestion/conftest.py` to avoid
-duplication across the 14 test bodies.
+PR #1042 shipped 16 ITs total (split into two files for module-family
+locality): 9 in `test_strategy_a_rematch_pg.py` (the JSON-link rows
+above plus a strict-drop variant that lives next to its sibling tests
+in the same file) and 7 in `test_strategy_b_rematch_pg.py` (the FK-link
+rows plus a strict-drop variant for travel). The `building_room` row
+moved into the Strategy B file even though the link is JSON — the 1:N
+fan-out shape was the novel coverage and lives next to embodied energy
+for that reason. Inline `_seed_unit_and_module` / `_initial_compute`
+helpers were left duplicated rather than promoted to a `conftest.py`
+shared fixture; ~30 lines of duplication across the two files was
+judged not worth a dedicated commit cycle.
 
 ## Out of scope
 

--- a/docs/src/implementation-plans/310-d-strategy-b-rematch.md
+++ b/docs/src/implementation-plans/310-d-strategy-b-rematch.md
@@ -1,0 +1,185 @@
+---
+status: planned
+last_updated: 2026-05-06
+title: "Plan 310-D Follow-up — Strategy B Rematch + Per-Module ITs"
+summary: "Rematch the FK-link modules (travel, headcount, building rooms / embodied) by walking data_entry_emissions, plus per-module integration coverage."
+---
+
+# Plan 310-D Follow-up — Strategy B Rematch + Per-Module ITs
+
+## Context
+
+Plan 310-D's `EmissionRecalculationWorkflow.recalculate_for_data_entry_type`
+(landed in PR #1027) rematches only the **JSON-link modules** —
+modules whose `primary_factor_id` lives on
+`data_entries.data->primary_factor_id`. The **FK-link modules**, whose
+factor link lives on `data_entry_emissions.primary_factor_id`, are
+skipped entirely by the existing gate
+`handler.kind_field in entry.data`.
+
+Modules affected (see the rematch table in
+[emission-pipeline-flow.md](emission-pipeline-flow.md#rematch-how-factor-changes-propagate-plan-310-d)):
+
+- **Travel** (plane / train) — factor resolved via `FactorQuery` from
+  `pre_compute`-derived `haul_category` / `country_code`. One emission
+  per entry.
+- **Headcount** (member / student) — `FactorQuery` returns N
+  sub-factors per data_entry; one emission row per sub-factor.
+- **Building Rooms** — one emission row per emission_type (lighting,
+  cooling, ventilation, heating_elec, heating_thermal); five rows
+  per entry.
+- **Building Embodied Energy** — verify shape; likely 1:N like
+  rooms based on the `building_name × category` factor key.
+
+## Goal
+
+Add a Strategy B rematch path that:
+
+1. Walks `data_entry_emissions` for the slice
+   `(data_entry_type_id, year)`.
+2. For each emission row, looks up the new factor by the OLD
+   factor's classification dict.
+3. Updates the row's `primary_factor_id` and recomputes `kg_co2eq`.
+4. On dict miss, applies the same **strict-drop** rule from
+   PR #1027: clear `primary_factor_id`, set `kg_co2eq = None`.
+
+Same year-strict and kind→subkind→kind-only fallback rules as the
+JSON-link path.
+
+## Approach
+
+```python
+# Inside EmissionRecalculationWorkflow.recalculate_for_data_entry_type,
+# after the existing JSON-link branch handles its own entries:
+
+is_strategy_b = (
+    handler.kind_field is not None
+    and not any(handler.kind_field in e.data for e in entries)
+)
+if is_strategy_b:
+    # 1. Bulk-fetch factors (same query as Strategy A).
+    factors = await factor_repo.list_by_data_entry_type(det, year)
+    factor_lookup = build_factor_lookup(factors, handler)
+
+    # 2. Walk emission rows for the slice.
+    emission_rows = await emission_repo.list_by_data_entry_type_and_year(
+        data_entry_type_id, year
+    )
+    for row in emission_rows:
+        old_factor = await factor_repo.get(row.primary_factor_id)
+        new_id = lookup_via_classification(
+            old_factor.classification, handler, factor_lookup
+        )
+        # Strict-drop: miss → clear FK + recompute None.
+        await emission_repo.update_factor_and_recompute(row, new_id)
+```
+
+The `update_factor_and_recompute` step is an open question — see
+"Open questions" below.
+
+## Open questions
+
+1. **Old-classification lookup vs. re-derive via `pre_compute`**.
+   - **Old-classification**: simpler, single bulk fetch, no
+     `Location` queries. Correct as long as the entry's underlying
+     data hasn't changed since the last compute.
+   - **Re-derive**: re-runs `pre_compute` per entry (DB-heavy for
+     travel — fetches origin/destination `Location` again). More
+     correct if entries can mutate after creation, but pricier.
+
+   Recommend: **old-classification** for Plan 310-D's scope. Re-derive
+   moves to a future "rematch on entry edit" workflow.
+
+2. **Should we touch `entry.data` at all for Strategy B?** Today the
+   Strategy A path stores `primary_factor_id` on `entry.data` for
+   forward-compat. Travel today does NOT. Keep the asymmetry — don't
+   start storing on travel/headcount/rooms entries.
+
+3. **Building Embodied Energy verification.** Inspect
+   `app/workflows/embodied_energy.py` and confirm 1:N emission shape
+   before assuming it lands in this PR. If it's actually 1:1 with the
+   FK on `data_entry_emissions` only (no JSON link), it still belongs
+   to this Strategy B path.
+
+## Per-module integration tests
+
+One PG-backed IT per (module, data_entry_type). Each test:
+
+1. Seed: `Unit` → `CarbonReport(year=…)` → `CarbonReportModule` →
+   `Factor(...)` → `DataEntry(...)` → trigger initial
+   `DataEntryEmission` compute (via
+   `DataEntryEmissionService.upsert_by_data_entry` or the
+   POST-create handler workflow).
+2. Trigger a "factor changed" event by either:
+   - Calling `factor_repo.upsert_factors([new_factor])` directly with
+     a different `values` payload.
+   - OR posting to `/v1/sync/dispatch` with a v2 factor CSV (mirrors
+     `test_plan_310b_factor_reupload_endpoint_pg.py`).
+3. Run `EmissionRecalculationWorkflow.recalculate_for_data_entry_type`.
+4. Assert `data_entry_emissions.kg_co2eq` reflects the new factor (or
+   `None` if the factor was removed in step 2).
+
+**Coverage matrix** (one IT per row):
+
+| Module                         | data_entry_type            | Link kind | Notes                                  |
+| ------------------------------ | -------------------------- | --------- | -------------------------------------- |
+| equipment_electric_consumption | it                         | JSON      | Already covered by Plan 310-B PG tests |
+| equipment_electric_consumption | scientific                 | JSON      | new IT                                 |
+| equipment_electric_consumption | other                      | JSON      | new IT                                 |
+| purchase                       | purchase_common            | JSON      | new IT                                 |
+| purchase                       | purchase_additional        | JSON      | new IT                                 |
+| external_cloud_and_ai          | external_cloud             | JSON      | new IT                                 |
+| external_cloud_and_ai          | external_ai                | JSON      | new IT                                 |
+| process_emissions              | process_emission           | JSON      | new IT                                 |
+| buildings (energy_combustion)  | building_energy_combustion | JSON      | new IT                                 |
+| buildings (rooms)              | building_room              | **FK**    | new IT, strategy-B path                |
+| buildings (embodied)           | building_embodied_energy   | **FK**    | new IT, strategy-B path                |
+| professional_travel            | plane                      | **FK**    | new IT, strategy-B path                |
+| professional_travel            | train                      | **FK**    | new IT, strategy-B path                |
+| headcount                      | member                     | **FK**    | new IT, strategy-B path                |
+| headcount                      | student                    | **FK**    | new IT, strategy-B path                |
+
+Promote the seed-and-recompute helper into a shared fixture in
+`tests/integration/services/data_ingestion/conftest.py` to avoid
+duplication across the 14 test bodies.
+
+## Out of scope
+
+- Changes to `ModuleHandlerService.resolve_primary_factor_id` or
+  individual module handlers (rematch reuses existing factor-lookup
+  semantics — it does not redefine them).
+- Concurrency / locking improvements during rematch (the existing
+  `claim_job` / `is_current` mechanism from Plan 310-A is reused).
+- The `aggregation` job (Plan 310-D's bulk-path-pure-async work) —
+  that's a separate Plan-D-Tier-2 PR.
+
+## Critical files
+
+| File                                                                              | Change                                                           |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `backend/app/workflows/emission_recalculation.py`                                 | Add Strategy B branch in `recalculate_for_data_entry_type`       |
+| `backend/app/repositories/data_entry_emission_repo.py`                            | Add `list_by_data_entry_type_and_year(det, year)` if missing     |
+| `backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py` | New file — 4 strategy-B per-module ITs                           |
+| `backend/tests/integration/services/data_ingestion/test_strategy_a_rematch_pg.py` | New file — 9 JSON-link per-module ITs (regression net for #1027) |
+| `backend/tests/integration/services/data_ingestion/conftest.py`                   | Add `seed_module_with_emission` helper fixture                   |
+
+## Verification
+
+After implementation:
+
+1. `rtk uv run pytest tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py -v`
+   — all 4 Strategy B modules pass.
+2. `rtk uv run pytest tests/integration/services/data_ingestion/test_strategy_a_rematch_pg.py -v`
+   — regression net catches no breakage from the new branch.
+3. `rtk uv run pytest tests/unit/workflows/test_emission_recalculation.py -v`
+   — existing 10 unit tests still pass (no churn in the JSON path).
+4. End-to-end smoke: upload a v2 travel factor CSV via `/v1/sync/dispatch`,
+   confirm a previously-computed travel emission row's `kg_co2eq`
+   updates without the operator needing to delete/recreate the entry.
+
+---
+
+**Related PRs**
+
+- #1027 — Plan 310-D batch rematch (JSON-link modules), strict-drop semantics. This follow-up rides on top.
+- (future) — `aggregation` handler + dedup index migration (separate Plan-D Tier-2 PR).

--- a/docs/src/implementation-plans/310-d-strategy-b-rematch.md
+++ b/docs/src/implementation-plans/310-d-strategy-b-rematch.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: delivered
 last_updated: 2026-05-06
 title: "Plan 310-D Follow-up — Strategy B Rematch + Per-Module ITs"
 summary: "Rematch the FK-link modules (travel, headcount, building rooms / embodied) by walking data_entry_emissions, plus per-module integration coverage."
@@ -182,4 +182,96 @@ After implementation:
 **Related PRs**
 
 - #1027 — Plan 310-D batch rematch (JSON-link modules), strict-drop semantics. This follow-up rides on top.
+- #1042 — Delivered: per-module IT matrix + plan-doc realignment (see below).
 - (future) — `aggregation` handler + dedup index migration (separate Plan-D Tier-2 PR).
+
+---
+
+## Delivered: PR #1042
+
+The investigation phase of this PR turned up a key empirical finding
+that simplified the deliverable substantially. Documented here so the
+next reader can build on the right architecture.
+
+### What actually shipped
+
+- **No workflow code change.** `EmissionRecalculationWorkflow` is
+  unchanged from PR #1027.
+- **16 PG-backed integration tests** covering Plan 310-D's 14-row matrix:
+  - `backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py` —
+    7 tests for the FK-link path (plane values, plane drop, train,
+    member, student, embodied energy, building rooms 1:N).
+  - `backend/tests/integration/services/data_ingestion/test_strategy_a_rematch_pg.py` —
+    9 tests for the JSON-link path (equipment × 3, purchase × 2,
+    external cloud, external AI, process emissions, energy combustion).
+- **Plan-doc realignment** (this section).
+
+### Why the plan's "walk data_entry_emissions" branch was not needed
+
+The plan assumed FK-link entries (travel, headcount, embodied energy)
+were skipped entirely by the rematch path. Empirically:
+
+1. `EmissionRecalculationWorkflow` walks **every** `DataEntry` for
+   `(det, year)` and calls `upsert_by_data_entry` on each. The
+   gate at `handler.kind_field in entry.data` only short-circuits
+   the `entry.data['primary_factor_id']` rewrite — a JSON-link
+   concern. The per-entry `upsert_by_data_entry` runs unconditionally.
+2. `upsert_by_data_entry` → `prepare_create` runs the handler's
+   `pre_compute` (re-resolving `haul_category` from Locations,
+   `country_code` from train stations, etc.) and then `_fetch_factors`
+   on each `EmissionComputation`.
+3. `_fetch_factors` in `data_entry_emission_service.py:343-415`
+   **already** runs the live Strategy B classification query — same
+   factor lookup the initial compute used. A factor whose `values`
+   changed is picked up automatically; a factor whose row was deleted
+   produces an empty list and the per-entry strict-drop kicks in.
+
+The only thing missing was test coverage to make this contract durable.
+
+### Strict-drop contract clarification
+
+The plan's "preserve row with primary_factor_id=None, kg_co2eq=None"
+language is imprecise. The actual behaviour shared by both Strategy A
+and Strategy B is **delete the entry's emission rows**:
+
+- Strategy A: bulk lookup miss → `entry.data['primary_factor_id']`
+  set to `None` → `resolve_computations` returns `[]` → `upsert_by_data_entry`
+  hits the `if not prepared_emissions` branch → `delete_by_data_entry_id`.
+- Strategy B: `_fetch_factors` returns `[]` (classification miss
+  or factor row deleted) → no `DataEntryEmission` rows produced →
+  same `delete_by_data_entry_id` branch.
+
+The dashboards surface this as "no emission for this entry", which
+matches the plan's intended operator-visible signal.
+
+### Module reclassification
+
+The plan listed `buildings__rooms` (`DataEntryTypeEnum.building`)
+under FK-link. In fact `BuildingRoomModuleHandler` declares
+`kind_field='building_name'` and `subkind_field='room_type'`, both
+on `entry.data` — so the existing Strategy A bulk-prefetch covers it.
+The `test_building_room_factor_values_change_propagates_all_5_emissions`
+test in the Strategy B file lives there because rooms emits 1:N (5
+emission rows per entry, one per energy type), which is the only
+genuinely new shape the FK-link conversation introduced. Verifying all
+5 rows scale linearly with the factor's `ef_kg_co2eq_per_kwh` belongs
+to this PR even though the lookup path itself is JSON-link.
+
+### Files touched
+
+| File                                                                              | Change                                                      |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `backend/app/workflows/emission_recalculation.py`                                 | No change. Plan's Strategy B branch turned out unnecessary. |
+| `backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py` | New file — 7 FK-link ITs incl. 1:N rooms regression.        |
+| `backend/tests/integration/services/data_ingestion/test_strategy_a_rematch_pg.py` | New file — 9 JSON-link ITs (regression net for #1027).      |
+| `docs/src/implementation-plans/310-d-strategy-b-rematch.md`                       | This "Delivered: PR #1042" section.                         |
+
+### What's still on the follow-up list
+
+The plan's "Open question 1" (old-classification lookup vs. re-derive
+via `pre_compute`) collapses to "re-derive" because that's what the
+existing per-entry path already does. If a future "rematch on entry
+edit" workflow wants to skip the LocationService roundtrip on travel,
+it could read `meta['distance_km']` from the existing
+`DataEntryEmission` row — but that's a perf optimisation, not a
+correctness gap.

--- a/docs/src/implementation-plans/310-d-strategy-b-rematch.md
+++ b/docs/src/implementation-plans/310-d-strategy-b-rematch.md
@@ -2,7 +2,7 @@
 status: delivered
 last_updated: 2026-05-06
 title: "Plan 310-D Follow-up — Strategy B Rematch + Per-Module ITs"
-summary: "Rematch the FK-link modules (travel, headcount, building rooms / embodied) by walking data_entry_emissions, plus per-module integration coverage."
+summary: "Rematch the FK-link modules (travel, headcount, building embodied energy) plus regression coverage for JSON-link modules including the 1:N building-rooms fan-out."
 ---
 
 # Plan 310-D Follow-up — Strategy B Rematch + Per-Module ITs
@@ -25,11 +25,17 @@ Modules affected (see the rematch table in
   per entry.
 - **Headcount** (member / student) — `FactorQuery` returns N
   sub-factors per data_entry; one emission row per sub-factor.
-- **Building Rooms** — one emission row per emission_type (lighting,
-  cooling, ventilation, heating_elec, heating_thermal); five rows
-  per entry.
-- **Building Embodied Energy** — verify shape; likely 1:N like
-  rooms based on the `building_name × category` factor key.
+- **Building Embodied Energy** — confirmed FK-link via PR #1042's per-module
+  integration test; the `building_name × category` factor key drives a
+  1:N emission shape.
+
+`building_room` was originally listed here as FK-link but PR #1042's audit
+confirmed it carries `primary_factor_id` on `entry.data` with
+`kind_field='building_name'` / `subkind_field='room_type'` — the existing
+JSON-link bulk-prefetch path covers it. The 1:N emission fan-out (one row
+per `room_type`) was the novel coverage that justified its IT living next
+to the FK-link tests in `test_strategy_b_rematch_pg.py`, but the link
+itself is JSON.
 
 ## Goal
 

--- a/docs/src/implementation-plans/emission-pipeline-flow.md
+++ b/docs/src/implementation-plans/emission-pipeline-flow.md
@@ -134,18 +134,23 @@ When a factor is updated (CSV reupload, manual edit), existing
 governs the rematch path** — and it's a different axis from the
 factor-retrieval Strategy A/B above.
 
-| Link location                                 | Rematch shape | Modules                                                                                                                  | Status        |
-| --------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| `data_entries.data->primary_factor_id` (JSON) | 1:1 per entry | Equipment, Purchase (common + additional), Process Emissions, External Cloud, External AI, Buildings — Energy Combustion | ✅ Plan 310-D |
-| `data_entry_emissions.primary_factor_id` (FK) | 1:N per entry | Travel (plane / train), Headcount (member / student), Buildings — Rooms, Buildings — Embodied Energy                     | 🚧 Follow-up  |
+| Link location                                 | Rematch shape        | Modules                                                                                                                                           | Status        |
+| --------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `data_entries.data->primary_factor_id` (JSON) | 1:1 or 1:N per entry | Equipment, Purchase (common + additional), Process Emissions, External Cloud, External AI, Buildings — Energy Combustion, Buildings — Rooms (1:N) | ✅ Plan 310-D |
+| `data_entry_emissions.primary_factor_id` (FK) | 1:N per entry        | Travel (plane / train), Headcount (member / student), Buildings — Embodied Energy                                                                 | ✅ PR #1042   |
 
-**Why two paths**: the JSON-link modules carry one factor per entry —
-the rematch updates the JSON column on the entry. The FK-link modules
-either generate multiple emission rows per entry (one per emission_type
-or per sub-factor — Headcount, Buildings Rooms) OR resolve their
-factor via `FactorQuery` so the link only ever lived on the emission
-row (Travel). For these, the rematch must walk
-`data_entry_emissions` directly, not `data_entries`.
+**Why two paths**: the JSON-link modules carry the factor on the entry
+itself — the rematch updates the JSON column on the entry, and any
+fan-out to multiple emission rows (Buildings Rooms emits one row per
+`room_type`) follows from the same canonical entry-side link. The
+FK-link modules either generate multiple emission rows per entry from
+sub-factors (Headcount) OR resolve their factor via `FactorQuery` at
+compute time so the link only ever lived on the emission row (Travel).
+For FK-link, the rematch walks `data_entry_emissions` directly via
+`upsert_by_data_entry` — `pre_compute` + `_fetch_factors` re-runs the
+live Strategy B query, which is empirically what propagates new factor
+values into the existing chain (PR #1042 finding — no workflow code
+change was required for FK-link rematch; only test coverage was missing).
 
 ### Plan 310-D Rematch Contract (JSON-link modules)
 
@@ -160,10 +165,16 @@ year)` in one query, indexed in a Python dict keyed by
    to `(kind, None)` (only succeeds if a `subkind=NULL` row was
    prefetched).
 3. **Strict-drop on overall miss** — a factor not in the current CSV
-   is treated as deleted. The entry's `primary_factor_id` is set to
-   `None` and the recomputed `kg_co2eq` is `None`. Operators see the
-   missing-factor signal on the dashboard rather than silent
-   substitution via a per-entry resolver lookup.
+   is treated as deleted. The entry's `primary_factor_id` is cleared
+   on the in-memory `entry.data`, then `upsert_by_data_entry` is called
+   with the now-unmatched payload — `prepare_create` returns no
+   computations and the no-emissions branch invokes
+   `delete_by_data_entry_id`, so **the entry's existing emission rows
+   are removed**. The entry itself stays around (so operators see the
+   missing-factor signal on the dashboard) but no `kg_co2eq` row
+   persists. (Earlier wording said "set `kg_co2eq` to None"; the
+   actual code deletes the row entirely — see PR #1042's
+   strict-drop clarification in `310-d-strategy-b-rematch.md`.)
 4. **Year-strict** — `(year IS NULL)` factors do not satisfy a
    year-scoped query. No fallback; if no year-matched factor exists,
    the entry's link is dropped per rule 3.

--- a/docs/src/implementation-plans/emission-pipeline-flow.md
+++ b/docs/src/implementation-plans/emission-pipeline-flow.md
@@ -1,8 +1,8 @@
 ---
 status: delivered
-last_updated: 2026-03-12
+last_updated: 2026-05-06
 title: "Emission Pipeline Flow"
-summary: "resolveemissiontypes(dataentrytype, data) returns the list of."
+summary: "Reference for the emission compute pipeline AND for how factor changes propagate to existing emissions (Plan 310-D rematch)."
 ---
 
 # Emission Pipeline Flow
@@ -123,6 +123,60 @@ Computes `kg_co2eq` from `ctx` (user data + pre-computed values) and
 2. Kind only (no subkind/context)
 3. By emission_type → returns N factors
 4. By data_entry_type → broadest
+
+---
+
+## Rematch: How Factor Changes Propagate (Plan 310-D)
+
+When a factor is updated (CSV reupload, manual edit), existing
+`DataEntry` rows must be re-linked to the new factor IDs and their
+`DataEntryEmission` rows recomputed. **Where the link is stored
+governs the rematch path** — and it's a different axis from the
+factor-retrieval Strategy A/B above.
+
+| Link location                                 | Rematch shape | Modules                                                                                                                  | Status        |
+| --------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `data_entries.data->primary_factor_id` (JSON) | 1:1 per entry | Equipment, Purchase (common + additional), Process Emissions, External Cloud, External AI, Buildings — Energy Combustion | ✅ Plan 310-D |
+| `data_entry_emissions.primary_factor_id` (FK) | 1:N per entry | Travel (plane / train), Headcount (member / student), Buildings — Rooms, Buildings — Embodied Energy                     | 🚧 Follow-up  |
+
+**Why two paths**: the JSON-link modules carry one factor per entry —
+the rematch updates the JSON column on the entry. The FK-link modules
+either generate multiple emission rows per entry (one per emission_type
+or per sub-factor — Headcount, Buildings Rooms) OR resolve their
+factor via `FactorQuery` so the link only ever lived on the emission
+row (Travel). For these, the rematch must walk
+`data_entry_emissions` directly, not `data_entries`.
+
+### Plan 310-D Rematch Contract (JSON-link modules)
+
+`EmissionRecalculationWorkflow.recalculate_for_data_entry_type`:
+
+1. **Single bulk-fetch** — all factors for `(data_entry_type_id,
+year)` in one query, indexed in a Python dict keyed by
+   `(kind, subkind)`. No per-entry DB roundtrips.
+2. **In-memory kind→subkind→kind-only fallback** — mirrors the chain
+   `ModuleHandlerService.resolve_primary_factor_id` runs in DB. Try
+   `(kind, subkind)` first; on miss with subkind set, fall through
+   to `(kind, None)` (only succeeds if a `subkind=NULL` row was
+   prefetched).
+3. **Strict-drop on overall miss** — a factor not in the current CSV
+   is treated as deleted. The entry's `primary_factor_id` is set to
+   `None` and the recomputed `kg_co2eq` is `None`. Operators see the
+   missing-factor signal on the dashboard rather than silent
+   substitution via a per-entry resolver lookup.
+4. **Year-strict** — `(year IS NULL)` factors do not satisfy a
+   year-scoped query. No fallback; if no year-matched factor exists,
+   the entry's link is dropped per rule 3.
+5. **Per-entry rollback** — the in-memory `entry.data` mutation is
+   restored if `upsert_by_data_entry` raises, so a partial-failure
+   batch never persists a stale `primary_factor_id` next to an old
+   `data_entry_emissions` row.
+
+The Strategy B handlers (kind_field declared but value derived in
+`pre_compute`, e.g. travel) are skipped by the gate
+`kind_field is not None and kind_field in entry.data` — their
+correct rematch path lands in the follow-up
+([310-d-strategy-b-rematch](310-d-strategy-b-rematch.md)).
 
 ---
 


### PR DESCRIPTION
## Summary

Two doc changes that ride on top of #1027 (still in review).

1. **`docs/src/implementation-plans/emission-pipeline-flow.md`** — adds a \"Rematch: How Factor Changes Propagate\" section. It distinguishes the two rematch paths by where the factor link is stored (JSON vs FK column), which is a different axis from the existing factor-retrieval Strategy A/B. Documents Plan 310-D's JSON-link contract: bulk fetch → in-memory kind→subkind→kind-only fallback → strict-drop on miss → year-strict → per-entry rollback.

2. **`docs/src/implementation-plans/310-d-strategy-b-rematch.md`** — new plan doc scaffolding the follow-up implementation work. Covers travel, headcount, building rooms, building embodied energy (the FK-link modules currently skipped by the existing handler.kind_field gate). Includes a 14-row coverage matrix for per-module integration tests.

## Why this is a draft

This PR ships the plan + reference doc only. The actual code change (the Strategy B branch in `EmissionRecalculationWorkflow` + the per-module ITs) lands in subsequent commits on this same branch (or a separate PR — TBD by reviewer preference).

## Open question

The pipeline-flow doc is reference-shape, not plan-shape. Likely belongs under an \`architecture/\` tree rather than \`implementation-plans/\`. Not moving it here to avoid a doc-tree shuffle in the same PR.

## Verification

- [x] Markdown renders cleanly (mkdocs preview not required for plan docs)
- [x] Cross-links between the two docs resolve (anchor link from plan doc to pipeline-flow's new section)

🚧 No code changes in this PR yet. Implementation tracked in the plan doc above.