### PR TITLE
fix(#857 workspace-setup): source year list from started config × unit rep…

### DIFF
--- a/frontend/src/pages/app/WorkspaceSetupPage.vue
+++ b/frontend/src/pages/app/WorkspaceSetupPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
-import { useTimelineStore, useModuleStore } from 'src/stores/modules';
+import { useTimelineStore } from 'src/stores/modules';
+import { useYearConfigStore } from 'src/stores/yearConfig';
 import type { Unit } from 'src/stores/workspace';
 import { useRouter, useRoute } from 'vue-router';
 import LabSelectorItem from 'src/components/organisms/workspace-selector/LabSelectorItem.vue';
@@ -13,7 +14,7 @@ import { MODULES_LIST } from 'src/constant/modules';
 
 const workspaceStore = useWorkspaceStore();
 const timelineStore = useTimelineStore();
-const moduleStore = useModuleStore();
+const yearConfigStore = useYearConfigStore();
 const router = useRouter();
 const route = useRoute();
 
@@ -22,26 +23,23 @@ const selectedWorkspace = ref<'calculator' | 'simulator' | null>(null);
 // --- COMPUTED ---
 const unitsWithRoles = computed(() => workspaceStore.units);
 
-const yearsCount = computed(
-  () => workspaceStore.availableCarbonReportYears.length,
-);
-const hasMultipleYears = computed(
-  () => workspaceStore.availableCarbonReportYears.length > 1,
-);
-
+// Intersection: years globally opened (year-configuration `is_started`) AND
+// having a carbon report for this unit. tCO₂-eq comes from that report's
+// pre-computed `stats.total` (stored in kg, hence /1000).
 const yearRows = computed<YearData[]>(() => {
-  const emissionsMap = new Map<number, number>();
-  for (const row of moduleStore.state.yearlyValidatedEmissions) {
-    const year = row.year;
-    const tonnes = row.total_tonnes_co2eq;
-    emissionsMap.set(year, tonnes);
-  }
-  return workspaceStore.availableCarbonReportYears.map((year) => ({
-    year,
-    tco2eq: emissionsMap.get(year) ?? null,
-    status: workspaceStore.carbonReportForYear(year) ? 'complete' : 'missing',
-  }));
+  const startedYears = yearConfigStore.startedYears;
+  return workspaceStore.carbonReports
+    .filter((report) => startedYears.has(report.year))
+    .map((report) => ({
+      year: report.year,
+      tco2eq: report.stats?.total != null ? report.stats.total / 1000 : null,
+      status: 'complete',
+    }))
+    .sort((a, b) => a.year - b.year);
 });
+
+const yearsCount = computed(() => yearRows.value.length);
+const hasMultipleYears = computed(() => yearRows.value.length > 1);
 
 const selectedUnitAffiliations = computed(() => {
   const unit = workspaceStore.selectedUnit;
@@ -85,10 +83,7 @@ const handleUnitSelect = async (unit: Unit) => {
   workspaceStore.setUnit(unit);
   workspaceStore.setYear(null);
   selectedWorkspace.value = null;
-  await Promise.all([
-    workspaceStore.fetchCarbonReportsForUnit(unit.id),
-    moduleStore.getYearlyValidatedEmissions(unit.id),
-  ]);
+  await workspaceStore.fetchCarbonReportsForUnit(unit.id);
   // Show real module progress for the most recent report straight away
   const reports = workspaceStore.carbonReports;
   if (reports.length > 0) {
@@ -157,7 +152,11 @@ const reset = () => {
 onMounted(async () => {
   workspaceStore.reset();
   timelineStore.reset();
-  await workspaceStore.getUnits();
+  // Configured years are global (not unit-scoped) — fetch once per mount.
+  await Promise.all([
+    workspaceStore.getUnits(),
+    yearConfigStore.fetchConfiguredYears(),
+  ]);
 });
 </script>
 

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -35,11 +35,6 @@ interface ValidatedTotalsResponse {
   total_fte: number;
 }
 
-interface YearlyValidatedEmission {
-  year: number;
-  total_tonnes_co2eq: number;
-}
-
 export interface EmbodiedEnergyCategoryEntry {
   category: string;
   kg_co2eq: number;
@@ -302,9 +297,6 @@ export const useModuleStore = defineStore('modules', () => {
     validatedTotals: ValidatedTotalsResponse | null;
     loadingValidatedTotals: boolean;
     errorValidatedTotals: string | null;
-    yearlyValidatedEmissions: YearlyValidatedEmission[];
-    loadingYearlyValidatedEmissions: boolean;
-    errorYearlyValidatedEmissions: string | null;
     emissionBreakdown: EmissionBreakdownResponse | null;
     loadingEmissionBreakdown: boolean;
     errorEmissionBreakdown: string | null;
@@ -338,9 +330,6 @@ export const useModuleStore = defineStore('modules', () => {
     validatedTotals: null,
     loadingValidatedTotals: false,
     errorValidatedTotals: null,
-    yearlyValidatedEmissions: [],
-    loadingYearlyValidatedEmissions: false,
-    errorYearlyValidatedEmissions: null,
     emissionBreakdown: null,
     loadingEmissionBreakdown: false,
     errorEmissionBreakdown: null,
@@ -953,26 +942,6 @@ export const useModuleStore = defineStore('modules', () => {
     }
   }
 
-  async function getYearlyValidatedEmissions(unitId: number) {
-    state.loadingYearlyValidatedEmissions = true;
-    state.errorYearlyValidatedEmissions = null;
-    try {
-      const path = `unit/${encodeURIComponent(unitId)}/yearly-validated-emissions`;
-      const data = await api.get(path).json<YearlyValidatedEmission[]>();
-      state.yearlyValidatedEmissions = data;
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        state.errorYearlyValidatedEmissions = err.message ?? 'Unknown error';
-        state.yearlyValidatedEmissions = [];
-      } else {
-        state.errorYearlyValidatedEmissions = 'Unknown error';
-        state.yearlyValidatedEmissions = [];
-      }
-    } finally {
-      state.loadingYearlyValidatedEmissions = false;
-    }
-  }
-
   async function getItBreakdown(
     carbonReportId: number,
     excludeModules: number[] = [],
@@ -1037,7 +1006,6 @@ export const useModuleStore = defineStore('modules', () => {
     getTopClassBreakdown,
     getValidatedTotals,
     invalidateValidatedTotals,
-    getYearlyValidatedEmissions,
     getEmissionBreakdown,
     invalidateEmissionBreakdown,
     refreshEmissionBreakdownIfNeeded,

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -4,8 +4,6 @@ import type { PersistenceOptions } from 'pinia-plugin-persistedstate';
 import { ref, computed } from 'vue';
 import { api } from 'src/api/http';
 
-export const WORKSPACE_DEFAULT_YEAR = 2025;
-
 export interface Unit {
   id: number;
   name: string;
@@ -36,12 +34,18 @@ interface SelectedParams {
   year: number;
   unit: string; // unit id-name string
 }
+export interface CarbonReportStats {
+  // Pre-computed aggregate written by the backend. `total` is in kg CO2eq.
+  total?: number | null;
+  [key: string]: unknown;
+}
 export interface CarbonReport {
   id: number;
   unit_id: number;
   year: number;
   reference_year?: number | null;
   carbon_project_id: number;
+  stats?: CarbonReportStats | null;
 }
 
 export const useWorkspaceStore = defineStore(
@@ -103,20 +107,6 @@ export const useWorkspaceStore = defineStore(
         carbonReportsLoading.value = false;
       }
     }
-
-    // Compute year range for selection (min year in DB or WORKSPACE_DEFAULT_YEAR, up to N-1)
-    const availableCarbonReportYears = computed(() => {
-      const currentYear = new Date().getFullYear();
-      const yearsInDb = carbonReports.value.map((inv) => inv.year);
-      const minDbYear =
-        yearsInDb.length > 0 ? Math.min(...yearsInDb) : WORKSPACE_DEFAULT_YEAR;
-      const startYear =
-        minDbYear < WORKSPACE_DEFAULT_YEAR ? minDbYear : WORKSPACE_DEFAULT_YEAR;
-      const maxYear = currentYear - 1;
-      const years: number[] = [];
-      for (let y = startYear; y <= maxYear; y++) years.push(y);
-      return years;
-    });
 
     // Helper: does carbon report exist for year?
     function carbonReportForYear(year: number) {
@@ -324,7 +314,6 @@ export const useWorkspaceStore = defineStore(
       carbonReportsError,
       selectedCarbonReport,
       fetchCarbonReportsForUnit,
-      availableCarbonReportYears,
       carbonReportForYear,
       createCarbonReport,
       selectCarbonReportForYear,

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -120,6 +120,13 @@ export interface YearConfigurationResponse {
   pipeline_id?: string | null;
 }
 
+/** Lightweight row from `GET /year-configuration/` (workspace year selector). */
+export interface YearConfigurationListItem {
+  year: number;
+  is_started: boolean;
+  updated_at: string;
+}
+
 interface YearConfigurationCreate {
   is_started?: boolean;
   config?: Partial<YearConfig>;
@@ -146,6 +153,29 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
   const loading = ref(false);
   /** True when the backend returned 404 — no configuration exists yet for this year. */
   const notFound = ref(false);
+  /** All year-configuration rows visible to the caller (workspace year selector). */
+  const configuredYears = ref<YearConfigurationListItem[]>([]);
+
+  /**
+   * Set of years that are globally open (`is_started`). The list endpoint
+   * already filters these for regular users; admins receive every row, so we
+   * re-filter client-side to keep the meaning identical for both.
+   */
+  const startedYears = computed(
+    () =>
+      new Set(
+        configuredYears.value.filter((y) => y.is_started).map((y) => y.year),
+      ),
+  );
+
+  /** Fetch the list of year-configuration rows (global, not unit-scoped). */
+  async function fetchConfiguredYears(): Promise<YearConfigurationListItem[]> {
+    const rows = (await api
+      .get('year-configuration/')
+      .json()) as YearConfigurationListItem[];
+    configuredYears.value = rows;
+    return rows;
+  }
 
   // Methods
   async function fetchConfig(
@@ -519,7 +549,9 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     config,
     loading,
     notFound,
+    configuredYears,
     // Computed
+    startedYears,
     anyModuleIncomplete,
     isReductionObjectiveIncomplete,
     unifiedModuleConfig,
@@ -541,6 +573,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     getModuleUncertaintyTag,
     // Methods
     fetchConfig,
+    fetchConfiguredYears,
     createConfig,
     updateConfig,
     openForUsers,


### PR DESCRIPTION
…orts

yearRows mixed three unrelated sources: a fabricated contiguous year range (availableCarbonReportYears), a separate validated-emissions endpoint for tCO2eq, and an unrendered status lookup. It listed years that did not exist and missed real ones.

Now yearRows is the intersection of globally-started year-configurations (is_started) and the unit's carbon reports, with tCO2eq read from each report's pre-computed stats.total (kg, /1000). yearsCount and hasMultipleYears derive from the same source.

Adds yearConfig.fetchConfiguredYears()/startedYears and stats on the CarbonReport type. Removes the now-orphaned availableCarbonReportYears, WORKSPACE_DEFAULT_YEAR, and the getYearlyValidatedEmissions store plumbing. Configured years are global, fetched once per mount.

## What does this change?

<!-- Briefly describe what you're adding, fixing, or improving -->

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
