### PR TITLE
fix(310): a11y — pipeline diagnostic accessible on focus [F-C1]

### DIFF
--- a/docs/src/implementation-plans/310-d-frontend-stale-stats.md
+++ b/docs/src/implementation-plans/310-d-frontend-stale-stats.md
@@ -106,15 +106,32 @@ plumbing.
 - Relative timestamp via a small inline `formatRelative()` helper —
   no project-wide time utility was available; bespoke helper kept
   inside the component to avoid premature abstraction.
+- **Keyboard a11y on the badge** (fix F-C1, follow-up after PR #1059).
+  Quasar's `<q-tooltip>` only registers `mouseenter` / `mouseleave`
+  on the anchor (verified at
+  `frontend/node_modules/quasar/src/components/tooltip/QTooltip.js:247-266`),
+  so `tabindex="0"` alone never opens it for keyboard users.
+  `PipelineDiagnosticTooltip.vue` re-exposes Quasar's `show()` /
+  `hide()` via `defineExpose`; the parent badge drives them from
+  `@focus` / `@blur`. Tabbing onto the badge now opens the
+  diagnostic; tabbing off closes it. The copy-pipeline-id button
+  inside the tooltip portal is still mouse-only — `blur` fires when
+  focus tries to enter the portal, which collapses the tooltip.
+  Honest partial-a11y; full keyboard reachability requires switching
+  to `<q-popup-proxy>` / `<q-menu>` (see Future enhancements).
 
 ### Future enhancements (out of scope for this PR)
 
-- **Click-to-stick on mobile / no-mouse devices.** Quasar's
-  `<q-tooltip>` is hover-only by spec; switching to
-  `<q-popup-proxy>` (which supports both hover and click) is more
-  invasive (different anchor model, different escape semantics) and
-  was deferred to keep this PR scoped. Tracked as a separate UX
-  follow-up if mobile support becomes a requirement.
+- **Click-to-stick on mobile / no-mouse devices, and full keyboard
+  reachability of the in-tooltip copy button.** Quasar's
+  `<q-tooltip>` is hover-only by spec, and the badge-driven
+  `@focus` / `@blur` bridge added for F-C1 cannot keep the tooltip
+  open while focus moves into its portal. Switching to
+  `<q-popup-proxy>` (supports both hover and click, plus focus
+  retention) is more invasive (different anchor model, different
+  escape semantics) and was deferred to keep this PR scoped.
+  Tracked as a separate UX follow-up if mobile support or full
+  in-tooltip keyboard navigation becomes a requirement.
 
 ---
 

--- a/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
+++ b/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
@@ -16,8 +16,8 @@
  * component owns no fetching or subscription.
  */
 
-import { computed } from 'vue';
-import { copyToClipboard, Notify } from 'quasar';
+import { computed, ref } from 'vue';
+import { copyToClipboard, Notify, type QTooltip } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import { usePipelineStreamStore } from 'src/stores/pipelineStream';
 
@@ -30,6 +30,19 @@ const { t } = useI18n();
 const store = usePipelineStreamStore();
 
 const jobs = computed(() => store.jobsFor(props.pipelineId));
+
+/**
+ * Re-expose Quasar's ``show()`` / ``hide()`` so the parent badge can
+ * drive the tooltip from ``@focus`` / ``@blur`` events.  ``<q-tooltip>``
+ * itself only registers ``mouseenter`` / ``mouseleave`` triggers
+ * (verified at ``QTooltip.js:247-266``); without this bridge a
+ * keyboard-focused badge stays mute.
+ */
+const tooltipRef = ref<QTooltip>();
+defineExpose({
+  show: (): void => tooltipRef.value?.show(),
+  hide: (): void => tooltipRef.value?.hide(),
+});
 
 async function copyPipelineId(): Promise<void> {
   try {
@@ -90,6 +103,7 @@ function formatRelative(iso: string | null): string | null {
 
 <template>
   <q-tooltip
+    ref="tooltipRef"
     anchor="bottom middle"
     self="top middle"
     class="bg-grey-10 q-pa-md"

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -148,6 +148,23 @@ const showRecalcDialog = ref(false);
 const recalcDialogModuleTypeId = ref<number | null>(null);
 const recalcOnlyStale = ref(true);
 
+// Plan 310-D — fix(F-C1): Quasar's ``<q-tooltip>`` is hover-only by
+// spec (verified at ``QTooltip.js:247-266`` — only ``mouseenter`` /
+// ``mouseleave`` are registered as triggers).  ``tabindex="0"`` alone
+// makes the badge focusable but never opens the tooltip for keyboard
+// users.  ``PipelineDiagnosticTooltip`` re-exposes Quasar's
+// ``show()`` / ``hide()`` via ``defineExpose``; the parent badge
+// drives them from ``@focus`` / ``@blur`` so the diagnostic content
+// (pipeline UUID, per-job state, status messages) is reachable
+// without a mouse.  The copy-pipeline-id button inside the tooltip
+// stays mouse-only because the tooltip portal closes on ``blur`` —
+// honest partial-a11y; full keyboard reachability would require
+// switching primitives (``<q-popup-proxy>`` / ``<q-menu>``) which the
+// plan tracks as a future enhancement.
+type TooltipExposed = { show: () => void; hide: () => void };
+const recalcTooltip = ref<TooltipExposed>();
+const failureTooltip = ref<TooltipExposed>();
+
 function openDataEntryDialog(row: ImportRow, targetType: TargetType | null) {
   dialogCurrentRow.value = row;
   dialogTargetType.value = targetType;
@@ -223,11 +240,14 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               the live state.
             -->
             <!--
-              Plan 310-D — ``tabindex="0"`` + ``aria-label`` make the
-              badge keyboard-focusable so the diagnostic tooltip
-              opens on focus (and the copy-pipeline-id button inside
-              becomes reachable).  Without these, keyboard-only users
-              can't see what the badge promises to surface.
+              Plan 310-D — fix(F-C1): ``tabindex="0"`` + ``aria-label``
+              make the badge keyboard-focusable and named for screen
+              readers, but Quasar's ``<q-tooltip>`` is hover-only.  The
+              child component re-exposes ``show()`` / ``hide()`` via
+              ``defineExpose``; the badge drives them from ``@focus`` /
+              ``@blur`` so the diagnostic content is reachable without
+              a mouse.  See the ref declarations in ``<script setup>``
+              for the full rationale.
             -->
             <q-badge
               v-if="isRecalculating"
@@ -238,9 +258,12 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               tabindex="0"
               :aria-label="$t('data_management_pipeline_recalculating')"
               :label="$t('data_management_pipeline_recalculating')"
+              @focus="recalcTooltip?.show()"
+              @blur="recalcTooltip?.hide()"
             >
               <PipelineDiagnosticTooltip
                 v-if="currentPipelineId"
+                ref="recalcTooltip"
                 :pipeline-id="currentPipelineId"
               />
             </q-badge>
@@ -253,9 +276,12 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               tabindex="0"
               :aria-label="$t('data_management_pipeline_failed')"
               :label="$t('data_management_pipeline_failed')"
+              @focus="failureTooltip?.show()"
+              @blur="failureTooltip?.hide()"
             >
               <PipelineDiagnosticTooltip
                 v-if="currentPipelineId"
+                ref="failureTooltip"
                 :pipeline-id="currentPipelineId"
               />
             </q-badge>


### PR DESCRIPTION
## Summary

Fixes finding **F-C1** from `docs/code-review/310-overall-review.md` — the
post-merge review proved that PR #1059's `tabindex="0"` + `aria-label` on
the pipeline status badges did not actually make the diagnostic tooltip
reachable for keyboard users.

Quasar's `<q-tooltip>` only registers `mouseenter` / `mouseleave` on the
anchor (verified at
`frontend/node_modules/quasar/src/components/tooltip/QTooltip.js:247-266`).
The badge was focusable but the tooltip stayed hidden.

### Fix

- `PipelineDiagnosticTooltip.vue` re-exposes Quasar's `show()` / `hide()`
  via `defineExpose` (the methods are part of the public `<q-tooltip>` API
  at `QTooltip.js:268`).
- `ModuleConfig.vue` declares `recalcTooltip` / `failureTooltip` refs and
  drives them from `@focus` / `@blur` on each badge.
- `310-d-frontend-stale-stats.md` documents the actual mechanism and the
  honest partial-a11y limitation below.

### Honest partial-a11y limitation

The copy-pipeline-id button inside the tooltip portal stays mouse-only.
When focus tries to leave the badge to enter the tooltip portal, `blur`
fires on the badge → `hide()` → tooltip collapses → the button is never
reachable. Full in-tooltip keyboard navigation requires switching to
`<q-popup-proxy>` / `<q-menu>` — already tracked in the plan's "Future
enhancements" section, updated here to reflect this constraint
explicitly.

The diagnostic content itself (pipeline UUID text, per-job state,
status messages, timestamps) is now visible to keyboard-only users on
badge focus — meeting the originally-stated F-C1 goal of "see what the
badge promises to surface."

## Test plan

- [x] `tsgo --noEmit -p tsconfig.typecheck.json` (frontend) — exit 0
- [x] frontend prettier `--check` on the two modified `.vue` files —
      clean
- [x] docs prettier `--check` on the modified plan doc — clean
- [ ] **Manual browser verification**: tab to a recalculating or failed
      badge; tooltip diagnostic content opens. Tab away; tooltip closes.
      (Not performed in this worktree — no browser dev server. The
      mechanism is identical to the manual-trigger pattern documented in
      the Quasar `q-tooltip` API; the QTooltip source confirms `show()` /
      `hide()` are public methods.)

### Pre-existing lint baseline note

`make lint` reports a pre-existing prettier warning on
`docs/src/implementation-plans/310-d-pipeline-responsibility-split.md`
(double-space-after-period in a quoted block). That file is **not in
this PR's scope** — it's already on `feat/310/dev`. Confirmed by
stashing this PR's changes and re-running `prettier --check .` from
`docs/`: same warning surfaces. Out-of-scope for F-C1.

## Files

- `frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue`
- `frontend/src/components/organisms/data-management/ModuleConfig.vue`
- `docs/src/implementation-plans/310-d-frontend-stale-stats.md`