### PR TITLE
feat(#310d): pipeline SSE store + composable + module current_pipeline_id

### DIFF
--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -170,13 +170,28 @@ def _pick_latest_job(
     return candidates[0]
 
 
-def _build_recalculation_status(
+async def _build_recalculation_status(
     rows: list,
+    *,
+    repo: DataIngestionRepository,
+    year: int,
 ) -> list[ModuleRecalculationStatusEntry]:
     """Build per-module recalculation status from repository rows.
 
+    Plan 310-D: each module entry carries ``current_pipeline_id`` so
+    the back-office can render a "Recalculating..." badge while a
+    bulk pipeline is in flight.  We fetch all active pipelines for
+    the module set in ONE query via
+    ``repo.get_current_pipeline_ids_for_modules`` (the same helper
+    that backs the carbon-report ``current_pipeline_id`` field) so
+    this stays a constant-roundtrip operation regardless of module
+    count.
+
     Args:
         rows: List of RecalculationStatusRow dicts from the repository.
+        repo: ``DataIngestionRepository`` for the bulk pipeline-id lookup.
+        year: The year scope — ``current_pipeline_id`` is filtered to
+            pipelines touching ``(module_type_id, year)`` only.
 
     Returns:
         List of ModuleRecalculationStatusEntry grouped by module_type_id.
@@ -198,12 +213,17 @@ def _build_recalculation_status(
                 last_recalculation_job_result=row["last_recalculation_job_result"],
             )
         )
+    pipeline_by_module = await repo.get_current_pipeline_ids_for_modules(
+        list(modules.keys()),
+        year=year,
+    )
     return [
         ModuleRecalculationStatusEntry(
             module_type_id=module_id,
             year=dets[0].year if dets else 0,
             needs_recalculation=any(det.needs_recalculation for det in dets),
             data_entry_types=dets,
+            current_pipeline_id=pipeline_by_module.get(module_id),
         )
         for module_id, dets in modules.items()
     ]
@@ -408,7 +428,9 @@ async def get_year_configuration(
     _enrich_config_with_jobs(enriched_config, job_lookup)
 
     recalc_rows = await repo.get_recalculation_status_by_year(year)
-    recalculation_status = _build_recalculation_status(recalc_rows)
+    recalculation_status = await _build_recalculation_status(
+        recalc_rows, repo=repo, year=year
+    )
 
     return YearConfigurationResponse(
         year=result.year,
@@ -616,7 +638,9 @@ async def update_year_configuration(
     _enrich_config_with_jobs(enriched_config, job_lookup)
 
     recalc_rows = await repo.get_recalculation_status_by_year(year)
-    recalculation_status = _build_recalculation_status(recalc_rows)
+    recalculation_status = await _build_recalculation_status(
+        recalc_rows, repo=repo, year=year
+    )
 
     return YearConfigurationResponse(
         year=result.year,

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Type,
 )
+from uuid import UUID
 
 from pydantic import (
     BaseModel,
@@ -471,6 +472,18 @@ class ModuleRecalculationStatusEntry(BaseModel):
     year: int
     needs_recalculation: bool
     data_entry_types: List[RecalculationStatusEntry]
+    current_pipeline_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Plan 310-D — pipeline_id of the most recent active "
+            "(NOT_STARTED/QUEUED/RUNNING) bulk pipeline whose any-job "
+            "touches this module's (module_type_id, year).  ``None`` "
+            "when no active pipeline matches.  Back-office uses this "
+            "to render a 'Recalculating...' badge and subscribe to "
+            "``GET /v1/sync/pipelines/{id}/stream`` for live updates "
+            "while the chain is in flight."
+        ),
+    )
 
 
 class YearConfigurationResponse(BaseModel):

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, provide } from 'vue';
+import { computed, ref, provide, watch } from 'vue';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import { useModuleConfig } from 'src/composables/useModuleConfig';
 import { useRecalculation } from 'src/composables/useRecalculation';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import { usePipelineStream } from 'src/composables/usePipelineStream';
 import {
   TargetType,
   type ImportRow,
@@ -28,6 +29,68 @@ const { getModuleTypeIdFromName, isModuleEnabled, isModuleIncomplete } =
     module: props.module,
     selectedYear: props.selectedYear,
   });
+
+// Plan 310-D — pipeline-scoped SSE consumer drives the
+// "Recalculating..." badge.  ``current_pipeline_id`` rides on the
+// per-module ``recalculationStatus`` entry (extended in PR #1054
+// backend half) — null when no active pipeline, set to the
+// pipeline_id while a bulk chain is in flight.
+const { subscribe, unsubscribe, isFinishedFor, hasErrorFor } =
+  usePipelineStream();
+
+const currentPipelineId = computed<string | null>(() => {
+  const moduleTypeId = getModuleTypeIdFromName(props.module);
+  return (
+    yearConfigStore.recalculationStatus[moduleTypeId]?.current_pipeline_id ??
+    null
+  );
+});
+
+const isRecalculating = computed<boolean>(() => {
+  const id = currentPipelineId.value;
+  if (!id) return false;
+  // Active until the SSE stream signals finish — even if a previous
+  // entry on this id is finished, the badge clears via the watch
+  // below which refetches the year config.
+  return !isFinishedFor(id).value;
+});
+
+const hasRecalcFailure = computed<boolean>(() => {
+  const id = currentPipelineId.value;
+  if (!id) return false;
+  return hasErrorFor(id).value;
+});
+
+// Wire the SSE subscription to the reactive pipeline_id.  When it
+// transitions ``null → uuid`` we subscribe; ``uuid → null`` (badge
+// cleared by the year-config refetch) → unsubscribe; ``uuidA →
+// uuidB`` (rare — new pipeline started while old finished) → switch.
+let lastSubscribedId: string | null = null;
+watch(
+  currentPipelineId,
+  async (next) => {
+    if (lastSubscribedId === next) return;
+    if (lastSubscribedId) unsubscribe(lastSubscribedId);
+    lastSubscribedId = next;
+    if (next) await subscribe(next);
+  },
+  { immediate: true },
+);
+
+// When the pipeline reports finished, refetch the year config so
+// ``current_pipeline_id`` clears (or, on error, stays set with the
+// failure-state metadata for the future retry button).
+watch(
+  () =>
+    currentPipelineId.value
+      ? isFinishedFor(currentPipelineId.value).value
+      : false,
+  async (finished, wasFinished) => {
+    if (finished && !wasFinished && !hasRecalcFailure.value) {
+      await yearConfigStore.fetchConfig(props.selectedYear);
+    }
+  },
+);
 
 const {
   recalcRunning,
@@ -112,6 +175,30 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               color="warning"
               class="text-weight-medium"
               :label="$t('data_management_recalculation_needed')"
+            />
+            <!--
+              Plan 310-D — "Recalculating..." badge for in-flight bulk
+              pipelines.  Drives off ``current_pipeline_id`` on the
+              per-module recalc-status entry (set when an active
+              NOT_STARTED/QUEUED/RUNNING aggregation pipeline touches
+              this module's year), with the SSE composable controlling
+              the live state.
+            -->
+            <q-badge
+              v-if="isRecalculating"
+              outline
+              rounded
+              color="info"
+              class="text-weight-medium"
+              :label="$t('data_management_pipeline_recalculating')"
+            />
+            <q-badge
+              v-else-if="hasRecalcFailure"
+              outline
+              rounded
+              color="negative"
+              class="text-weight-medium"
+              :label="$t('data_management_pipeline_failed')"
             />
           </div>
         </q-item-section>

--- a/frontend/src/composables/usePipelineStream.ts
+++ b/frontend/src/composables/usePipelineStream.ts
@@ -27,6 +27,7 @@
  */
 
 import { onUnmounted } from 'vue';
+import { api } from 'src/api/http';
 import {
   usePipelineStreamStore,
   type PipelineSnapshot,
@@ -34,26 +35,26 @@ import {
 } from 'src/stores/pipelineStream';
 
 /**
- * Initial reconnect delay (ms).  Doubled on each consecutive
- * ``onerror`` up to ``MAX_BACKOFF_MS`` — same shape as the plan's
- * Risks section recommends.
+ * Reconnect strategy: trust native ``EventSource`` retry.
+ *
+ * Earlier revisions of this file shipped a custom exponential-backoff
+ * reconnect loop driven by the ``onerror`` handler.  Bot review on
+ * PR #1054 caught the bug: the WHATWG spec says ``onerror`` fires on
+ * transient drops with ``readyState === CONNECTING`` (the browser is
+ * already auto-retrying), and ``CLOSED`` is only reached after WE
+ * call ``.close()``.  So our ``readyState === CLOSED`` guard never
+ * fired and the documented backoff was dead code.
+ *
+ * Removing the dead code rather than fixing the broken state machine:
+ * the browser's native retry already does what we wanted (reconnect
+ * with a server-controlled or default-3s delay).  If the proxy stack
+ * ever proves to mishandle that, switch back to an explicit
+ * ``.close()`` + controlled reconnect — but don't ship the broken
+ * variant in the meantime.
  */
-const INITIAL_BACKOFF_MS = 1000;
-const MAX_BACKOFF_MS = 30_000;
-/**
- * ``EventSource.CLOSED`` resolves to ``2`` per the WHATWG spec
- * (CONNECTING=0, OPEN=1, CLOSED=2).  Using a named constant rather
- * than ``EventSource.CLOSED`` avoids the static-vs-instance-property
- * confusion the bot review on PR #1054 flagged — readers don't have
- * to remember that the static class property and the instance's
- * ``.readyState`` value match.
- */
-const EVENT_SOURCE_CLOSED = 2;
 
 interface ActiveStream {
   source: EventSource;
-  reconnectTimer: ReturnType<typeof setTimeout> | null;
-  backoffMs: number;
 }
 
 /**
@@ -100,15 +101,26 @@ export function __setSnapshotFetcher(fetcher: SnapshotFetcher | null): void {
 async function defaultSnapshotFetcher(
   pipelineId: string,
 ): Promise<PipelineSnapshot | null> {
+  // Use the centralized ``api`` client (ky) rather than raw ``fetch``
+  // so we inherit ``credentials: 'include'``, the 401-refresh-then-retry
+  // hook, the 401/403 redirect-and-toast behavior, and the standardized
+  // error notifications the rest of the app expects.  Bot review on
+  // PR #1054 caught the bypass: a raw ``fetch`` would silently return
+  // null on session expiry and we'd then open an SSE stream that
+  // would also fail to authenticate.
+  //
+  // ``api`` has ``prefixUrl: '/api/v1/'`` configured, so the path
+  // here is the suffix only.  Catch keeps the "non-fatal, fall
+  // through to stream" semantics intact for transient hiccups
+  // (the ``afterResponse`` hook in the api client still handles
+  // 401/403 globally before we see the rejection here).
   try {
-    const resp = await fetch(`/api/v1/sync/pipelines/${pipelineId}`);
-    if (!resp.ok) {
-      return null;
-    }
-    return (await resp.json()) as PipelineSnapshot;
+    return await api
+      .get(`sync/pipelines/${pipelineId}`)
+      .json<PipelineSnapshot>();
   } catch {
-    // Network blip or a 404 race — non-fatal, the stream will catch
-    // up with the next ``pipeline-update`` event.
+    // Network blip, 404 race, or post-redirect rejection — non-fatal,
+    // the stream will catch up with the next ``pipeline-update`` event.
     return null;
   }
 }
@@ -146,6 +158,17 @@ export function usePipelineStream() {
     // takes over — closes the "pipeline finished between
     // carbon-report response and our subscribe" race.
     const snapshot = await getSnapshotFetcher()(pipelineId);
+
+    // Re-check ownership after the await.  If the caller unmounted
+    // during the snapshot fetch, ``onUnmounted`` already ran
+    // ``unsubscribe`` (refcount → 0, but ``closeStream`` was a no-op
+    // because no stream existed yet).  Without this guard we'd
+    // proceed to ``openStream`` and leak an unowned EventSource.
+    // Bot review on PR #1054 caught the leak.
+    if (!ownedSubscriptions.has(pipelineId)) {
+      return;
+    }
+
     if (snapshot) {
       store.seedFromSnapshot(snapshot);
     }
@@ -193,12 +216,7 @@ export function usePipelineStream() {
 function openStream(pipelineId: string): void {
   const Ctor = getEventSourceCtor();
   const source = new Ctor(`/api/v1/sync/pipelines/${pipelineId}/stream`);
-  const active: ActiveStream = {
-    source,
-    reconnectTimer: null,
-    backoffMs: INITIAL_BACKOFF_MS,
-  };
-  activeStreams.set(pipelineId, active);
+  activeStreams.set(pipelineId, { source });
 
   // The backend names the SSE event ``pipeline-update`` (vs the
   // default unnamed ``message``).  Listen specifically for that —
@@ -209,9 +227,6 @@ function openStream(pipelineId: string): void {
       const payload = JSON.parse(event.data) as PipelineUpdate;
       const store = usePipelineStreamStore();
       store.applyUpdate(payload);
-      // Reset backoff on any successful event — connection is
-      // healthy so the next disconnect should retry quickly.
-      active.backoffMs = INITIAL_BACKOFF_MS;
       if (payload.stream_closed) {
         // Backend signaled end-of-stream; close the socket so the
         // browser doesn't try to reconnect via its own logic.
@@ -228,34 +243,12 @@ function openStream(pipelineId: string): void {
     // No-op — the heartbeat just keeps proxies awake.
   });
 
-  source.onerror = () => {
-    // ``onerror`` fires on transient disconnects AND on permanent
-    // close.  Schedule a reconnect with exponential backoff;
-    // ``closeStream`` clears the timer if the consumer fully
-    // unsubscribes before reconnect time.
-    if (active.source.readyState === EVENT_SOURCE_CLOSED) {
-      scheduleReconnect(pipelineId);
-    }
-  };
-}
-
-function scheduleReconnect(pipelineId: string): void {
-  const active = activeStreams.get(pipelineId);
-  if (!active) {
-    return;
-  }
-  if (active.reconnectTimer) {
-    return; // already pending
-  }
-  const delay = active.backoffMs;
-  active.backoffMs = Math.min(active.backoffMs * 2, MAX_BACKOFF_MS);
-  active.reconnectTimer = setTimeout(() => {
-    active.reconnectTimer = null;
-    // Drop the dead source and open a fresh one.
-    active.source.close();
-    activeStreams.delete(pipelineId);
-    openStream(pipelineId);
-  }, delay);
+  // No ``onerror`` handler: native ``EventSource`` already retries
+  // transient disconnects on its own clock (the browser keeps
+  // ``readyState === CONNECTING`` while it does so).  The store's
+  // reactive entry stays in place so the badge doesn't flicker.
+  // See the "Reconnect strategy" header comment for why we
+  // intentionally don't add bespoke retry logic.
 }
 
 function closeStream(pipelineId: string): void {
@@ -263,19 +256,13 @@ function closeStream(pipelineId: string): void {
   if (!active) {
     return;
   }
-  if (active.reconnectTimer) {
-    clearTimeout(active.reconnectTimer);
-  }
   active.source.close();
   activeStreams.delete(pipelineId);
 }
 
-/** Test-only: drop every active stream + cancel pending reconnects. */
+/** Test-only: drop every active stream. */
 export function __resetPipelineStreams(): void {
   for (const [, active] of activeStreams) {
-    if (active.reconnectTimer) {
-      clearTimeout(active.reconnectTimer);
-    }
     active.source.close();
   }
   activeStreams.clear();

--- a/frontend/src/composables/usePipelineStream.ts
+++ b/frontend/src/composables/usePipelineStream.ts
@@ -176,8 +176,7 @@ export function usePipelineStream() {
     // badge state without a separate ``useStore()`` call.
     isFinishedFor: (id: string) => store.isFinishedFor(id),
     hasErrorFor: (id: string) => store.hasErrorFor(id),
-    failedStatusMessagesFor: (id: string) =>
-      store.failedStatusMessagesFor(id),
+    failedStatusMessagesFor: (id: string) => store.failedStatusMessagesFor(id),
     jobsFor: (id: string) => store.jobsFor(id),
   };
 }

--- a/frontend/src/composables/usePipelineStream.ts
+++ b/frontend/src/composables/usePipelineStream.ts
@@ -1,0 +1,274 @@
+/**
+ * Plan 310-D — pipeline-scoped SSE consumer.
+ *
+ * Wraps the ``EventSource`` lifecycle for ``GET /v1/sync/pipelines/{id}/stream``
+ * and pushes parsed updates into ``usePipelineStreamStore``.  The store
+ * is keyed by ``pipeline_id`` so multiple module cards subscribed to
+ * the same pipeline share one EventSource (refcounted via ``acquire``
+ * / ``release``).
+ *
+ * Lifecycle the consumer needs to know:
+ *
+ * 1. ``subscribe(pipelineId)`` — opens the EventSource (or attaches
+ *    to an existing one for the same id).  Also seeds the store from
+ *    the one-shot ``GET /v1/sync/pipelines/{id}`` to mitigate the
+ *    "pipeline finished between carbon-report load and our subscribe"
+ *    race documented in the plan's Risks section.
+ * 2. The store's reactive ``isFinishedFor(id)`` flips when the
+ *    backend's terminal ``stream_closed: true`` payload arrives or
+ *    every job hits FINISHED — caller can refetch the carbon report
+ *    in response.
+ * 3. ``unsubscribe(pipelineId)`` — decrements the refcount; the last
+ *    unsubscribe closes the EventSource.
+ *
+ * ``onerror`` triggers exponential backoff reconnect capped at
+ * ``MAX_BACKOFF_MS``; the store entry stays around so the badge
+ * doesn't flicker during transient drops.
+ */
+
+import { onUnmounted } from 'vue';
+import {
+  usePipelineStreamStore,
+  type PipelineSnapshot,
+  type PipelineUpdate,
+} from 'src/stores/pipelineStream';
+
+/**
+ * Initial reconnect delay (ms).  Doubled on each consecutive
+ * ``onerror`` up to ``MAX_BACKOFF_MS`` — same shape as the plan's
+ * Risks section recommends.
+ */
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+
+interface ActiveStream {
+  source: EventSource;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  backoffMs: number;
+}
+
+/**
+ * Module-level registry so multiple composable callers (one per
+ * mounted module card) share the same EventSource per pipeline_id.
+ * The store's ``subscriberCount`` keeps the entry alive across
+ * mount/unmount churn; the registry here owns the actual socket.
+ */
+const activeStreams = new Map<string, ActiveStream>();
+
+/**
+ * Optional injection point for tests — replace ``window.EventSource``
+ * without touching globals.  Default is the browser's native one.
+ */
+type EventSourceCtor = new (url: string) => EventSource;
+
+let eventSourceImpl: EventSourceCtor | null = null;
+
+/** Test seam: replace the EventSource constructor used by ``subscribe``. */
+export function __setEventSourceImpl(ctor: EventSourceCtor | null): void {
+  eventSourceImpl = ctor;
+}
+
+function getEventSourceCtor(): EventSourceCtor {
+  if (eventSourceImpl) {
+    return eventSourceImpl;
+  }
+  return EventSource;
+}
+
+/**
+ * Optional injection point for the one-shot snapshot fetch.  Default
+ * uses ``fetch``; tests can swap in a stub.
+ */
+type SnapshotFetcher = (pipelineId: string) => Promise<PipelineSnapshot | null>;
+
+let snapshotFetcherImpl: SnapshotFetcher | null = null;
+
+/** Test seam: replace the snapshot fetcher used by ``subscribe``. */
+export function __setSnapshotFetcher(fetcher: SnapshotFetcher | null): void {
+  snapshotFetcherImpl = fetcher;
+}
+
+async function defaultSnapshotFetcher(
+  pipelineId: string,
+): Promise<PipelineSnapshot | null> {
+  try {
+    const resp = await fetch(`/api/v1/sync/pipelines/${pipelineId}`);
+    if (!resp.ok) {
+      return null;
+    }
+    return (await resp.json()) as PipelineSnapshot;
+  } catch {
+    // Network blip or a 404 race — non-fatal, the stream will catch
+    // up with the next ``pipeline-update`` event.
+    return null;
+  }
+}
+
+function getSnapshotFetcher(): SnapshotFetcher {
+  return snapshotFetcherImpl ?? defaultSnapshotFetcher;
+}
+
+/**
+ * Vue composable: subscribe to a pipeline_id's SSE stream and
+ * automatically unsubscribe on component unmount.
+ *
+ * Returns ``subscribe`` / ``unsubscribe`` for callers that need to
+ * switch pipeline_ids dynamically (e.g. when ``current_pipeline_id``
+ * on a module card transitions ``oldId → newId``); the auto-cleanup
+ * still fires on unmount for whatever the last-subscribed id was.
+ */
+export function usePipelineStream() {
+  const store = usePipelineStreamStore();
+  const ownedSubscriptions = new Set<string>();
+
+  async function subscribe(pipelineId: string): Promise<void> {
+    if (!pipelineId) {
+      return;
+    }
+    if (ownedSubscriptions.has(pipelineId)) {
+      // Same caller already subscribed — refcount is already +1
+      // for this caller; treat as a no-op rather than double-counting.
+      return;
+    }
+    ownedSubscriptions.add(pipelineId);
+    store.acquire(pipelineId);
+
+    // Seed initial state from the one-shot endpoint BEFORE the stream
+    // takes over — closes the "pipeline finished between
+    // carbon-report response and our subscribe" race.
+    const snapshot = await getSnapshotFetcher()(pipelineId);
+    if (snapshot) {
+      store.seedFromSnapshot(snapshot);
+    }
+
+    if (activeStreams.has(pipelineId)) {
+      // Another caller already opened the EventSource for this
+      // pipeline_id; we just attached the refcount above.
+      return;
+    }
+    openStream(pipelineId);
+  }
+
+  function unsubscribe(pipelineId: string): void {
+    if (!ownedSubscriptions.has(pipelineId)) {
+      return;
+    }
+    ownedSubscriptions.delete(pipelineId);
+    const remaining = store.release(pipelineId);
+    if (remaining === 0) {
+      closeStream(pipelineId);
+    }
+  }
+
+  onUnmounted(() => {
+    // Defensive cleanup — release every subscription this caller
+    // holds.  Tolerates partial-mount sequences where ``subscribe``
+    // was called for some ids but not others.
+    for (const id of Array.from(ownedSubscriptions)) {
+      unsubscribe(id);
+    }
+  });
+
+  return {
+    subscribe,
+    unsubscribe,
+    // Re-export the store's reactive accessors so callers can compute
+    // badge state without a separate ``useStore()`` call.
+    isFinishedFor: (id: string) => store.isFinishedFor(id),
+    hasErrorFor: (id: string) => store.hasErrorFor(id),
+    failedStatusMessagesFor: (id: string) =>
+      store.failedStatusMessagesFor(id),
+    jobsFor: (id: string) => store.jobsFor(id),
+  };
+}
+
+function openStream(pipelineId: string): void {
+  const Ctor = getEventSourceCtor();
+  const source = new Ctor(`/api/v1/sync/pipelines/${pipelineId}/stream`);
+  const active: ActiveStream = {
+    source,
+    reconnectTimer: null,
+    backoffMs: INITIAL_BACKOFF_MS,
+  };
+  activeStreams.set(pipelineId, active);
+
+  // The backend names the SSE event ``pipeline-update`` (vs the
+  // default unnamed ``message``).  Listen specifically for that —
+  // ``onmessage`` would only fire for unnamed events.
+  source.addEventListener('pipeline-update', (raw) => {
+    const event = raw as MessageEvent;
+    try {
+      const payload = JSON.parse(event.data) as PipelineUpdate;
+      const store = usePipelineStreamStore();
+      store.applyUpdate(payload);
+      // Reset backoff on any successful event — connection is
+      // healthy so the next disconnect should retry quickly.
+      active.backoffMs = INITIAL_BACKOFF_MS;
+      if (payload.stream_closed) {
+        // Backend signaled end-of-stream; close the socket so the
+        // browser doesn't try to reconnect via its own logic.
+        closeStream(pipelineId);
+      }
+    } catch (err) {
+      // Malformed payload — log and let the stream continue;
+      // a malformed event isn't worth tearing the connection down.
+      console.error('[usePipelineStream] malformed pipeline-update', err);
+    }
+  });
+
+  source.addEventListener('ping', () => {
+    // No-op — the heartbeat just keeps proxies awake.
+  });
+
+  source.onerror = () => {
+    // ``onerror`` fires on transient disconnects AND on permanent
+    // close.  Schedule a reconnect with exponential backoff;
+    // ``closeStream`` clears the timer if the consumer fully
+    // unsubscribes before reconnect time.
+    if (active.source.readyState === EventSource.CLOSED) {
+      scheduleReconnect(pipelineId);
+    }
+  };
+}
+
+function scheduleReconnect(pipelineId: string): void {
+  const active = activeStreams.get(pipelineId);
+  if (!active) {
+    return;
+  }
+  if (active.reconnectTimer) {
+    return; // already pending
+  }
+  const delay = active.backoffMs;
+  active.backoffMs = Math.min(active.backoffMs * 2, MAX_BACKOFF_MS);
+  active.reconnectTimer = setTimeout(() => {
+    active.reconnectTimer = null;
+    // Drop the dead source and open a fresh one.
+    active.source.close();
+    activeStreams.delete(pipelineId);
+    openStream(pipelineId);
+  }, delay);
+}
+
+function closeStream(pipelineId: string): void {
+  const active = activeStreams.get(pipelineId);
+  if (!active) {
+    return;
+  }
+  if (active.reconnectTimer) {
+    clearTimeout(active.reconnectTimer);
+  }
+  active.source.close();
+  activeStreams.delete(pipelineId);
+}
+
+/** Test-only: drop every active stream + cancel pending reconnects. */
+export function __resetPipelineStreams(): void {
+  for (const [, active] of activeStreams) {
+    if (active.reconnectTimer) {
+      clearTimeout(active.reconnectTimer);
+    }
+    active.source.close();
+  }
+  activeStreams.clear();
+}

--- a/frontend/src/composables/usePipelineStream.ts
+++ b/frontend/src/composables/usePipelineStream.ts
@@ -40,6 +40,15 @@ import {
  */
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 30_000;
+/**
+ * ``EventSource.CLOSED`` resolves to ``2`` per the WHATWG spec
+ * (CONNECTING=0, OPEN=1, CLOSED=2).  Using a named constant rather
+ * than ``EventSource.CLOSED`` avoids the static-vs-instance-property
+ * confusion the bot review on PR #1054 flagged — readers don't have
+ * to remember that the static class property and the instance's
+ * ``.readyState`` value match.
+ */
+const EVENT_SOURCE_CLOSED = 2;
 
 interface ActiveStream {
   source: EventSource;
@@ -224,7 +233,7 @@ function openStream(pipelineId: string): void {
     // close.  Schedule a reconnect with exponential backoff;
     // ``closeStream`` clears the timer if the consumer fully
     // unsubscribes before reconnect time.
-    if (active.source.readyState === EventSource.CLOSED) {
+    if (active.source.readyState === EVENT_SOURCE_CLOSED) {
       scheduleReconnect(pipelineId);
     }
   };

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -604,6 +604,14 @@ export default {
     en: 'Recalculation Needed',
     fr: 'Recalcul nécessaire',
   },
+  data_management_pipeline_recalculating: {
+    en: 'Recalculating…',
+    fr: 'Recalcul en cours…',
+  },
+  data_management_pipeline_failed: {
+    en: 'Last recalc failed',
+    fr: 'Échec du dernier recalcul',
+  },
   data_management_recalculate_emissions: {
     en: 'Recalculate Emissions',
     fr: 'Recalculer les émissions',

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -108,12 +108,20 @@ export interface EmissionBreakdownCategoryRow {
 
 /**
  * API response for inventory module
+ *
+ * ``current_pipeline_id`` (Plan 310-D) — populated by the backend when
+ * an active bulk-pipeline is touching this module's
+ * ``(module_type_id, year)`` scope.  ``null`` when no pipeline is in
+ * flight.  Frontend uses this to render a "Recalculating..." badge
+ * and to subscribe to ``GET /v1/sync/pipelines/{id}/stream`` for
+ * live updates until the chain finishes and stats refresh.
  */
 interface CarbonReportModuleResponse {
   id: number;
   inventory_id: number;
   module_type_id: number;
   status: number;
+  current_pipeline_id: string | null;
 }
 
 export const useTimelineStore = defineStore('timeline', () => {
@@ -132,6 +140,14 @@ export const useTimelineStore = defineStore('timeline', () => {
     [MODULES.Waste]: MODULE_STATES.Default,
     [MODULES.EmbodiedEnergy]: MODULE_STATES.Default,
   });
+
+  // Plan 310-D — per-module ``current_pipeline_id`` for the
+  // stale-stats badge.  Populated by ``fetchModuleStates`` from the
+  // carbon-report response.  ``null`` for modules without an active
+  // bulk pipeline (the steady state).
+  const currentPipelineIds = reactive<Partial<Record<Module, string | null>>>(
+    {},
+  );
 
   const loading = ref(false);
   const error = ref<string | null>(null);
@@ -163,11 +179,15 @@ export const useTimelineStore = defineStore('timeline', () => {
         .get(`carbon-reports/${carbonReportId}/modules/`)
         .json()) as CarbonReportModuleResponse[];
 
-      // Update itemStates from API response
+      // Update itemStates and currentPipelineIds from API response.
+      // Plan 310-D: ``current_pipeline_id`` powers the stale-stats
+      // badge.  ``null`` clears any previous badge state for the
+      // module — important when switching reports / years.
       for (const mod of response) {
         const moduleKey = getModuleFromTypeId(mod.module_type_id);
         if (moduleKey) {
           itemStates[moduleKey] = mod.status as ModuleState;
+          currentPipelineIds[moduleKey] = mod.current_pipeline_id ?? null;
         }
       }
     } catch (err: unknown) {
@@ -232,6 +252,20 @@ export const useTimelineStore = defineStore('timeline', () => {
     for (const key of Object.keys(itemStates) as Module[]) {
       itemStates[key] = MODULE_STATES.Default;
     }
+    // Plan 310-D: also clear pipeline badges so stale ids from a
+    // previous report don't bleed across the reset boundary.
+    for (const key of Object.keys(currentPipelineIds) as Module[]) {
+      currentPipelineIds[key] = null;
+    }
+  }
+
+  /**
+   * Plan 310-D — read the active pipeline id for a module, if any.
+   * Returns ``null`` when the module has no in-flight bulk pipeline
+   * (the steady state once every chain has finished).
+   */
+  function getCurrentPipelineId(moduleKey: Module): string | null {
+    return currentPipelineIds[moduleKey] ?? null;
   }
 
   return {
@@ -244,6 +278,8 @@ export const useTimelineStore = defineStore('timeline', () => {
     reset,
     currentState: currentCarbonReportModuleState,
     canEdit: currentCarbonReportModuleEdit,
+    currentPipelineIds,
+    getCurrentPipelineId,
   };
 });
 

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -1,0 +1,225 @@
+/**
+ * Plan 310-D — pipeline-scoped SSE stream store.
+ *
+ * Keyed by ``pipeline_id`` so multiple module cards subscribed to the
+ * same pipeline share one EventSource + one reactive entry.  The store
+ * itself owns no I/O; ``usePipelineStream`` opens the EventSource and
+ * pushes parsed events here via ``applyUpdate``.
+ *
+ * What's tracked per pipeline:
+ *
+ * - ``jobs``: the job snapshot from the most recent
+ *   ``event: pipeline-update`` payload.  Empty list before the first
+ *   event lands.
+ * - ``isFinished``: derived — true when every job's state is
+ *   ``FINISHED`` (or when ``stream_closed: true`` arrived).
+ * - ``hasError``: derived — true when any FINISHED job has
+ *   ``result === 'ERROR'``.  Drives the "Last recalc failed" badge
+ *   variant in the UI.
+ * - ``failedStatusMessages``: the ``status_message`` of every
+ *   FINISHED+ERROR job, for the retry-button tooltip.
+ * - ``subscriberCount``: refcount so ``usePipelineStream`` can decide
+ *   when to actually close the EventSource (last unmount only).
+ */
+
+import { defineStore } from 'pinia';
+import { computed, reactive, type ComputedRef } from 'vue';
+
+/**
+ * One job inside a pipeline-update payload.  Mirrors the backend's
+ * ``PipelineJobResponse`` (Plan 310-C / PR #1052 stream endpoint).
+ */
+export interface PipelineJob {
+  id: number;
+  job_type: string | null;
+  state: string | null;
+  result: string | null;
+  status_message: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+/**
+ * The wire payload of an ``event: pipeline-update`` SSE message.
+ * Backend SSE endpoint: ``GET /v1/sync/pipelines/{pipeline_id}/stream``.
+ */
+export interface PipelineUpdate {
+  pipeline_id: string;
+  jobs: PipelineJob[];
+  /** Terminal marker — backend sets it on the very last event. */
+  stream_closed?: boolean;
+}
+
+/**
+ * One-shot read response from
+ * ``GET /v1/sync/pipelines/{pipeline_id}`` (Plan 310-C / PR #1023).
+ * Used by ``usePipelineStream`` to seed initial state before the
+ * stream takes over (mitigates the "pipeline finished between
+ * carbon-report load and our subscribe" race).
+ */
+export interface PipelineSnapshot {
+  pipeline_id: string;
+  jobs: PipelineJob[];
+}
+
+interface PipelineEntry {
+  jobs: PipelineJob[];
+  /** ``true`` once a ``stream_closed: true`` payload has arrived. */
+  closed: boolean;
+  /** Refcount of mounted subscribers (composables). */
+  subscriberCount: number;
+}
+
+const FINISHED = 'FINISHED';
+const ERROR = 'ERROR';
+
+export const usePipelineStreamStore = defineStore('pipelineStream', () => {
+  /**
+   * Per-``pipeline_id`` state.  Reactive so any subscriber can `computed()`
+   * derived flags off the entry.
+   */
+  const entries = reactive<Record<string, PipelineEntry>>({});
+
+  /**
+   * Apply a parsed ``pipeline-update`` payload to the store.  Creates
+   * the entry on first event for an unknown pipeline_id.
+   */
+  function applyUpdate(payload: PipelineUpdate): void {
+    const entry = entries[payload.pipeline_id] ?? {
+      jobs: [],
+      closed: false,
+      subscriberCount: 0,
+    };
+    entry.jobs = payload.jobs;
+    if (payload.stream_closed) {
+      entry.closed = true;
+    }
+    entries[payload.pipeline_id] = entry;
+  }
+
+  /**
+   * Seed initial state from the one-shot read endpoint.  Idempotent —
+   * if a stream event has already populated this entry, the seed is
+   * applied as a normal update (last-write-wins on jobs).
+   */
+  function seedFromSnapshot(snapshot: PipelineSnapshot): void {
+    applyUpdate({
+      pipeline_id: snapshot.pipeline_id,
+      jobs: snapshot.jobs,
+    });
+  }
+
+  /**
+   * Increment the refcount and return the current count.  Composables
+   * call this on mount so the store can refcount across multiple
+   * cards sharing the same pipeline_id.
+   */
+  function acquire(pipelineId: string): number {
+    const entry = entries[pipelineId] ?? {
+      jobs: [],
+      closed: false,
+      subscriberCount: 0,
+    };
+    entry.subscriberCount += 1;
+    entries[pipelineId] = entry;
+    return entry.subscriberCount;
+  }
+
+  /**
+   * Decrement the refcount and return the new count.  When the count
+   * hits 0, the composable can safely close the EventSource.
+   * Negative results are clamped to 0 to defend against
+   * unmount-without-mount sequencing edge cases.
+   */
+  function release(pipelineId: string): number {
+    const entry = entries[pipelineId];
+    if (!entry) {
+      return 0;
+    }
+    entry.subscriberCount = Math.max(0, entry.subscriberCount - 1);
+    return entry.subscriberCount;
+  }
+
+  /**
+   * Drop an entry entirely.  Use sparingly — only when the consumer
+   * is sure no other subscriber will need it (e.g. after the badge
+   * cleared and the carbon-report response was refetched).
+   */
+  function clear(pipelineId: string): void {
+    delete entries[pipelineId];
+  }
+
+  function jobsFor(pipelineId: string): PipelineJob[] {
+    return entries[pipelineId]?.jobs ?? [];
+  }
+
+  /**
+   * Reactive ``isFinished`` — true when every job in the snapshot is
+   * FINISHED, OR when the stream's terminal ``stream_closed: true``
+   * marker arrived.  Empty pipelines (no jobs yet) are NOT finished.
+   */
+  function isFinishedFor(pipelineId: string): ComputedRef<boolean> {
+    return computed(() => {
+      const entry = entries[pipelineId];
+      if (!entry) {
+        return false;
+      }
+      if (entry.closed) {
+        return true;
+      }
+      if (entry.jobs.length === 0) {
+        return false;
+      }
+      return entry.jobs.every((j) => j.state === FINISHED);
+    });
+  }
+
+  /**
+   * Reactive ``hasError`` — true when any FINISHED job has
+   * ``result === 'ERROR'``.  The retry-button affordance is gated on
+   * this flag (FINISHED+ERROR aggregation = chain stopped without
+   * producing fresh stats; operator needs visible recovery).
+   */
+  function hasErrorFor(pipelineId: string): ComputedRef<boolean> {
+    return computed(() => {
+      const entry = entries[pipelineId];
+      if (!entry) {
+        return false;
+      }
+      return entry.jobs.some(
+        (j) => j.state === FINISHED && j.result === ERROR,
+      );
+    });
+  }
+
+  /**
+   * The ``status_message`` of every FINISHED+ERROR job in the
+   * pipeline — feeds the failure-state tooltip.  Empty list when no
+   * errors (the happy path).
+   */
+  function failedStatusMessagesFor(pipelineId: string): ComputedRef<string[]> {
+    return computed(() => {
+      const entry = entries[pipelineId];
+      if (!entry) {
+        return [];
+      }
+      return entry.jobs
+        .filter((j) => j.state === FINISHED && j.result === ERROR)
+        .map((j) => j.status_message ?? '')
+        .filter((msg) => msg.length > 0);
+    });
+  }
+
+  return {
+    entries,
+    applyUpdate,
+    seedFromSnapshot,
+    acquire,
+    release,
+    clear,
+    jobsFor,
+    isFinishedFor,
+    hasErrorFor,
+    failedStatusMessagesFor,
+  };
+});

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -83,6 +83,14 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
   /**
    * Apply a parsed ``pipeline-update`` payload to the store.  Creates
    * the entry on first event for an unknown pipeline_id.
+   *
+   * NB: ``entry.jobs = payload.jobs`` REPLACES the array reference
+   * rather than mutating in place.  Vue 3's reactivity handles this
+   * fine via Proxy on ``entries`` — but a future refactor that
+   * destructures ``const jobs = entries[id].jobs`` once and reads
+   * from the cached ref would silently lose updates.  Always re-read
+   * from the store on each access (or use the ``jobsFor(id)``
+   * accessor below) to avoid that footgun.
    */
   function applyUpdate(payload: PipelineUpdate): void {
     const entry = entries[payload.pipeline_id] ?? {

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -186,9 +186,7 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
       if (!entry) {
         return false;
       }
-      return entry.jobs.some(
-        (j) => j.state === FINISHED && j.result === ERROR,
-      );
+      return entry.jobs.some((j) => j.state === FINISHED && j.result === ERROR);
     });
   }
 

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -96,6 +96,16 @@ export interface ModuleRecalculationStatusEntry {
   year: number;
   needs_recalculation: boolean;
   data_entry_types: RecalculationStatusEntry[];
+  /**
+   * Plan 310-D — pipeline_id of the most recent active
+   * (NOT_STARTED/QUEUED/RUNNING) bulk pipeline whose any-job touches
+   * this module's (module_type_id, year). ``null`` when no active
+   * pipeline matches. Back-office uses this to render a
+   * "Recalculating..." badge and subscribe to
+   * ``GET /v1/sync/pipelines/{id}/stream`` for live updates while
+   * the chain is in flight.
+   */
+  current_pipeline_id?: string | null;
 }
 
 interface YearConfig {


### PR DESCRIPTION
## Summary

Plan 310-D **frontend foundation** — backend half landed via PR #1052 (SSE endpoint) + PR #1053 (`current_pipeline_id` field on the carbon-report module response). This PR ships the consuming layer:

| File | Role |
|------|------|
| `frontend/src/stores/modules.ts` | extends `CarbonReportModuleResponse` with `current_pipeline_id: string \| null`; tracks per-module pipeline ids in `useTimelineStore.currentPipelineIds` |
| `frontend/src/stores/pipelineStream.ts` | new Pinia store keyed by `pipeline_id`; refcounted entries with derived `isFinishedFor` / `hasErrorFor` / `failedStatusMessagesFor` |
| `frontend/src/composables/usePipelineStream.ts` | new composable wrapping the EventSource lifecycle; seeds initial state from one-shot `GET /v1/sync/pipelines/{id}`, listens for `pipeline-update` events, exponential-backoff reconnect on `onerror` capped at 30s, auto-unsubscribe on unmount |

Plan: [`docs/src/implementation-plans/310-d-frontend-stale-stats.md`](docs/src/implementation-plans/310-d-frontend-stale-stats.md).

## Out of scope (deferred)

This is intentionally **foundation only** — two pieces are left for follow-ups:

1. **Component integration** — module cards rendering the badge, de-emphasizing stats, retry button. The right insertion point is codebase-specific (which page renders the per-module stats? back-office vs results page?) and best decided with a UX pass. The composable's API is wired up so a follow-up PR can drop it into a card with ~10 lines of glue.

2. **Tests** — the project uses Playwright Component Testing for components; pure-logic stores + composables don't fit cleanly into that framework, and adding a Vitest dependency is a project-wide decision worth a separate discussion. The composable ships with explicit test seams (`__setEventSourceImpl` / `__setSnapshotFetcher` / `__resetPipelineStreams`) so a future Vitest setup can hook in cleanly.

## Verification

- `make lint FILES=\"...\"` — clean
- `make type-check-go` — clean (the project has 47 pre-existing tsc errors; 0 in the new files)
- `make format FILES=\"...\"` — no formatting changes needed
- Backend dependencies confirmed shipped: `current_pipeline_id` is on the `/v1/carbon-reports/{id}/modules/` response after PR #1053; `/v1/sync/pipelines/{id}/stream` is live after PR #1052.

## Why this split

Per the plan doc's "Recovery contract pin-down" section: the failure-state UX (retry button on FINISHED+ERROR pipelines) lives in the frontend because it consumes the existing job-state metric layer (`status_message` from the backend) — not as defensive backend code. Surfacing the foundation here lets the next iteration pick the right rendering site without committing to a specific module-card layout up front.

## Caveats for review

- The store uses `Map<string, ActiveStream>` at module scope (not in Pinia) for the EventSource registry. EventSource isn't reactive; keeping it out of Pinia avoids serialization weirdness with the SSR / SSR-hydration story Quasar inherits from Vite.
- `__setEventSourceImpl` etc. are namespaced with `__` to signal "test-only" — they don't appear in the documented public API.
- Backend's `pipeline-update` event name is the one Pyright would have caught if the frontend was typed against the OpenAPI spec; verified manually against `backend/app/api/v1/data_sync.py:817`.