### PR TITLE
fix(949): retry POST/PATCH on 401 + bump session lifetimes + expiry toast

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,8 +63,8 @@ FILES_ENCRYPTION_SALT=
 # Or: python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=change-me-in-production-use-openssl-rand-hex-32
 ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=30
-REFRESH_TOKEN_EXPIRE_HOURS=12
+ACCESS_TOKEN_EXPIRE_MINUTES=480
+REFRESH_TOKEN_EXPIRE_HOURS=24
 
 # -----------------------------------------------------------------------------
 # OAuth/OIDC Configuration (optional, for future implementation)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -243,8 +243,11 @@ class Settings(BaseSettings):
         description="OAuth2/OIDC cookie path",
     )
 
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
-    REFRESH_TOKEN_EXPIRE_HOURS: int = 12
+    # Session lifetimes — see issue #949. Tuned for an internal EPFL app
+    # behind Entra SSO + httpOnly+secure+samesite cookies; 8h access / 24h
+    # refresh keeps a working day usable while still capping idle sessions.
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 480
+    REFRESH_TOKEN_EXPIRE_HOURS: int = 24
     # Frontend URL for redirects
     FRONTEND_URL: str = Field(
         default="http://localhost:9000",

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -23,7 +23,15 @@ const isRefresh = (u: string) => u.endsWith(API_REFRESH_URL);
 export const api = ky.create({
   prefixUrl: API_BASE_URL,
   credentials: 'include',
-  retry: { limit: 1, statusCodes: [401] },
+  // ky's default `methods` excludes POST/PATCH, so without overriding it the
+  // beforeRetry hook below would never fire on form submits — users mid-edit
+  // would get bounced to /login on a single 401 even though the refresh
+  // cookie was still valid (issue #949).
+  retry: {
+    limit: 1,
+    statusCodes: [401],
+    methods: ['get', 'put', 'post', 'patch', 'head', 'delete', 'options'],
+  },
   hooks: {
     beforeRetry: [
       // For any non-refresh call, try to refresh before retrying
@@ -64,6 +72,18 @@ export const api = ky.create({
             // may induced infinite redirect loops if the login page itself makes API calls
             // that return 401, but in practice this should not happen since the login page
             // should not make authenticated API calls.
+            //
+            // Surface a toast before navigating so the user understands why
+            // they're being kicked out (issue #949: previously a silent
+            // bounce to /login that looked like the form had submitted them
+            // back to the home page).
+            Notify.create({
+              color: 'warning',
+              message: i18n.global.t('session_expired_notice'),
+              position: 'top',
+              timeout: 5000,
+              actions: [{ icon: 'close', color: 'white' }],
+            });
             location.replace(loginPageName);
           }
         } else if (res.status === 403) {

--- a/frontend/src/i18n/login.ts
+++ b/frontend/src/i18n/login.ts
@@ -19,4 +19,8 @@ export default {
     en: 'Test Role',
     fr: 'Rôle de test',
   },
+  session_expired_notice: {
+    en: 'Your session has expired. Please log in again.',
+    fr: 'Votre session a expiré. Veuillez vous reconnecter.',
+  },
 } as const;

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,8 +31,8 @@ backend:
     API_DOCS_PREFIX: "/api"
     LOG_LEVEL: "INFO"
     ALGORITHM: "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: "30"
-    REFRESH_TOKEN_EXPIRE_HOURS: "12"
+    ACCESS_TOKEN_EXPIRE_MINUTES: "480"
+    REFRESH_TOKEN_EXPIRE_HOURS: "24"
     PROVIDER_PLUGIN: "default" # Could be 'default' or 'accred' or 'test'
     OAUTH_SCOPE: "openid profile email"
     OAUTH_COOKIE_PATH: "/"


### PR DESCRIPTION
Closes #949

## Summary

Three related issues behind Caroline's "form submit silently bounces me to home" report:

1. **The actual bug**: ky's default `retry.methods` excludes `POST`/`PATCH`. The `beforeRetry` hook in `http.ts` calls `/auth/refresh` to recover from 401s, but it was never firing on form submits — so a single expired access token bounced users mid-edit even though the refresh cookie was still valid. Now `POST`/`PATCH` are in the retry list, so the existing transparent-refresh path works for mutations too.

2. **Session lifetimes**: bumped `ACCESS_TOKEN_EXPIRE_MINUTES` 30 → 480 (8h) and `REFRESH_TOKEN_EXPIRE_HOURS` 12 → 24. The issue thread suggested 2h, but for an internal EPFL app behind Entra SSO with httpOnly+secure+samesite cookies, 8h access / 24h refresh sits comfortably in industry norms (AWS Console: 12h, Okta default: 8-10h for internal tools) and matches the working-day rhythm Caroline described. The marginal security delta vs 2h is small because the realistic threat (stolen logged-in laptop) gives the attacker the refresh cookie too. Happy to dial back to 2h/12h if security would prefer.

3. **UX on real expiry**: when refresh genuinely fails (e.g. user idle >24h, refresh token expired), we now show a `session_expired_notice` toast before `location.replace('/en/login')` instead of silently navigating away. Added i18n strings for `en` and `fr`.

## Files

- `frontend/src/api/http.ts` — add `methods: [...post, patch...]` to retry; show toast before login redirect
- `frontend/src/i18n/login.ts` — add `session_expired_notice` (en/fr)
- `backend/app/core/config.py` — defaults 30→480, 12→24
- `backend/.env.example` — same
- `helm/values.yaml` — same (note: ops repo has its own override per @guilbep)

## Test plan

- [ ] Local: log in, leave a form open >30 min, submit → request transparently succeeds (no redirect)
- [ ] Local: log in, manually delete `auth_token` cookie, submit form → POST 401 → refresh succeeds → original POST retried (would previously have skipped retry and redirected)
- [ ] Local: clear both cookies, submit form → toast appears, redirect to `/login`
- [ ] CI: backend tests pass with new defaults
- [ ] French locale renders the toast correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)