### PR TITLE
feat(310): stale-stats health endpoint [#1063]

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -1,9 +1,18 @@
 import asyncio
 import json
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    status,
+)
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -23,7 +32,7 @@ from app.models.data_ingestion import (
 )
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
 from app.models.user import User
-from app.repositories.data_ingestion import DataIngestionRepository
+from app.repositories.data_ingestion import DataIngestionRepository, WhyStaleLiteral
 from app.services.data_ingestion.provider_factory import ProviderFactory
 from app.tasks._background import fire_and_forget
 from app.tasks.runner import run_job
@@ -178,6 +187,18 @@ class PipelineResponse(BaseModel):
 
     pipeline_id: UUID
     jobs: list[PipelineJobResponse]
+
+
+class StaleStatsEntry(BaseModel):
+    """One ``(module_type_id, year)`` scope whose aggregation is missing,
+    failed, stuck, or too old.  Returned by ``GET /sync/health/stale-stats``
+    for Datadog/Prometheus scrape — Plan 310-D Follow-up 1 (#1063)."""
+
+    module_type_id: int
+    year: int
+    last_finished_aggregation_at: Optional[datetime] = None
+    why_stale: WhyStaleLiteral
+    last_aggregation_job_id: Optional[int] = None
 
 
 @router.post("/dispatch", response_model=SyncStatusResponse)
@@ -1100,3 +1121,43 @@ async def recover_job(
         locked_by=recovered.locked_by,
         is_current=recovered.is_current,
     )
+
+
+@router.get("/health/stale-stats", response_model=list[StaleStatsEntry])
+async def get_stale_stats(
+    older_than_minutes: int = Query(
+        60,
+        ge=1,
+        description=(
+            "Threshold (minutes) — successful aggregations whose ``finished_at`` "
+            "is younger than this are considered fresh and excluded.  Pending and "
+            "failed rows surface regardless of age."
+        ),
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
+) -> list[StaleStatsEntry]:
+    """Read-only backstop for the aggregation pipeline (Plan 310-D Follow-up 1
+    / #1063).
+
+    The interactive runner-driven chain surfaces failures via the recalc
+    badge and pipeline diagnostic tooltip, but background failures with
+    nobody watching (stuck NOT_STARTED rows, last-run errors, slow-burn
+    drift) had no single owner.  This endpoint walks ``carbon_report_modules``
+    × ``carbon_reports.year`` (the source-of-truth for "what should have an
+    aggregation") and joins the latest ``job_type='aggregation'`` row per
+    scope, returning one entry per stale or missing aggregation.
+
+    Intended for Datadog / Prometheus scrape — emits a count per
+    ``why_stale`` bucket and lets operator dashboards alert on
+    non-zero values.  No auto-retry: the operator decides what to do
+    based on which bucket lit up.
+
+    **Required Permission**: ``backoffice.data_management.view``
+    """
+    rows = await DataIngestionRepository(db).find_stale_aggregations(
+        older_than_minutes
+    )
+    return [StaleStatsEntry(**row) for row in rows]

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_
@@ -9,6 +9,7 @@ from sqlmodel import col, desc, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
+from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_ingestion import (
     DataIngestionJob,
     IngestionMethod,
@@ -904,6 +905,179 @@ class DataIngestionRepository:
             )
         return status_rows
 
+    async def find_stale_aggregations(
+        self, threshold_minutes: int
+    ) -> list["StaleStatsRow"]:
+        """Return one row per ``(module_type_id, year)`` whose aggregation is
+        stale or missing.
+
+        Plan 310-D Follow-up 1 (#1063) — backstop for passive monitoring of
+        the aggregation pipeline.  The runner-driven chain surfaces failures
+        interactively (badge + logs); this query catches the cases nobody is
+        watching: stuck NOT_STARTED rows, last-run errors, slow-burn drift.
+
+        Source-of-truth for "what should have an aggregation" is
+        ``carbon_report_modules`` × ``carbon_reports.year`` (the modules
+        themselves declare their own scope).  We LEFT JOIN to the latest
+        ``job_type='aggregation'`` row per scope (``MAX(id)`` — within a
+        scope, id ordering tracks chronological insertion since serial PKs
+        are monotonically allocated).
+
+        Classification (``why_stale``):
+
+        - ``no_aggregation_ever`` — module exists but no aggregation row
+          was ever inserted for that ``(module_type_id, year)``.
+        - ``pending_aggregation_stuck`` — latest row is in a non-terminal
+          state (NOT_STARTED / QUEUED / RUNNING).  The stuck-state runner
+          sweeper handles RUNNING leases separately, but a NOT_STARTED row
+          that never got picked up surfaces here.
+        - ``last_aggregation_failed`` — latest row is FINISHED with
+          ``result=ERROR``.
+        - ``last_aggregation_too_old`` — latest row is FINISHED with
+          ``result != ERROR`` but ``finished_at`` is older than the cutoff
+          (or NULL).
+
+        Successful, fresh aggregations (FINISHED, non-ERROR, finished_at
+        within the window) are filtered out — they aren't stale.
+
+        Args:
+            threshold_minutes: How long since ``finished_at`` qualifies as
+                "too old".  Caller is responsible for range-checking
+                (``>= 1``).
+
+        Returns:
+            Unsorted list of stale entries.  The endpoint stamps the HTTP
+            response shape; the repo stays Pydantic-free.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=threshold_minutes)
+
+        # Latest aggregation row per (module_type_id, year), regardless of
+        # state — pending rows must be visible alongside finished ones.
+        latest_agg_sub = (
+            select(
+                col(DataIngestionJob.module_type_id).label("module_type_id"),
+                col(DataIngestionJob.year).label("year"),
+                func.max(col(DataIngestionJob.id)).label("latest_job_id"),
+            )
+            .where(
+                col(DataIngestionJob.job_type) == "aggregation",
+                col(DataIngestionJob.module_type_id).isnot(None),
+                col(DataIngestionJob.year).isnot(None),
+            )
+            .group_by(
+                col(DataIngestionJob.module_type_id),
+                col(DataIngestionJob.year),
+            )
+            .subquery()
+        )
+
+        # Seed: distinct (module_type_id, carbon_reports.year) the modules
+        # themselves declare.  DISTINCT keeps the seed one row per scope
+        # even when many units share the same (module_type_id, year).
+        scopes_sub = (
+            select(
+                col(CarbonReportModule.module_type_id).label("module_type_id"),
+                col(CarbonReport.year).label("year"),
+            )
+            .join(
+                CarbonReport,
+                col(CarbonReportModule.carbon_report_id) == col(CarbonReport.id),
+            )
+            .distinct()
+            .subquery()
+        )
+
+        # LEFT JOIN scopes → latest aggregation; rows with NULL latest_job_id
+        # are the "no_aggregation_ever" bucket.
+        stmt = select(
+            scopes_sub.c.module_type_id,
+            scopes_sub.c.year,
+            latest_agg_sub.c.latest_job_id,
+        ).join(
+            latest_agg_sub,
+            and_(
+                scopes_sub.c.module_type_id == latest_agg_sub.c.module_type_id,
+                scopes_sub.c.year == latest_agg_sub.c.year,
+            ),
+            isouter=True,
+        )
+        scope_rows = (await self.session.execute(stmt)).all()
+
+        # Hydrate the latest job rows in one extra round-trip — only the
+        # state/result/finished_at columns are needed for classification.
+        latest_ids = [
+            r.latest_job_id for r in scope_rows if r.latest_job_id is not None
+        ]
+        latest_jobs: dict[int, DataIngestionJob] = {}
+        if latest_ids:
+            jobs_stmt = select(DataIngestionJob).where(
+                col(DataIngestionJob.id).in_(latest_ids)
+            )
+            jobs_result = await self.session.execute(jobs_stmt)
+            for job in jobs_result.scalars().all():
+                if job.id is not None:
+                    latest_jobs[job.id] = job
+
+        out: list[StaleStatsRow] = []
+        for r in scope_rows:
+            job = (
+                latest_jobs.get(r.latest_job_id)
+                if r.latest_job_id is not None
+                else None
+            )
+            if job is None:
+                out.append(
+                    StaleStatsRow(
+                        module_type_id=r.module_type_id,
+                        year=r.year,
+                        last_finished_aggregation_at=None,
+                        why_stale="no_aggregation_ever",
+                        last_aggregation_job_id=None,
+                    )
+                )
+                continue
+
+            if job.state != IngestionState.FINISHED:
+                # NOT_STARTED / QUEUED / RUNNING — runner hasn't terminally
+                # resolved this row yet.
+                out.append(
+                    StaleStatsRow(
+                        module_type_id=r.module_type_id,
+                        year=r.year,
+                        last_finished_aggregation_at=None,
+                        why_stale="pending_aggregation_stuck",
+                        last_aggregation_job_id=job.id,
+                    )
+                )
+                continue
+
+            if job.result == IngestionResult.ERROR:
+                out.append(
+                    StaleStatsRow(
+                        module_type_id=r.module_type_id,
+                        year=r.year,
+                        last_finished_aggregation_at=job.finished_at,
+                        why_stale="last_aggregation_failed",
+                        last_aggregation_job_id=job.id,
+                    )
+                )
+                continue
+
+            # FINISHED, non-ERROR — only stale if finished_at is missing or
+            # older than the cutoff.  Fresh successes don't surface.
+            if job.finished_at is None or job.finished_at < cutoff:
+                out.append(
+                    StaleStatsRow(
+                        module_type_id=r.module_type_id,
+                        year=r.year,
+                        last_finished_aggregation_at=job.finished_at,
+                        why_stale="last_aggregation_too_old",
+                        last_aggregation_job_id=job.id,
+                    )
+                )
+
+        return out
+
 
 class RecalculationStatusRow(TypedDict):
     """Lightweight status row returned by get_recalculation_status_by_year."""
@@ -916,3 +1090,25 @@ class RecalculationStatusRow(TypedDict):
     last_factor_job_result: Optional[IngestionResult]
     last_recalculation_job_id: Optional[int]
     last_recalculation_job_result: Optional[IngestionResult]
+
+
+WhyStaleLiteral = Literal[
+    "no_aggregation_ever",
+    "last_aggregation_failed",
+    "last_aggregation_too_old",
+    "pending_aggregation_stuck",
+]
+
+
+class StaleStatsRow(TypedDict):
+    """Lightweight stale-aggregation row returned by ``find_stale_aggregations``.
+
+    Mirrors the ``StaleStatsEntry`` Pydantic schema in ``api/v1/data_sync.py``;
+    the repo stays Pydantic-free so unit tests don't need the FastAPI stack.
+    """
+
+    module_type_id: int
+    year: int
+    last_finished_aggregation_at: Optional[datetime]
+    why_stale: WhyStaleLiteral
+    last_aggregation_job_id: Optional[int]

--- a/backend/tests/integration/services/data_ingestion/test_stale_stats_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_stale_stats_endpoint_pg.py
@@ -1,0 +1,365 @@
+"""Integration tests for ``GET /v1/sync/health/stale-stats`` against a
+real Postgres.
+
+Plan 310-D Follow-up 1 (#1063) — read-only backstop endpoint that walks
+``carbon_report_modules`` × ``carbon_reports.year`` (the source-of-truth
+for "what should have an aggregation") and returns one entry per
+``(module_type_id, year)`` whose latest ``job_type='aggregation'`` row
+is missing, failed, stuck, or too old.
+
+Each ``why_stale`` bucket gets its own dedicated scope here: a single
+seed exercising all four classifications side-by-side proves the
+endpoint is bucketing rows correctly and stamping ``last_aggregation_job_id``
+from the right row.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+)
+from app.models.unit import Unit
+from app.models.user import UserProvider
+
+# Four module_type_ids — one per why_stale bucket — keep classifications
+# decoupled from each other.  Concrete ModuleTypeEnum values aren't
+# required (the seed query keys on module_type_id integers), but using
+# real ints keeps the test honest about the production schema.
+_MT_NO_AGG = 1  # ModuleTypeEnum.headcount
+_MT_FAILED = 2  # ModuleTypeEnum.professional_travel
+_MT_TOO_OLD = 3  # ModuleTypeEnum.buildings
+_MT_STUCK = 4  # ModuleTypeEnum.equipment_electric_consumption
+
+_YEAR = 2025
+
+
+def _make_aggregation(
+    *,
+    module_type_id: int,
+    year: int,
+    state: IngestionState,
+    result: IngestionResult | None = None,
+    finished_at: datetime | None = None,
+) -> DataIngestionJob:
+    """Construct a ``job_type='aggregation'`` row for seeding.
+
+    Mirrors the shape ``_chain.py`` produces — entity_type per-year,
+    ingestion_method=computed (aggregation isn't a CSV/API ingest, it's
+    derived) — so tests stay close to production rows.
+    """
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=module_type_id,
+        year=year,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=state,
+        result=result,
+        finished_at=finished_at,
+        job_type="aggregation",
+        is_current=False,
+        meta={},
+    )
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn_with_310b, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth.
+
+    Same pattern as ``test_factors_stale_endpoint_pg.py``: use the
+    ``pg_dsn_with_310b`` fixture so the production schema's partial unique
+    indexes (and any future per-batch DDL added there) are present even
+    though our seed doesn't actually need them.
+    """
+    engine = create_async_engine(pg_dsn_with_310b, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+
+    yield {"factory": Sf, "engine": engine}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+async def _seed_four_buckets(Sf) -> dict[str, int | None]:
+    """Seed one scope per ``why_stale`` bucket and one fresh-success
+    control scope (which must NOT surface).
+
+    Returns a dict mapping bucket key → expected ``last_aggregation_job_id``
+    (None for the no-aggregation-ever scope).
+    """
+    now = datetime.now(timezone.utc)
+    expected: dict[str, int | None] = {}
+
+    async with Sf() as s:
+        unit = Unit(
+            institutional_code="STALE-TEST",
+            institutional_id="STALE-TEST-UNIT",
+            name="Stale Stats Test Unit",
+            level=1,
+        )
+        s.add(unit)
+        await s.commit()
+        assert unit.id is not None
+        unit_id: int = unit.id
+
+        report = CarbonReport(year=_YEAR, unit_id=unit_id)
+        s.add(report)
+        await s.commit()
+        assert report.id is not None
+        report_id: int = report.id
+
+        # ── Seed one CarbonReportModule per bucket ─────────────────────
+        # The endpoint's seed-of-truth is carbon_report_modules; without
+        # these rows the LEFT JOIN drops the scopes entirely.
+        for mt in (_MT_NO_AGG, _MT_FAILED, _MT_TOO_OLD, _MT_STUCK):
+            s.add(
+                CarbonReportModule(
+                    carbon_report_id=report_id,
+                    module_type_id=mt,
+                )
+            )
+        # Also seed a fresh-success control scope — must NOT show up in
+        # the response.
+        _MT_FRESH = 5  # ModuleTypeEnum.purchase
+        s.add(
+            CarbonReportModule(
+                carbon_report_id=report_id,
+                module_type_id=_MT_FRESH,
+            )
+        )
+        await s.commit()
+
+        # ── Seed aggregation jobs for buckets that have one ────────────
+        # last_aggregation_failed
+        failed_job = _make_aggregation(
+            module_type_id=_MT_FAILED,
+            year=_YEAR,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            finished_at=now - timedelta(minutes=5),
+        )
+        s.add(failed_job)
+
+        # last_aggregation_too_old — finished_at well outside any
+        # reasonable threshold.
+        too_old_job = _make_aggregation(
+            module_type_id=_MT_TOO_OLD,
+            year=_YEAR,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            finished_at=now - timedelta(days=2),
+        )
+        s.add(too_old_job)
+
+        # pending_aggregation_stuck — NOT_STARTED, never picked up.
+        stuck_job = _make_aggregation(
+            module_type_id=_MT_STUCK,
+            year=_YEAR,
+            state=IngestionState.NOT_STARTED,
+        )
+        s.add(stuck_job)
+
+        # Fresh control — FINISHED + SUCCESS + recent.  Must be excluded.
+        fresh_job = _make_aggregation(
+            module_type_id=_MT_FRESH,
+            year=_YEAR,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            finished_at=now,
+        )
+        s.add(fresh_job)
+
+        await s.commit()
+        expected["last_aggregation_failed"] = failed_job.id
+        expected["last_aggregation_too_old"] = too_old_job.id
+        expected["pending_aggregation_stuck"] = stuck_job.id
+        expected["no_aggregation_ever"] = None
+
+    return expected
+
+
+@pytest.mark.asyncio
+async def test_stale_stats_classifies_each_why_stale_bucket(pg_app):
+    """End-to-end: seed all four ``why_stale`` shapes plus a fresh
+    control, hit the endpoint, assert each entry has the correct
+    classification + the correct ``last_aggregation_job_id``."""
+    Sf = pg_app["factory"]
+    expected = await _seed_four_buckets(Sf)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        # Threshold = 60 min — well below the 2-day too-old job's age and
+        # well above the 5-min failed job's age.  finished_at is
+        # irrelevant for the failed/stuck buckets, but exercising a
+        # realistic value keeps the test honest.
+        resp = await client.get(
+            "/v1/sync/health/stale-stats", params={"older_than_minutes": 60}
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, list)
+    # Four stale buckets, fresh control excluded.
+    assert len(body) == 4, f"Expected 4 stale rows, got {body!r}"
+
+    by_module = {row["module_type_id"]: row for row in body}
+    assert set(by_module.keys()) == {_MT_NO_AGG, _MT_FAILED, _MT_TOO_OLD, _MT_STUCK}
+
+    no_agg = by_module[_MT_NO_AGG]
+    assert no_agg["why_stale"] == "no_aggregation_ever"
+    assert no_agg["last_aggregation_job_id"] is None
+    assert no_agg["last_finished_aggregation_at"] is None
+    assert no_agg["year"] == _YEAR
+
+    failed = by_module[_MT_FAILED]
+    assert failed["why_stale"] == "last_aggregation_failed"
+    assert failed["last_aggregation_job_id"] == expected["last_aggregation_failed"]
+    assert failed["last_finished_aggregation_at"] is not None
+    assert failed["year"] == _YEAR
+
+    too_old = by_module[_MT_TOO_OLD]
+    assert too_old["why_stale"] == "last_aggregation_too_old"
+    assert too_old["last_aggregation_job_id"] == expected["last_aggregation_too_old"]
+    assert too_old["last_finished_aggregation_at"] is not None
+    assert too_old["year"] == _YEAR
+
+    stuck = by_module[_MT_STUCK]
+    assert stuck["why_stale"] == "pending_aggregation_stuck"
+    assert stuck["last_aggregation_job_id"] == expected["pending_aggregation_stuck"]
+    # NOT_STARTED rows haven't finished — no finished_at to surface.
+    assert stuck["last_finished_aggregation_at"] is None
+    assert stuck["year"] == _YEAR
+
+
+@pytest.mark.asyncio
+async def test_stale_stats_returns_403_for_user_without_permission(
+    pg_dsn, monkeypatch
+):
+    """Permission gate — ``GET /v1/sync/health/stale-stats`` is behind
+    ``backoffice.data_management.view``.  Users without that permission
+    get HTTP 403, not the stale list.
+
+    Bypasses ``pg_app`` (which monkeypatches ``is_permitted`` to True) so
+    the real permission check fires.  Mirrors the pattern in
+    ``test_factors_stale_endpoint_pg.py``."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _deny(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("app.core.security.is_permitted", _deny)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/v1/sync/health/stale-stats")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_stale_stats_returns_empty_list_with_no_modules(pg_app):
+    """No ``carbon_report_modules`` rows → endpoint returns ``[]``.
+
+    The endpoint's seed is the modules table; if no module declares a
+    scope, there's nothing to be stale about — even if orphan aggregation
+    rows exist for unrelated module types.  Validates that the LEFT JOIN
+    starts from modules and not from jobs."""
+    Sf = pg_app["factory"]
+
+    # Seed a stuck aggregation row WITHOUT a matching CarbonReportModule.
+    # If the query joined the wrong direction it would surface here.
+    async with Sf() as s:
+        s.add(
+            _make_aggregation(
+                module_type_id=99,
+                year=_YEAR,
+                state=IngestionState.NOT_STARTED,
+            )
+        )
+        await s.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/health/stale-stats")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_stale_stats_rejects_zero_threshold(pg_app):
+    """``older_than_minutes`` is range-checked (``ge=1``).  Calling with
+    0 must 422 — guards against a misconfigured scrape job sending the
+    default and getting back the entire universe."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(
+            "/v1/sync/health/stale-stats", params={"older_than_minutes": 0}
+        )
+
+    assert resp.status_code == 422, resp.text

--- a/docs/src/implementation-plans/310-d-architecture-followups.md
+++ b/docs/src/implementation-plans/310-d-architecture-followups.md
@@ -1,0 +1,106 @@
+---
+status: in-progress
+issue: 310-d
+last_updated: 2026-05-07
+title: "310-d Architecture follow-ups (#1062 / #1063 / #1064)"
+summary: "Three architectural follow-ups staged from the 310-D landing — passive-monitoring backstop, unified pipeline state store, and DedupConfig generalisation. Each is tracked on a dedicated GitHub issue and lands in the post-merge fix batch."
+---
+
+# 310-d Architecture follow-ups
+
+The 310-D pipeline shipped a runner-driven aggregation chain plus a
+reactive frontend story. Three architecture-shaped follow-ups were
+deferred during that landing — they aren't bug fixes (those live in
+`docs/code-review/310-overall-review.md`), they're shape work for the
+next iteration.
+
+This document is the umbrella; each follow-up has a dedicated section
+below tracking its delivery state.
+
+---
+
+## Follow-up 1 — Pipeline-failure observability backstop endpoint (#1063)
+
+### Status
+
+**Delivered in PR #<TBD>** (post-merge fix batch, Unit 10).
+
+### Problem
+
+The runner-driven chain surfaces failures interactively (recalc badge +
+pipeline diagnostic tooltip) when an operator is watching. The
+passive-monitoring case has no single owner:
+
+- Background failures with no operator watching never trigger an alert.
+- Stuck `NOT_STARTED` aggregation rows (claim never happened) are
+  invisible to the recalc UI.
+- Slow-burn drift — a successful aggregation grows older than its data —
+  goes unnoticed.
+
+### Decision
+
+**Operator-triggered, no auto-retry**: a read-only health endpoint
+suitable for Datadog / Prometheus scrape. Auto-retry was rejected
+because it has retry-storm modes that aren't worth the complexity now.
+
+### Shape
+
+- `GET /v1/sync/health/stale-stats?older_than_minutes=60` (default 60,
+  `ge=1`).
+- Gated on `backoffice.data_management.view`.
+- Returns `list[StaleStatsEntry]` — one row per
+  `(module_type_id, year)` that is stale or missing an aggregation,
+  classified by `why_stale`:
+  - `no_aggregation_ever` — module exists but no aggregation row ever
+    inserted.
+  - `pending_aggregation_stuck` — latest row in a non-terminal state
+    (`NOT_STARTED` / `QUEUED` / `RUNNING`).
+  - `last_aggregation_failed` — latest row `FINISHED` with
+    `result = ERROR`.
+  - `last_aggregation_too_old` — latest row `FINISHED` with non-error
+    result but `finished_at` older than the cutoff (or `NULL`).
+
+The seed-of-truth for "what should have an aggregation" is
+`carbon_report_modules × carbon_reports.year` — the modules themselves
+declare their own scope. The query LEFT JOINs from the modules to the
+latest `job_type='aggregation'` row per scope; rows without a match fall
+into `no_aggregation_ever`.
+
+### Operator workflow
+
+1. Datadog / Prometheus scrapes the endpoint on a schedule, counts rows
+   per `why_stale` bucket, and alerts on non-zero values.
+2. Operator opens the back-office, navigates to the affected scope, and
+   triggers a recalc manually via the existing pipeline-control UI.
+
+No retry storms, no opaque background sweeps — the operator stays in
+control.
+
+---
+
+## Follow-up 2 — `<TBD — owner to fill in>` (#TBD)
+
+### Status
+
+**Pending.**
+
+This section is a placeholder for a separately-tracked follow-up. Update
+it as part of the relevant PR.
+
+---
+
+## Follow-up 3 — Unified frontend `pipelineStateStore` + bulk active-pipelines endpoint (#1062)
+
+### Status
+
+**Pending** — scheduled in the post-merge fix batch (Unit 11). The
+worker for that unit will replace this section with the delivery shape
+and PR link.
+
+---
+
+## Cross-references
+
+- Source-of-truth for the post-merge review findings:
+  `docs/code-review/310-overall-review.md`.
+- Coordinator workstream: `docs/src/implementation-plans/310-post-merge-fix-batch.md`.


### PR DESCRIPTION
## Summary

- Adds `GET /v1/sync/health/stale-stats?older_than_minutes=60` — a read-only backstop for passive monitoring of the aggregation pipeline (Plan 310-D Follow-up 1, #1063). Suitable for Datadog / Prometheus scrape; alerts trip when any `why_stale` bucket goes non-zero.
- New repo helper `find_stale_aggregations(threshold_minutes)` walks `carbon_report_modules x carbon_reports.year` (the source-of-truth for "what should have an aggregation") and classifies each scope into one of: `no_aggregation_ever`, `pending_aggregation_stuck`, `last_aggregation_failed`, `last_aggregation_too_old`. Fresh successes are excluded.
- Decision (per the post-merge fix batch plan): operator-triggered, no auto-retry — auto-retry has retry-storm modes that aren't worth the complexity now. The operator decides what to do based on which bucket lit up.

## Shape

- Endpoint gated on `backoffice.data_management.view`.
- `older_than_minutes` range-checked via FastAPI `Query(60, ge=1)`.
- `StaleStatsEntry` inlined in `data_sync.py` to match the existing schema convention there; `WhyStaleLiteral` lives in the repo and is re-used by the api module so the bucket names are defined exactly once.
- Repo stays Pydantic-free (returns a `TypedDict`), so future unit tests don't need to pull in the FastAPI stack.

## Test plan

- [x] `rtk uv run pytest backend/tests/integration/services/data_ingestion/test_stale_stats_endpoint_pg.py` — 4 tests cover each `why_stale` bucket, the permission gate (403), the empty-modules case (proves the LEFT JOIN seeds from modules, not jobs), and the range check (`older_than_minutes=0` -> 422).
- [x] `rtk uv run pytest backend/tests/integration/services/data_ingestion/` — 82 passed.
- [x] `rtk uv run pytest backend/tests/unit/` — 1288 passed.
- [x] `rtk uv run ruff check backend/app/ backend/tests/` — clean.

## Plan doc

- Creates `docs/src/implementation-plans/310-d-architecture-followups.md` (referenced by the post-merge fix batch but not yet present on `feat/310/dev`).
- Follow-up 1 marked Delivered in this PR; thin placeholders left for Follow-ups 2 and 3 so the unit-11 worker (#1062) can fill in their own without conflict.

Closes #1063