### PR TITLE
feat: add multiple patterns for colorblind mode

### DIFF
--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -577,19 +577,47 @@ export const uncertaintyColor = (hex: string): string => {
   return hex;
 };
 
-/** Standard hatch-pattern decal used for accessibility/colorblind mode across all charts. */
-export const CHART_DECAL_PATTERN = {
-  symbol: 'rect',
-  dashArrayX: [2, 0] as [number, number],
-  dashArrayY: [2, 4] as [number, number],
-  rotation: -Math.PI / 4,
-  color: 'rgba(0, 0, 0, 0.15)',
-} as const;
+/**
+ * Three visually distinct decal patterns for accessibility/colorblind mode.
+ * ECharts cycles through these across series so segments differ by texture, not just colour.
+ */
+export const CHART_DECAL_PATTERNS: Array<{
+  symbol: string;
+  dashArrayX: [number, number];
+  dashArrayY: [number, number];
+  rotation: number;
+  color: string;
+}> = [
+  // Pattern 1: diagonal lines (−45°)
+  {
+    symbol: 'rect',
+    dashArrayX: [2, 0],
+    dashArrayY: [2, 4],
+    rotation: -Math.PI / 4,
+    color: 'rgba(0, 0, 0, 0.15)',
+  },
+  // Pattern 2: dots
+  {
+    symbol: 'circle',
+    dashArrayX: [3, 5],
+    dashArrayY: [3, 5],
+    rotation: 0,
+    color: 'rgba(0, 0, 0, 0.15)',
+  },
+  // Pattern 3: vertical lines (90°)
+  {
+    symbol: 'rect',
+    dashArrayX: [2, 0],
+    dashArrayY: [2, 4],
+    rotation: Math.PI / 2,
+    color: 'rgba(0, 0, 0, 0.15)',
+  },
+];
 
 /**
  * Builds a full ECharts `aria.decal` block.
- * @param show - Whether to show the decal (typically driven by colorblind mode).
- * @param overrides - Optional overrides for the decal pattern fields.
+ * @param show
+ * @param overrides
  */
 export function buildChartDecal(
   show: boolean,
@@ -602,8 +630,11 @@ export function buildChartDecal(
     lineWidth?: number;
   }>,
 ) {
+  const patterns = overrides
+    ? CHART_DECAL_PATTERNS.map((p) => ({ ...p, ...overrides }))
+    : CHART_DECAL_PATTERNS;
   return {
     show,
-    decals: { ...CHART_DECAL_PATTERN, ...overrides },
+    decals: patterns,
   };
 }


### PR DESCRIPTION
## What does this change?

**Colorblind mode:** Replaces the single shared hatch pattern (`CHART_DECAL_PATTERN`) with an array
of three visually distinct patterns (`CHART_DECAL_PATTERNS`) — diagonal lines, dots, and vertical
lines. ECharts cycles through these across series so chart segments differ by both colour and texture.

**Reduction objective chart:** Excludes the `research_facilities` category from the EPFL footprint
totals used in the reduction objective view, both in the year-by-year sum and the baseline total
calculation.

**Data management page:** Shifts the available years range to start at 2024 (instead of 2023) and
excludes the current year from the selectable list.

## Why is this needed?

A single repeated pattern is not sufficient for colorblind users — when multiple series share the
same texture, segments remain indistinguishable. Three distinct patterns ensure each series is
differentiable by texture alone.

The `research_facilities` exclusion corrects a scoping issue where that category was inflating the
displayed EPFL footprint totals in this view.

The year range fix ensures the data management page only shows years for which complete data can
reasonably exist.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🎨 Design/UI improvement

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #