### PR TITLE
fix(alembic): merge two heads after dev integration

### DIFF
--- a/backend/alembic/versions/2026_05_07_1645-1e56d303cc85_merge_heads_backfill_carbon_project_id_.py
+++ b/backend/alembic/versions/2026_05_07_1645-1e56d303cc85_merge_heads_backfill_carbon_project_id_.py
@@ -1,0 +1,40 @@
+# codeql[py/unused-global-variable]
+"""merge heads: backfill_carbon_project_id + emission_recalc_dedup_index
+
+Revision ID: 1e56d303cc85
+Revises: f9e8d7c6b5a4, f8a9b1c2d3e4
+Create Date: 2026-05-07 16:45:28.360146
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1e56d303cc85' # noqa: F841
+down_revision: Union[str, Sequence[str], None] = ('f9e8d7c6b5a4', 'f8a9b1c2d3e4') # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary

`alembic upgrade head` was failing on `dev` with **Multiple head revisions are present** because two recent merges each added a revision branching from `e7f1a2b3c4d5`:

- `f9e8d7c6b5a4` — backfill carbon_project_id (`c38e5065`)
- `f8a9b1c2d3e4` — emission_recalc dedup-active partial unique index (#1064)

This blocks `make db-migrate` and any local/CI deploy step that targets `head`.

This PR adds an **empty merge revision** `1e56d303cc85` whose `down_revision = (f9e8d7c6b5a4, f8a9b1c2d3e4)`. No schema change — `upgrade()` and `downgrade()` are `pass`. The chain is linear again.

## Verification

- `uv run alembic heads` → single head (`1e56d303cc85`)
- `uv run alembic history -r e7f1a2b3c4d5:` shows both branches reconverging at the merge point
- `uv run alembic upgrade --sql e7f1a2b3c4d5:head` plans cleanly through both branches and the merge — emits the expected `DELETE` + `UPDATE` on `alembic_version` to collapse the two-row state back to one

## Test plan

- [ ] `cd backend && uv run alembic heads` returns exactly `1e56d303cc85 (head)` after pulling this branch
- [ ] `make db-migrate` succeeds against a freshly migrated dev DB (or one already at either prior head)
- [ ] CI migration step on `dev` is green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)