### PR TITLE
fix(perf): disable production sourcemaps to unbloat JS bundles

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,8 +46,8 @@ COPY nginx.conf /etc/nginx/nginx.conf
 # it writes and why.
 COPY --chmod=755 docker/entrypoint.sh /docker-entrypoint.d/40-inject-env.sh
 
-# Copy built static files (includes .map files; nginx 404s them publicly so
-# they're shipped privately for a future GlitchTip sourcemap upload step).
+# Copy built static files. (Source maps are not generated — see
+# `sourcemap: false` in quasar.config.js for the reason.)
 # --chown=nginx:nginx so the entrypoint script (run as the nginx user) can
 # write injectEnv.js into this directory at startup.
 COPY --from=builder --chown=nginx:nginx /app/dist/spa /usr/share/nginx/html

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,6 @@
     "dev": "quasar dev",
     "preview": "npx vite preview --outDir dist/spa",
     "build": "quasar build",
-    "sourcemaps:upload": "glitchtip-cli sourcemaps inject ./dist/spa && glitchtip-cli sourcemaps upload ./dist/spa --release \"${GIT_SHA:-$(git rev-parse --short HEAD)}\" --org \"$GLITCHTIP_ORG\" --project \"$GLITCHTIP_PROJECT\"",
     "postinstall": "quasar prepare",
     "mock:auth": "node src/mock/mockauth.js",
     "storybook": "storybook dev -p 6006 --config-dir storybook/.storybook",

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -64,7 +64,7 @@ const APP_VERSION = (() => {
 })();
 const APP_BUILD_TIME = new Date().toISOString();
 
-export default defineConfig(function (ctx) {
+export default defineConfig(function () {
   return {
     eslint: {
       // fix: true,

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -127,11 +127,14 @@ export default defineConfig(function (ctx) {
       // rawDefine: {}
       // ignorePublicFolder: true,
       minify: true,
-      // Source maps in production only — needed for readable Sentry stack
-      // traces. nginx.conf 404s `*.map` requests publicly; uploaded to
-      // GlitchTip via `npm run sourcemaps:upload` and shipped inside the
-      // Docker image so the upload step has access to them post-build.
-      sourcemap: ctx.prod,
+      // Source maps disabled in production. Empirically, `sourcemap: true`
+      // here shipped an inline base64 data-URL sourcemap appended to every
+      // .js file (bundles ended in `//# sourceMappingURL=data:...`), which
+      // roughly tripled bundle resource size and tanked the Lighthouse
+      // score. To get readable Sentry/GlitchTip stack traces back without
+      // the bloat, switch to `'hidden'` (external .map next to .js, no
+      // sourceMappingURL comment in the JS) and reinstate the upload step.
+      sourcemap: false,
       // polyfillModulePreload: true,
       // distDir
       sassVariables: 'src/css/quasar.variables.scss',


### PR DESCRIPTION
## Summary

The previous Sentry/sourcemap PR set `sourcemap: ctx.prod` in `frontend/quasar.config.js`. Empirically, that shipped an **inline base64 sourcemap appended to every .js file** via `//# sourceMappingURL=data:application/json;base64,...` (verified via curl on dev) — not the external .map files Vite documents `sourcemap: true` to produce.

Consequences in production:

| Symptom | Before | Cause |
| --- | --- | --- |
| `esm-*.js` resource size | **3.2 MB** (932 KB transfer) | ~2.7 MB inline base64 sourcemap |
| Lighthouse "Minify JavaScript" | **Est savings 1,904 KiB** | base64 blob trips the unminified-JS heuristic |
| Total network payload | **2,740 KiB** | dominated by the inflated chunks |
| LCP / FCP | degraded | 1.7s FCP, 2.5s LCP on the dev page |

## Fix

`sourcemap: false`. Plus housekeeping for the now-dead pipeline:
- Removed the `sourcemaps:upload` script from `frontend/package.json` (was only invoked manually; no CI reference, no devDep on `glitchtip-cli`).
- Updated the `frontend/Dockerfile` comment that claimed .map files were shipped for a future upload step.
- Left a comment in `quasar.config.js` explaining the why and pointing the next person at `'hidden'` mode if they want readable Sentry stack traces back without re-bloating.

## Tradeoff

Sentry/GlitchTip stack traces revert to minified `line:col` for now. The cleanest path back is `sourcemap: 'hidden'` (external `.map` next to `.js`, no `sourceMappingURL` comment in the JS) plus reinstating the upload step — that gets you readable stacks **without** the bundle bloat.

## Test plan

- [ ] Local: `npm run build` in `frontend/` — confirm `dist/spa/assets/*.js` files end with normal minified code (no `sourceMappingURL=data:` line) and no `*.map` files are produced
- [ ] Deploy to dev: `curl -sI https://co2-calculator-dev.epfl.ch/assets/<chunk>.js` — `content-length` should drop ~3x for the larger chunks
- [ ] Re-run Lighthouse on `/en/<unit>/2025/home` — "Minify JavaScript" should clear; total payload should drop well below 2,740 KiB

🤖 Generated with [Claude Code](https://claude.com/claude-code)