### PR TITLE
fix(310): heartbeat failure aborts handler [B-H3]

### DIFF
--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -136,19 +136,74 @@ async def run_job(job_id: int) -> None:
         # cancellation-WARNING (kept loud for diagnosing the 310-B
         # incident) on every successful run, drowning out genuine
         # cancellations.
+        #
+        # B-H3: ``abort_event`` is set by the heartbeat loop when
+        # heartbeats have failed for long enough that the auto-recovery
+        # sweep on another pod has almost certainly preempted us
+        # (consecutive failures spanning ``STALE_JOB_TIMEOUT_MINUTES``).
+        # The runner races handler completion against this event and,
+        # if the event wins, cancels the handler so we stop burning
+        # work on a row we no longer own.
+        abort_event = asyncio.Event()
         heartbeat_task = asyncio.create_task(
-            _heartbeat_loop(job_id),
+            _heartbeat_loop(job_id, abort_event),
             name=f"heartbeat-{job_id}",
         )
 
         try:
+            handler_aborted = False
             try:
                 handler = get_handler(job_type)
-                meta = await handler(job, job_session, data_session)
-                status_message = str(meta.get("status_message", "Success"))
-                metadata = dict(meta)
-                result = meta.get("result", IngestionResult.SUCCESS)
-                handler_succeeded = True
+                handler_task = asyncio.create_task(
+                    handler(job, job_session, data_session),
+                    name=f"handler-{job_id}",
+                )
+                abort_waiter = asyncio.create_task(
+                    abort_event.wait(),
+                    name=f"abort-waiter-{job_id}",
+                )
+                try:
+                    done, _pending = await asyncio.wait(
+                        {handler_task, abort_waiter},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                finally:
+                    if not abort_waiter.done():
+                        abort_waiter.cancel()
+                        try:
+                            await abort_waiter
+                        except asyncio.CancelledError:
+                            pass
+
+                if handler_task in done:
+                    meta = handler_task.result()
+                    status_message = str(meta.get("status_message", "Success"))
+                    metadata = dict(meta)
+                    result = meta.get("result", IngestionResult.SUCCESS)
+                    handler_succeeded = True
+                else:
+                    # Heartbeat-driven abort: stop the handler, drop down
+                    # to the rollback-and-return branch.  The new owner —
+                    # the pod that recovered the stale row — will write
+                    # the FINISHED row.
+                    logger.error(
+                        f"run_job: aborting handler for job {job_id} after "
+                        "sustained heartbeat failures — another pod has "
+                        "almost certainly preempted this row"
+                    )
+                    handler_task.cancel()
+                    try:
+                        await handler_task
+                    except (asyncio.CancelledError, Exception):
+                        # Swallow both cancellation and any exception the
+                        # handler raised on the way out: we're already in
+                        # the abort path and won't write its result.
+                        pass
+                    handler_aborted = True
+                    status_message = ""
+                    metadata = {}
+                    result = IngestionResult.ERROR
+                    handler_succeeded = False
             except Exception as exc:
                 logger.exception(
                     f"run_job: handler for job_type={job_type!r} failed (job {job_id})"
@@ -157,6 +212,16 @@ async def run_job(job_id: int) -> None:
                 metadata = {}
                 result = IngestionResult.ERROR
                 handler_succeeded = False
+
+            if handler_aborted:
+                # We no longer own the lock (or are about to lose it):
+                # roll back the half-written data session and exit
+                # without touching the job row.  The preemption check
+                # below would do the same, but skipping it avoids an
+                # extra DB round-trip on a path we already know is
+                # exiting.
+                await data_session.rollback()
+                return
 
             # Preemption check covers BOTH success and error paths: if a
             # stale-lock sweep recovered this row mid-handler, a different
@@ -195,7 +260,7 @@ async def run_job(job_id: int) -> None:
                 pass
 
 
-async def _heartbeat_loop(job_id: int) -> None:
+async def _heartbeat_loop(job_id: int, abort_event: asyncio.Event) -> None:
     """Refresh ``locked_at`` on the active job until cancelled.
 
     Wake every ``STALE_JOB_TIMEOUT_MINUTES / 4`` (default: every
@@ -207,9 +272,24 @@ async def _heartbeat_loop(job_id: int) -> None:
     Each tick uses a fresh session: heartbeats fire concurrently
     with the handler's session, so sharing would deadlock or
     serialize on the underlying connection.
+
+    B-H3: count consecutive heartbeat exceptions.  If they span
+    ``STALE_JOB_TIMEOUT_MINUTES`` (i.e. the auto-recovery sweep's
+    threshold), set ``abort_event`` so the runner cancels the handler
+    — by then another pod's stale-recovery sweep has almost certainly
+    re-claimed this row, and continuing to run the handler would
+    burn duplicate work that Unit 1's CAS will only be able to drop
+    at the very end.  Successful heartbeats reset the counter.
     """
     settings = get_settings()
     interval_seconds = max(1.0, settings.STALE_JOB_TIMEOUT_MINUTES * 60 / 4)
+    # Threshold: enough consecutive failures to span the stale-job
+    # window.  ``max(1, ...)`` so a tiny mis-configured interval still
+    # gives the loop one chance to recover before aborting.
+    failure_threshold = max(
+        1, int(settings.STALE_JOB_TIMEOUT_MINUTES * 60 / interval_seconds)
+    )
+    consecutive_failures = 0
     while True:
         try:
             await asyncio.sleep(interval_seconds)
@@ -223,6 +303,7 @@ async def _heartbeat_loop(job_id: int) -> None:
                         "stopping heartbeat"
                     )
                     return
+            consecutive_failures = 0
         except asyncio.CancelledError:
             # Normal shutdown path — the runner cancels us in its
             # ``finally`` block.  Re-raise so asyncio sees the
@@ -230,5 +311,21 @@ async def _heartbeat_loop(job_id: int) -> None:
             raise
         except Exception as exc:
             # Don't let a transient DB hiccup kill the heartbeat;
-            # log and try again next interval.
-            logger.warning(f"_heartbeat_loop: heartbeat for job {job_id} failed: {exc}")
+            # log and try again next interval.  But if failures span
+            # the stale-job window, signal the runner to abort: the
+            # row is almost certainly owned by another pod now.
+            consecutive_failures += 1
+            logger.warning(
+                f"_heartbeat_loop: heartbeat for job {job_id} failed "
+                f"({consecutive_failures}/{failure_threshold}): {exc}"
+            )
+            if consecutive_failures >= failure_threshold:
+                logger.error(
+                    f"_heartbeat_loop: heartbeat for job {job_id} failed "
+                    f"{consecutive_failures} consecutive times "
+                    f"(>= {failure_threshold}, spanning "
+                    f"STALE_JOB_TIMEOUT_MINUTES={settings.STALE_JOB_TIMEOUT_MINUTES}) "
+                    "— signalling runner to abort handler"
+                )
+                abort_event.set()
+                return

--- a/backend/tests/unit/tasks/test_runner.py
+++ b/backend/tests/unit/tasks/test_runner.py
@@ -83,11 +83,14 @@ def _patch_session_local():
     return patch.object(runner_mod, "SessionLocal", _mock_session_ctx)
 
 
-async def _noop_heartbeat(_job_id: int) -> None:
+async def _noop_heartbeat(_job_id: int, _abort_event=None) -> None:
     """Drop-in for ``_heartbeat_loop`` that returns immediately so
     tests don't await real sleeps.  ``asyncio.create_task(noop())``
     produces a task that completes; the runner's cancel + await in
-    ``finally`` is then a no-op."""
+    ``finally`` is then a no-op.
+
+    ``_abort_event`` is the second arg the production loop accepts
+    (B-H3); the noop ignores it."""
     return None
 
 

--- a/backend/tests/unit/tasks/test_runner_heartbeat_abort.py
+++ b/backend/tests/unit/tasks/test_runner_heartbeat_abort.py
@@ -1,0 +1,256 @@
+"""Unit tests for the B-H3 heartbeat-failure-abort path.
+
+Plan 310 post-merge fix B-H3: when a heartbeat fails consecutively
+for long enough that the auto-recovery sweep on another pod has
+almost certainly preempted the row, ``_heartbeat_loop`` sets the
+shared ``abort_event`` and the runner cancels the handler instead
+of running it to completion against a row it no longer owns.
+
+These tests:
+
+1. Drive ``_heartbeat_loop`` directly with ``repo.heartbeat`` raising
+   on every call, and assert the abort event is set after exactly
+   ``failure_threshold`` failures.
+
+2. Drive ``run_job`` with a handler that awaits an
+   ``asyncio.Event()`` that never fires, alongside a heartbeat that
+   trips the abort path almost immediately, and assert:
+
+     - the handler task is cancelled within a bounded wall-clock window,
+     - ``update_ingestion_job`` is NOT called (the new owner closes the row),
+     - ``data_session.rollback`` IS called.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.tasks import runner as runner_mod
+from app.tasks.registry import _REGISTRY, register
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    snapshot = dict(_REGISTRY)
+    _REGISTRY.clear()
+    try:
+        yield
+    finally:
+        _REGISTRY.clear()
+        _REGISTRY.update(snapshot)
+
+
+def _make_job(job_id: int = 1, job_type: str = "test_job") -> MagicMock:
+    job = MagicMock()
+    job.id = job_id
+    job.job_type = job_type
+    job.module_type_id = 11
+    job.data_entry_type_id = 22
+    job.year = 2025
+    job.pipeline_id = None
+    job.locked_by = runner_mod.POD_ID
+    return job
+
+
+def _make_repo_returning(job: MagicMock | None) -> MagicMock:
+    repo = MagicMock()
+    repo.get_job_by_id = AsyncMock(return_value=job)
+    repo.claim_job = AsyncMock(return_value=True)
+    repo.update_ingestion_job = AsyncMock(return_value=job)
+    repo.heartbeat = AsyncMock(return_value=1)
+    return repo
+
+
+@asynccontextmanager
+async def _mock_session_ctx():
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.add = MagicMock()
+    yield session
+
+
+def _patch_session_local():
+    return patch.object(runner_mod, "SessionLocal", _mock_session_ctx)
+
+
+# ---------------------------------------------------------------------------
+# _heartbeat_loop — abort threshold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_sets_abort_event_after_threshold_failures(
+    monkeypatch,
+):
+    """Repeated heartbeat exceptions accumulate; on the threshold-th
+    consecutive failure, ``abort_event`` is set and the loop returns.
+
+    Use a short stale timeout (1 minute) so ``interval_seconds = 15``
+    and ``failure_threshold = 4``.  Patch ``asyncio.sleep`` (on the
+    real ``asyncio`` module the runner imported ``asyncio`` from) with
+    a no-op coroutine so the test runs in real-time milliseconds.
+    Capture the original ``asyncio.sleep`` first so the patched
+    function can yield control without recursing into itself.
+    """
+    settings_mock = MagicMock()
+    settings_mock.STALE_JOB_TIMEOUT_MINUTES = 1
+    monkeypatch.setattr(runner_mod, "get_settings", lambda: settings_mock)
+
+    sleeps: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(secs: float) -> None:
+        sleeps.append(secs)
+        # Yield control via the *real* asyncio.sleep so the abort_event
+        # waiter can wake — without recursing into the patched version.
+        await real_sleep(0)
+
+    monkeypatch.setattr(runner_mod.asyncio, "sleep", _fast_sleep)
+
+    failing_repo = MagicMock()
+    failing_repo.heartbeat = AsyncMock(side_effect=RuntimeError("db down"))
+    monkeypatch.setattr(
+        runner_mod, "DataIngestionRepository", lambda _s: failing_repo
+    )
+    monkeypatch.setattr(runner_mod, "SessionLocal", _mock_session_ctx)
+
+    abort_event = asyncio.Event()
+
+    # Loop should return on its own once threshold is hit; bound the
+    # wait so a regression doesn't hang the suite forever.
+    await asyncio.wait_for(
+        runner_mod._heartbeat_loop(job_id=42, abort_event=abort_event),
+        timeout=5.0,
+    )
+
+    assert abort_event.is_set(), "abort_event must be set after threshold failures"
+    # 1-minute timeout / 15s interval = 4 attempts before abort.
+    assert failing_repo.heartbeat.await_count == 4
+    # And we slept four times, once per attempt.
+    assert len(sleeps) == 4
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_resets_counter_on_success(monkeypatch):
+    """A successful heartbeat between failures resets the counter,
+    so the loop tolerates intermittent DB blips below the threshold."""
+    settings_mock = MagicMock()
+    settings_mock.STALE_JOB_TIMEOUT_MINUTES = 1  # 4 attempts to abort
+    monkeypatch.setattr(runner_mod, "get_settings", lambda: settings_mock)
+
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_secs: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(runner_mod.asyncio, "sleep", _fast_sleep)
+
+    # Pattern: fail, fail, fail, OK (resets to 0), fail, fail, fail (now
+    # at 3 — still under threshold), then preempt-style 0-update which
+    # short-circuits the loop.  Total: 7 calls; abort_event NEVER set.
+    side_effects: list = [
+        RuntimeError("blip 1"),
+        RuntimeError("blip 2"),
+        RuntimeError("blip 3"),
+        1,  # success — resets counter
+        RuntimeError("blip 4"),
+        RuntimeError("blip 5"),
+        0,  # preemption (updated == 0) — clean exit, NOT abort
+    ]
+    repo_mock = MagicMock()
+    repo_mock.heartbeat = AsyncMock(side_effect=side_effects)
+    monkeypatch.setattr(
+        runner_mod, "DataIngestionRepository", lambda _s: repo_mock
+    )
+    monkeypatch.setattr(runner_mod, "SessionLocal", _mock_session_ctx)
+
+    abort_event = asyncio.Event()
+    await asyncio.wait_for(
+        runner_mod._heartbeat_loop(job_id=7, abort_event=abort_event),
+        timeout=5.0,
+    )
+
+    # The counter reset means we never reach the threshold even though
+    # there were five failure exceptions in total.
+    assert not abort_event.is_set()
+    assert repo_mock.heartbeat.await_count == 7
+
+
+# ---------------------------------------------------------------------------
+# run_job — abort cancels the handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_job_aborts_handler_when_heartbeat_signals(monkeypatch):
+    """Production scenario: the handler is stuck (``await never_done``)
+    and the heartbeat trips the abort event.  Runner must:
+
+      - cancel the handler task,
+      - skip the FINISHED state write (the new owner does that),
+      - roll back the data_session.
+    """
+    job = _make_job()
+    repo = _make_repo_returning(job)
+
+    # The handler awaits an event that is never set, so it would
+    # otherwise hang forever.
+    never_done = asyncio.Event()
+    handler_was_cancelled = asyncio.Event()
+
+    @register("test_job")
+    async def _stuck_handler(j, js, ds) -> dict:
+        try:
+            await never_done.wait()
+            return {}
+        except asyncio.CancelledError:
+            handler_was_cancelled.set()
+            raise
+
+    # Replace ``_heartbeat_loop`` with a fast version that sets the
+    # abort event after a single tick — no need to drive the real
+    # threshold logic again here (the dedicated tests above already
+    # cover that); this test exercises the runner-side wait/cancel.
+    async def _fast_aborting_heartbeat(
+        _job_id: int, abort_event: asyncio.Event
+    ) -> None:
+        # Yield once so the handler actually gets to ``await never_done``
+        # before we trip the abort event — exercises the FIRST_COMPLETED
+        # race path rather than a synchronous shortcut.
+        await asyncio.sleep(0)
+        abort_event.set()
+
+    captured_sessions = []
+
+    @asynccontextmanager
+    async def _capture_session():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        session.add = MagicMock()
+        captured_sessions.append(session)
+        yield session
+
+    with (
+        patch.object(runner_mod, "SessionLocal", _capture_session),
+        patch.object(runner_mod, "_heartbeat_loop", _fast_aborting_heartbeat),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+    ):
+        # Bound the test so a regression that loses the cancel doesn't
+        # hang the suite forever.
+        await asyncio.wait_for(runner_mod.run_job(1), timeout=5.0)
+
+    assert handler_was_cancelled.is_set(), (
+        "handler must observe a CancelledError after the heartbeat aborts"
+    )
+    # The new owner closes the row out — we MUST NOT race a FINISHED write.
+    repo.update_ingestion_job.assert_not_called()
+
+    # Two sessions opened (job_session + data_session); the data_session
+    # MUST have rolled back.
+    assert len(captured_sessions) == 2
+    _job_session, data_session = captured_sessions
+    data_session.rollback.assert_awaited()


### PR DESCRIPTION
## Summary

- Track consecutive heartbeat failures in `_heartbeat_loop`. After failures span `STALE_JOB_TIMEOUT_MINUTES` (the auto-recovery sweep window), set a shared `asyncio.Event` and exit the loop.
- In `run_job`, race the handler task against the abort event via `asyncio.wait(FIRST_COMPLETED)`. If the abort event fires first: cancel the handler, roll back the data session, and exit without writing FINISHED.
- Successful heartbeats reset the counter so transient DB blips below the threshold don't trip the abort path.

## Why

Pre-fix, `_heartbeat_loop` swallowed every heartbeat exception silently. If a DB outage exceeded `STALE_JOB_TIMEOUT_MINUTES`, the auto-recovery sweep on another pod would re-claim the row while this pod's handler kept running all the way to the FINISHED tail — burning duplicate work that Unit 1's CAS would only be able to drop at the end.

Pairs with B-C1 (atomic FINISHED CAS). The cleanup race with the new owner is acceptable here because by the time we'd write a FINISHED row, `locked_by` no longer points to this pod and either the preempt check or the upcoming CAS catches it.

## Test plan

- [x] `rtk uv run pytest backend/tests/unit/tasks/` — 82 passed, including 3 new tests in `test_runner_heartbeat_abort.py`:
  - threshold count: heartbeat raises N times → `abort_event` set on the Nth failure
  - counter resets: success between failures keeps `abort_event` clear
  - end-to-end: stuck handler awaiting `Event` is cancelled within the test bound after heartbeat trips the abort, `update_ingestion_job` not called, `data_session.rollback` called
- [x] `rtk uv run pytest backend/tests/unit/` — 1291 passed
- [x] `rtk uv run pytest backend/tests/integration/services/data_ingestion/` — 78 passed
- [x] `rtk uv run ruff check backend/app/ backend/tests/` — clean