### PR TITLE
fix(344): write injectEnv.js to /tmp under readOnlyRootFilesystem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,8 +120,21 @@ services:
     container_name: co2-frontend
     ports:
       - "3000:8080"
-    volumes:
-      - ./frontend:/app:ro
+    # Match the k8s pod's securityContext (readOnlyRootFilesystem: true plus
+    # the three emptyDir mounts in helm/templates/frontend-deployment.yaml).
+    # Catches read-only-fs regressions locally before they ship to a cluster
+    # — see fix(344): write injectEnv.js to /tmp.
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/cache/nginx
+      - /var/run
+    environment:
+      # Empty by default. Set in your shell (or repo-root .env) to enable
+      # Sentry/GlitchTip from a `docker compose up` run. Same vars the k8s
+      # pod receives via helm/values.yaml frontend.env.
+      APP_SENTRY_DSN: "${APP_SENTRY_DSN:-}"
+      APP_ENVIRONMENT: "${APP_ENVIRONMENT:-compose}"
     labels:
       - "traefik.enable=true"
       # match everything else

--- a/frontend/docker/entrypoint.sh
+++ b/frontend/docker/entrypoint.sh
@@ -14,15 +14,21 @@
 # no-cache surface, so per-env values must live there or they get pinned to
 # the first deploy.
 #
+# Why /tmp and not /usr/share/nginx/html: in our k8s deployment the pod runs
+# with readOnlyRootFilesystem: true (see helm/values.yaml frontend.securityContext)
+# so the html dir is read-only at runtime. /tmp is mounted as an emptyDir
+# (writable) by the deployment template. nginx.conf has a `location =
+# /injectEnv.js` alias that maps the URL to this file.
+#
 # Why no jq dep: the base nginx-unprivileged image doesn't ship jq, and
 # our values are single-line ASCII (DSNs, env names, git SHAs), so a small
 # bash escape function is sufficient and keeps the image lean.
 
 set -euo pipefail
 
-WWW_DIR="${WWW_DIR:-/usr/share/nginx/html}"
+OUT_DIR="${OUT_DIR:-/tmp}"
 PREFIX="${FRONTEND_ENV_PREFIX:-APP_}"
-INJECT_FILE="${WWW_DIR}/injectEnv.js"
+INJECT_FILE="${OUT_DIR}/injectEnv.js"
 
 # JSON-string escape for value side: backslash, then double-quote. Values are
 # assumed single-line ASCII; if you need to inject multi-line or unicode
@@ -49,7 +55,7 @@ done < <(printenv)
 
 # Atomic write: temp file in the same dir, then mv. Prevents nginx from
 # serving a half-written injectEnv.js if this script is killed mid-execution.
-tmp=$(mktemp "${WWW_DIR}/injectEnv.js.XXXXXX")
+tmp=$(mktemp "${OUT_DIR}/injectEnv.js.XXXXXX")
 {
   printf '%s\n' \
     "// Generated at container startup by /docker-entrypoint.d/40-inject-env.sh." \

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -66,8 +66,21 @@ http {
       add_header Content-Type text/plain;
     }
 
+    # Runtime config injected at container startup by
+    # /docker-entrypoint.d/40-inject-env.sh. Lives in /tmp (writable emptyDir)
+    # because the html dir is read-only under our k8s securityContext. Exact-
+    # match `location =` so this beats both the no-cache regex below and the
+    # static-asset cache regex further down.
+    location = /injectEnv.js {
+      alias /tmp/injectEnv.js;
+      default_type application/javascript;
+      expires -1y;
+      add_header Pragma "no-cache, must-revalidate";
+      add_header Cache-Control "no-cache, must-revalidate";
+    }
+
     # HTML files and service workers: no cache (for updates)
-    location ~* (\.html|\/sw\.js|injectEnv\.js)$ {
+    location ~* (\.html|\/sw\.js)$ {
       expires -1y;
       add_header Pragma "no-cache, must-revalidate";
       add_header Cache-Control "no-cache, must-revalidate";


### PR DESCRIPTION
Follow-up to #1102 (merged). Container failed to start in k8s with:

```
mktemp: failed to create file via template
'/usr/share/nginx/html/injectEnv.js.XXXXXX': Read-only file system
```

The pod runs with `readOnlyRootFilesystem: true` (set in `helm/values.yaml` `frontend.securityContext`), so `/usr/share/nginx/html` isn't writable at container start — but `docker/entrypoint.sh` was trying to mktemp + atomic-mv `injectEnv.js` there.

## Fix

- `docker/entrypoint.sh`: write to `/tmp/injectEnv.js` instead. `/tmp` is mounted as a writable `emptyDir` by the deployment template (existing volume, no helm change needed).
- `nginx.conf`: add an exact-match `location = /injectEnv.js { alias /tmp/injectEnv.js; ... }`. Exact-match wins over both the no-cache regex rule and the static-asset cache rule, so headers stay correct without restating them everywhere.

`quasar dev` is unaffected — Vite serves `public/injectEnv.js` directly from disk; the placeholder still works as the dev fallback.

## Test plan

- [ ] `docker build -t co2-frontend:test ./frontend && docker run --read-only --tmpfs /tmp -e APP_SENTRY_DSN=https://foo@bar/1 -e APP_ENVIRONMENT=stage -p 8080:8080 co2-frontend:test` — container starts cleanly, `curl localhost:8080/injectEnv.js` returns the populated values, no `Read-only file system` error.
- [ ] Deploy to stage cluster and confirm pod starts and `/injectEnv.js` returns populated config.