### PR TITLE
feat(#310d): aggregation handler + dedup-active partial unique index

### DIFF
--- a/backend/alembic/versions/2026_05_06_1000-e7f1a2b3c4d5_aggregation_dedup_index.py
+++ b/backend/alembic/versions/2026_05_06_1000-e7f1a2b3c4d5_aggregation_dedup_index.py
@@ -1,0 +1,86 @@
+# codeql[py/unused-global-variable]
+"""aggregation dedup-active partial unique index
+
+Revision ID: e7f1a2b3c4d5
+Revises: d3e5f7a9b1c4
+Create Date: 2026-05-06 10:00:00.000000
+
+Plan 310-D — partial unique index that prevents N redundant
+``aggregation`` jobs being created when ``factor_ingest`` fan-out
+chains N ``emission_recalc`` children for the same
+``(module_type_id, year)``.
+
+Each child wants to chain a follow-up ``aggregation`` job for the
+same scope.  Without dedup that's N aggregation jobs.  With this
+index, ``chain_job(dedup_active=True)`` (added in a separate PR)
+uses ``INSERT ... ON CONFLICT DO NOTHING`` — the first child wins,
+the rest see the existing pending row and skip.  Once the first
+aggregation finishes (state=FINISHED), the index permits a new
+aggregation row, so subsequent fan-out batches stay correct.
+
+The WHERE clause covers every non-terminal state — ``NOT_STARTED``,
+``QUEUED``, ``RUNNING`` — so dedup applies for the entire window
+between "we want one" and "the work is done".  ``FINISHED`` rows
+are excluded so historical aggregation jobs don't block future
+ones for the same scope.
+
+State values use native PG enum labels because the column is
+``SAEnum(IngestionState, name='ingestion_state_enum',
+native_enum=True)``; mirrors the existing
+``ix_data_ingestion_jobs_pending`` partial-index style.
+
+Chains off ``d3e5f7a9b1c4`` (Plan 310-C observability columns) —
+``feat/310c-handler-registrations`` (PR #1048) carries no migrations
+of its own, so dev's head ``d3e5f7a9b1c4`` is also our parent.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "e7f1a2b3c4d5"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "d3e5f7a9b1c4"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+_INDEX_NAME = "uq_aggregation_active"
+_TABLE_NAME = "data_ingestion_jobs"
+_PARTIAL_WHERE = (
+    "job_type = 'aggregation' "
+    "AND state IN ("
+    "'NOT_STARTED'::ingestion_state_enum, "
+    "'QUEUED'::ingestion_state_enum, "
+    "'RUNNING'::ingestion_state_enum"
+    ")"
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(
+        _INDEX_NAME,
+        _TABLE_NAME,
+        ["module_type_id", "year"],
+        unique=True,
+        postgresql_where=sa.text(_PARTIAL_WHERE),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        _INDEX_NAME,
+        table_name=_TABLE_NAME,
+        postgresql_where=sa.text(_PARTIAL_WHERE),
+    )

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -137,6 +137,29 @@ class CarbonReportModuleRepository:
         result = await self.session.execute(statement)
         return list(result.scalars().all())
 
+    async def list_by_module_type_and_year(
+        self, module_type_id: int, year: int
+    ) -> List[CarbonReportModule]:
+        """List all modules for a given (module_type_id, year) slice.
+
+        ``module_type_id`` lives on ``CarbonReportModule``; ``year`` lives on
+        the parent ``CarbonReport``, so the filter joins through it.  Mirrors
+        ``get_by_year_and_unit`` minus the unit filter.
+        """
+        statement = (
+            select(CarbonReportModule)
+            .join(
+                CarbonReport,
+                col(CarbonReportModule.carbon_report_id) == col(CarbonReport.id),
+            )
+            .where(
+                CarbonReportModule.module_type_id == module_type_id,
+                CarbonReport.year == year,
+            )
+        )
+        result = await self.session.execute(statement)
+        return list(result.scalars().all())
+
     async def update_status(
         self, carbon_report_id: int, module_type_id: int, status: int
     ) -> Optional[CarbonReportModule]:

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -194,6 +194,19 @@ class CarbonReportModuleService:
             CarbonReportModuleRead.model_validate(crm) for crm in carbon_report_modules
         ]
 
+    async def list_modules_for(
+        self, module_type_id: int, year: int
+    ) -> List[CarbonReportModule]:
+        """Return all CarbonReportModule rows for a (module_type_id, year) slice.
+
+        Used by the Plan 310-D ``aggregation`` handler to identify which
+        modules need their stats recomputed after a bulk recalc / ingest
+        pipeline writes new emissions for that scope.
+        """
+        return await self.repo.list_by_module_type_and_year(
+            module_type_id=module_type_id, year=year
+        )
+
     async def update_status(
         self, carbon_report_id: int, module_type_id: int, status: int
     ) -> Optional[CarbonReportModuleRead]:

--- a/backend/app/tasks/aggregation_tasks.py
+++ b/backend/app/tasks/aggregation_tasks.py
@@ -1,0 +1,75 @@
+"""Background task — Plan 310-D ``aggregation`` handler.
+
+Owns ``carbon_reports.stats`` writes for the bulk path.  After
+``emission_recalc`` finishes writing the underlying ``data_entry_emissions``
+rows, the recalc handler chains to ``aggregation`` for the scope
+``(module_type_id, year)``; this handler walks every ``CarbonReportModule``
+in that slice and calls ``CarbonReportModuleService.recompute_stats``,
+which is the same code Path 1 (manual edits) calls inline.
+
+Additive in this PR — no caller invokes this handler yet.  The cutover
+PR (`emission_recalc_handler` chains here, providers stop calling
+``recompute_stats`` directly) lands next in the Plan-D Tier-2 sequence.
+"""
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.data_ingestion import DataIngestionJob, IngestionResult
+from app.services.carbon_report_module_service import CarbonReportModuleService
+from app.tasks.registry import register
+
+logger = get_logger(__name__)
+
+
+@register("aggregation")
+async def aggregation_handler(
+    job: DataIngestionJob,
+    job_session: AsyncSession,
+    data_session: AsyncSession,
+) -> dict:
+    """Plan 310-D handler — sole writer of ``carbon_reports.stats`` for the
+    bulk path.
+
+    Reads scope ``(module_type_id, year)`` from the job row.  Walks every
+    ``CarbonReportModule`` in that slice and invokes
+    ``CarbonReportModuleService.recompute_stats``, which reads
+    ``data_entry_emissions`` for the module, rebuilds the stats JSON, and
+    persists it (with the parent ``CarbonReport.stats`` rollup as a
+    side-effect of the existing service implementation).
+
+    The runner has already claimed the job (state=RUNNING, attempts++,
+    started_at stamped).  This handler does not call ``claim_job`` and
+    must not write the FINISHED state — both belong to ``run_job``.
+
+    Returns the meta dict the runner persists on the FINISHED-state write.
+    ``status_message`` and ``result`` keys are read by the runner.
+    """
+    if job.id is None:
+        raise ValueError("aggregation: job has no id")
+    if job.module_type_id is None or job.year is None:
+        raise ValueError(f"aggregation job {job.id} missing module_type_id or year")
+
+    svc = CarbonReportModuleService(data_session)
+    affected = await svc.list_modules_for(
+        module_type_id=job.module_type_id, year=job.year
+    )
+
+    logger.info(
+        f"aggregation handler (job {job.id}): recomputing stats for "
+        f"{len(affected)} module(s) "
+        f"in scope module_type_id={job.module_type_id}/year={job.year}"
+    )
+
+    for module in affected:
+        if module.id is None:
+            # Defensive: rows fetched from DB always have ids, but the
+            # SQLModel field is Optional[int] so mypy needs the guard.
+            continue
+        await svc.recompute_stats(module.id)
+
+    return {
+        "status_message": "Aggregation completed",
+        "result": IngestionResult.SUCCESS,
+        "modules_refreshed": len(affected),
+    }

--- a/backend/tests/integration/services/data_ingestion/test_aggregation_dedup_index_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_aggregation_dedup_index_pg.py
@@ -1,0 +1,188 @@
+"""Postgres tests for the Plan 310-D ``uq_aggregation_active`` partial
+unique index.
+
+The migration creates a partial unique index on ``(module_type_id, year)``
+restricted to ``job_type = 'aggregation' AND state IN
+(NOT_STARTED, QUEUED, RUNNING)``.  The shared ``pg_dsn`` fixture builds
+the schema via ``SQLModel.metadata.create_all`` which doesn't run
+Alembic, so this file inlines the DDL via a local fixture (mirrors the
+pattern in ``conftest.py``'s ``_install_plan_310b_indexes``).
+
+What we cover:
+
+- Two NOT_STARTED ``aggregation`` rows with the same ``(module_type_id,
+  year)`` → second insert raises ``IntegrityError`` (the dedup window
+  catches duplicates).
+- One NOT_STARTED + one FINISHED for the same scope → both succeed
+  (FINISHED rows are excluded from the partial index, so historical
+  jobs don't block new ones).
+- Two NOT_STARTED rows with DIFFERENT ``(module_type_id, year)`` →
+  both succeed (dedup is per-scope, not global).
+- Non-``aggregation`` job_types are unaffected (the index is
+  job_type-scoped).
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionState,
+)
+from app.models.user import UserProvider
+
+_DEDUP_INDEX_DDL = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS uq_aggregation_active "
+    "ON data_ingestion_jobs (module_type_id, year) "
+    "WHERE job_type = 'aggregation' "
+    "AND state IN ("
+    "'NOT_STARTED'::ingestion_state_enum, "
+    "'QUEUED'::ingestion_state_enum, "
+    "'RUNNING'::ingestion_state_enum"
+    ")"
+)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def pg_dsn_with_aggregation_dedup(pg_dsn):
+    """``pg_dsn`` plus the Plan 310-D ``uq_aggregation_active`` index.
+
+    Inlined locally instead of extending the shared
+    ``pg_dsn_with_310b`` fixture — that one's scope is Plan 310B
+    factor indexes; mixing in unrelated DDL hurts maintainability.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(_DEDUP_INDEX_DDL))
+    finally:
+        await engine.dispose()
+    yield pg_dsn
+
+
+def _make_aggregation_job(
+    *,
+    module_type_id: int,
+    year: int,
+    state: IngestionState = IngestionState.NOT_STARTED,
+    job_type: str = "aggregation",
+) -> DataIngestionJob:
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=module_type_id,
+        year=year,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=state,
+        job_type=job_type,
+        is_current=False,
+        meta={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_active_aggregation_jobs_same_scope_raises(
+    pg_dsn_with_aggregation_dedup,
+):
+    """Two NOT_STARTED aggregation rows for the same (module_type_id,
+    year) violate the partial unique index → second insert raises."""
+    engine = create_async_engine(pg_dsn_with_aggregation_dedup, future=True)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            session.add(_make_aggregation_job(module_type_id=11, year=2025))
+            await session.commit()
+
+        async with factory() as session:
+            session.add(_make_aggregation_job(module_type_id=11, year=2025))
+            with pytest.raises(IntegrityError):
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_finished_does_not_block_new_active(
+    pg_dsn_with_aggregation_dedup,
+):
+    """FINISHED rows are outside the dedup window — a NOT_STARTED
+    aggregation can be inserted alongside an already-FINISHED one for
+    the same scope.  Otherwise historical jobs would permanently block
+    new aggregations."""
+    engine = create_async_engine(pg_dsn_with_aggregation_dedup, future=True)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            session.add(
+                _make_aggregation_job(
+                    module_type_id=11,
+                    year=2025,
+                    state=IngestionState.FINISHED,
+                )
+            )
+            await session.commit()
+
+        async with factory() as session:
+            session.add(
+                _make_aggregation_job(
+                    module_type_id=11,
+                    year=2025,
+                    state=IngestionState.NOT_STARTED,
+                )
+            )
+            # Must succeed — partial index excludes FINISHED.
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_different_scopes_both_succeed(pg_dsn_with_aggregation_dedup):
+    """Dedup is per-(module_type_id, year) scope.  Different module
+    types or different years run in parallel — covering all three
+    cross-product cases (different module, different year, different
+    both)."""
+    engine = create_async_engine(pg_dsn_with_aggregation_dedup, future=True)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            session.add(_make_aggregation_job(module_type_id=11, year=2025))
+            session.add(_make_aggregation_job(module_type_id=12, year=2025))
+            session.add(_make_aggregation_job(module_type_id=11, year=2026))
+            session.add(_make_aggregation_job(module_type_id=12, year=2026))
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_non_aggregation_job_type_unaffected(
+    pg_dsn_with_aggregation_dedup,
+):
+    """The partial index is scoped to ``job_type = 'aggregation'``;
+    other job types share the table without dedup interference."""
+    engine = create_async_engine(pg_dsn_with_aggregation_dedup, future=True)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            session.add(
+                _make_aggregation_job(
+                    module_type_id=11, year=2025, job_type="emission_recalc"
+                )
+            )
+            session.add(
+                _make_aggregation_job(
+                    module_type_id=11, year=2025, job_type="emission_recalc"
+                )
+            )
+            # Same scope, same non-aggregation job_type — both must
+            # succeed because the index excludes them.
+            await session.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/unit/tasks/test_aggregation_handler.py
+++ b/backend/tests/unit/tasks/test_aggregation_handler.py
@@ -1,0 +1,159 @@
+"""Unit tests for the Plan 310-D ``aggregation`` handler.
+
+Pins the contract:
+
+- ``@register("aggregation")`` ran at import time.
+- Reads ``module_type_id`` and ``year`` from the job row; raises
+  ``ValueError`` if either is missing so the runner records
+  FINISHED+ERROR with a clear message.
+- Calls ``CarbonReportModuleService.recompute_stats`` once per affected
+  module; returns ``modules_refreshed`` in the meta dict.
+- Empty module set → ``modules_refreshed: 0`` and no recompute calls.
+
+The integration shape (the dedup partial unique index) lives in
+``tests/integration/services/data_ingestion/``; this file stays in
+``tests/unit/`` because it patches the service layer.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.data_ingestion import IngestionResult
+from app.tasks import aggregation_tasks as aggregation_mod
+from app.tasks.registry import _REGISTRY, get_handler
+
+
+@pytest.fixture(autouse=True)
+def _registry_snapshot():
+    """Snapshot+restore the registry so test order doesn't matter and
+    re-importing ``aggregation_tasks`` between test files doesn't trip
+    the duplicate-registration guard."""
+    snapshot = dict(_REGISTRY)
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(snapshot)
+
+
+def _make_job(
+    *,
+    job_id: int = 1,
+    module_type_id: int | None = 11,
+    year: int | None = 2025,
+    meta: dict | None = None,
+) -> MagicMock:
+    job = MagicMock()
+    job.id = job_id
+    job.job_type = "aggregation"
+    job.module_type_id = module_type_id
+    job.year = year
+    job.meta = meta or {}
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Registration smoke
+# ---------------------------------------------------------------------------
+
+
+def test_aggregation_registered():
+    assert get_handler("aggregation") is aggregation_mod.aggregation_handler
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregation_calls_recompute_stats_for_each_affected_module():
+    """N modules in the (module_type, year) slice → N ``recompute_stats``
+    calls, one per module id."""
+    job = _make_job()
+    job_session = MagicMock()
+    data_session = MagicMock()
+
+    modules = [MagicMock(id=101), MagicMock(id=202), MagicMock(id=303)]
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=modules)
+    svc.recompute_stats = AsyncMock()
+
+    with patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc):
+        meta = await aggregation_mod.aggregation_handler(job, job_session, data_session)
+
+    svc.list_modules_for.assert_awaited_once_with(module_type_id=11, year=2025)
+    assert svc.recompute_stats.await_count == 3
+    svc.recompute_stats.assert_any_await(101)
+    svc.recompute_stats.assert_any_await(202)
+    svc.recompute_stats.assert_any_await(303)
+    assert meta["modules_refreshed"] == 3
+    assert meta["status_message"] == "Aggregation completed"
+    assert meta["result"] == IngestionResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_aggregation_returns_modules_refreshed_in_meta():
+    """Single module case — meta dict shape pinned (status_message,
+    result, modules_refreshed)."""
+    job = _make_job()
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=[MagicMock(id=42)])
+    svc.recompute_stats = AsyncMock()
+
+    with patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc):
+        meta = await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+    assert set(meta.keys()) == {"status_message", "result", "modules_refreshed"}
+    assert meta["modules_refreshed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_aggregation_handles_empty_module_set():
+    """Empty slice → ``modules_refreshed: 0`` and no recompute calls.
+
+    Defensive but realistic: a fan-out can chain an aggregation job for a
+    scope whose modules were deleted between schedule and execute; we
+    must finish SUCCESS with a no-op result rather than fail.
+    """
+    job = _make_job()
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=[])
+    svc.recompute_stats = AsyncMock()
+
+    with patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc):
+        meta = await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+    svc.recompute_stats.assert_not_called()
+    assert meta["modules_refreshed"] == 0
+    assert meta["result"] == IngestionResult.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Scope validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregation_raises_on_missing_module_type_id():
+    """Missing ``module_type_id`` → ValueError so the runner records
+    FINISHED+ERROR with a clear scope-error message."""
+    job = _make_job(module_type_id=None)
+    with pytest.raises(ValueError, match="missing module_type_id or year"):
+        await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_aggregation_raises_on_missing_year():
+    job = _make_job(year=None)
+    with pytest.raises(ValueError, match="missing module_type_id or year"):
+        await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_aggregation_raises_on_missing_job_id():
+    """Defensive — a job without an id isn't persisted, so we shouldn't
+    try to recompute on its behalf.  Mirrors the pattern in
+    ``emission_recalc_handler``."""
+    job = _make_job(job_id=None)
+    with pytest.raises(ValueError, match="job has no id"):
+        await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())

--- a/docs/src/implementation-plans/310-d-pipeline-responsibility-split.md
+++ b/docs/src/implementation-plans/310-d-pipeline-responsibility-split.md
@@ -85,21 +85,51 @@ await chain_job(
 
 ### 3. New `aggregation` handler
 
+> **Delivered: PR #310d (this PR).** The handler ships in
+> `backend/app/tasks/aggregation_tasks.py`; `CarbonReportModuleService.list_modules_for`
+> is added in the same PR. Two divergences from the sketch below were applied
+> at delivery and are reflected in the snippet:
+>
+> 1. `recompute_stats` takes `module.id: int`, not the module instance — that
+>    matches the existing service signature, which the sketch had wrong.
+> 2. The handler validates scope (`module_type_id`, `year`, `job.id`) up
+>    front and raises `ValueError` so the runner records FINISHED+ERROR,
+>    matching the contract pinned by the other 310-C handlers.
+> 3. The returned meta dict carries `status_message` and `result` (not just
+>    `modules_refreshed`) so the runner has the keys it needs for the
+>    FINISHED-state write.
+>
+> The handler is **strictly additive** in this PR — no caller invokes it
+> yet. The cutover (`emission_recalc_handler` chains to `aggregation`,
+> providers stop calling `recompute_stats` directly) is a follow-up
+> Plan-D PR.
+
 ```python
 @register("aggregation")
-async def aggregation_handler(job, job_session, data_session):
+async def aggregation_handler(job, job_session, data_session) -> dict:
     """
     Sole writer of carbon_reports.stats for the bulk path.
     Reads data_entry_emissions for (module_type_id, year), recomputes stats per
     affected CarbonReportModule, writes carbon_reports.stats with ON CONFLICT.
     """
+    if job.id is None:
+        raise ValueError("aggregation: job has no id")
+    if job.module_type_id is None or job.year is None:
+        raise ValueError(
+            f"aggregation job {job.id} missing module_type_id or year"
+        )
+
     svc = CarbonReportModuleService(data_session)
     affected = await svc.list_modules_for(
         module_type_id=job.module_type_id, year=job.year
     )
     for module in affected:
-        await svc.recompute_stats(module)   # existing method, unchanged internals
-    return {"modules_refreshed": len(affected)}
+        await svc.recompute_stats(module.id)   # int signature, unchanged internals
+    return {
+        "status_message": "Aggregation completed",
+        "result": IngestionResult.SUCCESS,
+        "modules_refreshed": len(affected),
+    }
 ```
 
 ### 4. Aggregation dedup (the N-jobs problem)
@@ -108,14 +138,25 @@ When `factor_ingest` fans out to N `emission_recalc` (one per stale det), each c
 `aggregation` for the same `(module_type_id, year)` — that is N redundant aggregation jobs
 per module.
 
-**Dedup mechanism**: a partial unique index on **active** (NOT_STARTED or RUNNING)
+> **Delivered: PR #310d (this PR) — index only.** The partial unique index
+> ships now via Alembic revision `e7f1a2b3c4d5_aggregation_dedup_index`.
+> The `chain_job(dedup_active=True)` helper extension is a separate
+> follow-up PR; this PR ships only the index that makes dedup possible.
+> The DDL uses native PG enum labels (the column is `SAEnum(..., native_enum=True)`),
+> not the int values the sketch shows.
+
+**Dedup mechanism**: a partial unique index on **active** (NOT_STARTED, QUEUED, or RUNNING)
 aggregation jobs:
 
 ```sql
 CREATE UNIQUE INDEX uq_aggregation_active
     ON data_ingestion_jobs (module_type_id, year)
     WHERE job_type = 'aggregation'
-      AND state IN (0, 1, 2);    -- NOT_STARTED, QUEUED, RUNNING
+      AND state IN (
+          'NOT_STARTED'::ingestion_state_enum,
+          'QUEUED'::ingestion_state_enum,
+          'RUNNING'::ingestion_state_enum
+      );
 ```
 
 `chain_job(job_type="aggregation", ...)` uses `INSERT ... ON CONFLICT DO NOTHING` against


### PR DESCRIPTION
## Summary

Plan 310-D Tier-2 PR #4 — adds the `aggregation` handler that owns `carbon_reports.stats` writes for the bulk path, plus the partial unique index that prevents N redundant aggregation jobs being created when factor fan-out triggers N `emission_recalc` children for the same `(module_type_id, year)`.

**Strictly additive**, like PR #1048: the handler exists but no caller invokes it yet. The cutover (`emission_recalc_handler` chains to `aggregation`, providers stop calling `recompute_stats` directly) is a separate Plan-D PR that depends on the `chain_job(dedup_active=True)` helper extension.

## What ships

- `backend/app/tasks/aggregation_tasks.py` — `@register("aggregation")` handler. Reads `(module_type_id, year)` from the job, calls `CarbonReportModuleService.list_modules_for(...)`, then `recompute_stats(module.id)` per module. Returns `{status_message, result, modules_refreshed}` for the runner's FINISHED-state write.
- `backend/app/repositories/carbon_report_module_repo.py` — `list_by_module_type_and_year` repo method (joins `CarbonReportModule` to `CarbonReport` for the year filter).
- `backend/app/services/carbon_report_module_service.py` — `list_modules_for` thin delegator on the service.
- `backend/alembic/versions/2026_05_06_1000-e7f1a2b3c4d5_aggregation_dedup_index.py` — partial unique index on `(module_type_id, year)` where `job_type = 'aggregation' AND state IN ('NOT_STARTED', 'QUEUED', 'RUNNING')`. Single-head chain off `d3e5f7a9b1c4`.
- Tests: 7 unit (handler contract + scope validation) + 4 integration against Postgres (dup-active raises, FINISHED doesn't block, different scopes succeed, other job_types unaffected).

## Divergences from the plan sketch

Captured via `> **Delivered: PR #310d.**` callouts in `docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`:

1. `recompute_stats` takes `module.id: int`, not the module instance — matches the existing service signature, which the sketch had wrong.
2. DDL uses native PG enum labels (`'NOT_STARTED'::ingestion_state_enum`) not int values — the column is `SAEnum(..., native_enum=True)`.
3. Handler validates `(job.id, module_type_id, year)` up front and raises `ValueError`; meta carries `status_message` + `result` so the runner can do the FINISHED-state write — matches the contract pinned by the other 310-C handlers.

## Dependency

Base branch is `feat/310c-handler-registrations` (PR #1048), not `dev`. PR #1048 carries the registry consumer pattern + #1044's runner this code depends on. Rebases to `dev` after #1048 lands.

## Test plan

- [x] `rtk uv run pytest tests/unit/tasks/test_aggregation_handler.py` — 7 pass
- [x] `rtk uv run pytest tests/integration/services/data_ingestion/test_aggregation_dedup_index_pg.py` — 4 pass (Docker / Postgres testcontainer)
- [x] `rtk uv run pytest tests/unit/` — 1250 pass (no regressions)
- [x] `rtk uv run mypy app/tasks/aggregation_tasks.py app/services/carbon_report_module_service.py app/repositories/carbon_report_module_repo.py` — clean
- [x] `rtk uv run ruff format --check app/ tests/` — clean
- [x] `rtk uv run ruff check app/ tests/` — clean
- [x] `rtk uv run alembic heads` — `e7f1a2b3c4d5 (head)` (single head preserved)

## Out of scope

- The `chain_job(dedup_active=True)` helper extension (separate PR; this PR ships only the index that makes dedup possible).
- The `emission_recalc` → `aggregation` cutover.
- Provider files dropping inline `recompute_stats` calls.
- Frontend stale-stats UX.