### PR TITLE
feat(#867): U4 — year-level active-pipelines endpoint + page-mount rehydrate

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -862,6 +862,50 @@ async def get_active_pipelines(
     return {module_id: str(pid) for module_id, pid in pipeline_by_module.items()}
 
 
+@router.get("/active-pipelines/year/{year}", response_model=list[str])
+async def get_active_year_level_pipelines(
+    year: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
+) -> list[str]:
+    """Return active **year-level** pipeline_ids (``entity_type=GLOBAL_PER_YEAR``).
+
+    **Required Permission**: ``backoffice.data_management.view``
+
+    Issue #867 — back-office data-management page reload reattach.  The
+    sibling ``GET /active-pipelines`` only sees module-scoped pipelines
+    (it requires a ``modules`` query param and filters by
+    ``module_type_id``).  Year-level chains (e.g. the unit-sync pipeline
+    minted by the create-year flow) carry no ``module_type_id`` and
+    were invisible to that endpoint, so the frontend SSE watcher could
+    not re-attach after a reload.
+
+    Returns a flat list of pipeline_id UUIDs (string-serialised) for
+    every job in ``NOT_STARTED`` / ``QUEUED`` / ``RUNNING`` with
+    ``entity_type=GLOBAL_PER_YEAR`` and the given ``year``.  Order is
+    most-recent-first by job id; the frontend treats the list as a
+    set, but a stable order makes assertion-based tests trivial.
+
+    The endpoint applies only the global ``backoffice.data_management.view``
+    gate — there is no per-module decision loop here because year-level
+    pipelines are not module-scoped (the per-module security guard on
+    the sibling endpoint defends against pipeline_id enumeration across
+    *modules* a backoffice user can't read; year-level pipelines have
+    no equivalent sub-perimeter today).
+
+    Empty result is the steady state — both "no active year-level
+    pipelines" and "U1's pipeline-stamping for unit_sync hasn't shipped
+    yet" surface as the same empty list, which is what the watcher
+    needs to safely no-op.
+    """
+    pipeline_ids = await DataIngestionRepository(
+        db
+    ).get_active_year_level_pipeline_ids(year)
+    return [str(pid) for pid in pipeline_ids]
+
+
 @router.get("/recalculation-status", response_model=list[ModuleRecalculationStatus])
 async def get_recalculation_status(
     year: int,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -900,9 +900,9 @@ async def get_active_year_level_pipelines(
     yet" surface as the same empty list, which is what the watcher
     needs to safely no-op.
     """
-    pipeline_ids = await DataIngestionRepository(
-        db
-    ).get_active_year_level_pipeline_ids(year)
+    pipeline_ids = await DataIngestionRepository(db).get_active_year_level_pipeline_ids(
+        year
+    )
     return [str(pid) for pid in pipeline_ids]
 
 

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -12,6 +12,7 @@ from app.core.logging import get_logger
 from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_ingestion import (
     DataIngestionJob,
+    EntityType,
     IngestionMethod,
     IngestionResult,
     IngestionState,
@@ -445,6 +446,62 @@ class DataIngestionRepository:
                 continue
             picked.setdefault(module_id, pipeline_id)
         return picked
+
+    async def get_active_year_level_pipeline_ids(self, year: int) -> list[UUID]:
+        """Return active ``GLOBAL_PER_YEAR`` pipeline_ids for the given year.
+
+        Plan 310-D / Issue #867 — sibling of ``get_current_pipeline_ids_for_modules``
+        for **year-level** pipelines (e.g. the unit-sync chain minted by
+        the back-office "create year" flow).  These are not module-scoped
+        so the existing module-keyed helper can't see them; the SSE
+        watcher on ``DataManagementPage.vue`` reload-rehydrate path needs
+        to enumerate them on its own.
+
+        "Active" mirrors the module-scoped sibling: any non-terminal
+        state (``NOT_STARTED`` / ``QUEUED`` / ``RUNNING``).  The
+        ``pipeline_id IS NOT NULL`` guard is what keeps the result
+        empty when the pipeline-stamping side of the unit-sync flow
+        hasn't shipped yet — legacy unit_sync jobs stay invisible
+        (no SSE stream to attach to anyway), and the watcher idles.
+
+        We dedupe in Python rather than ``DISTINCT`` server-side so
+        the SQLite-backed unit-test fixture works the same as PG (the
+        pattern used by the module sibling) and the result is ordered
+        most-recent-first by job id for deterministic test output.
+        """
+        stmt = (
+            select(DataIngestionJob.pipeline_id, DataIngestionJob.id)
+            .where(
+                col(DataIngestionJob.entity_type) == EntityType.GLOBAL_PER_YEAR,
+                col(DataIngestionJob.year) == year,
+                col(DataIngestionJob.pipeline_id).isnot(None),
+                col(DataIngestionJob.state).in_(
+                    [
+                        IngestionState.NOT_STARTED,
+                        IngestionState.QUEUED,
+                        IngestionState.RUNNING,
+                    ]
+                ),
+            )
+            .order_by(col(DataIngestionJob.id).desc())
+        )
+        exec_result = await self.session.execute(stmt)
+
+        # Multiple jobs can share one pipeline_id (parent + fan-out
+        # children — same pattern as module pipelines).  Dedupe while
+        # preserving the id-DESC traversal order so the first
+        # occurrence (most recent job) wins.
+        seen: set[UUID] = set()
+        ordered: list[UUID] = []
+        for row in exec_result.all():
+            pipeline_id, _job_id = row
+            if pipeline_id is None:
+                continue
+            if pipeline_id in seen:
+                continue
+            seen.add(pipeline_id)
+            ordered.append(pipeline_id)
+        return ordered
 
     # ---- Plan 310A: atomic claim, recovery, poller helpers ----
 

--- a/backend/tests/integration/services/data_ingestion/test_active_pipelines_year_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_active_pipelines_year_endpoint_pg.py
@@ -1,0 +1,334 @@
+"""Integration test for ``GET /v1/sync/active-pipelines/year/{year}`` against PG.
+
+Issue #867 — year-level (``entity_type=GLOBAL_PER_YEAR``) sibling of
+the module-scoped ``GET /sync/active-pipelines`` endpoint.  Backs the
+``DataManagementPage.vue`` reload-rehydrate path: the SSE watcher
+re-attaches to in-flight unit-sync (or any future GLOBAL_PER_YEAR)
+pipelines after a hard reload.
+
+Mirrors the auth / dependency-override pattern in
+``test_active_pipelines_endpoint_pg.py``.  Postgres is required because
+``DataIngestionJob.pipeline_id`` is a native ``UUID`` column; SQLite
+doesn't enforce UUID typing and would hide a serialisation regression.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+import app.core.security as security_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch):
+    """Wire the FastAPI app to the test Postgres + bypass auth.
+
+    The 403 test below deliberately bypasses this fixture to exercise
+    the real permission gate on the endpoint.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _allow(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("app.core.security.is_permitted", _allow)
+
+    yield {"factory": Sf}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+def _make_year_level_job(
+    *,
+    year: int,
+    pipeline_id,
+    state: IngestionState = IngestionState.RUNNING,
+) -> DataIngestionJob:
+    """Active year-level (``GLOBAL_PER_YEAR``) job carrying a
+    ``pipeline_id`` — what the new helper picks as 'currently in
+    flight' for this year.
+
+    Mirrors the unit-sync job shape in
+    ``app/api/v1/data_sync.py::sync_units_from_accred`` plus the
+    ``pipeline_id`` U1 stamps onto these chains.
+    """
+    return DataIngestionJob(
+        entity_type=EntityType.GLOBAL_PER_YEAR,
+        module_type_id=None,
+        data_entry_type_id=None,
+        year=year,
+        target_type=TargetType.REFERENCE_DATA,
+        ingestion_method=IngestionMethod.api,
+        provider=UserProvider.DEFAULT,
+        state=state,
+        pipeline_id=pipeline_id,
+        job_type="unit_sync",
+        meta={"config": {"target_year": year}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_returns_running_pipeline_id(pg_app):
+    """A single in-flight year-level chain → endpoint returns its
+    pipeline_id as the only entry.  This is the canonical case for
+    the reload-rehydrate flow: operator triggers a unit-sync, hard
+    reloads the page, the page re-attaches to the live stream."""
+    Sf = pg_app["factory"]
+    pipeline = uuid4()
+
+    async with Sf() as session:
+        session.add(_make_year_level_job(year=2025, pipeline_id=pipeline))
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == [str(pipeline)]
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_omits_finished(pg_app):
+    """Finished year-level jobs must NOT appear — the watcher would
+    open an SSE stream that immediately resolves to ``stream_closed``,
+    wasting a request and momentarily flickering UI."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        session.add(
+            _make_year_level_job(
+                year=2025,
+                pipeline_id=uuid4(),
+                state=IngestionState.FINISHED,
+            )
+        )
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_filters_by_year(pg_app):
+    """A 2024 chain must not surface in 2025's response — guards the
+    watcher from cross-year bleed when the operator is viewing one
+    year while a chain runs for another."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        session.add(_make_year_level_job(year=2024, pipeline_id=uuid4()))
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_omits_jobs_without_pipeline_id(pg_app):
+    """Year-level jobs with ``pipeline_id IS NULL`` (legacy / U1
+    not-yet-shipped) must not appear.  Without a pipeline_id the SSE
+    stream endpoint has nothing to subscribe to — including these
+    would mean the watcher opens a 404 stream.  This is what makes
+    the U1-independence guarantee in the unit's spec hold."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        # Same shape as a real unit_sync job pre-U1 — note no pipeline_id.
+        session.add(
+            DataIngestionJob(
+                entity_type=EntityType.GLOBAL_PER_YEAR,
+                year=2025,
+                target_type=TargetType.REFERENCE_DATA,
+                ingestion_method=IngestionMethod.api,
+                provider=UserProvider.DEFAULT,
+                state=IngestionState.RUNNING,
+                pipeline_id=None,
+                job_type="unit_sync",
+                meta={"config": {"target_year": 2025}},
+            )
+        )
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_omits_module_scoped(pg_app):
+    """Module-scoped (``MODULE_PER_YEAR``) pipelines are the
+    sibling endpoint's concern — they must NOT leak into the
+    year-level endpoint, even when ``year`` matches.  Otherwise the
+    watcher would double-subscribe (ModuleConfig.vue already covers
+    these via the per-module endpoint)."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        session.add(
+            DataIngestionJob(
+                entity_type=EntityType.MODULE_PER_YEAR,
+                module_type_id=1,
+                year=2025,
+                target_type=TargetType.DATA_ENTRIES,
+                ingestion_method=IngestionMethod.computed,
+                provider=UserProvider.DEFAULT,
+                state=IngestionState.RUNNING,
+                is_current=True,
+                pipeline_id=uuid4(),
+                job_type="aggregation",
+                meta={},
+            )
+        )
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_dedupes_pipeline_ids(pg_app):
+    """A pipeline can have multiple jobs sharing one ``pipeline_id``
+    (parent + fan-out children).  The endpoint returns each
+    pipeline_id once — the frontend treats the result as a set."""
+    Sf = pg_app["factory"]
+    shared_pipeline = uuid4()
+
+    async with Sf() as session:
+        # Two jobs in the same pipeline (e.g. parent + a fan-out child).
+        session.add(_make_year_level_job(year=2025, pipeline_id=shared_pipeline))
+        session.add(
+            _make_year_level_job(
+                year=2025,
+                pipeline_id=shared_pipeline,
+                state=IngestionState.QUEUED,
+            )
+        )
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == [str(shared_pipeline)]
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_returns_empty_when_no_jobs(pg_app):
+    """Steady state: no year-level pipelines anywhere → empty list.
+    The watcher idles, no SSE streams open."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/v1/sync/active-pipelines/year/2025")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_year_level_active_pipelines_returns_403_for_user_without_permission(
+    pg_dsn, monkeypatch
+):
+    """``GET /v1/sync/active-pipelines/year/{year}`` is gated behind
+    ``backoffice.data_management.view``.  Users without that permission
+    get HTTP 403.
+
+    Deliberately bypasses ``pg_app`` (which monkeypatches ``is_permitted``
+    to always-True) so the real permission check fires.
+    """
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+    fake_user.institutional_id = "TEST-USER"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
+        fake_user
+    )
+
+    async def _deny(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("app.core.security.is_permitted", _deny)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/v1/sync/active-pipelines/year/2025")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+    assert resp.status_code == 403, resp.text

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, provide } from 'vue';
+import { ref, watch, provide } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
@@ -15,6 +15,8 @@ import {
   type ImportRow,
 } from 'src/stores/backofficeDataManagement';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import { usePipelineStateStore } from 'src/stores/pipelineState';
+import { usePipelineStream } from 'src/composables/usePipelineStream';
 import { Notify, Loading } from 'quasar';
 import { useI18n } from 'vue-i18n';
 
@@ -40,7 +42,45 @@ const selectedYear = ref<number>(
 
 const backofficeDataManagement = useBackofficeDataManagement();
 const yearConfigStore = useYearConfigStore();
+const pipelineStateStore = usePipelineStateStore();
 const { t: $t } = useI18n();
+
+// Issue #867 — re-attach the SSE watcher to year-level pipelines on
+// page mount + on year change.  The Pinia stores live in memory and
+// reset on hard reload, so an in-flight unit-sync (or any future
+// ``entity_type=GLOBAL_PER_YEAR`` chain) loses its watcher across the
+// reload boundary.  ``ModuleConfig.vue`` already covers the
+// per-module rehydrate path via the module-scoped active-pipelines
+// endpoint; year-level pipelines carry no ``module_type_id`` and are
+// invisible there, so they need their own channel.
+//
+// ``usePipelineStream`` auto-installs ``onUnmounted`` cleanup for the
+// subscriptions it owns, so we only call ``unsubscribe`` explicitly
+// on the year-change transition (N pipelines may run in parallel —
+// today only ``unit_sync`` uses GLOBAL_PER_YEAR so N is 0 or 1, but
+// the wire shape is ``list[str]`` and the diff loop generalises).
+const { subscribe, unsubscribe } = usePipelineStream();
+let lastYearLevelSubscriptions = new Set<string>();
+
+async function rehydrateYearLevelPipelines(year: number): Promise<void> {
+  await pipelineStateStore.loadYearLevelFor(year);
+  const next = new Set<string>(pipelineStateStore.getYearLevelPipelineIds(year));
+
+  for (const id of lastYearLevelSubscriptions) {
+    if (!next.has(id)) unsubscribe(id);
+  }
+  const subscribePromises: Array<Promise<void>> = [];
+  for (const id of next) {
+    if (!lastYearLevelSubscriptions.has(id)) {
+      subscribePromises.push(subscribe(id));
+    }
+  }
+  lastYearLevelSubscriptions = next;
+  // Each ``subscribe`` does its own one-shot snapshot fetch before
+  // opening the EventSource — parallelise so a slow snapshot for one
+  // id doesn't block the others.
+  await Promise.all(subscribePromises);
+}
 
 const fetchYearConfig = async () => {
   await yearConfigStore.fetchConfig(selectedYear.value);
@@ -63,6 +103,25 @@ watch(
 watch(selectedYear, (year) => {
   void router.replace({ query: { ...route.query, year: String(year) } });
 });
+
+// A failed rehydrate is non-fatal — the page just runs without live
+// progress for year-level pipelines, the same UX as before #867.  We
+// log rather than toast so a transient active-pipelines hiccup doesn't
+// crowd the year-config error notification path.
+watch(
+  selectedYear,
+  async (year) => {
+    try {
+      await rehydrateYearLevelPipelines(year);
+    } catch (err) {
+      console.warn(
+        '[DataManagementPage] failed to rehydrate year-level pipelines',
+        err,
+      );
+    }
+  },
+  { immediate: true },
+);
 
 const handleCreateYear = async () => {
   try {
@@ -113,10 +172,6 @@ watch(
     }
   },
 );
-
-onMounted(() => {
-  // intentionally empty — loading is handled by the yearConfigStore.loading watcher
-});
 
 // ── Data-entry dialog (provided to child components like ReductionObjectivesSection) ──
 const showDataEntryDialog = ref(false);

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -64,7 +64,9 @@ let lastYearLevelSubscriptions = new Set<string>();
 
 async function rehydrateYearLevelPipelines(year: number): Promise<void> {
   await pipelineStateStore.loadYearLevelFor(year);
-  const next = new Set<string>(pipelineStateStore.getYearLevelPipelineIds(year));
+  const next = new Set<string>(
+    pipelineStateStore.getYearLevelPipelineIds(year),
+  );
 
   for (const id of lastYearLevelSubscriptions) {
     if (!next.has(id)) unsubscribe(id);

--- a/frontend/src/stores/pipelineState.ts
+++ b/frontend/src/stores/pipelineState.ts
@@ -36,6 +36,15 @@ import { api } from 'src/api/http';
 type ActivePipelinesResponse = Record<string, string>;
 
 /**
+ * Wire shape of ``GET /v1/sync/active-pipelines/year/{year}``.
+ *
+ * Flat list of pipeline_id UUIDs (strings) for every active
+ * ``entity_type=GLOBAL_PER_YEAR`` job for the requested year.  Empty
+ * list is the steady state.  Issue #867.
+ */
+type ActiveYearLevelPipelinesResponse = string[];
+
+/**
  * Composite key — pipeline state is scoped to ``(module_type_id, year)``
  * because the same ``module_type_id`` can have different pipeline state
  * across years (e.g. operator looking at 2024 while a 2025 chain runs
@@ -52,6 +61,15 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
    * "not yet loaded".
    */
   const pipelineByModuleYear = reactive<Record<string, string | null>>({});
+
+  /**
+   * Per-``year`` list of active ``GLOBAL_PER_YEAR`` pipeline_ids
+   * (Issue #867).  Year-level pipelines (e.g. unit-sync) are not
+   * module-scoped, so they live in a separate map keyed only on
+   * ``year``.  Absence means "not yet loaded"; an empty array means
+   * "loaded, no active year-level pipeline" — the steady state.
+   */
+  const yearLevelPipelinesByYear = reactive<Record<number, string[]>>({});
 
   /**
    * Bulk-fetch active pipeline_ids for the given modules in one round
@@ -92,6 +110,35 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
   }
 
   /**
+   * Issue #867 — bulk-fetch active year-level pipeline_ids
+   * (``entity_type=GLOBAL_PER_YEAR``) for the given year.  Backs the
+   * ``DataManagementPage.vue`` reload-rehydrate path: on mount + on
+   * year change the page re-attaches to live year-level pipelines
+   * (e.g. an in-flight unit-sync) so the SSE watcher resumes after
+   * a hard reload.
+   *
+   * Idempotent — calling twice for the same year refreshes the list.
+   * The result is the source of truth for ``getYearLevelPipelineIds``;
+   * absence from the map means "not yet loaded".
+   */
+  async function loadYearLevelFor(year: number): Promise<void> {
+    const response = (await api
+      .get(`sync/active-pipelines/year/${year}`)
+      .json()) as ActiveYearLevelPipelinesResponse;
+    yearLevelPipelinesByYear[year] = response;
+  }
+
+  /**
+   * Read the active year-level pipeline_ids for a year.  Returns an
+   * empty array both pre-load and when no year-level pipeline is
+   * active — the watcher in ``DataManagementPage.vue`` treats both as
+   * "nothing to subscribe to" (the steady state).
+   */
+  function getYearLevelPipelineIds(year: number): string[] {
+    return yearLevelPipelinesByYear[year] ?? [];
+  }
+
+  /**
    * Drop every entry — used when switching reports / years to ensure
    * stale ids from a previous context don't bleed through.
    */
@@ -99,12 +146,18 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
     for (const key of Object.keys(pipelineByModuleYear)) {
       delete pipelineByModuleYear[key];
     }
+    for (const key of Object.keys(yearLevelPipelinesByYear)) {
+      delete yearLevelPipelinesByYear[Number(key)];
+    }
   }
 
   return {
     pipelineByModuleYear,
+    yearLevelPipelinesByYear,
     loadFor,
+    loadYearLevelFor,
     getPipelineId,
+    getYearLevelPipelineIds,
     clear,
   };
 });

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -292,6 +292,53 @@ test.describe('back-office data-management — happy paths', () => {
     // Storybook / component-test coverage for the SubmoduleItem
     // emit chain — see Plan 310 Unit 11.
   });
+
+  test('8 — year-level reload-rehydrate (Issue #867): GET /sync/active-pipelines/year/{year} fires on mount and on year change', async ({
+    page,
+  }) => {
+    // The page's empty steady-state response (``[]``) is enough — we
+    // are asserting the REQUEST is fired, not the badge UI (the per-
+    // pipeline UI lives further down the chain in
+    // ``PipelineDiagnosticTooltip`` and is covered by its own spec).
+    const { requests } = await mockBackend(page);
+
+    await page.goto(DATA_MANAGEMENT_URL);
+
+    // Wait for the page to finish first-render before asserting
+    // request counts — the ``immediate: true`` watcher fires during
+    // the synchronous setup, but the ``api.get(...).json()`` await
+    // resolves a tick later.
+    await expect(page.getByText(/year configuration/i).first()).toBeVisible();
+
+    // Initial year (2024 — URL query param) must trigger one
+    // year-level fetch.  Without this fetch the SSE watcher has no
+    // way to discover an in-flight unit-sync after a hard reload.
+    await expect
+      .poll(() =>
+        requests.filter(
+          (r) =>
+            r.method === 'GET' &&
+            /\/sync\/active-pipelines\/year\/2024$/.test(r.url),
+        ).length,
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    // Change year → second fetch for the new year.  Mirrors the
+    // year-config fetch pattern (test 1) but for the year-level
+    // pipeline channel.
+    await page.locator('.q-select').first().click();
+    await page.getByRole('option', { name: '2025' }).click();
+
+    await expect
+      .poll(() =>
+        requests.filter(
+          (r) =>
+            r.method === 'GET' &&
+            /\/sync\/active-pipelines\/year\/2025$/.test(r.url),
+        ).length,
+      )
+      .toBeGreaterThanOrEqual(1);
+  });
 });
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -314,12 +314,13 @@ test.describe('back-office data-management — happy paths', () => {
     // year-level fetch.  Without this fetch the SSE watcher has no
     // way to discover an in-flight unit-sync after a hard reload.
     await expect
-      .poll(() =>
-        requests.filter(
-          (r) =>
-            r.method === 'GET' &&
-            /\/sync\/active-pipelines\/year\/2024$/.test(r.url),
-        ).length,
+      .poll(
+        () =>
+          requests.filter(
+            (r) =>
+              r.method === 'GET' &&
+              /\/sync\/active-pipelines\/year\/2024$/.test(r.url),
+          ).length,
       )
       .toBeGreaterThanOrEqual(1);
 
@@ -330,12 +331,13 @@ test.describe('back-office data-management — happy paths', () => {
     await page.getByRole('option', { name: '2025' }).click();
 
     await expect
-      .poll(() =>
-        requests.filter(
-          (r) =>
-            r.method === 'GET' &&
-            /\/sync\/active-pipelines\/year\/2025$/.test(r.url),
-        ).length,
+      .poll(
+        () =>
+          requests.filter(
+            (r) =>
+              r.method === 'GET' &&
+              /\/sync\/active-pipelines\/year\/2025$/.test(r.url),
+          ).length,
       )
       .toBeGreaterThanOrEqual(1);
   });

--- a/frontend/tests/integration/setup/data-management-mocks.ts
+++ b/frontend/tests/integration/setup/data-management-mocks.ts
@@ -187,6 +187,15 @@ export interface RouteOverrides {
     route: Route,
     moduleIds: number[],
   ) => Promise<void> | void;
+  /**
+   * Override active-pipelines/year/{year} response (Issue #867 —
+   * year-level pipelines).  Default returns ``[]`` (no live year-level
+   * chain) which matches the steady state.
+   */
+  onYearLevelActivePipelines?: (
+    route: Route,
+    year: number,
+  ) => Promise<void> | void;
   /** Override sync/units POST. */
   onSyncUnits?: (route: Route) => Promise<void> | void;
   /** Override files/temp-upload POST. */
@@ -270,6 +279,27 @@ export async function mockBackend(
     }
     await route.fallback();
   });
+
+  // active-pipelines/year/{year} — empty list by default (no live
+  // year-level pipeline).  Issue #867 reload-rehydrate path.
+  // Registered BEFORE the module-scoped catch-all so this more
+  // specific URL pattern wins for ``…/active-pipelines/year/2025``.
+  await page.route(
+    /.*\/api\/v1\/sync\/active-pipelines\/year\/(\d+)$/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      const year = parseInt(url.pathname.split('/').pop() ?? '0', 10);
+      if (overrides.onYearLevelActivePipelines) {
+        await overrides.onYearLevelActivePipelines(route, year);
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+      });
+    },
+  );
 
   // active-pipelines — empty by default (no recalculating badge).
   await page.route('**/api/v1/sync/active-pipelines**', async (route) => {


### PR DESCRIPTION
## Summary

Issue #867 / Unit 4 of 5 — back-office data-management page reload-rehydrate for **year-level** pipelines.

When the operator hard-reloads `DataManagementPage.vue` while an `entity_type=GLOBAL_PER_YEAR` chain (e.g. unit-sync) is in flight, the Pinia stores reset and the SSE watcher is not re-attached.  The existing `GET /sync/active-pipelines` endpoint requires `modules=…` and only sees module-scoped pipelines, so year-level chains were invisible to the rehydrate path.  `ModuleConfig.vue` already covers the per-module rehydrate (lines 124-157); this PR complements it for year-level chains, which carry no `module_type_id`.

- **Backend** — new `GET /v1/sync/active-pipelines/year/{year}` returning `list[str]` of pipeline_id UUIDs for every active GLOBAL_PER_YEAR job (NOT_STARTED / QUEUED / RUNNING) for the year.  Single SELECT, Python-side dedupe, `pipeline_id IS NOT NULL` guard so the result stays empty until U1 ships pipeline stamping for unit_sync.  Sibling repo helper `get_active_year_level_pipeline_ids` mirrors `get_current_pipeline_ids_for_modules`'s shape.
- **Frontend** — `pipelineStateStore.loadYearLevelFor(year)` / `getYearLevelPipelineIds(year)` mirror the per-module shape.  `DataManagementPage.vue` watcher (`{ immediate: true }`) diff-subscribes / -unsubscribes on mount + year change; the composable's `onUnmounted` handles page-leave.

### Independence from U1

- If U1 hasn't shipped: no GLOBAL_PER_YEAR job has `pipeline_id` stamped, the new endpoint returns `[]`, the watcher idles.  Safe.
- If U1 ships afterwards: a reload picks up the live pipeline.

## Notes for reviewers

- **Frontend unit test via vitest is not possible** in this repo — there's no vitest config/script in `package.json`.  The frontend coverage is the new test 8 in `tests/integration/data-management.spec.ts` (Playwright HTTP-route mocking) which asserts the new endpoint is hit on mount and on year change.
- **Self-reviewed via the simplify skill prompts** (Reuse / Quality / Efficiency).  My harness lacks the multi-agent Agent tool the skill spawns; I performed the three reviews inline and applied the cleanup pass (trimmed verbose comments, added explicit `Set<string>` type annotation).
- **Concurrent year-changes** (operator clicks 2024→2025→2024 in rapid succession): `lastYearLevelSubscriptions = next` runs before `Promise.all(subscribePromises)`.  If two rehydrates overlap, the second sees the first's not-yet-resolved subscription set as already in place; worst case is a redundant snapshot fetch, not a leak (the composable's `ownedSubscriptions` set guards `subscribe` against double-counting).  Acceptable, but flagging for awareness.
- **Branch base**: `dev` (the file references in the unit spec — `data_sync.py:801-862`, `pipelineState.ts`, `usePipelineStream.ts` — exist on `dev`, not `main`).

## Test plan

- [x] `uv run pytest backend/tests/integration/services/data_ingestion/test_active_pipelines_year_endpoint_pg.py` — 8/8 pass (running, finished, year-filter, no-pipeline-id, module-scoped exclusion, pipeline-id dedupe, empty steady state, 403 without permission).
- [x] `uv run pytest backend/tests/unit/` — 1307 pass (no regressions; existing PG-IT failures unrelated to diff — port 55432 unbound).
- [ ] `playwright test data-management` — unrunnable in this worktree (no `node_modules`).  Test 8 (`year-level reload-rehydrate`) added to `tests/integration/data-management.spec.ts`; please run on a working dev environment before merge.
- [ ] Manual: trigger a unit-sync from the page (POST `/sync/units`), hard-reload while RUNNING, verify the badge / progress reattaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)