### PR TITLE
838/textures in colorblind charts

### DIFF
--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -9,6 +9,7 @@ import {
   TooltipComponent,
   LegendComponent,
   GridComponent,
+  AriaComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 import EvolutionOverTimeChart from './EvolutionOverTimeChart.vue';
@@ -17,7 +18,9 @@ import { useEchartsTooltip } from './results/useEchartsTooltip';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
+import { useColorblindStore } from 'src/stores/colorblind';
 
+import { buildChartDecal } from 'src/constant/charts';
 import type { EmissionTreemapCategory } from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
 
@@ -25,6 +28,7 @@ const { t } = useI18n();
 const moduleStore = useModuleStore();
 const workspaceStore = useWorkspaceStore();
 const isPrintMode = usePrintMode();
+const colorblindStore = useColorblindStore();
 
 const LABEL_KEY_MAP: Record<string, string> = {
   // process_emissions
@@ -83,6 +87,7 @@ use([
   TooltipComponent,
   LegendComponent,
   GridComponent,
+  AriaComponent,
 ]);
 
 const props = defineProps<{
@@ -165,6 +170,10 @@ const chartOption = computed((): EChartsOption => {
 
   return {
     animation: false,
+    aria: {
+      enabled: true,
+      decal: buildChartDecal(colorblindStore.enabled),
+    },
     tooltip: isPrintMode.value
       ? { show: false }
       : {
@@ -322,7 +331,7 @@ const babyBlueScheme = computed(() => {
   <q-card-section class="chart-container q-pa-none">
     <v-chart
       ref="chartRef"
-      :key="visibleData.map((c) => c.name).join('|')"
+      :key="`${visibleData.map((c) => c.name).join('|')}-${colorblindStore.enabled}`"
       class="chart"
       autoresize
       :option="chartOption"

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -7,7 +7,12 @@ import { BarChart } from 'echarts/charts';
 import TooltipEcharts from './TooltipEcharts.vue';
 import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
 import type { EChartsOption } from 'echarts';
-import { CHART_CATEGORY_COLOR_SCHEMES, colors } from 'src/constant/charts';
+import {
+  buildChartDecal,
+  CHART_CATEGORY_COLOR_SCHEMES,
+  colors,
+} from 'src/constant/charts';
+import { useColorblindStore } from 'src/stores/colorblind';
 import {
   TooltipComponent,
   LegendComponent,
@@ -41,6 +46,8 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const isPrintMode = usePrintMode();
+const colorblindStore = useColorblindStore();
+const isColorblind = computed(() => colorblindStore.enabled);
 const toggleAdditionalData = ref(false);
 const effectiveToggle = computed(
   () => props.viewAdditionalData ?? toggleAdditionalData.value,
@@ -407,6 +414,10 @@ const chartOption = computed((): EChartsOption => {
     xAxis: chartXAxisOption.value,
     yAxis: chartYAxisOption.value,
     graphic: chartGraphicOption.value,
+    aria: {
+      enabled: isColorblind.value,
+      decal: buildChartDecal(isColorblind.value),
+    },
     dataset: {
       dimensions: [
         'category',
@@ -518,6 +529,7 @@ const downloadCSV = () => {
       <q-card-section class="chart-container flex justify-center items-center">
         <v-chart
           ref="chartRef"
+          :key="colorblindStore.enabled ? 'cb' : 'default'"
           :class="['chart', { 'chart--print': isPrintMode }]"
           autoresize
           :option="chartOption"

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -6,6 +6,7 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import {
+  buildChartDecal,
   getChartSubcategoryColor,
   CHART_CATEGORY_COLOR_SCALES,
   RESULTS_CATEGORY_LABEL_KEYS,
@@ -15,10 +16,12 @@ import {
   LegendComponent,
   GridComponent,
   DatasetComponent,
+  AriaComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 import TooltipEcharts from './TooltipEcharts.vue';
 import { useEchartsTooltip } from './useEchartsTooltip';
+import { useColorblindStore } from 'src/stores/colorblind';
 
 use([
   CanvasRenderer,
@@ -27,6 +30,7 @@ use([
   LegendComponent,
   GridComponent,
   DatasetComponent,
+  AriaComponent,
 ]);
 
 import type { EmissionBreakdownCategoryRow } from 'src/stores/modules';
@@ -107,6 +111,7 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const isPrintMode = usePrintMode();
+const colorblindStore = useColorblindStore();
 
 const categoryKeyPrefixes = Object.keys(CATEGORY_LABEL_MAP);
 
@@ -367,6 +372,10 @@ const chartOption = computed((): EChartsOption => {
 
   return {
     animation: false,
+    aria: {
+      enabled: true,
+      decal: buildChartDecal(colorblindStore.enabled),
+    },
     tooltip: isPrintMode.value
       ? { show: false }
       : {
@@ -454,6 +463,7 @@ const onChartReady = async () => {
       <v-chart
         v-if="chartData.bars.length"
         ref="chartRef"
+        :key="colorblindStore.enabled ? 'cb' : 'default'"
         class="chart"
         autoresize
         :option="chartOption"

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -6,16 +6,19 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import {
+  buildChartDecal,
   colors,
   getChartSubcategoryColor,
   RESULTS_CATEGORY_LABEL_KEYS,
 } from 'src/constant/charts';
+import { useColorblindStore } from 'src/stores/colorblind';
 import {
   TooltipComponent,
   LegendComponent,
   GridComponent,
   DatasetComponent,
   GraphicComponent,
+  AriaComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 import TooltipEcharts from './TooltipEcharts.vue';
@@ -29,6 +32,7 @@ use([
   GridComponent,
   DatasetComponent,
   GraphicComponent,
+  AriaComponent,
 ]);
 
 import type { EmissionBreakdownResponse } from 'src/stores/modules';
@@ -54,6 +58,8 @@ const props = defineProps({
 
 const { t } = useI18n();
 const isPrintMode = usePrintMode();
+const colorblindStore = useColorblindStore();
+
 const toggleAdditionalData = ref(false);
 const effectiveToggle = computed(
   () => props.viewAdditionalData ?? toggleAdditionalData.value,
@@ -1250,6 +1256,11 @@ const chartOption = computed((): EChartsOption => {
       },
     },
     graphic: [],
+    aria: {
+      enabled: true,
+      decal: buildChartDecal(colorblindStore.enabled),
+    },
+
     dataset: {
       dimensions: [
         'category',
@@ -1455,6 +1466,7 @@ const downloadCSV = () => {
     >
       <v-chart
         ref="chartRef"
+        :key="colorblindStore.enabled ? 'cb' : 'default'"
         :class="['chart', { 'chart--print': isPrintMode }]"
         autoresize
         :option="chartOption"

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -13,13 +13,16 @@ import {
   TitleComponent,
   ToolboxComponent,
   TooltipComponent,
+  AriaComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 import TooltipEcharts from './TooltipEcharts.vue';
 import { useEchartsTooltip } from './useEchartsTooltip';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { useColorblindStore } from 'src/stores/colorblind';
 import {
+  buildChartDecal,
   CHART_CATEGORY_COLOR_SCHEMES,
   colors,
   getModuleForCategoryKey,
@@ -52,6 +55,7 @@ use([
   GridComponent,
   ToolboxComponent,
   GraphicComponent,
+  AriaComponent,
 ]);
 
 type FootprintRow = { year: number; category: string; co2: number };
@@ -65,6 +69,8 @@ const INT_FORMATTER = new Intl.NumberFormat(undefined, {
 
 const yearConfigStore = useYearConfigStore();
 const workspaceStore = useWorkspaceStore();
+const colorblindStore = useColorblindStore();
+const isColorblind = computed(() => colorblindStore.enabled);
 
 const currentYear = computed(
   () => workspaceStore.selectedYear ?? new Date().getFullYear(),
@@ -484,10 +490,12 @@ const epflSeriesData = computed<EpflSeriesPayload | null>(() => {
     lineStyle: { width: 0 },
     itemStyle: { opacity: 0 },
     areaStyle: {
-      color: new graphic.LinearGradient(0, 0, 0, 1, [
-        { offset: 0, color: totalColor },
-        { offset: 1, color: 'rgba(255,255,255,0)' },
-      ]),
+      color: isColorblind.value
+        ? totalColor
+        : new graphic.LinearGradient(0, 0, 0, 1, [
+            { offset: 0, color: totalColor },
+            { offset: 1, color: 'rgba(255,255,255,0)' },
+          ]),
       opacity: 0.18,
     },
     emphasis: { disabled: true },
@@ -673,6 +681,10 @@ const chartOption = computed<EChartsOption | null>(() => {
           populationTooltipSeries,
         ]
       : [...payload.stackedSeries, totalTooltipSeries, populationTooltipSeries],
+    aria: {
+      enabled: true,
+      decal: buildChartDecal(isColorblind.value),
+    },
   } as EChartsOption;
 });
 </script>
@@ -682,6 +694,7 @@ const chartOption = computed<EChartsOption | null>(() => {
     <VChart
       v-if="chartOption && !showEpflEmptyState"
       ref="chartRef"
+      :key="colorblindStore.enabled ? 'cb' : 'default'"
       :option="chartOption"
       autoresize
       class="objective-chart__canvas"

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -6,6 +6,7 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { LineChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
 import {
+  AriaComponent,
   GraphicComponent,
   GridComponent,
   LegendComponent,
@@ -25,8 +26,10 @@ import {
 } from 'src/utils/chart-tooltip-extractors';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { useColorblindStore } from 'src/stores/colorblind';
 import { useModuleStore, useTimelineStore } from 'src/stores/modules';
 import {
+  buildChartDecal,
   CHART_CATEGORY_COLOR_SCHEMES,
   getModuleForCategoryKey,
   RESULTS_CATEGORY_LABEL_KEYS,
@@ -53,6 +56,7 @@ use([
   GridComponent,
   ToolboxComponent,
   GraphicComponent,
+  AriaComponent,
 ]);
 
 type PopulationRow = { year: number; pop: number };
@@ -65,6 +69,7 @@ const INT_FORMATTER = new Intl.NumberFormat(undefined, {
 
 const yearConfigStore = useYearConfigStore();
 const workspaceStore = useWorkspaceStore();
+const colorblindStore = useColorblindStore();
 const moduleStore = useModuleStore();
 const timelineStore = useTimelineStore();
 
@@ -493,6 +498,12 @@ const chartOption = computed<EChartsOption | null>(() => {
     series: popSeries
       ? [...payload.stackedSeries, popSeries]
       : [...payload.stackedSeries],
+    aria: {
+      enabled: true,
+      decal: buildChartDecal(colorblindStore.enabled, {
+        color: 'rgba(0, 0, 0, 0.35)',
+      }),
+    },
   } as EChartsOption;
 });
 </script>
@@ -518,6 +529,7 @@ const chartOption = computed<EChartsOption | null>(() => {
         <VChart
           v-if="chartOption"
           ref="chartRef"
+          :key="colorblindStore.enabled ? 'cb' : 'default'"
           :option="chartOption"
           autoresize
           class="objective-chart__canvas"

--- a/frontend/src/components/organisms/AdditionalCategoriesSection.vue
+++ b/frontend/src/components/organisms/AdditionalCategoriesSection.vue
@@ -13,10 +13,15 @@ import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { PieChart } from 'echarts/charts';
 import type { EChartsOption } from 'echarts';
-import { TooltipComponent, LegendComponent } from 'echarts/components';
+import {
+  TooltipComponent,
+  LegendComponent,
+  AriaComponent,
+} from 'echarts/components';
 import VChart from 'vue-echarts';
 import TooltipEcharts from 'src/components/charts/results/TooltipEcharts.vue';
 import { useEchartsTooltip } from 'src/components/charts/results/useEchartsTooltip';
+import { useColorblindStore } from 'src/stores/colorblind';
 import {
   CHART_CATEGORY_COLOR_SCHEMES,
   CHART_SUBCATEGORY_COLOR_SCHEMES,
@@ -33,7 +38,13 @@ import type {
   EmbodiedEnergyCategoryEntry,
 } from 'src/stores/modules';
 
-use([CanvasRenderer, PieChart, TooltipComponent, LegendComponent]);
+use([
+  CanvasRenderer,
+  PieChart,
+  TooltipComponent,
+  LegendComponent,
+  AriaComponent,
+]);
 
 const props = defineProps<{
   commutingRow?: EmissionBreakdownCategoryRow | null;
@@ -47,6 +58,7 @@ const props = defineProps<{
 }>();
 
 const { t, te } = useI18n();
+const colorblindStore = useColorblindStore();
 
 const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
 
@@ -111,8 +123,7 @@ onBeforeUnmount(() => {
   chartVisibilityObserver = null;
 });
 
-watch(chartsInView, async (v) => {
-  if (!v || props.printMode) return;
+async function reAttachAll() {
   await nextTick();
   for (const r of [
     commutingCO2Ref,
@@ -126,7 +137,20 @@ watch(chartsInView, async (v) => {
     const chart = r.value?.chart;
     if (chart) attach(chart);
   }
+}
+
+watch(chartsInView, (v) => {
+  if (!v || props.printMode) return;
+  reAttachAll();
 });
+
+watch(
+  () => colorblindStore.enabled,
+  () => {
+    if (!chartsInView.value || props.printMode) return;
+    reAttachAll();
+  },
+);
 
 function getCategoryAccent(
   categoryKey: 'commuting' | 'food' | 'waste' | 'embodied_energy',
@@ -202,6 +226,7 @@ const commutingCO2Option = computed(() =>
     commutingEntries.value,
     false,
     emitTooltip,
+    colorblindStore.enabled,
   ),
 );
 
@@ -212,6 +237,7 @@ const commutingPhysicalOption = computed(() => {
     commutingEntries.value,
     true,
     emitTooltip,
+    colorblindStore.enabled,
   );
 });
 
@@ -230,7 +256,14 @@ const foodEntries = computed((): DisplayEntry[] => {
 });
 
 const foodCO2Option = computed(() =>
-  buildDoughnutOption({ t, te }, 'food', foodEntries.value, false, emitTooltip),
+  buildDoughnutOption(
+    { t, te },
+    'food',
+    foodEntries.value,
+    false,
+    emitTooltip,
+    colorblindStore.enabled,
+  ),
 );
 
 const foodPhysicalOption = computed(() => {
@@ -240,6 +273,7 @@ const foodPhysicalOption = computed(() => {
     foodEntries.value,
     true,
     emitTooltip,
+    colorblindStore.enabled,
   );
 });
 
@@ -292,6 +326,7 @@ const wasteCO2Option = computed(() =>
     wasteGrouped.value,
     false,
     emitTooltip,
+    colorblindStore.enabled,
   ),
 );
 
@@ -302,6 +337,7 @@ const wastePhysicalOption = computed(() => {
     wasteGrouped.value,
     true,
     emitTooltip,
+    colorblindStore.enabled,
   );
 });
 
@@ -357,6 +393,7 @@ const embodiedEnergyCO2Option = computed((): EChartsOption => {
     entries,
     false,
     emitTooltip,
+    colorblindStore.enabled,
   );
 });
 
@@ -452,7 +489,7 @@ const embodiedEnergyLegend = computed(() =>
                 <VChart
                   v-if="chartsInView"
                   ref="commutingCO2Ref"
-                  :key="`commuting-co2-${commutingEntries.length}`"
+                  :key="`commuting-co2-${commutingEntries.length}-${colorblindStore.enabled}`"
                   :option="commutingCO2Option"
                   :autoresize="chartsInView"
                   class="chart"
@@ -470,7 +507,7 @@ const embodiedEnergyLegend = computed(() =>
                 <VChart
                   v-if="chartsInView"
                   ref="commutingPhysicalRef"
-                  :key="`commuting-qty-${commutingEntries.length}`"
+                  :key="`commuting-qty-${commutingEntries.length}-${colorblindStore.enabled}`"
                   :option="commutingPhysicalOption"
                   :autoresize="chartsInView"
                   class="chart"
@@ -531,6 +568,7 @@ const embodiedEnergyLegend = computed(() =>
                 <VChart
                   v-if="chartsInView"
                   ref="foodCO2Ref"
+                  :key="`food-co2-${colorblindStore.enabled}`"
                   :option="foodCO2Option"
                   :autoresize="chartsInView"
                   class="chart"
@@ -546,6 +584,7 @@ const embodiedEnergyLegend = computed(() =>
                 <VChart
                   v-if="chartsInView"
                   ref="foodPhysicalRef"
+                  :key="`food-qty-${colorblindStore.enabled}`"
                   :option="foodPhysicalOption"
                   :autoresize="chartsInView"
                   class="chart"
@@ -616,6 +655,7 @@ const embodiedEnergyLegend = computed(() =>
                 <VChart
                   v-if="chartsInView"
                   ref="wasteCO2Ref"
+                  :key="`waste-co2-${colorblindStore.enabled}`"
                   :option="wasteCO2Option"
                   :autoresize="chartsInView"
                   class="chart"
@@ -631,6 +671,7 @@ const embodiedEnergyLegend = computed(() =>
                 <VChart
                   v-if="chartsInView"
                   ref="wastePhysicalRef"
+                  :key="`waste-qty-${colorblindStore.enabled}`"
                   :option="wastePhysicalOption"
                   :autoresize="chartsInView"
                   class="chart"
@@ -738,6 +779,7 @@ const embodiedEnergyLegend = computed(() =>
               <VChart
                 v-if="chartsInView"
                 ref="embodiedEnergyCO2Ref"
+                :key="`embodied-co2-${colorblindStore.enabled}`"
                 :option="embodiedEnergyCO2Option"
                 :autoresize="chartsInView"
                 class="chart"

--- a/frontend/src/composables/results/useAdditionalCategoryCharts.ts
+++ b/frontend/src/composables/results/useAdditionalCategoryCharts.ts
@@ -1,5 +1,6 @@
 import type { EChartsOption } from 'echarts';
 import {
+  buildChartDecal,
   CHART_SUBCATEGORY_COLOR_SCHEMES,
   getChartSubcategoryColor,
 } from 'src/constant/charts';
@@ -34,6 +35,7 @@ export function buildDoughnutOption(
   entries: DisplayEntry[],
   useQuantity: boolean,
   emitTooltip?: (state: TooltipState) => void,
+  showDecal?: boolean,
 ): EChartsOption {
   const colorScheme = CHART_SUBCATEGORY_COLOR_SCHEMES.value[category] ?? {};
   const noBreakdownColor = '#D5D5D5';
@@ -77,6 +79,10 @@ export function buildDoughnutOption(
 
   return {
     animation: false,
+    aria: {
+      enabled: true,
+      decal: buildChartDecal(showDecal ?? false),
+    },
     tooltip: {
       trigger: 'item',
       formatter: (params: unknown) => {

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -576,3 +576,34 @@ export const uncertaintyColor = (hex: string): string => {
   }
   return hex;
 };
+
+/** Standard hatch-pattern decal used for accessibility/colorblind mode across all charts. */
+export const CHART_DECAL_PATTERN = {
+  symbol: 'rect',
+  dashArrayX: [2, 0] as [number, number],
+  dashArrayY: [2, 4] as [number, number],
+  rotation: -Math.PI / 4,
+  color: 'rgba(0, 0, 0, 0.15)',
+} as const;
+
+/**
+ * Builds a full ECharts `aria.decal` block.
+ * @param show - Whether to show the decal (typically driven by colorblind mode).
+ * @param overrides - Optional overrides for the decal pattern fields.
+ */
+export function buildChartDecal(
+  show: boolean,
+  overrides?: Partial<{
+    symbol: string;
+    dashArrayX: [number, number];
+    dashArrayY: [number, number];
+    rotation: number;
+    color: string;
+    lineWidth?: number;
+  }>,
+) {
+  return {
+    show,
+    decals: { ...CHART_DECAL_PATTERN, ...overrides },
+  };
+}


### PR DESCRIPTION
## What does this change?

Adds texture/decal overlays to all ECharts-based visualizations when colorblind mode is enabled.
The decals use a hatched pattern (diagonal lines) layered on top of chart segments, providing a
secondary visual encoding beyond color alone. Affected charts include:

- Doughnut charts (commuting, food, waste, embodied energy) via `buildDoughnutOption`
- Treemap (`GenericEmissionTreeMapChart`)
- Bar charts (`EmissionTypeBreakdownChart`, `ModuleCarbonFootprintChart`, `CarbonFootPrintPerPersonChart`)
- Line/area charts (`ReductionObjectiveEpflView`, `ReductionObjectiveUnitView`)

Each chart now registers `AriaComponent` from ECharts, passes a `showDecal` flag derived from
`colorblindStore.enabled`, and uses a `:key` binding that includes the colorblind state so the
chart fully re-renders when the mode is toggled.

## Why is this needed?

Color alone is insufficient for users with color vision deficiencies. By adding pattern overlays
when colorblind mode is active, chart segments remain distinguishable even when colors appear
similar, improving accessibility without affecting the default visual experience.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup