### PR TITLE
feat(310): chain_job DedupConfig + emission_recalc dedup [#1064]

### DIFF
--- a/backend/alembic/versions/2026_05_07_1432-f8a9b1c2d3e4_emission_recalc_dedup_index.py
+++ b/backend/alembic/versions/2026_05_07_1432-f8a9b1c2d3e4_emission_recalc_dedup_index.py
@@ -1,0 +1,94 @@
+# codeql[py/unused-global-variable]
+"""emission_recalc dedup-active partial unique index
+
+Revision ID: f8a9b1c2d3e4
+Revises: e7f1a2b3c4d5
+Create Date: 2026-05-07 14:32:00.000000
+
+Plan 310-D / #1064 — partial unique index that prevents redundant
+``emission_recalc`` jobs being created when ``factor_ingest`` fan-out
+chains ``emission_recalc`` children for the same
+``(module_type_id, data_entry_type_id, year)`` scope back-to-back.
+
+Generalises the dedup pattern introduced for ``aggregation`` in
+``e7f1a2b3c4d5`` to a second job type.  The dedup contract lives in
+``app.tasks._chain.DedupConfig`` so additional consumers can opt in
+with one new ``DedupConfig`` instance + one matching partial index
+migration.
+
+The WHERE clause covers every non-terminal state (``NOT_STARTED``,
+``QUEUED``, ``RUNNING``) so dedup applies for the entire window
+between "we want one" and "the work is done".  ``FINISHED`` rows
+are excluded so historical recalcs don't block future ones for the
+same scope (each fan-out batch gets its own recalc; subsequent
+batches are not blocked by completed history).
+
+The scope keys are required NOT NULL in the partial WHERE — Postgres
+treats NULLs as distinct in unique indexes by default, so an index
+without those guards would silently allow duplicates whenever any
+key was NULL.  The matching ``chain_job`` entry validation refuses
+NULL scope values for any ``DedupConfig`` so prod paths can't reach
+the index with NULLs anyway, but the guard keeps the index correct
+in isolation.
+
+State values use native PG enum labels because the column is
+``SAEnum(IngestionState, name='ingestion_state_enum',
+native_enum=True)``; mirrors the existing ``uq_aggregation_active``
+and ``ix_data_ingestion_jobs_pending`` partial-index style.
+
+Uses ``CREATE UNIQUE INDEX CONCURRENTLY`` inside an autocommit_block
+so the migration cannot block writers on ``data_ingestion_jobs``
+while it runs.  The aggregation index migration was created on a
+fresh table and didn't need this; the emission_recalc index lands
+on a table that's already hot in dev/staging environments.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "f8a9b1c2d3e4"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "e7f1a2b3c4d5"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+_INDEX_NAME = "uq_emission_recalc_active"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # CONCURRENTLY cannot run inside a transaction; autocommit_block
+    # detaches the connection from Alembic's per-migration transaction
+    # for the duration of this statement.  Equivalent to running this
+    # migration with transaction_per_migration=False, but scoped.
+    with op.get_context().autocommit_block():
+        op.execute(
+            f"""
+            CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME}
+              ON data_ingestion_jobs (module_type_id, data_entry_type_id, year)
+              WHERE job_type = 'emission_recalc'
+                AND state IN (
+                    'NOT_STARTED'::ingestion_state_enum,
+                    'QUEUED'::ingestion_state_enum,
+                    'RUNNING'::ingestion_state_enum
+                )
+                AND module_type_id IS NOT NULL
+                AND data_entry_type_id IS NOT NULL
+                AND year IS NOT NULL
+            """
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -170,6 +170,18 @@ async def chain_job(
     # downstream handler would then choke on the missing scope.
     # Refuse at chain_job entry instead.
     if dedup_config is not None:
+        # Misconfiguration guard: a caller that passes ``job_type='X'``
+        # alongside ``dedup_config=Y_DEDUP`` would have the pre-check
+        # query Y while the INSERT writes X — silently disabling dedup
+        # and confusing future readers of the partial unique index.
+        # Refuse loudly at the entry instead.
+        if job_type != dedup_config.job_type:
+            raise ValueError(
+                f"chain_job: job_type={job_type!r} does not match "
+                f"dedup_config.job_type={dedup_config.job_type!r}.  "
+                "Use the matching DedupConfig (or pass dedup_config=None)."
+            )
+
         scope_values = {
             "module_type_id": resolved_module_type_id,
             "data_entry_type_id": data_entry_type_id,
@@ -397,15 +409,16 @@ async def _insert_child_with_dedup(
                 "meta": meta_json,
             },
         )
-    except IntegrityError:
-        # A concurrent INSERT-then-COMMIT can race past the pre-check
-        # above (two pods chaining the same scope at the same time);
-        # the partial unique index trips and raises IntegrityError.
-        # Surface as a clean dedup signal rather than letting it
-        # bubble — the existing pending row will run, our caller
-        # treats None as "no-op".  Log at INFO so prod can distinguish
-        # race-loss from pre-check-loss (the pre-check path also logs
-        # at INFO with a different phrasing in ``chain_job`` itself).
+    except IntegrityError as exc:
+        # Narrow the catch to the configured partial unique index.
+        # A blanket catch would swallow unrelated NOT NULL / FK / enum
+        # violations and silently skip dispatching the chained child —
+        # treat anything other than the expected dedup constraint as a
+        # real bug worth bubbling up.
+        msg = str(getattr(exc.orig, "diag", None) or exc).lower()
+        if dedup_config.constraint_name.lower() not in msg:
+            await session.rollback()
+            raise
         logger.info(
             f"chain_job(dedup): {job_type!r} for "
             f"module={module_type_id}/det={data_entry_type_id}/year={year} "

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -24,6 +24,8 @@ contract narrow (parent + child shape + dispatch).
 """
 
 import json
+import warnings
+from dataclasses import dataclass
 from typing import Optional
 from uuid import uuid4
 
@@ -45,6 +47,37 @@ from app.tasks._background import fire_and_forget
 logger = get_logger(__name__)
 
 
+@dataclass(frozen=True)
+class DedupConfig:
+    """Per-job-type dedup contract for ``chain_job``.
+
+    ``scope_columns`` are the row columns that define the unique scope
+    (the partial unique index covers exactly these columns); they must
+    all be non-NULL on the child row.  ``constraint_name`` matches the
+    Postgres index name so a race-loss ``IntegrityError`` is logged
+    with the right context.  ``job_type`` filters the pre-check so a
+    different job type for the same scope can coexist with us.
+    """
+
+    job_type: str
+    scope_columns: tuple[str, ...]
+    constraint_name: str
+
+
+AGGREGATION_DEDUP = DedupConfig(
+    job_type="aggregation",
+    scope_columns=("module_type_id", "year"),
+    constraint_name="uq_aggregation_active",
+)
+
+
+EMISSION_RECALC_DEDUP = DedupConfig(
+    job_type="emission_recalc",
+    scope_columns=("module_type_id", "data_entry_type_id", "year"),
+    constraint_name="uq_emission_recalc_active",
+)
+
+
 async def chain_job(
     parent: DataIngestionJob,
     *,
@@ -57,7 +90,8 @@ async def chain_job(
     target_type: TargetType = TargetType.DATA_ENTRIES,
     ingestion_method: IngestionMethod = IngestionMethod.computed,
     entity_type: EntityType = EntityType.MODULE_PER_YEAR,
-    dedup_active: bool = False,
+    dedup_config: Optional[DedupConfig] = None,
+    dedup_active: Optional[bool] = None,
 ) -> Optional[int]:
     """Create a child job and fire it through ``run_job``.
 
@@ -84,25 +118,37 @@ async def chain_job(
     different UUID and the child would be orphaned from the parent's
     run.
 
-    ``dedup_active=True`` (Plan 310-D): pre-check for an active
-    aggregation row in the ``(module_type_id, year)`` scope and INSERT
-    only when none exists — caller must pass non-NULL scope keys
-    (``ValueError`` is raised otherwise; see the guard above).  The
+    ``dedup_config`` (Plan 310-D, generalised by #1064): pre-check
+    for an active row in the configured ``scope_columns`` and INSERT
+    only when none exists — caller must pass non-NULL values for
+    every scope column (``ValueError`` is raised otherwise).  The
     pre-check covers the common case (sequential chains within the
     same fan-out batch on the same connection); a concurrent writer
-    that wins the race trips the partial unique index
-    ``uq_aggregation_active`` (which covers only NOT_STARTED/QUEUED/
+    that wins the race trips the matching partial unique index
+    (``constraint_name``, which covers only NOT_STARTED/QUEUED/
     RUNNING rows) and the ``IntegrityError`` is caught and surfaced
     as the same dedup signal.  Returns ``None`` on dedup so the
     caller knows it's a no-op and skips its own follow-up fan-out;
     returns the new child id otherwise.
 
-    Currently aggregation-specific: the SQL hard-codes
-    ``job_type='aggregation'`` and the dedup index is named for it.
-    Generalising to other dedupable handlers (e.g. progress-bar
-    refresh) would require both a per-type partial unique index and
-    parameterising the pre-check's job_type filter — out of scope here.
+    ``dedup_active=True`` is a deprecated shim mapping to
+    ``AGGREGATION_DEDUP`` for one release cycle; new callers should
+    pass ``dedup_config=AGGREGATION_DEDUP`` directly.
     """
+    if dedup_active is not None:
+        # Deprecation shim — kept for one release cycle so callers
+        # outside this PR's diff (and any unmerged branches) keep
+        # compiling.  Maps boolean True to the original behaviour
+        # (aggregation dedup); False is the no-dedup default.
+        warnings.warn(
+            "chain_job(dedup_active=...) is deprecated; pass "
+            "dedup_config=AGGREGATION_DEDUP (or another DedupConfig) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if dedup_active and dedup_config is None:
+            dedup_config = AGGREGATION_DEDUP
+
     repo = DataIngestionRepository(session)
 
     pipeline_id = parent.pipeline_id
@@ -117,25 +163,30 @@ async def chain_job(
     )
     resolved_year = year if year is not None else parent.year
 
-    # Plan 310-D — fail fast when caller asks for dedup but the scope
-    # keys are NULL.  The pre-check SQL already handles ``year IS NULL``
-    # via ``(:year IS NULL AND year IS NULL)`` but ``module_type_id``
-    # uses straight equality — a NULL there silently bypasses dedup
-    # because ``NULL = NULL`` yields NULL, the SELECT returns nothing,
-    # and the partial unique index can't catch the duplicate either
-    # (PG treats NULLs as distinct in unique indexes by default).  The
-    # downstream aggregation handler raises on NULL scope at execution
-    # time, so prod won't run garbage either way — but bad rows pile
-    # up.  Refuse at chain_job entry instead.
-    if dedup_active and (resolved_module_type_id is None or resolved_year is None):
-        raise ValueError(
-            f"chain_job(dedup_active=True): scope keys must be set — "
-            f"got module_type_id={resolved_module_type_id!r}, "
-            f"year={resolved_year!r}.  Pass them explicitly or ensure "
-            f"the parent job has them populated."
-        )
+    # Plan 310-D — fail fast when caller asks for dedup but any scope
+    # key is NULL.  PG treats NULLs as distinct in unique indexes by
+    # default (and our partial WHERE filters NOT NULL only), so a NULL
+    # would silently bypass dedup at the index level and the
+    # downstream handler would then choke on the missing scope.
+    # Refuse at chain_job entry instead.
+    if dedup_config is not None:
+        scope_values = {
+            "module_type_id": resolved_module_type_id,
+            "data_entry_type_id": data_entry_type_id,
+            "year": resolved_year,
+        }
+        missing = [
+            col for col in dedup_config.scope_columns if scope_values.get(col) is None
+        ]
+        if missing:
+            raise ValueError(
+                f"chain_job(dedup_config={dedup_config.job_type!r}): "
+                f"scope keys must be set — missing {missing}; "
+                f"got {scope_values}.  Pass them explicitly or ensure "
+                f"the parent job has them populated."
+            )
 
-    if dedup_active:
+    if dedup_config is not None:
         child_id = await _insert_child_with_dedup(
             session=session,
             parent=parent,
@@ -148,6 +199,7 @@ async def chain_job(
             ingestion_method=ingestion_method,
             entity_type=entity_type,
             config=config,
+            dedup_config=dedup_config,
         )
         if child_id is None:
             # Dedup hit — an active child already exists for this
@@ -155,7 +207,8 @@ async def chain_job(
             # fan out further" so we don't double-dispatch the
             # work the existing pending row will do.
             logger.info(
-                f"chain_job(dedup): {job_type!r} for module={resolved_module_type_id}/"
+                f"chain_job(dedup): {job_type!r} for "
+                f"module={resolved_module_type_id}/det={data_entry_type_id}/"
                 f"year={resolved_year} already pending — skipped"
             )
             return None
@@ -183,7 +236,7 @@ async def chain_job(
 
     if child_id is None:
         # Two paths can land here:
-        #   1. ``dedup_active=True`` already returned ``None`` above —
+        #   1. ``dedup_config`` already returned ``None`` above —
         #      we never reach this branch in that case (early return).
         #   2. The ORM insert path got a row back without an id (a
         #      real driver bug), or the dedup INSERT's RETURNING
@@ -224,24 +277,25 @@ async def _insert_child_with_dedup(
     ingestion_method: IngestionMethod,
     entity_type: EntityType,
     config: Optional[dict],
+    dedup_config: DedupConfig,
 ) -> Optional[int]:
     """Pre-check + INSERT, falling back to IntegrityError on race.
 
     Returns the new child id on success, or ``None`` when the partial
-    unique index ``uq_aggregation_active`` already covers an active
-    (NOT_STARTED/QUEUED/RUNNING) row for the same ``(module_type_id,
-    year, job_type='aggregation')`` scope.
+    unique index named by ``dedup_config.constraint_name`` already
+    covers an active (NOT_STARTED/QUEUED/RUNNING) row for the same
+    scope.
 
     Why pre-check + INSERT rather than ``INSERT ... ON CONFLICT DO
     NOTHING``: PG's ON CONFLICT inference for partial indexes
     requires the inferred predicate to imply the index's WHERE
     clause, and the implied-by check stumbles on nullable columns
-    (``module_type_id``/``year`` are nullable on the table even
-    though our partial WHERE filters NOT NULL only).  The pre-check
-    handles the common case (sequential chains within the same
-    fan-out batch on the same connection); the ``IntegrityError``
-    catch covers the genuine concurrent race so the first writer
-    wins regardless of interleaving.
+    (the scope columns are nullable on the table even though our
+    partial WHERE filters NOT NULL only).  The pre-check handles
+    the common case (sequential chains within the same fan-out
+    batch on the same connection); the ``IntegrityError`` catch
+    covers the genuine concurrent race so the first writer wins
+    regardless of interleaving.
 
     Implemented as raw SQL because SQLModel's ORM-level insert path
     doesn't expose the ON CONFLICT clause cleanly for partial indexes.
@@ -257,13 +311,28 @@ async def _insert_child_with_dedup(
     pipeline_id_str = str(pipeline_id) if pipeline_id is not None else None
     meta_json = json.dumps({"config": config or {}, "parent_job_id": parent.id})
 
+    # The chain_job entry guard already rejected NULL scope values,
+    # so simple equality is sufficient here — no ``(:col IS NULL AND
+    # col IS NULL)`` branch needed.
+    scope_param_map = {
+        "module_type_id": module_type_id,
+        "data_entry_type_id": data_entry_type_id,
+        "year": year,
+    }
+    scope_predicate = " AND ".join(
+        f"{col} = :{col}" for col in dedup_config.scope_columns
+    )
+    pre_check_params = {
+        col: scope_param_map[col] for col in dedup_config.scope_columns
+    }
+    pre_check_params["job_type"] = dedup_config.job_type
+
     pre_check = text(
-        """
+        f"""
         SELECT 1
         FROM data_ingestion_jobs
-        WHERE job_type = 'aggregation'
-          AND module_type_id = :module_type_id
-          AND (year = :year OR (:year IS NULL AND year IS NULL))
+        WHERE job_type = :job_type
+          AND {scope_predicate}
           AND state IN (
               'NOT_STARTED'::ingestion_state_enum,
               'QUEUED'::ingestion_state_enum,
@@ -272,10 +341,7 @@ async def _insert_child_with_dedup(
         LIMIT 1
         """
     )
-    existing = await session.execute(
-        pre_check,
-        {"module_type_id": module_type_id, "year": year},
-    )
+    existing = await session.execute(pre_check, pre_check_params)
     if existing.first() is not None:
         # Active row already pending — caller treats None as "no-op".
         return None
@@ -334,17 +400,17 @@ async def _insert_child_with_dedup(
     except IntegrityError:
         # A concurrent INSERT-then-COMMIT can race past the pre-check
         # above (two pods chaining the same scope at the same time);
-        # the partial unique index ``uq_aggregation_active`` trips and
-        # raises IntegrityError.  Surface as a clean dedup signal
-        # rather than letting it bubble — the existing pending row
-        # will run, our caller treats None as "no-op".  Log at INFO
-        # so prod can distinguish race-loss from pre-check-loss
-        # (the pre-check path also logs at INFO with a different
-        # phrasing in ``chain_job`` itself).
+        # the partial unique index trips and raises IntegrityError.
+        # Surface as a clean dedup signal rather than letting it
+        # bubble — the existing pending row will run, our caller
+        # treats None as "no-op".  Log at INFO so prod can distinguish
+        # race-loss from pre-check-loss (the pre-check path also logs
+        # at INFO with a different phrasing in ``chain_job`` itself).
         logger.info(
-            f"chain_job(dedup): {job_type!r} for module={module_type_id}/"
-            f"year={year} lost partial-unique-index race — sibling owns "
-            "the aggregation row"
+            f"chain_job(dedup): {job_type!r} for "
+            f"module={module_type_id}/det={data_entry_type_id}/year={year} "
+            f"lost partial-unique-index race ({dedup_config.constraint_name})"
+            " — sibling owns the row"
         )
         await session.rollback()
         return None
@@ -356,8 +422,9 @@ async def _insert_child_with_dedup(
     # paths), so a None here would be a real driver bug — surface it.
     if row is None:
         logger.error(
-            f"chain_job(dedup): {job_type!r} for module={module_type_id}/"
-            f"year={year} — INSERT RETURNING yielded no row despite no "
+            f"chain_job(dedup): {job_type!r} for "
+            f"module={module_type_id}/det={data_entry_type_id}/year={year} "
+            "— INSERT RETURNING yielded no row despite no "
             "IntegrityError; treating as dedup hit but please investigate"
         )
         return None

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -25,7 +25,7 @@ from app.models.data_ingestion import (
     TargetType,
 )
 from app.repositories.data_ingestion import DataIngestionRepository
-from app.tasks._chain import chain_job
+from app.tasks._chain import AGGREGATION_DEDUP, chain_job
 from app.tasks.registry import register
 from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
 
@@ -89,17 +89,17 @@ async def emission_recalc_handler(
 
     # Plan 310-D — chain the aggregation handler instead of calling
     # ``recompute_stats`` inline (the workflow no longer does it
-    # either).  ``dedup_active=True`` collapses N concurrent
-    # aggregation jobs for the same (module, year) into one — when
-    # ``factor_ingest`` fans out N ``emission_recalc`` children, each
-    # would otherwise queue its own follow-up aggregation.  The
-    # partial unique index ``uq_aggregation_active`` covers
-    # NOT_STARTED/QUEUED/RUNNING rows so the first child wins and the
-    # rest skip; the aggregation runs once after the fan-out (or
-    # while later siblings are still finishing — it reads the current
-    # snapshot of ``data_entry_emissions`` and produces correct stats
-    # for that snapshot, with the dedup window reopening on
-    # FINISHED).
+    # either).  ``dedup_config=AGGREGATION_DEDUP`` collapses N
+    # concurrent aggregation jobs for the same (module, year) into
+    # one — when ``factor_ingest`` fans out N ``emission_recalc``
+    # children, each would otherwise queue its own follow-up
+    # aggregation.  The partial unique index ``uq_aggregation_active``
+    # covers NOT_STARTED/QUEUED/RUNNING rows so the first child wins
+    # and the rest skip; the aggregation runs once after the fan-out
+    # (or while later siblings are still finishing — it reads the
+    # current snapshot of ``data_entry_emissions`` and produces
+    # correct stats for that snapshot, with the dedup window reopening
+    # on FINISHED).
     #
     # Skip when ``module_type_id`` is missing — every endpoint pins
     # it for emission_recalc, but a defensive log + skip is safer
@@ -114,7 +114,7 @@ async def emission_recalc_handler(
             module_type_id=job.module_type_id,
             year=job.year,
             session=job_session,
-            dedup_active=True,
+            dedup_config=AGGREGATION_DEDUP,
         )
     elif job.module_type_id is None:
         logger.warning(
@@ -235,8 +235,8 @@ async def module_emission_recalc_handler(
     # Plan 310-D — chain a single deduplicated aggregation child for
     # the module + year scope.  Module-level recalc covers N data
     # entry types in sequence; we want one aggregation pass at the
-    # end, not one per type.  ``dedup_active=True`` would also
-    # collapse concurrent fan-outs to the same scope, but in this
+    # end, not one per type.  ``dedup_config=AGGREGATION_DEDUP`` would
+    # also collapse concurrent fan-outs to the same scope, but in this
     # handler we only ever issue one chain so it's primarily a
     # safety net.
     chained_aggregation_id = None
@@ -247,7 +247,7 @@ async def module_emission_recalc_handler(
             module_type_id=job.module_type_id,
             year=job.year,
             session=job_session,
-            dedup_active=True,
+            dedup_config=AGGREGATION_DEDUP,
         )
 
     return {

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -27,7 +27,7 @@ from app.models.data_ingestion import (
 )
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.services.data_ingestion.provider_factory import ProviderFactory
-from app.tasks._chain import chain_job
+from app.tasks._chain import EMISSION_RECALC_DEDUP, chain_job
 from app.tasks.registry import register
 
 logger = get_logger(__name__)
@@ -217,6 +217,13 @@ async def _chain_recalc_for_stale(
     ``_enqueue_stale_recalculations`` — the same scope-resolution logic,
     but each target now goes through ``chain_job`` (uniform pipeline_id
     inheritance, runner-driven dispatch, no manual fire_and_forget).
+
+    Each chain passes ``dedup_config=EMISSION_RECALC_DEDUP`` (#1064): the
+    partial unique index ``uq_emission_recalc_active`` collapses
+    back-to-back factor reuploads for the same ``(module, det, year)``
+    into a single pending recalc.  Without this, a user re-uploading
+    a corrected factors CSV seconds after the first upload would queue
+    a redundant recalc on top of the already-pending one.
     """
     # Late import to avoid circular: module_type → data_ingestion → tasks.
     from app.models.module_type import (
@@ -307,6 +314,7 @@ async def _chain_recalc_for_stale(
             data_entry_type_id=row["data_entry_type_id"],
             year=year,
             session=session,
+            dedup_config=EMISSION_RECALC_DEDUP,
         )
     logger.info(
         f"factor_ingest job {job.id}: chained {len(targets)} emission_recalc "

--- a/backend/tests/integration/services/data_ingestion/test_emission_recalc_dedup_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_emission_recalc_dedup_pg.py
@@ -1,0 +1,358 @@
+"""Real-Postgres tests for #1064 ``chain_job(dedup_config=EMISSION_RECALC_DEDUP)``.
+
+Pins the contract that two ``chain_job`` calls for the same
+``(module_type_id, data_entry_type_id, year, job_type='emission_recalc')``
+scope collapse to a single pending row via the
+``uq_emission_recalc_active`` partial unique index.  Mirrors the
+shape of ``test_aggregation_dedup_chain_pg.py`` with the three-column
+scope substitution.
+
+SQLite can't represent partial indexes the same way Postgres does and
+the ``IngestionState`` enum types differ, so this is a real-PG-only
+test.  Requires Docker — see ``conftest.py``'s ``postgres_container``
+fixture.
+"""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+from app.tasks._chain import EMISSION_RECALC_DEDUP, chain_job
+
+
+async def _install_emission_recalc_dedup_index(engine) -> None:
+    """Create the ``uq_emission_recalc_active`` partial unique index that
+    the #1064 Alembic migration adds.
+
+    ``pg_dsn`` builds the schema via ``SQLModel.metadata.create_all``,
+    which doesn't run Alembic, so the partial index is missing.  Re-add
+    it here so the dedup INSERT can hit the index on a real race.
+    Uses plain (non-CONCURRENT) creation because we're inside a fresh
+    test schema with no concurrent writers — CONCURRENTLY is only
+    needed in production migrations.
+    """
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_emission_recalc_active "
+                "ON data_ingestion_jobs "
+                "(module_type_id, data_entry_type_id, year) "
+                "WHERE job_type = 'emission_recalc' "
+                "AND state IN ("
+                "'NOT_STARTED'::ingestion_state_enum, "
+                "'QUEUED'::ingestion_state_enum, "
+                "'RUNNING'::ingestion_state_enum"
+                ") "
+                "AND module_type_id IS NOT NULL "
+                "AND data_entry_type_id IS NOT NULL "
+                "AND year IS NOT NULL"
+            )
+        )
+
+
+def _parent_factor_job(
+    module_type_id: int = 5,
+    data_entry_type_id: int = 11,
+    year: int = 2025,
+) -> DataIngestionJob:
+    """A minimal ``factor_ingest`` parent that ``chain_job`` inherits from."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=module_type_id,
+        data_entry_type_id=data_entry_type_id,
+        year=year,
+        target_type=TargetType.FACTORS,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.RUNNING,
+        is_current=True,
+        job_type="factor_ingest",
+        pipeline_id=uuid4(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_back_to_back_factor_reuploads_collapse_to_one_recalc(pg_dsn):
+    """Two sequential ``chain_job(emission_recalc, dedup_config=EMISSION_RECALC_DEDUP)``
+    calls for the same ``(module, det, year)`` → only the first creates
+    a row; the second sees the existing pending row and returns ``None``.
+
+    Models the user-visible scenario in #1064 / B-M1: a user uploads a
+    corrected factors CSV seconds after the first upload — the second
+    fan-out must not queue a redundant recalc on top of the pending one.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_emission_recalc_dedup_index(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent = _parent_factor_job()
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+
+    with patch(
+        "app.tasks._chain.fire_and_forget",
+        side_effect=lambda coro, *, name=None: (coro.close(), None)[1],
+    ):
+        async with Sf() as session1:
+            parent1 = await session1.get(DataIngestionJob, parent.id)
+            child_id_1 = await chain_job(
+                parent1,
+                job_type="emission_recalc",
+                module_type_id=parent.module_type_id,
+                data_entry_type_id=parent.data_entry_type_id,
+                year=parent.year,
+                session=session1,
+                dedup_config=EMISSION_RECALC_DEDUP,
+            )
+
+        async with Sf() as session2:
+            parent2 = await session2.get(DataIngestionJob, parent.id)
+            child_id_2 = await chain_job(
+                parent2,
+                job_type="emission_recalc",
+                module_type_id=parent.module_type_id,
+                data_entry_type_id=parent.data_entry_type_id,
+                year=parent.year,
+                session=session2,
+                dedup_config=EMISSION_RECALC_DEDUP,
+            )
+
+    # First chain wins; second is dedup'd.
+    assert child_id_1 is not None
+    assert child_id_2 is None
+
+    # Exactly one emission_recalc child row in the active state for
+    # this scope (the first parent factor row stays in its own
+    # job_type='factor_ingest' bucket and is not counted).
+    async with Sf() as session:
+        result = await session.execute(
+            select(DataIngestionJob).where(
+                DataIngestionJob.job_type == "emission_recalc",
+                DataIngestionJob.module_type_id == parent.module_type_id,
+                DataIngestionJob.data_entry_type_id == parent.data_entry_type_id,
+                DataIngestionJob.year == parent.year,
+            )
+        )
+        rows = list(result.scalars().all())
+        assert len(rows) == 1
+        assert rows[0].id == child_id_1
+        assert rows[0].state == IngestionState.NOT_STARTED
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dedup_releases_after_first_recalc_finishes(pg_dsn):
+    """Once the first emission_recalc transitions to FINISHED, the
+    partial index releases the (module, det, year) slot and a follow-up
+    chain creates a new row.  Each fan-out batch gets one recalc;
+    subsequent batches are not blocked by historical jobs."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_emission_recalc_dedup_index(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent = _parent_factor_job()
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+
+    with patch(
+        "app.tasks._chain.fire_and_forget",
+        side_effect=lambda coro, *, name=None: (coro.close(), None)[1],
+    ):
+        async with Sf() as session:
+            parent1 = await session.get(DataIngestionJob, parent.id)
+            first_id = await chain_job(
+                parent1,
+                job_type="emission_recalc",
+                module_type_id=parent.module_type_id,
+                data_entry_type_id=parent.data_entry_type_id,
+                year=parent.year,
+                session=session,
+                dedup_config=EMISSION_RECALC_DEDUP,
+            )
+
+        # Simulate the first recalc finishing.
+        async with Sf() as session:
+            first = await session.get(DataIngestionJob, first_id)
+            first.state = IngestionState.FINISHED
+            session.add(first)
+            await session.commit()
+
+        # A new fan-out batch chains again; partial index lets it through.
+        async with Sf() as session:
+            parent2 = await session.get(DataIngestionJob, parent.id)
+            second_id = await chain_job(
+                parent2,
+                job_type="emission_recalc",
+                module_type_id=parent.module_type_id,
+                data_entry_type_id=parent.data_entry_type_id,
+                year=parent.year,
+                session=session,
+                dedup_config=EMISSION_RECALC_DEDUP,
+            )
+
+    assert first_id is not None
+    assert second_id is not None
+    assert second_id != first_id
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dedup_does_not_collide_across_dets_or_years(pg_dsn):
+    """The partial index is keyed on ``(module_type_id,
+    data_entry_type_id, year)`` — three chains differing in det,
+    year, or both all succeed.  Without per-det keying, a multi-det
+    factor reupload would serialize into one recalc instead of one
+    per det."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_emission_recalc_dedup_index(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent_a = _parent_factor_job(
+            module_type_id=5, data_entry_type_id=11, year=2025
+        )
+        parent_b = _parent_factor_job(
+            module_type_id=5, data_entry_type_id=12, year=2025
+        )  # different det
+        parent_c = _parent_factor_job(
+            module_type_id=5, data_entry_type_id=11, year=2026
+        )  # different year
+        session.add_all([parent_a, parent_b, parent_c])
+        await session.commit()
+        await session.refresh(parent_a)
+        await session.refresh(parent_b)
+        await session.refresh(parent_c)
+
+    chained_ids = []
+    with patch(
+        "app.tasks._chain.fire_and_forget",
+        side_effect=lambda coro, *, name=None: (coro.close(), None)[1],
+    ):
+        for parent in (parent_a, parent_b, parent_c):
+            async with Sf() as session:
+                p = await session.get(DataIngestionJob, parent.id)
+                cid = await chain_job(
+                    p,
+                    job_type="emission_recalc",
+                    module_type_id=parent.module_type_id,
+                    data_entry_type_id=parent.data_entry_type_id,
+                    year=parent.year,
+                    session=session,
+                    dedup_config=EMISSION_RECALC_DEDUP,
+                )
+                chained_ids.append(cid)
+
+    assert all(cid is not None for cid in chained_ids)
+    assert len(set(chained_ids)) == 3
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dedup_skips_run_job_dispatch_on_collision(pg_dsn):
+    """``fire_and_forget(run_job(...))`` must NOT be called on the
+    dedup'd path — the existing pending row will run; a redundant
+    dispatch would race-claim the same row."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_emission_recalc_dedup_index(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent = _parent_factor_job()
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+
+    fired_names: list[str | None] = []
+
+    def _record_fire(coro, *, name=None):
+        coro.close()
+        fired_names.append(name)
+        return None
+
+    with patch("app.tasks._chain.fire_and_forget", side_effect=_record_fire):
+        async with Sf() as session:
+            p1 = await session.get(DataIngestionJob, parent.id)
+            await chain_job(
+                p1,
+                job_type="emission_recalc",
+                module_type_id=parent.module_type_id,
+                data_entry_type_id=parent.data_entry_type_id,
+                year=parent.year,
+                session=session,
+                dedup_config=EMISSION_RECALC_DEDUP,
+            )
+
+        async with Sf() as session:
+            p2 = await session.get(DataIngestionJob, parent.id)
+            await chain_job(
+                p2,
+                job_type="emission_recalc",
+                module_type_id=parent.module_type_id,
+                data_entry_type_id=parent.data_entry_type_id,
+                year=parent.year,
+                session=session,
+                dedup_config=EMISSION_RECALC_DEDUP,
+            )
+
+    # Only the first chain dispatched; the dedup'd second did not.
+    assert len(fired_names) == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_config_rejects_null_scope_keys(pg_dsn):
+    """``chain_job`` must refuse to use EMISSION_RECALC_DEDUP when any
+    scope column would be NULL on the child row.  PG treats NULLs as
+    distinct in unique indexes, so a NULL would silently bypass dedup
+    at the index level — we'd rather raise than create a half-broken
+    row."""
+    engine = create_async_engine(pg_dsn, future=True)
+    await _install_emission_recalc_dedup_index(engine)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as session:
+        parent = _parent_factor_job()
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+
+    with patch(
+        "app.tasks._chain.fire_and_forget",
+        side_effect=lambda coro, *, name=None: (coro.close(), None)[1],
+    ):
+        async with Sf() as session:
+            p = await session.get(DataIngestionJob, parent.id)
+            with pytest.raises(ValueError, match="scope keys must be set"):
+                # data_entry_type_id is one of EMISSION_RECALC_DEDUP's
+                # scope columns and does NOT inherit from the parent;
+                # passing None must trip the entry guard.
+                await chain_job(
+                    p,
+                    job_type="emission_recalc",
+                    module_type_id=parent.module_type_id,
+                    data_entry_type_id=None,
+                    year=parent.year,
+                    session=session,
+                    dedup_config=EMISSION_RECALC_DEDUP,
+                )
+
+    await engine.dispose()

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -23,6 +23,7 @@ from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import IngestionResult
 from app.tasks import emission_recalculation_tasks as recalc_mod
 from app.tasks import unit_sync_tasks as unit_sync_mod
+from app.tasks._chain import AGGREGATION_DEDUP
 from app.tasks.registry import _REGISTRY, get_handler
 
 
@@ -121,8 +122,8 @@ async def test_emission_recalc_handler_calls_workflow_and_returns_meta():
 async def test_emission_recalc_handler_chains_aggregation_with_dedup_on_success():
     """Plan 310-D — the handler no longer calls ``recompute_stats``
     inline; it chains the runner-driven ``aggregation`` handler with
-    ``dedup_active=True`` so a fan-out of N siblings collapses into
-    one aggregation pass per (module, year)."""
+    ``dedup_config=AGGREGATION_DEDUP`` so a fan-out of N siblings
+    collapses into one aggregation pass per (module, year)."""
     job = _make_job()
     job_session = MagicMock()
     job_session.commit = AsyncMock()
@@ -165,7 +166,7 @@ async def test_emission_recalc_handler_chains_aggregation_with_dedup_on_success(
     assert chain_kwargs["job_type"] == "aggregation"
     assert chain_kwargs["module_type_id"] == job.module_type_id
     assert chain_kwargs["year"] == job.year
-    assert chain_kwargs["dedup_active"] is True
+    assert chain_kwargs["dedup_config"] is AGGREGATION_DEDUP
     # ``session`` for ``chain_job`` is the job_session (the row write
     # for the dedup INSERT lives on the job-progress session, not the
     # data_session that the workflow scrubbed and committed).
@@ -314,7 +315,7 @@ async def test_module_emission_recalc_iterates_all_types():
     mock_chain.assert_awaited_once()
     chain_kwargs = mock_chain.await_args.kwargs
     assert chain_kwargs["job_type"] == "aggregation"
-    assert chain_kwargs["dedup_active"] is True
+    assert chain_kwargs["dedup_config"] is AGGREGATION_DEDUP
     assert meta["status_message"] == "Module emission recalculation completed"
     assert meta["result"] == IngestionResult.SUCCESS
     assert meta["total_recalculated"] == 6


### PR DESCRIPTION
## Summary

Generalise `chain_job`'s dedup path from aggregation-specific to a per-job-type `DedupConfig` dataclass driving dynamic pre-check SQL and IntegrityError handling, and add `EMISSION_RECALC_DEDUP` so back-to-back factor reuploads collapse to a single pending recalc per `(module, det, year)` (#1064 + review finding B-M1).

- `app/tasks/_chain.py`: new `DedupConfig` dataclass + `AGGREGATION_DEDUP` / `EMISSION_RECALC_DEDUP` constants. `_insert_child_with_dedup` now builds the pre-check WHERE and IntegrityError log from `dedup_config.scope_columns` + `constraint_name`. `chain_job(dedup_active=True)` retained as a deprecation shim mapping to `AGGREGATION_DEDUP` for one release cycle (logs `DeprecationWarning`).
- New alembic migration `f8a9b1c2d3e4_emission_recalc_dedup_index`: `CREATE UNIQUE INDEX CONCURRENTLY uq_emission_recalc_active ON data_ingestion_jobs (module_type_id, data_entry_type_id, year) WHERE job_type='emission_recalc' AND state IN (NOT_STARTED, QUEUED, RUNNING) AND module_type_id IS NOT NULL AND data_entry_type_id IS NOT NULL AND year IS NOT NULL`. Uses `op.get_context().autocommit_block()` so CONCURRENTLY runs outside Alembic's per-migration transaction. Downgrade drops it CONCURRENTLY.
- `ingestion_tasks._chain_recalc_for_stale`: passes `dedup_config=EMISSION_RECALC_DEDUP`; docstring now documents dedup behaviour.
- `emission_recalculation_tasks`: migrated the two aggregation chain call-sites (`emission_recalc_handler`, `module_emission_recalc_handler`) from `dedup_active=True` to `dedup_config=AGGREGATION_DEDUP`.
- New `tests/integration/services/data_ingestion/test_emission_recalc_dedup_pg.py`: pins the new contract (collapse on second chain, scope independence across det/year, FINISHED releases the lock, no `run_job` dispatch on collision, NULL scope rejected).
- `tests/unit/tasks/test_handler_registrations.py`: assertion updates from `chain_kwargs["dedup_active"] is True` to `chain_kwargs["dedup_config"] is AGGREGATION_DEDUP`.

## Verification

- `rtk uv run pytest backend/tests/unit/` - 1288 passed (incl. existing `test_chain.py` exercising the deprecated shim path).
- `rtk uv run ruff check backend/app/ backend/tests/` - clean.
- `alembic upgrade --sql` and `downgrade --sql` previews confirm the autocommit_block produces correct `COMMIT;` boundaries around `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY`.

## Notes for the reviewer

- **CI must validate**: the new `test_emission_recalc_dedup_pg.py` and a live `alembic upgrade head && downgrade -1 && upgrade head` could not be exercised in this worker because the shared local Postgres container is in active use by 10 parallel workers and a temp test DB cannot be provisioned. The SQL preview confirms migration shape; CI's PG fixture will exercise the live path.
- **Out of scope, follow-up**: `_chain_emission_recalc_for_data_ingest` (CSV/API ingest fan-out, `ingestion_tasks.py:418`) calls `chain_job` for `emission_recalc` with the same `(module, det, year)` shape and would benefit from the same dedup; B-M1 specifically named only `_chain_recalc_for_stale` so I left it for a follow-up PR rather than expand scope.
- The `dedup_active=True` shim emits `DeprecationWarning`; pytest's `filterwarnings = ["ignore::DeprecationWarning"]` in `pyproject.toml` keeps existing callers (test files at `test_chain.py`, `test_aggregation_dedup_chain_pg.py`) green.

Closes #1064.

## Test plan

- [ ] CI runs `tests/integration/services/data_ingestion/test_emission_recalc_dedup_pg.py` against the PG testcontainer.
- [ ] CI runs `tests/integration/services/data_ingestion/test_aggregation_dedup_chain_pg.py` to confirm the deprecation shim still works for the aggregation path.
- [ ] CI runs `alembic upgrade head` + `downgrade -1` + `upgrade head` against the PG fixture to confirm CONCURRENTLY index creation reverses cleanly.