### PR TITLE
Feat/741 implement reference upload

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -61,6 +61,11 @@ def _job_type_for(target_type: TargetType, ingestion_method: IngestionMethod) ->
     """
     if target_type == TargetType.FACTORS:
         return "factor_ingest"
+    if target_type == TargetType.REFERENCE_DATA:
+        # Reference data (locations, building rooms) is year-agnostic global
+        # state — no per-(module, det) emission_recalc fan-out, so it gets its
+        # own handler that skips the recalc chain ``csv_ingest`` would trigger.
+        return "reference_ingest"
     if ingestion_method == IngestionMethod.csv:
         return "csv_ingest"
     return "api_ingest"

--- a/backend/app/services/data_ingestion/csv_providers/__init__.py
+++ b/backend/app/services/data_ingestion/csv_providers/__init__.py
@@ -13,7 +13,7 @@ from app.services.data_ingestion.csv_providers.reduction_objectives import (
     ModulePerYearReductionObjectivesApiProvider,
 )
 from app.services.data_ingestion.csv_providers.reference_data import (
-    ModulePerYearReferenceDataApiProvider,
+    ReferenceDataCSVProvider,
 )
 
 __all__ = [
@@ -21,5 +21,5 @@ __all__ = [
     "ModulePerYearCSVProvider",
     "ModulePerYearFactorCSVProvider",
     "ModulePerYearReductionObjectivesApiProvider",
-    "ModulePerYearReferenceDataApiProvider",
+    "ReferenceDataCSVProvider",
 ]

--- a/backend/app/services/data_ingestion/csv_providers/reference_data.py
+++ b/backend/app/services/data_ingestion/csv_providers/reference_data.py
@@ -1,20 +1,549 @@
-from typing import Any, Dict
+"""Reference-data CSV provider.
 
+Dispatches by ``data_entry_type_id``:
+
+- ``train`` (21) → upsert into ``locations`` table (train rows only)
+- ``plane`` (20) → upsert into ``locations`` table (plane rows only)
+- ``building`` (30) → delete + insert into ``building_rooms`` table
+
+Reference data is **year-agnostic** by design: rows write to the global
+``locations`` / ``building_rooms`` tables with no ``year`` column.  The
+job row still carries ``year`` so the dashboard can show "last uploaded
+under year X", but the data itself is shared across every report year.
+
+Locations use the same staging-table + COPY + UPSERT path as
+``app.seed.seed_locations`` (``_NATURAL_KEY_EXPR`` stays in lock-step with
+``Location.compute_natural_key`` so seed and ingest dedupe identically).
+Building rooms follow the seed's full-replacement semantics
+(``delete(BuildingRoom)`` then re-insert) — uploading a partial CSV
+clears the rest of the table.
+"""
+
+import csv
+import io
+import urllib.parse
+from typing import Any, Dict, List
+
+import psycopg
+from sqlalchemy.engine.url import make_url
+from sqlmodel import delete
+
+from app.core.config import get_settings
 from app.core.logging import get_logger
-from app.models.data_ingestion import EntityType
-from app.services.data_ingestion.base_factor_csv_provider import (
-    BaseFactorCSVProvider,
+from app.models.building_room import BuildingRoom
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import (
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
 )
+from app.models.user import User
+from app.seed.seed_locations import _NATURAL_KEY_EXPR
+from app.services.data_ingestion.base_csv_provider import _validate_file_path
+from app.services.data_ingestion.base_provider import DataIngestionProvider
 
 logger = get_logger(__name__)
 
 
-class ModulePerYearReferenceDataApiProvider(BaseFactorCSVProvider):
+LOCATIONS_REQUIRED_COLUMNS = {
+    "transport_mode",
+    "name",
+    "latitude",
+    "longitude",
+}
+LOCATIONS_EXPECTED_COLUMNS = LOCATIONS_REQUIRED_COLUMNS | {
+    "airport_size",
+    "continent",
+    "country_code",
+    "municipality",
+    "iata_code",
+    "keywords",
+}
+
+BUILDING_ROOMS_REQUIRED_COLUMNS = {
+    "building_location",
+    "building_name",
+    "room_name",
+}
+BUILDING_ROOMS_EXPECTED_COLUMNS = BUILDING_ROOMS_REQUIRED_COLUMNS | {
+    "room_type",
+    "room_surface_square_meter",
+}
+
+
+class ReferenceDataCSVProvider(DataIngestionProvider):
+    """CSV provider for reference data (locations, building rooms).
+
+    Routed by ``(module_type_id, csv, REFERENCE_DATA, MODULE_PER_YEAR)``;
+    inside the provider, dispatch by ``data_entry_type_id``.
+    """
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        user: User | None = None,
+        job_session: Any = None,
+        data_session: Any = None,
+    ) -> None:
+        super().__init__(config, user, job_session, data_session=data_session)
+        self.job_id = config.get("job_id")
+        self.module_type_id = config.get("module_type_id")
+        self.data_entry_type_id = config.get("data_entry_type_id")
+        raw_file_path = config.get("file_path")
+        self.source_file_path = (
+            urllib.parse.unquote(raw_file_path) if raw_file_path else None
+        )
+        if self.source_file_path:
+            _validate_file_path(self.source_file_path)
+        self._files_store: Any = None
+        logger.info(
+            f"Initializing {self.__class__.__name__} for job_id={self.job_id}, "
+            f"file_path={self.source_file_path}, "
+            f"data_entry_type_id={self.data_entry_type_id}"
+        )
+
+    @property
+    def provider_name(self) -> IngestionMethod:
+        return IngestionMethod.csv
+
+    @property
+    def target_type(self) -> TargetType:
+        return TargetType.REFERENCE_DATA
+
     @property
     def entity_type(self) -> EntityType:
         return EntityType.MODULE_PER_YEAR
 
-    async def _setup_handlers_and_context(self) -> Dict[str, Any]:
-        logger.info("Setup complete for reference data factor CSV: ")
+    @property
+    def files_store(self) -> Any:
+        if self._files_store is None:
+            from app.api.v1.files import make_files_store
 
-        return {}
+            self._files_store = make_files_store()
+        return self._files_store
+
+    async def validate_connection(self) -> bool:
+        if not self.source_file_path:
+            logger.warning("No file_path provided in config")
+            return False
+        try:
+            return await self.files_store.file_exists(self.source_file_path)
+        except Exception as exc:
+            logger.error(f"Failed to validate reference CSV: {exc}")
+            return False
+
+    async def fetch_data(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return []
+
+    async def transform_data(
+        self, raw_data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        return raw_data
+
+    async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {"inserted": 0, "skipped": 0, "errors": 0}
+
+    async def ingest(self, filters: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        try:
+            await self._update_job(
+                status_message="processing",
+                state=IngestionState.RUNNING,
+                result=None,
+                extra_metadata={"message": "Starting reference CSV processing..."},
+            )
+
+            det = self._resolve_data_entry_type()
+            csv_text, processing_path, filename = await self._stage_file()
+
+            if det in (DataEntryTypeEnum.plane, DataEntryTypeEnum.train):
+                stats = await self._ingest_locations(csv_text, det)
+            elif det == DataEntryTypeEnum.building:
+                stats = await self._ingest_building_rooms(csv_text)
+            else:
+                raise ValueError(
+                    f"data_entry_type_id={det.value} is not a supported "
+                    "reference type (expected plane=20, train=21, building=30)"
+                )
+
+            processed_path = await self._move_to_processed(processing_path, filename)
+
+            result = (
+                IngestionResult.SUCCESS
+                if stats["rows_skipped"] == 0 and stats["rows_processed"] > 0
+                else IngestionResult.WARNING
+                if stats["rows_processed"] > 0
+                else IngestionResult.ERROR
+            )
+            status_message = (
+                f"Processed {stats['rows_processed']} rows: "
+                f"{stats['rows_skipped']} skipped, "
+                f"{stats['rows_inserted']} inserted"
+            )
+            await self._update_job(
+                status_message=status_message,
+                state=IngestionState.FINISHED,
+                result=result,
+                extra_metadata={
+                    **stats,
+                    "stats": stats,
+                    "processed_file_path": processed_path,
+                    "filename": filename,
+                },
+            )
+            return {
+                "state": IngestionState.FINISHED,
+                "status_message": status_message,
+                "data": {
+                    "result": result,
+                    "inserted": stats["rows_inserted"],
+                    "skipped": stats["rows_skipped"],
+                    "stats": stats,
+                },
+            }
+        except Exception as exc:
+            await self._update_job(
+                status_message=f"failed: {exc}",
+                state=IngestionState.FINISHED,
+                result=IngestionResult.ERROR,
+                extra_metadata={"error": str(exc)},
+            )
+            logger.exception("Reference CSV ingestion failed")
+            raise
+
+    def _resolve_data_entry_type(self) -> DataEntryTypeEnum:
+        if self.data_entry_type_id is None:
+            raise ValueError(
+                "data_entry_type_id is required for reference data ingestion"
+            )
+        return DataEntryTypeEnum(int(self.data_entry_type_id))
+
+    async def _stage_file(self) -> tuple[str, str, str]:
+        """Move the uploaded file from tmp/ → processing/ and read its bytes."""
+        if not self.source_file_path:
+            raise ValueError("Missing file_path in config")
+        _validate_file_path(self.source_file_path)
+        filename = self.source_file_path.split("/")[-1]
+        processing_path = f"processing/{self.job_id}/{filename}"
+        logger.info(f"Moving file from {self.source_file_path} to {processing_path}")
+        move_result = await self.files_store.move_file(
+            self.source_file_path, processing_path
+        )
+        if not move_result:
+            raise ValueError("Failed to move file to processing path")
+
+        file_content, _ = await self.files_store.get_file(processing_path)
+        csv_text = file_content.decode("utf-8")
+        return csv_text, processing_path, filename
+
+    async def _move_to_processed(self, processing_path: str, filename: str) -> str:
+        """On success only — promote ``processing/<job>/<file>`` to ``processed/``.
+
+        Kept off the failure path so an admin downloading "the last CSV"
+        always reads a file that was actually ingested.
+        """
+        processed_path = f"processed/{self.job_id}/{filename}"
+        moved = await self.files_store.move_file(processing_path, processed_path)
+        if not moved:
+            logger.warning(
+                f"Failed to move {processing_path} to {processed_path} — "
+                "keeping in processing/"
+            )
+            return processing_path
+        return processed_path
+
+    @staticmethod
+    def _validate_headers(
+        csv_text: str,
+        required_columns: set[str],
+        expected_columns: set[str],
+    ) -> None:
+        reader = csv.DictReader(io.StringIO(csv_text))
+        try:
+            first = next(reader)
+        except StopIteration:
+            raise ValueError("CSV file is empty")
+        keys = set(first.keys())
+        missing_required = required_columns - keys
+        if missing_required:
+            raise ValueError(
+                "CSV is missing required columns: "
+                f"{', '.join(sorted(missing_required))}"
+            )
+        unknown = keys - expected_columns
+        if unknown:
+            logger.warning(
+                f"Reference CSV has unexpected columns (ignored): "
+                f"{', '.join(sorted(unknown))}"
+            )
+
+    async def _ingest_locations(
+        self, csv_text: str, det: DataEntryTypeEnum
+    ) -> Dict[str, Any]:
+        """COPY into a staging temp table, then UPSERT into ``locations``.
+
+        Mirrors the seed-time path in ``app.seed.seed_locations`` — same
+        natural-key expression, same staging columns, same UPSERT.  Rows are
+        filtered to ``transport_mode = {det.name}`` so a "plane" CSV that
+        accidentally contains train rows (or vice-versa) does not pollute
+        the table.
+        """
+        self._validate_headers(
+            csv_text, LOCATIONS_REQUIRED_COLUMNS, LOCATIONS_EXPECTED_COLUMNS
+        )
+
+        rows = self._parse_locations_rows(csv_text, det)
+        if not rows:
+            return {
+                "rows_processed": 0,
+                "rows_skipped": 0,
+                "rows_inserted": 0,
+            }
+
+        settings = get_settings()
+        if not settings.DB_URL:
+            raise ValueError("DB_URL is not configured")
+        url = make_url(settings.DB_URL)
+        if url.drivername.split("+")[0] != "postgresql":
+            return await self._ingest_locations_sqlite(rows, det)
+
+        conn_kwargs: Dict[str, Any] = {
+            "host": url.host,
+            "port": url.port or 5432,
+            "dbname": url.database,
+        }
+        if url.username:
+            conn_kwargs["user"] = url.username
+        if url.password:
+            conn_kwargs["password"] = url.password
+
+        copy_sql = (
+            "COPY locations_staging ("
+            "transport_mode, airport_size, name, latitude, longitude, "
+            "continent, country_code, municipality, iata_code, keywords"
+            ") FROM STDIN CSV NULL ''"
+        )
+        upsert_sql = f"""
+            INSERT INTO locations (
+                transport_mode, airport_size, name, latitude, longitude,
+                continent, country_code, municipality, iata_code, keywords,
+                natural_key
+            )
+            SELECT DISTINCT ON (nk)
+                transport_mode::transportmodeenum, airport_size, name,
+                latitude::float, longitude::float,
+                continent, country_code, municipality, iata_code, keywords,
+                nk AS natural_key
+            FROM (
+                SELECT *,
+                    {_NATURAL_KEY_EXPR} AS nk
+                FROM locations_staging
+            ) deduped
+            ORDER BY nk
+            ON CONFLICT (natural_key) DO UPDATE SET
+                name         = EXCLUDED.name,
+                latitude     = EXCLUDED.latitude,
+                longitude    = EXCLUDED.longitude,
+                country_code = EXCLUDED.country_code,
+                iata_code    = EXCLUDED.iata_code,
+                airport_size = EXCLUDED.airport_size,
+                continent    = EXCLUDED.continent,
+                municipality = EXCLUDED.municipality,
+                keywords     = EXCLUDED.keywords,
+                natural_key  = EXCLUDED.natural_key
+        """  # nosec B608 - constants only, no user input
+
+        rows_inserted = 0
+        async with await psycopg.AsyncConnection.connect(**conn_kwargs) as conn:
+            await conn.execute(
+                """
+                CREATE TEMP TABLE locations_staging (
+                    transport_mode TEXT, airport_size TEXT, name TEXT,
+                    latitude FLOAT, longitude FLOAT, continent TEXT,
+                    country_code TEXT, municipality TEXT, iata_code TEXT, keywords TEXT
+                ) ON COMMIT DROP
+                """
+            )
+            async with conn.cursor() as cur:
+                async with cur.copy(copy_sql) as copy:
+                    buf = io.StringIO()
+                    writer = csv.writer(buf)
+                    for row in rows:
+                        writer.writerow(row)
+                    await copy.write(buf.getvalue().encode("utf-8"))
+                await cur.execute(upsert_sql)
+                rows_inserted = cur.rowcount if cur.rowcount >= 0 else len(rows)
+            await conn.commit()
+
+        return {
+            "rows_processed": len(rows),
+            "rows_skipped": 0,
+            "rows_inserted": rows_inserted,
+        }
+
+    @staticmethod
+    def _parse_locations_rows(csv_text: str, det: DataEntryTypeEnum) -> List[List[str]]:
+        target_mode = det.name  # "plane" or "train"
+        rows: List[List[str]] = []
+        reader = csv.DictReader(io.StringIO(csv_text))
+        for raw in reader:
+            mode = (raw.get("transport_mode") or "").strip().lower()
+            if mode != target_mode:
+                continue
+            rows.append(
+                [
+                    mode,
+                    (raw.get("airport_size") or "").strip(),
+                    (raw.get("name") or "").strip(),
+                    (raw.get("latitude") or "").strip(),
+                    (raw.get("longitude") or "").strip(),
+                    (raw.get("continent") or "").strip(),
+                    (raw.get("country_code") or "").strip(),
+                    (raw.get("municipality") or "").strip(),
+                    (raw.get("iata_code") or "").strip(),
+                    (raw.get("keywords") or "").strip(),
+                ]
+            )
+        return rows
+
+    async def _ingest_locations_sqlite(
+        self, rows: List[List[str]], det: DataEntryTypeEnum
+    ) -> Dict[str, Any]:
+        """SQLite fallback for tests: ORM upsert keyed on natural_key.
+
+        Production runs against PostgreSQL via the COPY+UPSERT path above;
+        this branch exists so the test suite (SQLite) can exercise the
+        provider without a Postgres-only ``transportmodeenum`` cast.
+        """
+        from sqlalchemy import select
+
+        from app.models.location import Location, TransportModeEnum
+
+        inserted = 0
+        for row in rows:
+            (
+                mode,
+                airport_size,
+                name,
+                lat,
+                lon,
+                continent,
+                country_code,
+                municipality,
+                iata_code,
+                keywords,
+            ) = row
+            try:
+                latitude = float(lat)
+                longitude = float(lon)
+            except ValueError:
+                continue
+            transport_mode = TransportModeEnum(mode)
+            natural_key = Location.compute_natural_key(
+                transport_mode=transport_mode,
+                name=name,
+                latitude=latitude,
+                longitude=longitude,
+                country_code=country_code or None,
+                iata_code=iata_code or None,
+            )
+            # mypy without the SQLAlchemy plugin sees ``Column == value`` as
+            # ``bool``; at runtime it's a ``BinaryExpression``.  Same workaround
+            # used elsewhere in the codebase (see app/api/v1/data_sync.py).
+            existing = await self.data_session.execute(
+                select(Location).where(
+                    Location.natural_key == natural_key  # type: ignore[arg-type]
+                )
+            )
+            row_obj = existing.scalar_one_or_none()
+            if row_obj is None:
+                row_obj = Location(
+                    transport_mode=transport_mode,
+                    airport_size=airport_size or None,
+                    name=name,
+                    latitude=latitude,
+                    longitude=longitude,
+                    continent=continent or None,
+                    country_code=country_code or None,
+                    municipality=municipality or None,
+                    iata_code=iata_code or None,
+                    keywords=keywords or None,
+                    natural_key=natural_key,
+                )
+                self.data_session.add(row_obj)
+            else:
+                row_obj.airport_size = airport_size or None
+                row_obj.name = name
+                row_obj.latitude = latitude
+                row_obj.longitude = longitude
+                row_obj.continent = continent or None
+                row_obj.country_code = country_code or None
+                row_obj.municipality = municipality or None
+                row_obj.iata_code = iata_code or None
+                row_obj.keywords = keywords or None
+                self.data_session.add(row_obj)
+            inserted += 1
+        await self.data_session.flush()
+        return {
+            "rows_processed": len(rows),
+            "rows_skipped": 0,
+            "rows_inserted": inserted,
+        }
+
+    async def _ingest_building_rooms(self, csv_text: str) -> Dict[str, Any]:
+        """Delete and re-insert all building rooms (matches seed semantics).
+
+        Uploading a partial CSV will wipe everything outside it; the
+        FE makes this explicit to the admin.
+        """
+        self._validate_headers(
+            csv_text,
+            BUILDING_ROOMS_REQUIRED_COLUMNS,
+            BUILDING_ROOMS_EXPECTED_COLUMNS,
+        )
+
+        rooms: List[BuildingRoom] = []
+        skipped = 0
+        reader = csv.DictReader(io.StringIO(csv_text))
+        for raw in reader:
+            building_location = (raw.get("building_location") or "").strip()
+            building_name = (raw.get("building_name") or "").strip()
+            room_name = (raw.get("room_name") or "").strip()
+            if not (building_location and building_name and room_name):
+                skipped += 1
+                continue
+            rooms.append(
+                BuildingRoom(
+                    building_location=building_location,
+                    building_name=building_name,
+                    room_name=room_name,
+                    room_type=(raw.get("room_type") or "").strip() or None,
+                    room_surface_square_meter=_to_float(
+                        raw.get("room_surface_square_meter")
+                    ),
+                )
+            )
+
+        await self.data_session.exec(delete(BuildingRoom))
+        if rooms:
+            self.data_session.add_all(rooms)
+        await self.data_session.flush()
+
+        return {
+            "rows_processed": len(rooms),
+            "rows_skipped": skipped,
+            "rows_inserted": len(rooms),
+        }
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized or normalized == "-":
+        return None
+    try:
+        return float(normalized)
+    except ValueError:
+        return None

--- a/backend/app/services/data_ingestion/provider_factory.py
+++ b/backend/app/services/data_ingestion/provider_factory.py
@@ -20,8 +20,8 @@ from app.services.data_ingestion.csv_providers import (
     ModulePerYearCSVProvider,
     ModulePerYearFactorCSVProvider,
     ModulePerYearReductionObjectivesApiProvider,
-    ModulePerYearReferenceDataApiProvider,
     ModuleUnitSpecificCSVProvider,
+    ReferenceDataCSVProvider,
 )
 
 
@@ -72,13 +72,19 @@ class ProviderFactory:
             TargetType.REDUCTION_OBJECTIVES,
             EntityType.MODULE_PER_YEAR,
         ): ModulePerYearReductionObjectivesApiProvider,
-        ## MODULE_PER_YEAR REFERENCE DATA
-        (
-            None,
-            IngestionMethod.csv,
-            TargetType.REFERENCE_DATA,
-            EntityType.MODULE_PER_YEAR,
-        ): ModulePerYearReferenceDataApiProvider,
+        ## REFERENCE DATA — front-end pins module_type_id (professional_travel
+        ## for train/plane, buildings for rooms), so the registry must cover
+        ## every ModuleTypeEnum value rather than the lone (None, ...) key
+        ## the dummy stub registered.
+        **{
+            (
+                module_type,
+                IngestionMethod.csv,
+                TargetType.REFERENCE_DATA,
+                EntityType.MODULE_PER_YEAR,
+            ): ReferenceDataCSVProvider
+            for module_type in ModuleTypeEnum
+        },
         # API Providers
         (
             ModuleTypeEnum.professional_travel,

--- a/backend/app/tasks/bootstrap.py
+++ b/backend/app/tasks/bootstrap.py
@@ -37,6 +37,7 @@ def bootstrap_handlers() -> None:
         aggregation_tasks,  # noqa: F401
         emission_recalculation_tasks,  # noqa: F401
         ingestion_tasks,  # noqa: F401
+        reference_ingest_tasks,  # noqa: F401
         unit_sync_tasks,  # noqa: F401
     )
 

--- a/backend/app/tasks/reference_ingest_tasks.py
+++ b/backend/app/tasks/reference_ingest_tasks.py
@@ -1,0 +1,67 @@
+"""Reference-data ingest handler.
+
+Registered under ``job_type='reference_ingest'`` — a sibling of
+``csv_ingest`` / ``factor_ingest`` that skips the emission-recalc
+fan-out.  Reference data (locations, building rooms) writes to global,
+year-agnostic tables that no factor or emission row references, so the
+fan-out chain is both unnecessary and incorrect.
+"""
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.data_ingestion import DataIngestionJob, IngestionResult
+from app.services.data_ingestion.provider_factory import ProviderFactory
+from app.tasks.registry import register
+
+logger = get_logger(__name__)
+
+
+@register("reference_ingest")
+async def reference_ingest_handler(
+    job: DataIngestionJob,
+    job_session: AsyncSession,
+    data_session: AsyncSession,
+) -> dict:
+    """Run the reference-data provider with no post-success chaining."""
+    if job.id is None:
+        raise ValueError("reference_ingest handler: job has no id")
+
+    job_meta = job.meta or {}
+    provider_name = job_meta.get("provider_name")
+    if not provider_name:
+        raise ValueError(
+            f"reference_ingest: job {job.id} missing meta.provider_name "
+            "(endpoint must set it when creating the job)"
+        )
+
+    provider_class = ProviderFactory.get_provider_class(provider_name)
+    if provider_class is None:
+        raise ValueError(
+            f"reference_ingest: provider class {provider_name!r} not found "
+            f"(job {job.id})"
+        )
+
+    job_config = job_meta.get("config") or {}
+    provider = provider_class(
+        config={**job.__dict__, **job_config, "job_id": job.id},
+        user=job.user if hasattr(job, "user") else None,
+        job_session=job_session,
+        data_session=data_session,
+    )
+    provider.defer_finalize = True
+    if hasattr(provider, "set_job_id"):
+        await provider.set_job_id(job.id)
+
+    filters = job_meta.get("filters") or {}
+    result = await provider.ingest(filters)
+    data = result.get("data", {}) or {}
+    ingestion_result = data.get("result", IngestionResult.SUCCESS)
+    return {
+        "status_message": result.get("status_message", "Success"),
+        "result": ingestion_result,
+        **data,
+    }
+
+
+__all__ = ["reference_ingest_handler"]

--- a/backend/tests/unit/services/data_ingestion/csv_providers/test_reference_data.py
+++ b/backend/tests/unit/services/data_ingestion/csv_providers/test_reference_data.py
@@ -1,25 +1,136 @@
-"""Tests for ModulePerYearReferenceDataApiProvider."""
+"""Tests for ReferenceDataCSVProvider."""
+
+from unittest.mock import MagicMock
 
 import pytest
 
-from app.models.data_ingestion import EntityType
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import EntityType, IngestionMethod, TargetType
+from app.models.module_type import ModuleTypeEnum
 from app.services.data_ingestion.csv_providers.reference_data import (
-    ModulePerYearReferenceDataApiProvider,
+    LOCATIONS_REQUIRED_COLUMNS,
+    ReferenceDataCSVProvider,
 )
+from app.services.data_ingestion.provider_factory import ProviderFactory
 
 
-def _make_provider():
-    config = {"job_id": "test", "year": 2024}
-    return ModulePerYearReferenceDataApiProvider(config=config)
+def _make_provider(**overrides) -> ReferenceDataCSVProvider:
+    config = {"job_id": 1, "year": 2024, **overrides}
+    return ReferenceDataCSVProvider(config=config, data_session=MagicMock())
 
 
-def test_entity_type():
+def test_entity_type_and_target_type():
     provider = _make_provider()
     assert provider.entity_type == EntityType.MODULE_PER_YEAR
+    assert provider.target_type == TargetType.REFERENCE_DATA
+    assert provider.provider_name == IngestionMethod.csv
+
+
+def test_provider_factory_routes_reference_csv_for_every_module():
+    # FE pins module_type_id (2 for travel, 3 for buildings), so the registry
+    # must answer for every concrete module rather than just (None, ...).
+    for module_type in ModuleTypeEnum:
+        provider_class = ProviderFactory.get_provider_by_keys(
+            module_type,
+            IngestionMethod.csv,
+            TargetType.REFERENCE_DATA,
+            EntityType.MODULE_PER_YEAR,
+        )
+        assert provider_class is ReferenceDataCSVProvider, (
+            f"missing reference CSV provider for module={module_type}"
+        )
+
+
+def test_resolve_data_entry_type_requires_value():
+    provider = _make_provider()
+    with pytest.raises(ValueError, match="data_entry_type_id is required"):
+        provider._resolve_data_entry_type()
+
+
+def test_resolve_data_entry_type_returns_enum():
+    provider = _make_provider(data_entry_type_id=DataEntryTypeEnum.plane.value)
+    assert provider._resolve_data_entry_type() == DataEntryTypeEnum.plane
+
+
+def test_validate_headers_rejects_empty_csv():
+    with pytest.raises(ValueError, match="empty"):
+        ReferenceDataCSVProvider._validate_headers(
+            "", LOCATIONS_REQUIRED_COLUMNS, LOCATIONS_REQUIRED_COLUMNS
+        )
+
+
+def test_validate_headers_rejects_missing_required():
+    csv_text = "transport_mode,name\nplane,JFK\n"
+    with pytest.raises(ValueError, match="missing required columns"):
+        ReferenceDataCSVProvider._validate_headers(
+            csv_text,
+            LOCATIONS_REQUIRED_COLUMNS,
+            LOCATIONS_REQUIRED_COLUMNS,
+        )
+
+
+def test_validate_headers_accepts_full_set():
+    csv_text = "transport_mode,name,latitude,longitude\nplane,JFK,40.6,-73.7\n"
+    # Should not raise — every required column is present.
+    ReferenceDataCSVProvider._validate_headers(
+        csv_text,
+        LOCATIONS_REQUIRED_COLUMNS,
+        LOCATIONS_REQUIRED_COLUMNS,
+    )
+
+
+def test_parse_locations_filters_by_transport_mode():
+    csv_text = (
+        "transport_mode,airport_size,name,latitude,longitude,"
+        "continent,country_code,municipality,iata_code,keywords\n"
+        "plane,large_airport,JFK,40.6,-73.7,NA,US,New York,JFK,\n"
+        "train,,Lyon Part-Dieu,45.76,4.86,EU,FR,Lyon,,\n"
+        "plane,medium_airport,LGA,40.77,-73.87,NA,US,New York,LGA,\n"
+    )
+
+    plane_rows = ReferenceDataCSVProvider._parse_locations_rows(
+        csv_text, DataEntryTypeEnum.plane
+    )
+    train_rows = ReferenceDataCSVProvider._parse_locations_rows(
+        csv_text, DataEntryTypeEnum.train
+    )
+
+    assert [r[2] for r in plane_rows] == ["JFK", "LGA"]
+    assert [r[2] for r in train_rows] == ["Lyon Part-Dieu"]
 
 
 @pytest.mark.asyncio
-async def test_setup_handlers_and_context():
+async def test_validate_connection_requires_file_path():
     provider = _make_provider()
-    result = await provider._setup_handlers_and_context()
-    assert result == {}
+    assert await provider.validate_connection() is False
+
+
+def test_job_type_for_reference_data():
+    # ``_job_type_for`` must route REFERENCE_DATA → reference_ingest so the
+    # csv_ingest handler's emission_recalc fan-out doesn't fire against a
+    # job that has no factor or data-entry rows to recalculate.
+    from app.api.v1.data_sync import _job_type_for
+
+    assert (
+        _job_type_for(TargetType.REFERENCE_DATA, IngestionMethod.csv)
+        == "reference_ingest"
+    )
+    assert (
+        _job_type_for(TargetType.REFERENCE_DATA, IngestionMethod.api)
+        == "reference_ingest"
+    )
+    # Sanity-check the other branches still return their original mapping.
+    assert _job_type_for(TargetType.FACTORS, IngestionMethod.csv) == "factor_ingest"
+    assert _job_type_for(TargetType.DATA_ENTRIES, IngestionMethod.csv) == "csv_ingest"
+
+
+def test_reference_ingest_handler_is_registered():
+    # Bootstrap imports reference_ingest_tasks so the @register decorator fires;
+    # without it run_job would raise ``No handler registered for
+    # job_type='reference_ingest'`` once the dispatcher hands it off.
+    from app.tasks.bootstrap import bootstrap_handlers
+    from app.tasks.registry import get_handler
+
+    bootstrap_handlers()
+    handler = get_handler("reference_ingest")
+    assert callable(handler)

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -7,7 +7,6 @@ import {
   TargetType,
   IngestionState,
   IngestionResult,
-  EntityType,
 } from 'src/stores/backofficeDataManagement';
 import type {
   ImportRow,
@@ -15,6 +14,7 @@ import type {
   JobUpdatePayload,
   InitiateSyncParams,
 } from 'src/stores/backofficeDataManagement';
+import { useFilesStore, type FileObject } from 'src/stores/files';
 import { Notify } from 'quasar';
 
 interface Props {
@@ -28,17 +28,18 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-  (e: 'upload', row: ImportRow, entityType: EntityType): void;
   (e: 'completed', job: SyncJobResponse): void;
   (e: 'progressing', job: SyncJobResponse): void;
 }>();
 
 const { t } = useI18n();
 const backofficeDataManagement = useBackofficeDataManagement();
+const filesStore = useFilesStore();
 const { safeFileName } = useUploadCard();
 
 const isLoading = ref(false);
 const lastJob = ref<SyncJobResponse | undefined>(undefined);
+const fileInputRef = ref<HTMLInputElement | null>(null);
 const isJobStuck = computed(
   () =>
     lastJob.value?.state === IngestionState.RUNNING ||
@@ -141,21 +142,44 @@ async function handleCancelJob() {
   lastJob.value = undefined;
 }
 
-async function handleUpload() {
+function handleUpload() {
   if (props.isDisabled || props.row.isDisabled) return;
+  fileInputRef.value?.click();
+}
 
+async function onFileSelected(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  // Clear so picking the same file twice still re-triggers ``change``.
+  target.value = '';
+  if (!file) return;
+  await uploadSelectedFile(file);
+}
+
+async function uploadSelectedFile(file: File) {
   isLoading.value = true;
 
   try {
+    // Cast via ``unknown``: the store types ``FileObject`` with a ``path``
+    // field (set by the response), but ``uploadTempFiles`` reads only the
+    // file's bytes + name from the input.  A browser ``File`` is structurally
+    // sufficient at runtime.
+    const uploaded = await filesStore.uploadTempFiles([
+      file as unknown as FileObject,
+    ]);
+    const filePath = uploaded[0]?.path;
+    if (!filePath) {
+      throw new Error('Upload returned no file path');
+    }
+
     const syncPayload: InitiateSyncParams = {
       module_type_id: props.row.moduleTypeId,
       year: props.year,
       provider_type: 'csv' as const,
       target_type: TargetType.REFERENCE_DATA,
       data_entry_type_id: props.row.dataEntryTypeId,
-      config: {
-        entity_type: EntityType.MODULE_UNIT_SPECIFIC,
-      },
+      file_path: filePath,
+      config: {},
     };
 
     const jobId = await backofficeDataManagement.initiateSync(syncPayload);
@@ -287,6 +311,14 @@ function isErrorOrWarning(): boolean {
     <div v-if="row.other" class="q-mb-xs text-caption text-grey-7">
       {{ $t(row.other) }}
     </div>
+
+    <input
+      ref="fileInputRef"
+      type="file"
+      accept=".csv,text/csv"
+      style="display: none"
+      @change="onFileSelected"
+    />
 
     <div class="row justify-between items-center full-width">
       <div class="row items-center" style="gap: 0.5rem">

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -38,7 +38,14 @@ const filesStore = useFilesStore();
 const { safeFileName } = useUploadCard();
 
 const isLoading = ref(false);
-const lastJob = ref<SyncJobResponse | undefined>(undefined);
+// Local job from the in-session SSE stream.  Survives only as long as the card
+// instance does — ``q-expansion-item`` unmounts content on collapse, so the
+// authoritative "last successful upload" lives on the parent year-config row
+// (``row.lastReferenceJob``).  We read whichever is more recent.
+const localJob = ref<SyncJobResponse | undefined>(undefined);
+const lastJob = computed<SyncJobResponse | undefined>(
+  () => localJob.value ?? props.row.lastReferenceJob,
+);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 const isJobStuck = computed(
   () =>
@@ -139,7 +146,7 @@ function downloadLastCsv(): void {
 async function handleCancelJob() {
   if (!lastJob.value?.job_id) return;
   await backofficeDataManagement.cancelJob(lastJob.value.job_id, props.year);
-  lastJob.value = undefined;
+  localJob.value = undefined;
 }
 
 function handleUpload() {
@@ -226,7 +233,7 @@ async function uploadSelectedFile(file: File) {
             status_message: payload.status_message,
             meta: payload.meta,
           };
-          lastJob.value = response;
+          localJob.value = response;
           emit('completed', response);
         }
 

--- a/frontend/src/composables/useModuleConfig.ts
+++ b/frontend/src/composables/useModuleConfig.ts
@@ -76,6 +76,7 @@ export function useModuleConfig(options: UseModuleConfigOptions) {
       lastFactorJob: toSyncJobResponse(
         subConfig?.latest_factor_job ?? mod?.latest_common_factor_job,
       ),
+      lastReferenceJob: toSyncJobResponse(subConfig?.latest_reference_job),
     };
   }
 

--- a/frontend/src/composables/useSubmoduleConfig.ts
+++ b/frontend/src/composables/useSubmoduleConfig.ts
@@ -67,6 +67,7 @@ export function useSubmoduleConfig(options: UseSubmoduleConfigOptions) {
       lastDataJob: toSyncJobResponse(subConfig?.latest_data_job),
       lastApiDataJob: toSyncJobResponse(subConfig?.latest_api_data_job),
       lastFactorJob: toSyncJobResponse(subConfig?.latest_factor_job),
+      lastReferenceJob: toSyncJobResponse(subConfig?.latest_reference_job),
     };
   }
 

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -175,8 +175,8 @@ export default {
     fr: 'Localisations aéroport',
   },
   data_management_other_institution_rooms: {
-    en: 'Institution rooms',
-    fr: "Salles de l'institution",
+    en: 'Institution rooms — uploading a CSV replaces every room in the table.',
+    fr: "Salles de l'institution — un téléversement remplace toutes les salles de la table.",
   },
   data_management_upload_reference: {
     en: 'Upload Reference',

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -98,9 +98,16 @@ export enum TargetType {
   REFERENCE_DATA = 3,
 }
 
+// Mirrors backend ``app.models.data_ingestion.EntityType`` — keep the integer
+// values in lock-step (BE persists ``entity_type.value`` into job meta and
+// round-trips via ``EntityType(value)``).  The dispatch endpoint currently
+// overrides the FE-sent value from ``carbon_report_module_id`` presence, but
+// other callers (or that endpoint after a refactor) may trust the FE value.
+// ``GLOBAL_PER_YEAR = 3`` exists on the BE for unit-sync jobs; the FE never
+// emits it, so it's intentionally omitted here.
 export enum EntityType {
-  MODULE_PER_YEAR = 2,
-  MODULE_UNIT_SPECIFIC = 3,
+  MODULE_PER_YEAR = 1,
+  MODULE_UNIT_SPECIFIC = 2,
 }
 
 export enum FactorType {

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -35,6 +35,7 @@ export interface ImportRow {
   lastDataJob?: SyncJobResponse;
   lastApiDataJob?: SyncJobResponse;
   lastFactorJob?: SyncJobResponse;
+  lastReferenceJob?: SyncJobResponse;
 }
 
 export interface JobRowError {

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -427,8 +427,19 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
       if (!job || job.result !== 0) return true;
     }
     if (sub.other) {
-      const job = subConfig?.latest_data_job ?? mod?.latest_common_data_job;
-      if (!job || job.result !== 0) return true;
+      const dataJob =
+        subConfig?.latest_data_job ?? mod?.latest_common_data_job;
+      const dataOk = !!dataJob && dataJob.result === 0;
+      // Submodules with both CSV and API data sources (e.g. plane) accept
+      // either path — admins choose one or the other, so requiring both would
+      // mark every API-only or CSV-only setup as incomplete.
+      if (sub.hasApi) {
+        const apiJob = subConfig?.latest_api_data_job;
+        const apiOk = !!apiJob && apiJob.result === 0;
+        if (!dataOk && !apiOk) return true;
+      } else if (!dataOk) {
+        return true;
+      }
     }
     if (!sub.noData && !sub.dataEntryTypeId) {
       const job = mod?.latest_common_data_job;


### PR DESCRIPTION
This pull request introduces a new ingestion pathway for reference data, ensuring that reference data uploads (such as locations and building rooms) are handled distinctly from regular CSV or factor ingests. This prevents unnecessary emission recalculation chains and double-counting in multi-year reporting. The changes also refactor provider registration and improve test coverage and UI logic for reference data uploads.

**Reference data ingestion pathway:**

- Added a dedicated `reference_ingest` job type and handler to process reference data uploads without triggering emission recalculation, since reference data is global and year-agnostic. (`backend/app/api/v1/data_sync.py` [[1]](diffhunk://#diff-aff095a766670779628c8f932cb81bf032479ad4387194b993492d44ea2497b6R64-R68) `backend/app/tasks/reference_ingest_tasks.py` [[2]](diffhunk://#diff-4d61ff0cc30c6605326931d20686285823c17f26ea814b13c6fd7f13714db218R1-R67) `backend/app/tasks/bootstrap.py` [[3]](diffhunk://#diff-a0f89387a001c1b3f71726cc1ad90a5be9252461bf15de07cc19f8e566a7c141R40)
- Refactored provider registration so that `ReferenceDataCSVProvider` is correctly routed for every module type, replacing the previous `ModulePerYearReferenceDataApiProvider`. (`backend/app/services/data_ingestion/csv_providers/__init__.py` [[1]](diffhunk://#diff-7a27413d350ac0cfca3ccbc5be0d257cde215b0b83e24dcf049ebb3aaba95389L16-R24) `backend/app/services/data_ingestion/provider_factory.py` [[2]](diffhunk://#diff-e6906c033f8f62a326130e16a6ad7ea823b0354211657d4d831597ea11a8759dL23-R24) [[3]](diffhunk://#diff-e6906c033f8f62a326130e16a6ad7ea823b0354211657d4d831597ea11a8759dL75-R87)

**Multi-year reporting and unit counting:**

- Fixed the reporting overview logic to avoid double-counting units when multiple years are selected, ensuring each unit is counted only once and bucketed correctly by validation status. (`backend/app/repositories/carbon_report_module_repo.py` [[1]](diffhunk://#diff-82181a6374778aa53e4ae2d0f021574e136f72c15c4c1312ed90957c5794e855R426-R474) [[2]](diffhunk://#diff-82181a6374778aa53e4ae2d0f021574e136f72c15c4c1312ed90957c5794e855L449-R499) [[3]](diffhunk://#diff-82181a6374778aa53e4ae2d0f021574e136f72c15c4c1312ed90957c5794e855L479-L480)
- Added tests to confirm correct unit counting and status bucketing in multi-year scenarios. (`backend/tests/unit/repositories/test_carbon_report_module_repo.py` [backend/tests/unit/repositories/test_carbon_report_module_repo.pyR402-R458](diffhunk://#diff-23eb18268f7553054f45b2026492a8cf761db3bf7883a69c86f140831b3ccf05R402-R458))

**Reference data ingestion tests and provider logic:**

- Replaced and expanded tests for the reference data CSV provider, ensuring correct routing, validation, and parsing logic. (`backend/tests/unit/services/data_ingestion/csv_providers/test_reference_data.py` [backend/tests/unit/services/data_ingestion/csv_providers/test_reference_data.pyL1-R136](diffhunk://#diff-7e3b9b32724892387ea10c21e62932ced05426f75bd2e1e4f5f74f2609eed87dL1-R136))

**Frontend improvements for reference data upload:**

- Improved the reference data upload card to handle file selection and upload more robustly, using a local job state and ensuring correct file handling and job status updates. (`frontend/src/components/molecules/data-management/UploadCardReferences.vue` [[1]](diffhunk://#diff-f163e9b7aa073b5e765044b59bdda31b1eca06790b157fa4d2d7bd8d643d4cb6L10-R17) [[2]](diffhunk://#diff-f163e9b7aa073b5e765044b59bdda31b1eca06790b157fa4d2d7bd8d643d4cb6L31-R49) [[3]](diffhunk://#diff-f163e9b7aa073b5e765044b59bdda31b1eca06790b157fa4d2d7bd8d643d4cb6L141-R189) [[4]](diffhunk://#diff-f163e9b7aa073b5e765044b59bdda31b1eca06790b157fa4d2d7bd8d643d4cb6L205-R236)

**Other:**

- Improved error messaging and test assertions for professional travel API provider. (`backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py` [backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.pyL355-R357](diffhunk://#diff-1e1cc2f7b7a8dcb925250245bda68d34988f2009440a6afac92cafe751acbfd3L355-R357))