### PR TITLE
feat/888 design refactor

### DIFF
--- a/frontend/playwright-ct.config.ts
+++ b/frontend/playwright-ct.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from '@playwright/experimental-ct-vue';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -26,6 +31,47 @@ export default defineConfig({
 
     /* Port to use for Playwright component endpoint. */
     ctPort: 3100,
+    /**
+     * Playwright Component Testing starts its own Vite instance and does not
+     * automatically inherit Quasar's generated Vite configuration.
+     *
+     * Quasar injects aliases such as:
+     *   - src/*
+     *   - components/*
+     *   - stores/*
+     * during `quasar dev/build`, so application code resolves correctly there.
+     *
+     * However, Playwright CT only sees TypeScript path mappings from
+     * `.quasar/tsconfig.json`, and Vite/Rollup cannot use TS `paths`
+     * without additional configuration.
+     *
+     * Without `vite-tsconfig-paths` (or equivalent manual aliases),
+     * imports such as:
+     *
+     *   import { useFooStore } from 'src/stores/foo'
+     *
+     * fail at bundle time with:
+     *
+     *   Rollup failed to resolve import "src/..."
+     *
+     * The plugin below makes the Playwright CT Vite instance reuse the
+     * same path aliases defined by Quasar/TypeScript, avoiding alias drift
+     * between app runtime, IDE tooling, and component tests.
+     */
+
+    ctViteConfig: {
+      resolve: {
+        alias: {
+          src: resolve(__dirname, './src'),
+          components: resolve(__dirname, './src/components'),
+          layouts: resolve(__dirname, './src/layouts'),
+          pages: resolve(__dirname, './src/pages'),
+          assets: resolve(__dirname, './src/assets'),
+          boot: resolve(__dirname, './src/boot'),
+          stores: resolve(__dirname, './src/stores'),
+        },
+      },
+    },
   },
 
   /* Configure projects for major browsers */

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,4 +2,16 @@
   <router-view />
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { watch } from 'vue';
+import { useColorblindStore } from 'src/stores/colorblind';
+import { colorblindMode } from 'src/constant/charts';
+import { storeToRefs } from 'pinia';
+
+// Keep the module-level colorblindMode ref in sync with the Pinia store.
+// Charts import colorblindMode directly from charts.ts; this bridge ensures
+// toggling the store propagates reactively to all chart computed refs.
+const colorblindStore = useColorblindStore();
+const { enabled } = storeToRefs(colorblindStore);
+watch(enabled, (v) => (colorblindMode.value = v), { immediate: true });
+</script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,16 +2,4 @@
   <router-view />
 </template>
 
-<script setup lang="ts">
-import { watch } from 'vue';
-import { useColorblindStore } from 'src/stores/colorblind';
-import { colorblindMode } from 'src/constant/charts';
-import { storeToRefs } from 'pinia';
-
-// Keep the module-level colorblindMode ref in sync with the Pinia store.
-// Charts import colorblindMode directly from charts.ts; this bridge ensures
-// toggling the store propagates reactively to all chart computed refs.
-const colorblindStore = useColorblindStore();
-const { enabled } = storeToRefs(colorblindStore);
-watch(enabled, (v) => (colorblindMode.value = v), { immediate: true });
-</script>
+<script setup lang="ts"></script>

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n';
 import Co2LanguageSelector from 'src/components/atoms/Co2LanguageSelector.vue';
 import { useAuthStore } from 'src/stores/auth';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { useColorblindStore } from 'src/stores/colorblind';
 import { useRouter } from 'vue-router';
 import { useRoute } from 'vue-router';
 import { isBackOfficeRoute } from 'src/router/routes';
@@ -13,6 +14,7 @@ const authStore = useAuthStore();
 const router = useRouter();
 const route = useRoute();
 const workspaceStore = useWorkspaceStore();
+const colorblindStore = useColorblindStore();
 const { t } = useI18n();
 
 const unitName = computed(() => {
@@ -199,6 +201,20 @@ const logoRoute = computed(() => {
         class="q-ml-xl text-weight-medium"
       >
         <q-list>
+          <q-item>
+            <q-item-section>
+              <q-toggle
+                :model-value="colorblindStore.enabled"
+                :label="$t('results_colorblind_mode')"
+                color="accent"
+                keep-color
+                size="md"
+                class="text-weight-medium"
+                @update:model-value="colorblindStore.setEnabled"
+              />
+            </q-item-section>
+          </q-item>
+          <q-separator />
           <q-item clickable @click="handleLogout">
             <q-item-section>
               <q-item-label>{{ $t('logout') }}</q-item-label>

--- a/frontend/src/components/layout/ResultsFilterPill.vue
+++ b/frontend/src/components/layout/ResultsFilterPill.vue
@@ -10,12 +10,12 @@
       >
         <q-icon
           :name="store.hideResearchFacilities ? 'visibility_off' : 'visibility'"
-          size="16px"
+          size="xs"
         />
         <span>{{ $t('charts-research-facilities-category') }}</span>
         <q-icon
           name="o_info"
-          size="14px"
+          size="xs"
           class="results-filter-pill__info"
           @click.stop
         >
@@ -32,12 +32,12 @@
       >
         <q-icon
           :name="store.hideAdditionalData ? 'visibility_off' : 'visibility'"
-          size="16px"
+          size="xs"
         />
         <span>{{ $t('results_additional_data') }}</span>
         <q-icon
           name="o_info"
-          size="14px"
+          size="xs"
           class="results-filter-pill__info"
           @click.stop
         >
@@ -56,54 +56,56 @@ import { useResultsFiltersStore } from 'src/stores/resultsFilters';
 const store = useResultsFiltersStore();
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
 .results-filter-pill {
   position: fixed;
-  bottom: 32px;
-  right: 32px;
+  bottom: tokens.$spacing-xxl;
+  right: tokens.$spacing-xxl;
   z-index: 9999;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  background: #ffffff;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  padding: 8px 16px;
-  gap: 8px;
+  background: tokens.$color-surface;
+  border: 1px solid tokens.$color-border;
+  border-radius: tokens.$radius-lg;
+  box-shadow: tokens.$shadow-default;
+  padding: tokens.$spacing-sm tokens.$spacing-lg;
+  gap: tokens.$spacing-sm;
 }
 
 .results-filter-pill__item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: tokens.$spacing-xs;
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
-  color: #212121;
+  font-size: tokens.$text-size-sm;
+  font-weight: tokens.$text-weight-medium;
+  color: tokens.$color-text;
   transition:
-    color 0.2s ease,
-    opacity 0.2s ease;
+    color tokens.$transition-default,
+    opacity tokens.$transition-default;
 }
 
 .results-filter-pill__item--off {
-  color: #9e9e9e;
+  color: tokens.$color-text-muted;
   opacity: 0.7;
 }
 
 .results-filter-pill__divider {
   width: 100%;
-  height: 1px;
-  background: #e0e0e0;
+  height: tokens.$spacing-xxs;
+  background: tokens.$color-border;
 }
 
 .results-filter-pill__info {
   margin-left: auto;
   cursor: default;
-  color: #212121;
+  color: tokens.$color-text;
 }
 
 .results-filter-pill__item--off .results-filter-pill__info {
-  color: #9e9e9e;
+  color: tokens.$color-text-muted;
 }
 </style>

--- a/frontend/src/components/layout/ResultsFilterPill.vue
+++ b/frontend/src/components/layout/ResultsFilterPill.vue
@@ -1,0 +1,109 @@
+<template>
+  <Teleport to="body">
+    <div class="results-filter-pill non-selectable">
+      <div
+        class="results-filter-pill__item"
+        :class="{
+          'results-filter-pill__item--off': store.hideResearchFacilities,
+        }"
+        @click="store.hideResearchFacilities = !store.hideResearchFacilities"
+      >
+        <q-icon
+          :name="store.hideResearchFacilities ? 'visibility_off' : 'visibility'"
+          size="16px"
+        />
+        <span>{{ $t('charts-research-facilities-category') }}</span>
+        <q-icon
+          name="o_info"
+          size="14px"
+          class="results-filter-pill__info"
+          @click.stop
+        >
+          <q-tooltip class="text-body2 text-black">
+            {{ $t('results_filter_pill_research_facilities_tooltip') }}
+          </q-tooltip>
+        </q-icon>
+      </div>
+      <div class="results-filter-pill__divider" />
+      <div
+        class="results-filter-pill__item"
+        :class="{ 'results-filter-pill__item--off': store.hideAdditionalData }"
+        @click="store.hideAdditionalData = !store.hideAdditionalData"
+      >
+        <q-icon
+          :name="store.hideAdditionalData ? 'visibility_off' : 'visibility'"
+          size="16px"
+        />
+        <span>{{ $t('results_additional_data') }}</span>
+        <q-icon
+          name="o_info"
+          size="14px"
+          class="results-filter-pill__info"
+          @click.stop
+        >
+          <q-tooltip class="text-body2 text-black">
+            {{ $t('results_filter_pill_additional_data_tooltip') }}
+          </q-tooltip>
+        </q-icon>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { useResultsFiltersStore } from 'src/stores/resultsFilters';
+
+const store = useResultsFiltersStore();
+</script>
+
+<style scoped>
+.results-filter-pill {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 8px 16px;
+  gap: 8px;
+}
+
+.results-filter-pill__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: #212121;
+  transition:
+    color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.results-filter-pill__item--off {
+  color: #9e9e9e;
+  opacity: 0.7;
+}
+
+.results-filter-pill__divider {
+  width: 100%;
+  height: 1px;
+  background: #e0e0e0;
+}
+
+.results-filter-pill__info {
+  margin-left: auto;
+  cursor: default;
+  color: #212121;
+}
+
+.results-filter-pill__item--off .results-filter-pill__info {
+  color: #9e9e9e;
+}
+</style>

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -1,6 +1,4 @@
-import { computed } from 'vue';
-import { useColorblindStore } from 'src/stores/colorblind';
-import { storeToRefs } from 'pinia';
+import { computed, ref } from 'vue';
 import { MODULES, type Module } from './modules';
 
 /** Interpolate between two `#RRGGBB` colours. */
@@ -15,10 +13,11 @@ function lerpHex(a: string, b: string, t: number): string {
   return '#' + mix(1) + mix(3) + mix(5);
 }
 
-// Get the store instance and export colorblindMode for backward compatibility
-const colorblindStore = useColorblindStore();
-const { enabled: colorblindMode } = storeToRefs(colorblindStore);
-export { colorblindMode };
+// Plain ref kept in sync by App.vue via a watch on useColorblindStore.
+// Using a module-level useColorblindStore() call or getActivePinia() computed
+// does not work because Pinia is not yet active at module-load time and
+// computed() caches the result without a reactive dependency on the store.
+export const colorblindMode = ref(false);
 
 // Color definitions with default and colorblind variants
 const colorDefinitions = {

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -1,4 +1,5 @@
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
+import { useColorblindStore } from 'src/stores/colorblind';
 import { MODULES, type Module } from './modules';
 
 /** Interpolate between two `#RRGGBB` colours. */
@@ -12,12 +13,6 @@ function lerpHex(a: string, b: string, t: number): string {
   };
   return '#' + mix(1) + mix(3) + mix(5);
 }
-
-// Plain ref kept in sync by App.vue via a watch on useColorblindStore.
-// Using a module-level useColorblindStore() call or getActivePinia() computed
-// does not work because Pinia is not yet active at module-load time and
-// computed() caches the result without a reactive dependency on the store.
-export const colorblindMode = ref(false);
 
 // Color definitions with default and colorblind variants
 const colorDefinitions = {
@@ -312,7 +307,7 @@ const colorDefinitions = {
 
 // Single computed that returns colors based on colorblind mode
 export const colors = computed(() => {
-  const mode = colorblindMode.value ? 'colorblind' : 'default';
+  const mode = useColorblindStore().enabled ? 'colorblind' : 'default';
   return {
     yellow: colorDefinitions.yellow[mode],
     peach: colorDefinitions.peach[mode],

--- a/frontend/src/css/02-tokens/_decisions.scss
+++ b/frontend/src/css/02-tokens/_decisions.scss
@@ -30,6 +30,7 @@ $spacing-page: opt.$tokens-spacing-48 !default;
 // Radii
 $radius-default: opt.$tokens-border-radius-generic-border-radius !default;
 $radius-default-px: opt.$tokens-border-radius-generic-border-radius-px !default;
+$radius-lg: opt.$tokens-border-radius-lg-border-radius !default;
 $radius-pill: opt.$tokens-border-radius-full-border-radius !default;
 
 // Typography
@@ -72,6 +73,12 @@ $modal-width-sm: opt.$tokens-layout-sm-modal-width !default;
 $icon-size-sm: opt.$tokens-icon-size-sm !default;
 $icon-size-md: opt.$tokens-icon-size-md !default;
 $icon-size-lg: opt.$tokens-icon-size-lg !default;
+
+// Shadows
+$shadow-default: opt.$tokens-box-shadow !default;
+
+// Transitions
+$transition-default: opt.$tokens-transitions-default !default;
 
 // Tooltip
 $tooltip-color: opt.$tokens-colors-base-black !default;

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -1107,6 +1107,14 @@ export default {
     en: 'IT research facilities',
     fr: 'Infrastructures de recherche IT',
   },
+  results_filter_pill_research_facilities_tooltip: {
+    en: 'These emissions are calculated based on research facilities data.',
+    fr: 'Ces émissions sont calculées à partir des données propres aux infrastructure de recherche.',
+  },
+  results_filter_pill_additional_data_tooltip: {
+    en: "These emissions are calculated based on EPFL's general assumptions.",
+    fr: "Ces émissions sont calculées à partir des hypothèses générales de l'EPFL.",
+  },
   'it-title': {
     en: 'IT focus',
     fr: 'Focus numérique',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -4,13 +4,13 @@ import {
   defineAsyncComponent,
   h,
   onMounted,
+  onUnmounted,
   reactive,
   ref,
   watch,
 } from 'vue';
 import { QSkeleton } from 'quasar';
 import { MODULES_LIST, MODULES, type Module } from 'src/constant/modules';
-import { useColorblindStore } from 'src/stores/colorblind';
 const ModuleIcon = defineAsyncComponent(
   () => import('src/components/atoms/ModuleIcon.vue'),
 );
@@ -23,11 +23,14 @@ import {
 
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useTimelineStore, useModuleStore } from 'src/stores/modules';
+import { useResultsFiltersStore } from 'src/stores/resultsFilters';
+import { storeToRefs } from 'pinia';
 import { IT_FOCUS_SOURCE_MODULES } from 'src/constant/itFocus';
 import { MODULE_STATES, getModuleTypeId } from 'src/constant/moduleStates';
 import { useI18n } from 'vue-i18n';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import ReductionObjectiveChart from 'src/components/charts/results/ReductionObjectiveChart.vue';
+import ResultsFilterPill from 'src/components/layout/ResultsFilterPill.vue';
 import { useRoute, useRouter } from 'vue-router';
 
 const yearConfigStore = useYearConfigStore();
@@ -138,21 +141,17 @@ function formatPercentChange(value: number | null | undefined): string {
 const workspaceStore = useWorkspaceStore();
 const timelineStore = useTimelineStore();
 const moduleStore = useModuleStore();
-const colorblindStore = useColorblindStore();
+const resultsFiltersStore = useResultsFiltersStore();
+const { hideResearchFacilities, hideAdditionalData } =
+  storeToRefs(resultsFiltersStore);
 const router = useRouter();
 const route = useRoute();
-const colorblindMode = computed({
-  get: () => colorblindStore.enabled,
-  set: (v: boolean) => colorblindStore.setEnabled(v),
-});
 const currentYear = computed(() => {
   return workspaceStore.selectedYear ?? new Date().getFullYear();
 });
 
 const resultsSummary = ref<ResultsSummary | null>(null);
 const resultsSummaryLoading = ref(true);
-
-const hideResearchFacilities = ref(false);
 
 const mountPrimaryCharts = ref(false);
 const mountBelowFold = ref(false);
@@ -271,8 +270,9 @@ function getTotalModuleCarbonFootprintTitle(module: Module): string {
   return t('results_total_module_carbon_footprint', { module: t(module) });
 }
 
+onUnmounted(() => resultsFiltersStore.reset());
+
 const viewUncertainties = ref(false);
-const hideAdditionalData = ref(false);
 const viewAdditionalData = computed(() => !hideAdditionalData.value);
 const compareYears = ref(false);
 
@@ -379,6 +379,7 @@ const getUncertainty = (
 
 <template>
   <q-page>
+    <ResultsFilterPill />
     <Co2Timeline />
     <q-separator />
     <div class="page-grid">
@@ -405,35 +406,6 @@ const getUncertainty = (
               @click="downloadPDF"
             />
             <div class="flex column">
-              <q-checkbox
-                v-model="colorblindMode"
-                :label="$t('results_colorblind_mode')"
-                color="accent"
-                class="text-weight-medium"
-                size="xs"
-              />
-              <q-checkbox
-                v-model="viewUncertainties"
-                :label="$t('results_view_uncertainties')"
-                color="accent"
-                class="text-weight-medium"
-                size="xs"
-              />
-              <q-checkbox
-                v-model="hideResearchFacilities"
-                :label="$t('results_hide_research_facilities')"
-                color="accent"
-                class="text-weight-medium"
-                size="xs"
-              />
-              <q-checkbox
-                v-model="hideAdditionalData"
-                :label="$t('results_hide_additional_data')"
-                color="accent"
-                class="text-weight-medium"
-                size="xs"
-              />
-              <q-separator class="q-my-sm" />
               <q-checkbox
                 v-model="compareYears"
                 :label="$t('results_compare_years')"
@@ -663,6 +635,14 @@ const getUncertainty = (
                 })
               }}</span>
             </div>
+            <q-toggle
+              v-model="viewUncertainties"
+              :label="$t('results_view_uncertainties')"
+              color="accent"
+              keep-color
+              size="lg"
+              class="text-weight-medium"
+            />
           </div>
         </q-card>
         <!-- Module Collapse Items -->

--- a/frontend/src/stores/resultsFilters.ts
+++ b/frontend/src/stores/resultsFilters.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useResultsFiltersStore = defineStore('resultsFilters', () => {
+  const hideResearchFacilities = ref(false);
+  const hideAdditionalData = ref(false);
+
+  function reset() {
+    hideResearchFacilities.value = false;
+    hideAdditionalData.value = false;
+  }
+
+  return {
+    hideResearchFacilities,
+    hideAdditionalData,
+    reset,
+  };
+});


### PR DESCRIPTION
## What does this change?

Refactors how results-page filter controls are surfaced and how the colorblind mode is wired up:

- Extracts `hideResearchFacilities` and `hideAdditionalData` into a new `useResultsFiltersStore` (with a `reset()` called on page unmount) and removes the local `ref`s from `ResultsPage`.
- Adds a `ResultsFilterPill` component — a fixed bottom-right overlay with toggle items for the two data-visibility filters, each with an info tooltip — rendered via `Teleport`.
- Removes the four checkboxes from the results page sidebar; replaces the uncertainties checkbox with a `q-toggle`.
- Moves the colorblind mode toggle from the results page into the app header menu (under a separator, above logout).
- Fixes a Pinia-at-module-load-time bug in `charts.ts`: replaces the `useColorblindStore()` call with a plain `ref(false)` kept in sync by a `watch` in `App.vue`, so chart computeds have a proper reactive dependency.
- Adds i18n tooltip strings for the two filter pill items (EN + FR).

## Why is this needed?

The filter checkboxes were scattered in the results page sidebar with no clear visual hierarchy. Moving them to a persistent floating pill makes them accessible regardless of scroll position. The colorblind toggle belongs in a global settings location (the header) rather than per-page. The `charts.ts` Pinia fix resolves a runtime error seen in Playwright CT tests where the store wasn't yet active at module-load time.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #888 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
