### PR TITLE
fix(867): silence 404 toast on missing year-configuration / explore report

### DIFF
--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -167,7 +167,9 @@ export const useWorkspaceStore = defineStore(
       const url = `carbon-reports/simulator/explore/unit/${unitId}/reference-year/${referenceYear}/`;
       let inv: CarbonReport;
       try {
-        inv = await api.get(url).json();
+        // 404 is expected here — the catch branch seeds an explore report.
+        // Opt out of the global error toast for that status only.
+        inv = await api.get(url, { skipErrorCodes: [404] }).json();
       } catch (err) {
         if (err instanceof HTTPError && err.response.status === 404) {
           // No explore report exists yet — seed one from the Calculator report.

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -149,8 +149,11 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     notFound.value = false;
 
     try {
+      // Suppress the global 404 error toast: a missing year-configuration is
+      // expected on first visit and is rendered as a "Create year" empty-state
+      // by the caller. Non-404 errors still surface via the global handler.
       const response = (await api
-        .get(`year-configuration/${year}`)
+        .get(`year-configuration/${year}`, { skipErrorCodes: [404] })
         .json()) as YearConfigurationResponse;
       config.value = response;
       return response;

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -69,6 +69,13 @@ test.describe('back-office data-management — happy paths', () => {
     });
     await expect(createBtn).toBeVisible();
 
+    // Issue #867 — the 404 from year-configuration GET is an expected
+    // empty-state, not a user-facing error. The store opts out via
+    // ``skipErrorCodes: [404]`` so no error toast should appear on landing.
+    // (``bg-negative`` is the Quasar utility class applied by
+    // ``Notify.create({ color: 'negative' })``.)
+    await expect(page.locator('.q-notification.bg-negative')).toHaveCount(0);
+
     await createBtn.click();
 
     // POST must hit the singular-form endpoint.


### PR DESCRIPTION
## Summary

- Issue [#867](https://github.com/EPFL-ENAC/co2-calculator/issues/867), Unit 3/5 — silence the spurious "404 Not Found" toast on the data-management page when the user lands on a year that has no `year_configuration` row yet.
- The global axios `afterResponse` handler added in 4f0940b6 fires a default error toast for any non-2xx response unless the caller passes `skipErrorCodes`. The data-management page already handles the empty-state by setting `notFound = true` and rendering a "Create year" card — we just need to opt that one call out of the toast.
- Apply the existing `skipErrorCodes` pattern (see `frontend/src/api/factors.ts:34`) to two stores where the catch already treats 404 as a meaningful "no resource yet" signal:
  - `stores/yearConfig.ts::fetchConfig` (the bug reported in #867)
  - `stores/workspace.ts::selectSimulatorExploreCarbonReport` (same shape: catch on 404 to seed a fresh explore report)
- Non-404 errors still surface through the global handler. The `throw err;` on the non-404 branch is kept intentionally.

## Test plan

- [x] TypeScript: `tsc -p tsconfig.typecheck.json --noEmit` passes (no new errors).
- [x] Playwright: `playwright test tests/integration/data-management.spec.ts` — all 6 active specs pass, including the augmented `2 — create year happy path` which now also asserts no `.q-notification.bg-negative` appears on the empty-state landing.
- [ ] Manual smoke (reviewer): land on a year with no `year_configuration` row and verify the "Create year" card renders without a "404 Not Found" toast.