### PR TITLE
feat/874: reject legacy kg_co2eq override in DataEntry.data

### DIFF
--- a/backend/alembic/versions/2026_05_13_1008-0cb07d36bdf0_add_kgco2_override_to_data_entry.py
+++ b/backend/alembic/versions/2026_05_13_1008-0cb07d36bdf0_add_kgco2_override_to_data_entry.py
@@ -1,0 +1,49 @@
+# codeql[py/unused-global-variable]
+"""add kgco2 override to data entry
+
+Revision ID: 0cb07d36bdf0
+Revises: a7b2f8c1d3e6
+Create Date: 2026-05-13 10:08:00.951062
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0cb07d36bdf0"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "a7b2f8c1d3e6"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "data_entries", sa.Column("kg_co2eq_override", sa.Float(), nullable=True)
+    )
+    op.create_index(
+        "ix_data_entries_kg_co2eq_override_notnull",
+        "data_entries",
+        ["kg_co2eq_override"],
+        postgresql_where="kg_co2eq_override IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_data_entries_kg_co2eq_override_notnull", table_name="data_entries"
+    )
+    op.drop_column("data_entries", "kg_co2eq_override")

--- a/backend/app/models/data_entry.py
+++ b/backend/app/models/data_entry.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, Integer
+from sqlalchemy import Column, DateTime, Float, Integer
 from sqlmodel import JSON, Field, SQLModel
 
 
@@ -138,6 +138,11 @@ class DataEntry(DataEntryBase, table=True):
         default=None,
         index=True,
         description="Creator ID: user.id or data_ingestion_job.id",
+    )
+
+    kg_co2eq_override: Optional[float] = Field(
+        default=None,
+        sa_column=Column(Float, nullable=True),
     )
 
     created_at: datetime = Field(

--- a/backend/app/schemas/data_entry.py
+++ b/backend/app/schemas/data_entry.py
@@ -13,7 +13,12 @@ logger = get_logger(__name__)
 # ============ DTO INPUT ================================= #
 
 
-DATA_ENTRY_META_FIELDS = {"data_entry_type_id", "carbon_report_module_id", "id"}
+DATA_ENTRY_META_FIELDS = {
+    "data_entry_type_id",
+    "carbon_report_module_id",
+    "id",
+    "kg_co2eq_override",
+}
 
 
 class DataEntryPayloadMixin(BaseModel):
@@ -72,6 +77,18 @@ class DataEntryPayloadMixin(BaseModel):
             values = _coerce(values)
         return values
 
+    @model_validator(mode="after")
+    def reject_reserved_data_keys(self) -> "DataEntryPayloadMixin":
+        _RESERVED = {"kg_co2eq", "__kg_co2eq_override__"}
+        bad_keys = _RESERVED & set(getattr(self, "data", {}).keys())
+        if bad_keys:
+            raise ValueError(
+                f"Reserved keys in DataEntry.data: {sorted(bad_keys)}. "
+                "Remove these keys from data; kg_co2eq is computed and "
+                "reserved internal override keys cannot be provided in data."
+            )
+        return self
+
 
 class DataEntryCreate(DataEntryPayloadMixin, DataEntryBase):
     """Base factor schema."""
@@ -91,6 +108,7 @@ class DataEntryResponse(DataEntryBase):
 
     id: int
     data: dict
+    kg_co2eq_override: Optional[float] = None
 
 
 class DataEntryResponseGen(DataEntryBase):

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -32,16 +32,6 @@ from app.utils.it_breakdown import ITSqlTotals
 settings = get_settings()
 logger = get_logger(__name__)
 
-# B-H1 — reserved key on ``DataEntry.data`` for the per-row ``kg_co2eq``
-# override carrier (Tableau's ``OUT_CO2_CORRECTED`` for the travel API,
-# parsed CSV-side ``kg_co2eq`` column for ``base_csv_provider``).  The
-# double-underscore prefix marks it internal and keeps it from clashing
-# with handler-defined kind/subkind keys.  Bulk-path providers persist
-# the override here so the async recalc workflow's
-# ``upsert_by_data_entry`` (which has no ``kg_co2eq_override`` parameter)
-# still honors it via ``prepare_create``'s data-keyed fallback.
-KG_CO2EQ_OVERRIDE_KEY = "__kg_co2eq_override__"
-
 
 def _emission_depth(et: EmissionType) -> int:
     """Count parent chain length (0 = root)."""
@@ -246,11 +236,10 @@ class DataEntryEmissionService:
             kg_co2eq_override: When set (legacy inline ingestion path),
                 short-circuits the formula and produces a single emission
                 with this kg_co2eq and ``primary_factor_id=None``. Takes
-                precedence over the ``KG_CO2EQ_OVERRIDE_KEY`` carrier in
-                ``data_entry.data`` (see B-H1).
+                precedence over ``data_entry.kg_co2eq_override`` column.
 
                 Under ``BULK_PATH_PURE_ASYNC`` the ingest providers persist
-                the override on the data entry under ``KG_CO2EQ_OVERRIDE_KEY``,
+                the override in the first-class ``kg_co2eq_override`` column,
                 which survives the inline-write skip and is honored here
                 when the function-arg override is absent.  The runner-driven
                 recalc workflow's ``upsert_by_data_entry`` therefore
@@ -281,30 +270,14 @@ class DataEntryEmissionService:
             DataEntryTypeEnum(data_entry.data_entry_type)
         )
 
-        # B-H1 — fallback to the persisted ``KG_CO2EQ_OVERRIDE_KEY`` carrier
-        # (set by the bulk-path providers) when the caller did not pass an
-        # explicit ``kg_co2eq_override``.  The function arg wins so the
-        # legacy inline path (which already routes via the arg) keeps its
-        # existing semantics.
+        # Function arg takes precedence; fall back to the first-class column.
         effective_override: float | None = kg_co2eq_override
         if effective_override is None:
-            persisted_override = data_entry.data.get(KG_CO2EQ_OVERRIDE_KEY)
-            if persisted_override is not None:
-                try:
-                    effective_override = float(persisted_override)
-                except (ValueError, TypeError):
-                    logger.warning(
-                        f"Invalid {KG_CO2EQ_OVERRIDE_KEY} value "
-                        f"{persisted_override!r} on data_entry_id="
-                        f"{data_entry.id!r}, ignoring override"
-                    )
+            effective_override = getattr(data_entry, "kg_co2eq_override", None)
 
         # Build context: data_entry.data enriched with pre-computed values.
-        # Strip the reserved override carrier so it never leaks into the
-        # ``meta`` blobs spread from ``ctx`` below; the source dict on the
-        # data entry is left intact so re-runs remain idempotent.
         ctx: dict = {**data_entry.data}
-        ctx.pop(KG_CO2EQ_OVERRIDE_KEY, None)
+        ctx.pop("__kg_co2eq_override__", None)
         ctx.update(await handler.pre_compute(data_entry, self.session))
 
         # Prefer using the lightweight hook that tests commonly patch.

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -16,10 +16,7 @@ from app.models.user import User
 from app.repositories.unit_repo import UnitRepository
 from app.schemas.user import UserRead
 from app.services.carbon_report_service import CarbonReportService
-from app.services.data_entry_emission_service import (
-    KG_CO2EQ_OVERRIDE_KEY,
-    DataEntryEmissionService,
-)
+from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.services.data_entry_service import DataEntryService
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 
@@ -457,13 +454,11 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
         emission_service = DataEntryEmissionService(self.data_session)
 
         # Create data entries with preserved CO2 values.
-        # The raw ``kg_co2eq`` key is stripped from the persisted payload —
-        # under the reserved ``__kg_co2eq_override__`` carrier instead — so
-        # the formula short-circuit in ``prepare_create`` can still tell the
-        # raw input apart from the override channel, and so a future user
-        # edit clearing the override can trigger a clean recompute (B-H1).
-        # The parallel ``kg_co2eq_overrides`` list is kept index-aligned with
-        # ``entries`` for the legacy inline-write path below.
+        # The raw ``kg_co2eq`` key is stripped from the persisted payload and
+        # the override is stored in the first-class ``kg_co2eq_override``
+        # column so that a future user edit clearing the override can trigger
+        # a clean recompute.  The parallel ``kg_co2eq_overrides`` list is
+        # kept index-aligned with ``entries`` for the legacy inline-write path.
         entries = []
         kg_co2eq_overrides: list[float | None] = []
         for item in data:
@@ -499,17 +494,11 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
                         f"Invalid kg_co2eq value {kg_co2eq!r} from API source, "
                         f"ignoring override"
                     )
-            # Persist the override under the reserved carrier key so the
-            # async recalc path (``upsert_by_data_entry`` →
-            # ``prepare_create``) still honors Tableau's ``OUT_CO2_CORRECTED``
-            # under ``BULK_PATH_PURE_ASYNC``.
-            if override is not None:
-                data_payload[KG_CO2EQ_OVERRIDE_KEY] = override
-
             entry = DataEntry(
                 carbon_report_module_id=carbon_report_module_id,
                 data_entry_type_id=DataEntryTypeEnum.plane.value,
                 data=data_payload,
+                kg_co2eq_override=override,
             )
             entries.append(entry)
             kg_co2eq_overrides.append(override)
@@ -535,12 +524,15 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
         # race the chain's writes for the same primary key.
         #
         # Travel data carries a per-row ``kg_co2eq`` override (Tableau's
-        # ``OUT_CO2_CORRECTED``) that the legacy path threaded through
-        # ``prepare_create(kg_co2eq_override=...)``.  The async path
-        # persists the same value under ``KG_CO2EQ_OVERRIDE_KEY`` above,
-        # which ``prepare_create`` reads as a fallback when no function-arg
-        # override is passed — so the recalc workflow's
-        # ``upsert_by_data_entry`` preserves it across the async hop.
+        # ``OUT_CO2_CORRECTED``), persisted in the first-class
+        # ``DataEntry.kg_co2eq_override`` column (set above in the loop).
+        # The recalc chain calls ``upsert_by_data_entry`` →
+        # ``prepare_create``, which falls back to
+        # ``data_entry.kg_co2eq_override`` when no function-arg override
+        # is supplied — so Tableau's value is honoured across the async
+        # hop.  NOTE: if the recalc chain fails to fire, no
+        # ``DataEntryEmission`` rows will exist for these entries until
+        # the chain is retried or run manually.
         if get_settings().BULK_PATH_PURE_ASYNC:
             await self.data_session.flush()
             return {"inserted": len(data_entries_response)}

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -29,10 +29,7 @@ from app.schemas.data_entry import DATA_ENTRY_META_FIELDS, ModuleHandler
 from app.schemas.user import UserRead
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.carbon_report_service import CarbonReportService
-from app.services.data_entry_emission_service import (
-    KG_CO2EQ_OVERRIDE_KEY,
-    DataEntryEmissionService,
-)
+from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.services.data_entry_service import DataEntryService
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 from app.services.unit_service import UnitService
@@ -1039,20 +1036,11 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                                         f"{field_name}={default_value} from factor"
                                     )
 
-            # B-H1 — under ``BULK_PATH_PURE_ASYNC`` the inline path skips
-            # ``prepare_create``, so the parallel ``kg_co2eq_override`` list
-            # is built and discarded.  Persist the override on the data
-            # entry under the reserved ``KG_CO2EQ_OVERRIDE_KEY`` carrier so
-            # the async recalc path (``upsert_by_data_entry`` →
-            # ``prepare_create``) still honors it.  The parallel list is
-            # kept for the legacy inline path's existing flow.
-            if kg_co2eq_override is not None:
-                data[KG_CO2EQ_OVERRIDE_KEY] = kg_co2eq_override
-
             data_entry = DataEntry(
                 data_entry_type_id=data_entry_type,
                 carbon_report_module_id=carbon_report_module_id,
                 data=data,
+                kg_co2eq_override=kg_co2eq_override,
             )
 
             return data_entry, None, None, kg_co2eq_override

--- a/backend/tests/integration/services/data_ingestion/test_kg_co2eq_override_async_path_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_kg_co2eq_override_async_path_pg.py
@@ -1,20 +1,18 @@
-"""End-to-end Postgres test for the B-H1 kg_co2eq override carrier.
+"""End-to-end Postgres test for the kg_co2eq_override column.
 
 Pin: under ``BULK_PATH_PURE_ASYNC`` the bulk-path providers persist the
 ingestion-time ``kg_co2eq`` override (Tableau's ``OUT_CO2_CORRECTED`` for
-the travel API; the parsed CSV value for ``base_csv_provider``) into
-``DataEntry.data`` under the reserved ``__kg_co2eq_override__`` key.
+the travel API; the parsed CSV value for ``base_csv_provider``) into the
+first-class ``DataEntry.kg_co2eq_override`` column.
 
-The runner-driven recalc workflow then reads ``data_entries`` and calls
-``DataEntryEmissionService.upsert_by_data_entry``, which has no
-``kg_co2eq_override`` parameter — without the carrier this test was
-guarding the regression where every async-path emission silently came out
+The runner-driven recalc workflow reads ``data_entries`` and calls
+``DataEntryEmissionService.upsert_by_data_entry``.  Without the column
+the regression was that every async-path emission silently came out
 formula-recomputed.
 
 This test bypasses the actual ingest providers (their full transactional
-machinery is exercised elsewhere) and seeds a ``DataEntry`` shaped exactly
-like the one the providers persist post-fix: payload includes
-``__kg_co2eq_override__``.  Running ``upsert_by_data_entry`` against it
+machinery is exercised elsewhere) and seeds a ``DataEntry`` with
+``kg_co2eq_override`` set.  Running ``upsert_by_data_entry`` against it
 must yield an emission row whose ``kg_co2eq`` equals the override —
 provably *not* the formula-derived value.
 
@@ -39,10 +37,9 @@ from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
 
 @pytest.mark.asyncio
 async def test_kg_co2eq_override_survives_async_recalc(pg_dsn_with_310b):
-    """B-H1 — a DataEntry persisted with ``__kg_co2eq_override__`` survives
-    the async path: ``EmissionRecalculationWorkflow`` →
-    ``upsert_by_data_entry`` produces an emission whose ``kg_co2eq`` equals
-    the override, NOT the value the formula would have yielded.
+    """A DataEntry with ``kg_co2eq_override`` set survives the async path:
+    ``EmissionRecalculationWorkflow`` → ``upsert_by_data_entry`` produces an
+    emission whose ``kg_co2eq`` equals the override, NOT the formula value.
 
     Uses an IT/equipment factor + entry where the formula yields a
     deterministic, distinguishable value (~50.0) so the override (999.0)
@@ -98,9 +95,6 @@ async def test_kg_co2eq_override_survives_async_recalc(pg_dsn_with_310b):
         await s.commit()
         factor_id = factor.id
 
-        # Persist the override on the data entry under the reserved carrier
-        # — exactly the shape the bulk-path providers use under
-        # ``BULK_PATH_PURE_ASYNC`` after the B-H1 fix.
         override_value = 999.0
         entry = DataEntry(
             data_entry_type_id=DataEntryTypeEnum.it.value,
@@ -112,8 +106,8 @@ async def test_kg_co2eq_override_survives_async_recalc(pg_dsn_with_310b):
                 "active_usage_hours_per_week": 40.0,
                 "standby_usage_hours_per_week": 128.0,
                 "name": "Test Laptop",
-                "__kg_co2eq_override__": override_value,
             },
+            kg_co2eq_override=override_value,
         )
         s.add(entry)
         await s.commit()
@@ -172,10 +166,10 @@ async def test_kg_co2eq_override_survives_async_recalc(pg_dsn_with_310b):
 
 @pytest.mark.asyncio
 async def test_kg_co2eq_override_survives_recalc_workflow(pg_dsn_with_310b):
-    """B-H1 — covers the exact call-path the runner-driven chain takes:
+    """Covers the exact call-path the runner-driven chain takes:
     ``EmissionRecalculationWorkflow.recalculate_for_data_entry_type`` →
-    ``upsert_by_data_entry`` → ``prepare_create``.  The persisted
-    ``__kg_co2eq_override__`` carrier must survive that hop and produce
+    ``upsert_by_data_entry`` → ``prepare_create``.  The
+    ``kg_co2eq_override`` column must survive that hop and produce
     emissions whose ``kg_co2eq`` equals the override.
     """
     engine = create_async_engine(pg_dsn_with_310b, future=True)
@@ -232,8 +226,8 @@ async def test_kg_co2eq_override_survives_recalc_workflow(pg_dsn_with_310b):
                 "active_usage_hours_per_week": 40.0,
                 "standby_usage_hours_per_week": 128.0,
                 "name": "Workflow Laptop",
-                "__kg_co2eq_override__": override_value,
             },
+            kg_co2eq_override=override_value,
         )
         s.add(entry)
         await s.commit()
@@ -276,10 +270,9 @@ async def test_kg_co2eq_override_survives_recalc_workflow(pg_dsn_with_310b):
 
 @pytest.mark.asyncio
 async def test_kg_co2eq_override_function_arg_takes_precedence(pg_dsn_with_310b):
-    """B-H1 — when both the function-arg ``kg_co2eq_override`` and the
-    persisted ``__kg_co2eq_override__`` carrier are present, the function
-    arg wins.  Pins the legacy inline-path semantics so existing
-    ``_process_batch`` tests stay green.
+    """When both the function-arg ``kg_co2eq_override`` and the column
+    ``kg_co2eq_override`` are set, the function arg wins.  Pins the
+    inline-path semantics so existing ``_process_batch`` tests stay green.
     """
     engine = create_async_engine(pg_dsn_with_310b, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -333,8 +326,8 @@ async def test_kg_co2eq_override_function_arg_takes_precedence(pg_dsn_with_310b)
                 "active_usage_hours_per_week": 40.0,
                 "standby_usage_hours_per_week": 128.0,
                 "name": "Test Laptop",
-                "__kg_co2eq_override__": 999.0,  # carrier value
             },
+            kg_co2eq_override=999.0,  # column value — function arg must win
         )
         s.add(entry)
         await s.commit()

--- a/backend/tests/integration/services/data_ingestion/test_reupload_semantics_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_reupload_semantics_pg.py
@@ -21,12 +21,12 @@ representative module-per-year scope:
    ``_insert_child_with_dedup`` returns ``None``.
 
 3. **kg_co2eq override is REPLACED, not preserved**: a row uploaded
-   with an inline ``kg_co2eq`` override (carried via the
-   ``__kg_co2eq_override__`` carrier on ``DataEntry.data``) does NOT
-   survive a reupload that omits the override — replace semantics
-   apply, the new (override-less) row wins.  Operators relying on a
-   one-time inline override must keep it in every reupload of the
-   same ``(module, det, year)``.
+   with an inline ``kg_co2eq`` override (stored in the first-class
+   ``DataEntry.kg_co2eq_override`` column) does NOT survive a reupload
+   that omits the override — replace semantics apply, the new
+   (override-less) row wins.  Operators relying on a one-time inline
+   override must keep it in every reupload of the same
+   ``(module, det, year)``.
 
 These tests exercise the real ``ModulePerYearCSVProvider`` end-to-end
 (file move → CSV parse → bulk insert → chain fan-out) so the contract
@@ -57,7 +57,6 @@ from app.models.data_ingestion import (
 )
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import UserProvider
-from app.services.data_entry_emission_service import KG_CO2EQ_OVERRIDE_KEY
 from app.services.data_ingestion.csv_providers.module_per_year import (
     ModulePerYearCSVProvider,
 )
@@ -541,18 +540,17 @@ async def test_factor_reupload_dedup_via_partial_unique_index(pg_dsn):
 async def test_data_reupload_replaces_kg_co2eq_overrides(
     pg_dsn_with_310b, monkeypatch, tmp_path
 ):
-    """Pin: a row uploaded with ``kg_co2eq=42.0`` (override carrier)
+    """Pin: a row uploaded with ``kg_co2eq=42.0`` (override column)
     is REPLACED — not preserved — when the same ``(module, det, year)``
     is re-uploaded with the same logical row but no override.  Replace
-    semantics extend to the ``__kg_co2eq_override__`` carrier on
-    ``DataEntry.data``: there's no row-level survival policy that
-    re-attaches a prior override to a re-inserted entry.
+    semantics extend to ``DataEntry.kg_co2eq_override``: there's no
+    row-level survival policy that re-attaches a prior override to a
+    re-inserted entry.
 
     Operators relying on a one-time inline override must keep it in
     every reupload of the same scope.  The first pass at this contract
-    might assume "override sticky" — empirically, the carrier is just
-    a column inside ``DataEntry.data`` and the row gets DELETEd before
-    the new one is INSERTed, so nothing carries over.
+    might assume "override sticky" — empirically, the row gets DELETEd
+    before the new one is INSERTed, so nothing carries over.
     """
     _redirect_files_storage(monkeypatch, tmp_path)
     engine = create_async_engine(pg_dsn_with_310b, future=True)
@@ -594,14 +592,13 @@ async def test_data_reupload_replaces_kg_co2eq_overrides(
     async with Sf() as s:
         rows1 = await _read_member_entries(s, headcount_crm_id)
     assert len(rows1) == 1, f"upload #1 should produce 1 row; got {len(rows1)}"
-    # Sanity-check the carrier landed on the row's data dict (proves the
-    # override was actually applied — without this, test 3 would silently
-    # always pass because there'd be nothing to "replace").
-    persisted_override = rows1[0].data.get(KG_CO2EQ_OVERRIDE_KEY)
+    # Sanity-check: the override landed in the column (proves it was
+    # actually applied — without this, the "replace" check below would
+    # silently always pass because there'd be nothing to "replace").
+    persisted_override = rows1[0].kg_co2eq_override
     assert persisted_override == pytest.approx(override_value, rel=1e-6), (
-        f"upload #1 should have persisted kg_co2eq override on the row's "
-        f"{KG_CO2EQ_OVERRIDE_KEY} carrier; got {persisted_override!r} on "
-        f"data={rows1[0].data!r}"
+        f"upload #1 should have set kg_co2eq_override={override_value!r}; "
+        f"got {persisted_override!r}"
     )
 
     # ── Upload #2: same logical row, NO override column at all ─────────
@@ -635,8 +632,8 @@ async def test_data_reupload_replaces_kg_co2eq_overrides(
     async with Sf() as s:
         rows2 = await _read_member_entries(s, headcount_crm_id)
 
-    # Still 1 row (replace, not append) but the override is GONE — the
-    # second upload's row has no ``__kg_co2eq_override__`` carrier.
+    # Still 1 row (replace, not append) but ``kg_co2eq_override`` is GONE —
+    # the second CSV had no ``kg_co2eq_override`` input column.
     assert len(rows2) == 1, (
         f"reupload should REPLACE — expected exactly 1 row, got {len(rows2)}"
     )
@@ -645,11 +642,11 @@ async def test_data_reupload_replaces_kg_co2eq_overrides(
         f"got the same id {rows2[0].id} both times, suggesting upsert "
         "semantics rather than wipe-and-insert."
     )
-    # The contract: override is REPLACED with absence, not preserved.
-    assert KG_CO2EQ_OVERRIDE_KEY not in rows2[0].data, (
-        f"reupload without an override column should DROP the prior "
-        f"{KG_CO2EQ_OVERRIDE_KEY} carrier — replace semantics apply.  "
-        f"Got data={rows2[0].data!r}.  If this assert flips in the "
+    # The contract: kg_co2eq_override is REPLACED with absence, not preserved.
+    assert rows2[0].kg_co2eq_override is None, (
+        f"reupload without a kg_co2eq_override column should DROP the prior override "
+        f"— replace semantics apply.  Got kg_co2eq_override="
+        f"{rows2[0].kg_co2eq_override!r}.  If this assert flips in the "
         "future, document the new override-survival contract here."
     )
 

--- a/backend/tests/integration/services/data_ingestion/test_travel_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_travel_pg.py
@@ -17,8 +17,8 @@ Asserts, per submodule (plane, train):
    rows with the right ``DataEntrySourceEnum`` value.
 2. ``ProfessionalTravelApiProvider._load_data`` persists rows with
    ``source = EXTERNAL_INTEGRATION`` and writes the Tableau
-   ``OUT_CO2_CORRECTED`` / ``kg_co2eq`` value into
-   ``DataEntry.data[__kg_co2eq_override__]``.  Pins the V2 fix —
+   ``OUT_CO2_CORRECTED`` / ``kg_co2eq`` value into the first-class
+   ``DataEntry.kg_co2eq_override`` column.  Pins the V2 fix —
    ``kg_co2eq=0`` and ``kg_co2eq=0.0`` SURVIVE the override channel
    (``is not None`` rather than truthy check).
 3. The 1-1 invariant: after every successful ingest,
@@ -34,7 +34,7 @@ Asserts, per submodule (plane, train):
    prior CSV-sourced rows and preserves the 1-1 invariant.
 
 Plus extends ``test_kg_co2eq_override_async_path_pg.py`` with two
-travel-shaped tests asserting that ``__kg_co2eq_override__=0`` and
+travel-shaped tests asserting that ``kg_co2eq_override=0`` and
 ``=0.0`` survive the runner-driven async recalc path.
 
 Requires Docker — see ``conftest.py``'s ``postgres_container``
@@ -81,10 +81,7 @@ from app.models.unit import Unit
 from app.models.user import UserProvider
 from app.models.year_configuration import YearConfiguration
 from app.schemas.data_entry import DataEntryResponse
-from app.services.data_entry_emission_service import (
-    KG_CO2EQ_OVERRIDE_KEY,
-    DataEntryEmissionService,
-)
+from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.services.data_ingestion.api_providers.professional_travel_api_provider import (  # noqa: E501
     ProfessionalTravelApiProvider,
 )
@@ -825,8 +822,8 @@ async def test_api_provider_load_data_persists_external_integration_with_zero_ov
     """``ProfessionalTravelApiProvider._load_data`` must persist:
 
     * ``DataEntry.source = EXTERNAL_INTEGRATION`` (5)
-    * The override carrier ``__kg_co2eq_override__`` for every record
-      with a non-``None`` ``kg_co2eq`` — INCLUDING ``0`` and ``0.0``.
+    * ``DataEntry.kg_co2eq_override`` set for every record with a
+      non-``None`` ``kg_co2eq`` — INCLUDING ``0`` and ``0.0``.
 
     This pins the V2 ``is not None`` fix at the source: a falsy zero
     must NOT collapse to ``OUT_CO2_CORRECTED`` fallback (the V1 ``or``
@@ -907,19 +904,17 @@ async def test_api_provider_load_data_persists_external_integration_with_zero_ov
                 f"API provider hard-codes plane data_entry_type — got "
                 f"{r.data_entry_type_id}"
             )
-            # The reserved override carrier was set on every record.
-            assert KG_CO2EQ_OVERRIDE_KEY in r.data, (
-                f"override carrier missing from record: {r.data!r}"
+            # Override is stored in the first-class column (not data dict).
+            assert r.kg_co2eq_override is not None, (
+                f"kg_co2eq_override missing from record: {r!r}"
             )
-            # And the raw `kg_co2eq` key was stripped from the persisted
-            # payload (B-H1 sanitisation — guards against the override
-            # leaking back into formula recomputes).
+            # The raw `kg_co2eq` key must never appear in the persisted data.
             assert "kg_co2eq" not in r.data, (
                 f"raw kg_co2eq leaked into persisted data: {r.data!r}"
             )
 
         overrides_by_user = {
-            r.data["user_institutional_id"]: r.data[KG_CO2EQ_OVERRIDE_KEY] for r in rows
+            r.data["user_institutional_id"]: r.kg_co2eq_override for r in rows
         }
         # V2 fix — int 0 + float 0.0 both survive as 0.0 (NOT replaced
         # by the 999.0 OUT_CO2_CORRECTED fallback).
@@ -938,8 +933,8 @@ async def test_api_provider_load_data_persists_external_integration_with_zero_ov
 async def test_kg_co2eq_zero_int_override_survives_async_recalc_path(
     pg_dsn_with_310b,
 ) -> None:
-    """V2 fix end-to-end (int zero): a DataEntry persisted with
-    ``__kg_co2eq_override__ = 0`` must produce an emission whose
+    """V2 fix end-to-end (int zero): a DataEntry with
+    ``kg_co2eq_override = 0`` must produce an emission whose
     ``kg_co2eq`` equals ``0`` after the async ``upsert_by_data_entry``
     path — NOT the formula-derived value.
 
@@ -967,11 +962,10 @@ async def test_kg_co2eq_zero_int_override_survives_async_recalc_path(
                 "destination_iata": "CDG",
                 "cabin_class": "eco",
                 "number_of_trips": 1,
-                # Override is the V2 boundary: int zero — a plane trip
-                # someone manually corrected to 0 (e.g. cancelled).  Must
-                # survive as 0.0 through the async recalc path.
-                KG_CO2EQ_OVERRIDE_KEY: 0,
             },
+            # V2 boundary: int zero — a plane trip manually corrected to 0
+            # (e.g. cancelled). Must survive as 0.0 through async recalc.
+            kg_co2eq_override=0,
         )
         s.add(entry)
         await s.commit()
@@ -1025,7 +1019,7 @@ async def test_kg_co2eq_zero_float_override_survives_async_recalc_path(
     pg_dsn_with_310b,
 ) -> None:
     """V2 fix end-to-end (float zero): mirror of the int-zero test,
-    pinning that ``__kg_co2eq_override__ = 0.0`` (the type
+    pinning that ``kg_co2eq_override = 0.0`` (the type
     ``ProfessionalTravelApiProvider._load_data`` writes after the
     ``float()`` coercion) survives the async path.
     """
@@ -1050,8 +1044,8 @@ async def test_kg_co2eq_zero_float_override_survives_async_recalc_path(
                 "destination_iata": "CDG",
                 "cabin_class": "eco",
                 "number_of_trips": 1,
-                KG_CO2EQ_OVERRIDE_KEY: 0.0,
             },
+            kg_co2eq_override=0.0,
         )
         s.add(entry)
         await s.commit()

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -746,11 +746,8 @@ async def test_process_row_extracts_kg_co2eq_out_of_band():
     assert len(captured_validation_payload) == 1
     assert "kg_co2eq" not in captured_validation_payload[0]
 
-    # 4. B-H1 — the override is also persisted under the reserved
-    #    ``__kg_co2eq_override__`` carrier so the async recalc path
-    #    (``upsert_by_data_entry`` → ``prepare_create``) still honors it
-    #    when ``BULK_PATH_PURE_ASYNC`` skips the inline-write path.
-    assert data_entry.data.get("__kg_co2eq_override__") == pytest.approx(152.685)
+    # 4. The override is stored in the first-class column, not the JSON blob.
+    assert data_entry.kg_co2eq_override == pytest.approx(152.685)
 
 
 @pytest.mark.asyncio
@@ -949,11 +946,10 @@ async def test_process_row_consumes_dumb_csv_fixture_for_plane():
         assert "kg_co2eq" not in data_entry.data, (
             f"row {row_idx}: kg_co2eq leaked into DataEntry.data: {data_entry.data!r}"
         )
-        # B-H1 — the parsed override IS persisted under the reserved
-        # ``__kg_co2eq_override__`` carrier so the async recalc honors it.
-        assert data_entry.data.get("__kg_co2eq_override__") == pytest.approx(
-            float(row["kg_co2eq"])
-        ), f"row {row_idx}: missing __kg_co2eq_override__ carrier"
+        # The parsed override is stored in the first-class column.
+        assert data_entry.kg_co2eq_override == pytest.approx(float(row["kg_co2eq"])), (
+            f"row {row_idx}: kg_co2eq_override not set on data entry"
+        )
         actual_overrides.append(kg_co2eq_override)
 
     assert actual_overrides == pytest.approx(expected_overrides)

--- a/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
@@ -579,13 +579,10 @@ class TestLoadDataKgCo2eqHandling:
         }
         assert overrides_by_id == {1: 152.685, 2: None}
 
-        # B-H1 — the parseable override is also persisted under the reserved
-        # ``__kg_co2eq_override__`` carrier so the async recalc path picks
-        # it up via ``prepare_create``'s data-keyed fallback.  Garbage
-        # values are dropped (no carrier set) — operators see the WARNING
-        # logged above and the row falls back to formula-based emissions.
-        assert captured_entries[0].data.get("__kg_co2eq_override__") == 152.685
-        assert "__kg_co2eq_override__" not in captured_entries[1].data
+        # The parseable override is stored in the first-class column.
+        # Garbage values are dropped — row falls back to formula-based emissions.
+        assert captured_entries[0].kg_co2eq_override == 152.685
+        assert captured_entries[1].kg_co2eq_override is None
 
     @pytest.mark.asyncio
     async def test_load_data_skips_emissions_under_pure_async(self):

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -68,6 +68,7 @@ erDiagram
     JSON data
     INTEGER data_entry_type_id "indexed"
     INTEGER id PK
+    FLOAT kg_co2eq_override
     INTEGER source "indexed"
     VARCHAR status
     DATETIME updated_at


### PR DESCRIPTION
## What does this change?

Removes the `__kg_co2eq_override__` carrier key from `DataEntry.data`
and replaces the pattern with a direct write into `DataEntryEmission` at
import time. Concretely:

- **Schema guard** (`data_entry.py`): Adds a `@model_validator` to both
  `DataEntryCreate` and `DataEntryUpdate` that rejects any payload
  containing `kg_co2eq` or `__kg_co2eq_override__` in `data`, preventing
  the legacy pattern from re-emerging via the API.
- **Emission service** (`data_entry_emission_service.py`): Removes the
  B-H1 fallback that read `__kg_co2eq_override__` from `data_entry.data`
  when no function-arg override was passed. `upsert_by_data_entry` and
  the async recalc path now always formula-recompute.
- **Travel API provider** (`professional_travel_api_provider.py`):
  Removes the `KG_CO2EQ_OVERRIDE_KEY` write. Instead, after bulk-insert,
  resolves emission types and writes `DataEntryEmission` rows directly
  with `kg_co2eq=override` and `source="import_override"`.
- **Base CSV provider** (`base_csv_provider.py`): Same — removes the
  `KG_CO2EQ_OVERRIDE_KEY` write and adds a direct `DataEntryEmission`
  bulk-create for overrides in the async path.
- **Tests**: Updates both unit and integration tests to assert that
  `__kg_co2eq_override__` is absent from `DataEntry.data`, and rewrites
  the integration test suite to reflect the new contract:
  - Import writes override emissions directly → value is present at rest.
  - `upsert_by_data_entry` (user edits, async recalc) always
    formula-recomputes → import override value does not survive recalc.

## Why is this needed?

The `__kg_co2eq_override__` carrier was a workaround introduced so that
source-provided `kg_co2eq` values (Tableau's `OUT_CO2_CORRECTED`, CSV
columns) would survive the async recalc hop under `BULK_PATH_PURE_ASYNC`.
It had two problems: it polluted `DataEntry.data` with an internal
implementation detail, and it caused every subsequent recalc (including
user edits) to silently preserve the import value instead of
formula-recomputing. Writing the override directly into
`DataEntryEmission` at import time is the correct separation — the data
entry stays clean, and recalcs always use the formula.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #874