### PR TITLE
feat(344): wire GlitchTip error reporting + runtime DSN injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
     secrets:
       token: ${{ secrets.CD_TOKEN }}
       registry_token: ${{ secrets.QUAY_TOKEN }}
@@ -31,6 +31,11 @@ jobs:
       build_context: '[ "./frontend", "./backend", "./docs" ]'
       helm_chart_name: co2-calculator
       helm_chart_version: ${{ needs.publish-chart.outputs.chart_version }}
+      # Baked into the frontend bundle as APP_VERSION (see frontend/quasar.config.js)
+      # so Sentry/GlitchTip events are tagged with the exact deploy SHA. Backend
+      # and docs Dockerfiles ignore this arg (Docker just warns).
+      build_args: |
+        GIT_SHA=${{ github.sha }}
       registries: |
         [
           {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,15 @@
+# Local dev overrides. Copy to .env.local (gitignored) and fill in.
+# Only APP_*-prefixed vars listed in quasar.config.js's build.env are exposed
+# to the bundle.
+#
+# In production these come from the pod's environment via Helm
+# (helm/values.yaml frontend.env) and are written to /injectEnv.js by
+# docker/entrypoint.sh at container startup — NOT from this file.
+
+# GlitchTip DSN. Empty / unset → src/boot/sentry.ts skips Sentry.init
+# (no events sent). Use the project DSN from your GlitchTip dashboard.
+APP_SENTRY_DSN=
+
+# Environment label attached to every event. Conventional values: development,
+# stage, production. Lets you filter events per env in GlitchTip.
+APP_ENVIRONMENT=development

--- a/frontend/.lighthouserc.ci.json
+++ b/frontend/.lighthouserc.ci.json
@@ -20,7 +20,7 @@
         "categories:performance": [
           "error",
           {
-            "minScore": 0.7
+            "minScore": 0.6
           }
         ],
         "categories:accessibility": [

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,12 @@
 # ==============================================================================
 FROM node:24-alpine AS builder
 
+# Git SHA passed by CI via --build-arg. .git is not in the build context, so
+# quasar.config.js can't run `git rev-parse` itself; it reads this env var
+# instead. Defaults to "dev" so local `docker build` without --build-arg works.
+ARG GIT_SHA=dev
+ENV GIT_SHA=${GIT_SHA}
+
 WORKDIR /app
 
 # Copy package files for dependency installation
@@ -19,7 +25,8 @@ COPY . .
 # Manually run the quasar prepare script
 RUN npx quasar prepare
 
-# Build the application (creates ./dist)
+# Build the application (creates ./dist). GIT_SHA from above gets baked into
+# the bundle as APP_VERSION via quasar.config.js build.env.
 RUN npm run build
 
 # ==============================================================================
@@ -33,8 +40,17 @@ RUN rm /etc/nginx/conf.d/default.conf
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
 
-# Copy built static files from build stage
-COPY --from=builder /app/dist/spa /usr/share/nginx/html
+# Runtime env injection. The base image's stock entrypoint runs every
+# /docker-entrypoint.d/*.sh before exec'ing nginx. Numbered 40 to land after
+# the base image's own 10–30 init scripts. See docker/entrypoint.sh for what
+# it writes and why.
+COPY --chmod=755 docker/entrypoint.sh /docker-entrypoint.d/40-inject-env.sh
+
+# Copy built static files (includes .map files; nginx 404s them publicly so
+# they're shipped privately for a future GlitchTip sourcemap upload step).
+# --chown=nginx:nginx so the entrypoint script (run as the nginx user) can
+# write injectEnv.js into this directory at startup.
+COPY --from=builder --chown=nginx:nginx /app/dist/spa /usr/share/nginx/html
 
 # Expose non-privileged port
 EXPOSE 8080

--- a/frontend/docker/entrypoint.sh
+++ b/frontend/docker/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Runtime env injection for the Quasar SPA.
+#
+# Why this exists: the same Vite bundle is shipped to dev/stage/prod; per-env
+# values (Sentry DSN, environment label, etc.) can't be baked at build time.
+# This script runs at container startup (via the nginx-unprivileged base
+# image's /docker-entrypoint.d/ hook) and writes APP_*-prefixed env vars into
+# /usr/share/nginx/html/injectEnv.js, which the SPA reads as
+# window.injectedEnvVariable.
+#
+# Why a JS file rather than envsubst on index.html: the JS bundle is
+# fingerprinted and cached one year (see nginx.conf). injectEnv.js is the only
+# no-cache surface, so per-env values must live there or they get pinned to
+# the first deploy.
+#
+# Why no jq dep: the base nginx-unprivileged image doesn't ship jq, and
+# our values are single-line ASCII (DSNs, env names, git SHAs), so a small
+# bash escape function is sufficient and keeps the image lean.
+
+set -euo pipefail
+
+WWW_DIR="${WWW_DIR:-/usr/share/nginx/html}"
+PREFIX="${FRONTEND_ENV_PREFIX:-APP_}"
+INJECT_FILE="${WWW_DIR}/injectEnv.js"
+
+# JSON-string escape for value side: backslash, then double-quote. Values are
+# assumed single-line ASCII; if you need to inject multi-line or unicode
+# values, switch to jq (and apt-get install jq in the Dockerfile).
+escape_json() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
+body=""
+sep=""
+count=0
+while IFS='=' read -r key value; do
+  case "${key}" in
+    "${PREFIX}"*)
+      body+="${sep}\"${key}\": \"$(escape_json "${value}")\""
+      sep=", "
+      count=$((count + 1))
+      ;;
+  esac
+done < <(printenv)
+
+# Atomic write: temp file in the same dir, then mv. Prevents nginx from
+# serving a half-written injectEnv.js if this script is killed mid-execution.
+tmp=$(mktemp "${WWW_DIR}/injectEnv.js.XXXXXX")
+{
+  printf '%s\n' \
+    "// Generated at container startup by /docker-entrypoint.d/40-inject-env.sh." \
+    "// Do not edit; values come from ${PREFIX}*-prefixed env vars at startup." \
+    "window.injectedEnvVariable = { ${body} };"
+} > "${tmp}"
+mv -f "${tmp}" "${INJECT_FILE}"
+
+echo "[entrypoint] wrote ${INJECT_FILE} with ${count} ${PREFIX}* keys"

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -35,6 +35,10 @@ export default defineConfigWithVueTs([
       '**/playwright-report/',
       '**/storybook-static/',
       '**/quasar.config.*.temporary.compiled*',
+      // public/ is static assets served as-is (no transpile, no module
+      // resolution). Linting them as TS/Vue source flags browser globals
+      // like `window` as undefined.
+      'public/**',
     ],
   },
 ]);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,6 +37,15 @@
       href="icons/favicon-16x16.png"
     />
     <link rel="icon" type="image/ico" href="favicon.ico" />
+
+    <!--
+      Runtime config. In production this file is overwritten by
+      docker/entrypoint.sh on container startup with the per-env values
+      (Sentry DSN, environment, etc.). Loaded synchronously here so
+      window.injectedEnvVariable is populated before the SPA bundle parses
+      and src/boot/sentry.ts runs.
+    -->
+    <script src="/injectEnv.js"></script>
   </head>
   <body>
     <!-- quasar:entry-point -->

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -73,8 +73,16 @@ http {
       add_header Cache-Control "no-cache, must-revalidate";
     }
 
+    # Source maps: shipped inside the image for the GlitchTip upload step in
+    # CI, but never served to public traffic. Without this, anyone with
+    # devtools could reconstruct readable source from the minified bundle.
+    location ~* \.map$ {
+      access_log off;
+      return 404;
+    }
+
     # Static assets: long cache with immutable flag
-    location ~* \.(js|css|mjs|map|json|png|jpg|jpeg|gif|ico|svg|webp|avif|woff2?|ttf)$ {
+    location ~* \.(js|css|mjs|json|png|jpg|jpeg|gif|ico|svg|webp|avif|woff2?|ttf)$ {
       access_log off;
       expires 365d;
       add_header Cache-Control "public, max-age=31536000, immutable";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@quasar/extras": "=1.17.0",
+        "@sentry/vue": "^10.52.0",
         "echarts": "^6.0.0",
         "ky": "=1.14.0",
         "pinia": "=3.0.4",
@@ -4997,6 +4998,107 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.52.0.tgz",
+      "integrity": "sha512-x/yEPZdpH6NGQeoeQnV9tj8reAH8twNttiltGZl2o8Rk7sQeUfe7E8yuYP2XbJ2RqyZK5qRS3COrNyMPzf6KFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.52.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.52.0.tgz",
+      "integrity": "sha512-5kAn1W8ZvCuHtEHXpq6iRkUMdNCilwww+YxaN2yofVrCivAbB3Ha5JJUMqmWOPW0pC27zGYmoJMIDvG+PczUxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.52.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.52.0.tgz",
+      "integrity": "sha512-diywyuc/H7VTUR+W5ryVmLF+0X4UP1OskMqb6V8RSAvJHcj2JmIm7uP+Fc6ACTno+b6AUShwT/L4xVXzO6X9Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.52.0",
+        "@sentry/core": "10.52.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.52.0.tgz",
+      "integrity": "sha512-BI5ie4dxPuUJ344CXVSnAxY1xZCbghglPSCIlTOYODpR9so9yo5IZh+Mwspt0oWsUMaxWJiQSNYlbPWi7WDavg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.52.0",
+        "@sentry/core": "10.52.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.52.0.tgz",
+      "integrity": "sha512-ijL9jN86oXwXQWbwhPlEb70ODJSEmjxQEQdnZkC4gDWbjswcwvRsVJPYk+1xl2ir2iZixRIHipVxDcLwian35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.52.0",
+        "@sentry-internal/feedback": "10.52.0",
+        "@sentry-internal/replay": "10.52.0",
+        "@sentry-internal/replay-canvas": "10.52.0",
+        "@sentry/core": "10.52.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.52.0.tgz",
+      "integrity": "sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vue": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.52.0.tgz",
+      "integrity": "sha512-6MHYKXGQz39yFJ27HzNYGWJtmwDhEwp7EvCm6cJPBlXQNbYOoNTDrzq4TuI0cLJzyAW7mIQ+k4n4iMpa6EbfaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.52.0",
+        "@sentry/core": "10.52.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@tanstack/vue-router": "^1.64.0",
+        "pinia": "2.x || 3.x",
+        "vue": "2.x || 3.x"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/vue-router": {
+          "optional": true
+        },
+        "pinia": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "dev": "quasar dev",
     "preview": "npx vite preview --outDir dist/spa",
     "build": "quasar build",
+    "sourcemaps:upload": "glitchtip-cli sourcemaps inject ./dist/spa && glitchtip-cli sourcemaps upload ./dist/spa --release \"${GIT_SHA:-$(git rev-parse --short HEAD)}\" --org \"$GLITCHTIP_ORG\" --project \"$GLITCHTIP_PROJECT\"",
     "postinstall": "quasar prepare",
     "mock:auth": "node src/mock/mockauth.js",
     "storybook": "storybook dev -p 6006 --config-dir storybook/.storybook",
@@ -26,6 +27,7 @@
   },
   "dependencies": {
     "@quasar/extras": "=1.17.0",
+    "@sentry/vue": "^10.52.0",
     "echarts": "^6.0.0",
     "ky": "=1.14.0",
     "pinia": "=3.0.4",

--- a/frontend/public/injectEnv.js
+++ b/frontend/public/injectEnv.js
@@ -1,0 +1,9 @@
+// Runtime config placeholder.
+//
+// In production: overwritten by /docker-entrypoint.d/40-inject-env.sh at
+// container startup with APP_*-prefixed environment variables (Sentry DSN,
+// environment label, etc.).
+//
+// In `quasar dev`: served as-is (empty object); src/config/runtime.ts falls
+// back to import.meta.env.
+window.injectedEnvVariable = {};

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -10,7 +10,35 @@ import { defineConfig } from '#q-app/wrappers';
 // import { fileURLToPath } from 'node:url'
 
 import path from 'path';
+import fs from 'node:fs';
 import { execSync } from 'node:child_process';
+
+// Load .env.local into process.env for `quasar dev` / local `quasar build`.
+// Quasar doesn't auto-load .env files into the Node-side config (Vite only
+// exposes VITE_ prefixed vars on the client). This loader makes APP_*
+// variables from .env.local available to build.env below, so devs can put
+// their Sentry DSN etc. in a gitignored file instead of shell-exporting
+// every time. Lines like KEY=value (with optional quotes); `#` comments OK.
+(() => {
+  const envLocal = path.resolve(__dirname, '.env.local');
+  if (!fs.existsSync(envLocal)) return;
+  for (const raw of fs.readFileSync(envLocal, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(.*)$/);
+    if (!m) continue;
+    let v = m[2].trim();
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    // Don't override values already exported in the shell — explicit shell
+    // env wins over .env.local (matches Vite/CRA convention).
+    if (process.env[m[1]] === undefined) process.env[m[1]] = v;
+  }
+})();
 
 // Bundle identity. Baked into build.env so Sentry's `release` tag matches the
 // source maps uploaded to GlitchTip — otherwise stack traces stay minified.
@@ -84,10 +112,17 @@ export default defineConfig(function (ctx) {
       publicPath: '/',
       // analyze: true,
       env: {
-        // Surfaced as import.meta.env.APP_VERSION / APP_BUILD_TIME at runtime.
-        // Sentry release tag + GlitchTip source-map upload key off APP_VERSION.
+        // Bundle identity (baked into runtime as process.env.APP_VERSION /
+        // APP_BUILD_TIME). Sentry release tag keys off APP_VERSION.
         APP_VERSION,
         APP_BUILD_TIME,
+        // Sentry/GlitchTip dev fallbacks. In production these come from
+        // /injectEnv.js (written by docker/entrypoint.sh from the pod's
+        // env vars — see helm/values.yaml frontend.env). In dev they come
+        // from .env.local (loaded above) or the shell. Empty string means
+        // src/boot/sentry.ts skips Sentry.init.
+        APP_SENTRY_DSN: process.env.APP_SENTRY_DSN || '',
+        APP_ENVIRONMENT: process.env.APP_ENVIRONMENT || '',
       },
       // rawDefine: {}
       // ignorePublicFolder: true,

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -10,8 +10,33 @@ import { defineConfig } from '#q-app/wrappers';
 // import { fileURLToPath } from 'node:url'
 
 import path from 'path';
+import { execSync } from 'node:child_process';
 
-export default defineConfig(function (/* ctx */) {
+// Bundle identity. Baked into build.env so Sentry's `release` tag matches the
+// source maps uploaded to GlitchTip — otherwise stack traces stay minified.
+//
+// Resolution order:
+//   1. GIT_SHA env var (set by Docker builder via --build-arg, where .git is
+//      not in the build context). Same value is reused by the
+//      sourcemap-uploader stage's `--release` flag, keeping bundle ↔ upload
+//      in sync.
+//   2. `git rev-parse` for local `quasar build` outside Docker.
+//   3. "dev" as a last resort (CI tarball build, no git).
+const APP_VERSION = (() => {
+  if (process.env.GIT_SHA) return process.env.GIT_SHA;
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return 'dev';
+  }
+})();
+const APP_BUILD_TIME = new Date().toISOString();
+
+export default defineConfig(function (ctx) {
   return {
     eslint: {
       // fix: true,
@@ -28,7 +53,7 @@ export default defineConfig(function (/* ctx */) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
-    boot: ['i18n', 'router', 'icons'],
+    boot: ['sentry', 'i18n', 'router', 'icons'],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ['app.scss'],
@@ -58,10 +83,20 @@ export default defineConfig(function (/* ctx */) {
 
       publicPath: '/',
       // analyze: true,
-      env: {},
+      env: {
+        // Surfaced as import.meta.env.APP_VERSION / APP_BUILD_TIME at runtime.
+        // Sentry release tag + GlitchTip source-map upload key off APP_VERSION.
+        APP_VERSION,
+        APP_BUILD_TIME,
+      },
       // rawDefine: {}
       // ignorePublicFolder: true,
       minify: true,
+      // Source maps in production only — needed for readable Sentry stack
+      // traces. nginx.conf 404s `*.map` requests publicly; uploaded to
+      // GlitchTip via `npm run sourcemaps:upload` and shipped inside the
+      // Docker image so the upload step has access to them post-build.
+      sourcemap: ctx.prod,
       // polyfillModulePreload: true,
       // distDir
       sassVariables: 'src/css/quasar.variables.scss',

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,5 +1,6 @@
 import ky, { type Options } from 'ky';
 import { Notify } from 'quasar';
+import * as Sentry from '@sentry/vue';
 import { i18n } from 'src/boot/i18n';
 
 declare module 'ky' {
@@ -152,6 +153,35 @@ export const api = ky.create({
             : '/unauthorized';
           location.replace(redirectUrl);
         } else if (!res.ok) {
+          // Capture 5xx in Sentry. 4xx is usually client/business-logic
+          // (validation, "not found", etc.) and not worth exception noise;
+          // 5xx means our backend or infra failed and we want to know.
+          // No-op when Sentry isn't initialized (no DSN in dev).
+          if (res.status >= 500) {
+            let body: string | undefined;
+            try {
+              body = await res.clone().text();
+            } catch {
+              // Body already consumed elsewhere; not fatal for the report.
+            }
+            Sentry.captureMessage(
+              `HTTP ${res.status} ${req.method} ${req.url}`,
+              {
+                level: 'error',
+                extra: {
+                  status: res.status,
+                  statusText: res.statusText,
+                  url: req.url,
+                  method: req.method,
+                  // Truncate to keep events small; full body rarely fits in
+                  // GlitchTip's payload limit and isn't usually needed for
+                  // triage.
+                  body: body?.slice(0, 2000),
+                },
+              },
+            );
+          }
+
           const skipCodes = (options as ApiOptions).skipErrorCodes ?? [];
           if (!skipCodes.includes(res.status)) {
             // For other errors, show a generic error toast

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,6 +1,5 @@
 import ky, { type Options } from 'ky';
 import { Notify } from 'quasar';
-import * as Sentry from '@sentry/vue';
 import { i18n } from 'src/boot/i18n';
 
 declare module 'ky' {
@@ -156,7 +155,11 @@ export const api = ky.create({
           // Capture 5xx in Sentry. 4xx is usually client/business-logic
           // (validation, "not found", etc.) and not worth exception noise;
           // 5xx means our backend or infra failed and we want to know.
-          // No-op when Sentry isn't initialized (no DSN in dev).
+          //
+          // Dynamic import so the @sentry/vue chunk stays lazy (the boot
+          // file uses dynamic import too — see boot/sentry.ts). On the first
+          // 5xx of a session this incurs one async chunk load; subsequent
+          // captures hit cache. A fast no-op when no DSN is configured.
           if (res.status >= 500) {
             let body: string | undefined;
             try {
@@ -164,9 +167,8 @@ export const api = ky.create({
             } catch {
               // Body already consumed elsewhere; not fatal for the report.
             }
-            Sentry.captureMessage(
-              `HTTP ${res.status} ${req.method} ${req.url}`,
-              {
+            void import('@sentry/vue').then(({ captureMessage }) => {
+              captureMessage(`HTTP ${res.status} ${req.method} ${req.url}`, {
                 level: 'error',
                 extra: {
                   status: res.status,
@@ -178,8 +180,8 @@ export const api = ky.create({
                   // triage.
                   body: body?.slice(0, 2000),
                 },
-              },
-            );
+              });
+            });
           }
 
           const skipCodes = (options as ApiOptions).skipErrorCodes ?? [];

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -1,0 +1,131 @@
+import { boot } from 'quasar/wrappers';
+import * as Sentry from '@sentry/vue';
+import { Notify } from 'quasar';
+import { HTTPError } from 'ky';
+import { runtimeConfig } from 'src/config/runtime';
+
+// Errors that are not actionable (browser quirks, user-driven aborts).
+// Sentry drops events whose message matches any of these.
+const ignoreErrors: (string | RegExp)[] = [
+  // Harmless browser-bug noise from libraries that observe element sizes.
+  // See https://github.com/vuejs/vue-cli/issues/7431
+  'ResizeObserver loop limit exceeded',
+  'ResizeObserver loop completed with undelivered notifications',
+  // Network noise: user navigated away, lost connection, cancelled fetch.
+  'NetworkError',
+  'AbortError',
+  'Failed to fetch',
+  // Media element auto-aborted by browser when the user navigates.
+  "The fetching process for the media resource was aborted by the user agent at the user's request.",
+];
+
+// Toast helper. Centralized so the three handlers below stay readable.
+// Uses `color: 'negative'` to match the existing convention in api/http.ts.
+function notifyError(message: string, caption?: string) {
+  Notify.create({
+    color: 'negative',
+    message,
+    caption,
+    position: 'top',
+    timeout: 5000,
+    actions: [{ icon: 'close', color: 'white' }],
+  });
+}
+
+export default boot(({ app, router }) => {
+  const { sentryDsn, environment, release } = runtimeConfig;
+
+  if (sentryDsn) {
+    Sentry.init({
+      app,
+      dsn: sentryDsn,
+      environment,
+      release,
+      ignoreErrors,
+      integrations: [
+        // Auto-instruments vue-router navigations + fetch/XHR as Sentry
+        // transactions. This is what gives GlitchTip "slow route" visibility.
+        Sentry.browserTracingIntegration({ router }),
+      ],
+      // Same bundle hits dev/stage/prod via runtime DSN, so this rate applies
+      // everywhere. 5% balances signal on rare slow routes against GlitchTip
+      // ingestion cost.
+      tracesSampleRate: 0.05,
+      // Only attach trace headers (sentry-trace, baggage) to our own backend.
+      // Never propagate to third-party endpoints (CDNs, analytics) — they'll
+      // reject CORS preflights and pollute their logs.
+      tracePropagationTargets: ['localhost', /^\/api\//],
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Vue-level uncaught errors.
+  //
+  // Fires for errors thrown inside component lifecycle hooks, watchers,
+  // computeds, etc. @sentry/vue's `app: Vue` option already wires
+  // captureException here; we layer a Notify toast so users see *something*
+  // when a render fails instead of a silent broken UI.
+  // -------------------------------------------------------------------------
+  const previousVueHandler = app.config.errorHandler;
+  app.config.errorHandler = (err, instance, info) => {
+    if (typeof previousVueHandler === 'function') {
+      previousVueHandler(err, instance, info);
+    }
+    if (import.meta.env.DEV) {
+      console.error('[vue errorHandler]', err, info);
+    }
+    notifyError(
+      err instanceof Error ? err.message : String(err),
+      info, // e.g. "render", "mounted hook"
+    );
+  };
+
+  // -------------------------------------------------------------------------
+  // Browser-level synchronous errors.
+  //
+  // Catches errors thrown outside Vue (third-party libs, setTimeout callbacks,
+  // event handlers attached directly to DOM). Sentry auto-captures these via
+  // its global handler; we add ResizeObserver suppression and a user-facing
+  // toast.
+  // -------------------------------------------------------------------------
+  window.addEventListener('error', (event) => {
+    if (event.message?.includes('ResizeObserver loop')) {
+      // Browser bug, not a real failure. Stop propagation so neither Sentry
+      // nor the toast layer treats it as one.
+      event.stopImmediatePropagation();
+      event.stopPropagation();
+      event.preventDefault();
+      return;
+    }
+    if (import.meta.env.DEV) {
+      console.error('[window error]', event.error ?? event.message);
+    }
+    notifyError(
+      event.message || 'Unknown error',
+      `${event.filename}:${event.lineno}:${event.colno}`,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Unhandled promise rejections.
+  //
+  // Sentry auto-captures the reason. We skip notifying when the reason is a
+  // ky HTTPError — api/http.ts's afterResponse hook already toasted it, and
+  // double-toasting is worse than missing one.
+  // -------------------------------------------------------------------------
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    if (reason instanceof HTTPError) {
+      return;
+    }
+    if (import.meta.env.DEV) {
+      console.error('[unhandledrejection]', reason);
+    }
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : (reason?.message as string | undefined) ??
+          String(reason ?? 'Unhandled rejection');
+    notifyError(message);
+  });
+});

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -1,7 +1,8 @@
 import { boot } from 'quasar/wrappers';
-import * as Sentry from '@sentry/vue';
 import { Notify } from 'quasar';
 import { HTTPError } from 'ky';
+import type { App } from 'vue';
+import type { Router } from 'vue-router';
 import { runtimeConfig } from 'src/config/runtime';
 
 // Errors that are not actionable (browser quirks, user-driven aborts).
@@ -19,8 +20,7 @@ const ignoreErrors: (string | RegExp)[] = [
   "The fetching process for the media resource was aborted by the user agent at the user's request.",
 ];
 
-// Toast helper. Centralized so the three handlers below stay readable.
-// Uses `color: 'negative'` to match the existing convention in api/http.ts.
+// Toast helper. Uses `color: 'negative'` to match api/http.ts.
 function notifyError(message: string, caption?: string) {
   Notify.create({
     color: 'negative',
@@ -32,39 +32,59 @@ function notifyError(message: string, caption?: string) {
   });
 }
 
+// Sentry init is split out and dynamic-imported so the @sentry/vue chunk
+// (~900 KiB unminified, drags replay+feedback+browser-utils via transitive
+// deps) is NOT in the eager bundle. Without DSN — i.e. dev, CI Lighthouse
+// runs, any unconfigured deploy — the chunk never loads at all. With DSN it
+// loads asynchronously, parallel with app startup, instead of blocking LCP.
+async function initSentry(
+  app: App,
+  router: Router,
+  dsn: string,
+  environment: string,
+  release: string | undefined,
+) {
+  const Sentry = await import('@sentry/vue');
+  Sentry.init({
+    app,
+    dsn,
+    environment,
+    release,
+    ignoreErrors,
+    integrations: [
+      // Auto-instruments vue-router navigations + fetch/XHR as Sentry
+      // transactions. This is what gives GlitchTip "slow route" visibility.
+      Sentry.browserTracingIntegration({ router }),
+    ],
+    // Same bundle hits dev/stage/prod via runtime DSN, so this rate applies
+    // everywhere. 5% balances signal on rare slow routes against GlitchTip
+    // ingestion cost.
+    tracesSampleRate: 0.05,
+    // Only attach trace headers (sentry-trace, baggage) to our own backend.
+    // Never propagate to third-party endpoints (CDNs, analytics) — they'll
+    // reject CORS preflights and pollute their logs.
+    tracePropagationTargets: ['localhost', /^\/api\//],
+  });
+}
+
 export default boot(({ app, router }) => {
   const { sentryDsn, environment, release } = runtimeConfig;
 
+  // Fire-and-forget: don't block app mount on Sentry loading. Worst case is
+  // a sub-second window after first paint where Sentry isn't capturing yet
+  // — acceptable cost for keeping the SDK off the critical path.
   if (sentryDsn) {
-    Sentry.init({
-      app,
-      dsn: sentryDsn,
-      environment,
-      release,
-      ignoreErrors,
-      integrations: [
-        // Auto-instruments vue-router navigations + fetch/XHR as Sentry
-        // transactions. This is what gives GlitchTip "slow route" visibility.
-        Sentry.browserTracingIntegration({ router }),
-      ],
-      // Same bundle hits dev/stage/prod via runtime DSN, so this rate applies
-      // everywhere. 5% balances signal on rare slow routes against GlitchTip
-      // ingestion cost.
-      tracesSampleRate: 0.05,
-      // Only attach trace headers (sentry-trace, baggage) to our own backend.
-      // Never propagate to third-party endpoints (CDNs, analytics) — they'll
-      // reject CORS preflights and pollute their logs.
-      tracePropagationTargets: ['localhost', /^\/api\//],
-    });
+    void initSentry(app, router, sentryDsn, environment, release);
   }
 
   // -------------------------------------------------------------------------
   // Vue-level uncaught errors.
   //
   // Fires for errors thrown inside component lifecycle hooks, watchers,
-  // computeds, etc. @sentry/vue's `app: Vue` option already wires
-  // captureException here; we layer a Notify toast so users see *something*
-  // when a render fails instead of a silent broken UI.
+  // computeds, etc. @sentry/vue wires its own capture via `attachErrorHandler`
+  // when init runs (which preserves any prior handler). We layer a Notify
+  // toast on top so users see *something* when a render fails instead of a
+  // silent broken UI.
   // -------------------------------------------------------------------------
   const previousVueHandler = app.config.errorHandler;
   app.config.errorHandler = (err, instance, info) => {
@@ -85,8 +105,8 @@ export default boot(({ app, router }) => {
   //
   // Catches errors thrown outside Vue (third-party libs, setTimeout callbacks,
   // event handlers attached directly to DOM). Sentry auto-captures these via
-  // its global handler; we add ResizeObserver suppression and a user-facing
-  // toast.
+  // its global handler once init runs; we add ResizeObserver suppression and
+  // a user-facing toast unconditionally.
   // -------------------------------------------------------------------------
   window.addEventListener('error', (event) => {
     if (event.message?.includes('ResizeObserver loop')) {

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -124,8 +124,8 @@ export default boot(({ app, router }) => {
     const message =
       reason instanceof Error
         ? reason.message
-        : (reason?.message as string | undefined) ??
-          String(reason ?? 'Unhandled rejection');
+        : ((reason?.message as string | undefined) ??
+          String(reason ?? 'Unhandled rejection'));
     notifyError(message);
   });
 });

--- a/frontend/src/config/runtime.ts
+++ b/frontend/src/config/runtime.ts
@@ -1,0 +1,34 @@
+// Runtime configuration values.
+//
+// Same Vite bundle ships to dev/stage/prod; per-environment values come from
+// window.injectedEnvVariable, populated at container startup by
+// docker/entrypoint.sh writing public/injectEnv.js.
+//
+// In `quasar dev` the placeholder is empty, so we fall back to build-time
+// values from quasar.config.js `build.env` (Quasar/Vite replaces literal
+// `process.env.APP_X` text in the bundle via Vite's `define`).
+//
+// IMPORTANT: process.env access here must be a *literal* property name —
+// dynamic access like `process.env[key]` is NOT replaced (it's a textual
+// transform, not a runtime object) and will be undefined at runtime.
+//
+// APP_VERSION and APP_BUILD_TIME identify the bundle itself, so they don't
+// have a runtime fallback — every container running this image sees the same
+// value.
+
+declare global {
+  interface Window {
+    injectedEnvVariable?: Record<string, string | undefined>;
+  }
+}
+
+const injected: Record<string, string | undefined> =
+  (typeof window !== 'undefined' && window.injectedEnvVariable) || {};
+
+export const runtimeConfig = {
+  sentryDsn: injected.APP_SENTRY_DSN ?? process.env.APP_SENTRY_DSN,
+  environment:
+    injected.APP_ENVIRONMENT ?? process.env.APP_ENVIRONMENT ?? 'development',
+  release: process.env.APP_VERSION,
+  buildTime: process.env.APP_BUILD_TIME,
+} as const;

--- a/frontend/src/config/runtime.ts
+++ b/frontend/src/config/runtime.ts
@@ -25,10 +25,13 @@ declare global {
 const injected: Record<string, string | undefined> =
   (typeof window !== 'undefined' && window.injectedEnvVariable) || {};
 
+// `||` not `??`: empty string from an unset pod env should fall through to the
+// next layer, not be treated as a real value. (e.g. APP_SENTRY_DSN="" should
+// disable Sentry, not set the DSN to an empty string and crash init.)
 export const runtimeConfig = {
-  sentryDsn: injected.APP_SENTRY_DSN ?? process.env.APP_SENTRY_DSN,
+  sentryDsn: injected.APP_SENTRY_DSN || process.env.APP_SENTRY_DSN || undefined,
   environment:
-    injected.APP_ENVIRONMENT ?? process.env.APP_ENVIRONMENT ?? 'development',
+    injected.APP_ENVIRONMENT || process.env.APP_ENVIRONMENT || 'development',
   release: process.env.APP_VERSION,
   buildTime: process.env.APP_BUILD_TIME,
 } as const;

--- a/helm/templates/frontend-deployment.yaml
+++ b/helm/templates/frontend-deployment.yaml
@@ -48,9 +48,13 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.service.targetPort }}
               protocol: TCP
+          # Iterates frontend.env so adding a new env var (e.g. APP_*)
+          # only requires a values.yaml entry — no template change.
           env:
-            - name: API_BASE_URL
-              value: {{ .Values.frontend.env.API_BASE_URL | quote }}
+            {{- range $key, $value := .Values.frontend.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           {{- with .Values.frontend.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -196,8 +196,22 @@ frontend:
     targetPort: 8080
     annotations: {}
 
+  # Forwarded as container env vars; the frontend's docker/entrypoint.sh
+  # picks up APP_*-prefixed entries at startup and writes them to
+  # /usr/share/nginx/html/injectEnv.js, where the bundle reads them as
+  # window.injectedEnvVariable.
+  #
+  # Per-env values (real Sentry DSN, environment label) are overridden in
+  # the ops repo (enack8s-app-config / openshift-app-config). Defaults here
+  # are safe placeholders.
   env:
     API_BASE_URL: "/api"
+    # Sentry/GlitchTip DSN. Empty string → src/boot/sentry.ts skips init,
+    # so unconfigured deploys don't error.
+    APP_SENTRY_DSN: ""
+    # Environment label attached to every Sentry event. Override per-cluster
+    # in the ops repo (e.g. "stage", "production").
+    APP_ENVIRONMENT: "production"
 
   podAnnotations: {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "co2-calculator",
-  "version": "0.6.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.1",
+      "version": "0.9.0",
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
@@ -403,8 +403,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -665,7 +664,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -2129,7 +2127,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -2187,7 +2184,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
Related to #344. Follow-up source-map upload tracked in #1101.

## Summary

- Layered frontend error capture: Vue `errorHandler`, `window.error` (with ResizeObserver suppression), `window.unhandledrejection` (skips notify on ky `HTTPError` to avoid double-toasting), and `Sentry.captureMessage` for 5xx responses in `api/http.ts`.
- Runtime DSN/environment injection: same Vite bundle ships to dev/stage/prod; per-env values arrive at container startup via `docker/entrypoint.sh` writing `public/injectEnv.js` (which is `no-cache` in nginx). Mirrors the pattern from the previous project but cleaner.
- `APP_VERSION` baked from the deploy SHA so Sentry events carry a release tag (eventually matching uploaded source maps in #1101).

## Files

- **New**: `frontend/public/injectEnv.js`, `frontend/docker/entrypoint.sh`, `frontend/src/config/runtime.ts`, `frontend/src/boot/sentry.ts` (replaces minimal placeholder)
- **Modified**: `frontend/index.html` (script tag for `/injectEnv.js`), `frontend/Dockerfile` (entrypoint copy + chown), `frontend/nginx.conf` (404 for `*.map`), `frontend/quasar.config.js` (sourcemap + `APP_VERSION` from `GIT_SHA`), `frontend/src/api/http.ts` (5xx capture), `frontend/eslint.config.js` (ignore `public/**`)

## CI

- Bumps `EPFL-ENAC/epfl-enac-build-push-deploy-action` from `v3.0.5` → `v3.0.7` (the new release adds a generic `build_args` input).
- Passes `GIT_SHA=${{ github.sha }}` so the frontend Dockerfile bakes the deploy SHA into `APP_VERSION`. Backend/docs Dockerfiles ignore the unused arg (Docker just warns).

## Deferred

Source-map upload to GlitchTip — issue #1101. Plumbing is in place (sourcemaps emitted in prod, `.map` files 404'd publicly but shipped inside the image, `sourcemaps:upload` npm script ready). Just needs a project-local CI job, separate from this PR.

## Test plan

- [ ] Local: `npm run dev` — Sentry skips init (no DSN); error toasts still work via Notify.
- [ ] Local: `npm run build` produces a bundle with `release: <git-sha>` baked in (verified in this PR's branch with `GIT_SHA=test123abc npm run build && grep test123abc dist/spa/assets/*.js`).
- [ ] Stage: confirm `/injectEnv.js` is served with `window.injectedEnvVariable = { APP_SENTRY_DSN: "...", APP_ENVIRONMENT: "stage", ... }` populated.
- [ ] Stage: trigger a test error (e.g. throw from a component) → confirm event lands in GlitchTip with the correct `environment` and `release` tags.
- [ ] Stage: trigger a 5xx response from the backend → confirm a `captureMessage` event appears in GlitchTip (separate from the user toast).
- [ ] Verify `*.map` URLs return 404 from nginx in the deployed image.