### PR TITLE
test(310): frontend Playwright — pipeline observability + a11y (Unit 11/11)

### DIFF
--- a/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
+++ b/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
@@ -1,0 +1,395 @@
+/**
+ * Plan 310 / Issue #310 — Unit 11 Playwright coverage for the bulk
+ * pipeline observability surfaces shipped by PR #1059 (badge + tooltip)
+ * and PR #1071 (keyboard a11y wiring).
+ *
+ * Boundaries:
+ *
+ *   - HTTP boundary is mocked via ``page.route`` (no backend dev server).
+ *   - The SSE boundary is mocked via a controllable ``EventSource``
+ *     shim installed BEFORE the SPA bundle boots; tests drive the
+ *     stream timeline with ``page.evaluate`` calls into
+ *     ``window.__ssePipes``.
+ *
+ * What is covered:
+ *
+ *   1. Badge transitions: ``null → uuid → finished`` faithfully (see
+ *      the per-test comment for why the literal mid-page transition
+ *      isn't testable without a user upload action).
+ *   2. Tooltip content: pipeline UUID, copy-to-clipboard, per-job rows
+ *      with state/result/status_message, FINISHED+ERROR rendered red.
+ *   3. Keyboard a11y: focus opens / blur closes the tooltip — the
+ *      F-C1 regression gate.  In-tooltip Copy button is intentionally
+ *      ``test.fixme`` per the plan's Risks/Limitations section.
+ *   4. SSE error path: backend 5xx on the SNAPSHOT endpoint (the only
+ *      transport failure observable from the consumer — production
+ *      ``usePipelineStream`` has no stream ``onerror`` handler by
+ *      design) must NOT flip the badge into a permanent error state
+ *      and must not spam console.error.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import {
+  defaultSelectedYear,
+  setupDataManagementMocks,
+  mockPipelineSnapshot,
+  mockPipelineStream,
+  type ActivePipelinesController,
+} from './setup/pipeline-tooltip-mocks';
+
+const PIPELINE_UUID = '11111111-2222-3333-4444-555555555555';
+const HEADCOUNT_MODULE_TYPE_ID = 1;
+const RECALCULATING_LABEL = 'Recalculating…';
+const PIPELINE_LABEL = 'Pipeline:';
+
+/**
+ * Drive an SSE event into the in-page shim.  ``url`` is the full
+ * production stream URL (``/api/v1/sync/pipelines/{id}/stream``);
+ * the shim looks the pipe up in ``window.__ssePipes`` and fires every
+ * registered ``pipeline-update`` listener with the JSON-serialized
+ * payload.
+ *
+ * Returns ``true`` if the pipe was found and dispatched, ``false``
+ * otherwise — useful for the error-path test where we expect no pipe
+ * to exist.
+ */
+async function dispatchPipelineUpdate(
+  page: Page,
+  pipelineId: string,
+  payload: Record<string, unknown>,
+): Promise<boolean> {
+  return await page.evaluate(
+    ({ pipelineId, payload }) => {
+      const map = (window as Window & { __ssePipes?: Map<string, unknown> })
+        .__ssePipes;
+      if (!map) return false;
+      const url = `/api/v1/sync/pipelines/${pipelineId}/stream`;
+      const pipe = map.get(url) as
+        | { dispatch(eventName: string, payload: unknown): void }
+        | undefined;
+      if (!pipe) return false;
+      pipe.dispatch('pipeline-update', payload);
+      return true;
+    },
+    { pipelineId, payload },
+  );
+}
+
+/**
+ * Wait until the in-page shim has registered an EventSource for
+ * ``pipelineId``.  ``usePipelineStream.subscribe`` awaits the snapshot
+ * fetch before opening the stream, so there's a non-zero gap between
+ * the badge appearing and the pipe being available for ``dispatch``.
+ */
+async function waitForSsePipe(page: Page, pipelineId: string): Promise<void> {
+  await page.waitForFunction((pipelineId) => {
+    const map = (window as Window & { __ssePipes?: Map<string, unknown> })
+      .__ssePipes;
+    if (!map) return false;
+    return map.has(`/api/v1/sync/pipelines/${pipelineId}/stream`);
+  }, pipelineId);
+}
+
+/**
+ * Navigate to the back-office data-management page with an explicit
+ * year query param so tests are deterministic across calendar boundaries.
+ */
+async function gotoDataManagement(page: Page, year: number): Promise<void> {
+  await page.goto(`/en/back-office/data-management?year=${year}`);
+}
+
+test.describe('data-management — pipeline observability + a11y (Unit 11)', () => {
+  let activePipelines: ActivePipelinesController;
+  const year = defaultSelectedYear();
+
+  test.beforeEach(async ({ page, context }) => {
+    // Clipboard API is gated behind permissions in chromium — tests
+    // that read ``navigator.clipboard.readText`` need both grants.
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    ({ activePipelines } = await setupDataManagementMocks(page, year));
+  });
+
+  test('no badge when no active pipeline', async ({ page }) => {
+    activePipelines.set({});
+    await gotoDataManagement(page, year);
+
+    // Wait for ``ModuleConfig`` to render — the "Headcount" expand-item
+    // header is the earliest stable signal that the year-config
+    // response landed and the v-for over ``MODULES_LIST`` ran.
+    await expect(page.getByText('Headcount').first()).toBeVisible();
+    await expect(page.getByText(RECALCULATING_LABEL)).toHaveCount(0);
+  });
+
+  test('badge appears when active pipeline exists, tooltip shows UUID and per-job rows', async ({
+    page,
+  }) => {
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    // Badge is rendered for the headcount module.
+    const badge = page.getByText(RECALCULATING_LABEL).first();
+    await expect(badge).toBeVisible();
+
+    // The SSE pipe should be opened by the composable; once it's
+    // there, dispatch a representative ``pipeline-update`` so the
+    // tooltip has per-job rows to show.
+    await waitForSsePipe(page, PIPELINE_UUID);
+    await dispatchPipelineUpdate(page, PIPELINE_UUID, {
+      pipeline_id: PIPELINE_UUID,
+      jobs: [
+        {
+          id: 1,
+          job_type: 'aggregation',
+          state: 'RUNNING',
+          result: null,
+          status_message: 'Processing batches',
+          started_at: new Date(Date.now() - 5000).toISOString(),
+          finished_at: null,
+        },
+      ],
+    });
+
+    // Hover the badge — Quasar's q-tooltip is mouse-driven.
+    await badge.hover();
+
+    // UUID renders inside the tooltip.
+    await expect(page.getByText(PIPELINE_LABEL)).toBeVisible();
+    await expect(
+      page.locator('code').filter({ hasText: PIPELINE_UUID }),
+    ).toBeVisible();
+
+    // Per-job row: job_type · state · status_message.
+    await expect(page.getByText('aggregation', { exact: false })).toBeVisible();
+    await expect(page.getByText('RUNNING', { exact: false })).toBeVisible();
+    await expect(page.getByText('Processing batches')).toBeVisible();
+  });
+
+  test('copy button writes pipeline UUID to clipboard', async ({ page }) => {
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    const badge = page.getByText(RECALCULATING_LABEL).first();
+    await expect(badge).toBeVisible();
+    await waitForSsePipe(page, PIPELINE_UUID);
+    await badge.hover();
+
+    // The copy button is the only ``content_copy`` icon in the
+    // tooltip.  Quasar's tooltip portal sets ``no-pointer-events`` on
+    // the wrapper, so even ``click({ force: true })`` lands on the
+    // overlay and the underlying Vue ``@click`` handler never fires.
+    // Dispatch a synthetic ``click`` event straight at the button
+    // element instead — the same event Vue listens for.
+    const copyButton = page
+      .locator('button')
+      .filter({ has: page.locator('.q-icon').getByText('content_copy') })
+      .first();
+    await copyButton.evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+
+    // Read from the deterministic clipboard mirror installed by
+    // ``installPlaywrightTestShims`` — see the comment there for why
+    // we can't rely on ``navigator.clipboard.readText()`` round-trips
+    // in headless chromium.
+    const clipboardContents = await page.evaluate(() => {
+      return (
+        (window as Window & { __clipboard?: { value: string } }).__clipboard
+          ?.value ?? ''
+      );
+    });
+    expect(clipboardContents).toBe(PIPELINE_UUID);
+  });
+
+  test('FINISHED + ERROR job renders red status_message', async ({ page }) => {
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    // The SSE event flips the pipeline into the failed state.  The
+    // composable's ``hasErrorFor`` returns true and the badge variant
+    // becomes "Last recalc failed" (negative color).  We verify the
+    // tooltip contents are rendered with the negative-color class.
+    await waitForSsePipe(page, PIPELINE_UUID);
+    await dispatchPipelineUpdate(page, PIPELINE_UUID, {
+      pipeline_id: PIPELINE_UUID,
+      jobs: [
+        {
+          id: 7,
+          job_type: 'emission_recalc',
+          state: 'FINISHED',
+          result: 'ERROR',
+          status_message: 'Database deadlock; retry recommended',
+          started_at: new Date(Date.now() - 10000).toISOString(),
+          finished_at: new Date(Date.now() - 1000).toISOString(),
+        },
+      ],
+    });
+
+    // Failure-state badge ("Last recalc failed") is the variant that
+    // surfaces hasError=true; hover it to open its diagnostic tooltip.
+    const failedBadge = page.getByText('Last recalc failed').first();
+    await expect(failedBadge).toBeVisible();
+    await failedBadge.hover();
+
+    const errorMsg = page
+      .getByText('Database deadlock; retry recommended')
+      .first();
+    await expect(errorMsg).toBeVisible();
+    // Quasar's negative color resolves to the ``text-negative`` class.
+    await expect(errorMsg).toHaveClass(/text-negative/);
+  });
+
+  test('badge clears after stream_closed event + active-pipelines refetch', async ({
+    page,
+  }) => {
+    // Faithful "uuid → cleared" transition: the page loads with an
+    // active pipeline (badge visible).  The SSE stream then fires its
+    // terminal ``stream_closed: true`` event, which (a) sets the
+    // store's ``closed`` flag → ``isFinishedFor`` flips to true → the
+    // ``isRecalculating`` computed flips to false; (b) the watcher
+    // refetches active-pipelines, which we flip to ``{}`` so the
+    // pipelineId clears entirely.  Both effects are needed for the
+    // badge to disappear in steady state — see ModuleConfig.vue's
+    // post-finish watcher chain.
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    const badge = page.getByText(RECALCULATING_LABEL).first();
+    await expect(badge).toBeVisible();
+    await waitForSsePipe(page, PIPELINE_UUID);
+
+    // Flip the closure-controlled mock BEFORE dispatching the
+    // terminal event; the watcher's refetch fires synchronously
+    // after the SSE event.
+    activePipelines.set({});
+
+    await dispatchPipelineUpdate(page, PIPELINE_UUID, {
+      pipeline_id: PIPELINE_UUID,
+      jobs: [
+        {
+          id: 1,
+          job_type: 'aggregation',
+          state: 'FINISHED',
+          result: 'OK',
+          status_message: null,
+          started_at: new Date(Date.now() - 5000).toISOString(),
+          finished_at: new Date().toISOString(),
+        },
+      ],
+      stream_closed: true,
+    });
+
+    await expect(page.getByText(RECALCULATING_LABEL)).toHaveCount(0);
+  });
+
+  test('keyboard a11y: focus opens tooltip, blur closes it (F-C1 regression gate)', async ({
+    page,
+  }) => {
+    // Pin PR #1071 / commit b801ac56: ``q-tooltip`` is mouse-only by
+    // default, so ``tabindex="0"`` alone never opens it for keyboard
+    // users.  ``ModuleConfig.vue`` wires ``@focus="recalcTooltip?.show()"``
+    // and ``@blur="recalcTooltip?.hide()"`` so the diagnostic content
+    // is reachable without a mouse.  This test fails if that wiring
+    // regresses.
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    const badge = page.getByText(RECALCULATING_LABEL).first();
+    await expect(badge).toBeVisible();
+    await waitForSsePipe(page, PIPELINE_UUID);
+    await dispatchPipelineUpdate(page, PIPELINE_UUID, {
+      pipeline_id: PIPELINE_UUID,
+      jobs: [
+        {
+          id: 1,
+          job_type: 'aggregation',
+          state: 'RUNNING',
+          result: null,
+          status_message: 'Processing',
+          started_at: new Date().toISOString(),
+          finished_at: null,
+        },
+      ],
+    });
+
+    // Programmatic focus mirrors what Tab navigation does for
+    // ``tabindex="0"`` elements without the noise of relying on the
+    // browser's tab-order calculus over a deeply-nested page.
+    await badge.focus();
+
+    // Tooltip opens — ``Pipeline:`` label is exclusive to the
+    // diagnostic tooltip body.
+    await expect(page.getByText(PIPELINE_LABEL)).toBeVisible();
+
+    // Blur — Quasar's ``q-tooltip`` removes itself from the DOM on
+    // ``hide``, so the assertion is "no Pipeline: anywhere".
+    await badge.blur();
+    await expect(page.getByText(PIPELINE_LABEL)).toHaveCount(0);
+  });
+
+  // Documented limitation from PR #1071: the in-tooltip Copy button is
+  // not keyboard-reachable today because tabbing into it blurs the
+  // anchor badge and Quasar's ``<q-tooltip>`` portal collapses on
+  // anchor blur.  Full keyboard reachability requires switching the
+  // primitive (``<q-popup-proxy>`` / ``<q-menu>``) — tracked in the
+  // 310-D plan's Limitations section.  Marking ``test.fixme`` so this
+  // shows up in the report as known-not-implemented rather than a
+  // silent gap.
+  test.fixme('keyboard a11y: copy-pipeline-id button is reachable via Tab (known limitation)', async () => {
+    // Intentionally empty — see comment above and
+    // docs/src/implementation-plans/310-d-frontend-stale-stats.md
+    // (Click-to-stick / full keyboard reachability follow-up).
+  });
+
+  test('snapshot 5xx does not turn badge into a permanent error', async ({
+    page,
+  }) => {
+    // Production ``usePipelineStream`` has no ``onerror`` handler by
+    // design (see the file's "Reconnect strategy" header comment —
+    // native ``EventSource`` retries transient drops on its own
+    // clock).  So a stream-endpoint 5xx is structurally unobservable
+    // from the consumer side: this test exercises the SNAPSHOT 5xx
+    // path (``GET /api/v1/sync/pipelines/{id}``, the one-shot fetch
+    // ``subscribe`` does before opening the stream).  The composable's
+    // ``defaultSnapshotFetcher`` swallows the rejection and falls
+    // through to ``openStream``; the badge should stay in the
+    // "Recalculating…" state (not flip to a failure variant) and the
+    // page should not emit unhandled console errors.
+
+    // Tear down the default mocks for the two stream-related routes
+    // and re-register them with 5xx behaviour.  Playwright matches
+    // last-registered first, so the new handlers win without
+    // disturbing the catch-all from beforeEach.
+    await page.unroute(/\/api\/v1\/sync\/pipelines\/[^/]+$/);
+    await page.unroute(/\/api\/v1\/sync\/pipelines\/[^/]+\/stream$/);
+    await mockPipelineSnapshot(page, { status: 502 });
+    await mockPipelineStream(page, { status: 502 });
+
+    // Track console.error: error path should be silent (composable's
+    // catch-and-fall-through behaviour means no thrown rejection
+    // bubbles up).  ``[usePipelineStream] malformed pipeline-update``
+    // is the only allow-listed source from the production code, but
+    // we don't dispatch malformed events here.
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    const badge = page.getByText(RECALCULATING_LABEL).first();
+    await expect(badge).toBeVisible();
+
+    // The badge still says "Recalculating…" (info color) — it has not
+    // flipped to "Last recalc failed" because the store has no
+    // FINISHED+ERROR jobs.  The ``hasErrorFor`` computed only flips
+    // on actual job state, not on transport-level failures.
+    await expect(page.getByText('Last recalc failed')).toHaveCount(0);
+
+    // No console spam from the snapshot 5xx — the composable
+    // intentionally swallows the rejection.
+    expect(
+      consoleErrors.filter((msg) => msg.includes('[usePipelineStream]')),
+    ).toEqual([]);
+  });
+});

--- a/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
+++ b/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
@@ -1,0 +1,420 @@
+/**
+ * Plan 310 / Issue #310 — shared HTTP-boundary mocks for the back-office
+ * data-management Playwright suite.
+ *
+ * Two responsibilities:
+ *
+ * 1. Inject a stub ``window.EventSource`` BEFORE the SPA bundle boots
+ *    so ``usePipelineStream`` ends up wired to a controllable shim
+ *    (the composable's ``__setEventSourceImpl`` test seam is
+ *    bundle-internal and unreachable from a Playwright e2e context).
+ *    The shim captures every ``new EventSource(url)`` into a global
+ *    map keyed by URL and exposes ``dispatch(eventName, payload)``
+ *    per instance — tests drive the SSE timeline via ``page.evaluate``.
+ *
+ * 2. Stub the small set of HTTP endpoints DataManagementPage hits on
+ *    mount so navigation reaches a fully-rendered ``ModuleConfig``
+ *    without a backend dev server.  The active-pipelines mock is
+ *    closure-controlled so tests can flip its return mid-flow without
+ *    re-registering the route handler.
+ *
+ * Unit 10 may extend this file as new data-management specs land —
+ * the helpers here are deliberately additive (each ``installX`` is a
+ * one-shot setup; extra routes can stack on the same ``page``).
+ */
+
+import type { Page } from '@playwright/test';
+
+/**
+ * Wire shape for ``GET /api/v1/sync/active-pipelines?year=Y&modules=...``.
+ * Sparse: only modules with an active pipeline are present.
+ */
+export type ActivePipelinesResponse = Record<string, string>;
+
+/**
+ * Test-side handle to a single SSE pipe (one ``new EventSource`` call).
+ * ``page.evaluate`` retrieves the live shim instance via
+ * ``window.__ssePipes.get(url)`` and ``dispatch`` re-fires
+ * ``addEventListener`` callbacks.
+ */
+export interface SsePipe {
+  url: string;
+  // The shim object is created in page context; tests call its
+  // ``dispatch`` from ``page.evaluate``.  Typed as ``unknown`` here to
+  // discourage Node-side use.
+  __pageContext: unknown;
+}
+
+/**
+ * Install a controllable EventSource shim into the page BEFORE the
+ * SPA bundle loads.  Also sets ``__LIGHTHOUSE_BYPASS__`` so the
+ * router auth/permission guards let the back-office route through.
+ *
+ * MUST be called before ``page.goto``.  ``addInitScript`` runs on
+ * every navigation, including the initial one, before any in-page
+ * script — that's the only way to capture the ``EventSource``
+ * constructor (``usePipelineStream`` calls it eagerly inside the
+ * Vue ``setup``).
+ */
+export async function installPlaywrightTestShims(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // 1. Auth bypass — router guards short-circuit when this is set.
+    //    The page still renders ``DataManagementPage`` and ``ModuleConfig``
+    //    against whatever the HTTP route mocks return.
+    (
+      window as Window & { __LIGHTHOUSE_BYPASS__?: boolean }
+    ).__LIGHTHOUSE_BYPASS__ = true;
+
+    // 2. EventSource shim.
+    //    ``usePipelineStream`` wires listeners only for ``pipeline-update``
+    //    (and the heartbeat ``ping``) — implementing the full WHATWG
+    //    EventSource contract is overkill.  The shim:
+    //      - stores itself in ``window.__ssePipes`` (Map<url, instance>)
+    //      - implements ``addEventListener`` / ``removeEventListener`` /
+    //        ``close``
+    //      - exposes ``dispatch(eventName, payload)`` for tests
+    //
+    //    Tests pull the instance out of the map and call ``dispatch``
+    //    to simulate a backend SSE event with the parsed-JSON payload
+    //    matching ``PipelineUpdate``.
+    interface ShimSse extends EventSource {
+      __listeners: Record<string, ((ev: MessageEvent) => void)[]>;
+      __closed: boolean;
+      dispatch(eventName: string, payload: unknown): void;
+    }
+    type SsePipeMap = Map<string, ShimSse>;
+    const pipes: SsePipeMap = new Map();
+    (window as Window & { __ssePipes?: SsePipeMap }).__ssePipes = pipes;
+
+    class FakeEventSource {
+      url: string;
+      readyState = 0; // CONNECTING
+      onopen: ((ev: Event) => void) | null = null;
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      onerror: ((ev: Event) => void) | null = null;
+      __listeners: Record<string, ((ev: MessageEvent) => void)[]> = {};
+      __closed = false;
+
+      constructor(url: string) {
+        this.url = url;
+        // Match the production EventSource: open is async.  Schedule
+        // the OPEN transition on a microtask so the calling code can
+        // attach listeners before any event fires.
+        queueMicrotask(() => {
+          this.readyState = 1; // OPEN
+          if (this.onopen) this.onopen(new Event('open'));
+        });
+        pipes.set(url, this as unknown as ShimSse);
+      }
+
+      addEventListener(
+        eventName: string,
+        cb: (ev: MessageEvent) => void,
+      ): void {
+        if (!this.__listeners[eventName]) {
+          this.__listeners[eventName] = [];
+        }
+        this.__listeners[eventName].push(cb);
+      }
+
+      removeEventListener(
+        eventName: string,
+        cb: (ev: MessageEvent) => void,
+      ): void {
+        const list = this.__listeners[eventName];
+        if (!list) return;
+        const idx = list.indexOf(cb);
+        if (idx >= 0) list.splice(idx, 1);
+      }
+
+      close(): void {
+        this.__closed = true;
+        this.readyState = 2; // CLOSED
+        pipes.delete(this.url);
+      }
+
+      /**
+       * Test-only — re-fire every registered listener for ``eventName``
+       * with a synthetic MessageEvent whose ``data`` is the JSON-stringified
+       * payload (the production listener calls ``JSON.parse(event.data)``).
+       */
+      dispatch(eventName: string, payload: unknown): void {
+        if (this.__closed) return;
+        const list = this.__listeners[eventName] ?? [];
+        const ev = new MessageEvent(eventName, {
+          data: typeof payload === 'string' ? payload : JSON.stringify(payload),
+        });
+        for (const cb of list) cb(ev);
+      }
+    }
+
+    // Replace the native constructor.  Keep the static constants
+    // attached so ``readyState`` comparisons in production code keep
+    // resolving to the right values (defensive — usePipelineStream
+    // doesn't read them today, but a future caller might).
+    const Native = (window as Window & { EventSource?: typeof EventSource })
+      .EventSource;
+    (FakeEventSource as unknown as { CONNECTING: number }).CONNECTING = 0;
+    (FakeEventSource as unknown as { OPEN: number }).OPEN = 1;
+    (FakeEventSource as unknown as { CLOSED: number }).CLOSED = 2;
+    (
+      window as Window & { EventSource: unknown; __NativeEventSource?: unknown }
+    ).EventSource = FakeEventSource;
+    (window as Window & { __NativeEventSource?: unknown }).__NativeEventSource =
+      Native;
+
+    // 3. Clipboard mirror.
+    //    Headless chromium accepts the ``clipboard-write`` permission
+    //    grant but the resulting write doesn't always flow back through
+    //    ``navigator.clipboard.readText()`` reliably across the
+    //    Playwright transport.  Hijack
+    //    ``Clipboard.prototype.writeText`` (the prototype is shared
+    //    by every ``navigator.clipboard`` instance) and mirror the
+    //    value into ``window.__clipboard`` so the spec asserts off
+    //    the deterministic mirror instead of fighting transport
+    //    quirks.  Quasar's ``copyToClipboard`` also has an
+    //    ``execCommand`` fallback when ``navigator.clipboard`` is
+    //    undefined; we leave clipboard defined so the prototype
+    //    patch is what runs.
+    type ClipMirror = { value: string };
+    const mirror: ClipMirror = { value: '' };
+    (window as Window & { __clipboard?: ClipMirror }).__clipboard = mirror;
+    if (
+      typeof Clipboard !== 'undefined' &&
+      Clipboard.prototype &&
+      typeof Clipboard.prototype.writeText === 'function'
+    ) {
+      const original = Clipboard.prototype.writeText;
+      Clipboard.prototype.writeText = function (
+        this: Clipboard,
+        text: string,
+      ): Promise<void> {
+        mirror.value = text;
+        try {
+          return original.call(this, text);
+        } catch {
+          return Promise.resolve();
+        }
+      };
+    }
+  });
+}
+
+/**
+ * Build the minimal year-configuration response that lets
+ * DataManagementPage render the Headcount module card (moduleTypeId = 1).
+ *
+ * Only ``recalculation_status`` matters for the badge tests (we drive
+ * everything else via the active-pipelines + SSE pipes).  The module
+ * config bag is intentionally minimal — ``ModuleConfig.vue`` reads the
+ * ``recalculation_status`` map but happily renders against an empty
+ * submodule list.
+ */
+export function buildYearConfigResponse(year: number): unknown {
+  return {
+    year,
+    is_started: false,
+    is_reports_synced: false,
+    config: {
+      modules: {
+        '1': {
+          enabled: true,
+          uncertainty_tag: 'medium',
+          submodules: {},
+          latest_common_data_job: null,
+          latest_common_factor_job: null,
+        },
+      },
+      reduction_objectives: {},
+    },
+    recalculation_status: [
+      {
+        module_type_id: 1,
+        year,
+        needs_recalculation: false,
+        data_entry_types: [],
+      },
+    ],
+    updated_at: new Date(year, 0, 1).toISOString(),
+  };
+}
+
+/**
+ * Closure-controlled wrapper around the active-pipelines route handler.
+ * Tests get back a setter so they can flip the response mid-flow
+ * (e.g. simulate the post-stream-close refetch returning ``{}`` after
+ * having returned ``{1: <uuid>}`` initially).
+ */
+export interface ActivePipelinesController {
+  set(response: ActivePipelinesResponse): void;
+}
+
+/**
+ * Register a closure-controlled mock for
+ * ``GET /api/v1/sync/active-pipelines?...``.  Initial state is the
+ * empty map (no active pipelines), matching the steady state.
+ */
+export async function mockActivePipelines(
+  page: Page,
+): Promise<ActivePipelinesController> {
+  let current: ActivePipelinesResponse = {};
+  await page.route('**/api/v1/sync/active-pipelines*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(current),
+    });
+  });
+  return {
+    set(response) {
+      current = response;
+    },
+  };
+}
+
+/**
+ * Register the per-pipeline snapshot mock — ``GET /api/v1/sync/pipelines/{id}``
+ * (NOT the ``/stream`` suffix).  ``usePipelineStream`` calls this once
+ * before opening the SSE stream to seed initial state; the test
+ * normally just returns an empty job list and lets the SSE events
+ * drive the store.
+ */
+export async function mockPipelineSnapshot(
+  page: Page,
+  options: {
+    /** Override the default ``{pipeline_id, jobs: []}`` response. */
+    response?: (pipelineId: string) => unknown;
+    /** Return 5xx for the error-path test. */
+    status?: number;
+  } = {},
+): Promise<void> {
+  await page.route(/\/api\/v1\/sync\/pipelines\/[^/]+$/, async (route) => {
+    const url = new URL(route.request().url());
+    const pipelineId = url.pathname.split('/').pop() ?? '';
+    if (options.status && options.status >= 500) {
+      await route.fulfill({
+        status: options.status,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'mocked snapshot failure' }),
+      });
+      return;
+    }
+    const body = options.response?.(pipelineId) ?? {
+      pipeline_id: pipelineId,
+      jobs: [],
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/**
+ * Stub the SSE stream HTTP endpoint.  This catches the request that
+ * the FAKE EventSource constructor would normally fire on its way to
+ * the wire — but since we replaced ``EventSource`` itself with a shim
+ * that never opens a real connection, this route is a defensive
+ * fallback (e.g. for the error-path test where we WANT the production
+ * EventSource to see a 5xx).
+ */
+export async function mockPipelineStream(
+  page: Page,
+  options: { status?: number } = {},
+): Promise<void> {
+  await page.route(
+    /\/api\/v1\/sync\/pipelines\/[^/]+\/stream$/,
+    async (route) => {
+      if (options.status && options.status >= 500) {
+        await route.fulfill({
+          status: options.status,
+          contentType: 'text/plain',
+          body: 'mocked stream failure',
+        });
+        return;
+      }
+      // Default: empty SSE response — the shim is doing the real work.
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: '',
+      });
+    },
+  );
+}
+
+/**
+ * Catch-all guard for any ``/api/**`` request the suite did not
+ * explicitly stub.  Returns 200 ``{}`` so the page never trips a
+ * production ``Notify`` toast on an unmocked endpoint.  Routes
+ * registered ABOVE this one win (Playwright matches in registration
+ * order, last-registered first).  Call this LAST.
+ */
+export async function mockApiCatchAll(page: Page): Promise<void> {
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url();
+    // Auth-me: return a permissive identity so any code path that
+    // bypasses the LIGHTHOUSE_BYPASS guard (e.g. components reading
+    // the auth store directly) still has something to chew on.
+    if (url.includes('/auth/me')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 1,
+          email: 'test@example.com',
+          roles_raw: [{ role: 'admin' }],
+          permissions: [],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{}',
+    });
+  });
+}
+
+/**
+ * Convenience: wire every default mock + the test shims in one call.
+ *
+ * Playwright matches routes in REVERSE registration order (most-recent
+ * first), so the catch-all has to be registered FIRST — every specific
+ * route registered after it gets first-match priority.  Tests that
+ * need bespoke responses should layer their ``page.route`` calls
+ * AFTER this returns; their handlers will then win against everything
+ * registered here.
+ */
+export async function setupDataManagementMocks(
+  page: Page,
+  year: number,
+): Promise<{ activePipelines: ActivePipelinesController }> {
+  await installPlaywrightTestShims(page);
+  // Register most-general first; the specific routes layered below
+  // win because page.route matches last-registered first.
+  await mockApiCatchAll(page);
+  await page.route(`**/api/v1/year-configuration/${year}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildYearConfigResponse(year)),
+    });
+  });
+  const activePipelines = await mockActivePipelines(page);
+  await mockPipelineSnapshot(page);
+  await mockPipelineStream(page);
+  return { activePipelines };
+}
+
+/**
+ * Compute the year DataManagementPage will land on by default — the
+ * page picks ``currentYear - 1`` from a hardcoded ``MIN_YEARS=2024``
+ * sequence.  Centralized here so specs don't drift if the page logic
+ * changes.
+ */
+export function defaultSelectedYear(): number {
+  return new Date().getFullYear() - 1;
+}


### PR DESCRIPTION
## Summary
- Adds Playwright integration coverage for the back-office data-management pipeline observability surfaces shipped by PR #1059 (badge + diagnostic tooltip) and PR #1071 (keyboard a11y wiring).
- Introduces a shared mocks helper (\`tests/integration/setup/data-management-mocks.ts\`) that any future data-management Playwright spec can extend: HTTP route stubs for the small set of endpoints the page hits on mount, a controllable \`EventSource\` shim wired into \`window.__ssePipes\`, a clipboard mirror at \`window.__clipboard\`, and the \`__LIGHTHOUSE_BYPASS__\` auth/permission shim.
- 7 passing tests + 1 \`test.fixme\` documenting a known limitation; no backend changes.

## Coverage
1. Badge transitions — no badge with no active pipeline; badge appears once active-pipelines returns a uuid; badge clears after \`stream_closed: true\` + post-finish active-pipelines refetch.
2. Tooltip content — pipeline UUID rendered, copy button writes the UUID, per-job rows show \`state\` / \`result\` / \`status_message\`, FINISHED+ERROR \`status_message\` rendered with \`text-negative\`.
3. Keyboard a11y (F-C1 regression gate) — Tab/focus opens the tooltip, blur closes it. Pins PR #1071 / commit b801ac56's \`@focus\` / \`@blur\` wiring on the badge.
4. SSE error path — snapshot endpoint returning 5xx does not flip the badge into the failure variant and does not surface a \`[usePipelineStream]\` console.error. (Stream-endpoint 5xx is structurally unobservable from the consumer because production \`usePipelineStream\` has no \`onerror\` handler by design — see the file's \"Reconnect strategy\" header comment. The test name and inline comment make this explicit.)

## Documented \`test.fixme\`
\`keyboard a11y: copy-pipeline-id button is reachable via Tab (known limitation)\` — the in-tooltip Copy button is not keyboard-reachable today because Quasar's \`<q-tooltip>\` portal collapses on anchor blur; full keyboard reachability requires switching the primitive (\`<q-popup-proxy>\` / \`<q-menu>\`) and is tracked in the 310-D plan's Limitations section. Marked \`test.fixme\` so the report flags this as known-not-implemented rather than a silent gap.

## Test plan
- [x] \`pnpm playwright test tests/integration/pipeline-diagnostic-tooltip.spec.ts\` — 7 passed, 1 skipped (the documented fixme).
- [x] \`make lint\` — clean (existing pre-existing warnings unrelated to this PR).
- [x] \`make type-check-go\` — clean.
- [x] Full integration suite (\`tests/integration\`) — passes alongside existing \`home.spec.ts\` with default parallelism.