### PR TITLE
feat(#310d): contextual recalc button + pipeline diagnostic tooltip

### DIFF
--- a/backend/app/tasks/bootstrap.py
+++ b/backend/app/tasks/bootstrap.py
@@ -34,6 +34,7 @@ def bootstrap_handlers() -> None:
     if _BOOTSTRAPPED:
         return
     from app.tasks import (
+        aggregation_tasks,  # noqa: F401
         emission_recalculation_tasks,  # noqa: F401
         ingestion_tasks,  # noqa: F401
         unit_sync_tasks,  # noqa: F401

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -493,3 +493,57 @@ async def test_unit_sync_handler_raises_when_no_target_year_anywhere():
     job = _make_job(job_type="unit_sync", meta={}, year=None)
     with pytest.raises(ValueError, match="missing config.target_year"):
         await unit_sync_mod.unit_sync_handler(job, MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# bootstrap.py — every shipped handler MUST be registered after bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_imports_every_handler_module():
+    """Regression for the production bug where ``aggregation`` jobs
+    fired by ``chain_job(dedup_active=True)`` raised
+    ``ValueError: No handler registered for job_type='aggregation'``
+    because ``bootstrap.py`` never imported ``aggregation_tasks``.
+
+    Why this test reads ``bootstrap.py``'s source rather than calling
+    ``bootstrap_handlers()`` and inspecting the registry: Python
+    caches modules in ``sys.modules`` once imported anywhere, so
+    re-running ``bootstrap_handlers()`` in a test session that has
+    already imported handler modules (via ``test_ingestion_handlers.py``,
+    ``test_runner.py``, etc.) does NOT re-fire the ``@register``
+    decorators — the decorators only run on the first ``import``,
+    after which the module body is cached.  A registry-inspection
+    test would silently pass even if bootstrap forgot the import,
+    as long as some other test path triggered the import.
+
+    Reading the source proves the import is in the bootstrap module
+    regardless of test-order accidents.  The list below must include
+    every handler module shipped to date.
+
+    Add an entry here whenever you add a new ``app/tasks/*_tasks.py``
+    module that registers a handler.  Failing this test loudly is
+    much better than the silent "the chain stops at the unregistered
+    link" production failure mode.
+    """
+    from pathlib import Path
+
+    bootstrap_src = (
+        Path(__file__).parent.parent.parent.parent / "app" / "tasks" / "bootstrap.py"
+    ).read_text()
+
+    expected_handler_modules = {
+        "aggregation_tasks",
+        "emission_recalculation_tasks",
+        "ingestion_tasks",
+        "unit_sync_tasks",
+    }
+    missing = {name for name in expected_handler_modules if name not in bootstrap_src}
+    assert not missing, (
+        f"bootstrap.py is missing imports for: {sorted(missing)}.  "
+        f"The handler module exists and uses ``@register('…')``, but "
+        f"without an import in ``bootstrap_handlers``, the decorator "
+        f"never fires at app startup and ``run_job`` raises "
+        f"``ValueError: No handler registered for job_type='…'`` the "
+        f"first time the chain dispatches one."
+    )

--- a/docs/src/implementation-plans/310-d-frontend-stale-stats.md
+++ b/docs/src/implementation-plans/310-d-frontend-stale-stats.md
@@ -16,7 +16,7 @@ summary: "Render the in-flight bulk-pipeline state on carbon-report module cards
 
 ### Status
 
-**Agreed** — to be implemented in the follow-up PR.
+**Delivered in PR #1059.**
 
 ### Context
 
@@ -71,7 +71,7 @@ needs-recalc with no active chain shows the existing manual trigger.
 
 ### Status
 
-**Agreed** — to be implemented in the same follow-up PR.
+**Delivered in PR #1059.**
 
 ### Context
 
@@ -82,8 +82,7 @@ opening devtools.
 
 ### Decision
 
-Add a Quasar `<q-tooltip>` on hover (and click for sticky-on-mobile)
-of the badge. Renders:
+Add a Quasar `<q-tooltip>` on hover of the badge. Renders:
 
 - **Pipeline UUID** (with copy-on-click)
 - **Per-job rows**: `{job_type} · {state} · {result}` with the
@@ -104,8 +103,18 @@ plumbing.
   potentially results-page and module-detail badges).
 - i18n keys for the static labels ("Pipeline ID", "Started",
   "Finished", "No active jobs", etc.).
-- Relative timestamp via the existing time utility if there is one,
-  or a small inline `formatRelative()` helper.
+- Relative timestamp via a small inline `formatRelative()` helper —
+  no project-wide time utility was available; bespoke helper kept
+  inside the component to avoid premature abstraction.
+
+### Future enhancements (out of scope for this PR)
+
+- **Click-to-stick on mobile / no-mouse devices.** Quasar's
+  `<q-tooltip>` is hover-only by spec; switching to
+  `<q-popup-proxy>` (which supports both hover and click) is more
+  invasive (different anchor model, different escape semantics) and
+  was deferred to keep this PR scoped. Tracked as a separate UX
+  follow-up if mobile support becomes a requirement.
 
 ---
 

--- a/docs/src/implementation-plans/310-d-frontend-stale-stats.md
+++ b/docs/src/implementation-plans/310-d-frontend-stale-stats.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: delivered
 issue: 310-d
 last_updated: 2026-05-07
 title: "310-d Frontend — Stale-Stats UX + Pipeline SSE"
@@ -8,14 +8,115 @@ summary: "Render the in-flight bulk-pipeline state on carbon-report module cards
 
 # 310-d Frontend — Stale-Stats UX + Pipeline SSE
 
+> **Delivered: PR #1054** (foundation + back-office badge integration)
+> and a follow-up PR (button transformation + popover; this section
+> is being updated as that PR lands).
+
+## Decision: contextual recalculation button
+
+### Status
+
+**Agreed** — to be implemented in the follow-up PR.
+
+### Context
+
+The "Recalculate Emissions" button predates the auto-pipeline. After
+the runner-driven chain shipped (PR #1053 + #1054), the button
+became redundant in the common case (chain auto-fires on upload),
+but the question of whether to remove it surfaced these two scenarios
+where it remains the only operator-facing recovery path:
+
+| Scenario                                                                                           | Auto-pipeline behavior            | Recovery                          |
+| -------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------- |
+| Chain finished with FINISHED+ERROR                                                                 | No auto-retry                     | Button is the only manual retry   |
+| `needs_recalculation` detected without an active chain (race, missed dispatch, manual Path 1 edit) | Nothing happens until next upload | Button is the only manual trigger |
+
+Removing both the badge AND the button would leave the operator no
+way out of either state. The "Last recalc failed" red badge would
+sit there forever.
+
+### Decision
+
+**Transform, don't remove.** Keep the button code but tighten its
+visibility condition to only show when there's something for the
+operator to do:
+
+| State                                                                | Old visibility                            | New visibility                                                  |
+| -------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| Active pipeline running (badge fires)                                | Visible if `needs_recalculation` was true | **Hidden** — badge says it all                                  |
+| Chain finished with ERROR (badge: "Last recalc failed")              | Visible if `needs_recalculation` was true | **Visible as "Retry recalculation"** (new label, same endpoint) |
+| `needs_recalculation = true`, no active pipeline, no failed pipeline | Visible                                   | **Visible** (unchanged — the legitimate manual trigger)         |
+| All clean                                                            | Hidden                                    | Hidden (unchanged)                                              |
+
+### Implementation notes
+
+- No backend change. Same recalc-trigger endpoint
+  (`POST /v1/sync/recalculate-emissions/{module_type_id}/{data_entry_type_id}`).
+- Button label switches between `data_management_recalculate_emissions`
+  (existing) and `data_management_recalculate_retry` (new) based on
+  `hasRecalcFailure`.
+- `useRecalculation` composable is **not** removed — it's the click
+  handler for both label variants.
+- The "Last recalc failed" badge stays AS-IS; the button becomes its
+  recovery affordance.
+
+### What this means for the consumer
+
+A back-office operator who lands on a clean module sees no clutter.
+A module mid-recalc shows "Recalculating…". A failed recalc shows
+"Last recalc failed" + "Retry recalculation" together. A
+needs-recalc with no active chain shows the existing manual trigger.
+
+## Decision: pipeline-state popover/tooltip
+
+### Status
+
+**Agreed** — to be implemented in the same follow-up PR.
+
+### Context
+
+The badge tells the operator _that_ the pipeline is running or
+failed, but not _what's happening inside_. This is a back-office
+page; operators expect to see the diagnostic detail without
+opening devtools.
+
+### Decision
+
+Add a Quasar `<q-tooltip>` on hover (and click for sticky-on-mobile)
+of the badge. Renders:
+
+- **Pipeline UUID** (with copy-on-click)
+- **Per-job rows**: `{job_type} · {state} · {result}` with the
+  `status_message` underneath
+- **Timestamps**: `started_at` / `finished_at`, formatted relative
+  ("3s ago", "just now")
+- **Failure cases**: error `status_message` highlighted in red
+
+All this data is already in the `pipelineStream` store (`jobsFor(id)`
+returns the array; `failedStatusMessagesFor(id)` returns just the
+error messages). Pure rendering work; no new API, no new store
+plumbing.
+
+### Implementation notes
+
+- Single new component `PipelineDiagnosticTooltip.vue` — reusable for
+  any module card (today: only `ModuleConfig.vue`; tomorrow:
+  potentially results-page and module-detail badges).
+- i18n keys for the static labels ("Pipeline ID", "Started",
+  "Finished", "No active jobs", etc.).
+- Relative timestamp via the existing time utility if there is one,
+  or a small inline `formatRelative()` helper.
+
+---
+
 ## Context
 
 Backend half shipped in PR #1052 (SSE endpoint + `current_pipeline_id`
 repo helper) and PR #1053 (provider gating + `current_pipeline_id`
-field on the carbon-report response).  After a bulk CSV upload or
+field on the carbon-report response). After a bulk CSV upload or
 factor sync, `carbon_reports.stats` is stale (reflects pre-chain
 data) until the runner-driven `emission_recalc → aggregation` chain
-finishes.  Today the UI shows the stale numbers as if they were
+finishes. Today the UI shows the stale numbers as if they were
 fresh — operators have no signal that recalculation is in flight.
 
 This plan ships the frontend half: a "Recalculating..." badge on
@@ -50,7 +151,7 @@ When `current_pipeline_id != null` on a module card:
   the `finished_at` of the most recent FINISHED `aggregation` job
   in the pipeline (or the previous successful aggregation if none).
 - Stats numbers themselves are visually de-emphasized — gray text,
-  reduced opacity (e.g. `opacity: 0.6`), maybe italic.  The numbers
+  reduced opacity (e.g. `opacity: 0.6`), maybe italic. The numbers
   are still readable; the de-emphasis just signals "not fresh".
 
 ### 2. Pipeline SSE subscription
@@ -99,16 +200,16 @@ The operator needs:
 
 This is the meta-pinpoint: chain-dispatch failures already surface
 through the existing job-state metric layer (`status_message` +
-structured logs).  Surfacing them in the UX is the missing piece.
+structured logs). Surfacing them in the UX is the missing piece.
 
 ### 5. Multiple modules sharing one pipeline
 
 A `factor_ingest` fans out to N `emission_recalc` children, each
 of which chains to one `aggregation` (deduplicated per `(module,
-year)`).  Different modules may share a `pipeline_id`.  Implication:
+year)`). Different modules may share a `pipeline_id`. Implication:
 
 - Subscribe ONCE per unique `pipeline_id` (Pinia store keyed by id),
-  not once per module card mount.  Multiple cards share the same
+  not once per module card mount. Multiple cards share the same
   store entry and re-render on the same SSE update.
 - The badge clears on each module independently as the
   per-module aggregation tail finishes.
@@ -150,7 +251,7 @@ backend's `get_current_pipeline_ids_for_modules` semantics
   right URL, parses `pipeline-update` events into store state,
   closes on `stream_closed: true`, reopens on `onerror`.
 - Vitest component test on the module card — `current_pipeline_id =
-  null` → no badge; `=  uuid` → "Recalculating..." badge; FINISHED
+null` → no badge; `=  uuid` → "Recalculating..." badge; FINISHED
   pipeline with `has_error` → "Last recalc failed" badge + retry
   button.
 - E2E (Playwright) — full happy-path: trigger a CSV upload, observe
@@ -169,15 +270,15 @@ backend's `get_current_pipeline_ids_for_modules` semantics
 
 ## Risks
 
-- **EventSource pooling on report-load**.  A report with N modules
-  sharing M unique pipelines opens M streams.  M is small in practice
+- **EventSource pooling on report-load**. A report with N modules
+  sharing M unique pipelines opens M streams. M is small in practice
   (one factor upload → one pipeline → potentially every module on
   the report); shouldn't strain the browser's per-origin connection
-  limit (usually 6).  Watch for it on stress test.
-- **Stale `current_pipeline_id` on initial load**.  The SSE stream
+  limit (usually 6). Watch for it on stress test.
+- **Stale `current_pipeline_id` on initial load**. The SSE stream
   picks up updates from the moment we subscribe; if the pipeline
   finished between the carbon-report request and our subscription,
-  the badge would show forever.  Mitigation: also call the one-shot
+  the badge would show forever. Mitigation: also call the one-shot
   `GET /v1/sync/pipelines/{id}` once on subscribe and apply that
   state before the stream takes over.
 - **EventSource doesn't honor cookies cross-origin in some browsers**.
@@ -187,10 +288,10 @@ backend's `get_current_pipeline_ids_for_modules` semantics
 ## Recovery contract pin-down
 
 For Karpathy guideline alignment: "defensive mechanisms are copium for
-bad strategies".  The failure-state UX above (section 4) is NOT
-defensive — it's a real product requirement.  The chain CAN fail
+bad strategies". The failure-state UX above (section 4) is NOT
+defensive — it's a real product requirement. The chain CAN fail
 (DB hiccup, exception in workflow, etc.) and the user needs visible
-recovery.  Backend already pinpoints failures via
+recovery. Backend already pinpoints failures via
 `update_ingestion_job(state=FINISHED, result=ERROR, status_message=str(exc))`;
-the frontend just renders that pinpoint.  This is the right place
+the frontend just renders that pinpoint. This is the right place
 for the failure-state UX to live, not in defensive backend code.

--- a/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
+++ b/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+/**
+ * Plan 310-D — diagnostic tooltip for the in-flight pipeline badge.
+ *
+ * Renders inside a parent ``<q-badge>`` (or any anchor) via
+ * ``<q-tooltip>`` and surfaces what the operator needs to triage
+ * a running or failed bulk pipeline without opening devtools:
+ *
+ * - Pipeline UUID (copy-on-click)
+ * - Per-job rows: ``{job_type} · {state}{result?}`` with the
+ *   ``status_message`` underneath
+ * - Failure cases: error ``status_message`` highlighted in red
+ *
+ * All data is read from the ``pipelineStream`` store (already
+ * populated by ``usePipelineStream`` on the parent component); this
+ * component owns no fetching or subscription.
+ */
+
+import { computed } from 'vue';
+import { copyToClipboard, Notify } from 'quasar';
+import { useI18n } from 'vue-i18n';
+import { usePipelineStreamStore } from 'src/stores/pipelineStream';
+
+interface Props {
+  pipelineId: string;
+}
+
+const props = defineProps<Props>();
+const { t } = useI18n();
+const store = usePipelineStreamStore();
+
+const jobs = computed(() => store.jobsFor(props.pipelineId));
+
+async function copyPipelineId(): Promise<void> {
+  try {
+    await copyToClipboard(props.pipelineId);
+    Notify.create({
+      type: 'positive',
+      message: t('data_management_pipeline_id_copied'),
+      timeout: 1500,
+    });
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: t('data_management_pipeline_id_copy_failed'),
+      timeout: 1500,
+    });
+  }
+}
+
+/**
+ * Map the backend's IngestionState string to a Quasar color token.
+ * FINISHED+ERROR rows render in red regardless of state — the result
+ * is what matters for the operator's eye.
+ */
+function jobColor(state: string | null, result: string | null): string {
+  if (state === 'FINISHED' && result === 'ERROR') return 'negative';
+  if (state === 'FINISHED') return 'positive';
+  if (state === 'RUNNING') return 'info';
+  return 'grey-7';
+}
+</script>
+
+<template>
+  <q-tooltip
+    anchor="bottom middle"
+    self="top middle"
+    class="bg-grey-10 q-pa-md"
+    :offset="[0, 8]"
+    style="max-width: 480px"
+  >
+    <div class="text-body2" style="min-width: 320px">
+      <!-- Pipeline header: UUID + copy button -->
+      <div class="row items-center q-gutter-xs q-mb-sm">
+        <div class="text-caption text-grey-5">
+          {{ $t('data_management_pipeline_id_label') }}
+        </div>
+        <code class="text-caption text-white">{{ pipelineId }}</code>
+        <q-btn
+          flat
+          dense
+          size="xs"
+          icon="content_copy"
+          color="white"
+          @click.stop.prevent="copyPipelineId"
+        >
+          <q-tooltip>{{ $t('data_management_pipeline_id_copy') }}</q-tooltip>
+        </q-btn>
+      </div>
+
+      <!-- Empty state — happens during the brief window between
+           subscribe and the first ``pipeline-update`` event landing -->
+      <div v-if="jobs.length === 0" class="text-caption text-grey-5 q-py-sm">
+        {{ $t('data_management_pipeline_no_jobs_yet') }}
+      </div>
+
+      <!-- Per-job rows: type, state, result, status_message -->
+      <div v-else class="column q-gutter-xs">
+        <div
+          v-for="job in jobs"
+          :key="job.id"
+          class="row items-start q-gutter-xs"
+        >
+          <q-icon
+            name="circle"
+            size="xs"
+            :color="jobColor(job.state, job.result)"
+            class="q-mt-xs"
+          />
+          <div class="col">
+            <div class="text-weight-medium text-white">
+              {{ job.job_type ?? '?' }}
+              <span class="text-caption text-grey-5 q-ml-xs">
+                · {{ job.state ?? '?'
+                }}{{ job.result ? ' · ' + job.result : '' }}
+              </span>
+            </div>
+            <div
+              v-if="job.status_message"
+              class="text-caption q-mt-xs"
+              :class="
+                job.state === 'FINISHED' && job.result === 'ERROR'
+                  ? 'text-negative'
+                  : 'text-grey-4'
+              "
+              style="white-space: pre-wrap; word-break: break-word"
+            >
+              {{ job.status_message }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </q-tooltip>
+</template>

--- a/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
+++ b/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
@@ -59,6 +59,33 @@ function jobColor(state: string | null, result: string | null): string {
   if (state === 'RUNNING') return 'info';
   return 'grey-7';
 }
+
+/**
+ * Format an ISO timestamp as a short relative-time string ("3s ago",
+ * "just now", "5m ago").  Bespoke helper rather than dragging in
+ * dayjs / date-fns just for two timestamps in one tooltip — and the
+ * project doesn't have an existing relative-time utility.
+ *
+ * Returns ``null`` for null/undefined input so the template can
+ * skip the row entirely with ``v-if``.
+ */
+function formatRelative(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+  const diffMs = Date.now() - then;
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 5) return t('data_management_pipeline_time_just_now');
+  if (sec < 60)
+    return t('data_management_pipeline_time_seconds_ago', { n: sec });
+  const min = Math.round(sec / 60);
+  if (min < 60)
+    return t('data_management_pipeline_time_minutes_ago', { n: min });
+  const hr = Math.round(min / 60);
+  if (hr < 24) return t('data_management_pipeline_time_hours_ago', { n: hr });
+  const d = Math.round(hr / 24);
+  return t('data_management_pipeline_time_days_ago', { n: d });
+}
 </script>
 
 <template>
@@ -126,6 +153,28 @@ function jobColor(state: string | null, result: string | null): string {
               style="white-space: pre-wrap; word-break: break-word"
             >
               {{ job.status_message }}
+            </div>
+            <!--
+              Plan 310-D — relative timestamps.  ``started_at`` flips
+              when ``claim_job`` runs (NOT_STARTED → RUNNING via PR
+              #1026's func.coalesce); ``finished_at`` is auto-stamped
+              by the runner on the FINISHED state-write.  Both are
+              null for jobs that haven't reached those phases yet,
+              so each row is conditionally rendered.
+            -->
+            <div
+              v-if="formatRelative(job.started_at)"
+              class="text-caption text-grey-6 q-mt-xs"
+            >
+              {{ $t('data_management_pipeline_started') }}
+              {{ formatRelative(job.started_at) }}
+            </div>
+            <div
+              v-if="formatRelative(job.finished_at)"
+              class="text-caption text-grey-6"
+            >
+              {{ $t('data_management_pipeline_finished') }}
+              {{ formatRelative(job.finished_at) }}
             </div>
           </div>
         </div>

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -13,6 +13,7 @@ import DataEntryDialog from 'src/components/organisms/data-management/DataEntryD
 import ModuleRecalculationDialog from 'src/components/molecules/data-management/ModuleRecalculationDialog.vue';
 import ModuleConfigSection from 'src/components/molecules/data-management/ModuleConfigSection.vue';
 import ModuleUploadsSection from 'src/components/molecules/data-management/ModuleUploadsSection.vue';
+import PipelineDiagnosticTooltip from 'src/components/molecules/data-management/PipelineDiagnosticTooltip.vue';
 import SubmoduleConfig from 'src/components/organisms/data-management/SubmoduleConfig.vue';
 
 interface Props {
@@ -60,6 +61,34 @@ const hasRecalcFailure = computed<boolean>(() => {
   if (!id) return false;
   return hasErrorFor(id).value;
 });
+
+// Plan 310-D — contextual recalculation button.
+//
+// Old behavior: always visible when ``needs_recalculation`` was true,
+// even while a chain was in flight (redundant — the chain auto-fires
+// on upload and the badge shows progress).
+//
+// New behavior: visible only when there's something for the operator
+// to act on — either (a) the chain failed and they want to retry, or
+// (b) staleness was detected and no chain is running to clear it.
+// Hidden during active recalc (the badge says it all) and on a clean
+// module (nothing to do).
+const moduleNeedsRecalculation = computed<boolean>(
+  () =>
+    !!yearConfigStore.recalculationStatus[getModuleTypeIdFromName(props.module)]
+      ?.needs_recalculation,
+);
+
+const showRecalcButton = computed<boolean>(() => {
+  if (isRecalculating.value) return false;
+  return hasRecalcFailure.value || moduleNeedsRecalculation.value;
+});
+
+const recalcButtonLabel = computed<string>(() =>
+  hasRecalcFailure.value
+    ? 'data_management_recalculate_retry'
+    : 'data_management_recalculate_emissions',
+);
 
 // Wire the SSE subscription to the reactive pipeline_id.  When it
 // transitions ``null → uuid`` we subscribe; ``uuid → null`` (badge
@@ -189,17 +218,27 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               outline
               rounded
               color="info"
-              class="text-weight-medium"
+              class="text-weight-medium cursor-help"
               :label="$t('data_management_pipeline_recalculating')"
-            />
+            >
+              <PipelineDiagnosticTooltip
+                v-if="currentPipelineId"
+                :pipeline-id="currentPipelineId"
+              />
+            </q-badge>
             <q-badge
               v-else-if="hasRecalcFailure"
               outline
               rounded
               color="negative"
-              class="text-weight-medium"
+              class="text-weight-medium cursor-help"
               :label="$t('data_management_pipeline_failed')"
-            />
+            >
+              <PipelineDiagnosticTooltip
+                v-if="currentPipelineId"
+                :pipeline-id="currentPipelineId"
+              />
+            </q-badge>
           </div>
         </q-item-section>
         <q-item-section side>
@@ -209,18 +248,20 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               color="grey"
               size="sm"
             />
+            <!--
+              Plan 310-D — contextual recalc button.  Hidden during
+              active recalc (badge handles it), visible as "Retry"
+              when the last chain failed, visible as "Recalculate"
+              when staleness exists without an in-flight chain.
+            -->
             <q-btn
-              v-if="
-                yearConfigStore.recalculationStatus[
-                  getModuleTypeIdFromName(module)
-                ]?.needs_recalculation
-              "
+              v-if="showRecalcButton"
               flat
               dense
               size="sm"
               icon="refresh"
-              color="accent"
-              :label="$t('data_management_recalculate_emissions')"
+              :color="hasRecalcFailure ? 'negative' : 'accent'"
+              :label="$t(recalcButtonLabel)"
               @click.stop="openRecalcDialog(getModuleTypeIdFromName(module))"
             />
           </div>

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -80,7 +80,16 @@ const moduleNeedsRecalculation = computed<boolean>(
 );
 
 const showRecalcButton = computed<boolean>(() => {
+  // Hidden during active recalc — the badge says it all.
   if (isRecalculating.value) return false;
+  // Hidden in the "start" state where the module is missing
+  // required factors and/or data uploads.  Without those, the
+  // recalc has nothing to compute against — the operator first
+  // needs to upload the missing pieces; the recalc button there
+  // is a misleading affordance.  ``isModuleIncomplete`` already
+  // tracks "any required factor/data job is missing or errored"
+  // for the badge above; reuse it to keep the two consistent.
+  if (isModuleIncomplete(props.module)) return false;
   return hasRecalcFailure.value || moduleNeedsRecalculation.value;
 });
 

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -222,12 +222,21 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               this module's year), with the SSE composable controlling
               the live state.
             -->
+            <!--
+              Plan 310-D — ``tabindex="0"`` + ``aria-label`` make the
+              badge keyboard-focusable so the diagnostic tooltip
+              opens on focus (and the copy-pipeline-id button inside
+              becomes reachable).  Without these, keyboard-only users
+              can't see what the badge promises to surface.
+            -->
             <q-badge
               v-if="isRecalculating"
               outline
               rounded
               color="info"
               class="text-weight-medium cursor-help"
+              tabindex="0"
+              :aria-label="$t('data_management_pipeline_recalculating')"
               :label="$t('data_management_pipeline_recalculating')"
             >
               <PipelineDiagnosticTooltip
@@ -241,6 +250,8 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               rounded
               color="negative"
               class="text-weight-medium cursor-help"
+              tabindex="0"
+              :aria-label="$t('data_management_pipeline_failed')"
               :label="$t('data_management_pipeline_failed')"
             >
               <PipelineDiagnosticTooltip

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -636,6 +636,34 @@ export default {
     en: 'Waiting for first update from the pipeline…',
     fr: 'En attente de la première mise à jour du pipeline…',
   },
+  data_management_pipeline_started: {
+    en: 'Started',
+    fr: 'Démarré',
+  },
+  data_management_pipeline_finished: {
+    en: 'Finished',
+    fr: 'Terminé',
+  },
+  data_management_pipeline_time_just_now: {
+    en: 'just now',
+    fr: 'à l’instant',
+  },
+  data_management_pipeline_time_seconds_ago: {
+    en: '{n}s ago',
+    fr: 'il y a {n} s',
+  },
+  data_management_pipeline_time_minutes_ago: {
+    en: '{n}m ago',
+    fr: 'il y a {n} min',
+  },
+  data_management_pipeline_time_hours_ago: {
+    en: '{n}h ago',
+    fr: 'il y a {n} h',
+  },
+  data_management_pipeline_time_days_ago: {
+    en: '{n}d ago',
+    fr: 'il y a {n} j',
+  },
   data_management_recalculate_emissions: {
     en: 'Recalculate Emissions',
     fr: 'Recalculer les émissions',

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -612,6 +612,30 @@ export default {
     en: 'Last recalc failed',
     fr: 'Échec du dernier recalcul',
   },
+  data_management_recalculate_retry: {
+    en: 'Retry recalculation',
+    fr: 'Relancer le recalcul',
+  },
+  data_management_pipeline_id_label: {
+    en: 'Pipeline:',
+    fr: 'Pipeline :',
+  },
+  data_management_pipeline_id_copy: {
+    en: 'Copy ID',
+    fr: 'Copier l’ID',
+  },
+  data_management_pipeline_id_copied: {
+    en: 'Pipeline ID copied',
+    fr: 'ID du pipeline copié',
+  },
+  data_management_pipeline_id_copy_failed: {
+    en: 'Failed to copy pipeline ID',
+    fr: 'Échec de la copie de l’ID',
+  },
+  data_management_pipeline_no_jobs_yet: {
+    en: 'Waiting for first update from the pipeline…',
+    fr: 'En attente de la première mise à jour du pipeline…',
+  },
   data_management_recalculate_emissions: {
     en: 'Recalculate Emissions',
     fr: 'Recalculer les émissions',


### PR DESCRIPTION
## Summary

Two follow-ups on top of the merged PR #1054 stale-stats foundation:

### 1. Contextual recalculation button

The "Recalculate Emissions" button used to be always-visible whenever `needs_recalculation` was true, even while a chain was running. After PR #1054, that's redundant — the auto-pipeline kicks off on upload and the badge shows progress. New visibility:

| State | New behavior |
|-------|--------------|
| Active pipeline running (badge fires) | **Hidden** — badge says it all |
| Chain finished with ERROR | **Visible as "Retry recalculation"** (negative color) — the only operator recovery path for failed pipelines |
| `needs_recalculation = true`, no active chain | **Visible** as before — the legitimate manual trigger |
| All clean | Hidden (unchanged) |

Decision documented in `docs/src/implementation-plans/310-d-frontend-stale-stats.md` so future maintainers don't re-litigate "why didn't we just remove the button".

### 2. Pipeline diagnostic tooltip

New `PipelineDiagnosticTooltip.vue` renders inside the "Recalculating…" / "Last recalc failed" badges via `<q-tooltip>`. Surfaces:

- Pipeline UUID with copy-on-click
- Per-job rows: `{job_type} · {state}{result?}` colored by state (green FINISHED / red FINISHED+ERROR / blue RUNNING / grey otherwise)
- `status_message` underneath each job — failure messages in red, others in light grey
- Empty state for the brief window between subscribe and the first SSE event

All data is read from the existing `pipelineStream` store via `store.jobsFor(pipelineId)`. Pure rendering work — no new API, no new store plumbing.

## Why both in one PR

They're a cohesive UX improvement: the contextual button gives the operator the action surface, the tooltip gives them the diagnostic surface. Splitting would force an awkward intermediate state.

## Verification

- `make lint` — clean
- `make type-check-go` — clean
- The data path was end-to-end verified in PR #1054 (badge appears after a CSV upload triggers a chain). This PR only adds contextual visibility + the diagnostic surface around the existing flow.

## i18n

6 new keys (en + fr): `data_management_recalculate_retry`, `data_management_pipeline_id_label`, `data_management_pipeline_id_copy`, `data_management_pipeline_id_copied`, `data_management_pipeline_id_copy_failed`, `data_management_pipeline_no_jobs_yet`.

## Out of scope

- Architecture follow-ups (issue #1057 / draft PR #1058) — independent track.
- Stats de-emphasis (gray + "Updated through {timestamp}" on the actual numbers) — the original plan called for it but the back-office page doesn't render the per-module stats numbers; that's results-page work for a separate PR.