### PR TITLE
feat(#310c): register emission_recalc / module_emission_recalc / unit_sync handlers (Tier-2 PR #2)

### DIFF
--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -3,7 +3,18 @@
 Mirrors the dual-session pattern from ingestion_tasks.py:
 - job_session: frequent commits for SSE progress visibility
 - data_session: single atomic commit at the end
+
+Plan 310-C registers two handlers via the runner registry
+(``emission_recalc``, ``module_emission_recalc``) alongside the
+existing ``run_recalculation_task`` / ``run_module_recalculation_task``
+functions.  The handlers are ADDITIVE in this PR — endpoints + the
+poller still use the legacy functions.  The cutover (replace
+``BackgroundTasks.add_task(run_recalculation_task, …)`` with
+``fire_and_forget(run_job(id))`` and delete the legacy functions)
+lands in a follow-up PR once all handler shapes are validated.
 """
+
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
 from app.db import SessionLocal
@@ -18,13 +29,186 @@ from app.models.data_ingestion import (
 )
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.tasks._pod_id import POD_ID
+from app.tasks.registry import register
 from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
 
 logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Single-type variant
+# Plan 310-C registered handlers (additive — coexist with the legacy
+# functions below until the endpoint+poller cutover PR removes them).
+# ---------------------------------------------------------------------------
+
+
+@register("emission_recalc")
+async def emission_recalc_handler(
+    job: DataIngestionJob,
+    job_session: AsyncSession,
+    data_session: AsyncSession,
+) -> dict:
+    """Plan 310-C handler — single ``(data_entry_type, year)`` recalc.
+
+    Reads scope from the job row.  The runner has already claimed the
+    job (state=RUNNING, attempts++, started_at stamped via PR #1026's
+    atomic claim), so this handler does not call ``claim_job`` and
+    must not write the FINISHED state — both responsibilities belong
+    to ``run_job``.
+
+    Returns the ``meta`` dict the runner will persist to
+    ``DataIngestionJob.meta``.  ``status_message`` and ``result``
+    keys are read by the runner for the FINISHED-state write.
+    """
+    if job.id is None:
+        raise ValueError("emission_recalc: job has no id")
+    if job.data_entry_type_id is None or job.year is None:
+        raise ValueError(
+            f"emission_recalc job {job.id} missing data_entry_type_id or year"
+        )
+
+    data_entry_type = DataEntryTypeEnum(job.data_entry_type_id)
+    job_repo = DataIngestionRepository(job_session)
+
+    # In-progress status update (visible to the SSE stream); commit
+    # immediately on job_session so subscribers see it before the
+    # workflow returns.
+    await job_repo.update_ingestion_job(
+        job_id=job.id,
+        status_message="Recalculating emissions...",
+        metadata={},
+    )
+    await job_session.commit()
+
+    logger.info(
+        f"emission_recalc handler (job {job.id}): "
+        f"running workflow for det={data_entry_type.name}/year={job.year}"
+    )
+    svc = EmissionRecalculationWorkflow(data_session)
+    stats = await svc.recalculate_for_data_entry_type(data_entry_type, job.year)
+
+    result = (
+        IngestionResult.SUCCESS if stats["errors"] == 0 else IngestionResult.WARNING
+    )
+    return {
+        "status_message": "Emission recalculation completed",
+        "result": result,
+        "recalculation": stats,
+    }
+
+
+@register("module_emission_recalc")
+async def module_emission_recalc_handler(
+    job: DataIngestionJob,
+    job_session: AsyncSession,
+    data_session: AsyncSession,
+) -> dict:
+    """Plan 310-C handler — module-level bulk recalc across N data
+    entry types in sequence.
+
+    Reads ``data_entry_type_ids`` from ``job.meta['config']`` (set
+    by the endpoint that creates the job).  Same per-type isolation
+    as the legacy ``run_module_recalculation_task``: a single failing
+    type never aborts the others, errors are accumulated.
+
+    Creates per-type stub FINISHED jobs so
+    ``recalc_jobs_sub`` / ``get_recalculation_status_by_year``
+    (which exclude rows with ``data_entry_type_id IS NULL``) can
+    match the module-level work back to specific types.
+    """
+    if job.id is None:
+        raise ValueError("module_emission_recalc: job has no id")
+    if job.module_type_id is None or job.year is None:
+        raise ValueError(
+            f"module_emission_recalc job {job.id} missing module_type_id or year"
+        )
+    config = (job.meta or {}).get("config") or {}
+    data_entry_type_ids: list[int] = list(config.get("data_entry_type_ids") or [])
+    if not data_entry_type_ids:
+        raise ValueError(
+            f"module_emission_recalc job {job.id} missing config.data_entry_type_ids"
+        )
+
+    job_repo = DataIngestionRepository(job_session)
+    svc = EmissionRecalculationWorkflow(data_session)
+    n = len(data_entry_type_ids)
+    per_type_stats: dict[int, dict] = {}
+    total_errors = 0
+    total_recalculated = 0
+
+    for i, det_id in enumerate(data_entry_type_ids, start=1):
+        data_entry_type = DataEntryTypeEnum(det_id)
+        await job_repo.update_ingestion_job(
+            job_id=job.id,
+            status_message=f"Recalculating {data_entry_type.name} ({i}/{n})...",
+            metadata={},
+        )
+        await job_session.commit()
+
+        try:
+            async with data_session.begin_nested():
+                stats = await svc.recalculate_for_data_entry_type(
+                    data_entry_type, job.year
+                )
+            per_type_stats[det_id] = stats
+            total_errors += stats["errors"]
+            total_recalculated += stats["recalculated"]
+        except Exception as exc:
+            logger.error(
+                f"module_emission_recalc job {job.id}: type {det_id} "
+                f"failed entirely: {exc}",
+                exc_info=True,
+            )
+            per_type_stats[det_id] = {
+                "recalculated": 0,
+                "modules_refreshed": 0,
+                "errors": -1,  # -1 signals a fatal type-level error
+                "error_details": [{"error": str(exc)}],
+            }
+            total_errors += 1
+
+    # Per-type stub FINISHED jobs so the recalc-status query can match
+    # the module-level work back to specific data_entry_type_ids.
+    for det_id, stats in per_type_stats.items():
+        if stats["errors"] == -1:
+            type_result = IngestionResult.ERROR
+        elif stats["errors"] > 0:
+            type_result = IngestionResult.WARNING
+        else:
+            type_result = IngestionResult.SUCCESS
+        type_job = DataIngestionJob(
+            module_type_id=job.module_type_id,
+            data_entry_type_id=det_id,
+            year=job.year,
+            ingestion_method=IngestionMethod.computed,
+            target_type=TargetType.DATA_ENTRIES,
+            entity_type=EntityType.MODULE_PER_YEAR,
+            state=IngestionState.FINISHED,
+            result=type_result,
+            status_message=f"Bulk recalculation via module job {job.id}",
+            meta={"parent_job_id": job.id, "recalculation": stats},
+        )
+        created = await job_repo.create_ingestion_job(type_job)
+        await job_repo.mark_job_as_current(created)
+
+    types_with_fatal = [d for d, s in per_type_stats.items() if s["errors"] == -1]
+    if len(types_with_fatal) == n:
+        final_result = IngestionResult.ERROR
+    elif total_errors > 0:
+        final_result = IngestionResult.WARNING
+    else:
+        final_result = IngestionResult.SUCCESS
+
+    return {
+        "status_message": "Module emission recalculation completed",
+        "result": final_result,
+        "recalculation": per_type_stats,
+        "total_recalculated": total_recalculated,
+        "total_errors": total_errors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Single-type variant (LEGACY — kept until the endpoint+poller cutover PR)
 # ---------------------------------------------------------------------------
 
 
@@ -108,7 +292,7 @@ async def run_recalculation_task(
 
 
 # ---------------------------------------------------------------------------
-# Module-level (multi-type) variant
+# Module-level (multi-type) variant (LEGACY — kept until cutover PR)
 # ---------------------------------------------------------------------------
 
 

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -10,10 +10,15 @@ shows progress.
 from typing import Any, Dict
 
 from pydantic import BaseModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
 from app.db import SessionLocal
-from app.models.data_ingestion import IngestionResult, IngestionState
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    IngestionResult,
+    IngestionState,
+)
 from app.models.user import UserProvider
 from app.providers.role_provider import get_role_provider
 from app.providers.unit_provider import get_unit_provider
@@ -23,12 +28,111 @@ from app.services.carbon_report_service import CarbonReportService
 from app.services.unit_service import UnitService
 from app.services.user_service import UserService
 from app.tasks._pod_id import POD_ID
+from app.tasks.registry import register
 
 logger = get_logger(__name__)
 
 
 class SyncUnitRequest(BaseModel):
     target_year: int
+
+
+@register("unit_sync")
+async def unit_sync_handler(
+    job: DataIngestionJob,
+    job_session: AsyncSession,
+    data_session: AsyncSession,
+) -> dict:
+    """Plan 310-C handler — Accred unit + principal-user sync.
+
+    Reads ``target_year`` from ``job.meta['config']['target_year']``
+    (set by the endpoint that creates the job; the safety poller's
+    ``unit_sync`` branch reads the same path).  The runner has already
+    claimed the job; this handler does the work and returns the meta
+    dict the runner persists alongside the FINISHED state-write.
+
+    Additive in this PR — coexists with ``run_sync_task_accred``
+    until the endpoint+poller cutover removes the legacy function.
+    """
+    if job.id is None:
+        raise ValueError("unit_sync: job has no id")
+
+    config = (job.meta or {}).get("config") or {}
+    target_year = config.get("target_year") or job.year
+    if target_year is None:
+        raise ValueError(
+            f"unit_sync job {job.id} missing config.target_year (and job.year)"
+        )
+
+    job_repo = DataIngestionRepository(job_session)
+
+    await job_repo.update_ingestion_job(
+        job_id=job.id,
+        status_message="Fetching units from Accred…",
+        metadata={},
+    )
+    await job_session.commit()
+
+    unit_provider = get_unit_provider(UserProvider.ACCRED)
+    role_provider = get_role_provider(UserProvider.ACCRED)
+    units_raw, principal_users_raw = await unit_provider.fetch_all_units()
+
+    units = [unit_provider.map_api_unit(u) for u in units_raw]
+    principal_users = [role_provider.map_api_user(u) for u in principal_users_raw]
+
+    await job_repo.update_ingestion_job(
+        job_id=job.id,
+        status_message=(
+            f"Upserting {len(units)} units and {len(principal_users)} principal users…"
+        ),
+        metadata={},
+    )
+    await job_session.commit()
+
+    unit_service = UnitService(data_session)
+    unit_upsert_result = await unit_service.bulk_upsert(units)
+    units = unit_upsert_result.data
+
+    user_service = UserService(data_session)
+    user_upsert_result = await user_service.bulk_upsert(principal_users)
+    principal_users = user_upsert_result.data
+
+    await job_repo.update_ingestion_job(
+        job_id=job.id,
+        status_message=f"Creating carbon reports for year {target_year}…",
+        metadata={},
+    )
+    await job_session.commit()
+
+    carbon_report_service = CarbonReportService(data_session)
+    report_create_data = [
+        CarbonReportCreate(year=target_year, unit_id=u.id)
+        for u in units
+        if u.id is not None
+    ]
+    new_carbon_reports = await carbon_report_service.bulk_upsert(report_create_data)
+
+    await job_repo.update_ingestion_job(
+        job_id=job.id,
+        status_message=(
+            f"Ensuring modules for {len(new_carbon_reports)} carbon reports…"
+        ),
+        metadata={},
+    )
+    await job_session.commit()
+
+    await carbon_report_service.ensure_modules_for_reports(new_carbon_reports)
+
+    return {
+        "status_message": "Unit sync completed",
+        "result": IngestionResult.SUCCESS,
+        "units_synced": len(units),
+        "users_synced": len(principal_users),
+        "unit_results": str(unit_upsert_result),
+        "user_results": str(user_upsert_result),
+        "carbon_reports_created": len(new_carbon_reports),
+        "carbon_report_year": target_year,
+    }
 
 
 async def run_sync_task_accred(

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -1,0 +1,365 @@
+"""Unit tests for the Plan 310-C registered handlers.
+
+These cover only the handler bodies (not ``run_job``).  The runner's
+own behavior — claim, preempt-check, FINISHED state-write,
+heartbeat — is tested in ``test_runner.py``; this file pins the
+contract handlers must satisfy:
+
+- Read scope from the ``DataIngestionJob`` row (or its ``meta.config``).
+- Use the runner-supplied ``job_session`` / ``data_session`` (do not
+  open new ``SessionLocal`` connections).
+- Do NOT call ``claim_job`` or write the FINISHED state — the
+  runner owns both.
+- Return a dict the runner persists as ``meta``; ``status_message``
+  and ``result`` keys are read by the runner for the FINISHED-state
+  write.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import IngestionResult
+from app.tasks import emission_recalculation_tasks as recalc_mod
+from app.tasks import unit_sync_tasks as unit_sync_mod
+from app.tasks.registry import _REGISTRY, get_handler
+
+
+@pytest.fixture(autouse=True)
+def _registry_snapshot():
+    """Snapshot+restore the registry so test order doesn't matter once
+    Tier-2 PRs add more registrations next to the runner suite."""
+    snapshot = dict(_REGISTRY)
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(snapshot)
+
+
+def _make_job(
+    *,
+    job_id: int = 1,
+    job_type: str = "emission_recalc",
+    module_type_id: int = 11,
+    data_entry_type_id: int | None = DataEntryTypeEnum.it.value,
+    year: int | None = 2025,
+    meta: dict | None = None,
+) -> MagicMock:
+    job = MagicMock()
+    job.id = job_id
+    job.job_type = job_type
+    job.module_type_id = module_type_id
+    job.data_entry_type_id = data_entry_type_id
+    job.year = year
+    job.meta = meta or {}
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Registration smoke (PR #2's main proof that the @register decorators ran)
+# ---------------------------------------------------------------------------
+
+
+def test_emission_recalc_registered():
+    assert get_handler("emission_recalc") is recalc_mod.emission_recalc_handler
+
+
+def test_module_emission_recalc_registered():
+    assert (
+        get_handler("module_emission_recalc")
+        is recalc_mod.module_emission_recalc_handler
+    )
+
+
+def test_unit_sync_registered():
+    assert get_handler("unit_sync") is unit_sync_mod.unit_sync_handler
+
+
+# ---------------------------------------------------------------------------
+# emission_recalc_handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emission_recalc_handler_calls_workflow_and_returns_meta():
+    job = _make_job()
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+
+    workflow = MagicMock()
+    workflow.recalculate_for_data_entry_type = AsyncMock(
+        return_value={"recalculated": 7, "errors": 0, "modules_refreshed": 1}
+    )
+
+    with (
+        patch.object(recalc_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            recalc_mod, "EmissionRecalculationWorkflow", return_value=workflow
+        ),
+    ):
+        meta = await recalc_mod.emission_recalc_handler(job, job_session, data_session)
+
+    workflow.recalculate_for_data_entry_type.assert_awaited_once_with(
+        DataEntryTypeEnum(DataEntryTypeEnum.it.value), 2025
+    )
+    assert meta["status_message"] == "Emission recalculation completed"
+    assert meta["result"] == IngestionResult.SUCCESS
+    assert meta["recalculation"]["recalculated"] == 7
+
+
+@pytest.mark.asyncio
+async def test_emission_recalc_handler_warning_when_errors_present():
+    """``errors > 0`` flips the result to WARNING (per-entry isolation
+    means the run still finished; some rows just failed)."""
+    job = _make_job()
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+
+    workflow = MagicMock()
+    workflow.recalculate_for_data_entry_type = AsyncMock(
+        return_value={"recalculated": 5, "errors": 2, "modules_refreshed": 1}
+    )
+
+    with (
+        patch.object(recalc_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            recalc_mod, "EmissionRecalculationWorkflow", return_value=workflow
+        ),
+    ):
+        meta = await recalc_mod.emission_recalc_handler(job, job_session, data_session)
+
+    assert meta["result"] == IngestionResult.WARNING
+
+
+@pytest.mark.asyncio
+async def test_emission_recalc_handler_raises_on_missing_scope():
+    """Missing ``data_entry_type_id`` or ``year`` → ValueError so the
+    runner records FINISHED+ERROR with a clear message."""
+    job = _make_job(data_entry_type_id=None)
+    with pytest.raises(ValueError, match="missing data_entry_type_id or year"):
+        await recalc_mod.emission_recalc_handler(job, MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# module_emission_recalc_handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_module_emission_recalc_iterates_all_types():
+    job = _make_job(
+        job_type="module_emission_recalc",
+        data_entry_type_id=None,
+        meta={"config": {"data_entry_type_ids": [1, 2]}},
+    )
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+    data_session.begin_nested = MagicMock()
+    data_session.begin_nested.return_value.__aenter__ = AsyncMock()
+    data_session.begin_nested.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+    repo.create_ingestion_job = AsyncMock(side_effect=lambda j: j)
+    repo.mark_job_as_current = AsyncMock()
+
+    workflow = MagicMock()
+    workflow.recalculate_for_data_entry_type = AsyncMock(
+        return_value={"recalculated": 3, "errors": 0, "modules_refreshed": 1}
+    )
+
+    with (
+        patch.object(recalc_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            recalc_mod, "EmissionRecalculationWorkflow", return_value=workflow
+        ),
+    ):
+        meta = await recalc_mod.module_emission_recalc_handler(
+            job, job_session, data_session
+        )
+
+    # Both data_entry_type_ids processed.
+    assert workflow.recalculate_for_data_entry_type.await_count == 2
+    # Per-type stub jobs created (one per type).
+    assert repo.create_ingestion_job.await_count == 2
+    assert repo.mark_job_as_current.await_count == 2
+    assert meta["status_message"] == "Module emission recalculation completed"
+    assert meta["result"] == IngestionResult.SUCCESS
+    assert meta["total_recalculated"] == 6
+    assert meta["total_errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_module_emission_recalc_partial_failure_returns_warning():
+    """One type fails entirely (savepoint rollback) → WARNING; remaining
+    types continue."""
+    job = _make_job(
+        job_type="module_emission_recalc",
+        data_entry_type_id=None,
+        meta={"config": {"data_entry_type_ids": [1, 2]}},
+    )
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+    data_session.begin_nested = MagicMock()
+    data_session.begin_nested.return_value.__aenter__ = AsyncMock()
+    data_session.begin_nested.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+    repo.create_ingestion_job = AsyncMock(side_effect=lambda j: j)
+    repo.mark_job_as_current = AsyncMock()
+
+    workflow = MagicMock()
+    # Type 1 succeeds, Type 2 raises.
+    workflow.recalculate_for_data_entry_type = AsyncMock(
+        side_effect=[
+            {"recalculated": 3, "errors": 0, "modules_refreshed": 1},
+            RuntimeError("type 2 blew up"),
+        ]
+    )
+
+    with (
+        patch.object(recalc_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            recalc_mod, "EmissionRecalculationWorkflow", return_value=workflow
+        ),
+    ):
+        meta = await recalc_mod.module_emission_recalc_handler(
+            job, job_session, data_session
+        )
+
+    assert meta["result"] == IngestionResult.WARNING
+    assert meta["total_errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_module_emission_recalc_raises_when_config_missing():
+    job = _make_job(
+        job_type="module_emission_recalc",
+        data_entry_type_id=None,
+        meta={},
+    )
+    with pytest.raises(ValueError, match="missing config.data_entry_type_ids"):
+        await recalc_mod.module_emission_recalc_handler(job, MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# unit_sync_handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_handler_runs_full_chain_and_returns_summary():
+    job = _make_job(
+        job_type="unit_sync",
+        meta={"config": {"target_year": 2025}},
+    )
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+
+    unit_provider = MagicMock()
+    unit_provider.fetch_all_units = AsyncMock(return_value=([{}, {}], [{}]))
+    unit_provider.map_api_unit = MagicMock(side_effect=lambda u: MagicMock())
+
+    role_provider = MagicMock()
+    role_provider.map_api_user = MagicMock(return_value=MagicMock())
+
+    seeded_units = [MagicMock(id=1), MagicMock(id=2)]
+    unit_service = MagicMock()
+    unit_upsert_result = MagicMock(data=seeded_units)
+    unit_service.bulk_upsert = AsyncMock(return_value=unit_upsert_result)
+
+    user_service = MagicMock()
+    user_upsert_result = MagicMock(data=[MagicMock()])
+    user_service.bulk_upsert = AsyncMock(return_value=user_upsert_result)
+
+    carbon_report_service = MagicMock()
+    carbon_report_service.bulk_upsert = AsyncMock(
+        return_value=[MagicMock(), MagicMock()]
+    )
+    carbon_report_service.ensure_modules_for_reports = AsyncMock()
+
+    with (
+        patch.object(unit_sync_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(unit_sync_mod, "get_unit_provider", return_value=unit_provider),
+        patch.object(unit_sync_mod, "get_role_provider", return_value=role_provider),
+        patch.object(unit_sync_mod, "UnitService", return_value=unit_service),
+        patch.object(unit_sync_mod, "UserService", return_value=user_service),
+        patch.object(
+            unit_sync_mod,
+            "CarbonReportService",
+            return_value=carbon_report_service,
+        ),
+    ):
+        meta = await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
+
+    assert meta["status_message"] == "Unit sync completed"
+    assert meta["result"] == IngestionResult.SUCCESS
+    assert meta["units_synced"] == 2
+    assert meta["carbon_reports_created"] == 2
+    assert meta["carbon_report_year"] == 2025
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_handler_falls_back_to_job_year_when_config_missing():
+    """Plan 310-B's poller branch reads ``meta.config.target_year``;
+    when ``meta`` doesn't carry one, fall back to ``job.year`` so
+    legacy callers keep working."""
+    job = _make_job(job_type="unit_sync", meta={}, year=2024)
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+
+    unit_provider = MagicMock()
+    unit_provider.fetch_all_units = AsyncMock(return_value=([], []))
+    unit_provider.map_api_unit = MagicMock(side_effect=lambda u: MagicMock())
+    role_provider = MagicMock()
+    role_provider.map_api_user = MagicMock(return_value=MagicMock())
+
+    unit_service = MagicMock()
+    unit_service.bulk_upsert = AsyncMock(return_value=MagicMock(data=[]))
+    user_service = MagicMock()
+    user_service.bulk_upsert = AsyncMock(return_value=MagicMock(data=[]))
+    carbon_report_service = MagicMock()
+    carbon_report_service.bulk_upsert = AsyncMock(return_value=[])
+    carbon_report_service.ensure_modules_for_reports = AsyncMock()
+
+    with (
+        patch.object(unit_sync_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(unit_sync_mod, "get_unit_provider", return_value=unit_provider),
+        patch.object(unit_sync_mod, "get_role_provider", return_value=role_provider),
+        patch.object(unit_sync_mod, "UnitService", return_value=unit_service),
+        patch.object(unit_sync_mod, "UserService", return_value=user_service),
+        patch.object(
+            unit_sync_mod,
+            "CarbonReportService",
+            return_value=carbon_report_service,
+        ),
+    ):
+        meta = await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
+
+    assert meta["carbon_report_year"] == 2024
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_handler_raises_when_no_target_year_anywhere():
+    job = _make_job(job_type="unit_sync", meta={}, year=None)
+    with pytest.raises(ValueError, match="missing config.target_year"):
+        await unit_sync_mod.unit_sync_handler(job, MagicMock(), MagicMock())


### PR DESCRIPTION
## Summary

Plan 310-C Tier-2 PR #2 — registers three of the five existing background tasks as runner-shaped handlers. **Strictly additive**: nothing today calls these handlers; the legacy functions stay the canonical path until the cutover PR.

## What lands

### Three new registered handlers

- **\`emission_recalc_handler\`** in \`backend/app/tasks/emission_recalculation_tasks.py\` — single \`(data_entry_type, year)\` recalc.
- **\`module_emission_recalc_handler\`** in same file — module-level bulk recalc across N data_entry_types, with per-type savepoint isolation and per-type stub FINISHED jobs (so \`get_recalculation_status_by_year\` can match the work back to specific dets — same pattern as the legacy function).
- **\`unit_sync_handler\`** in \`backend/app/tasks/unit_sync_tasks.py\` — Accred unit + principal-user sync.

Each handler:

- Matches the runner contract from #1044: \`(job, job_session, data_session) -> dict\`.
- Reads scope from \`job\` (and \`job.meta.config\` where the legacy task took kwargs — mirrors the safety poller's path).
- Does NOT call \`claim_job\` and does NOT write the FINISHED state. Both belong to \`run_job\`.
- Returns the meta dict the runner persists; \`status_message\` and \`result\` keys drive the runner's FINISHED-state write.

### Tests (12 new in \`tests/unit/tasks/test_handler_registrations.py\`)

| Test | What it pins |
|---|---|
| \`test_emission_recalc_registered\` etc. (×3) | \`@register\` decorators ran at import |
| \`emission_recalc_handler_calls_workflow_and_returns_meta\` | happy path: workflow called, meta keys present |
| \`emission_recalc_handler_warning_when_errors_present\` | \`errors > 0\` → WARNING result |
| \`emission_recalc_handler_raises_on_missing_scope\` | missing det/year → ValueError so runner can record FINISHED+ERROR |
| \`module_emission_recalc_iterates_all_types\` | walks every det in \`config.data_entry_type_ids\`, creates per-type stubs |
| \`module_emission_recalc_partial_failure_returns_warning\` | one type fails entirely, others continue → WARNING |
| \`module_emission_recalc_raises_when_config_missing\` | missing \`config.data_entry_type_ids\` → ValueError |
| \`unit_sync_handler_runs_full_chain_and_returns_summary\` | full sync chain (units → users → carbon reports → modules) |
| \`unit_sync_handler_falls_back_to_job_year_when_config_missing\` | poller-compat: \`job.year\` is the fallback when \`meta.config.target_year\` is absent |
| \`unit_sync_handler_raises_when_no_target_year_anywhere\` | both missing → ValueError |

## Why three handlers, not all five

Ingestion handlers (\`csv_ingest\` / \`api_ingest\` / \`factor_ingest\`) need provider-class lookup plumbing that's tightly coupled to the endpoint cutover (the endpoint is what knows which provider to instantiate). Splitting them off means PR #2 stays additive and safely reviewable; the cutover PR ships ingestion handlers AND endpoint dispatch changes together.

## Test plan

- [x] \`rtk uv run pytest backend/tests/unit/tasks/test_handler_registrations.py\` — 12/12
- [x] \`rtk uv run pytest backend/tests/unit/\` — 1243/1243 (no regressions)
- [x] \`rtk uv run mypy backend/app/tasks/emission_recalculation_tasks.py backend/app/tasks/unit_sync_tasks.py\` — clean
- [x] \`rtk uv run ruff format --check backend/app/ backend/tests/\` — clean
- [x] \`rtk uv run ruff check backend/app/ backend/tests/\` — clean

## What's next

- **Cutover PR (Tier-2 PR #3)**: switch \`data_sync.py\` endpoints from \`BackgroundTasks.add_task\` to \`fire_and_forget(run_job(id))\`, swap \`_poller.dispatch_job\` for \`run_job\`, register the three ingestion handlers, delete the now-unused legacy task functions.
- **Aggregation handler (Tier-2 PR #4)**: separate; doesn't depend on this PR's cutover, so being spawned in parallel.