### PR TITLE
fix: bring back module chart toggle

### DIFF
--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -132,13 +132,19 @@ import {
 } from 'src/constant/charts';
 import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakdownInfo';
 
-const props = defineProps<{
-  type: Module;
-  showEvolutionChart?: boolean;
-  forcedView?: 'breakdown' | 'type';
-  showControls?: boolean;
-  printMode?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    type: Module;
+    showEvolutionChart?: boolean;
+    forcedView?: 'breakdown' | 'type';
+    showControls?: boolean;
+    printMode?: boolean;
+  }>(),
+  {
+    showControls: true,
+    forcedView: 'breakdown',
+  },
+);
 
 const { t, te } = useI18n();
 
@@ -147,7 +153,7 @@ const moduleChartView = ref<'breakdown' | 'type'>(props.forcedView ?? 'type');
 const isPrintMode = usePrintMode();
 const showControls = computed(() => {
   if (isPrintMode.value) return false;
-  return props.showControls !== false && !props.forcedView;
+  return props.showControls !== false;
 });
 
 watch(

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -719,14 +719,12 @@ const getUncertainty = (
                   <!-- Module has results in the summary -->
                   <template v-if="getModuleResult(module)">
                     <!-- Per-module treemap -->
-                    <template v-if="isModuleValidated(module)">
-                      <ModuleCharts
-                        :type="module"
-                        :show-evolution-chart="
-                          module === MODULES.ProfessionalTravel
-                        "
-                      />
-                    </template>
+                    <ModuleCharts
+                      :type="module"
+                      :show-evolution-chart="
+                        module === MODULES.ProfessionalTravel
+                      "
+                    />
                     <q-card flat class="grid-3-col q-mb-lg q-px-lg">
                       <BigNumber
                         :title="


### PR DESCRIPTION
## What does this change?
Removes the `isModuleValidated` guard that was hiding module charts for non-validated modules, and fixes the `showControls` prop default so chart view toggle controls are visible by default.

## Why is this needed?
Module charts were not showing for modules that hadn't been explicitly validated, even when results existed. The `showControls` prop also lacked a default value, causing the breakdown/type view toggle to be hidden unintentionally. The original intent was to hide controls only in print mode or when `forcedView` is set.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally

## Related issues
- Closes #