### PR TITLE
feat: update FTE chart layout and labels

### DIFF
--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -7,14 +7,12 @@ import { BarChart } from 'echarts/charts';
 import TooltipEcharts from './TooltipEcharts.vue';
 import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
 import type { EChartsOption } from 'echarts';
-import { graphic } from 'echarts';
 import { CHART_CATEGORY_COLOR_SCHEMES, colors } from 'src/constant/charts';
 import {
   TooltipComponent,
   LegendComponent,
   GridComponent,
   DatasetComponent,
-  GraphicComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 
@@ -27,7 +25,6 @@ use([
   LegendComponent,
   GridComponent,
   DatasetComponent,
-  GraphicComponent,
 ]);
 
 import { formatTonnesForChart } from 'src/utils/number';
@@ -362,7 +359,7 @@ const chartGridOption = computed(() => {
       containLabel: true,
     };
   }
-  return { left: '5%', right: '4%', top: 80, bottom: '0%', containLabel: true };
+  return { left: 65, right: '4%', top: 80, bottom: '0%', containLabel: true };
 });
 
 const chartXAxisOption = computed(() => {
@@ -401,23 +398,7 @@ const chartYAxisOption = computed(() => {
   };
 });
 
-const chartGraphicOption = computed(() => {
-  if (isPrintMode.value) return [];
-  return [
-    {
-      type: 'rect',
-      left: '46px',
-      top: '15px',
-      shape: { width: 500, height: 500 },
-      style: {
-        fill: new graphic.LinearGradient(0, 0, 0, 1, [
-          { offset: 0, color: 'rgba(240,240,240,0.9)' },
-          { offset: 1, color: 'rgba(240,240,240,0.1)' },
-        ]),
-      },
-    },
-  ];
-});
+const chartGraphicOption = computed(() => []);
 
 const chartOption = computed((): EChartsOption => {
   return {
@@ -519,31 +500,7 @@ const downloadCSV = () => {
         </span>
       </div>
 
-      <div v-if="!isPrintMode" class="flex items-center no-wrap q-gutter-sm">
-        <q-btn
-          v-if="headcountValidated"
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_png')"
-          size="xs"
-          dense
-          class="text-weight-bold q-px-sm"
-          @click="downloadPNG"
-        />
-        <q-btn
-          v-if="headcountValidated"
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_csv')"
-          size="xs"
-          dense
-          class="text-weight-bold q-px-sm"
-          @click="downloadCSV"
-        />
+      <div v-if="!isPrintMode">
         <q-checkbox
           v-if="
             props.viewAdditionalData === undefined &&
@@ -573,6 +530,34 @@ const downloadCSV = () => {
             :style="style"
           />
         </Teleport>
+      </q-card-section>
+      <q-separator v-if="!isPrintMode && headcountValidated" />
+      <q-card-section
+        v-if="!isPrintMode && headcountValidated"
+        class="flex justify-start q-gutter-sm"
+      >
+        <q-btn
+          unelevated
+          no-caps
+          outline
+          icon="o_download"
+          :label="$t('common_download_as_png')"
+          size="xs"
+          dense
+          class="text-weight-bold q-px-sm"
+          @click="downloadPNG"
+        />
+        <q-btn
+          unelevated
+          no-caps
+          outline
+          icon="o_download"
+          :label="$t('common_download_as_csv')"
+          size="xs"
+          dense
+          class="text-weight-bold q-px-sm"
+          @click="downloadCSV"
+        />
       </q-card-section>
     </template>
 

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1398,29 +1398,7 @@ const downloadCSV = () => {
         </span>
       </div>
 
-      <div v-if="!isPrintMode" class="flex items-center no-wrap q-gutter-sm">
-        <q-btn
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_png')"
-          size="xs"
-          dense
-          class="text-weight-bold q-px-sm"
-          @click="downloadPNG"
-        />
-        <q-btn
-          unelevated
-          no-caps
-          outline
-          icon="o_download"
-          :label="$t('common_download_as_csv')"
-          size="xs"
-          dense
-          class="text-weight-bold q-px-sm"
-          @click="downloadCSV"
-        />
+      <div v-if="!isPrintMode">
         <q-checkbox
           v-if="props.viewAdditionalData === undefined"
           v-model="toggleAdditionalData"
@@ -1449,6 +1427,31 @@ const downloadCSV = () => {
           :style="style"
         />
       </Teleport>
+    </q-card-section>
+    <q-separator v-if="!isPrintMode" />
+    <q-card-section v-if="!isPrintMode" class="flex justify-start q-gutter-sm">
+      <q-btn
+        unelevated
+        no-caps
+        outline
+        icon="o_download"
+        :label="$t('common_download_as_png')"
+        size="xs"
+        dense
+        class="text-weight-bold q-px-sm"
+        @click="downloadPNG"
+      />
+      <q-btn
+        unelevated
+        no-caps
+        outline
+        icon="o_download"
+        :label="$t('common_download_as_csv')"
+        size="xs"
+        dense
+        class="text-weight-bold q-px-sm"
+        @click="downloadCSV"
+      />
     </q-card-section>
   </q-card>
 </template>

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -132,8 +132,8 @@ export default {
     fr: 'Empreinte carbone par ETP (total de {FTE})',
   },
   results_carbon_footprint_per_FTE_no_headcount: {
-    en: 'Carbon footprint per FTE',
-    fr: 'Empreinte carbone par ETP',
+    en: 'My unit carbon footprint per FTE',
+    fr: "Empreinte carbone de l'unité par ETP",
   },
   results_unit_carbon_footprint: {
     en: 'Comparison to previous year',
@@ -742,8 +742,8 @@ export default {
     fr: 'Scope',
   },
   'charts-my-unit-tick': {
-    en: 'My Unit',
-    fr: 'Mon unité',
+    en: 'Total',
+    fr: 'Total',
   },
   'charts-epf-tick': {
     en: 'EPFL',


### PR DESCRIPTION
## What does this change?

- Moves PNG/CSV download buttons out of the chart header toolbar into a
  dedicated `q-card-section` below a `q-separator`, in both
  `ModuleCarbonFootprintChart` and `CarbonFootPrintPerPersonChart`
- Removes the `GraphicComponent` import and the background gradient rect
  from `CarbonFootPrintPerPersonChart` (no longer needed)
- Fixes the chart grid left margin from `'5%'` to a fixed `65px` to
  prevent y-axis label clipping
- Updates two i18n strings:
  - `results_carbon_footprint_per_FTE_no_headcount`: clarifies the title
    to "My unit carbon footprint per FTE"
  - `charts-my-unit-tick`: renames "My Unit" / "Mon unité" to "Total"

## Why is this needed?

The download buttons were visually competing with the checkbox toggle
and other header controls, making the toolbar cluttered. Moving them
below a separator gives them a consistent, discoverable location across
charts. The label changes improve clarity — "Total" is more accurate
than "My Unit" as a chart axis tick, and the FTE chart title now
explicitly scopes it to the user's unit when no headcount is available.

## Type of change

- [ ] 🐛 Bug fix
- [x] 🎨 Design/UI improvement
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #865