### PR TITLE
feat(#310d): pipeline SSE stream endpoint + active-pipeline repo helper

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -729,6 +729,130 @@ async def get_pipeline_jobs(
     )
 
 
+@router.get("/pipelines/{pipeline_id}/stream")
+async def pipeline_stream_by_id(
+    pipeline_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
+):
+    """Server-Sent Events stream for every job sharing a ``pipeline_id``.
+
+    **Required Permission**: ``backoffice.data_management.view`` — same gate
+    as the read-only ``GET /sync/pipelines/{pipeline_id}`` endpoint.
+
+    Plan 310D — the frontend stale-stats UX subscribes here when a module's
+    carbon-report response surfaces a ``current_pipeline_id``.  Each tick
+    re-reads every job in the pipeline and emits an ``event:
+    pipeline-update`` SSE message *only when* a job's
+    ``(state, status_message, result, finished_at)`` tuple changed — so an
+    idle pipeline doesn't spam the wire.  A separate ``event: ping`` heartbeat
+    fires every ~15s to keep proxies (nginx, AWS ALB) from idling the
+    connection out.  The stream closes once **every** job in the pipeline is
+    ``FINISHED``; a final ``stream_closed`` flag is sent so the client can
+    react before the EventSource reconnect-on-close kicks in.
+
+    Returns ``404`` when no rows share the given ``pipeline_id`` — fired on
+    the first poll *before* the stream opens, so SSE clients see a clean
+    HTTP error rather than a 200-with-empty-body that they'd interpret as
+    an aborted connection.
+    """
+    # Up-front 404: the existing job-stream endpoint emits a "not found"
+    # event in-stream, but for pipeline streams the SSE client cannot
+    # tell "pipeline does not exist" from "pipeline exists, no events
+    # yet" once the 200 lands.  Surfacing the 404 before opening the
+    # stream makes the contract symmetric with
+    # ``GET /sync/pipelines/{pipeline_id}``.
+    repo = DataIngestionRepository(db)
+    initial_jobs = await repo.list_jobs_by_pipeline_id(pipeline_id)
+    if not initial_jobs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No jobs found for pipeline_id {pipeline_id}",
+        )
+
+    # Tunables — keep the polling cadence tight enough that UI updates
+    # feel real-time, but spread the heartbeat across many polls so the
+    # ping packet is rare.  Defaults match the existing job-stream poll.
+    poll_interval_seconds = 2
+    heartbeat_interval_seconds = 15
+
+    async def event_generator():
+        last_snapshot: Optional[list[dict]] = None
+        polls_after_completion = 0
+        seconds_since_heartbeat = 0
+        # First-iteration optimisation: the 404 guard above already issued
+        # the query, so reuse those rows on the opening tick instead of
+        # double-querying.  Subsequent ticks always re-fetch.
+        jobs = initial_jobs
+
+        while True:
+            # Snapshot the columns the spec calls out for the dashboard:
+            # only these fields trigger a re-emit, so meta-only mutations
+            # (e.g. progress dicts) don't flood the stream.
+            snapshot = [
+                {
+                    "id": job.id,
+                    "job_type": job.job_type,
+                    "state": (job.state.value if job.state is not None else None),
+                    "result": (job.result.value if job.result is not None else None),
+                    "status_message": job.status_message,
+                    "started_at": (
+                        job.started_at.isoformat() if job.started_at else None
+                    ),
+                    "finished_at": (
+                        job.finished_at.isoformat() if job.finished_at else None
+                    ),
+                }
+                for job in jobs
+                if job.id is not None
+            ]
+
+            if snapshot != last_snapshot:
+                payload = {
+                    "pipeline_id": str(pipeline_id),
+                    "jobs": snapshot,
+                }
+                yield f"event: pipeline-update\ndata: {json.dumps(payload)}\n\n"
+                last_snapshot = snapshot
+                # Snapshot change counts as keep-alive — reset the heartbeat
+                # clock so we don't double-emit on the next tick.
+                seconds_since_heartbeat = 0
+
+            all_finished = bool(jobs) and all(
+                job.state == IngestionState.FINISHED for job in jobs
+            )
+            if all_finished:
+                polls_after_completion += 1
+                # Mirror the job-stream endpoint's "send a final marker
+                # then close" handshake so clients can flip UI state
+                # before the EventSource reconnect logic fires.
+                if polls_after_completion >= 2:
+                    final_payload = {
+                        "pipeline_id": str(pipeline_id),
+                        "jobs": last_snapshot or snapshot,
+                        "stream_closed": True,
+                    }
+                    yield (
+                        f"event: pipeline-update\ndata: {json.dumps(final_payload)}\n\n"
+                    )
+                    break
+
+            await asyncio.sleep(poll_interval_seconds)
+            seconds_since_heartbeat += poll_interval_seconds
+            if seconds_since_heartbeat >= heartbeat_interval_seconds:
+                yield "event: ping\ndata: {}\n\n"
+                seconds_since_heartbeat = 0
+
+            # Re-fetch for the next iteration.  Done at the bottom of the
+            # loop (rather than the top) so the first tick reuses the
+            # ``initial_jobs`` already fetched for the 404 guard.
+            jobs = await repo.list_jobs_by_pipeline_id(pipeline_id)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
 @router.post(
     "/recalculate-emissions/{module_type_id}/{data_entry_type_id}",
     response_model=SyncStatusResponse,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -746,8 +746,11 @@ async def pipeline_stream_by_id(
     carbon-report response surfaces a ``current_pipeline_id``.  Each tick
     re-reads every job in the pipeline and emits an ``event:
     pipeline-update`` SSE message *only when* a job's
-    ``(state, status_message, result, finished_at)`` tuple changed — so an
-    idle pipeline doesn't spam the wire.  A separate ``event: ping`` heartbeat
+    ``(state, status_message, result, started_at, finished_at)`` tuple
+    changed — so an idle pipeline doesn't spam the wire.  ``started_at``
+    is included because PR #1026 made it transition NOT_STARTED → claim
+    via ``func.coalesce``, and the dashboard wants to surface that flip.
+    A separate ``event: ping`` heartbeat
     fires every ~15s to keep proxies (nginx, AWS ALB) from idling the
     connection out.  The stream closes once **every** job in the pipeline is
     ``FINISHED``; a final ``stream_closed`` flag is sent so the client can

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -210,11 +210,22 @@ class DataIngestionRepository:
         Plan 310C — backs the ``GET /sync/pipelines/{pipeline_id}`` endpoint
         so dashboards can render the whole multi-step run (parent + fan-out
         children seeded by ``_enqueue_stale_recalculations``) in id order.
+
+        ``populate_existing=True`` is required for Plan 310D's SSE polling
+        endpoint (``GET /sync/pipelines/{pipeline_id}/stream``): the runner
+        writes job state changes (claim, FINISHED, status_message) on its
+        OWN ``SessionLocal()`` connection, so without this flag SQLAlchemy's
+        identity map would serve the SSE session a stale cached row on
+        every poll and the change-detection (``snapshot != last_snapshot``)
+        would never fire.  The one-shot read endpoint pays no cost for the
+        flag (its session lives one request), so we set it here rather than
+        plumbing a ``populate_existing`` kwarg through.
         """
         stmt = (
             select(DataIngestionJob)
             .where(DataIngestionJob.pipeline_id == pipeline_id)
             .order_by(col(DataIngestionJob.id).asc())
+            .execution_options(populate_existing=True)
         )
         exec_result = await self.session.execute(stmt)
         return list(exec_result.scalars().all())

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -219,6 +219,47 @@ class DataIngestionRepository:
         exec_result = await self.session.execute(stmt)
         return list(exec_result.scalars().all())
 
+    async def get_current_pipeline_id_for_module(
+        self, module_type_id: int
+    ) -> Optional[UUID]:
+        """Return the pipeline_id of the most recent **active** pipeline
+        that includes any job for the given ``module_type_id``.
+
+        Plan 310D — powers the carbon-report stale-stats UX: when a module
+        has an in-flight recalculation pipeline, the report response carries
+        this id so the frontend can subscribe to
+        ``GET /sync/pipelines/{id}/stream`` and de-emphasise stale stats
+        until the chain finishes.
+
+        Active = state in (NOT_STARTED, QUEUED, RUNNING).  We pick the
+        highest ``id`` (monotonic serial PK) among active jobs for the
+        module — equivalent to "most recent" since ``DataIngestionJob`` has
+        no ``created_at`` column today and ``started_at`` is NULL for
+        not-yet-claimed rows, making ``id`` the only universally usable
+        ordering key.
+
+        Returns ``None`` when no active pipeline includes the module — the
+        common steady-state case after the last chain finished.
+        """
+        stmt = (
+            select(col(DataIngestionJob.pipeline_id))
+            .where(
+                col(DataIngestionJob.module_type_id) == module_type_id,
+                col(DataIngestionJob.pipeline_id).isnot(None),
+                col(DataIngestionJob.state).in_(
+                    [
+                        IngestionState.NOT_STARTED,
+                        IngestionState.QUEUED,
+                        IngestionState.RUNNING,
+                    ]
+                ),
+            )
+            .order_by(col(DataIngestionJob.id).desc())
+            .limit(1)
+        )
+        exec_result = await self.session.execute(stmt)
+        return exec_result.scalar_one_or_none()
+
     # ---- Plan 310A: atomic claim, recovery, poller helpers ----
 
     def _build_combo_where(self, job: DataIngestionJob):

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_stream_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_stream_endpoint_pg.py
@@ -1,0 +1,171 @@
+"""Integration test for ``GET /v1/sync/pipelines/{pipeline_id}/stream`` (PG).
+
+Plan 310D — backend half of the stale-stats UX.  Mirrors the read endpoint
+test in ``test_sync_pipeline_endpoint_pg.py``: same auth fixture pattern,
+same pipeline-id seeding, same Postgres rationale (native ``UUID`` column,
+enum types, asyncpg round-trip).
+
+Coverage scope: the *contract* assertions (404 short-circuit before the
+stream opens, 403 permission gate) — not the streaming body.
+
+**Streaming-body coverage is deferred.**  The pre-existing
+``GET /sync/jobs/{job_id}/stream`` endpoint (which this one mirrors) also
+ships without integration coverage — running ``StreamingResponse`` through
+``httpx.ASGITransport`` against an asyncpg-backed test engine triggers
+``InterfaceError: connection is closed`` when the FastAPI dep teardown
+races with the generator's queries on the same engine, regardless of pool
+class.  Producing a stable streaming-body test would require either
+extracting the snapshot/poll logic for direct unit-testing or moving the
+session lifetime out of ``Depends(get_db)`` for SSE endpoints — a
+codebase-wide refactor not in this PR's scope.  The repo-level unit tests
+in ``tests/unit/repositories/test_data_ingestion_repo.py`` cover the data
+shape; the contract tests below cover gating and not-found.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth.
+
+    Same shape as ``test_sync_pipeline_endpoint_pg.py``: the 403 test
+    bypasses this fixture so the real permission gate fires.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+
+    yield {"factory": Sf, "engine": engine}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+def _make_pending_factor_job(pipeline_id) -> DataIngestionJob:
+    """Active (NOT_STARTED) parent — the chain head, not yet picked up."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=1,
+        data_entry_type_id=1,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.NOT_STARTED,
+        is_current=True,
+        pipeline_id=pipeline_id,
+        job_type="factor_ingest",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_stream_unknown_pipeline_returns_404(pg_app):
+    """Unknown pipeline_id → 404 *before* the stream opens.
+
+    The endpoint short-circuits with ``HTTPException`` so SSE clients see
+    a proper HTTP error, not a 200-with-empty-body that they would
+    interpret as an aborted connection.  Symmetric with the
+    not-found contract on the read endpoint.
+    """
+    unknown = uuid4()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(f"/v1/sync/pipelines/{unknown}/stream")
+
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_pipeline_stream_returns_403_for_user_without_permission(
+    pg_dsn, monkeypatch
+):
+    """Permission gate matches the read endpoint's
+    ``backoffice.data_management.view``.
+
+    Bypasses ``pg_app`` (which monkeypatches ``is_permitted`` to True)
+    so the real ``require_permission`` dependency fires.  We still seed
+    a job so a permitted user *would* have hit a 200 — proves the 403
+    stems from the gate, not from the not-found short-circuit running
+    first.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    pipeline_id = uuid4()
+    async with Sf() as session:
+        session.add(_make_pending_factor_job(pipeline_id))
+        await session.commit()
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _deny(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("app.core.security.is_permitted", _deny)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get(f"/v1/sync/pipelines/{pipeline_id}/stream")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+    assert resp.status_code == 403, resp.text

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_stream_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_stream_endpoint_pg.py
@@ -169,3 +169,82 @@ async def test_pipeline_stream_returns_403_for_user_without_permission(
         await engine.dispose()
 
     assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_by_pipeline_id_reflects_cross_session_updates(pg_dsn):
+    """The SSE poll loop reuses one long-lived session and re-calls
+    ``list_jobs_by_pipeline_id`` per tick.  In production the runner
+    writes job state changes (claim, FINISHED, status_message,
+    started_at) on its OWN ``SessionLocal()`` connection — a different
+    session from the SSE handler's.  Without ``populate_existing=True``
+    on the repo's select, SQLAlchemy's identity map would serve the SSE
+    session a stale cached row on every poll, the change-detection
+    (``snapshot != last_snapshot``) would never fire, and the stream
+    would emit nothing until the connection finally drops.
+
+    This test pins the contract directly at the repo level (no httpx,
+    no SSE) — bot review on PR #1052 caught that the streaming-body
+    integration coverage was deferred and the staleness bug slipped
+    through.  Two real PG sessions on the same engine reproduce the
+    exact mismatch the runner+SSE handler experience.
+    """
+    from app.repositories.data_ingestion import DataIngestionRepository
+
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    pipeline_id = uuid4()
+
+    # Seed: a NOT_STARTED parent job — the kind the SSE consumer sees
+    # before the runner picks it up.
+    async with Sf() as seed_session:
+        seed_session.add(_make_pending_factor_job(pipeline_id))
+        await seed_session.commit()
+
+    try:
+        # SSE-side session: long-lived, polls repeatedly.
+        async with Sf() as sse_session:
+            repo = DataIngestionRepository(sse_session)
+
+            # First poll — populates the identity map with the
+            # NOT_STARTED row.
+            first_snapshot = await repo.list_jobs_by_pipeline_id(pipeline_id)
+            assert len(first_snapshot) == 1
+            assert first_snapshot[0].state == IngestionState.RUNNING or (
+                first_snapshot[0].state == IngestionState.NOT_STARTED
+            )
+            initial_state = first_snapshot[0].state
+
+            # Out-of-band: simulate the runner claiming the job from a
+            # SEPARATE session/connection — exactly what
+            # ``run_job → claim_job`` does in production.
+            async with Sf() as runner_session:
+                runner_repo = DataIngestionRepository(runner_session)
+                target = (await runner_repo.list_jobs_by_pipeline_id(pipeline_id))[0]
+                assert target.id is not None
+                await runner_repo.update_ingestion_job(
+                    target.id,
+                    status_message="claimed by pod-test",
+                    metadata={"phase": "claimed"},
+                    state=IngestionState.RUNNING,
+                )
+                await runner_session.commit()
+
+            # Second poll on the SSE session.  Without
+            # ``populate_existing=True`` on the select, SQLAlchemy's
+            # identity map would short-circuit the row reload and we'd
+            # see the original NOT_STARTED state cached from the first
+            # poll — the SSE stream would emit nothing.
+            second_snapshot = await repo.list_jobs_by_pipeline_id(pipeline_id)
+            assert len(second_snapshot) == 1
+            assert second_snapshot[0].state == IngestionState.RUNNING, (
+                f"Expected RUNNING after out-of-band claim, got "
+                f"{second_snapshot[0].state}.  Identity-map staleness "
+                f"regression — populate_existing=True missing on the "
+                f"select in DataIngestionRepository.list_jobs_by_pipeline_id."
+            )
+            assert second_snapshot[0].state != initial_state
+            assert second_snapshot[0].status_message == "claimed by pod-test"
+    finally:
+        await engine.dispose()

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -4,7 +4,10 @@ Covers:
 - ``get_recalculation_status_by_year`` (Plan 310B)
 - ``set_started_at`` plus state-driven ``finished_at`` auto-stamping in
   ``update_ingestion_job``, ``cancel_job`` (Plan 310C observability columns)
+- ``get_current_pipeline_id_for_module`` (Plan 310D stale-stats UX)
 """
+
+from uuid import uuid4
 
 import pytest
 from sqlmodel import select
@@ -605,3 +608,199 @@ async def test_cancel_job_stamps_finished_at(db_session: AsyncSession):
     assert refreshed.state == IngestionState.FINISHED
     assert refreshed.result == IngestionResult.ERROR
     assert refreshed.finished_at is not None
+
+
+# ======================================================================
+# get_current_pipeline_id_for_module Tests (Plan 310D)
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_current_pipeline_id_returns_none_when_no_active_pipeline(
+    db_session: AsyncSession,
+):
+    """No jobs exist for the module → returns None.
+
+    Steady state once every chain has finished; the carbon-report
+    response should NOT carry a current_pipeline_id then.
+    """
+    repo = DataIngestionRepository(db_session)
+    result = await repo.get_current_pipeline_id_for_module(module_type_id=1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_current_pipeline_id_ignores_finished_only_pipeline(
+    db_session: AsyncSession,
+):
+    """Pipeline whose only job is FINISHED is not "active" → returns None.
+
+    The plan calls active = state in (NOT_STARTED, QUEUED, RUNNING); a
+    completed pipeline must not keep showing the "Recalculating…" badge
+    forever.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    finished_pipeline = uuid4()
+    job = _make_job(
+        module_type_id=1,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+    job.pipeline_id = finished_pipeline
+    db_session.add(job)
+    await db_session.flush()
+
+    result = await repo.get_current_pipeline_id_for_module(module_type_id=1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_current_pipeline_id_returns_active_pipeline(
+    db_session: AsyncSession,
+):
+    """Single RUNNING job for the module → returns its pipeline_id.
+
+    The minimum positive case: backend has one in-flight pipeline and
+    the helper surfaces it for the carbon-report response.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    active_pipeline = uuid4()
+    job = _make_job(
+        module_type_id=1,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.RUNNING,
+        result=None,
+        is_current=True,
+    )
+    job.pipeline_id = active_pipeline
+    db_session.add(job)
+    await db_session.flush()
+
+    result = await repo.get_current_pipeline_id_for_module(module_type_id=1)
+    assert result == active_pipeline
+
+
+@pytest.mark.asyncio
+async def test_get_current_pipeline_id_picks_most_recent_when_multiple_active(
+    db_session: AsyncSession,
+):
+    """Two active pipelines for the module → returns the most-recent one
+    (highest job id).
+
+    Without a ``created_at`` column the serial PK is the only universal
+    monotonic ordering — the helper relies on ``ORDER BY id DESC LIMIT 1``
+    so adding a newer pipeline supersedes the older one immediately.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    older_pipeline = uuid4()
+    newer_pipeline = uuid4()
+
+    older = _make_job(
+        module_type_id=1,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.RUNNING,
+        result=None,
+        # Avoid tripping the partial unique index on (module, det,
+        # target, method, year) by toggling is_current off for the
+        # older row — both rows are active but only one can be current.
+        is_current=False,
+    )
+    older.pipeline_id = older_pipeline
+    db_session.add(older)
+    await db_session.flush()
+
+    newer = _make_job(
+        module_type_id=1,
+        data_entry_type_id=21,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.NOT_STARTED,
+        result=None,
+        is_current=True,
+    )
+    newer.pipeline_id = newer_pipeline
+    db_session.add(newer)
+    await db_session.flush()
+
+    assert older.id is not None
+    assert newer.id is not None
+    assert newer.id > older.id
+
+    result = await repo.get_current_pipeline_id_for_module(module_type_id=1)
+    assert result == newer_pipeline
+
+
+@pytest.mark.asyncio
+async def test_get_current_pipeline_id_ignores_other_modules(
+    db_session: AsyncSession,
+):
+    """Active pipeline for a different module → returns None.
+
+    Module-scoped lookup — the dashboard should only badge the module
+    whose data is being recalculated, never bleed to siblings.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    pipeline_for_module_2 = uuid4()
+    job = _make_job(
+        module_type_id=2,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.RUNNING,
+        result=None,
+        is_current=True,
+    )
+    job.pipeline_id = pipeline_for_module_2
+    db_session.add(job)
+    await db_session.flush()
+
+    # Asking about module 1 must not pick up module 2's pipeline.
+    result = await repo.get_current_pipeline_id_for_module(module_type_id=1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_current_pipeline_id_skips_jobs_without_pipeline_id(
+    db_session: AsyncSession,
+):
+    """Active job without a ``pipeline_id`` (NULL) → returns None.
+
+    Single-step jobs (e.g. unit_sync, manual recalcs) are not part of a
+    multi-step chain; they shouldn't trigger the stale-stats badge.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    job = _make_job(
+        module_type_id=1,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.computed,
+        state=IngestionState.RUNNING,
+        result=None,
+        is_current=True,
+    )
+    # Explicit None — single-step job, not chain-attached.
+    job.pipeline_id = None
+    db_session.add(job)
+    await db_session.flush()
+
+    result = await repo.get_current_pipeline_id_for_module(module_type_id=1)
+    assert result is None


### PR DESCRIPTION
## Summary

Backend half of Plan 310-D Tier-2 PR6 — the pieces the frontend stale-stats UX needs.

- New repo helper `DataIngestionRepository.get_current_pipeline_id_for_module(module_type_id) -> Optional[UUID]`. Returns the most-recent active (`NOT_STARTED|QUEUED|RUNNING`) pipeline_id for the given module. Sibling PR5 (`feat/310d-bulk-path-pure-async`) wires this into the carbon-report response so the UI can badge a module as "Recalculating…".
- New SSE endpoint `GET /sync/pipelines/{pipeline_id}/stream`. Mirrors the existing `/sync/jobs/{job_id}/stream` shape:
  - Permission gate: `backoffice.data_management.view` (matches the read endpoint shipped in #1023).
  - Emits `event: pipeline-update` whenever any job's `(state, status_message, result, started_at, finished_at)` tuple changes.
  - Heartbeat `event: ping` every ~15s so proxies don't idle the connection out.
  - Closes with a `stream_closed: true` marker once every job is `FINISHED`.
  - 404 fires *before* the stream opens for unknown pipeline_ids — symmetric with the read endpoint's not-found contract.

## Plan-divergence note

Plan 310-D says "ORDER BY `created_at` DESC LIMIT 1" for the active-pipeline query, but `DataIngestionJob` has no `created_at` column. `started_at` is also NULL for not-yet-claimed rows. The serial PK `id` is the only universally monotonic ordering column, so the helper uses `ORDER BY id DESC LIMIT 1` — equivalent to "most recent" for the spec's purpose. Plan author should update the spec text.

## Out of scope (per task brief)

- `backend/app/api/v1/carbon_report.py` — sibling PR5 wires the `current_pipeline_id` field onto the response.
- Frontend Vue components — separate PR after this one merges.

## Test plan

- [x] `rtk uv run pytest tests/unit/repositories/test_data_ingestion_repo.py` — 21/21 pass (6 new tests for the repo helper).
- [x] `rtk uv run pytest tests/unit/` — full unit sweep, 1258/1258 pass.
- [x] `rtk uv run pytest tests/integration/services/data_ingestion/` — 72/72 pass (PG container required).
- [x] `rtk uv run ruff check app/ tests/` — clean.

### Streaming-body integration coverage is deferred

The new test file covers the contract (`404` before stream opens, `403` permission gate) but **does not** assert on the streaming body itself. Reasons:

1. The pre-existing `GET /sync/jobs/{job_id}/stream` endpoint (which this one mirrors) also ships without integration coverage.
2. Running `StreamingResponse` through `httpx.ASGITransport` against an asyncpg-backed test engine triggers `InterfaceError: connection is closed` when the FastAPI dep teardown races with the generator's queries on the same engine, regardless of pool class. Producing a stable streaming-body test would require either extracting the snapshot/poll logic for direct unit-testing or moving session lifetime out of `Depends(get_db)` for SSE endpoints — a codebase-wide refactor that doesn't fit this PR's scope.
3. The repo unit tests cover the data-shape logic; the contract integration tests cover the gate.

A follow-up to add a session-per-poll pattern (or directly testing the snapshot/heartbeat helpers) would close that gap for both this endpoint and the existing job-stream endpoint.