### PR TITLE
feat(#310c): add run_job runner + chain_job + heartbeat (Tier-2 PR #1)

### DIFF
--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -126,6 +126,45 @@ class DataIngestionRepository:
             await self.session.refresh(result_job)
         return result_job
 
+    async def heartbeat(self, job_id: int, pod_id: str) -> int:
+        """Refresh ``locked_at`` on a RUNNING job we still own.
+
+        The Plan 310-C runner spawns a heartbeat task per active job that
+        wakes every ``STALE_JOB_TIMEOUT_MINUTES / 4`` and calls this
+        method.  Without it, the safety poller's stale-lock sweep would
+        falsely classify any legitimately long-running job as a crashed
+        pod once its runtime exceeds the timeout window — leading to the
+        same row being claimed by a second pod.
+
+        The WHERE clause guards against three failure modes:
+
+        - ``locked_by == pod_id`` — refuse to refresh someone else's
+          lock if a sweep already preempted us; the next preemption
+          check in the runner will then exit cleanly.
+        - ``state == RUNNING`` — refuse to revive a row that the runner
+          (or an admin) already moved out of RUNNING (cancelled,
+          finished, recovered).
+
+        Returns the rowcount actually updated (0 or 1) so the caller
+        can detect preemption and stop the heartbeat loop.
+        """
+        result = await self.session.execute(
+            update(DataIngestionJob)
+            .where(
+                col(DataIngestionJob.id) == job_id,
+                col(DataIngestionJob.locked_by) == pod_id,
+                col(DataIngestionJob.state) == IngestionState.RUNNING,
+            )
+            .values(locked_at=func.now())
+        )
+        await self.session.commit()
+        # ``rowcount`` is a SQLAlchemy ``Result`` attribute populated by
+        # the UPDATE driver — Pyright's stubs don't expose it, so guard
+        # via ``hasattr`` (matches the pattern in ``mark_job_as_current``).
+        if result is not None and hasattr(result, "rowcount"):
+            return int(result.rowcount or 0)
+        return 0
+
     async def set_started_at(self, job_id: int) -> None:
         """Stamp ``started_at`` on the FIRST successful claim only.
 

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -102,63 +102,96 @@ async def run_job(job_id: int) -> None:
             )
             return
 
+        # Capture job_type while it's narrowed to ``str`` by the
+        # check above; the post-claim re-fetch widens it back to
+        # ``Optional[str]`` (claim_job never touches job_type, so this
+        # is a type-narrowing convenience, not a behavior change).
+        job_type: str = job.job_type
+
         if not await repo.claim_job(job_id, POD_ID):
             # Another pod beat us, attempts exhausted, or the row is
             # already FINISHED.  Either way: not ours to run.
             return
 
-        # ``claim_job`` already set state=RUNNING, attempts++, locked_by,
-        # locked_at, and (via the func.coalesce in PR #1026) started_at
-        # atomically with the RUNNING transition.
+        # ``claim_job`` ran a raw SQL UPDATE (state=RUNNING, attempts++,
+        # locked_by, locked_at, and — via the func.coalesce from PR #1026
+        # — started_at).  The in-memory ``job`` instance from the pre-claim
+        # ``get_job_by_id`` still reflects the OLD row, so re-fetch to
+        # hand handlers the authoritative post-claim state (state, attempts,
+        # locked_by, started_at).  ``get_job_by_id`` already calls refresh.
+        job = await repo.get_job_by_id(job_id)
+        if job is None:
+            # Race: claimed but row vanished before the re-read.  Treat
+            # as preempted and exit; no state to write since there's no
+            # row to write to.
+            logger.warning(f"run_job: job {job_id} disappeared after claim — exiting")
+            return
 
-        heartbeat_task = fire_and_forget(
+        # Plain ``asyncio.create_task`` (not ``fire_and_forget``): the
+        # local ``heartbeat_task`` ref keeps the task alive for the
+        # lifetime of this function, and we cancel + await it in the
+        # ``finally`` block so the cancellation is observed cleanly.
+        # Routing through ``fire_and_forget`` would trip its deliberate
+        # cancellation-WARNING (kept loud for diagnosing the 310-B
+        # incident) on every successful run, drowning out genuine
+        # cancellations.
+        heartbeat_task = asyncio.create_task(
             _heartbeat_loop(job_id),
             name=f"heartbeat-{job_id}",
         )
 
         try:
-            handler = get_handler(job.job_type)
-            meta = await handler(job, job_session, data_session)
+            try:
+                handler = get_handler(job_type)
+                meta = await handler(job, job_session, data_session)
+                status_message = str(meta.get("status_message", "Success"))
+                metadata = dict(meta)
+                result = meta.get("result", IngestionResult.SUCCESS)
+                handler_succeeded = True
+            except Exception as exc:
+                logger.exception(
+                    f"run_job: handler for job_type={job_type!r} failed (job {job_id})"
+                )
+                status_message = str(exc)
+                metadata = {}
+                result = IngestionResult.ERROR
+                handler_succeeded = False
 
-            # Preemption check: did a stale-lock sweep recover this row
-            # to NOT_STARTED while our handler was running?  If so, a
-            # second pod has likely claimed it; abandon our work rather
-            # than racing with the new owner's commit.
+            # Preemption check covers BOTH success and error paths: if a
+            # stale-lock sweep recovered this row mid-handler, a different
+            # pod may now own it.  Either way, our writes — successful or
+            # error — must NOT race with the new owner's run.  Roll back
+            # data and skip the state update; the new owner will close out.
             current = await repo.get_job_by_id(job_id)
             if current is None or current.locked_by != POD_ID:
                 logger.warning(
                     f"run_job: job {job_id} preempted "
                     f"(locked_by={current and current.locked_by!r}); "
-                    "rolling back our data writes and exiting without "
+                    "rolling back data writes and exiting without "
                     "updating job state"
                 )
                 await data_session.rollback()
                 return
 
-            await data_session.commit()
+            if handler_succeeded:
+                await data_session.commit()
+            else:
+                await data_session.rollback()
             await repo.update_ingestion_job(
                 job_id,
-                status_message=str(meta.get("status_message", "Success")),
-                metadata=dict(meta),
+                status_message=status_message,
+                metadata=metadata,
                 state=IngestionState.FINISHED,
-                result=meta.get("result", IngestionResult.SUCCESS),
-            )
-            await job_session.commit()
-        except Exception as exc:
-            logger.exception(
-                f"run_job: handler for job_type={job.job_type!r} failed (job {job_id})"
-            )
-            await data_session.rollback()
-            await repo.update_ingestion_job(
-                job_id,
-                status_message=str(exc),
-                metadata={},
-                state=IngestionState.FINISHED,
-                result=IngestionResult.ERROR,
+                result=result,
             )
             await job_session.commit()
         finally:
             heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                # Expected — we cancelled it ourselves.
+                pass
 
 
 async def chain_job(
@@ -179,13 +212,19 @@ async def chain_job(
     Inherits the parent's ``pipeline_id`` (or generates a fresh UUID
     if the parent has none yet — the first chain on an ad-hoc run
     starts the pipeline).  The child is created NOT_STARTED with
-    ``run_after=now()`` so the safety poller can pick it up if this
-    pod crashes between the commit and the ``fire_and_forget``.
+    ``run_after=None`` (NULL means "runnable immediately"; the
+    safety poller's claim WHERE treats NULL as eligible, so it can
+    pick the row up if this pod crashes between the commit and the
+    ``fire_and_forget``).
 
     Defaults match the most common case (an ``emission_recalc``
     child of an ingest parent: same module, scoped to a single det,
-    DATA_ENTRIES target, computed source).  Callers override what
-    they need.
+    DATA_ENTRIES target, computed source).  ``module_type_id`` and
+    ``year`` inherit from the parent when the caller passes ``None``.
+    ``data_entry_type_id`` does NOT inherit by design: a multi-det
+    parent (e.g. a FACTORS ingest spanning several dets) fans out to
+    one child per det, so the caller must always pass the specific
+    child det.  Callers override the rest as they need.
 
     Returns the child's ``id``.  Persists the parent's
     ``pipeline_id`` if it had to generate one — without that, a

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -1,0 +1,277 @@
+"""Plan 310-C unified job runner.
+
+The runner is the single dispatch path for every Plan 310-C
+``DataIngestionJob``.  Endpoints, the safety poller, and ``chain_job``
+all funnel through ``run_job(job_id)``; the registry resolves the
+correct handler from ``job.job_type``.
+
+Why a single dispatcher:
+
+- **One claim path** — every job goes through ``claim_job``, so the
+  pod-safety guarantees from Plan 310-A (atomic state→RUNNING +
+  attempts++ + locked_by + ``started_at`` stamping) apply uniformly.
+- **One observability path** — every job ends with the same
+  ``update_ingestion_job(state=FINISHED, …)`` call, which auto-stamps
+  ``finished_at`` (Plan 310-C observability columns).  Dashboard
+  queries that rely on ``finished_at IS NOT NULL`` see every job.
+- **One preemption-safety story** — the heartbeat + worker-side
+  preemption check eliminate the duplicate-processing risk that the
+  safety poller's stale-recovery sweep introduced (PR #998 review).
+
+Concurrency model per ``run_job`` invocation:
+
+- Two SQLModel sessions: ``job_session`` for the
+  ``DataIngestionJob`` row's lifecycle, ``data_session`` for the
+  handler's domain writes.  Separate so a handler ``rollback`` does
+  not roll back the FINISHED+ERROR state-write the runner makes
+  afterward.
+- One per-job heartbeat task that wakes every
+  ``STALE_JOB_TIMEOUT_MINUTES / 4`` and refreshes ``locked_at`` via
+  its OWN session.  Cancelled in ``finally`` regardless of outcome
+  (handler success, handler raise, preemption).
+"""
+
+import asyncio
+from typing import Optional
+from uuid import uuid4
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db import SessionLocal
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.repositories.data_ingestion import DataIngestionRepository
+from app.tasks._background import fire_and_forget
+from app.tasks._pod_id import POD_ID
+from app.tasks.registry import get_handler
+
+logger = get_logger(__name__)
+
+
+async def run_job(job_id: int) -> None:
+    """Dispatch a job through its registered handler.
+
+    Single entry point used by:
+      - HTTP endpoints (``fire_and_forget(run_job(id))`` after creating a job)
+      - ``chain_job`` (parent handler chains a child)
+      - the safety poller (orphan recovery)
+
+    Lifecycle:
+
+      1. Open job_session + data_session.
+      2. Resolve job → reject if missing or ``job_type IS NULL``.
+      3. ``claim_job`` (atomic RUNNING + attempts++ + ``started_at``).
+         Returns False if the job was already claimed / finished /
+         out of retries — in which case run_job is a silent no-op.
+      4. Spawn heartbeat task (refreshes ``locked_at`` periodically).
+      5. Look up handler from registry → execute it.
+      6. Pre-commit preemption check: re-read the row; if
+         ``locked_by`` no longer equals our pod, roll back the
+         data_session and exit without state-changing the job (the
+         new owner will).
+      7. Commit data_session, update_ingestion_job to
+         FINISHED+SUCCESS (or FINISHED+ERROR on handler raise).
+      8. ``update_ingestion_job`` with state=FINISHED auto-stamps
+         ``finished_at`` (Plan 310-C observability), so the dashboard
+         duration query (finished_at - started_at) closes cleanly.
+      9. Cancel heartbeat task in ``finally``.
+
+    Errors raised by the handler are caught and persisted as
+    FINISHED+ERROR.  Errors raised by the runner itself (claim
+    contention, preemption) are logged and the job state is left for
+    the next claimer.
+    """
+    async with SessionLocal() as job_session, SessionLocal() as data_session:
+        repo = DataIngestionRepository(job_session)
+
+        job = await repo.get_job_by_id(job_id)
+        if job is None:
+            logger.error(f"run_job: job {job_id} not found")
+            return
+        if job.job_type is None:
+            logger.error(
+                f"run_job: job {job_id} has no job_type — refusing to dispatch"
+            )
+            return
+
+        if not await repo.claim_job(job_id, POD_ID):
+            # Another pod beat us, attempts exhausted, or the row is
+            # already FINISHED.  Either way: not ours to run.
+            return
+
+        # ``claim_job`` already set state=RUNNING, attempts++, locked_by,
+        # locked_at, and (via the func.coalesce in PR #1026) started_at
+        # atomically with the RUNNING transition.
+
+        heartbeat_task = fire_and_forget(
+            _heartbeat_loop(job_id),
+            name=f"heartbeat-{job_id}",
+        )
+
+        try:
+            handler = get_handler(job.job_type)
+            meta = await handler(job, job_session, data_session)
+
+            # Preemption check: did a stale-lock sweep recover this row
+            # to NOT_STARTED while our handler was running?  If so, a
+            # second pod has likely claimed it; abandon our work rather
+            # than racing with the new owner's commit.
+            current = await repo.get_job_by_id(job_id)
+            if current is None or current.locked_by != POD_ID:
+                logger.warning(
+                    f"run_job: job {job_id} preempted "
+                    f"(locked_by={current and current.locked_by!r}); "
+                    "rolling back our data writes and exiting without "
+                    "updating job state"
+                )
+                await data_session.rollback()
+                return
+
+            await data_session.commit()
+            await repo.update_ingestion_job(
+                job_id,
+                status_message=str(meta.get("status_message", "Success")),
+                metadata=dict(meta),
+                state=IngestionState.FINISHED,
+                result=meta.get("result", IngestionResult.SUCCESS),
+            )
+            await job_session.commit()
+        except Exception as exc:
+            logger.exception(
+                f"run_job: handler for job_type={job.job_type!r} failed (job {job_id})"
+            )
+            await data_session.rollback()
+            await repo.update_ingestion_job(
+                job_id,
+                status_message=str(exc),
+                metadata={},
+                state=IngestionState.FINISHED,
+                result=IngestionResult.ERROR,
+            )
+            await job_session.commit()
+        finally:
+            heartbeat_task.cancel()
+
+
+async def chain_job(
+    parent: DataIngestionJob,
+    *,
+    job_type: str,
+    session: AsyncSession,
+    module_type_id: Optional[int] = None,
+    data_entry_type_id: Optional[int] = None,
+    year: Optional[int] = None,
+    config: Optional[dict] = None,
+    target_type: TargetType = TargetType.DATA_ENTRIES,
+    ingestion_method: IngestionMethod = IngestionMethod.computed,
+    entity_type: EntityType = EntityType.MODULE_PER_YEAR,
+) -> int:
+    """Create a child job and fire it through ``run_job``.
+
+    Inherits the parent's ``pipeline_id`` (or generates a fresh UUID
+    if the parent has none yet — the first chain on an ad-hoc run
+    starts the pipeline).  The child is created NOT_STARTED with
+    ``run_after=now()`` so the safety poller can pick it up if this
+    pod crashes between the commit and the ``fire_and_forget``.
+
+    Defaults match the most common case (an ``emission_recalc``
+    child of an ingest parent: same module, scoped to a single det,
+    DATA_ENTRIES target, computed source).  Callers override what
+    they need.
+
+    Returns the child's ``id``.  Persists the parent's
+    ``pipeline_id`` if it had to generate one — without that, a
+    pod-crash-then-recovery-claim of the parent would generate a
+    different UUID and the child would be orphaned from the parent's
+    run.
+    """
+    repo = DataIngestionRepository(session)
+
+    pipeline_id = parent.pipeline_id
+    if pipeline_id is None:
+        pipeline_id = uuid4()
+        parent.pipeline_id = pipeline_id
+        session.add(parent)
+        await session.commit()
+
+    child = DataIngestionJob(
+        job_type=job_type,
+        module_type_id=(
+            module_type_id if module_type_id is not None else parent.module_type_id
+        ),
+        data_entry_type_id=data_entry_type_id,
+        year=year if year is not None else parent.year,
+        target_type=target_type,
+        ingestion_method=ingestion_method,
+        entity_type=entity_type,
+        state=IngestionState.NOT_STARTED,
+        is_current=False,
+        pipeline_id=pipeline_id,
+        # ``None`` means "runnable immediately" — claim_job's WHERE
+        # treats NULL run_after as eligible.  Matches the existing
+        # ingestion_tasks.py recalc-job creation pattern.
+        run_after=None,
+        meta={"config": config or {}, "parent_job_id": parent.id},
+    )
+    created = await repo.create_ingestion_job(child)
+    await session.commit()
+
+    if created.id is None:
+        # Defensive: create_ingestion_job should always return a
+        # row with id set after commit.  If it ever doesn't, the
+        # safety poller will pick up the row anyway via run_after.
+        logger.error(
+            f"chain_job: child {job_type!r} of parent {parent.id} "
+            "was created without an id — relying on poller for dispatch"
+        )
+        return -1
+
+    fire_and_forget(run_job(created.id), name=f"run_job-{created.id}")
+    return created.id
+
+
+async def _heartbeat_loop(job_id: int) -> None:
+    """Refresh ``locked_at`` on the active job until cancelled.
+
+    Wake every ``STALE_JOB_TIMEOUT_MINUTES / 4`` (default: every
+    15 min for a 60 min timeout) and call ``repo.heartbeat``.  If
+    the heartbeat returns 0 rows updated, our lock has been preempted
+    — exit the loop so the runner's preemption check can take over
+    on its next pass.
+
+    Each tick uses a fresh session: heartbeats fire concurrently
+    with the handler's session, so sharing would deadlock or
+    serialize on the underlying connection.
+    """
+    settings = get_settings()
+    interval_seconds = max(1.0, settings.STALE_JOB_TIMEOUT_MINUTES * 60 / 4)
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            async with SessionLocal() as session:
+                repo = DataIngestionRepository(session)
+                updated = await repo.heartbeat(job_id, POD_ID)
+                if updated == 0:
+                    logger.warning(
+                        f"_heartbeat_loop: lost lock on job {job_id} "
+                        "(preempted or state moved out of RUNNING) — "
+                        "stopping heartbeat"
+                    )
+                    return
+        except asyncio.CancelledError:
+            # Normal shutdown path — the runner cancels us in its
+            # ``finally`` block.  Re-raise so asyncio sees the
+            # cancellation cleanly.
+            raise
+        except Exception as exc:
+            # Don't let a transient DB hiccup kill the heartbeat;
+            # log and try again next interval.
+            logger.warning(f"_heartbeat_loop: heartbeat for job {job_id} failed: {exc}")

--- a/backend/tests/unit/tasks/test_runner.py
+++ b/backend/tests/unit/tasks/test_runner.py
@@ -83,6 +83,20 @@ def _patch_session_local():
     return patch.object(runner_mod, "SessionLocal", _mock_session_ctx)
 
 
+async def _noop_heartbeat(_job_id: int) -> None:
+    """Drop-in for ``_heartbeat_loop`` that returns immediately so
+    tests don't await real sleeps.  ``asyncio.create_task(noop())``
+    produces a task that completes; the runner's cancel + await in
+    ``finally`` is then a no-op."""
+    return None
+
+
+def _patch_heartbeat():
+    """Patch ``_heartbeat_loop`` to a no-op so the runner's heartbeat
+    spawn doesn't sleep through STALE_JOB_TIMEOUT_MINUTES/4 minutes."""
+    return patch.object(runner_mod, "_heartbeat_loop", _noop_heartbeat)
+
+
 # ---------------------------------------------------------------------------
 # run_job — guard rails
 # ---------------------------------------------------------------------------
@@ -160,12 +174,8 @@ async def test_run_job_success_commits_and_marks_finished_success():
 
     with (
         _patch_session_local(),
+        _patch_heartbeat(),
         patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
-        patch.object(
-            runner_mod,
-            "fire_and_forget",
-            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
-        ),
     ):
         await runner_mod.run_job(1)
 
@@ -202,12 +212,8 @@ async def test_run_job_handler_raises_marks_finished_error_and_rolls_back():
 
     with (
         patch.object(runner_mod, "SessionLocal", _capture_session),
+        _patch_heartbeat(),
         patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
-        patch.object(
-            runner_mod,
-            "fire_and_forget",
-            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
-        ),
     ):
         await runner_mod.run_job(1)
 
@@ -239,12 +245,14 @@ async def test_run_job_preempted_rolls_back_and_skips_state_update():
     job = _make_job()
     job.locked_by = runner_mod.POD_ID
 
-    # On the second get_job_by_id call (the preemption check), return a
-    # row owned by a different pod.
+    # ``get_job_by_id`` is called THREE times now: initial fetch (pre-
+    # claim), post-claim re-fetch (so the handler sees the authoritative
+    # post-claim row), and the preemption check (post-handler).  Only
+    # the third call returns the preempted row.
     preempted = _make_job()
     preempted.locked_by = "some-other-pod"
     repo = _make_repo_returning(job)
-    repo.get_job_by_id = AsyncMock(side_effect=[job, preempted])
+    repo.get_job_by_id = AsyncMock(side_effect=[job, job, preempted])
 
     @register("test_job")
     async def _handler(j, js, ds) -> dict:
@@ -263,12 +271,8 @@ async def test_run_job_preempted_rolls_back_and_skips_state_update():
 
     with (
         patch.object(runner_mod, "SessionLocal", _capture_session),
+        _patch_heartbeat(),
         patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
-        patch.object(
-            runner_mod,
-            "fire_and_forget",
-            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
-        ),
     ):
         await runner_mod.run_job(1)
 
@@ -284,7 +288,8 @@ async def test_run_job_preempted_to_deleted_rolls_back():
     job = _make_job()
     job.locked_by = runner_mod.POD_ID
     repo = _make_repo_returning(job)
-    repo.get_job_by_id = AsyncMock(side_effect=[job, None])
+    # initial fetch, post-claim refetch, then preempt-check sees None.
+    repo.get_job_by_id = AsyncMock(side_effect=[job, job, None])
 
     @register("test_job")
     async def _handler(j, js, ds) -> dict:
@@ -292,15 +297,61 @@ async def test_run_job_preempted_to_deleted_rolls_back():
 
     with (
         _patch_session_local(),
+        _patch_heartbeat(),
         patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
-        patch.object(
-            runner_mod,
-            "fire_and_forget",
-            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
-        ),
     ):
         await runner_mod.run_job(1)
 
+    repo.update_ingestion_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_job_handler_raise_with_preemption_skips_state_update():
+    """Plan 310-C runner contract: the preemption check guards BOTH
+    the success and the error paths.
+
+    If the handler raises AND the row was preempted mid-handler, the
+    runner must NOT write FINISHED+ERROR — that would race with the
+    new owner's own FINISHED write.  Instead: roll back data_session
+    and exit; the new owner closes out the job.
+    """
+    job = _make_job()
+    job.locked_by = runner_mod.POD_ID
+
+    preempted = _make_job()
+    preempted.locked_by = "another-pod"
+    repo = _make_repo_returning(job)
+    # Same shape as the success-path preemption test: initial fetch,
+    # post-claim refetch, then the preempt-check (after the handler
+    # raised) returns the preempted row.
+    repo.get_job_by_id = AsyncMock(side_effect=[job, job, preempted])
+
+    @register("test_job")
+    async def _handler(j, js, ds) -> dict:
+        raise RuntimeError("handler exploded mid-preempt")
+
+    captured_sessions = []
+
+    @asynccontextmanager
+    async def _capture_session():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        session.add = MagicMock()
+        captured_sessions.append(session)
+        yield session
+
+    with (
+        patch.object(runner_mod, "SessionLocal", _capture_session),
+        _patch_heartbeat(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+    ):
+        await runner_mod.run_job(1)
+
+    _, data_session = captured_sessions
+    data_session.rollback.assert_awaited()
+    # Critical: the FINISHED+ERROR write must NOT fire when we no
+    # longer own the row, even though the handler raised.
     repo.update_ingestion_job.assert_not_called()
 
 

--- a/backend/tests/unit/tasks/test_runner.py
+++ b/backend/tests/unit/tasks/test_runner.py
@@ -1,0 +1,450 @@
+"""Unit tests for ``app.tasks.runner`` (Plan 310-C unified dispatcher).
+
+Covers the test matrix from
+``docs/src/implementation-plans/310-c-dag-handler-registry.md`` lines
+433-446: registry handling, claim/preemption semantics, success and
+error paths, started_at / finished_at observability, chain_job
+inheritance, and heartbeat behavior.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.data_ingestion import (
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.tasks import runner as runner_mod
+from app.tasks.registry import _REGISTRY, register
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Snapshot+restore the global registry between tests (matches the
+    pattern in test_registry.py so this file stays order-independent
+    once Tier 2 wires real handlers via import-time decorators)."""
+    snapshot = dict(_REGISTRY)
+    _REGISTRY.clear()
+    try:
+        yield
+    finally:
+        _REGISTRY.clear()
+        _REGISTRY.update(snapshot)
+
+
+def _make_job(job_id: int = 1, job_type: str = "test_job") -> MagicMock:
+    """A DataIngestionJob shaped for the runner."""
+    job = MagicMock()
+    job.id = job_id
+    job.job_type = job_type
+    job.module_type_id = 11
+    job.data_entry_type_id = 22
+    job.year = 2025
+    job.pipeline_id = None
+    job.locked_by = None
+    return job
+
+
+def _make_repo_returning(job: MagicMock | None) -> MagicMock:
+    """Mock of ``DataIngestionRepository`` whose ``get_job_by_id``
+    returns the given job (or None for the not-found case)."""
+    repo = MagicMock()
+    repo.get_job_by_id = AsyncMock(return_value=job)
+    repo.claim_job = AsyncMock(return_value=True)
+    repo.update_ingestion_job = AsyncMock(return_value=job)
+    repo.create_ingestion_job = AsyncMock(side_effect=lambda j: j)
+    repo.heartbeat = AsyncMock(return_value=1)
+    return repo
+
+
+@asynccontextmanager
+async def _mock_session_ctx():
+    """An async context manager wrapping a MagicMock session.
+
+    ``SessionLocal()`` is an async context manager in production; the
+    runner uses ``async with SessionLocal() as session_a, SessionLocal()
+    as session_b``.  This mock yields a fresh MagicMock per ``with``,
+    matching that shape."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.add = MagicMock()
+    yield session
+
+
+def _patch_session_local():
+    """Patch ``runner.SessionLocal`` to yield mock sessions."""
+    return patch.object(runner_mod, "SessionLocal", _mock_session_ctx)
+
+
+# ---------------------------------------------------------------------------
+# run_job — guard rails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_job_unknown_job_id_logs_and_returns():
+    """Job not found → log error, no claim, no state change."""
+    repo = _make_repo_returning(None)
+    with (
+        _patch_session_local(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+    ):
+        await runner_mod.run_job(999)
+
+    repo.claim_job.assert_not_called()
+    repo.update_ingestion_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_job_null_job_type_refuses_to_dispatch():
+    """``job_type IS NULL`` (legacy in-flight rows) → no dispatch."""
+    job = _make_job()
+    job.job_type = None
+    repo = _make_repo_returning(job)
+    with (
+        _patch_session_local(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+    ):
+        await runner_mod.run_job(1)
+
+    repo.claim_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_job_claim_fails_returns_silently():
+    """``claim_job`` returns False (already claimed / out of retries)
+    → run_job exits without calling the handler or updating state."""
+    job = _make_job()
+    repo = _make_repo_returning(job)
+    repo.claim_job = AsyncMock(return_value=False)
+
+    handler = AsyncMock()
+
+    @register("test_job")
+    async def _handler(j, js, ds):
+        return await handler(j, js, ds)
+
+    with (
+        _patch_session_local(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+    ):
+        await runner_mod.run_job(1)
+
+    handler.assert_not_called()
+    repo.update_ingestion_job.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_job — success / error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_job_success_commits_and_marks_finished_success():
+    """Happy path: handler returns a meta dict, data committed,
+    state→FINISHED, result→SUCCESS, status_message from meta."""
+    job = _make_job()
+    job.locked_by = runner_mod.POD_ID
+    repo = _make_repo_returning(job)
+
+    @register("test_job")
+    async def _handler(j, js, ds) -> dict:
+        return {"status_message": "all good", "rows": 42}
+
+    with (
+        _patch_session_local(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            runner_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
+        ),
+    ):
+        await runner_mod.run_job(1)
+
+    repo.claim_job.assert_awaited_once()
+    repo.update_ingestion_job.assert_awaited_once()
+    args, kwargs = repo.update_ingestion_job.call_args
+    assert kwargs["state"] == IngestionState.FINISHED
+    assert kwargs["result"] == IngestionResult.SUCCESS
+    assert kwargs["status_message"] == "all good"
+
+
+@pytest.mark.asyncio
+async def test_run_job_handler_raises_marks_finished_error_and_rolls_back():
+    """Handler exception → data_session rolled back, state→FINISHED,
+    result→ERROR, status_message captures the exception."""
+    job = _make_job()
+    job.locked_by = runner_mod.POD_ID
+    repo = _make_repo_returning(job)
+
+    @register("test_job")
+    async def _handler(j, js, ds) -> dict:
+        raise RuntimeError("boom")
+
+    captured_sessions = []
+
+    @asynccontextmanager
+    async def _capture_session():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        session.add = MagicMock()
+        captured_sessions.append(session)
+        yield session
+
+    with (
+        patch.object(runner_mod, "SessionLocal", _capture_session),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            runner_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
+        ),
+    ):
+        await runner_mod.run_job(1)
+
+    # Two sessions opened (job_session + data_session); the data_session
+    # should have rolled back, the job_session should still commit
+    # the FINISHED+ERROR row update.
+    assert len(captured_sessions) == 2
+    job_session, data_session = captured_sessions
+    data_session.rollback.assert_awaited()
+
+    repo.update_ingestion_job.assert_awaited_once()
+    _, kwargs = repo.update_ingestion_job.call_args
+    assert kwargs["state"] == IngestionState.FINISHED
+    assert kwargs["result"] == IngestionResult.ERROR
+    assert "boom" in kwargs["status_message"]
+
+
+# ---------------------------------------------------------------------------
+# run_job — preemption check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_job_preempted_rolls_back_and_skips_state_update():
+    """The pre-commit re-read sees a different ``locked_by`` (a stale-
+    sweep recovered the row mid-handler) → roll back data_session,
+    skip the state update so the new owner can finish without a
+    racing FINISHED write."""
+    job = _make_job()
+    job.locked_by = runner_mod.POD_ID
+
+    # On the second get_job_by_id call (the preemption check), return a
+    # row owned by a different pod.
+    preempted = _make_job()
+    preempted.locked_by = "some-other-pod"
+    repo = _make_repo_returning(job)
+    repo.get_job_by_id = AsyncMock(side_effect=[job, preempted])
+
+    @register("test_job")
+    async def _handler(j, js, ds) -> dict:
+        return {}
+
+    captured_sessions = []
+
+    @asynccontextmanager
+    async def _capture_session():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        session.add = MagicMock()
+        captured_sessions.append(session)
+        yield session
+
+    with (
+        patch.object(runner_mod, "SessionLocal", _capture_session),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            runner_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
+        ),
+    ):
+        await runner_mod.run_job(1)
+
+    _, data_session = captured_sessions
+    data_session.rollback.assert_awaited()
+    repo.update_ingestion_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_job_preempted_to_deleted_rolls_back():
+    """Preemption check sees job has vanished (recovered + recreated
+    under a different id, or admin deleted) → same rollback path."""
+    job = _make_job()
+    job.locked_by = runner_mod.POD_ID
+    repo = _make_repo_returning(job)
+    repo.get_job_by_id = AsyncMock(side_effect=[job, None])
+
+    @register("test_job")
+    async def _handler(j, js, ds) -> dict:
+        return {}
+
+    with (
+        _patch_session_local(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            runner_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
+        ),
+    ):
+        await runner_mod.run_job(1)
+
+    repo.update_ingestion_job.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# chain_job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_job_inherits_pipeline_id_and_fires_run_job():
+    """Child created NOT_STARTED, inherits parent's pipeline_id,
+    parent_job_id stamped in meta, run_job scheduled via
+    fire_and_forget."""
+    parent = _make_job(job_id=100)
+    parent.pipeline_id = uuid4()
+
+    repo = _make_repo_returning(parent)
+    captured_child = MagicMock()
+    captured_child.id = 200
+
+    async def _create(child):
+        # Mirror what create_ingestion_job does: assign id post-flush.
+        child.id = 200
+        return child
+
+    repo.create_ingestion_job = AsyncMock(side_effect=_create)
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.add = MagicMock()
+
+    fired = []
+
+    def _fake_fire_and_forget(coro, *, name=None):
+        # Close the coroutine to avoid "coroutine was never awaited"
+        # warnings; we only care that the dispatcher would have fired.
+        coro.close()
+        fired.append(name)
+        return MagicMock()
+
+    with (
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(runner_mod, "fire_and_forget", side_effect=_fake_fire_and_forget),
+    ):
+        child_id = await runner_mod.chain_job(
+            parent,
+            job_type="emission_recalc",
+            session=session,
+        )
+
+    assert child_id == 200
+    repo.create_ingestion_job.assert_awaited_once()
+    created = repo.create_ingestion_job.await_args.args[0]
+    assert created.pipeline_id == parent.pipeline_id
+    assert created.state == IngestionState.NOT_STARTED
+    assert created.meta["parent_job_id"] == 100
+    assert created.module_type_id == parent.module_type_id  # inherited
+    assert created.year == parent.year  # inherited
+
+    # Default kw values applied.
+    assert created.target_type == TargetType.DATA_ENTRIES
+    assert created.ingestion_method == IngestionMethod.computed
+    assert created.entity_type == EntityType.MODULE_PER_YEAR
+
+    assert fired == [f"run_job-{child_id}"]
+
+
+@pytest.mark.asyncio
+async def test_chain_job_generates_pipeline_id_when_parent_has_none():
+    """Parent without pipeline_id → chain_job generates a UUID and
+    persists it on the parent BEFORE creating the child, so
+    pod-crash-then-recovery of the parent doesn't generate a different
+    pipeline_id and orphan the child."""
+    parent = _make_job(job_id=100)
+    parent.pipeline_id = None
+
+    async def _create(child):
+        child.id = 200
+        return child
+
+    repo = _make_repo_returning(parent)
+    repo.create_ingestion_job = AsyncMock(side_effect=_create)
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.add = MagicMock()
+
+    with (
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            runner_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
+        ),
+    ):
+        await runner_mod.chain_job(parent, job_type="emission_recalc", session=session)
+
+    # Parent's pipeline_id must now be set.
+    assert isinstance(parent.pipeline_id, UUID)
+    # And must equal the child's pipeline_id.
+    created = repo.create_ingestion_job.await_args.args[0]
+    assert created.pipeline_id == parent.pipeline_id
+    # And the parent must have been re-added to the session before
+    # commit (so the new pipeline_id actually persists).
+    session.add.assert_any_call(parent)
+
+
+@pytest.mark.asyncio
+async def test_chain_job_overrides_apply():
+    """Explicit kw args win over parent inheritance."""
+    parent = _make_job(job_id=100)
+    parent.pipeline_id = uuid4()
+
+    async def _create(child):
+        child.id = 200
+        return child
+
+    repo = _make_repo_returning(parent)
+    repo.create_ingestion_job = AsyncMock(side_effect=_create)
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.add = MagicMock()
+
+    with (
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            runner_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (coro.close(), MagicMock())[1],
+        ),
+    ):
+        await runner_mod.chain_job(
+            parent,
+            job_type="aggregation",
+            session=session,
+            module_type_id=99,
+            year=2030,
+            target_type=TargetType.FACTORS,
+            config={"foo": "bar"},
+        )
+
+    created = repo.create_ingestion_job.await_args.args[0]
+    assert created.module_type_id == 99
+    assert created.year == 2030
+    assert created.target_type == TargetType.FACTORS
+    assert created.meta["config"] == {"foo": "bar"}

--- a/docs/src/implementation-plans/310-c-dag-handler-registry.md
+++ b/docs/src/implementation-plans/310-c-dag-handler-registry.md
@@ -93,67 +93,148 @@ that calls `chain_job(...)` per stale type (see below).
 
 ## Unified `run_job(job_id)` runner (`backend/app/tasks/runner.py`)
 
+> **Delivered: PR #1044.** Notes inline below mark where the shipped
+> shape diverges from the original sketch (driven by Copilot review on
+> #1044 and prior-PR contracts that landed in the meantime: #1026's
+> `started_at` atomic stamping inside `claim_job` and FINISHED-state
+> auto-stamp of `finished_at`).
+
 ```python
-import asyncio, logging
+import asyncio
 from app.db import SessionLocal
+from app.core.logging import get_logger
 from app.models.data_ingestion import IngestionResult, IngestionState
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.tasks._pod_id import POD_ID
 from app.tasks.registry import get_handler
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 async def run_job(job_id: int) -> None:
     """
     Single dispatch path for every job_type. Used by:
-      - endpoints (asyncio.create_task(run_job(id)) after creating a job)
-      - chain_job (asyncio.create_task(run_job(child_id)) after a parent finishes)
+      - endpoints (fire_and_forget(run_job(id)) after creating a job)
+      - chain_job (fire_and_forget(run_job(child_id)) after a parent commits)
       - the safety poller (Plan A)
     """
     async with SessionLocal() as job_session, SessionLocal() as data_session:
         repo = DataIngestionRepository(job_session)
         job = await repo.get_job_by_id(job_id)
         if job is None:
-            logger.error(f"Job {job_id} not found")
+            logger.error(f"run_job: job {job_id} not found")
             return
         if job.job_type is None:
-            logger.error(f"Job {job_id} has no job_type — refusing to dispatch")
+            logger.error(f"run_job: job {job_id} has no job_type — refusing to dispatch")
             return
+
+        # Capture job_type while it's narrowed to ``str`` by the check above;
+        # the post-claim re-fetch widens it back to Optional[str].
+        job_type: str = job.job_type
 
         if not await repo.claim_job(job_id, POD_ID):
             return  # another pod claimed it, or attempts exhausted, or finished
 
-        # claim_job already set state=RUNNING and is_current=TRUE; record started_at if new
-        if job.started_at is None:
-            await repo.set_started_at(job_id)
-            await job_session.commit()
+        # claim_job ran a raw SQL UPDATE (state=RUNNING, attempts++,
+        # locked_by, locked_at, AND started_at via func.coalesce — atomic
+        # with the RUNNING transition, see PR #1026).  The in-memory `job`
+        # still reflects the pre-claim row; re-fetch so handlers see the
+        # authoritative post-claim state.  A vanished row here = preempted
+        # in the gap (treat as such).
+        job = await repo.get_job_by_id(job_id)
+        if job is None:
+            logger.warning(f"run_job: job {job_id} disappeared after claim — exiting")
+            return
+
+        # Plain asyncio.create_task (NOT fire_and_forget): cancellation in
+        # the finally block is the expected shutdown path, and
+        # fire_and_forget's deliberate cancellation-WARNING (kept loud
+        # for diagnosing the 310-B incident) would fire on every successful
+        # run, drowning out genuine cancellations elsewhere.
+        heartbeat_task = asyncio.create_task(
+            _heartbeat_loop(job_id), name=f"heartbeat-{job_id}"
+        )
 
         try:
-            handler = get_handler(job.job_type)
-            meta = await handler(job, job_session, data_session)
-            await data_session.commit()
+            try:
+                handler = get_handler(job_type)
+                meta = await handler(job, job_session, data_session)
+                status_message = str(meta.get("status_message", "Success"))
+                metadata = dict(meta)
+                result = meta.get("result", IngestionResult.SUCCESS)
+                handler_succeeded = True
+            except Exception as exc:
+                logger.exception(
+                    f"run_job: handler for job_type={job_type!r} failed (job {job_id})"
+                )
+                status_message = str(exc)
+                metadata = {}
+                result = IngestionResult.ERROR
+                handler_succeeded = False
+
+            # Preemption check covers BOTH success AND error paths.  If a
+            # stale-lock sweep recovered this row mid-handler, a different
+            # pod may now own it; our writes — successful or error — must
+            # NOT race with the new owner.  Roll back data and skip the
+            # state update; the new owner closes out.
+            current = await repo.get_job_by_id(job_id)
+            if current is None or current.locked_by != POD_ID:
+                logger.warning(
+                    f"run_job: job {job_id} preempted "
+                    f"(locked_by={current and current.locked_by!r}); "
+                    "rolling back data writes and exiting without updating job state"
+                )
+                await data_session.rollback()
+                return
+
+            if handler_succeeded:
+                await data_session.commit()
+            else:
+                await data_session.rollback()
             await repo.update_ingestion_job(
                 job_id,
-                status_message=meta.get("status_message", "Success"),
-                metadata=meta,
+                status_message=status_message,
+                metadata=metadata,
                 state=IngestionState.FINISHED,
-                result=meta.get("result", IngestionResult.SUCCESS),
-                finished_at=True,
+                result=result,
+                # NOTE: no finished_at parameter — PR #1026 dropped that
+                # opt-in flag and made FINISHED auto-stamp the column.
             )
             await job_session.commit()
-        except Exception as exc:
-            logger.exception(f"Handler for {job.job_type} failed (job {job_id})")
-            await data_session.rollback()
-            await repo.update_ingestion_job(
-                job_id,
-                status_message=str(exc),
-                metadata={},
-                state=IngestionState.FINISHED,
-                result=IngestionResult.ERROR,
-                finished_at=True,
-            )
-            await job_session.commit()
+        finally:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                pass
 ```
+
+### Divergences from the original sketch
+
+These changes landed in PR #1044; future Tier-2 PRs build on the
+delivered shape, not the original code block above:
+
+1. **Single preempt-check + state-write site** for both branches. The
+   original sketch had separate FINISHED+SUCCESS and FINISHED+ERROR
+   blocks with no preempt-check on the error path; that would race a
+   new owner if the handler raised AFTER preemption.
+2. **Re-fetch `job` after `claim_job`.** `claim_job` runs as a raw
+   SQL `UPDATE` (not an ORM mutation), so the in-memory `job`
+   instance still shows the pre-claim row state. Handlers that
+   introspect `job.attempts` or `job.state` would see lies without
+   the refresh.
+3. **`set_started_at` is no longer called from the runner.** PR
+   #1026 moved `started_at` stamping inside `claim_job` itself
+   (atomic with the RUNNING transition via `func.coalesce`). The
+   `set_started_at` repo helper remains as a primitive but is
+   redundant in this path.
+4. **`finished_at` stamping is automatic.** PR #1026 dropped the
+   opt-in `finished_at: bool = False` flag from
+   `update_ingestion_job`; transition to `state=FINISHED`
+   auto-stamps the column.
+5. **Heartbeat uses plain `asyncio.create_task`** (not
+   `fire_and_forget`) so the deterministic `cancel()` + `await` in
+   `finally` doesn't trip the loud cancellation WARNING that
+   `fire_and_forget` emits.
 
 All endpoints switch from per-task functions to:
 
@@ -221,7 +302,9 @@ to bound recovery latency on real crashes.
 
 ## DAG chaining via `chain_job` helper
 
-Plan B's `_enqueue_stale_recalculations` becomes a special case of:
+> **Delivered: PR #1044.** Plan B's `_enqueue_stale_recalculations`
+> will fold into a `chain_job` call when its `factor_ingest` handler
+> is registered (Tier-2 PR #2).
 
 ```python
 # backend/app/tasks/runner.py
@@ -230,6 +313,7 @@ async def chain_job(
     parent: DataIngestionJob,
     *,
     job_type: str,
+    session: AsyncSession,
     module_type_id: Optional[int] = None,
     data_entry_type_id: Optional[int] = None,
     year: Optional[int] = None,
@@ -237,32 +321,52 @@ async def chain_job(
     target_type: TargetType = TargetType.DATA_ENTRIES,
     ingestion_method: IngestionMethod = IngestionMethod.computed,
     entity_type: EntityType = EntityType.MODULE_PER_YEAR,
-    session: AsyncSession,
 ) -> int:
     """
     Create a child job that inherits parent's pipeline_id and fire it via
-    asyncio.create_task. Safety poller picks up if pod crashes between commit
-    and create_task.
+    fire_and_forget. Safety poller picks up if pod crashes between commit
+    and fire_and_forget.
 
-    Returns child job_id.
+    ``module_type_id`` and ``year`` inherit from the parent when the
+    caller passes None.  ``data_entry_type_id`` is intentionally NOT
+    inherited: a multi-det parent (e.g. a FACTORS ingest spanning
+    several dets) fans out to one child per det, so the caller MUST
+    pass the specific det per call.
+
+    Returns child job_id.  If ``parent.pipeline_id`` is None, generates
+    a fresh UUID and persists it on the parent BEFORE creating the
+    child — so a pod-crash-then-recovery of the parent doesn't
+    generate a different UUID and orphan the child.
     """
+    repo = DataIngestionRepository(session)
+
+    pipeline_id = parent.pipeline_id
+    if pipeline_id is None:
+        pipeline_id = uuid4()
+        parent.pipeline_id = pipeline_id
+        session.add(parent)
+        await session.commit()
+
     child = DataIngestionJob(
         job_type           = job_type,
-        module_type_id     = module_type_id   if module_type_id   is not None else parent.module_type_id,
-        data_entry_type_id = data_entry_type_id,
-        year               = year             if year             is not None else parent.year,
+        module_type_id     = module_type_id if module_type_id is not None else parent.module_type_id,
+        data_entry_type_id = data_entry_type_id,  # NO inheritance — see docstring
+        year               = year if year is not None else parent.year,
         target_type        = target_type,
         ingestion_method   = ingestion_method,
         entity_type        = entity_type,
         state              = IngestionState.NOT_STARTED,
-        pipeline_id        = parent.pipeline_id,    # inherit grouping
-        run_after          = func.now(),
+        is_current         = False,
+        pipeline_id        = pipeline_id,
+        # NULL means "runnable immediately" — claim_job's WHERE treats
+        # NULL run_after as eligible.  Matches the existing
+        # ingestion_tasks.py recalc-job creation pattern.
+        run_after          = None,
         meta               = {"config": config or {}, "parent_job_id": parent.id},
     )
-    repo = DataIngestionRepository(session)
     created = await repo.create_ingestion_job(child)
     await session.commit()
-    asyncio.create_task(run_job(created.id))
+    fire_and_forget(run_job(created.id), name=f"run_job-{created.id}")
     return created.id
 ```
 


### PR DESCRIPTION
## Summary

Plan 310-C Tier-2 PR #1 — the keystone of the unified-dispatch refactor. Adds the single \`run_job(job_id)\` runner that endpoints, the safety poller, and \`chain_job\` will all funnel through, plus the per-job heartbeat that closes the duplicate-processing window left open by PR #998's stale-job recovery sweep.

This PR is **greenfield infrastructure**: no existing callers are touched, so it's mergeable on its own. Handler registrations + endpoint cutover land in subsequent PRs.

## What lands

### \`backend/app/tasks/runner.py\` (new)

- **\`run_job(job_id)\`** — the dispatcher. Two sessions (job + data), claim_job, heartbeat task, registry lookup, handler call, **pre-commit preemption check**, then commit + FINISHED+SUCCESS (or FINISHED+ERROR on raise). \`finished_at\` auto-stamps via the FINISHED-state contract from #1026.
- **\`chain_job(parent, *, job_type, session, …)\`** — creates a NOT_STARTED child inheriting \`parent.pipeline_id\` (or generates a fresh UUID and persists it on the parent first, so a pod-crash-then-recovery doesn't orphan the child). Fires via \`fire_and_forget\`. Defaults match \`emission_recalc\`-style fan-out; callers override.
- **\`_heartbeat_loop(job_id)\`** — wakes every \`STALE_JOB_TIMEOUT_MINUTES / 4\` (default 15 min for a 60 min timeout). Returns gracefully when the lock is lost (rowcount=0) so the runner's preemption check takes over on its next pass.

### \`backend/app/repositories/data_ingestion.py\`

- **\`heartbeat(job_id, pod_id) -> int\`** — \`UPDATE … SET locked_at=now() WHERE id=:job AND locked_by=:pod AND state=RUNNING\`. Returns rowcount so the caller can detect preemption.

### \`backend/tests/unit/tasks/test_runner.py\` (new)

10 unit tests covering the matrix from the plan doc (lines 433-446):

| Test                                                                   | Assertion                                                       |
| ---------------------------------------------------------------------- | --------------------------------------------------------------- |
| \`run_job_unknown_job_id_logs_and_returns\`                            | job not found → no claim, no state change                       |
| \`run_job_null_job_type_refuses_to_dispatch\`                          | legacy in-flight rows (job_type=NULL) skipped                   |
| \`run_job_claim_fails_returns_silently\`                               | claim contention → silent no-op                                 |
| \`run_job_success_commits_and_marks_finished_success\`                 | happy path: handler meta → FINISHED+SUCCESS                     |
| \`run_job_handler_raises_marks_finished_error_and_rolls_back\`         | raise → data rollback + FINISHED+ERROR + status_message=exc str |
| \`run_job_preempted_rolls_back_and_skips_state_update\`                | locked_by changed → rollback, do NOT update state               |
| \`run_job_preempted_to_deleted_rolls_back\`                            | row vanished → same path                                        |
| \`chain_job_inherits_pipeline_id_and_fires_run_job\`                   | child inherits pipeline_id + parent_job_id in meta              |
| \`chain_job_generates_pipeline_id_when_parent_has_none\`               | parent persists new UUID before child creation                  |
| \`chain_job_overrides_apply\`                                          | explicit kw args win over inheritance                           |

## Why preemption check + heartbeat together

PR #998 added an auto-recovery sweep (jobs stuck in RUNNING past \`STALE_JOB_TIMEOUT_MINUTES\` get reset → NOT_STARTED). The review on that PR flagged a real concurrency hazard: any job whose runtime exceeds the timeout window gets falsely classified as stuck → second pod claims and re-runs while the first is still working. PR #998's mitigation was operational (bump timeout to 60 min). This PR fixes it properly:

- **Heartbeat**: refreshes \`locked_at\` periodically so the sweep only ever fires on real pod death.
- **Worker-side preemption check**: defence-in-depth for the brief window before the first heartbeat fires, AND for any future regression in heartbeat scheduling. Re-reads the row before commit; if \`locked_by\` no longer matches, rolls back rather than racing with the new owner.

Together they let \`STALE_JOB_TIMEOUT_MINUTES\` tighten back down to ~10-15 min in a follow-up.

## Test plan

- [x] \`rtk uv run pytest backend/tests/unit/tasks/test_runner.py\` — 10/10
- [x] \`rtk uv run pytest backend/tests/unit/\` — 1230/1230 (no regressions in adjacent suites)
- [x] \`rtk uv run mypy backend/app/tasks/runner.py backend/app/repositories/data_ingestion.py\` — clean
- [x] \`rtk uv run ruff format --check backend/app/ backend/tests/\` — clean
- [x] \`rtk uv run ruff check backend/app/ backend/tests/\` — clean

## Notes

- Builds atop #1020 (registry — \`get_handler\`) and #1026 (observability columns — \`started_at\` set atomically by claim_job, \`finished_at\` auto-stamped by FINISHED-state update). Both are in \`dev\`.
- Plan reference: \`docs/src/implementation-plans/310-c-dag-handler-registry.md\` lines 86-211.

## What's next

After this lands:

- **Tier-2 PR #2** — handler registrations on \`ingestion_tasks.py\`, \`emission_recalculation_tasks.py\`, \`unit_sync_tasks.py\`. Endpoint cutover from \`BackgroundTasks\` to \`fire_and_forget(run_job(id))\`. Removes legacy sync wrappers.
- **Tier-2 PR #3** — \`_poller.dispatch_job\` → \`run_job\` (one-line replacement once handlers are registered).