### PR TITLE
feat(867): wire 'Open year for users' button + reflect is_started in UI

### DIFF
--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -632,4 +632,20 @@ export default {
     en: 'All mandatory factor and reference uploads must be completed before opening the year for users.',
     fr: "Tous les téléversements obligatoires de facteurs et de références doivent être complétés avant d'ouvrir l'année pour les utilisateurs.",
   },
+  data_management_year_already_open: {
+    en: 'Year is already open to users',
+    fr: "L'année est déjà ouverte aux utilisateurs",
+  },
+  data_management_year_opened_success: {
+    en: 'Year {year} opened to users',
+    fr: 'Année {year} ouverte aux utilisateurs avec succès',
+  },
+  data_management_year_is_open: {
+    en: 'Open to users',
+    fr: 'Ouverte aux utilisateurs',
+  },
+  data_management_year_is_not_open: {
+    en: 'Not yet open',
+    fr: 'Pas encore ouverte',
+  },
 } as const;

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -66,6 +66,21 @@ const handleCreateYear = async () => {
   }
 };
 
+const handleOpenForUsers = async () => {
+  try {
+    await yearConfigStore.openForUsers(selectedYear.value);
+    Notify.create({
+      type: 'positive',
+      message: $t('data_management_year_opened_success', {
+        year: selectedYear.value,
+      }),
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    Notify.create({ type: 'negative', message: msg });
+  }
+};
+
 const handleUnitSync = async () => {
   try {
     await backofficeDataManagement.syncUnitsFromAccred(selectedYear.value);
@@ -159,6 +174,25 @@ async function handleDialogCompleted() {
             </template>
           </q-select>
 
+          <!-- Visibility chip: at-a-glance flag for whether the year is open
+               to non-admin users in their workspace year selector. -->
+          <q-chip
+            v-if="yearConfigStore.config"
+            data-test="year-open-status-chip"
+            :color="yearConfigStore.config.is_started ? 'positive' : 'grey-4'"
+            :text-color="yearConfigStore.config.is_started ? 'white' : 'grey-9'"
+            :icon="yearConfigStore.config.is_started ? 'lock_open' : 'lock'"
+            dense
+            square
+            class="q-mb-sm"
+          >
+            {{
+              yearConfigStore.config.is_started
+                ? $t('data_management_year_is_open')
+                : $t('data_management_year_is_not_open')
+            }}
+          </q-chip>
+
           <div class="text-body2 text-secondary">
             {{ $t('data_management_reporting_year_hint') }}
           </div>
@@ -214,9 +248,18 @@ async function handleDialogCompleted() {
         color="accent"
         :label="$t('open_year_for_users')"
         class="text-weight-medium text-capitalize q-mt-md"
-        :disable="yearConfigStore.anyModuleIncomplete"
+        :loading="yearConfigStore.loading"
+        :disable="
+          yearConfigStore.anyModuleIncomplete ||
+          !!yearConfigStore.config?.is_started
+        "
+        data-test="open-year-for-users-btn"
+        @click="handleOpenForUsers"
       >
-        <q-tooltip v-if="yearConfigStore.anyModuleIncomplete">
+        <q-tooltip v-if="yearConfigStore.config?.is_started">
+          {{ $t('data_management_year_already_open') }}
+        </q-tooltip>
+        <q-tooltip v-else-if="yearConfigStore.anyModuleIncomplete">
           {{ $t('data_management_open_year_disabled_tooltip') }}
         </q-tooltip>
       </q-btn>

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -167,6 +167,17 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     }
   }
 
+  /**
+   * Flip a year's `is_started` flag to true, making it visible to non-admin
+   * users in their workspace year selector. Thin wrapper over updateConfig
+   * so callers don't need to know the payload shape.
+   */
+  async function openForUsers(
+    year: number,
+  ): Promise<YearConfigurationResponse> {
+    return updateConfig(year, { is_started: true });
+  }
+
   /** All current ingestion jobs for the loaded year. */
   const latestJobs = computed<SyncJobSummary[]>(
     () => config.value?.latest_jobs ?? [],
@@ -281,5 +292,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     fetchConfig,
     createConfig,
     updateConfig,
+    openForUsers,
   };
 });

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for the back-office "Open year for users" flow (issue #867).
+ *
+ * The dev preview server has no auth/session by default, so these specs
+ * intercept the year-configuration API directly and assert UI behavior:
+ * the visibility chip reflects `is_started`, the button is disabled when
+ * the year is already open, and clicking the button when it is not open
+ * sends a PATCH with `{ is_started: true }` and shows a success toast.
+ *
+ * If the route is gated behind auth in this environment, these tests will
+ * skip (see the navigation guard below) instead of producing false failures.
+ */
+
+const PAGE_PATH = '/back-office/data-management';
+
+const baseConfig = (overrides: Partial<{ is_started: boolean }> = {}) => ({
+  year: 2025,
+  is_started: false,
+  is_reports_synced: false,
+  config: { modules: {}, reduction_objectives: {} },
+  latest_jobs: [],
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+test.describe('Data management — open year for users', () => {
+  test.beforeEach(async ({ page }) => {
+    // Stub the year-configuration GET so the page can render without a backend.
+    await page.route('**/api/v1/year-configuration/**', async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(baseConfig({ is_started: false })),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+  });
+
+  test('button is enabled and shows success toast when year is not yet open', async ({
+    page,
+  }) => {
+    let patchBody: unknown = null;
+
+    await page.route('**/api/v1/year-configuration/**', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        patchBody = route.request().postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(baseConfig({ is_started: true })),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(baseConfig({ is_started: false })),
+        });
+      }
+    });
+
+    const response = await page.goto(PAGE_PATH);
+    test.skip(
+      !response || response.status() >= 400,
+      'Back-office route is not reachable in this environment',
+    );
+
+    const chip = page.getByTestId('year-open-status-chip');
+    await expect(chip).toContainText(/Not yet open|Pas encore ouverte/);
+
+    const btn = page.getByTestId('open-year-for-users-btn');
+    await expect(btn).toBeEnabled();
+    await btn.click();
+
+    expect(patchBody).toEqual({ is_started: true });
+    await expect(chip).toContainText(/Open to users|Ouverte aux utilisateurs/);
+  });
+
+  test('button is disabled with tooltip when year is already open', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/year-configuration/**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(baseConfig({ is_started: true })),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    const response = await page.goto(PAGE_PATH);
+    test.skip(
+      !response || response.status() >= 400,
+      'Back-office route is not reachable in this environment',
+    );
+
+    const chip = page.getByTestId('year-open-status-chip');
+    await expect(chip).toContainText(/Open to users|Ouverte aux utilisateurs/);
+
+    const btn = page.getByTestId('open-year-for-users-btn');
+    await expect(btn).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Unit 5 of issue #867 (back-office data-management consolidation).

The "Open year for users" button on the back-office data-management page rendered but did nothing — there was no `@click` handler. This wires it up:

- New `openForUsers(year)` action on the `yearConfig` store — thin wrapper over `updateConfig` that PATCHes `{ is_started: true }`.
- Button now has `@click="handleOpenForUsers"` showing a positive toast on success and a negative toast on error (mirrors `handleCreateYear`).
- Button is `:disable`d when `anyModuleIncomplete` (existing) **or** the year is already open (new). Tooltip text differs per reason.
- New `q-chip` near the year selector at-a-glance shows whether the year is open to users (`Open to users` / `Not yet open`) — green chip with `lock_open` when open, neutral with `lock` when not.
- New i18n keys (en/fr): `data_management_year_already_open`, `data_management_year_opened_success`, `data_management_year_is_open`, `data_management_year_is_not_open`.

Distinct from "Create year" (U1's territory) — does not touch that flow.

## Independence from U1

If U1 ships first, new years will already have `is_started=true` so this button is automatically disabled with the "already open" tooltip — desired behavior. If U1 has not shipped yet, this still works for legacy years that have `is_started: false` (e.g. 2025).

## Test plan

- [x] `vue-tsc --noEmit` passes.
- [x] `eslint .` passes.
- [x] `prettier --check` passes.
- [x] New Playwright integration spec at `frontend/tests/integration/data-management.spec.ts` lists 2 cases (button enabled + PATCH on click; button disabled when year already open). Spec stubs the year-configuration API and skips cleanly if the back-office route is unreachable in the test env.
- [ ] Full Playwright e2e run not executed locally — no built `dist/spa` and the back-office route requires auth; CI is the right place to run this.
- [ ] Manual smoke: verify clicking the button on a 2025 year flips the chip to "Open to users" and disables the button.

## Notes

- The unit instructions called for vitest unit tests for the store action, but this project does not use vitest (Playwright only). Skipped accordingly.