### PR TITLE
docs(344): frontend GlitchTip error monitoring + backfilled plan

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Persona Flows: frontend/01-overview/personas.md
       - Design Tokens: frontend/02-design-tokens.md
       - Quasar Bridge: frontend/quasar-bridge.md
+      - Error Monitoring: frontend/error-monitoring.md
       - Data Management:
           - Overview: frontend/data-management/index.md
           - Architecture: frontend/data-management/architecture.md

--- a/docs/src/architecture/13-cross-cutting-concerns.md
+++ b/docs/src/architecture/13-cross-cutting-concerns.md
@@ -80,4 +80,4 @@ Tracing is implemented with:
 - Request span propagation
 - Service dependency mapping
 
-For detailed observability information, see [Infrastructure Monitoring](../infra/01-overview.md#monitoring--observability).
+For detailed observability information, see [Infrastructure Monitoring](../infra/01-overview.md#monitoring--observability). For client-side error tracking via self-hosted GlitchTip, see [Frontend Error Monitoring](../frontend/error-monitoring.md).

--- a/docs/src/frontend/error-monitoring.md
+++ b/docs/src/frontend/error-monitoring.md
@@ -1,0 +1,85 @@
+---
+status: delivered
+last_updated: 2026-05-19
+summary: Frontend error monitoring with self-hosted GlitchTip (Sentry-compatible).
+---
+
+# Frontend Error Monitoring
+
+The frontend reports uncaught JavaScript errors, server 5xx
+responses, and a 5% sample of route navigations to **GlitchTip**,
+EPFL ENAC-IT's self-hosted, Sentry-compatible error tracker. We use
+GlitchTip rather than hosted Sentry so error data stays on EPFL
+infrastructure. Wired in issue #344 — see the
+[implementation plan](../implementation-plans/344-frontend-error-monitoring.md).
+
+## Access
+
+- **Dashboard:** [enac-it-glitchtip.epfl.ch](https://enac-it-glitchtip.epfl.ch).
+  Sign in with a dedicated GlitchTip account (not EPFL SSO). Ask
+  **nicdub** for an account and project membership.
+- **Runbook:** ENAC-IT's
+  [Sentry self-host via GlitchTip](https://www.notion.so/enacit4r/Sentry-Self-Host-via-Glitchtip-35e53a25eee880448351e452829897cd)
+  Notion page — how the server is operated.
+- **Product docs:** [glitchtip.com/documentation](https://glitchtip.com/documentation).
+- **Project DSN:** stored in
+  [Infisical](https://enac-it-secrets.epfl.ch/project/17dcca22-b05d-4d28-b7aa-c2770018f5be/secrets/overview?secretPath=%2Fepfl-enac%2Fglitchtip),
+  never in the repo.
+
+## How errors reach GlitchTip
+
+`@sentry/vue` is lazy-loaded so the ~900 KiB SDK stays off the
+critical path. Four capture paths feed it:
+
+- Vue lifecycle/render errors via `app.config.errorHandler`.
+- Synchronous browser errors via the `window` `error` listener.
+- Unhandled promise rejections via the `unhandledrejection` listener.
+- HTTP 5xx responses via `captureMessage` in
+  [`src/api/http.ts:190`](https://github.com/epfl-enac/co2-calculator/blob/main/frontend/src/api/http.ts).
+
+Noise (ResizeObserver loops, aborted fetches) is filtered. See
+[`src/boot/sentry.ts`](https://github.com/epfl-enac/co2-calculator/blob/main/frontend/src/boot/sentry.ts)
+for the full list and the `tracesSampleRate: 0.05` setting.
+
+## Configuring a deployment
+
+Two env vars drive it, resolved at runtime in
+[`src/config/runtime.ts`](https://github.com/epfl-enac/co2-calculator/blob/main/frontend/src/config/runtime.ts):
+
+| Variable          | Purpose                                             |
+| ----------------- | --------------------------------------------------- |
+| `APP_SENTRY_DSN`  | Project DSN. Empty/unset → Sentry init skipped.     |
+| `APP_ENVIRONMENT` | Event label (`development`, `stage`, `production`). |
+
+> **⚠️ Empty DSN disables reporting.** `helm/values.yaml` ships
+> `APP_SENTRY_DSN: ""`; the real DSN is set per cluster in the ops
+> repo (`enack8s-app-config` / `openshift-app-config`), not here.
+
+Set them per context:
+
+- **Production/stage:** pod env via Helm `frontend.env`, overridden
+  in the ops repo. The same bundle ships everywhere; values are
+  injected at container startup, not baked in.
+- **Local dev:** copy `frontend/.env.example` to `.env.local` and
+  fill `APP_SENTRY_DSN`.
+- **docker-compose:** export `APP_SENTRY_DSN` in your shell before
+  `docker compose up`.
+
+Under the pod's `readOnlyRootFilesystem`, these values are injected
+at startup into `/tmp/injectEnv.js` and read from
+`window.injectedEnvVariable` — see the
+[implementation plan](../implementation-plans/344-frontend-error-monitoring.md)
+for the runtime-injection design.
+
+## Troubleshooting
+
+- **No events in GlitchTip:** open the deployed app, load
+  `/injectEnv.js` in the browser, and confirm `APP_SENTRY_DSN` is a
+  non-empty value. Empty → ops repo override is missing.
+- **Stack traces are minified:** known limitation. Source maps are
+  disabled (`sourcemap: false`) to keep the bundle small; traces show
+  line:column only. Reading minified frames is the current tradeoff.
+
+**Next step:** to enable reporting on a new environment, request a
+GlitchTip project from nicdub, then add the DSN to that cluster's
+ops-repo values — do not commit it here.

--- a/docs/src/implementation-plans/344-frontend-error-monitoring.md
+++ b/docs/src/implementation-plans/344-frontend-error-monitoring.md
@@ -1,0 +1,68 @@
+---
+status: delivered
+issue: 344
+last_updated: 2026-05-19
+title: "Frontend Error Monitoring via Self-Hosted GlitchTip"
+summary: Wire @sentry/vue to EPFL's self-hosted GlitchTip with runtime DSN injection under a read-only root filesystem.
+---
+
+# Frontend Error Monitoring via Self-Hosted GlitchTip
+
+Backfilled after delivery (work shipped without a plan-mode file).
+Records the delivered shape so future work builds on it. User-facing
+operation lives in
+[Frontend Error Monitoring](../frontend/error-monitoring.md) — this
+plan does not restate it.
+
+## Goal
+
+Capture uncaught frontend errors, server 5xx responses, and a route
+performance sample in a Sentry-compatible tracker, without shipping
+per-environment secrets in the bundle or breaking the hardened
+read-only pod.
+
+## Constraints
+
+- **One bundle, many environments.** The same image ships to
+  dev/stage/prod, so the DSN must be injected at runtime, not built in.
+- **`readOnlyRootFilesystem: true`.** Nothing may write to the image
+  filesystem at startup.
+- **Performance budget.** The Sentry SDK (~900 KiB) must not regress
+  the Lighthouse score gated in CI.
+- **No hosted Sentry.** Error data stays on EPFL infrastructure
+  (GlitchTip at `enac-it-glitchtip.epfl.ch`).
+
+## Delivered design
+
+1. **Runtime config resolution** — `src/config/runtime.ts` reads
+   `window.injectedEnvVariable` first, falling back to build-time
+   `process.env`. `||` (not `??`) so an empty pod env disables Sentry
+   instead of crashing init.
+2. **Runtime DSN injection** — `docker/entrypoint.sh` writes `APP_*`
+   env vars to `/tmp/injectEnv.js` at container startup; `nginx.conf`
+   aliases `/injectEnv.js` to `/tmp` with no-cache headers. `/tmp` is
+   a writable `emptyDir`, satisfying the read-only root.
+3. **Lazy SDK** — `@sentry/vue` is dynamic-imported in
+   `src/boot/sentry.ts` and `src/api/http.ts`, keeping the SDK off the
+   critical path; with no DSN the chunk never loads.
+4. **Four capture paths** — Vue `errorHandler`, `window` `error`,
+   `unhandledrejection`, and HTTP 5xx via `captureMessage`. Noise
+   (ResizeObserver, aborts) is filtered; `tracesSampleRate: 0.05`.
+5. **Helm wiring** — `helm/values.yaml` `frontend.env` exposes
+   `APP_SENTRY_DSN` (empty default) and `APP_ENVIRONMENT`; real values
+   are set per cluster in the ops repo. `docker-compose.yml` mirrors
+   the read-only fs + tmpfs so regressions surface locally.
+
+## Known tradeoff
+
+Source maps are disabled (`sourcemap: false`) to hold the bundle
+budget — GlitchTip stack traces are minified (line:column only).
+Revisiting with hidden source maps + a CI upload step is a possible
+follow-up.
+
+## Outcome
+
+Delivered across commits `d557b7e2`, `ad543124`, `13934f78`,
+`8778dbd4`, `c0a9cb85`, `43bbeea0`. Lighthouse CI threshold lowered to
+0.6 temporarily (`c0a9cb85`) pending a minification fix for the CI
+run; revisit before raising it back.

--- a/docs/src/infra/01-overview.md
+++ b/docs/src/infra/01-overview.md
@@ -311,6 +311,9 @@ spec:
 
 ## Monitoring & Observability
 
+Client-side JavaScript errors are tracked separately in self-hosted
+GlitchTip — see [Frontend Error Monitoring](../frontend/error-monitoring.md).
+
 ### Prometheus Metrics
 
 **Backend metrics** (`/metrics` endpoint):


### PR DESCRIPTION
## What

Documents the frontend Sentry/GlitchTip error-monitoring integration shipped for #344, and backfills the missing implementation plan.

- **New page** `docs/src/frontend/error-monitoring.md` — access (`enac-it-glitchtip.epfl.ch`, dedicated account via nicdub, project membership from ENAC-IT), the four capture paths, per-environment `APP_SENTRY_DSN`/`APP_ENVIRONMENT` config, troubleshooting. Added to the Frontend nav in `mkdocs.yml`.
- **Cross-links** added from architecture Cross-Cutting → Observability and infra → Monitoring (no content duplication).
- **Backfilled plan** `docs/src/implementation-plans/344-frontend-error-monitoring.md` (`status: delivered`) — #344 shipped across six commits with no plan file; this records the delivered design and commit shas.

## Why

#344 had no implementation-plan entry because the work went direct (no plan mode). The new docs make the GlitchTip setup discoverable and operable.

## Notes

- No credentials in the repo: the doc points to Infisical and the ENAC-IT Notion runbook, and to nicdub for account access.
- Verified: `npx prettier --check` clean and `uv run mkdocs build --strict` clean (only pre-existing unrelated INFO).
