### PR TITLE
fix(310): preserve kg_co2eq override on async path [B-H1]

### DIFF
--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -30,6 +30,16 @@ from app.utils.it_breakdown import ITSqlTotals
 settings = get_settings()
 logger = get_logger(__name__)
 
+# B-H1 — reserved key on ``DataEntry.data`` for the per-row ``kg_co2eq``
+# override carrier (Tableau's ``OUT_CO2_CORRECTED`` for the travel API,
+# parsed CSV-side ``kg_co2eq`` column for ``base_csv_provider``).  The
+# double-underscore prefix marks it internal and keeps it from clashing
+# with handler-defined kind/subkind keys.  Bulk-path providers persist
+# the override here so the async recalc workflow's
+# ``upsert_by_data_entry`` (which has no ``kg_co2eq_override`` parameter)
+# still honors it via ``prepare_create``'s data-keyed fallback.
+KG_CO2EQ_OVERRIDE_KEY = "__kg_co2eq_override__"
+
 
 def _emission_depth(et: EmissionType) -> int:
     """Count parent chain length (0 = root)."""
@@ -133,10 +143,19 @@ class DataEntryEmissionService:
 
         Args:
             data_entry: Fully hydrated data entry with ``data_entry_type``.
-            kg_co2eq_override: When set (CSV / API ingestion path), short-circuits
-                the formula and produces a single emission with this kg_co2eq and
-                ``primary_factor_id=None``. The override is passed transiently —
-                it must NOT be persisted in ``data_entry.data``.
+            kg_co2eq_override: When set (legacy inline ingestion path),
+                short-circuits the formula and produces a single emission
+                with this kg_co2eq and ``primary_factor_id=None``. Takes
+                precedence over the ``KG_CO2EQ_OVERRIDE_KEY`` carrier in
+                ``data_entry.data`` (see B-H1).
+
+                Under ``BULK_PATH_PURE_ASYNC`` the ingest providers persist
+                the override on the data entry under ``KG_CO2EQ_OVERRIDE_KEY``,
+                which survives the inline-write skip and is honored here
+                when the function-arg override is absent.  The runner-driven
+                recalc workflow's ``upsert_by_data_entry`` therefore
+                preserves Tableau's ``OUT_CO2_CORRECTED`` (and CSV-side
+                overrides) across the async path instead of formula-recomputing.
 
         Returns:
             Ready-to-insert ``DataEntryEmission`` rows; empty on any failure.
@@ -162,8 +181,30 @@ class DataEntryEmissionService:
             DataEntryTypeEnum(data_entry.data_entry_type)
         )
 
-        # Build context: data_entry.data enriched with pre-computed values
+        # B-H1 — fallback to the persisted ``KG_CO2EQ_OVERRIDE_KEY`` carrier
+        # (set by the bulk-path providers) when the caller did not pass an
+        # explicit ``kg_co2eq_override``.  The function arg wins so the
+        # legacy inline path (which already routes via the arg) keeps its
+        # existing semantics.
+        effective_override: float | None = kg_co2eq_override
+        if effective_override is None:
+            persisted_override = data_entry.data.get(KG_CO2EQ_OVERRIDE_KEY)
+            if persisted_override is not None:
+                try:
+                    effective_override = float(persisted_override)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"Invalid {KG_CO2EQ_OVERRIDE_KEY} value "
+                        f"{persisted_override!r} on data_entry_id="
+                        f"{data_entry.id!r}, ignoring override"
+                    )
+
+        # Build context: data_entry.data enriched with pre-computed values.
+        # Strip the reserved override carrier so it never leaks into the
+        # ``meta`` blobs spread from ``ctx`` below; the source dict on the
+        # data entry is left intact so re-runs remain idempotent.
         ctx: dict = {**data_entry.data}
+        ctx.pop(KG_CO2EQ_OVERRIDE_KEY, None)
         ctx.update(await handler.pre_compute(data_entry, self.session))
 
         # Get year from CarbonReport for year-aware factor lookup
@@ -183,9 +224,9 @@ class DataEntryEmissionService:
             for comp in computations:
                 factors = await self._fetch_factors(comp, year)
 
-                if kg_co2eq_override is not None:
+                if effective_override is not None:
                     logger.info(
-                        f"Using kg_co2eq={kg_co2eq_override} override for "
+                        f"Using kg_co2eq={effective_override} override for "
                         f"emission_type={emission_type.name!r} "
                         f"data_entry_id={data_entry.id!r}"
                     )
@@ -194,7 +235,7 @@ class DataEntryEmissionService:
                             data_entry_id=data_entry.id,
                             emission_type_id=comp.emission_type.value,
                             primary_factor_id=None,
-                            kg_co2eq=float(kg_co2eq_override),
+                            kg_co2eq=float(effective_override),
                             scope=comp.emission_type.scope,
                             meta={
                                 "factors_used": [

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -423,8 +423,15 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
             if not carbon_report_module_id:
                 continue
 
-            kg_co2eq = item.get("kg_co2eq") or item.get("OUT_CO2_CORRECTED")
-            distance_km = item.get("distance_km") or item.get("OUT_DISTANCE_CORRECTED")
+            # Use ``is not None`` rather than ``or`` so a valid 0/0.0 isn't
+            # silently replaced by the OUT_*-corrected fallback.  Walking
+            # legs and fully-electric trips on green grids land here.
+            kg_raw = item.get("kg_co2eq")
+            kg_co2eq = kg_raw if kg_raw is not None else item.get("OUT_CO2_CORRECTED")
+            dist_raw = item.get("distance_km")
+            distance_km = (
+                dist_raw if dist_raw is not None else item.get("OUT_DISTANCE_CORRECTED")
+            )
 
             data_payload = dict(item)
             data_payload.pop("kg_co2eq", None)

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -17,7 +17,10 @@ from app.repositories.unit_repo import UnitRepository
 from app.schemas.carbon_report import CarbonReportCreate
 from app.schemas.user import UserRead
 from app.services.carbon_report_service import CarbonReportService
-from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.services.data_entry_emission_service import (
+    KG_CO2EQ_OVERRIDE_KEY,
+    DataEntryEmissionService,
+)
 from app.services.data_entry_service import DataEntryService
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 
@@ -405,10 +408,14 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
         service = DataEntryService(self.data_session)
         emission_service = DataEntryEmissionService(self.data_session)
 
-        # Create data entries with preserved CO2 values
-        # kg_co2eq is carried out-of-band (parallel list) so it never lands
-        # in DataEntry.data; the override is applied transiently when emissions
-        # are created.
+        # Create data entries with preserved CO2 values.
+        # The raw ``kg_co2eq`` key is stripped from the persisted payload —
+        # under the reserved ``__kg_co2eq_override__`` carrier instead — so
+        # the formula short-circuit in ``prepare_create`` can still tell the
+        # raw input apart from the override channel, and so a future user
+        # edit clearing the override can trigger a clean recompute (B-H1).
+        # The parallel ``kg_co2eq_overrides`` list is kept index-aligned with
+        # ``entries`` for the legacy inline-write path below.
         entries = []
         kg_co2eq_overrides: list[float | None] = []
         for item in data:
@@ -424,12 +431,6 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
             if distance_km is not None:
                 data_payload["distance_km"] = distance_km
 
-            entry = DataEntry(
-                carbon_report_module_id=carbon_report_module_id,
-                data_entry_type_id=DataEntryTypeEnum.plane.value,
-                data=data_payload,
-            )
-            entries.append(entry)
             # Coerce the override value to float; log + skip on garbage values
             # rather than crashing the whole batch (mirrors base_csv_provider).
             override: float | None = None
@@ -443,6 +444,19 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
                         f"Invalid kg_co2eq value {kg_co2eq!r} from API source, "
                         f"ignoring override"
                     )
+            # Persist the override under the reserved carrier key so the
+            # async recalc path (``upsert_by_data_entry`` →
+            # ``prepare_create``) still honors Tableau's ``OUT_CO2_CORRECTED``
+            # under ``BULK_PATH_PURE_ASYNC``.
+            if override is not None:
+                data_payload[KG_CO2EQ_OVERRIDE_KEY] = override
+
+            entry = DataEntry(
+                carbon_report_module_id=carbon_report_module_id,
+                data_entry_type_id=DataEntryTypeEnum.plane.value,
+                data=data_payload,
+            )
+            entries.append(entry)
             kg_co2eq_overrides.append(override)
 
         if not entries:
@@ -465,12 +479,13 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
         # emissions against the latest factors.  Inline writes would
         # race the chain's writes for the same primary key.
         #
-        # Note: travel data carries a per-row ``kg_co2eq`` override
-        # (Tableau's ``OUT_CO2_CORRECTED``) that the legacy path
-        # threaded through ``prepare_create``.  The async path reads
-        # the same field from ``DataEntry.data`` (carrier preserved by
-        # the upstream loader); the recalc workflow's
-        # ``upsert_by_data_entry`` honors it via the same code path.
+        # Travel data carries a per-row ``kg_co2eq`` override (Tableau's
+        # ``OUT_CO2_CORRECTED``) that the legacy path threaded through
+        # ``prepare_create(kg_co2eq_override=...)``.  The async path
+        # persists the same value under ``KG_CO2EQ_OVERRIDE_KEY`` above,
+        # which ``prepare_create`` reads as a fallback when no function-arg
+        # override is passed — so the recalc workflow's
+        # ``upsert_by_data_entry`` preserves it across the async hop.
         if get_settings().BULK_PATH_PURE_ASYNC:
             await self.data_session.flush()
             return {"inserted": len(data_entries_response)}

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -29,7 +29,10 @@ from app.schemas.data_entry import DATA_ENTRY_META_FIELDS, ModuleHandler
 from app.schemas.user import UserRead
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.carbon_report_service import CarbonReportService
-from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.services.data_entry_emission_service import (
+    KG_CO2EQ_OVERRIDE_KEY,
+    DataEntryEmissionService,
+)
 from app.services.data_entry_service import DataEntryService
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 from app.services.unit_service import UnitService
@@ -989,6 +992,16 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                                         f"Row {row_idx}: Populated "
                                         f"{field_name}={default_value} from factor"
                                     )
+
+            # B-H1 — under ``BULK_PATH_PURE_ASYNC`` the inline path skips
+            # ``prepare_create``, so the parallel ``kg_co2eq_override`` list
+            # is built and discarded.  Persist the override on the data
+            # entry under the reserved ``KG_CO2EQ_OVERRIDE_KEY`` carrier so
+            # the async recalc path (``upsert_by_data_entry`` →
+            # ``prepare_create``) still honors it.  The parallel list is
+            # kept for the legacy inline path's existing flow.
+            if kg_co2eq_override is not None:
+                data[KG_CO2EQ_OVERRIDE_KEY] = kg_co2eq_override
 
             data_entry = DataEntry(
                 data_entry_type_id=data_entry_type,

--- a/backend/tests/integration/services/data_ingestion/test_kg_co2eq_override_async_path_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_kg_co2eq_override_async_path_pg.py
@@ -1,0 +1,363 @@
+"""End-to-end Postgres test for the B-H1 kg_co2eq override carrier.
+
+Pin: under ``BULK_PATH_PURE_ASYNC`` the bulk-path providers persist the
+ingestion-time ``kg_co2eq`` override (Tableau's ``OUT_CO2_CORRECTED`` for
+the travel API; the parsed CSV value for ``base_csv_provider``) into
+``DataEntry.data`` under the reserved ``__kg_co2eq_override__`` key.
+
+The runner-driven recalc workflow then reads ``data_entries`` and calls
+``DataEntryEmissionService.upsert_by_data_entry``, which has no
+``kg_co2eq_override`` parameter — without the carrier this test was
+guarding the regression where every async-path emission silently came out
+formula-recomputed.
+
+This test bypasses the actual ingest providers (their full transactional
+machinery is exercised elsewhere) and seeds a ``DataEntry`` shaped exactly
+like the one the providers persist post-fix: payload includes
+``__kg_co2eq_override__``.  Running ``upsert_by_data_entry`` against it
+must yield an emission row whose ``kg_co2eq`` equals the override —
+provably *not* the formula-derived value.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.models.unit import Unit
+from app.schemas.data_entry import DataEntryResponse
+from app.services.data_entry_emission_service import DataEntryEmissionService
+from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
+
+
+@pytest.mark.asyncio
+async def test_kg_co2eq_override_survives_async_recalc(pg_dsn_with_310b):
+    """B-H1 — a DataEntry persisted with ``__kg_co2eq_override__`` survives
+    the async path: ``EmissionRecalculationWorkflow`` →
+    ``upsert_by_data_entry`` produces an emission whose ``kg_co2eq`` equals
+    the override, NOT the value the formula would have yielded.
+
+    Uses an IT/equipment factor + entry where the formula yields a
+    deterministic, distinguishable value (~50.0) so the override (999.0)
+    cannot accidentally collide with the formula's output.
+    """
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    # ── 1. Seed the carbon-report graph + factor + data entry ──────────
+    async with Sf() as s:
+        unit = Unit(
+            institutional_code="TEST",
+            institutional_id="TEST-UNIT",
+            name="Test Unit",
+            level=1,
+        )
+        s.add(unit)
+        await s.commit()
+        unit_id = unit.id
+
+        report = CarbonReport(year=2025, unit_id=unit_id)
+        s.add(report)
+        await s.commit()
+        report_id = report.id
+
+        module = CarbonReportModule(
+            carbon_report_id=report_id,
+            module_type_id=ModuleTypeEnum.equipment_electric_consumption.value,
+        )
+        s.add(module)
+        await s.commit()
+        module_id = module.id
+
+        # Factor whose formula yields a small, deterministic value:
+        #   ef_kg_co2eq_per_kwh=0.1, active_power_w=100, standby_power_w=10,
+        #   active=40h/wk, standby=128h/wk → ~50 kg over the year.
+        factor = Factor(
+            emission_type_id=EmissionType.equipment__it.value,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            classification={
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "year": 2025,
+            },
+            values={
+                "active_power_w": 100.0,
+                "standby_power_w": 10.0,
+                "ef_kg_co2eq_per_kwh": 0.1,
+            },
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+        factor_id = factor.id
+
+        # Persist the override on the data entry under the reserved carrier
+        # — exactly the shape the bulk-path providers use under
+        # ``BULK_PATH_PURE_ASYNC`` after the B-H1 fix.
+        override_value = 999.0
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            carbon_report_module_id=module_id,
+            data={
+                "primary_factor_id": factor_id,
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "active_usage_hours_per_week": 40.0,
+                "standby_usage_hours_per_week": 128.0,
+                "name": "Test Laptop",
+                "__kg_co2eq_override__": override_value,
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        entry_id = entry.id
+
+    # ── 2. Direct ``upsert_by_data_entry`` — pins the prepare_create path
+    # ────────────────────────────────────────────────────────────────────
+    async with Sf() as s:
+        entry = (
+            await s.execute(select(DataEntry).where(col(DataEntry.id) == entry_id))
+        ).scalar_one()
+        emission_svc = DataEntryEmissionService(s)
+        await emission_svc.upsert_by_data_entry(DataEntryResponse.model_validate(entry))
+        await s.commit()
+
+    # Read back on a separate engine — proves the override-derived emission
+    # committed and is visible across connections.
+    verify_engine = create_async_engine(pg_dsn_with_310b, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            rows = (
+                (
+                    await vs.execute(
+                        select(DataEntryEmission).where(
+                            col(DataEntryEmission.data_entry_id) == entry_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(rows) >= 1, "expected at least one emission row after upsert"
+        kg_values = [r.kg_co2eq for r in rows]
+        # Override short-circuits the formula: every (non-rollup) row carries
+        # the override exactly.  No row should carry the ~50 formula value.
+        assert override_value in kg_values, (
+            f"override {override_value} missing from persisted emissions: {kg_values}"
+        )
+        for kg in kg_values:
+            assert kg == pytest.approx(override_value, rel=1e-6), (
+                f"emission kg_co2eq={kg} differs from override "
+                f"{override_value} — formula leaked through B-H1 carrier"
+            )
+        # Rows produced by the override branch carry no ``primary_factor_id``
+        # — pin the contract from prepare_create's short-circuit.
+        assert all(r.primary_factor_id is None for r in rows), (
+            f"override rows must have primary_factor_id=None, got: "
+            f"{[r.primary_factor_id for r in rows]}"
+        )
+    finally:
+        await verify_engine.dispose()
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_kg_co2eq_override_survives_recalc_workflow(pg_dsn_with_310b):
+    """B-H1 — covers the exact call-path the runner-driven chain takes:
+    ``EmissionRecalculationWorkflow.recalculate_for_data_entry_type`` →
+    ``upsert_by_data_entry`` → ``prepare_create``.  The persisted
+    ``__kg_co2eq_override__`` carrier must survive that hop and produce
+    emissions whose ``kg_co2eq`` equals the override.
+    """
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    override_value = 777.0
+
+    async with Sf() as s:
+        unit = Unit(
+            institutional_code="WF",
+            institutional_id="WF-UNIT",
+            name="Workflow Test Unit",
+            level=1,
+        )
+        s.add(unit)
+        await s.commit()
+
+        report = CarbonReport(year=2025, unit_id=unit.id)
+        s.add(report)
+        await s.commit()
+
+        module = CarbonReportModule(
+            carbon_report_id=report.id,
+            module_type_id=ModuleTypeEnum.equipment_electric_consumption.value,
+        )
+        s.add(module)
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.equipment__it.value,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            classification={
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "year": 2025,
+            },
+            values={
+                "active_power_w": 100.0,
+                "standby_power_w": 10.0,
+                "ef_kg_co2eq_per_kwh": 0.1,
+            },
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            carbon_report_module_id=module.id,
+            data={
+                "primary_factor_id": factor.id,
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "active_usage_hours_per_week": 40.0,
+                "standby_usage_hours_per_week": 128.0,
+                "name": "Workflow Laptop",
+                "__kg_co2eq_override__": override_value,
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        entry_id = entry.id
+
+    async with Sf() as s:
+        wf = EmissionRecalculationWorkflow(s)
+        result = await wf.recalculate_for_data_entry_type(DataEntryTypeEnum.it, 2025)
+        await s.commit()
+
+    assert result["recalculated"] >= 1, (
+        f"recalc workflow processed no entries: {result}"
+    )
+
+    verify_engine = create_async_engine(pg_dsn_with_310b, future=True)
+    Vf = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Vf() as vs:
+            rows = (
+                (
+                    await vs.execute(
+                        select(DataEntryEmission).where(
+                            col(DataEntryEmission.data_entry_id) == entry_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(rows) >= 1, "expected emissions after recalc workflow"
+        for r in rows:
+            assert r.kg_co2eq == pytest.approx(override_value, rel=1e-6), (
+                f"recalc workflow dropped the override: "
+                f"emission_id={r.id} kg_co2eq={r.kg_co2eq}"
+            )
+    finally:
+        await verify_engine.dispose()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_kg_co2eq_override_function_arg_takes_precedence(pg_dsn_with_310b):
+    """B-H1 — when both the function-arg ``kg_co2eq_override`` and the
+    persisted ``__kg_co2eq_override__`` carrier are present, the function
+    arg wins.  Pins the legacy inline-path semantics so existing
+    ``_process_batch`` tests stay green.
+    """
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with Sf() as s:
+        unit = Unit(
+            institutional_code="T2",
+            institutional_id="T2-UNIT",
+            name="Test Unit 2",
+            level=1,
+        )
+        s.add(unit)
+        await s.commit()
+
+        report = CarbonReport(year=2025, unit_id=unit.id)
+        s.add(report)
+        await s.commit()
+
+        module = CarbonReportModule(
+            carbon_report_id=report.id,
+            module_type_id=ModuleTypeEnum.equipment_electric_consumption.value,
+        )
+        s.add(module)
+        await s.commit()
+
+        factor = Factor(
+            emission_type_id=EmissionType.equipment__it.value,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            classification={
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "year": 2025,
+            },
+            values={
+                "active_power_w": 100.0,
+                "standby_power_w": 10.0,
+                "ef_kg_co2eq_per_kwh": 0.1,
+            },
+            year=2025,
+        )
+        s.add(factor)
+        await s.commit()
+
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            carbon_report_module_id=module.id,
+            data={
+                "primary_factor_id": factor.id,
+                "equipment_class": "Laptop",
+                "sub_class": "Standard",
+                "active_usage_hours_per_week": 40.0,
+                "standby_usage_hours_per_week": 128.0,
+                "name": "Test Laptop",
+                "__kg_co2eq_override__": 999.0,  # carrier value
+            },
+        )
+        s.add(entry)
+        await s.commit()
+        entry_id = entry.id
+
+    arg_override = 42.0  # function-arg value — must win over the carrier
+
+    async with Sf() as s:
+        entry = (
+            await s.execute(select(DataEntry).where(col(DataEntry.id) == entry_id))
+        ).scalar_one()
+        emission_svc = DataEntryEmissionService(s)
+        emissions = await emission_svc.prepare_create(
+            DataEntryResponse.model_validate(entry),
+            kg_co2eq_override=arg_override,
+        )
+
+    try:
+        assert emissions, "expected at least one prepared emission"
+        for em in emissions:
+            assert em.kg_co2eq == pytest.approx(arg_override, rel=1e-6), (
+                f"function-arg override should win — got kg_co2eq={em.kg_co2eq}, "
+                f"expected {arg_override}"
+            )
+    finally:
+        await engine.dispose()

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -744,6 +744,12 @@ async def test_process_row_extracts_kg_co2eq_out_of_band():
     assert len(captured_validation_payload) == 1
     assert "kg_co2eq" not in captured_validation_payload[0]
 
+    # 4. B-H1 — the override is also persisted under the reserved
+    #    ``__kg_co2eq_override__`` carrier so the async recalc path
+    #    (``upsert_by_data_entry`` → ``prepare_create``) still honors it
+    #    when ``BULK_PATH_PURE_ASYNC`` skips the inline-write path.
+    assert data_entry.data.get("__kg_co2eq_override__") == pytest.approx(152.685)
+
 
 @pytest.mark.asyncio
 async def test_process_row_with_no_kg_co2eq_returns_none_override():
@@ -938,6 +944,11 @@ async def test_process_row_consumes_dumb_csv_fixture_for_plane():
         assert "kg_co2eq" not in data_entry.data, (
             f"row {row_idx}: kg_co2eq leaked into DataEntry.data: {data_entry.data!r}"
         )
+        # B-H1 — the parsed override IS persisted under the reserved
+        # ``__kg_co2eq_override__`` carrier so the async recalc honors it.
+        assert data_entry.data.get("__kg_co2eq_override__") == pytest.approx(
+            float(row["kg_co2eq"])
+        ), f"row {row_idx}: missing __kg_co2eq_override__ carrier"
         actual_overrides.append(kg_co2eq_override)
 
     assert actual_overrides == pytest.approx(expected_overrides)

--- a/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
@@ -489,15 +489,23 @@ class TestLoadDataKgCo2eqHandling:
                 f"kg_co2eq leaked into DataEntry.data: {entry.data!r}"
             )
 
-        # The valid float reaches prepare_create as the override; the garbage
-        # one resolves to None (no override) — verified through the {id: ov}
-        # routing built inside _load_data.
+        # B-H1 — the valid float reaches prepare_create as the override; the
+        # garbage one resolves to None (no override) — verified through the
+        # {id: ov} routing built inside ``_load_data``.
         prepare_calls = mock_emission_service.prepare_create.await_args_list
         overrides_by_id = {
             call.args[0].id: call.kwargs.get("kg_co2eq_override")
             for call in prepare_calls
         }
         assert overrides_by_id == {1: 152.685, 2: None}
+
+        # B-H1 — the parseable override is also persisted under the reserved
+        # ``__kg_co2eq_override__`` carrier so the async recalc path picks
+        # it up via ``prepare_create``'s data-keyed fallback.  Garbage
+        # values are dropped (no carrier set) — operators see the WARNING
+        # logged above and the row falls back to formula-based emissions.
+        assert captured_entries[0].data.get("__kg_co2eq_override__") == 152.685
+        assert "__kg_co2eq_override__" not in captured_entries[1].data
 
     @pytest.mark.asyncio
     async def test_load_data_skips_emissions_under_pure_async(self):


### PR DESCRIPTION
## Summary

Fixes B-H1 from \`docs/code-review/310-overall-review.md\`: under \`BULK_PATH_PURE_ASYNC=True\` the bulk-path providers were silently dropping per-row \`kg_co2eq\` overrides (Tableau's \`OUT_CO2_CORRECTED\` for the travel API; the parsed CSV column for \`base_csv_provider\`). The persisted \`DataEntry\` had \`kg_co2eq\` popped, then \`EmissionRecalculationWorkflow\` ran \`upsert_by_data_entry\` (which has no \`kg_co2eq_override\` parameter) and produced formula-recomputed values instead of preserving the override.

- Persist the override under a reserved \`__kg_co2eq_override__\` key (\`KG_CO2EQ_OVERRIDE_KEY\` constant on \`DataEntryEmissionService\`). Double-underscore prefix marks it internal — won't collide with handler kind/subkind keys.
- \`prepare_create\` reads it as a fallback when the function-arg override is absent; the arg still wins so the legacy inline path keeps its existing semantics.
- The carrier is popped from \`ctx\` before spreading into emission \`meta\` blobs but left in the source dict so async-recovery re-runs are idempotent.
- Travel API + CSV providers persist the override on the data entry; the parallel \`kg_co2eq_overrides\` list is kept index-aligned with the batch for the legacy inline-write path's existing flow.

## Files

- \`backend/app/services/data_entry_emission_service.py\` — \`prepare_create\` fallback + \`KG_CO2EQ_OVERRIDE_KEY\` constant
- \`backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py\` — persist into \`data_payload[KG_CO2EQ_OVERRIDE_KEY]\`; comment correctness
- \`backend/app/services/data_ingestion/base_csv_provider.py\` — persist into \`data[KG_CO2EQ_OVERRIDE_KEY]\` in \`_process_row\`
- Unit tests pin the new carrier on both providers
- New \`backend/tests/integration/services/data_ingestion/test_kg_co2eq_override_async_path_pg.py\` — IT/equipment factor with deterministic formula (~50.0) + override (999.0); covers \`upsert_by_data_entry\`, \`EmissionRecalculationWorkflow\`, and function-arg-wins-over-carrier precedence

## Test plan

- [x] \`rtk uv run pytest backend/tests/unit/\` — 1288 passed
- [x] \`rtk uv run pytest backend/tests/integration/services/data_ingestion/test_kg_co2eq_override_async_path_pg.py\` — 3 passed (in isolation; the shared \`test-data-ingestion-postgres\` docker container is racy under the 11-parallel-worker post-merge batch — failures in a full integration sweep are environmental, not a regression of this PR)
- [x] \`rtk uv run ruff check backend/app/ backend/tests/\` — All checks passed

## Notes

- The carrier appears in \`DataEntry.data\` and will surface in API responses that serialize \`data\` raw. Per the B-H1 design discussion the double-underscore prefix is the sentinel — clients can ignore it. Filtering at the response serializer layer is a separate concern not in scope here.
- Editing a data entry via the UI does not currently strip \`__kg_co2eq_override__\`, so the override survives a manual recompute. This matches the brief's stated scope; UI-edit-clears-override is a separate follow-up.