### PR TITLE
docs: add dev release runbook and de-orphan architecture nav

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Auth Flow: architecture/04-auth-flow.md
       - Environments: architecture/05-environments.md
       - CI/CD Pipeline: architecture/06-cicd-pipeline.md
+      - Dev Release Runbook: architecture/release-runbook.md
       - Global Conventions: architecture/07-global-conventions.md
       - Tech Stack: architecture/08-tech-stack.md
       - Component Breakdown: architecture/09-component-breakdown.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - EPFL Compliance: architecture/epfl-compliance-mapping.md
       - EPFL IT Requirements (RFC-001): architecture/epfl-constraint.md
       - Code Standards: architecture/code-standards.md
+      - Documentation Standards: architecture/documentation-standards.md
       - RFC-First Process: architecture/rfc-first-process.md
 
   - Architecture Decision Records:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,6 +66,9 @@ nav:
       - Auth Flow: architecture/04-auth-flow.md
       - Environments: architecture/05-environments.md
       - CI/CD Pipeline: architecture/06-cicd-pipeline.md
+      - CI/CD Workflows: architecture/cicd-workflows.md
+      - Workflow Guide: architecture/workflow-guide.md
+      - Release Management: architecture/release-management.md
       - Dev Release Runbook: architecture/release-runbook.md
       - Global Conventions: architecture/07-global-conventions.md
       - Tech Stack: architecture/08-tech-stack.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -82,7 +82,9 @@ nav:
       - Architectural Decisions: architecture/14-architectural-decisions.md
       - Appendices: architecture/15-appendices.md
       - EPFL Compliance: architecture/epfl-compliance-mapping.md
+      - EPFL IT Requirements (RFC-001): architecture/epfl-constraint.md
       - Code Standards: architecture/code-standards.md
+      - RFC-First Process: architecture/rfc-first-process.md
 
   - Architecture Decision Records:
       - Overview: architecture-decision-records/index.md

--- a/docs/src/architecture/07-global-conventions.md
+++ b/docs/src/architecture/07-global-conventions.md
@@ -303,16 +303,19 @@ For scaling strategy, see [Scalability](12-scalability.md).
 
 ## Documentation Standards
 
-Keep documentation concise and actionable:
+Keep documentation concise and actionable — a reader should grasp it in
+one ~10-minute sitting:
 
-- Target 500-800 words per document (10-minute read) Okay if < 1200 words
-- Use active voice and imperative mood
-- Wrap text at 72 characters
-- Include examples after concepts
-- Add cross-references to related docs
-- Avoid duplicating content across files
+- Target 500–800 words per document; longer only when justified (e.g. multi-procedure runbooks)
+- Active voice, imperative mood; sentences under 20 words; wrap text at 72 characters
+- Examples after concepts; cross-reference related docs; never duplicate content across files
+- Use blockquote callouts, **not** `!!!` admonitions — the Prettier hook breaks admonition indentation
+- Add every new page to `mkdocs.yml` `nav:`; a cross-link-only page is orphaned
+- No agent-only tooling (e.g. `rtk`) in human-facing docs — use plain `git`/`gh`
+- Verify with `npx prettier --check` and `uv run mkdocs build --strict` before commit
+- Update documentation in the same PR as the code it describes
 
-Update documentation in the same PR as code changes.
-
-For detailed conventions and code examples, see the [Code Standards
-documentation](code-standards.md) and individual component guides.
+For the full guideline, length targets by document type, and the
+MkDocs-specific conventions, see
+[Documentation Standards](documentation-standards.md). For coding
+conventions, see [Code Standards](code-standards.md).

--- a/docs/src/architecture/documentation-standards.md
+++ b/docs/src/architecture/documentation-standards.md
@@ -1,0 +1,54 @@
+# Documentation Standards
+
+Write technical docs a reader understands in one ~10-minute sitting. This extends the summary in [Global Conventions → Documentation Standards](07-global-conventions.md#documentation-standards), and applies to every README, how-to, runbook, ADR, troubleshooting note, and proposal.
+
+## The 10-Minute Rule
+
+- Title under 60 characters, capitalized, no trailing punctuation. Blank line, then a context paragraph stating what the doc covers and why it matters.
+- Active voice; imperative mood for instructions ("Run the command", not "The command is run").
+- Sentences under 20 words. Wrap prose at ~72 characters.
+- No filler — drop "simply", "basically", "clearly". Keep terminology and capitalization consistent.
+- Commands and snippets in code blocks, never inline prose. Put examples after the concept they illustrate.
+- Numbered lists for ordered steps, bullets otherwise. A header every 2–3 paragraphs; a visual break (table, list, code) every ~20 lines.
+- For long docs, add a TL;DR or per-section summary. End every doc with a clear takeaway or next action.
+- The doc must make sense read in isolation, and must not duplicate content that lives in another `.md` — cross-link instead.
+- Update documentation in the same PR as the code it describes.
+
+## Length targets
+
+| Document type        | Target length |
+| -------------------- | ------------- |
+| README / how-to      | 30–60 lines   |
+| ADR / design doc     | 40–80 lines   |
+| Troubleshooting note | 25–50 lines   |
+| Technical proposal   | 60–120 lines  |
+| Whole document       | ≤ ~800 words  |
+
+A multi-procedure operational runbook may exceed these. When it must, say so and offer to split it, rather than silently overrunning.
+
+## MkDocs conventions (this repo)
+
+These follow from how the docs site and the Prettier hook actually behave:
+
+- **Use blockquote callouts, not `!!!` admonitions.** The repo Prettier hook strips the 4-space indentation MkDocs admonitions require and silently breaks their rendering. Write callouts as a blockquote with a bold lead-in:
+  ```markdown
+  > **⚠️ Warning.** One sentence, one line, bold lead-in.
+  ```
+- **Add every new page to `mkdocs.yml` `nav:`.** A page reachable only by cross-link is orphaned — it never appears in the sidebar. Place it near its topical neighbours.
+- **No agent-only tooling in human-facing docs.** Use plain `git` / `gh`; never `rtk` or other local wrappers the reader will not have installed.
+- **Critical operational docs:** keep commands in the runbook and policy in the policy doc — cross-link, do not restate. Density may favour inline prose over strict 72-character wrapping when the doc is operational and correctness-critical.
+
+## Before you commit
+
+Run both, from `docs/`:
+
+```bash
+npx prettier --check <file>.md
+uv run mkdocs build --strict
+```
+
+`--strict` promotes warnings to errors. A doc is not done until both pass.
+
+## Final check
+
+Confirm the doc explains **what and why**, not only how; reads in ~10 minutes; ends with a clear action; stands alone; and duplicates nothing in another `.md`.

--- a/docs/src/architecture/release-management.md
+++ b/docs/src/architecture/release-management.md
@@ -6,6 +6,7 @@ procedures for releases, hotfixes, and rollbacks.
 
 **Related documentation:**
 
+- [Dev Release Runbook](release-runbook.md) - Step-by-step commands to cut a release
 - [CI/CD Pipeline](06-cicd-pipeline.md) - Pipeline architecture
 - [CI/CD Workflows](cicd-workflows.md) - GitHub Actions details
 - [Workflow Guide](workflow-guide.md) - Developer daily workflow

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -1,25 +1,14 @@
 # Dev Release Runbook
 
-Step-by-step commands for the lead developer, or a temporary stand-in,
-to cut a release. This covers the _how_; for the _why_ — versioning,
-environments, calendar, approvals — see
-[Release Management](release-management.md).
+Step-by-step commands for the lead developer, or a temporary stand-in, to cut a release. This covers the _how_; for the _why_ — versioning, environments, calendar, approvals — see [Release Management](release-management.md). Use it to promote `stage → main` (the real release) or `dev → stage` (end of sprint).
 
-> Use this to promote `stage → main` (the real release) or
-> `dev → stage` (end of sprint). Commands, not policy.
+**Related:** [Release Management](release-management.md) · [CI/CD Pipeline](06-cicd-pipeline.md) · [CI/CD Workflows](cicd-workflows.md)
 
-**Related:** [Release Management](release-management.md) ·
-[CI/CD Pipeline](06-cicd-pipeline.md) ·
-[CI/CD Workflows](cicd-workflows.md)
-
-**Before you start:** you need write access to `dev`, `stage`, and
-`main`; the `gh` CLI (or the GitHub UI); and access to the OpenShift /
-ArgoCD console to verify deployments.
+**Before you start:** write access to `dev`, `stage`, `main`; the `gh` CLI (or the GitHub UI); access to the OpenShift / ArgoCD console to verify deployments.
 
 ## Overview
 
-A release is two ordered promotions. Do the real release first, then
-the end-of-sprint promotion.
+A release is two ordered promotions — do the real release first, then the end-of-sprint promotion. After each, verify the deployment in ArgoCD ([Troubleshooting](#troubleshooting-deployment)).
 
 ```mermaid
 graph LR
@@ -32,55 +21,34 @@ graph LR
 
 ## 1. Real release: stage to main
 
-This cuts the versioned GitHub release. The custom workflow
-`release-please.yml` ("Tag and Release") fires when a PR from `stage`
-merges into `main`, and releases the root `package.json` version.
+Cuts the versioned GitHub release. The custom workflow `release-please.yml` ("Tag and Release") fires when a PR **from `stage`** merges into `main`, and releases the root `package.json` version. (The `release-please` name is legacy — it no longer uses that tool; read the file to see what it does.)
 
-> The `release-please` name is legacy — the workflow no longer uses the
-> release-please tool. Read the file to see what it does.
-
-1. **Check the changelog and version.** `CHANGELOG.md` is already
-   generated (see section 2). Confirm its top entry, and that root
-   `package.json` `version` is the version you intend to release.
-2. **Open the PR** from `stage` into `main`:
+1. **Check changelog and version.** `CHANGELOG.md` is already generated (section 2); confirm its top entry, and that root `package.json` `version` is the version to release — "Tag and Release" tags from this value.
+2. **Open the PR** `stage → main` and get external review per [Release Management](release-management.md#release-process). The workflow only fires for `head.ref == 'stage'`, so head **must** be `stage`:
    ```bash
    gh pr create --base main --head stage --title "chore(release): vX.Y.Z"
    ```
-   Get external review per
-   [Release Management](release-management.md#release-process).
-3. **Merge the PR.** "Tag and Release" creates the git tag and GitHub
-   release. The `v*.*.*` tag also triggers the `deploy` workflow to
-   **prod**.
-4. **Re-sync branches** so they do not diverge (no PR needed; use the
-   GitHub UI if you are not comfortable on the CLI):
+3. **Merge the PR.** "Tag and Release" creates the git tag + GitHub release; the `v*.*.*` tag also triggers `deploy` to **prod**. Verify: GitHub → Releases shows `vX.Y.Z`; Actions → "Tag and Release" and "deploy" green.
+4. **Re-sync branches** so they don't diverge (no PR needed; use the GitHub UI if not comfortable on the CLI). Verify convergence with `git log --graph --oneline -15`:
    ```bash
    git checkout stage && git pull && git merge origin/main && git push
    git checkout dev   && git pull && git merge origin/stage && git push
    ```
-5. **Verify in ArgoCD** that **prod** is healthy on the new version.
-   If not, see [Troubleshooting](#troubleshooting-deployment).
+5. **Verify in ArgoCD** that **prod** is healthy on the new version. If not, fix before continuing — see [Troubleshooting](#troubleshooting-deployment).
 
 ## 2. End-of-sprint promotion: dev to stage
 
-This ships the sprint to the stage environment and generates the
-changelog. The workflow `changelog.yml` ("Generate Changelog") fires
-when a PR from `dev` merges into `stage`.
+Ships the sprint to stage and generates the changelog. `changelog.yml` ("Generate Changelog") fires when a PR **from `dev`** merges into `stage` (trigger: `pull_request: closed` into `stage`, `head.ref == 'dev'`).
 
-> **⚠️ Bump the version first.** Edit root `package.json` `version`
-> (e.g. `0.10.0`) and commit on `dev`. Skip this and the changelog is
-> not generated.
+> **⚠️ Bump the version first.** Edit root `package.json` `version` (e.g. `0.10.0`) and commit on `dev` **before** opening the PR — otherwise the changelog is not generated with the right version.
 
-1. **Open the PR** from `dev` into `stage`:
+1. **Open the PR** `dev → stage`. Head **must** be `dev`. Example title: `chore: promote dev to stage (end of sprint 7) (#770)`:
    ```bash
-   gh pr create --base stage --head dev \
-     --title "chore: promote dev to stage (end of sprint N) (#<issue>)"
+   gh pr create --base stage --head dev --title "chore: promote dev to stage (end of sprint N) (#<issue>)"
    ```
-   Example: `chore: promote dev to stage (end of sprint 7) (#770)`.
-2. **Merge the PR.** `deploy.yml` deploys to **stage**; "Generate
-   Changelog" commits the updated `CHANGELOG.md` to `stage`.
-3. **Verify in ArgoCD** that stage is healthy. Fix any issues — see
-   [Troubleshooting](#troubleshooting-deployment).
-4. **Re-sync:** merge `stage` back into `dev`:
+2. **Merge the PR.** `deploy.yml` deploys to **stage**; "Generate Changelog" commits `CHANGELOG.md` to `stage`. Verify: Actions → "deploy" and "Generate Changelog" green; `CHANGELOG.md` updated on `stage`.
+3. **Verify in ArgoCD** that stage is healthy; fix any issues — see [Troubleshooting](#troubleshooting-deployment).
+4. **Re-sync:** merge `stage` back into `dev` (brings back the changelog commit and any stage fixes):
    ```bash
    git checkout dev && git pull && git merge origin/stage && git push
    ```
@@ -89,37 +57,26 @@ Done. The only remaining step is to **communicate the release**.
 
 ## Troubleshooting: deployment
 
-If ArgoCD shows the environment unhealthy or on the wrong version, the
-usual suspects:
+If ArgoCD shows the environment unhealthy or on the wrong version, the usual suspects:
 
-| Symptom                     | Cause                               | Fix                          |
-| --------------------------- | ----------------------------------- | ---------------------------- |
-| App errors / missing config | `openshift-app-config` missing vars | Add the missing env vars     |
-| Auth failures / stale creds | OpenShift secrets not updated       | Update the OpenShift secrets |
-| Schema present, data wrong  | Migrations do not migrate data      | Rebuild the DB (below)       |
+| Symptom                            | Cause                                      | Fix                          |
+| ---------------------------------- | ------------------------------------------ | ---------------------------- |
+| App errors / missing config        | `openshift-app-config` missing env vars    | Add the missing env vars     |
+| Auth failures / stale creds        | OpenShift secrets not updated              | Update the OpenShift secrets |
+| Schema present, data wrong/missing | Migrations don't migrate data (pre-v1.0.0) | Rebuild the DB (below)       |
 
 ### Database rebuild (pre-v1.0.0 only)
 
-> **🚨 Destructive.** `make db-drop` deletes the target database.
-> First, open `backend/.env` and confirm `DB_URL` points to the
-> environment you intend. The wrong target on prod is unrecoverable.
+> **🚨 Destructive.** `make db-drop` deletes the target database. First open `backend/.env` and confirm `DB_URL` points to the environment you intend — the wrong target on prod is unrecoverable.
 
-Until v1.0.0, migrations do not migrate data, so rebuild and reseed.
-Get the target `DB_URL` from the secrets manager, set it in
-`backend/.env`, then from `backend/`:
+Until v1.0.0, migrations don't migrate data, so rebuild and reseed. Get the target `DB_URL` from the secrets manager, set it in `backend/.env`, then from `backend/`:
 
 ```bash
 make db-drop && make db-create && make db-migrate && make seed-data
 ```
 
-`make seed-data` loads the reference data (required up to 0.9.0; from
-0.10.0 it is no longer needed). Re-check ArgoCD afterwards.
+`make seed-data` loads the reference data (required up to 0.9.0; from 0.10.0 no longer needed). Re-check ArgoCD afterwards.
 
 ## Hotfix and rollback
 
-No fixed script — follow standard practice and common sense. For the
-policy and procedure, see:
-
-- [Release Management → Emergency Hotfix Process](release-management.md#emergency-hotfix-process)
-- [Release Management → Rollback Procedures](release-management.md#rollback-procedures)
-- [CI/CD Pipeline → Rollback Mechanisms](06-cicd-pipeline.md#rollback-mechanisms)
+No fixed script — follow standard practice and common sense. For policy and procedure see [Release Management → Emergency Hotfix Process](release-management.md#emergency-hotfix-process), [Release Management → Rollback Procedures](release-management.md#rollback-procedures), and [CI/CD Pipeline → Rollback Mechanisms](06-cicd-pipeline.md#rollback-mechanisms).

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -1,0 +1,92 @@
+# Dev Release Runbook
+
+Step-by-step operational runbook for the **lead developer** (or a
+**temporary lead developer** standing in) to cut a release. This is the
+copy-paste command sequence; for the _why_ — versioning rules,
+environment model, release calendar, approvals — see
+[Release Management](release-management.md).
+
+> Use this when you are the person promoting `dev → stage → main` for a
+> sprint-end release, a hotfix, or a rollback, and you want exact
+> commands in order, not policy.
+
+**Related documentation:**
+
+- [Release Management](release-management.md) — policy: versioning, environment model, calendar, approvals
+- [CI/CD Pipeline](06-cicd-pipeline.md) — pipeline & deployment architecture
+- [CI/CD Workflows](cicd-workflows.md) — GitHub Actions details
+- [Workflow Guide](workflow-guide.md) — daily developer workflow
+
+## Prerequisites
+
+<!-- TODO: access/tools the lead needs before starting -->
+<!-- e.g. write access to dev/stage/main, gh CLI authenticated, argocd -->
+<!-- access, who to notify, where to announce, code-freeze status -->
+
+_TBD_
+
+## Sprint-end release (v0.x.x)
+
+The normal path: promote the current sprint from `dev` through `stage`
+to `main`, where `release-please` cuts the version. Policy &
+environment rules: [Release Management → Release Process](release-management.md#release-process).
+
+### Step 1 — Pre-flight checks
+
+<!-- TODO: green CI on dev, PM sign-off done, code freeze in effect -->
+
+_TBD_
+
+### Step 2 — Promote dev → stage
+
+<!-- TODO: exact git commands; fast-forward stage to dev; how to verify -->
+
+_TBD_
+
+### Step 3 — Validate on stage
+
+<!-- TODO: what to run/check; who validates; how long; abort criteria -->
+
+_TBD_
+
+### Step 4 — Promote stage → main (release-please)
+
+<!-- TODO: open the stage→main PR, external code review, merge, -->
+<!-- release-please PR, merge that, tag/deploy verification -->
+
+_TBD_
+
+### Step 5 — Post-release verification
+
+<!-- TODO: health checks, logs, sprint board, known-issues note -->
+
+_TBD_
+
+## Hotfix release
+
+Critical production bug that cannot wait for the normal train. Policy
+& approvers: [Release Management → Emergency Hotfix Process](release-management.md#emergency-hotfix-process).
+
+<!-- TODO: branch from main, minimal fix, fast-track review, deploy, -->
+<!-- backport to dev and stage -->
+
+_TBD_
+
+## Rollback
+
+When a release is bad and must be reverted. Background:
+[CI/CD Pipeline → Rollback Mechanisms](06-cicd-pipeline.md#rollback-mechanisms).
+
+<!-- TODO: application rollback (argocd / git tag), DB rollback -->
+<!-- (alembic downgrade), order of operations, verification -->
+
+_TBD_
+
+## Troubleshooting
+
+Common failures during a release and how to recover.
+
+<!-- TODO: symptom → cause → recovery table; e.g. release-please PR -->
+<!-- not created, stage deploy stuck, migration fails on deploy -->
+
+_TBD_

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -82,12 +82,11 @@ rtk gh pr create --base main --head stage \
 - The **"Tag and Release"** workflow runs on merge: creates the git tag and the GitHub release from root `package.json` `version`.
 - Verify: GitHub → **Releases** shows the new `vX.Y.Z`; **Actions → Tag and Release** is green.
 
-!!! note "How `main`/prod deploys"
-`deploy.yml` triggers on pushes to `dev`/`stage` **and** on
-`v*.*.*` tag pushes (`tags: ["v*.*.*"]`). Creating the `vX.Y.Z` tag
-in this step therefore also triggers the **"deploy"** workflow for
-prod/main automatically — no extra action needed. Just verify it
-landed in ArgoCD (Step 5).
+> **Note — how `main`/prod deploys:** `deploy.yml` triggers on pushes
+> to `dev`/`stage` **and** on `v*.*.*` tag pushes (`tags: ["v*.*.*"]`).
+> Creating the `vX.Y.Z` tag in this step therefore also triggers the
+> **"deploy"** workflow for prod/main automatically — no extra action
+> needed. Just verify it landed in ArgoCD (Step 5).
 
 ### Step 4 — Re-sync branches (prevent divergence)
 
@@ -120,9 +119,9 @@ name **"Generate Changelog"**) runs when a PR **from `dev`** is
 
 ### Step 1 — Bump the version in root `package.json`
 
-!!! warning "Bump first"
-If you skip this, the automatic changelog will **not** be generated
-with the right version. Do this **before** opening the PR.
+> **⚠️ Bump first:** If you skip this, the automatic changelog will
+> **not** be generated with the right version. Do this **before**
+> opening the PR.
 
 - Edit root `package.json` → set `version` to the next sprint version (e.g. `0.10.0`).
 - Commit it on `dev` and push.
@@ -188,12 +187,12 @@ version, the usual suspects:
 
 ### Database rebuild (pre-v1.0.0 only)
 
-!!! danger "Destructive — drops the entire database"
-`make db-drop` **deletes the target database**. Until **v1.0.0**,
-migrations do not migrate data, so a full rebuild + reseed is the
-sanctioned recovery. **Before running anything**, open `backend/.env`
-and confirm `DB_URL` points to the environment you intend (stage or
-prod). Getting this wrong on **prod** is unrecoverable.
+> **🚨 Destructive — drops the entire database.** `make db-drop`
+> **deletes the target database**. Until **v1.0.0**, migrations do not
+> migrate data, so a full rebuild + reseed is the sanctioned recovery.
+> **Before running anything**, open `backend/.env` and confirm `DB_URL`
+> points to the environment you intend (stage or prod). Getting this
+> wrong on **prod** is unrecoverable.
 
 1. Get the target DB URL from the **secrets manager** (stage or prod).
 2. Set `DB_URL` in `backend/.env` to that URL. **Re-read it and confirm the host and database name are the ones you intend.**

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -53,6 +53,8 @@ Ships the sprint to stage and generates the changelog. `changelog.yml` ("Generat
    git checkout dev && git pull && git merge origin/stage && git push
    ```
 
+> **Optional — human-readable changelog.** The `CHANGELOG.md` generated at step 2 is raw commit messages. Feed the new version's entry to an LLM to rewrite it under three headings — `## Key Changes`, `## Bug Fixes`, `## Technical Improvements (Non-functional)` — then commit it to `stage` before the step 4 re-sync.
+
 Done. The only remaining step is to **communicate the release**.
 
 ## Troubleshooting: deployment

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -68,7 +68,7 @@ promotion (see [section 2](#2-end-of-sprint-promotion-dev-stage)).
 ### Step 2 — Open the `stage → main` PR
 
 ```bash
-rtk gh pr create --base main --head stage \
+gh pr create --base main --head stage \
   --title "chore(release): vX.Y.Z" \
   --body "Promote stage to main — release vX.Y.Z"
 ```
@@ -96,10 +96,10 @@ not comfortable on the command line, do these merges in the GitHub UI.**
 
 ```bash
 # main → stage
-rtk git checkout stage && rtk git pull && rtk git merge origin/main && rtk git push
+git checkout stage && git pull && git merge origin/main && git push
 
 # stage → dev
-rtk git checkout dev && rtk git pull && rtk git merge origin/stage && rtk git push
+git checkout dev && git pull && git merge origin/stage && git push
 ```
 
 - Verify: `git log --graph --oneline -15` shows the branches converged.
@@ -129,7 +129,7 @@ name **"Generate Changelog"**) runs when a PR **from `dev`** is
 ### Step 2 — Open the `dev → stage` promotion PR
 
 ```bash
-rtk gh pr create --base stage --head dev \
+gh pr create --base stage --head dev \
   --title "chore: promote dev to stage (end of sprint N) (#<issue>)" \
   --body "Promote dev to stage — end of sprint N"
 ```
@@ -166,7 +166,7 @@ Once stage is healthy and any fixes are in, merge `stage` back into
 any stage-only fixes back into `dev`).
 
 ```bash
-rtk git checkout dev && rtk git pull && rtk git merge origin/stage && rtk git push
+git checkout dev && git pull && git merge origin/stage && git push
 ```
 
 - Verify: `dev` contains the changelog commit and any stage fixes.

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -1,219 +1,124 @@
 # Dev Release Runbook
 
-Step-by-step operational runbook for the **lead developer** (or a
-**temporary lead developer** standing in) to cut a release. This is the
-copy-paste command sequence; for the _why_ — versioning rules,
-environment model, release calendar, approvals — see
+Step-by-step commands for the lead developer, or a temporary stand-in,
+to cut a release. This covers the _how_; for the _why_ — versioning,
+environments, calendar, approvals — see
 [Release Management](release-management.md).
 
-> Use this when you are the person promoting `stage → main` (the real
-> release) and `dev → stage` (end-of-sprint), and you want exact
-> commands in order, not policy.
+> Use this to promote `stage → main` (the real release) or
+> `dev → stage` (end of sprint). Commands, not policy.
 
-**Related documentation:**
+**Related:** [Release Management](release-management.md) ·
+[CI/CD Pipeline](06-cicd-pipeline.md) ·
+[CI/CD Workflows](cicd-workflows.md)
 
-- [Release Management](release-management.md) — policy: versioning, environment model, calendar, approvals
-- [CI/CD Pipeline](06-cicd-pipeline.md) — pipeline & deployment architecture
-- [CI/CD Workflows](cicd-workflows.md) — GitHub Actions details
-- [Workflow Guide](workflow-guide.md) — daily developer workflow
-
-## Prerequisites
-
-- Write access to `dev`, `stage`, and `main`.
-- `gh` CLI authenticated **or** willingness to use the GitHub UI for PRs/merges.
-- Access to the project's **OpenShift / ArgoCD** console (to verify deployment).
-- Access to the **secrets manager** — only if a DB rebuild is needed (see [Database rebuild](#database-rebuild-pre-v100-only)).
-- Know who to notify once the release is out (the final manual step is communication).
+**Before you start:** you need write access to `dev`, `stage`, and
+`main`; the `gh` CLI (or the GitHub UI); and access to the OpenShift /
+ArgoCD console to verify deployments.
 
 ## Overview
 
-A full release is **two distinct promotions**, done in this order:
+A release is two ordered promotions. Do the real release first, then
+the end-of-sprint promotion.
 
 ```mermaid
 graph LR
-    A[stage] -->|PR, merge| B[main]
-    B -->|Tag and Release workflow| R[GitHub Release]
-    B -->|sync back| A
-    A -->|sync back| D[dev]
-    D2[dev] -->|version bump + PR, merge| S[stage]
-    S -->|Generate Changelog + deploy| ENV[stage env]
+    S1[stage] -->|PR + merge| M[main]
+    M -->|Tag and Release + v*.*.* deploy| P[prod]
+    M -->|sync back| S1 --> D[dev]
+    D2[dev] -->|bump + PR + merge| S2[stage]
+    S2 -->|Generate Changelog + deploy| E[stage env]
 ```
 
-1. [**The real release** — `stage → main`](#1-the-real-release-promote-stage-main): cuts the versioned GitHub release, then re-sync branches.
-2. [**End-of-sprint promotion** — `dev → stage`](#2-end-of-sprint-promotion-dev-stage): ships the sprint to the stage environment and generates the changelog.
+## 1. Real release: stage to main
 
-After **each** promotion, verify the deployment in ArgoCD
-([Troubleshooting](#troubleshooting-stage-deployment)).
+This cuts the versioned GitHub release. The custom workflow
+`release-please.yml` ("Tag and Release") fires when a PR from `stage`
+merges into `main`, and releases the root `package.json` version.
 
-## 1. The real release: promote `stage` → `main`
+> The `release-please` name is legacy — the workflow no longer uses the
+> release-please tool. Read the file to see what it does.
 
-This creates the versioned GitHub release. The custom workflow
-`.github/workflows/release-please.yml` (display name **"Tag and
-Release"**) runs when a PR **from `stage`** is **merged into `main`**.
+1. **Check the changelog and version.** `CHANGELOG.md` is already
+   generated (see section 2). Confirm its top entry, and that root
+   `package.json` `version` is the version you intend to release.
+2. **Open the PR** from `stage` into `main`:
+   ```bash
+   gh pr create --base main --head stage --title "chore(release): vX.Y.Z"
+   ```
+   Get external review per
+   [Release Management](release-management.md#release-process).
+3. **Merge the PR.** "Tag and Release" creates the git tag and GitHub
+   release. The `v*.*.*` tag also triggers the `deploy` workflow to
+   **prod**.
+4. **Re-sync branches** so they do not diverge (no PR needed; use the
+   GitHub UI if you are not comfortable on the CLI):
+   ```bash
+   git checkout stage && git pull && git merge origin/main && git push
+   git checkout dev   && git pull && git merge origin/stage && git push
+   ```
+5. **Verify in ArgoCD** that **prod** is healthy on the new version.
+   If not, see [Troubleshooting](#troubleshooting-deployment).
 
-> The `release-please` filename is legacy — it no longer uses the
-> release-please tool. It is now a custom workflow that creates a GitHub
-> release based on the **root `package.json`** `version`. Read the file
-> to see exactly what it does.
+## 2. End-of-sprint promotion: dev to stage
 
-### Step 1 — Verify `CHANGELOG.md`
+This ships the sprint to the stage environment and generates the
+changelog. The workflow `changelog.yml` ("Generate Changelog") fires
+when a PR from `dev` merges into `stage`.
 
-`CHANGELOG.md` should already be up to date — it is generated
-automatically by the changelog workflow on each `dev → stage`
-promotion (see [section 2](#2-end-of-sprint-promotion-dev-stage)).
+> **⚠️ Bump the version first.** Edit root `package.json` `version`
+> (e.g. `0.10.0`) and commit on `dev`. Skip this and the changelog is
+> not generated.
 
-- Open `CHANGELOG.md`; confirm the entry for the version you are releasing exists and reads correctly.
-- Verify root `package.json` `version` matches the release you intend to cut — **"Tag and Release" tags and releases from this value.**
+1. **Open the PR** from `dev` into `stage`:
+   ```bash
+   gh pr create --base stage --head dev \
+     --title "chore: promote dev to stage (end of sprint N) (#<issue>)"
+   ```
+   Example: `chore: promote dev to stage (end of sprint 7) (#770)`.
+2. **Merge the PR.** `deploy.yml` deploys to **stage**; "Generate
+   Changelog" commits the updated `CHANGELOG.md` to `stage`.
+3. **Verify in ArgoCD** that stage is healthy. Fix any issues — see
+   [Troubleshooting](#troubleshooting-deployment).
+4. **Re-sync:** merge `stage` back into `dev`:
+   ```bash
+   git checkout dev && git pull && git merge origin/stage && git push
+   ```
 
-### Step 2 — Open the `stage → main` PR
+Done. The only remaining step is to **communicate the release**.
 
-```bash
-gh pr create --base main --head stage \
-  --title "chore(release): vX.Y.Z" \
-  --body "Promote stage to main — release vX.Y.Z"
-```
+## Troubleshooting: deployment
 
-- Get external code review per [Release Management → Release Process](release-management.md#release-process).
-- Verify the PR head is `stage` and base is `main` — "Tag and Release" only fires for `head.ref == 'stage'`.
+If ArgoCD shows the environment unhealthy or on the wrong version, the
+usual suspects:
 
-### Step 3 — Merge the PR → release is created
-
-- Merge the PR.
-- The **"Tag and Release"** workflow runs on merge: creates the git tag and the GitHub release from root `package.json` `version`.
-- Verify: GitHub → **Releases** shows the new `vX.Y.Z`; **Actions → Tag and Release** is green.
-
-> **Note — how `main`/prod deploys:** `deploy.yml` triggers on pushes
-> to `dev`/`stage` **and** on `v*.*.*` tag pushes (`tags: ["v*.*.*"]`).
-> Creating the `vX.Y.Z` tag in this step therefore also triggers the
-> **"deploy"** workflow for prod/main automatically — no extra action
-> needed. Just verify it landed in ArgoCD (Step 5).
-
-### Step 4 — Re-sync branches (prevent divergence)
-
-Merge `main` back into `stage`, then `stage` back into `dev`, so the
-three branches don't diverge. No PR is strictly required — **if you are
-not comfortable on the command line, do these merges in the GitHub UI.**
-
-```bash
-# main → stage
-git checkout stage && git pull && git merge origin/main && git push
-
-# stage → dev
-git checkout dev && git pull && git merge origin/stage && git push
-```
-
-- Verify: `git log --graph --oneline -15` shows the branches converged.
-
-### Step 5 — Verify the deployment (OpenShift / ArgoCD)
-
-- Open the project's ArgoCD; confirm the release deployed correctly.
-- If it is not healthy, fix it before proceeding — see [Troubleshooting](#troubleshooting-stage-deployment).
-
-## 2. End-of-sprint promotion: `dev` → `stage`
-
-This ships the sprint's work to the **stage** environment and generates
-the changelog. The workflow `.github/workflows/changelog.yml` (display
-name **"Generate Changelog"**) runs when a PR **from `dev`** is
-**merged into `stage`**, and reads the next version from root
-`package.json`.
-
-### Step 1 — Bump the version in root `package.json`
-
-> **⚠️ Bump first:** If you skip this, the automatic changelog will
-> **not** be generated with the right version. Do this **before**
-> opening the PR.
-
-- Edit root `package.json` → set `version` to the next sprint version (e.g. `0.10.0`).
-- Commit it on `dev` and push.
-
-### Step 2 — Open the `dev → stage` promotion PR
-
-```bash
-gh pr create --base stage --head dev \
-  --title "chore: promote dev to stage (end of sprint N) (#<issue>)" \
-  --body "Promote dev to stage — end of sprint N"
-```
-
-- Example title: `chore: promote dev to stage (end of sprint 7) (#770)`.
-- The PR is what triggers the changelog workflow (on `pull_request: closed` into `stage`). The PR head **must** be `dev`:
-
-  ```yaml
-  on:
-    pull_request:
-      types: [closed]
-      branches:
-        - stage
-  ```
-
-- Verify: base `stage`, head `dev`.
-
-### Step 3 — Merge & watch the `deploy` workflow
-
-- Merge the PR.
-- On merge (push to `stage`), `.github/workflows/deploy.yml` (**"deploy"**) runs and deploys to the stage environment.
-- The **"Generate Changelog"** workflow also runs and commits the updated `CHANGELOG.md` to `stage`.
-- Verify: **Actions → deploy** green; **Actions → Generate Changelog** green; `CHANGELOG.md` updated on `stage`.
-
-### Step 4 — Verify on OpenShift / ArgoCD
-
-- Confirm the release deployed to the stage environment.
-- If there are issues, fix them — see [Troubleshooting](#troubleshooting-stage-deployment).
-
-### Step 5 — Re-sync: merge `stage` back into `dev`
-
-Once stage is healthy and any fixes are in, merge `stage` back into
-`dev` so they stay in sync (this also brings the changelog commit and
-any stage-only fixes back into `dev`).
-
-```bash
-git checkout dev && git pull && git merge origin/stage && git push
-```
-
-- Verify: `dev` contains the changelog commit and any stage fixes.
-
-**And voilà — it's done.** The only remaining step is to **communicate**
-the release.
-
-## Troubleshooting: stage deployment
-
-If ArgoCD shows the stage environment unhealthy or not on the new
-version, the usual suspects:
-
-| Symptom                               | Cause                                                   | Fix                                        |
-| ------------------------------------- | ------------------------------------------------------- | ------------------------------------------ |
-| App errors / missing config           | `openshift-app-config` missing env variables            | Add the missing env vars to the app config |
-| Auth failures / stale credentials     | OpenShift secrets not updated                           | Update the OpenShift secrets               |
-| Schema present but data wrong/missing | Alembic migrations do not _migrate data_ (until v1.0.0) | Rebuild the DB — see below                 |
+| Symptom                     | Cause                               | Fix                          |
+| --------------------------- | ----------------------------------- | ---------------------------- |
+| App errors / missing config | `openshift-app-config` missing vars | Add the missing env vars     |
+| Auth failures / stale creds | OpenShift secrets not updated       | Update the OpenShift secrets |
+| Schema present, data wrong  | Migrations do not migrate data      | Rebuild the DB (below)       |
 
 ### Database rebuild (pre-v1.0.0 only)
 
-> **🚨 Destructive — drops the entire database.** `make db-drop`
-> **deletes the target database**. Until **v1.0.0**, migrations do not
-> migrate data, so a full rebuild + reseed is the sanctioned recovery.
-> **Before running anything**, open `backend/.env` and confirm `DB_URL`
-> points to the environment you intend (stage or prod). Getting this
-> wrong on **prod** is unrecoverable.
+> **🚨 Destructive.** `make db-drop` deletes the target database.
+> First, open `backend/.env` and confirm `DB_URL` points to the
+> environment you intend. The wrong target on prod is unrecoverable.
 
-1. Get the target DB URL from the **secrets manager** (stage or prod).
-2. Set `DB_URL` in `backend/.env` to that URL. **Re-read it and confirm the host and database name are the ones you intend.**
-3. From `backend/`:
+Until v1.0.0, migrations do not migrate data, so rebuild and reseed.
+Get the target `DB_URL` from the secrets manager, set it in
+`backend/.env`, then from `backend/`:
 
-   ```bash
-   make db-drop
-   make db-create
-   make db-migrate
-   make seed-data
-   ```
+```bash
+make db-drop && make db-create && make db-migrate && make seed-data
+```
 
-4. **Reference data:** for release **0.9.0** you must additionally
-   upload reference data. <!-- TODO: document the exact reference-data upload procedure for ≤0.9.0 (UI flow / script / the reference-upload feature, PR #1189). --> From sprint **0.10.0**
-   onward this is no longer needed (a priori).
-5. Re-check ArgoCD: the stage environment is healthy and on the new version.
+`make seed-data` loads the reference data (required up to 0.9.0; from
+0.10.0 it is no longer needed). Re-check ArgoCD afterwards.
 
-## Hotfix & rollback
+## Hotfix and rollback
 
-Command sequences for these are not duplicated here. For the policy and
-procedure, see:
+No fixed script — follow standard practice and common sense. For the
+policy and procedure, see:
 
 - [Release Management → Emergency Hotfix Process](release-management.md#emergency-hotfix-process)
 - [Release Management → Rollback Procedures](release-management.md#rollback-procedures)

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -6,8 +6,8 @@ copy-paste command sequence; for the _why_ — versioning rules,
 environment model, release calendar, approvals — see
 [Release Management](release-management.md).
 
-> Use this when you are the person promoting `dev → stage → main` for a
-> sprint-end release, a hotfix, or a rollback, and you want exact
+> Use this when you are the person promoting `stage → main` (the real
+> release) and `dev → stage` (end-of-sprint), and you want exact
 > commands in order, not policy.
 
 **Related documentation:**
@@ -19,74 +19,203 @@ environment model, release calendar, approvals — see
 
 ## Prerequisites
 
-<!-- TODO: access/tools the lead needs before starting -->
-<!-- e.g. write access to dev/stage/main, gh CLI authenticated, argocd -->
-<!-- access, who to notify, where to announce, code-freeze status -->
+- Write access to `dev`, `stage`, and `main`.
+- `gh` CLI authenticated **or** willingness to use the GitHub UI for PRs/merges.
+- Access to the project's **OpenShift / ArgoCD** console (to verify deployment).
+- Access to the **secrets manager** — only if a DB rebuild is needed (see [Database rebuild](#database-rebuild-pre-v100-only)).
+- Know who to notify once the release is out (the final manual step is communication).
 
-_TBD_
+## Overview
 
-## Sprint-end release (v0.x.x)
+A full release is **two distinct promotions**, done in this order:
 
-The normal path: promote the current sprint from `dev` through `stage`
-to `main`, where `release-please` cuts the version. Policy &
-environment rules: [Release Management → Release Process](release-management.md#release-process).
+```mermaid
+graph LR
+    A[stage] -->|PR, merge| B[main]
+    B -->|Tag and Release workflow| R[GitHub Release]
+    B -->|sync back| A
+    A -->|sync back| D[dev]
+    D2[dev] -->|version bump + PR, merge| S[stage]
+    S -->|Generate Changelog + deploy| ENV[stage env]
+```
 
-### Step 1 — Pre-flight checks
+1. [**The real release** — `stage → main`](#1-the-real-release-promote-stage-main): cuts the versioned GitHub release, then re-sync branches.
+2. [**End-of-sprint promotion** — `dev → stage`](#2-end-of-sprint-promotion-dev-stage): ships the sprint to the stage environment and generates the changelog.
 
-<!-- TODO: green CI on dev, PM sign-off done, code freeze in effect -->
+After **each** promotion, verify the deployment in ArgoCD
+([Troubleshooting](#troubleshooting-stage-deployment)).
 
-_TBD_
+## 1. The real release: promote `stage` → `main`
 
-### Step 2 — Promote dev → stage
+This creates the versioned GitHub release. The custom workflow
+`.github/workflows/release-please.yml` (display name **"Tag and
+Release"**) runs when a PR **from `stage`** is **merged into `main`**.
 
-<!-- TODO: exact git commands; fast-forward stage to dev; how to verify -->
+> The `release-please` filename is legacy — it no longer uses the
+> release-please tool. It is now a custom workflow that creates a GitHub
+> release based on the **root `package.json`** `version`. Read the file
+> to see exactly what it does.
 
-_TBD_
+### Step 1 — Verify `CHANGELOG.md`
 
-### Step 3 — Validate on stage
+`CHANGELOG.md` should already be up to date — it is generated
+automatically by the changelog workflow on each `dev → stage`
+promotion (see [section 2](#2-end-of-sprint-promotion-dev-stage)).
 
-<!-- TODO: what to run/check; who validates; how long; abort criteria -->
+- Open `CHANGELOG.md`; confirm the entry for the version you are releasing exists and reads correctly.
+- Verify root `package.json` `version` matches the release you intend to cut — **"Tag and Release" tags and releases from this value.**
 
-_TBD_
+### Step 2 — Open the `stage → main` PR
 
-### Step 4 — Promote stage → main (release-please)
+```bash
+rtk gh pr create --base main --head stage \
+  --title "chore(release): vX.Y.Z" \
+  --body "Promote stage to main — release vX.Y.Z"
+```
 
-<!-- TODO: open the stage→main PR, external code review, merge, -->
-<!-- release-please PR, merge that, tag/deploy verification -->
+- Get external code review per [Release Management → Release Process](release-management.md#release-process).
+- Verify the PR head is `stage` and base is `main` — "Tag and Release" only fires for `head.ref == 'stage'`.
 
-_TBD_
+### Step 3 — Merge the PR → release is created
 
-### Step 5 — Post-release verification
+- Merge the PR.
+- The **"Tag and Release"** workflow runs on merge: creates the git tag and the GitHub release from root `package.json` `version`.
+- Verify: GitHub → **Releases** shows the new `vX.Y.Z`; **Actions → Tag and Release** is green.
 
-<!-- TODO: health checks, logs, sprint board, known-issues note -->
+!!! note "How `main`/prod deploys"
+`deploy.yml` triggers on pushes to `dev`/`stage` **and** on
+`v*.*.*` tag pushes (`tags: ["v*.*.*"]`). Creating the `vX.Y.Z` tag
+in this step therefore also triggers the **"deploy"** workflow for
+prod/main automatically — no extra action needed. Just verify it
+landed in ArgoCD (Step 5).
 
-_TBD_
+### Step 4 — Re-sync branches (prevent divergence)
 
-## Hotfix release
+Merge `main` back into `stage`, then `stage` back into `dev`, so the
+three branches don't diverge. No PR is strictly required — **if you are
+not comfortable on the command line, do these merges in the GitHub UI.**
 
-Critical production bug that cannot wait for the normal train. Policy
-& approvers: [Release Management → Emergency Hotfix Process](release-management.md#emergency-hotfix-process).
+```bash
+# main → stage
+rtk git checkout stage && rtk git pull && rtk git merge origin/main && rtk git push
 
-<!-- TODO: branch from main, minimal fix, fast-track review, deploy, -->
-<!-- backport to dev and stage -->
+# stage → dev
+rtk git checkout dev && rtk git pull && rtk git merge origin/stage && rtk git push
+```
 
-_TBD_
+- Verify: `git log --graph --oneline -15` shows the branches converged.
 
-## Rollback
+### Step 5 — Verify the deployment (OpenShift / ArgoCD)
 
-When a release is bad and must be reverted. Background:
-[CI/CD Pipeline → Rollback Mechanisms](06-cicd-pipeline.md#rollback-mechanisms).
+- Open the project's ArgoCD; confirm the release deployed correctly.
+- If it is not healthy, fix it before proceeding — see [Troubleshooting](#troubleshooting-stage-deployment).
 
-<!-- TODO: application rollback (argocd / git tag), DB rollback -->
-<!-- (alembic downgrade), order of operations, verification -->
+## 2. End-of-sprint promotion: `dev` → `stage`
 
-_TBD_
+This ships the sprint's work to the **stage** environment and generates
+the changelog. The workflow `.github/workflows/changelog.yml` (display
+name **"Generate Changelog"**) runs when a PR **from `dev`** is
+**merged into `stage`**, and reads the next version from root
+`package.json`.
 
-## Troubleshooting
+### Step 1 — Bump the version in root `package.json`
 
-Common failures during a release and how to recover.
+!!! warning "Bump first"
+If you skip this, the automatic changelog will **not** be generated
+with the right version. Do this **before** opening the PR.
 
-<!-- TODO: symptom → cause → recovery table; e.g. release-please PR -->
-<!-- not created, stage deploy stuck, migration fails on deploy -->
+- Edit root `package.json` → set `version` to the next sprint version (e.g. `0.10.0`).
+- Commit it on `dev` and push.
 
-_TBD_
+### Step 2 — Open the `dev → stage` promotion PR
+
+```bash
+rtk gh pr create --base stage --head dev \
+  --title "chore: promote dev to stage (end of sprint N) (#<issue>)" \
+  --body "Promote dev to stage — end of sprint N"
+```
+
+- Example title: `chore: promote dev to stage (end of sprint 7) (#770)`.
+- The PR is what triggers the changelog workflow (on `pull_request: closed` into `stage`). The PR head **must** be `dev`:
+
+  ```yaml
+  on:
+    pull_request:
+      types: [closed]
+      branches:
+        - stage
+  ```
+
+- Verify: base `stage`, head `dev`.
+
+### Step 3 — Merge & watch the `deploy` workflow
+
+- Merge the PR.
+- On merge (push to `stage`), `.github/workflows/deploy.yml` (**"deploy"**) runs and deploys to the stage environment.
+- The **"Generate Changelog"** workflow also runs and commits the updated `CHANGELOG.md` to `stage`.
+- Verify: **Actions → deploy** green; **Actions → Generate Changelog** green; `CHANGELOG.md` updated on `stage`.
+
+### Step 4 — Verify on OpenShift / ArgoCD
+
+- Confirm the release deployed to the stage environment.
+- If there are issues, fix them — see [Troubleshooting](#troubleshooting-stage-deployment).
+
+### Step 5 — Re-sync: merge `stage` back into `dev`
+
+Once stage is healthy and any fixes are in, merge `stage` back into
+`dev` so they stay in sync (this also brings the changelog commit and
+any stage-only fixes back into `dev`).
+
+```bash
+rtk git checkout dev && rtk git pull && rtk git merge origin/stage && rtk git push
+```
+
+- Verify: `dev` contains the changelog commit and any stage fixes.
+
+**And voilà — it's done.** The only remaining step is to **communicate**
+the release.
+
+## Troubleshooting: stage deployment
+
+If ArgoCD shows the stage environment unhealthy or not on the new
+version, the usual suspects:
+
+| Symptom                               | Cause                                                   | Fix                                        |
+| ------------------------------------- | ------------------------------------------------------- | ------------------------------------------ |
+| App errors / missing config           | `openshift-app-config` missing env variables            | Add the missing env vars to the app config |
+| Auth failures / stale credentials     | OpenShift secrets not updated                           | Update the OpenShift secrets               |
+| Schema present but data wrong/missing | Alembic migrations do not _migrate data_ (until v1.0.0) | Rebuild the DB — see below                 |
+
+### Database rebuild (pre-v1.0.0 only)
+
+!!! danger "Destructive — drops the entire database"
+`make db-drop` **deletes the target database**. Until **v1.0.0**,
+migrations do not migrate data, so a full rebuild + reseed is the
+sanctioned recovery. **Before running anything**, open `backend/.env`
+and confirm `DB_URL` points to the environment you intend (stage or
+prod). Getting this wrong on **prod** is unrecoverable.
+
+1. Get the target DB URL from the **secrets manager** (stage or prod).
+2. Set `DB_URL` in `backend/.env` to that URL. **Re-read it and confirm the host and database name are the ones you intend.**
+3. From `backend/`:
+
+   ```bash
+   make db-drop
+   make db-create
+   make db-migrate
+   make seed-data
+   ```
+
+4. **Reference data:** for release **0.9.0** you must additionally
+   upload reference data. <!-- TODO: document the exact reference-data upload procedure for ≤0.9.0 (UI flow / script / the reference-upload feature, PR #1189). --> From sprint **0.10.0**
+   onward this is no longer needed (a priori).
+5. Re-check ArgoCD: the stage environment is healthy and on the new version.
+
+## Hotfix & rollback
+
+Command sequences for these are not duplicated here. For the policy and
+procedure, see:
+
+- [Release Management → Emergency Hotfix Process](release-management.md#emergency-hotfix-process)
+- [Release Management → Rollback Procedures](release-management.md#rollback-procedures)
+- [CI/CD Pipeline → Rollback Mechanisms](06-cicd-pipeline.md#rollback-mechanisms)

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -23,7 +23,7 @@ graph LR
 
 Cuts the versioned GitHub release. The custom workflow `release-please.yml` ("Tag and Release") fires when a PR **from `stage`** merges into `main`, and releases the root `package.json` version. (The `release-please` name is legacy — it no longer uses that tool; read the file to see what it does.)
 
-1. **Check changelog and version.** `CHANGELOG.md` is already generated (section 2); confirm its top entry, and that root `package.json` `version` is the version to release — "Tag and Release" tags from this value.
+1. **Check changelog and version.** `CHANGELOG.md` should already be present on `stage`, having been generated during the most recent `dev → stage` promotion (documented in section 2, and typically completed before this release). Confirm its top entry, and that root `package.json` `version` is the version to release — "Tag and Release" tags from this value.
 2. **Open the PR** `stage → main` and get external review per [Release Management](release-management.md#release-process). The workflow only fires for `head.ref == 'stage'`, so head **must** be `stage`:
    ```bash
    gh pr create --base main --head stage --title "chore(release): vX.Y.Z"

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -69,7 +69,7 @@ If ArgoCD shows the environment unhealthy or on the wrong version, the usual sus
 
 ### Database rebuild (pre-v1.0.0 only)
 
-> **🚨 Destructive.** `make db-drop` deletes the target database. First open `backend/.env` and confirm `DB_URL` points to the environment you intend — the wrong target on prod is unrecoverable.
+> **🚨 Destructive.** `make db-drop` deletes the target database. First open `backend/.env` and confirm `DB_URL` points to the environment you intend, and take a DB snapshot/backup before dropping — the wrong target on prod is unrecoverable.
 
 Until v1.0.0, migrations don't migrate data, so rebuild and reseed. Get the target `DB_URL` from the secrets manager, set it in `backend/.env`, then from `backend/`:
 

--- a/docs/src/user-docs/01-overview.md
+++ b/docs/src/user-docs/01-overview.md
@@ -1,3 +1,3 @@
 # User Documentation
 
-This section is reserved for end-user documentation owned by the product team and is not yet drafted.
+The user documentation is out at [https://epfl-enac.github.io/co2-calculator-user-doc/](https://epfl-enac.github.io/co2-calculator-user-doc/)

--- a/frontend/src/components/molecules/data-management/DataEntryDialogContent.vue
+++ b/frontend/src/components/molecules/data-management/DataEntryDialogContent.vue
@@ -136,15 +136,17 @@ watch(showDialog, (newVal) => {
           <q-icon name="warning" size="sm" class="q-mr-sm" />
           {{ $t('data_management_last_upload_overwrite') }}
         </q-banner>
-        <q-file
-          v-model="selectedFiles"
-          dense
-          outlined
-          multiple
-          :hint="$t('data_management_supported_file_types')"
-          counter
-          accept=".csv, text/csv"
-        />
+        <div data-testid="data-entry-file-input">
+          <q-file
+            v-model="selectedFiles"
+            dense
+            outlined
+            multiple
+            :hint="$t('data_management_supported_file_types')"
+            counter
+            accept=".csv, text/csv"
+          />
+        </div>
 
         <template v-if="row.hasApi && targetType === TargetType.DATA_ENTRIES">
           <div class="row items-center q-my-sm">

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -321,6 +321,7 @@ function isErrorOrWarning(): boolean {
 
     <input
       ref="fileInputRef"
+      :data-testid="`reference-file-input-${row.moduleTypeId}-${row.dataEntryTypeId}`"
       type="file"
       accept=".csv,text/csv"
       style="display: none"

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -269,11 +269,15 @@ test.describe('back-office data-management — happy paths', () => {
 
     await openHeadcountDataDialog(page);
 
-    // Pick a CSV file.  Quasar's ``q-file`` wraps the native input —
-    // setInputFiles on the underlying ``input[type=file]`` works.
+    // Pick a CSV file.  Target the dialog's q-file by its
+    // ``data-testid`` rather than a bare ``input[type=file]``: every
+    // submodule with an ``other`` reference dataset (e.g.
+    // Buildings/rooms) mounts its own hidden references file input
+    // regardless of expansion state, so ``.first()`` would otherwise
+    // hijack the references upload instead.
     await page
+      .getByTestId('data-entry-file-input')
       .locator('input[type=file]')
-      .first()
       .setInputFiles({
         name: 'data.csv',
         mimeType: 'text/csv',
@@ -317,8 +321,8 @@ test.describe('back-office data-management — happy paths', () => {
     await openHeadcountFactorsDialog(page);
 
     await page
+      .getByTestId('data-entry-file-input')
       .locator('input[type=file]')
-      .first()
       .setInputFiles({
         name: 'factors.csv',
         mimeType: 'text/csv',
@@ -339,6 +343,54 @@ test.describe('back-office data-management — happy paths', () => {
       (r) => r.method === 'POST' && r.url.endsWith('/api/v1/sync/dispatch'),
     );
     expect(dispatch?.body).toContain('"target_type":1'); // FACTORS
+  });
+
+  test('5c — references upload: hidden file input → POST sync/dispatch with target_type=REFERENCE_DATA', async ({
+    page,
+  }) => {
+    const { requests } = await mockBackend(page);
+    await page.goto(DATA_MANAGEMENT_URL);
+
+    // The Buildings/rooms submodule (module_type_id 3,
+    // data_entry_type_id 30) ships an ``other`` reference dataset, so
+    // its UploadCardReferences mounts a hidden file input even while
+    // the module is collapsed.  Drive that input directly — the
+    // visible "Upload Reference" button only proxies a native
+    // file-picker click, a dead-end in headless Chromium.
+    const refInput = page.getByTestId('reference-file-input-3-30');
+    await expect(refInput).toBeAttached({ timeout: 10000 });
+
+    await refInput.setInputFiles({
+      name: 'rooms.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from('room,area\nA,10\n', 'utf8'),
+    });
+
+    // References upload goes through the same temp-upload → dispatch
+    // path as the dialog flow, but with TargetType.REFERENCE_DATA (3)
+    // and no save-button step.
+    await expect
+      .poll(() =>
+        requests.find(
+          (r) =>
+            r.method === 'POST' && r.url.endsWith('/api/v1/files/temp-upload'),
+        ),
+      )
+      .toBeTruthy();
+
+    await expect
+      .poll(() =>
+        requests.find(
+          (r) => r.method === 'POST' && r.url.endsWith('/api/v1/sync/dispatch'),
+        ),
+      )
+      .toBeTruthy();
+
+    const dispatch = requests.find(
+      (r) => r.method === 'POST' && r.url.endsWith('/api/v1/sync/dispatch'),
+    );
+    expect(dispatch?.body).toContain('"target_type":3'); // REFERENCE_DATA
+    expect(dispatch?.body).toContain('"file_path":"/tmp/data.csv"');
   });
 
   test('6 — recalculate emissions: dialog → confirm → POST recalculate-emissions/{module}', async ({


### PR DESCRIPTION
## What

A **Dev Release Runbook** at `docs/src/architecture/release-runbook.md` — command-level, step-by-step instructions for the lead developer (or a temporary stand-in) to cut a release. Plus a nav de-orphaning fix.

No corresponding issue.

## Doc shape

Two ordered promotions:

1. **Real release — `stage → main`**: stage→main PR → "Tag and Release" cuts the GitHub release from root `package.json`; the `v*.*.*` tag also triggers `deploy` to **prod**; then re-sync `main→stage→dev`.
2. **End-of-sprint — `dev → stage`**: bump version first (so "Generate Changelog" fires), promotion PR, `deploy` to stage, ArgoCD verify, sync `stage→dev`.

Plus a deployment troubleshooting table and a guarded **pre-v1.0.0 DB rebuild** (`make seed-data` loads reference data, required ≤0.9.0). Hotfix/rollback: follow standard practice + policy links.

Written to the project's documentation style guide (10-Minute Rule): 125 lines, imperative mood, numbered steps, code blocks, cross-links instead of restating `release-management.md`.

## Also in this PR — nav de-orphaning

`release-management.md`, `workflow-guide.md`, `cicd-workflows.md`, `epfl-constraint.md`, `rfc-first-process.md` were reachable only via inline cross-links. All now in the Architecture nav, alongside the new runbook.

## Notes for reviewers

- Callouts are blockquotes, not `!!!` admonitions — the repo prettier hook strips the indent admonitions need.
- Verified: `prettier --check` clean, `mkdocs build --strict` passes.

## Status

- [x] Content complete, tightened to the doc style guide
- [x] Nav de-orphaned
- [x] Author Q resolved: stage→main release verifies **prod**; reference-data = `make seed-data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)