### PR TITLE
fix(310): emission_recalc chains aggregation on WARNING [B-C2]

### DIFF
--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -101,13 +101,20 @@ async def emission_recalc_handler(
     # for that snapshot, with the dedup window reopening on
     # FINISHED).
     #
+    # Chain on WARNING as well as SUCCESS — a 10k-row reupload that
+    # fails on a single entry flips ``result`` to WARNING, but the
+    # other 9999 rows have already been recomputed and
+    # ``carbon_reports.stats`` would stay stale forever if we skipped
+    # aggregation here.  Aligns with ``module_emission_recalc_handler``
+    # below which uses the same ``!= ERROR`` gate.
+    #
     # Skip when ``module_type_id`` is missing — every endpoint pins
     # it for emission_recalc, but a defensive log + skip is safer
     # than crashing the parent's FINISHED write.  The recalc itself
     # already succeeded; the operator sees the missing aggregation
     # via the dashboard's "stats stale" badge if they need it.
     chained_aggregation_id = None
-    if job.module_type_id is not None and result == IngestionResult.SUCCESS:
+    if job.module_type_id is not None and result != IngestionResult.ERROR:
         chained_aggregation_id = await chain_job(
             job,
             job_type="aggregation",

--- a/backend/tests/integration/services/data_ingestion/test_full_dag_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_full_dag_pipeline_pg.py
@@ -243,3 +243,117 @@ async def test_full_dag_csv_ingest_chains_emission_recalc_chains_aggregation(pg_
     assert aggregation.year == 2025
 
     await engine.dispose()
+
+
+def _emission_recalc_parent() -> DataIngestionJob:
+    """An ``emission_recalc`` parent already claimed by the runner —
+    the handler body is what we drive directly in the WARNING test
+    below.  Mirrors the rows endpoints+poller actually persist."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=5,
+        data_entry_type_id=DataEntryTypeEnum.it.value,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.RUNNING,
+        is_current=True,
+        job_type="emission_recalc",
+        pipeline_id=uuid4(),
+        meta={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregation_chains_on_warning_with_partial_failure(pg_dsn):
+    """Regression for B-C2: a per-entry failure during recalc must not
+    skip the aggregation chain.
+
+    Before the fix, ``emission_recalc`` only chained aggregation when
+    ``result == SUCCESS``.  A 10k-row reupload that failed on a single
+    entry flipped the result to WARNING, the chain was skipped, and
+    ``carbon_reports.stats`` stayed stale forever even though 9999
+    entries were correctly recomputed.
+
+    This test stubs ``EmissionRecalculationWorkflow`` to surface a
+    partial failure (``errors=1``) — equivalent to ``upsert_by_data_entry``
+    raising once on a single row — and asserts the aggregation child
+    is persisted with the parent's pipeline_id.
+    """
+    from app.tasks import _chain as chain_mod
+    from app.tasks import emission_recalculation_tasks as recalc_mod
+
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_dedup_index(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    # 1. Persist the emission_recalc parent (state=RUNNING — the
+    #    runner has claimed it and the handler body is what we run
+    #    here).
+    async with Sf() as session:
+        parent = _emission_recalc_parent()
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+        parent_pipeline_id = parent.pipeline_id
+        parent_id = parent.id
+
+    # 2. Workflow stub: partial-failure shape — recalculated>0 with
+    #    errors=1 makes the handler compute ``result=WARNING``, which
+    #    is the exact branch the bug skipped.
+    workflow = MagicMock()
+    workflow.recalculate_for_data_entry_type = AsyncMock(
+        return_value={
+            "recalculated": 9999,
+            "errors": 1,
+            "modules_refreshed": 0,
+            "affected_module_ids": [5],
+            "error_details": [{"data_entry_id": 42, "error": "boom"}],
+        }
+    )
+
+    # 3. ``fire_and_forget`` shim — we only care that the aggregation
+    #    row was persisted by ``chain_job``; we don't need to drive
+    #    the aggregation handler itself.  Closing the run_job coroutine
+    #    keeps it from running against the runner's (sqlite) engine.
+    def _drop_fire_and_forget(coro, *, name=None):
+        coro.close()
+        return MagicMock()
+
+    with (
+        patch.object(
+            recalc_mod, "EmissionRecalculationWorkflow", return_value=workflow
+        ),
+        patch.object(chain_mod, "fire_and_forget", side_effect=_drop_fire_and_forget),
+    ):
+        async with Sf() as session:
+            row = await session.get(DataIngestionJob, parent_id)
+            from app.tasks.registry import get_handler
+
+            handler = get_handler("emission_recalc")
+            async with Sf() as data_session:
+                meta = await handler(row, session, data_session)
+
+    # Sanity: the handler reported WARNING (the branch the bug skipped).
+    assert meta["result"] == IngestionResult.WARNING
+    assert meta["aggregation_job_id"] is not None
+
+    # The aggregation child exists in the DB, carries the parent's
+    # pipeline_id, and is module-scoped to (module=5, year=2025).
+    async with Sf() as session:
+        result = await session.execute(
+            select(DataIngestionJob)
+            .where(DataIngestionJob.pipeline_id == parent_pipeline_id)
+            .where(DataIngestionJob.job_type == "aggregation")
+        )
+        aggregation_rows = list(result.scalars().all())
+
+    assert len(aggregation_rows) == 1
+    aggregation = aggregation_rows[0]
+    assert aggregation.id == meta["aggregation_job_id"]
+    assert aggregation.module_type_id == 5
+    assert aggregation.data_entry_type_id is None
+    assert aggregation.year == 2025
+
+    await engine.dispose()

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -175,15 +175,13 @@ async def test_emission_recalc_handler_chains_aggregation_with_dedup_on_success(
 
 
 @pytest.mark.asyncio
-async def test_emission_recalc_handler_skips_aggregation_chain_on_warning():
-    """A WARNING result (per-entry errors > 0) means the recalc
-    completed but with partial failures.  Per Plan 310-D's
-    eventual-consistency model the aggregation pass should still
-    eventually happen, but for this PR we conservatively gate on
-    SUCCESS — partial-warning recalcs land before the aggregation
-    chain ships in production traffic, and the absence of a chain
-    surfaces as a stale-stats badge the operator can act on (the
-    PR is rollback-safe)."""
+async def test_emission_recalc_handler_chains_aggregation_on_warning():
+    """Regression for B-C2: a WARNING result (per-entry errors > 0)
+    must still chain aggregation.  A 10k-row reupload that fails on
+    one entry flips ``result`` to WARNING; if we skipped the chain
+    here ``carbon_reports.stats`` would stay stale forever even
+    though 9999 entries were recomputed.  Aligns with the
+    ``module_emission_recalc_handler`` gate (``!= ERROR``)."""
     job = _make_job()
     job_session = MagicMock()
     job_session.commit = AsyncMock()
@@ -195,8 +193,8 @@ async def test_emission_recalc_handler_skips_aggregation_chain_on_warning():
     workflow = MagicMock()
     workflow.recalculate_for_data_entry_type = AsyncMock(
         return_value={
-            "recalculated": 3,
-            "errors": 2,
+            "recalculated": 9999,
+            "errors": 1,
             "modules_refreshed": 0,
             "affected_module_ids": [],
         }
@@ -209,11 +207,17 @@ async def test_emission_recalc_handler_skips_aggregation_chain_on_warning():
         ),
         patch.object(recalc_mod, "chain_job", new_callable=AsyncMock) as mock_chain,
     ):
+        mock_chain.return_value = 777
         meta = await recalc_mod.emission_recalc_handler(job, job_session, data_session)
 
-    mock_chain.assert_not_awaited()
+    mock_chain.assert_awaited_once()
+    chain_kwargs = mock_chain.await_args.kwargs
+    assert chain_kwargs["job_type"] == "aggregation"
+    assert chain_kwargs["module_type_id"] == job.module_type_id
+    assert chain_kwargs["year"] == job.year
+    assert chain_kwargs["dedup_active"] is True
     assert meta["result"] == IngestionResult.WARNING
-    assert meta["aggregation_job_id"] is None
+    assert meta["aggregation_job_id"] == 777
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- A 10k-row reupload that fails on a single entry flips the recalc result to WARNING; the handler was gating the aggregation chain on `result == SUCCESS`, so `carbon_reports.stats` stayed stale forever even though 9999 rows were recomputed correctly.
- Switch the gate to `result != IngestionResult.ERROR` so WARNING also chains. Aligns with the sibling `module_emission_recalc_handler` (line 243) which already uses the same `!= ERROR` gate.
- Update the inline comment to document the new contract; rewrite the unit test that pinned the old (buggy) skip-on-WARNING behavior.

## Changes
- `backend/app/tasks/emission_recalculation_tasks.py` — flip `==SUCCESS` → `!=ERROR` on the aggregation-chain gate; update comment.
- `backend/tests/unit/tasks/test_handler_registrations.py` — replace `test_emission_recalc_handler_skips_aggregation_chain_on_warning` with `test_emission_recalc_handler_chains_aggregation_on_warning` that asserts the chain DOES fire on WARNING with the right kwargs.
- `backend/tests/integration/services/data_ingestion/test_full_dag_pipeline_pg.py` — add `test_aggregation_chains_on_warning_with_partial_failure`. Drives the `emission_recalc` handler with an `errors=1` workflow stub (mimicking a single `upsert_by_data_entry` failure) and asserts the aggregation child row is persisted in PG with the parent's pipeline_id.

## Test plan
- [x] `rtk uv run pytest backend/tests/unit/` — 1288 passed
- [x] `rtk uv run pytest backend/tests/integration/services/data_ingestion/` — 79 passed (Docker required)
- [x] `rtk uv run ruff check backend/app/ backend/tests/` — clean

## Context
Unit 2 of the 310 post-merge fix batch (B-C2 from `docs/code-review/310-overall-review.md`).