### PR TITLE
feat: adjust commuting chart colors and remove tooltip

### DIFF
--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -479,11 +479,11 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
       };
     })(),
     commuting: {
-      walking: colors.value.aqua.darker,
-      cycling: colors.value.aqua.dark,
-      powered_two_wheeler: colors.value.aqua.default,
-      public_transport: colors.value.aqua.light,
-      car: colors.value.aqua.lighter,
+      powered_two_wheeler: colors.value.aqua.darker,
+      public_transport: colors.value.aqua.dark,
+      car: colors.value.aqua.default,
+      cycling: colors.value.aqua.light,
+      walking: colors.value.aqua.lighter,
     },
     food: {
       vegetarian: colors.value.mint.darker,

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -887,11 +887,6 @@ const getUncertainty = (
                 <h2 class="text-h2 text-weight-medium q-mb-none">
                   {{ $t('results_additional_title') }}
                 </h2>
-                <q-icon name="o_info" size="sm" class="text-primary">
-                  <q-tooltip class="text-body2 text-black" max-width="320px">
-                    {{ $t('results_additional_waste_tooltip') }}
-                  </q-tooltip>
-                </q-icon>
               </div>
               <span class="text-body1 text-secondary">{{
                 $t('results_additional_subtitle')


### PR DESCRIPTION
## What does this change?

Two small adjustments to the results page and chart configuration:

- **Commuting color order** (`charts.ts`): Reorders the commuting
  subcategory color assignments so that higher-emission modes get darker
  shades. The new order from darkest to lightest is:
  `powered_two_wheeler → public_transport → car → cycling → walking`,
  replacing the previous alphabetical-ish order that started with
  `walking` as the darkest.
- **Additional categories tooltip removed** (`ResultsPage.vue`): Drops
  the `o_info` icon and its `results_additional_waste_tooltip` tooltip
  from the additional categories section heading.

## Why is this needed?

The commuting color scale was visually misleading — low-emission modes
like walking and cycling were rendered in the darkest shades, implying
higher impact. Reordering aligns color intensity with actual emission
weight. The tooltip on the additional categories title was flagged as
redundant or confusing in UX feedback and has been removed to simplify
the heading area.

## Type of change

- [ ] 🐛 Bug fix
- [x] 🎨 Design/UI improvement
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #878 