### PR TITLE
fix(310): atomic CAS on FINISHED job-write [B-C1]

### DIFF
--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -126,6 +126,97 @@ class DataIngestionRepository:
             await self.session.refresh(result_job)
         return result_job
 
+    async def finish_job(
+        self,
+        job_id: int,
+        pod_id: str,
+        result: IngestionResult,
+        status_message: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> bool:
+        """Atomic compare-and-set transition to ``FINISHED`` for the owning pod.
+
+        Plan 310 review finding **B-C1** — the prior ``update_ingestion_job``
+        FINISHED path did a ``SELECT … WHERE id`` then mutated state without
+        a CAS guard, so a pod whose heartbeat failed during a DB outage could
+        complete its handler AFTER another pod recovered the row and
+        re-claimed it; its FINISHED write then clobbered the new owner's
+        RUNNING state.
+
+        This method enforces the missing CAS:
+
+            UPDATE data_ingestion_jobs
+            SET state=FINISHED, result=:result, finished_at=…, meta=…, …
+            WHERE id=:job_id AND locked_by=:pod_id AND state=RUNNING
+            RETURNING id
+
+        Returns:
+            True  — the row was ours and we wrote FINISHED (rowcount==1).
+            False — we were preempted between handler completion and this
+                    write (rowcount==0).  The caller must NOT retry, must
+                    NOT re-raise, and must let the new owner close the row.
+
+        Atomicity:
+            ``locked_by == pod_id AND state == RUNNING`` makes meta-merge
+            safe: only the lock owner can write meta while it holds the
+            lock, so SELECT-then-merge-then-UPDATE-with-CAS has no TOCTOU
+            window for the same row.
+
+        Idempotent ``finished_at`` (Plan 310-C observability): use
+            ``coalesce(finished_at, now())`` — matches the ``started_at``
+            pattern in ``claim_job`` (the CAS UPDATE has no Python read step
+            we could guard with an ``IS NULL`` check, so the coalesce keeps
+            an already-stamped timestamp intact).
+
+        Optional kwargs (``status_message``, ``metadata``) match the
+        ``update_ingestion_job`` shape so the runner can swap call sites
+        without losing fields.  When omitted, those columns are not
+        touched (we don't NULL them out).
+        """
+        # Pre-read meta so we can merge with any new metadata.  Safe under
+        # the WHERE-CAS: if we're preempted between this read and the
+        # UPDATE, the UPDATE matches no row, the merged dict is dropped,
+        # and the new owner's eventual finish_job writes its own meta.
+        values: dict = {
+            "state": IngestionState.FINISHED,
+            "result": result,
+            "finished_at": func.coalesce(
+                col(DataIngestionJob.finished_at), func.now()
+            ),
+        }
+        if status_message is not None:
+            values["status_message"] = status_message
+
+        if metadata is not None:
+            existing = await self.session.execute(
+                select(DataIngestionJob.meta).where(
+                    col(DataIngestionJob.id) == job_id,
+                    col(DataIngestionJob.locked_by) == pod_id,
+                    col(DataIngestionJob.state) == IngestionState.RUNNING,
+                )
+            )
+            existing_meta = existing.scalar_one_or_none() or {}
+            merged_meta = {
+                **self.sanitize_for_json(existing_meta),
+                **self.sanitize_for_json(metadata),
+                "completed_at": datetime.now(timezone.utc).isoformat(),
+            }
+            values["meta"] = merged_meta
+
+        result_obj = await self.session.execute(
+            update(DataIngestionJob)
+            .where(
+                col(DataIngestionJob.id) == job_id,
+                col(DataIngestionJob.locked_by) == pod_id,
+                col(DataIngestionJob.state) == IngestionState.RUNNING,
+            )
+            .values(**values)
+            .returning(col(DataIngestionJob.id))
+        )
+        updated_id = result_obj.scalar_one_or_none()
+        await self.session.commit()
+        return updated_id is not None
+
     async def heartbeat(self, job_id: int, pod_id: str) -> int:
         """Refresh ``locked_at`` on a RUNNING job we still own.
 

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -11,7 +11,7 @@ Why a single dispatcher:
   pod-safety guarantees from Plan 310-A (atomic state→RUNNING +
   attempts++ + locked_by + ``started_at`` stamping) apply uniformly.
 - **One observability path** — every job ends with the same
-  ``update_ingestion_job(state=FINISHED, …)`` call, which auto-stamps
+  ``finish_job(...)`` CAS call (B-C1), which auto-stamps
   ``finished_at`` (Plan 310-C observability columns).  Dashboard
   queries that rely on ``finished_at IS NOT NULL`` see every job.
 - **One preemption-safety story** — the heartbeat + worker-side
@@ -38,7 +38,6 @@ from app.core.logging import get_logger
 from app.db import SessionLocal
 from app.models.data_ingestion import (
     IngestionResult,
-    IngestionState,
 )
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.tasks._pod_id import POD_ID
@@ -68,11 +67,14 @@ async def run_job(job_id: int) -> None:
          ``locked_by`` no longer equals our pod, roll back the
          data_session and exit without state-changing the job (the
          new owner will).
-      7. Commit data_session, update_ingestion_job to
-         FINISHED+SUCCESS (or FINISHED+ERROR on handler raise).
-      8. ``update_ingestion_job`` with state=FINISHED auto-stamps
-         ``finished_at`` (Plan 310-C observability), so the dashboard
-         duration query (finished_at - started_at) closes cleanly.
+      7. Commit data_session, ``finish_job`` (atomic CAS on
+         ``locked_by`` + ``state=RUNNING``) to FINISHED+SUCCESS
+         (or FINISHED+ERROR on handler raise).  CAS no-op return
+         means a stale-lock sweep preempted us between step 6 and
+         step 7 — log+exit, the new owner will close the row.
+      8. ``finish_job`` stamps ``finished_at`` via ``coalesce``
+         (Plan 310-C observability), so the dashboard duration
+         query (finished_at - started_at) closes cleanly.
       9. Cancel heartbeat task in ``finally``.
 
     Errors raised by the handler are caught and persisted as
@@ -178,14 +180,26 @@ async def run_job(job_id: int) -> None:
                 await data_session.commit()
             else:
                 await data_session.rollback()
-            await repo.update_ingestion_job(
+            # Plan 310 review finding B-C1: the FINISHED write must be a
+            # compare-and-set on ``(locked_by=POD_ID AND state=RUNNING)``,
+            # not a blind UPDATE.  The pre-handler preempt-check at line
+            # 166 catches the common case, but a stale-lock sweep between
+            # that check and the UPDATE below would otherwise let this
+            # pod clobber the new owner's RUNNING row with our FINISHED
+            # write.  ``finish_job`` returns False in that race; we log
+            # and exit cleanly so the new owner can close the row.
+            wrote = await repo.finish_job(
                 job_id,
+                POD_ID,
+                result=result,
                 status_message=status_message,
                 metadata=metadata,
-                state=IngestionState.FINISHED,
-                result=result,
             )
-            await job_session.commit()
+            if not wrote:
+                logger.warning(
+                    "preempted before FINISHED write: job_id=%s", job_id
+                )
+                return
         finally:
             heartbeat_task.cancel()
             try:

--- a/backend/tests/integration/services/data_ingestion/test_pod_safety_310a_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_pod_safety_310a_pg.py
@@ -22,6 +22,7 @@ from app.models.data_ingestion import (
     DataIngestionJob,
     EntityType,
     IngestionMethod,
+    IngestionResult,
     IngestionState,
     TargetType,
 )
@@ -216,3 +217,143 @@ async def test_claim_demotes_finished_sibling(pg_dsn):
         assert candidate_after.locked_by == "pod-B"
         assert candidate_after.attempts == 1
     await verify_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_finish_job_no_op_after_preemption(pg_dsn):
+    """Plan 310 review **B-C1** regression — ``finish_job`` must be a CAS
+    on ``(locked_by, state=RUNNING)`` so a pod whose heartbeat failed
+    cannot clobber the new owner's RUNNING row after the safety sweep
+    recovered it.
+
+    Sequence simulated:
+      1. Pod-A claims the job (state=RUNNING, locked_by=pod-A, attempts=1).
+      2. DB hiccup: pod-A's lock goes stale (we backdate ``locked_at``).
+      3. Sweep on the safety poller calls ``recover_job`` → resets to
+         NOT_STARTED, clears ``locked_by``.
+      4. Pod-B claims (state=RUNNING, locked_by=pod-B, attempts=2).
+      5. Pod-A's handler finally returns and calls ``finish_job(pod-A)``
+         → must return False, must NOT touch the row.
+      6. Verify pod-B's RUNNING state, ``locked_by``, and ``attempts`` are
+         intact, and the row's ``result`` / ``finished_at`` are still NULL.
+    """
+    # Seed one pending job.
+    seed_engine = create_async_engine(pg_dsn, future=True)
+    Sseed = async_sessionmaker(seed_engine, class_=AsyncSession, expire_on_commit=False)
+    async with Sseed() as s:
+        job = _make_pending_job()
+        s.add(job)
+        await s.commit()
+        assert job.id is not None
+        job_id: int = job.id
+    await seed_engine.dispose()
+
+    # Pod-A claims the row.
+    engine_a = create_async_engine(pg_dsn, future=True)
+    Sa = async_sessionmaker(engine_a, class_=AsyncSession, expire_on_commit=False)
+    async with Sa() as session_a:
+        claimed_by_a = await DataIngestionRepository(session_a).claim_job(
+            job_id, "pod-A"
+        )
+    assert claimed_by_a is True
+
+    # Simulate: pod-A's heartbeat fails for long enough that the safety
+    # sweep classifies the row as stale.  Backdate ``locked_at`` past the
+    # ``stale_timeout_minutes`` cutoff used by ``recover_job``.
+    from sqlalchemy import text
+
+    stale_engine = create_async_engine(pg_dsn, future=True)
+    async with stale_engine.begin() as conn:
+        await conn.execute(
+            text(
+                "UPDATE data_ingestion_jobs "
+                "SET locked_at = now() - interval '2 hours' "
+                "WHERE id = :id"
+            ),
+            {"id": job_id},
+        )
+    await stale_engine.dispose()
+
+    # Sweep recovers the row.  ``recover_job`` resets to NOT_STARTED and
+    # clears ``locked_by``.  ``stale_timeout_minutes=1`` makes our 2h
+    # backdate stale by a wide margin.
+    sweep_engine = create_async_engine(pg_dsn, future=True)
+    Ss = async_sessionmaker(sweep_engine, class_=AsyncSession, expire_on_commit=False)
+    async with Ss() as session_s:
+        recovered = await DataIngestionRepository(session_s).recover_job(
+            job_id, stale_timeout_minutes=1
+        )
+    await sweep_engine.dispose()
+    assert recovered is not None
+
+    # Pod-B claims the recovered row.
+    engine_b = create_async_engine(pg_dsn, future=True)
+    Sb = async_sessionmaker(engine_b, class_=AsyncSession, expire_on_commit=False)
+    async with Sb() as session_b:
+        claimed_by_b = await DataIngestionRepository(session_b).claim_job(
+            job_id, "pod-B"
+        )
+    assert claimed_by_b is True
+
+    # Pod-A's handler returns LATE — its FINISHED write must be a no-op.
+    async with Sa() as session_a:
+        wrote_a = await DataIngestionRepository(session_a).finish_job(
+            job_id,
+            "pod-A",
+            result=IngestionResult.SUCCESS,
+            status_message="pod-A finished (should be ignored)",
+            metadata={"pod_a_marker": True},
+        )
+    await engine_a.dispose()
+    assert wrote_a is False, (
+        "finish_job from preempted pod-A must return False (CAS no-op)"
+    )
+
+    # Verify pod-B still owns the RUNNING row.
+    verify_engine = create_async_engine(pg_dsn, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    async with Vf() as session_v:
+        repo = DataIngestionRepository(session_v)
+        after = await repo.get_job_by_id(job_id)
+        assert after is not None
+        # Pod-B is the owner; pod-A's late write did not touch the row.
+        assert after.state == IngestionState.RUNNING
+        assert after.locked_by == "pod-B"
+        # ``recover_job`` resets attempts to 0 (manual-recovery contract,
+        # distinct from the safety-sweep path which preserves attempts).
+        # Pod-B's subsequent claim then increments by 1 → attempts == 1.
+        # The point of the assertion is "this is pod-B's lifecycle, not
+        # pod-A's stale lifecycle" — pod-A's late finish_job did not
+        # touch this row.
+        assert after.attempts == 1
+        # No terminal fields written — pod-A's clobber was rejected.
+        assert after.result is None
+        assert after.finished_at is None
+        # Pod-A's metadata marker did not land.
+        assert "pod_a_marker" not in (after.meta or {})
+    await verify_engine.dispose()
+    await engine_b.dispose()
+
+    # Pod-B's own finish_job still works and writes the terminal row.
+    finalize_engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(
+        finalize_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with Sf() as session_f:
+        wrote_b = await DataIngestionRepository(session_f).finish_job(
+            job_id,
+            "pod-B",
+            result=IngestionResult.SUCCESS,
+            status_message="pod-B finished",
+            metadata={"pod_b_marker": True},
+        )
+    assert wrote_b is True
+
+    async with Sf() as session_f:
+        final = await DataIngestionRepository(session_f).get_job_by_id(job_id)
+        assert final is not None
+        assert final.state == IngestionState.FINISHED
+        assert final.result == IngestionResult.SUCCESS
+        assert final.finished_at is not None
+        assert (final.meta or {}).get("pod_b_marker") is True
+    await finalize_engine.dispose()

--- a/backend/tests/unit/tasks/test_runner.py
+++ b/backend/tests/unit/tasks/test_runner.py
@@ -18,7 +18,6 @@ import pytest
 
 from app.models.data_ingestion import (
     IngestionResult,
-    IngestionState,
 )
 from app.tasks import runner as runner_mod
 from app.tasks.registry import _REGISTRY, register
@@ -58,6 +57,10 @@ def _make_repo_returning(job: MagicMock | None) -> MagicMock:
     repo.get_job_by_id = AsyncMock(return_value=job)
     repo.claim_job = AsyncMock(return_value=True)
     repo.update_ingestion_job = AsyncMock(return_value=job)
+    # B-C1: terminal write goes through ``finish_job`` (CAS on locked_by +
+    # state=RUNNING).  Returns True on rowcount==1, False if the row was
+    # preempted between the runner's pre-write check and the UPDATE.
+    repo.finish_job = AsyncMock(return_value=True)
     repo.create_ingestion_job = AsyncMock(side_effect=lambda j: j)
     repo.heartbeat = AsyncMock(return_value=1)
     return repo
@@ -152,6 +155,7 @@ async def test_run_job_claim_fails_returns_silently():
         await runner_mod.run_job(1)
 
     handler.assert_not_called()
+    repo.finish_job.assert_not_called()
     repo.update_ingestion_job.assert_not_called()
 
 
@@ -180,9 +184,11 @@ async def test_run_job_success_commits_and_marks_finished_success():
         await runner_mod.run_job(1)
 
     repo.claim_job.assert_awaited_once()
-    repo.update_ingestion_job.assert_awaited_once()
-    args, kwargs = repo.update_ingestion_job.call_args
-    assert kwargs["state"] == IngestionState.FINISHED
+    repo.finish_job.assert_awaited_once()
+    args, kwargs = repo.finish_job.call_args
+    # finish_job(job_id, pod_id, result=..., status_message=..., metadata=...)
+    assert args[0] == 1  # job_id
+    assert args[1] == runner_mod.POD_ID
     assert kwargs["result"] == IngestionResult.SUCCESS
     assert kwargs["status_message"] == "all good"
 
@@ -224,9 +230,9 @@ async def test_run_job_handler_raises_marks_finished_error_and_rolls_back():
     job_session, data_session = captured_sessions
     data_session.rollback.assert_awaited()
 
-    repo.update_ingestion_job.assert_awaited_once()
-    _, kwargs = repo.update_ingestion_job.call_args
-    assert kwargs["state"] == IngestionState.FINISHED
+    repo.finish_job.assert_awaited_once()
+    args, kwargs = repo.finish_job.call_args
+    assert args[1] == runner_mod.POD_ID
     assert kwargs["result"] == IngestionResult.ERROR
     assert "boom" in kwargs["status_message"]
 
@@ -279,6 +285,7 @@ async def test_run_job_preempted_rolls_back_and_skips_state_update():
     _, data_session = captured_sessions
     data_session.rollback.assert_awaited()
     repo.update_ingestion_job.assert_not_called()
+    repo.finish_job.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -303,6 +310,7 @@ async def test_run_job_preempted_to_deleted_rolls_back():
         await runner_mod.run_job(1)
 
     repo.update_ingestion_job.assert_not_called()
+    repo.finish_job.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -353,6 +361,7 @@ async def test_run_job_handler_raise_with_preemption_skips_state_update():
     # Critical: the FINISHED+ERROR write must NOT fire when we no
     # longer own the row, even though the handler raised.
     repo.update_ingestion_job.assert_not_called()
+    repo.finish_job.assert_not_called()
 
 
 # chain_job tests live in ``test_chain.py``.


### PR DESCRIPTION
## Summary

Lands review finding **B-C1** from `docs/code-review/310-overall-review.md`: the FINISHED-write path in `update_ingestion_job` was a `SELECT ... WHERE id` → mutate, with **no** `WHERE locked_by AND state=RUNNING` guard. A pod whose heartbeat failed during a DB outage could complete its handler AFTER another pod recovered the row and re-claimed it; its FINISHED write then clobbered the new owner's RUNNING state.

## Changes

- `backend/app/repositories/data_ingestion.py` — new `finish_job(job_id, pod_id, result, status_message=None, metadata=None) -> bool`. Atomic `UPDATE ... WHERE id AND locked_by=:pod_id AND state=RUNNING RETURNING id`. Auto-stamps `finished_at` via `coalesce` (matches `claim_job`'s `started_at` pattern). Merges `meta` under the CAS guard (only the lock owner can write `meta`, so SELECT-then-merge-then-UPDATE is TOCTOU-safe). Commits internally (matches `heartbeat`/`claim_job` precedent). Returns `True` on rowcount==1, `False` on rowcount==0 (preempted).
- `backend/app/tasks/runner.py` — replace the FINISHED-write path with `finish_job(job_id, POD_ID, result=..., status_message=..., metadata=...)`. On `False`: `logger.warning("preempted before FINISHED write: ...")` and exit cleanly without re-raising. The pre-handler preempt-check at line 166 is **kept** — `finish_job`'s CAS is the tail-safety net for the narrow window between that check and the UPDATE.
- `backend/tests/integration/services/data_ingestion/test_pod_safety_310a_pg.py` — new `test_finish_job_no_op_after_preemption` simulates the exact race: pod-A claims, heartbeat hiccup, sweep recovers, pod-B claims, pod-A's `finish_job` returns False, pod-B's row is untouched (still RUNNING, `locked_by=pod-B`, `result is None`, `finished_at is None`, no `pod_a_marker` leak in `meta`). Also asserts pod-B's own `finish_job` then closes the row normally.
- `backend/tests/unit/tasks/test_runner.py` — mock-repo updated to include `finish_job`; success/error assertions migrated from `repo.update_ingestion_job` to `repo.finish_job`; preemption tests assert `not_called` on both methods.

## Scope notes

- `update_ingestion_job` is **unchanged** for non-terminal status updates. Other callers (`unit_sync_tasks`, `emission_recalculation_tasks`, `base_provider`) only ever pass `state in {None, RUNNING, ...}` for in-progress messages, or — in `base_provider`'s legacy path — a FINISHED state outside the runner. Those paths are out of scope for this unit and may be addressed by other workers.

## Test plan

- [x] Unit tests — `rtk uv run pytest backend/tests/unit/` (1288 passed)
- [x] Integration tests — `rtk uv run pytest backend/tests/integration/services/data_ingestion/` (79 passed, including the new `test_finish_job_no_op_after_preemption`)
- [x] Lint — `rtk uv run ruff check backend/app/ backend/tests/` (clean)