### PR TITLE
feat: validate calendar dates in ModuleForm

### DIFF
--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -493,13 +493,25 @@ function getFilteredOptions(
   return opts;
 }
 
+function isValidCalendarDate(val: string): boolean {
+  const parts = val.split(/[/.]/).map(Number);
+  if (parts.length !== 3) return false;
+  const [year, month, day] = parts;
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
+
 function getDateRules(required?: boolean) {
   const dateFormatRule = (val: string) => {
     if (!val || val === '') return required ? $t('validation_required') : true;
-    return (
-      /^\d{4}([/.])\d{2}\1\d{2}$/.test(val) ||
-      $t('validation_invalid_date_format')
-    );
+    if (!/^\d{4}([/.])\d{2}\1\d{2}$/.test(val))
+      return $t('validation_invalid_date_format');
+    if (!isValidCalendarDate(val)) return $t('validation_invalid_date');
+    return true;
   };
   return [dateFormatRule];
 }
@@ -784,6 +796,26 @@ function validateField(i: ModuleField) {
   }
 
   const effectiveType = i.type;
+
+  if (effectiveType === 'date') {
+    if (i.required && (v === '' || v === null || v === undefined)) {
+      errors[i.id] = $t('validation_required');
+      return false;
+    }
+    if (v && v !== '') {
+      const dateStr = String(v);
+      if (!/^\d{4}([/.])\d{2}\1\d{2}$/.test(dateStr)) {
+        errors[i.id] = $t('validation_invalid_date_format');
+        return false;
+      }
+      if (!isValidCalendarDate(dateStr)) {
+        errors[i.id] = $t('validation_invalid_date');
+        return false;
+      }
+    }
+    return !errors[i.id];
+  }
+
   // Handle direction-input validation (check origin and destination)
   if (effectiveType === 'direction-input') {
     // Clear previous errors

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -441,8 +441,12 @@ export default {
     fr: 'Obligatoire',
   },
   validation_invalid_date_format: {
-    en: 'Invalid date format, expected YYYY/MM/DD or YYYY.MM.DD',
-    fr: 'Format de date invalide, attendu AAAA/MM/JJ ou AAAA.MM.JJ',
+    en: 'Invalid date format, expected YYYY/MM/DD',
+    fr: 'Format de date invalide, attendu AAAA/MM/JJ',
+  },
+  validation_invalid_date: {
+    en: 'Invalid date',
+    fr: 'Date invalide',
   },
   validation_number_required: {
     en: 'Number required',


### PR DESCRIPTION
## What does this change?

Adds calendar date validation to `ModuleForm` for `date`-type fields.
Previously, the format regex was the only check — a structurally valid
but logically impossible date like `2024/02/31` would pass silently.
This PR adds:

- A new `isValidCalendarDate()` helper that constructs a `Date` object
  and verifies the parsed year/month/day components match the input,
  rejecting impossible dates
- A second validation pass in both `getDateRules()` and
  `validateField()` that returns `validation_invalid_date` for such
  cases
- Two updated i18n strings in `common.ts`:
  - `validation_invalid_date_format` simplified to show `YYYY/MM/DD`
    only (dot separator variant removed from the user-facing message)
  - `validation_invalid_date` added as a new key for the logical
    validity error

## Why is this needed?

Users could submit travel entries with dates that pass the regex but are
not real calendar dates (e.g. month 13, day 32, February 30). These
invalid values were reaching the backend and causing malformed data.
The calendar validity check catches them at the form level before
submission.

## Type of change

- [x] 🐛 Bug fix

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #920