### PR TITLE
feat947: use process-emissions i18n keys for gases

### DIFF
--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -28,10 +28,10 @@ const isPrintMode = usePrintMode();
 
 const LABEL_KEY_MAP: Record<string, string> = {
   // process_emissions
-  co2: 'charts-co2-subcategory',
-  ch4: 'charts-ch4-subcategory',
-  n2o: 'charts-n2o-subcategory',
-  refrigerants: 'charts-refrigerants-subcategory',
+  co2: 'process-emissions.category.co2',
+  ch4: 'process-emissions.category.ch4',
+  n2o: 'process-emissions.category.n2o',
+  refrigerants: 'process-emissions.category.refrigerant',
   // buildings
   heating_thermal: 'charts-heating-thermal-subcategory',
   lighting: 'charts-lighting-subcategory',

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -40,10 +40,10 @@ import { usePrintMode } from 'src/composables/print/usePrintMode';
 const CATEGORY_LABEL_MAP: Record<string, string> = RESULTS_CATEGORY_LABEL_KEYS;
 
 const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
-  co2: 'charts-co2-subcategory',
-  ch4: 'charts-ch4-subcategory',
-  n2o: 'charts-n2o-subcategory',
-  refrigerants: 'charts-refrigerants-subcategory',
+  co2: 'process-emissions.category.co2',
+  ch4: 'process-emissions.category.ch4',
+  n2o: 'process-emissions.category.n2o',
+  refrigerants: 'process-emissions.category.refrigerant',
   lighting: 'charts-lighting-subcategory',
   cooling: 'charts-cooling-subcategory',
   ventilation: 'charts-ventilation-subcategory',

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -472,6 +472,12 @@ function getFilteredOptions(
     moduleStore.state.taxonomySubmodule[props.submoduleType ?? ''];
   const opts = filteredOptionsMap.value[inp.id] ?? [];
   opts.forEach((opt) => {
+    if (inp.optionLabelKey) {
+      opt.label = $t(
+        inp.optionLabelKey.replace('{value}', opt.value.toLowerCase()),
+      );
+      return;
+    }
     const taxoOptNode = taxoNode?.children?.find(
       (node) => node.name === opt.value,
     );

--- a/frontend/src/components/organisms/module/ModuleInlineSelect.vue
+++ b/frontend/src/components/organisms/module/ModuleInlineSelect.vue
@@ -29,6 +29,7 @@
 <script setup lang="ts">
 import { computed, toRef } from 'vue';
 import { QSelect } from 'quasar';
+import { useI18n } from 'vue-i18n';
 import { useEquipmentClassOptions } from 'src/composables/useEquipmentClassOptions';
 import type { Module, ConditionalSubmoduleProps } from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
@@ -53,6 +54,7 @@ type CommonProps = {
   row: ModuleRow;
   fieldId: string;
   optionsId: string;
+  optionLabelKey?: string;
   hint?: string;
   cols: TableViewColumnSubset[];
   unitId: number;
@@ -63,6 +65,7 @@ type CommonProps = {
 type ModuleTableProps = ConditionalSubmoduleProps & CommonProps;
 
 const props = defineProps<ModuleTableProps>();
+const { t } = useI18n();
 const isClass = computed(() => props.optionsId === 'kind');
 const isSubClass = computed(() => props.optionsId === 'subkind');
 
@@ -86,7 +89,14 @@ const classOptions = computed(() => {
   const taxo = moduleStore.state.taxonomySubmodule[props.submoduleType ?? ''];
   const opts = dynamicOptions['kind'] ?? [];
   return opts.map((opt) => {
-    // Find node that includes the kind option
+    if (props.optionLabelKey) {
+      return {
+        value: opt.value,
+        label: t(
+          props.optionLabelKey.replace('{value}', opt.value.toLowerCase()),
+        ),
+      };
+    }
     const kindNode = taxo?.children?.find((node) => node.name === opt.value);
     return {
       value: opt.value,

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -139,6 +139,7 @@
               :row="slotProps.row"
               :field-id="col.field"
               :options-id="col.optionsId"
+              :option-label-key="col.optionLabelKey"
               :cols="qCols"
               :module-type="moduleType"
               :submodule-type="submoduleType as any"
@@ -738,6 +739,7 @@ type TableViewColumn = {
   editableInline: boolean;
   options?: Array<{ value: string; label: string }>;
   optionsId?: string;
+  optionLabelKey?: string;
   tooltip?: string;
   type: ModuleField['type'];
   minColumnWidth?: number;
@@ -823,6 +825,7 @@ const qCols = computed<TableViewColumn[]>(() => {
           editableInline,
           options,
           optionsId: f.optionsId,
+          optionLabelKey: f.optionLabelKey,
           tooltip,
           type: f.type,
           minColumnWidth: f.minColumnWidth,

--- a/frontend/src/constant/module-config/process_emissions.ts
+++ b/frontend/src/constant/module-config/process_emissions.ts
@@ -6,6 +6,7 @@ const processEmissionsFields: ModuleField[] = [
   {
     id: 'category',
     optionsId: 'kind',
+    optionLabelKey: `${MODULES.ProcessEmissions}.category.{value}`,
     labelKey: `${MODULES.ProcessEmissions}.inputs.category`,
     type: 'select',
     required: true,
@@ -32,7 +33,7 @@ const processEmissionsFields: ModuleField[] = [
     conditionalVisibility: {
       showWhen: {
         fieldId: 'category',
-        value: 'Refrigerant',
+        value: 'refrigerants',
       },
     },
     icon: 'o_category',

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -60,6 +60,7 @@ export interface ModuleField {
   defaultFrom?: 'total_fte';
   options?: Array<{ value: string; label: string }>;
   optionsId?: string; // ID to fetch options from store (kind or subkind)
+  optionLabelKey?: string; // i18n key template; use {value} as placeholder, e.g. 'process-emissions.category.{value}', where {value} matches the normalized option value used by the translation keys
   appendFromFieldId?: string;
   // Flat configuration (preferred): used by both table and form where relevant
   unit?: string;

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -37,6 +37,22 @@ export default {
     en: 'Emitted Gas',
     fr: 'Gaz émis',
   },
+  [`${MODULES.ProcessEmissions}.category.co2`]: {
+    en: 'CO₂',
+    fr: 'CO₂',
+  },
+  [`${MODULES.ProcessEmissions}.category.ch4`]: {
+    en: 'CH₄',
+    fr: 'CH₄',
+  },
+  [`${MODULES.ProcessEmissions}.category.n2o`]: {
+    en: 'N₂O',
+    fr: 'N₂O',
+  },
+  [`${MODULES.ProcessEmissions}.category.refrigerant`]: {
+    en: 'Refrigerants',
+    fr: 'Fluide Frigorigène',
+  },
   [`${MODULES.ProcessEmissions}.inputs.subcategory`]: {
     en: 'Sub-category',
     fr: 'Sous-catégorie',

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -645,22 +645,6 @@ export default {
     en: 'AI',
     fr: 'IA',
   },
-  'charts-co2-subcategory': {
-    en: 'CO₂',
-    fr: 'CO₂',
-  },
-  'charts-ch4-subcategory': {
-    en: 'CH4',
-    fr: 'CH4',
-  },
-  'charts-n2o-subcategory': {
-    en: 'N2O',
-    fr: 'N2O',
-  },
-  'charts-refrigerants-subcategory': {
-    en: 'Refrigerants',
-    fr: 'Réfrigérants',
-  },
   'charts-heating-subcategory': {
     en: 'Heating',
     fr: 'Chauffage',


### PR DESCRIPTION
# PR Description

## What does this change?

Consolidates i18n translations for process emission gas categories (CO₂, CH₄, N₂O, Refrigerants) into a single source of truth under `process-emissions.category.*` keys, and introduces an `optionLabelKey` mechanism on `ModuleField` so that select option labels can be driven by i18n templates instead of taxonomy node lookups.

## Why is this needed?

The old `charts-ch4-subcategory` / `charts-n2o-subcategory` etc. keys in `results.ts` used plain-text chemical formulas (`CH4`, `N2O`) without Unicode subscripts, and were duplicated across chart components and the module form. This PR removes that duplication, fixes the rendering of chemical formulas (now `CH₄`, `N₂O`, `CO₂`), and wires the process emissions category dropdown to use the same translated keys as the charts.

## Type of change

- [x] 🐛 Bug fix
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #947