### PR TITLE
chore: promote dev to stage (end of sprint 10.1)

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -39,6 +39,7 @@ from app.models.unit import Unit
 from app.models.user import User
 from app.repositories.data_ingestion import DataIngestionRepository, WhyStaleLiteral
 from app.services.data_ingestion.provider_factory import ProviderFactory
+from app.services.pipeline_progress import PhaseLabel, compute_pipeline_progress
 from app.tasks._background import fire_and_forget
 from app.tasks.runner import run_job
 from app.tasks.unit_sync_tasks import SyncUnitRequest
@@ -304,12 +305,27 @@ class PipelineJobResponse(BaseModel):
     year: Optional[int] = None
 
 
+class PipelineProgressResponse(BaseModel):
+    """Server-authoritative pipeline phase/done/error (Issue #1219).
+
+    Mirrors ``app.services.pipeline_progress.PipelineProgress``; the
+    frontend trusts this instead of inferring "done" from a
+    possibly-incomplete job snapshot."""
+
+    phase: int
+    phases_total: int
+    phase_label: PhaseLabel
+    done: bool
+    has_error: bool
+
+
 class PipelineResponse(BaseModel):
     """Wrapper for ``GET /sync/pipelines/{pipeline_id}`` — pipeline UUID
     plus the ordered job list (parent first, then fan-out children)."""
 
     pipeline_id: UUID
     jobs: list[PipelineJobResponse]
+    progress: PipelineProgressResponse
 
 
 class StaleStatsEntry(BaseModel):
@@ -1007,6 +1023,7 @@ async def get_pipeline_jobs(
             for job in jobs
             if job.id is not None
         ],
+        progress=PipelineProgressResponse(**compute_pipeline_progress(jobs)),
     )
 
 
@@ -1107,10 +1124,20 @@ async def pipeline_stream_by_id(
                 if job.id is not None
             ]
 
+            # Issue #1219 — server-authoritative completion.  The old
+            # "every job in the snapshot is FINISHED" test fired in the
+            # window where the parent upload was FINISHED but its
+            # recalc/aggregation children had not been INSERTed yet, so
+            # the UI flashed green on a half-done pipeline.  Derive
+            # phase/done from the expected fan-out recorded in meta
+            # instead, and ship it so the client trusts the same truth.
+            progress = compute_pipeline_progress(jobs)
+
             if snapshot != last_snapshot:
                 payload = {
                     "pipeline_id": str(pipeline_id),
                     "jobs": snapshot,
+                    "progress": progress,
                 }
                 yield f"event: pipeline-update\ndata: {json.dumps(payload)}\n\n"
                 last_snapshot = snapshot
@@ -1118,10 +1145,7 @@ async def pipeline_stream_by_id(
                 # clock so we don't double-emit on the next tick.
                 seconds_since_heartbeat = 0
 
-            all_finished = bool(jobs) and all(
-                job.state == IngestionState.FINISHED for job in jobs
-            )
-            if all_finished:
+            if progress["done"]:
                 polls_after_completion += 1
                 # Mirror the job-stream endpoint's "send a final marker
                 # then close" handshake so clients can flip UI state
@@ -1130,6 +1154,7 @@ async def pipeline_stream_by_id(
                     final_payload = {
                         "pipeline_id": str(pipeline_id),
                         "jobs": last_snapshot or snapshot,
+                        "progress": progress,
                         "stream_closed": True,
                     }
                     yield (

--- a/backend/app/services/pipeline_progress.py
+++ b/backend/app/services/pipeline_progress.py
@@ -1,0 +1,178 @@
+"""Server-authoritative pipeline-progress computation (Issue #1219).
+
+A data-ingestion *pipeline* is a parent upload job
+(``csv_ingest`` / ``api_ingest`` / ``factor_ingest``) plus the
+``emission_recalc`` children it fans out, plus the ``aggregation``
+grandchild each recalc chains.  Before this module the SSE stream
+declared a pipeline "finished" when *every job currently sharing the
+pipeline_id was FINISHED* — which fires prematurely in the window
+where the parent is FINISHED but its children have not been INSERTed
+yet, so the UI flashed green on a pipeline that had only done step 1.
+
+``compute_pipeline_progress`` derives completion from the *expected*
+fan-out recorded in job meta (``recalc_jobs_chained`` on the parent,
+``aggregation_job_id`` on each recalc — both written by the runner via
+``finish_job``), not from a possibly-incomplete snapshot.  It is a
+pure function: hand it the rows, get back the phase + done/error
+flags.  Consumed by both ``GET /sync/pipelines/{id}`` and the
+``/stream`` SSE endpoint so client and server agree on "done".
+
+The model is 3 fixed phases:
+
+1. ``data``        — parent upload FINISHED.
+2. ``emissions``   — every owned ``emission_recalc`` child FINISHED.
+3. ``aggregation`` — every aggregation referenced by a FINISHED
+   recalc is itself FINISHED.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Literal, TypedDict
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    IngestionResult,
+    IngestionState,
+)
+
+PhaseLabel = Literal["data", "emissions", "aggregation"]
+
+#: Job types that can be the root of a pipeline (no parent_job_id).
+_ROOT_JOB_TYPES = {"csv_ingest", "api_ingest", "factor_ingest"}
+
+_PHASE_LABELS: dict[int, PhaseLabel] = {
+    1: "data",
+    2: "emissions",
+    3: "aggregation",
+}
+
+
+class PipelineProgress(TypedDict):
+    """Authoritative pipeline status — see module docstring."""
+
+    phase: int
+    phases_total: int
+    phase_label: PhaseLabel
+    done: bool
+    has_error: bool
+
+
+def _is_finished(job: DataIngestionJob) -> bool:
+    return job.state == IngestionState.FINISHED
+
+
+def _is_finished_error(job: DataIngestionJob) -> bool:
+    return _is_finished(job) and job.result == IngestionResult.ERROR
+
+
+def _meta(job: DataIngestionJob) -> dict:
+    # ``meta`` is a nullable JSON column; normalise to a dict so
+    # callers can ``.get`` without a None guard at every site.
+    return job.meta or {}
+
+
+def _find_root(jobs: list[DataIngestionJob]) -> DataIngestionJob | None:
+    """The pipeline's parent: the row with no ``parent_job_id``.
+
+    Falls back to the lowest-id root-typed job when meta is absent
+    (legacy rows / defensive — every chained child records
+    ``parent_job_id``, so a row lacking it is the root).
+    """
+    rootless = [j for j in jobs if _meta(j).get("parent_job_id") is None]
+    candidates = rootless or [j for j in jobs if (j.job_type or "") in _ROOT_JOB_TYPES]
+    if not candidates:
+        return None
+    # ``id`` can be None only for unpersisted rows (never here); the
+    # ``or 0`` keeps mypy happy and is harmless for real rows.
+    return min(candidates, key=lambda j: j.id or 0)
+
+
+def compute_pipeline_progress(
+    jobs: Iterable[DataIngestionJob],
+) -> PipelineProgress:
+    """Compute the authoritative phase/done/error for a pipeline.
+
+    ``jobs`` is every row sharing one ``pipeline_id`` (any order).
+
+    Completion rules:
+
+    - **Phase 1 (data)** done ⇔ parent FINISHED.
+    - **Phase 2 (emissions)** done ⇔ parent FINISHED *and* the number
+      of FINISHED ``emission_recalc`` children ≥ the parent's
+      ``meta.recalc_jobs_chained`` (the count of children this
+      pipeline actually *owns* — dedup-skipped targets are owned by an
+      earlier pipeline and intentionally excluded, so 0 ⇒ phase 2 is
+      vacuously satisfied).  When the parent is FINISHED but the
+      counter is absent (legacy / non-ingest root), fall back to
+      "every recalc row present is FINISHED".
+    - **Phase 3 (aggregation)** done ⇔ phase 2 done *and* every
+      aggregation referenced by a FINISHED recalc
+      (``meta.aggregation_job_id``) is itself present and FINISHED.
+    - ``done`` ⇔ phase 3 done **or** any job is FINISHED+ERROR (a
+      broken chain spawns no further children, so an error anywhere is
+      terminal — the UI must stop the spinner and surface failure).
+    """
+    jobs = list(jobs)
+    has_error = any(_is_finished_error(j) for j in jobs)
+
+    root = _find_root(jobs)
+    if root is None:
+        # No identifiable parent — treat as not-started rather than
+        # crash the stream; the dashboard simply keeps polling.
+        return PipelineProgress(
+            phase=1,
+            phases_total=3,
+            phase_label="data",
+            done=has_error,
+            has_error=has_error,
+        )
+
+    recalc_jobs = [j for j in jobs if j.job_type == "emission_recalc"]
+    aggregation_jobs = {
+        j.id: j for j in jobs if j.job_type == "aggregation" and j.id is not None
+    }
+
+    phase1_done = _is_finished(root)
+
+    # Expected owned recalc children. ``recalc_jobs_chained`` is
+    # written by the parent handler's return meta (merged on
+    # finish_job); absent until the parent is FINISHED.
+    expected_recalc = _meta(root).get("recalc_jobs_chained")
+    finished_recalc = [j for j in recalc_jobs if _is_finished(j)]
+    if expected_recalc is None:
+        # Legacy / non-ingest root: best-effort — done when every
+        # recalc row we can see is FINISHED (and at least the parent
+        # is FINISHED so the fan-out has been issued).
+        phase2_done = phase1_done and len(finished_recalc) == len(recalc_jobs)
+    else:
+        phase2_done = phase1_done and len(finished_recalc) >= int(expected_recalc)
+
+    # Aggregations are only expected for recalc children that actually
+    # chained one (success/warning, module known). A FINISHED recalc
+    # records ``aggregation_job_id`` (None when it dedup-skipped or
+    # skipped on error) in its meta.
+    expected_agg_ids = {
+        agg_id
+        for j in finished_recalc
+        if (agg_id := _meta(j).get("aggregation_job_id")) is not None
+    }
+    aggregations_done = all(
+        agg_id in aggregation_jobs and _is_finished(aggregation_jobs[agg_id])
+        for agg_id in expected_agg_ids
+    )
+    phase3_done = phase2_done and aggregations_done
+
+    if not phase1_done:
+        phase = 1
+    elif not phase2_done:
+        phase = 2
+    else:
+        phase = 3
+
+    return PipelineProgress(
+        phase=phase,
+        phases_total=3,
+        phase_label=_PHASE_LABELS[phase],
+        done=phase3_done or has_error,
+        has_error=has_error,
+    )

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -306,8 +306,15 @@ async def _chain_recalc_for_stale(
     # ``emission_recalc_handler`` reads scope from the row's columns
     # (data_entry_type_id, year), not from meta.config, so the config
     # is intentionally minimal.
+    # Count only children this pipeline actually created — a
+    # dedup-skipped target (``chain_job`` returns ``None``) means an
+    # earlier active pipeline already owns that recalc, so it must NOT
+    # count toward THIS pipeline's expected fan-out (the
+    # pipeline-progress contract keys phase 2 off this number; counting
+    # skipped targets would make completion wait forever).
+    chained = 0
     for row in targets:
-        await chain_job(
+        child_id = await chain_job(
             job,
             job_type="emission_recalc",
             module_type_id=row["module_type_id"],
@@ -316,11 +323,13 @@ async def _chain_recalc_for_stale(
             session=session,
             dedup_config=EMISSION_RECALC_DEDUP,
         )
+        if child_id is not None:
+            chained += 1
     logger.info(
-        f"factor_ingest job {job.id}: chained {len(targets)} emission_recalc "
-        f"child(ren) for year={year}"
+        f"factor_ingest job {job.id}: chained {chained}/{len(targets)} "
+        f"emission_recalc child(ren) for year={year}"
     )
-    return len(targets)
+    return chained
 
 
 # ---------------------------------------------------------------------------
@@ -415,20 +424,30 @@ async def _chain_emission_recalc_for_data_ingest(
         )
         return 0
 
+    # ``dedup_config`` (Fix #1219): a pre-existing active recalc for
+    # this scope now yields a logged no-op (``chain_job`` returns
+    # ``None``) instead of an uncaught IntegrityError that poisoned the
+    # job_session and stranded the parent.  Mirror the factor path.
+    # Count only owned children — see ``_chain_recalc_for_stale``.
+    chained = 0
     for row in targets:
-        await chain_job(
+        child_id = await chain_job(
             job,
             job_type="emission_recalc",
             module_type_id=row["module_type_id"],
             data_entry_type_id=row["data_entry_type_id"],
             year=year,
             session=session,
+            dedup_config=EMISSION_RECALC_DEDUP,
         )
+        if child_id is not None:
+            chained += 1
     logger.info(
-        f"data ingest job {job.id}: chained {len(targets)} emission_recalc "
-        f"child(ren) for module_type_id={job.module_type_id}/year={year}"
+        f"data ingest job {job.id}: chained {chained}/{len(targets)} "
+        f"emission_recalc child(ren) for "
+        f"module_type_id={job.module_type_id}/year={year}"
     )
-    return len(targets)
+    return chained
 
 
 __all__ = [

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -222,6 +222,18 @@ async def run_job(job_id: int) -> None:
                 metadata = {}
                 result = IngestionResult.ERROR
                 handler_succeeded = False
+                # The handler may have left ``job_session`` in a
+                # PendingRollbackError state — e.g. an uncaught
+                # IntegrityError from a chain_job INSERT that tripped a
+                # partial unique index.  Without this rollback the
+                # preempt-check (``get_job_by_id``) and ``finish_job``
+                # below both run on the poisoned session, re-raise, and
+                # escape this ``except`` — so the job never reaches
+                # FINISHED+ERROR and stays RUNNING forever, with the
+                # zombie row self-propagating the stall to every job
+                # that touches it.  A clean rollback restores the
+                # session for the terminal-state write.
+                await job_session.rollback()
 
             if handler_aborted:
                 # We no longer own the lock (or are about to lose it):

--- a/backend/tests/unit/services/test_pipeline_progress.py
+++ b/backend/tests/unit/services/test_pipeline_progress.py
@@ -1,0 +1,171 @@
+"""Issue #1219 — server-authoritative pipeline progress.
+
+These cover the contract the SSE stream + ``GET /pipelines/{id}`` rely
+on so the UI never flashes "success" on a half-done pipeline, and the
+zombie/two-recalc scenarios that motivated the fix.
+"""
+
+from types import SimpleNamespace
+
+from app.models.data_ingestion import IngestionResult, IngestionState
+from app.services.pipeline_progress import compute_pipeline_progress
+
+S = IngestionState
+R = IngestionResult
+
+
+def _job(job_id, job_type, state, *, result=None, meta=None):
+    """Minimal duck-typed DataIngestionJob for the pure progress fn."""
+    return SimpleNamespace(
+        id=job_id,
+        job_type=job_type,
+        state=state,
+        result=result,
+        meta=meta or {},
+    )
+
+
+def _parent(state, *, recalc_chained=None, result=None):
+    meta = {}
+    if recalc_chained is not None:
+        meta["recalc_jobs_chained"] = recalc_chained
+    return _job(1, "csv_ingest", state, result=result, meta=meta)
+
+
+def _recalc(job_id, state, *, agg_id=None, result=None):
+    meta = {"parent_job_id": 1}
+    if agg_id is not None:
+        meta["aggregation_job_id"] = agg_id
+    return _job(job_id, "emission_recalc", state, result=result, meta=meta)
+
+
+def _agg(job_id, state, *, result=None):
+    return _job(job_id, "aggregation", state, result=result, meta={"parent_job_id": 2})
+
+
+def test_parent_not_started_is_phase_1_not_done():
+    p = compute_pipeline_progress([_parent(S.NOT_STARTED)])
+    assert p["phase"] == 1
+    assert p["phase_label"] == "data"
+    assert p["done"] is False
+    assert p["has_error"] is False
+
+
+def test_parent_only_snapshot_does_not_prematurely_complete():
+    """THE core UX bug: parent FINISHED, children not yet INSERTed.
+
+    Old "all snapshot jobs FINISHED" logic flashed the module green
+    here. The expected-fan-out contract keeps it at phase 2.
+    """
+    p = compute_pipeline_progress([_parent(S.FINISHED, recalc_chained=2)])
+    assert p["phase"] == 2
+    assert p["done"] is False
+
+
+def test_recalc_chained_zero_completes_after_parent():
+    """Intentional edge: every recalc target dedup-skipped (owned by an
+    earlier pipeline) or unknown module → recalc_jobs_chained == 0 ⇒
+    phases 2/3 vacuously satisfied once the parent is done."""
+    p = compute_pipeline_progress([_parent(S.FINISHED, recalc_chained=0)])
+    assert p["phase"] == 3
+    assert p["done"] is True
+    assert p["has_error"] is False
+
+
+def test_two_recalc_partial_is_not_done():
+    """Multi-det upload fans out 2 recalcs; only 1 finished → phase 2."""
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=2),
+        _recalc(2, S.FINISHED, agg_id=None),
+        _recalc(3, S.RUNNING),
+    ]
+    p = compute_pipeline_progress(jobs)
+    assert p["phase"] == 2
+    assert p["done"] is False
+
+
+def test_zombie_recalc_keeps_pipeline_unfinished():
+    """A recalc child stuck RUNNING forever (the zombie) must keep the
+    pipeline reported as in-progress — never falsely 'done'."""
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=1),
+        _recalc(2, S.RUNNING),  # zombie
+    ]
+    p = compute_pipeline_progress(jobs)
+    assert p["phase"] == 2
+    assert p["done"] is False
+    assert p["has_error"] is False
+
+
+def test_aggregation_pending_is_phase_3_not_done():
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=1),
+        _recalc(2, S.FINISHED, agg_id=99),
+        _agg(99, S.RUNNING),
+    ]
+    p = compute_pipeline_progress(jobs)
+    assert p["phase"] == 3
+    assert p["done"] is False
+
+
+def test_full_success_is_done():
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=2),
+        _recalc(2, S.FINISHED, agg_id=99),
+        _recalc(3, S.FINISHED, agg_id=100),
+        _agg(99, S.FINISHED),
+        _agg(100, S.FINISHED),
+    ]
+    p = compute_pipeline_progress(jobs)
+    assert p["phase"] == 3
+    assert p["done"] is True
+    assert p["has_error"] is False
+
+
+def test_recalc_with_no_aggregation_chained_still_completes():
+    """A recalc that didn't chain an aggregation (dedup-skip / WARNING
+    with module known but agg already pending) records
+    ``aggregation_job_id=None`` — phase 3 must not wait on it."""
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=1),
+        _recalc(2, S.FINISHED, agg_id=None),
+    ]
+    p = compute_pipeline_progress(jobs)
+    assert p["done"] is True
+
+
+def test_parent_error_is_terminal():
+    jobs = [_parent(S.FINISHED, recalc_chained=0, result=R.ERROR)]
+    p = compute_pipeline_progress(jobs)
+    assert p["has_error"] is True
+    assert p["done"] is True
+
+
+def test_recalc_error_is_terminal_even_without_aggregation():
+    """Recalc FINISHED+ERROR → no aggregation chained; pipeline is
+    done-with-error, UI must stop the spinner and show failure."""
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=1),
+        _recalc(2, S.FINISHED, result=R.ERROR),
+    ]
+    p = compute_pipeline_progress(jobs)
+    assert p["has_error"] is True
+    assert p["done"] is True
+
+
+def test_legacy_no_counter_falls_back_to_present_children():
+    """Non-ingest / legacy root without ``recalc_jobs_chained``: done
+    when every recalc row present is FINISHED (best-effort)."""
+    parent = _job(1, "factor_ingest", S.FINISHED, meta={})
+    jobs = [parent, _recalc(2, S.FINISHED, agg_id=None)]
+    p = compute_pipeline_progress(jobs)
+    assert p["done"] is True
+
+    jobs_pending = [parent, _recalc(2, S.RUNNING)]
+    assert compute_pipeline_progress(jobs_pending)["done"] is False
+
+
+def test_empty_pipeline_is_safe():
+    p = compute_pipeline_progress([])
+    assert p["phase"] == 1
+    assert p["done"] is False

--- a/backend/tests/unit/tasks/test_ingestion_handlers.py
+++ b/backend/tests/unit/tasks/test_ingestion_handlers.py
@@ -656,3 +656,83 @@ async def test_csv_ingest_handler_skips_fan_out_when_module_type_id_missing():
     mock_chain.assert_not_awaited()
     assert meta["recalc_jobs_chained"] == 0
     assert meta["result"] == IngestionResult.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Issue #1219 — dedup on the csv/api fan-out + owned-child count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_csv_ingest_fan_out_passes_dedup_config():
+    """Issue #1219 Fix 2: the csv/api recalc fan-out must pass
+    ``dedup_config=EMISSION_RECALC_DEDUP`` (it previously did not, so a
+    pre-existing active recalc raised an uncaught IntegrityError that
+    poisoned the job_session and stranded the parent)."""
+    from app.tasks._chain import EMISSION_RECALC_DEDUP
+
+    job = _make_job(
+        module_type_id=5,
+        data_entry_type_id=11,
+        year=2025,
+        meta={"provider_name": "FakeCSV"},
+    )
+    _, fake_class = _patch_provider(success=True)
+
+    with (
+        patch.object(
+            ingest_mod.ProviderFactory, "get_provider_class", return_value=fake_class
+        ),
+        patch.object(ingest_mod, "chain_job", new_callable=AsyncMock) as mock_chain,
+    ):
+        await ingest_mod.csv_ingest_handler(job, MagicMock(), MagicMock())
+
+    assert mock_chain.await_args.kwargs["dedup_config"] is EMISSION_RECALC_DEDUP
+
+
+@pytest.mark.asyncio
+async def test_csv_ingest_fan_out_counts_only_owned_children():
+    """Issue #1219 Fix 2b: a dedup-skipped target (``chain_job``
+    returns ``None`` — its recalc is owned by an earlier active
+    pipeline) must NOT count toward this pipeline's
+    ``recalc_jobs_chained``; otherwise the pipeline-progress contract
+    would wait forever for a child that lives under another pipeline.
+    """
+    from app.models.module_type import (
+        MODULE_TYPE_TO_DATA_ENTRY_TYPES,
+        ModuleTypeEnum,
+    )
+
+    module = ModuleTypeEnum.headcount
+    expected_dets = [d.value for d in MODULE_TYPE_TO_DATA_ENTRY_TYPES[module]]
+    assert len(expected_dets) >= 2  # multi-det module — fan-out > 1
+
+    job = _make_job(
+        module_type_id=module.value,
+        data_entry_type_id=None,
+        year=2025,
+        meta={"provider_name": "FakeCSV"},
+    )
+    _, fake_class = _patch_provider(success=True)
+
+    # First det: created (returns an id). Remaining dets: dedup-skipped
+    # (return None) — already owned by an earlier active pipeline.
+    returns = [42] + [None] * (len(expected_dets) - 1)
+
+    with (
+        patch.object(
+            ingest_mod.ProviderFactory, "get_provider_class", return_value=fake_class
+        ),
+        patch.object(
+            ingest_mod,
+            "chain_job",
+            new_callable=AsyncMock,
+            side_effect=returns,
+        ) as mock_chain,
+    ):
+        meta = await ingest_mod.csv_ingest_handler(job, MagicMock(), MagicMock())
+
+    # All dets attempted, but only the one owned child counts.
+    assert mock_chain.await_count == len(expected_dets)
+    assert meta["recalc_jobs_chained"] == 1
+    assert meta["result"] == IngestionResult.SUCCESS

--- a/backend/tests/unit/tasks/test_runner.py
+++ b/backend/tests/unit/tasks/test_runner.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import PendingRollbackError
 
 from app.models.data_ingestion import (
     IngestionResult,
@@ -365,6 +366,88 @@ async def test_run_job_handler_raise_with_preemption_skips_state_update():
     # longer own the row, even though the handler raised.
     repo.update_ingestion_job.assert_not_called()
     repo.finish_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_job_handler_poisons_job_session_still_marks_error():
+    """Issue #1219 regression — the CORE bug.
+
+    When a handler raises an exception that left ``job_session`` in a
+    PendingRollbackError state (e.g. an uncaught IntegrityError from a
+    chain_job INSERT tripping ``uq_emission_recalc_active``), the
+    runner must roll back ``job_session`` BEFORE the preempt-check so
+    ``get_job_by_id`` / ``finish_job`` can run and the job is durably
+    written FINISHED+ERROR.
+
+    Fidelity note: a bare ``raise IntegrityError`` does NOT reproduce
+    the bug — the handler ``except`` already swallows that. The bug is
+    that the *next* DB call on the poisoned session re-raises and
+    escapes. So this test makes the post-handler ``get_job_by_id``
+    raise ``PendingRollbackError`` UNTIL ``job_session.rollback()`` has
+    been awaited. Without the fix (no rollback) the third
+    ``get_job_by_id`` raises, ``run_job`` propagates it, and
+    ``finish_job`` is never called → the assertion below fails. With
+    the fix it succeeds and the job is marked ERROR.
+    """
+    job = _make_job()
+    job.locked_by = runner_mod.POD_ID
+    repo = _make_repo_returning(job)
+
+    captured_sessions: list[MagicMock] = []
+
+    @asynccontextmanager
+    async def _capture_session():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        session.add = MagicMock()
+        captured_sessions.append(session)
+        yield session
+
+    call_count = {"n": 0}
+
+    async def _get_job_by_id(_job_id: int):
+        call_count["n"] += 1
+        # Calls 1 (pre-claim) and 2 (post-claim refetch) are clean.
+        if call_count["n"] < 3:
+            return job
+        # Call 3 is the post-handler preempt-check, on what may be a
+        # poisoned job_session. job_session is captured_sessions[0].
+        job_session = captured_sessions[0]
+        if job_session.rollback.await_count == 0:
+            raise PendingRollbackError(
+                "This Session's transaction has been rolled back due to "
+                "a previous exception during flush."
+            )
+        return job
+
+    repo.get_job_by_id = AsyncMock(side_effect=_get_job_by_id)
+
+    @register("test_job")
+    async def _handler(j, js, ds) -> dict:
+        # Simulate an uncaught IntegrityError that poisoned the
+        # session — the message mirrors the production stack.
+        raise RuntimeError(
+            'duplicate key value violates unique constraint "uq_emission_recalc_active"'
+        )
+
+    with (
+        patch.object(runner_mod, "SessionLocal", _capture_session),
+        _patch_heartbeat(),
+        patch.object(runner_mod, "DataIngestionRepository", return_value=repo),
+    ):
+        await runner_mod.run_job(1)
+
+    job_session, data_session = captured_sessions
+    # The poisoned job_session was rolled back before the preempt-check.
+    job_session.rollback.assert_awaited()
+    data_session.rollback.assert_awaited()
+    # And the job was durably finalized FINISHED+ERROR — NOT left
+    # stuck RUNNING (the zombie-propagation defect).
+    repo.finish_job.assert_awaited_once()
+    _, kwargs = repo.finish_job.call_args
+    assert kwargs["result"] == IngestionResult.ERROR
+    assert "uq_emission_recalc_active" in kwargs["status_message"]
 
 
 # chain_job tests live in ``test_chain.py``.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,8 +41,8 @@ build-docs: ## Build documentation
 serve-docs: ## Serve documentation with live reload
 	UV_NO_ISOLATION=1 uv run mkdocs serve --dirtyreload --watch src --watch mkdocs.yml
 
-.PHONY: clean-docs
-clean-docs: ## Clean built documentation
+.PHONY: clean
+clean: ## Clean built documentation
 	rm -rf site/
 
 .PHONY: clean-docker

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Persona Flows: frontend/01-overview/personas.md
       - Design Tokens: frontend/02-design-tokens.md
       - Quasar Bridge: frontend/quasar-bridge.md
+      - Error Monitoring: frontend/error-monitoring.md
       - Data Management:
           - Overview: frontend/data-management/index.md
           - Architecture: frontend/data-management/architecture.md

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12.7"
 dependencies = [
     "brotli>=1.2.0",
-    "mkdocs>=1.6.1",
+    "mkdocs>=1.6.1,<1.7.0",
     "mkdocs-awesome-pages-plugin>=2.9.3",
     "mkdocs-gen-files>=0.5.0",
     "mkdocs-git-authors-plugin>=0.10.0",

--- a/docs/src/architecture/13-cross-cutting-concerns.md
+++ b/docs/src/architecture/13-cross-cutting-concerns.md
@@ -80,4 +80,4 @@ Tracing is implemented with:
 - Request span propagation
 - Service dependency mapping
 
-For detailed observability information, see [Infrastructure Monitoring](../infra/01-overview.md#monitoring--observability).
+For detailed observability information, see [Infrastructure Monitoring](../infra/01-overview.md#monitoring--observability). For client-side error tracking via self-hosted GlitchTip, see [Frontend Error Monitoring](../frontend/error-monitoring.md).

--- a/docs/src/architecture/release-runbook.md
+++ b/docs/src/architecture/release-runbook.md
@@ -12,11 +12,12 @@ A release is two ordered promotions — do the real release first, then the end-
 
 ```mermaid
 graph LR
-    S1[stage] -->|PR + merge| M[main]
-    M -->|Tag and Release + v*.*.* deploy| P[prod]
-    M -->|sync back| S1 --> D[dev]
-    D2[dev] -->|bump + PR + merge| S2[stage]
+    S1[stage] -->|1. PR + merge - sprint n-1| M[main]
+    M -->|Tag and Release + v*.*.* deploy| P[prod env]
+    M -->|2. Sync back| S1 -->|3. Sync back| D[dev]
+    D2[dev] -->|4. PR + merge - sprint n| S2[stage]
     S2 -->|Generate Changelog + deploy| E[stage env]
+    S2 -->|5. Sync back| D2
 ```
 
 ## 1. Real release: stage to main
@@ -42,9 +43,9 @@ Ships the sprint to stage and generates the changelog. `changelog.yml` ("Generat
 
 > **⚠️ Bump the version first.** Edit root `package.json` `version` (e.g. `0.10.0`) and commit on `dev` **before** opening the PR — otherwise the changelog is not generated with the right version.
 
-1. **Open the PR** `dev → stage`. Head **must** be `dev`. Example title: `chore: promote dev to stage (end of sprint 7) (#770)`:
+1. **Open the PR** `dev → stage`. Head **must** be `dev`. Example title: `chore: promote dev to stage (end of sprint 7)`:
    ```bash
-   gh pr create --base stage --head dev --title "chore: promote dev to stage (end of sprint N) (#<issue>)"
+   gh pr create --base stage --head dev --title "chore: promote dev to stage (end of sprint N)"
    ```
 2. **Merge the PR.** `deploy.yml` deploys to **stage**; "Generate Changelog" commits `CHANGELOG.md` to `stage`. Verify: Actions → "deploy" and "Generate Changelog" green; `CHANGELOG.md` updated on `stage`.
 3. **Verify in ArgoCD** that stage is healthy; fix any issues — see [Troubleshooting](#troubleshooting-deployment).
@@ -72,6 +73,11 @@ If ArgoCD shows the environment unhealthy or on the wrong version, the usual sus
 > **🚨 Destructive.** `make db-drop` deletes the target database. First open `backend/.env` and confirm `DB_URL` points to the environment you intend, and take a DB snapshot/backup before dropping — the wrong target on prod is unrecoverable.
 
 Until v1.0.0, migrations don't migrate data, so rebuild and reseed. Get the target `DB_URL` from the secrets manager, set it in `backend/.env`, then from `backend/`:
+
+Pre-requisites:
+
+- Make sure `stage` branch is up-to-date: `git checkout stage && git pull origin stage`
+- Have `backend/.env` with stage's `DB_URL`
 
 ```bash
 make db-drop && make db-create && make db-migrate && make seed-data

--- a/docs/src/frontend/error-monitoring.md
+++ b/docs/src/frontend/error-monitoring.md
@@ -1,0 +1,85 @@
+---
+status: delivered
+last_updated: 2026-05-19
+summary: Frontend error monitoring with self-hosted GlitchTip (Sentry-compatible).
+---
+
+# Frontend Error Monitoring
+
+The frontend reports uncaught JavaScript errors, server 5xx
+responses, and a 5% sample of route navigations to **GlitchTip**,
+EPFL ENAC-IT's self-hosted, Sentry-compatible error tracker. We use
+GlitchTip rather than hosted Sentry so error data stays on EPFL
+infrastructure. Wired in issue #344 — see the
+[implementation plan](../implementation-plans/344-frontend-error-monitoring.md).
+
+## Access
+
+- **Dashboard:** [enac-it-glitchtip.epfl.ch](https://enac-it-glitchtip.epfl.ch).
+  Sign in with a dedicated GlitchTip account (not EPFL SSO). Ask
+  **nicdub** for an account and project membership.
+- **Runbook:** ENAC-IT's
+  [Sentry self-host via GlitchTip](https://www.notion.so/enacit4r/Sentry-Self-Host-via-Glitchtip-35e53a25eee880448351e452829897cd)
+  Notion page — how the server is operated.
+- **Product docs:** [glitchtip.com/documentation](https://glitchtip.com/documentation).
+- **Project DSN:** stored in
+  [Infisical](https://enac-it-secrets.epfl.ch/project/17dcca22-b05d-4d28-b7aa-c2770018f5be/secrets/overview?secretPath=%2Fepfl-enac%2Fglitchtip),
+  never in the repo.
+
+## How errors reach GlitchTip
+
+`@sentry/vue` is lazy-loaded so the ~900 KiB SDK stays off the
+critical path. Four capture paths feed it:
+
+- Vue lifecycle/render errors via `app.config.errorHandler`.
+- Synchronous browser errors via the `window` `error` listener.
+- Unhandled promise rejections via the `unhandledrejection` listener.
+- HTTP 5xx responses via `captureMessage` in
+  [`src/api/http.ts:190`](https://github.com/epfl-enac/co2-calculator/blob/main/frontend/src/api/http.ts).
+
+Noise (ResizeObserver loops, aborted fetches) is filtered. See
+[`src/boot/sentry.ts`](https://github.com/epfl-enac/co2-calculator/blob/main/frontend/src/boot/sentry.ts)
+for the full list and the `tracesSampleRate: 0.05` setting.
+
+## Configuring a deployment
+
+Two env vars drive it, resolved at runtime in
+[`src/config/runtime.ts`](https://github.com/epfl-enac/co2-calculator/blob/main/frontend/src/config/runtime.ts):
+
+| Variable          | Purpose                                             |
+| ----------------- | --------------------------------------------------- |
+| `APP_SENTRY_DSN`  | Project DSN. Empty/unset → Sentry init skipped.     |
+| `APP_ENVIRONMENT` | Event label (`development`, `stage`, `production`). |
+
+> **⚠️ Empty DSN disables reporting.** `helm/values.yaml` ships
+> `APP_SENTRY_DSN: ""`; the real DSN is set per cluster in the ops
+> repo (`enack8s-app-config` / `openshift-app-config`), not here.
+
+Set them per context:
+
+- **Production/stage:** pod env via Helm `frontend.env`, overridden
+  in the ops repo. The same bundle ships everywhere; values are
+  injected at container startup, not baked in.
+- **Local dev:** copy `frontend/.env.example` to `.env.local` and
+  fill `APP_SENTRY_DSN`.
+- **docker-compose:** export `APP_SENTRY_DSN` in your shell before
+  `docker compose up`.
+
+Under the pod's `readOnlyRootFilesystem`, these values are injected
+at startup into `/tmp/injectEnv.js` and read from
+`window.injectedEnvVariable` — see the
+[implementation plan](../implementation-plans/344-frontend-error-monitoring.md)
+for the runtime-injection design.
+
+## Troubleshooting
+
+- **No events in GlitchTip:** open the deployed app, load
+  `/injectEnv.js` in the browser, and confirm `APP_SENTRY_DSN` is a
+  non-empty value. Empty → ops repo override is missing.
+- **Stack traces are minified:** known limitation. Source maps are
+  disabled (`sourcemap: false`) to keep the bundle small; traces show
+  line:column only. Reading minified frames is the current tradeoff.
+
+**Next step:** to enable reporting on a new environment, request a
+GlitchTip project from nicdub, then add the DSN to that cluster's
+ops-repo values — do not commit it here.

--- a/docs/src/implementation-plans/1219-stuck-jobs-and-pipeline-progress.md
+++ b/docs/src/implementation-plans/1219-stuck-jobs-and-pipeline-progress.md
@@ -68,7 +68,12 @@ gained a `progress` field.
 
 Frontend: `pipelineStream.ts` carries `progress`; `isFinishedFor`
 trusts `progress.done` / `closed` (the old "all snapshot jobs
-FINISHED" heuristic is gone); `ModuleConfig.vue` shows
+FINISHED" _success_ heuristic is gone — but a `FINISHED+ERROR` job
+still counts as terminal, matching the backend's `done ⇔ phase3 OR
+any FINISHED+ERROR` rule, so an errored pipeline shows the failure
+badge even before an authoritative `progress` payload). `seedFromSnapshot`
+forwards the one-shot endpoint's `progress` so the badge/card show the
+phase immediately on subscribe, not only after the first ~2s SSE poll. `ModuleConfig.vue` shows
 `Step N/3 · …` per phase.
 
 `ModuleConfig.vue` also `provide()`s the module's reactive
@@ -106,9 +111,10 @@ tests/unit/services/test_pipeline_progress.py tests/unit/tasks/test_chain.py`
   — 52 pass. The Fix-1 regression test simulates the
   `PendingRollbackError` state and is verified to fail when the
   rollback is reverted.
-- `frontend`: `tsc` clean; lint clean. Issue-#1219 Playwright case in
-  `tests/integration/pipeline-diagnostic-tooltip.spec.ts` (runs in CI
-  — needs the preview build).
+- `frontend`: `tsc` clean; lint clean. Playwright (rebuilt SPA):
+  `pipeline-diagnostic-tooltip.spec.ts` 8 passed / 1 skipped (incl.
+  the new Issue-#1219 case and the restored FINISHED+ERROR case);
+  `data-management.spec.ts` 14 passed / 1 skipped.
 - Pre-existing unrelated flake:
   `test_reference_data.py::test_reference_ingest_handler_is_registered`
   fails only under combined-suite ordering on clean `dev` (registry

--- a/docs/src/implementation-plans/1219-stuck-jobs-and-pipeline-progress.md
+++ b/docs/src/implementation-plans/1219-stuck-jobs-and-pipeline-progress.md
@@ -73,8 +73,8 @@ still counts as terminal, matching the backend's `done ⇔ phase3 OR
 any FINISHED+ERROR` rule, so an errored pipeline shows the failure
 badge even before an authoritative `progress` payload). `seedFromSnapshot`
 forwards the one-shot endpoint's `progress` so the badge/card show the
-phase immediately on subscribe, not only after the first ~2s SSE poll. `ModuleConfig.vue` shows
-`Step N/3 · …` per phase.
+phase immediately on subscribe, not only after the first ~2s SSE poll.
+`ModuleConfig.vue`'s badge shows `Step N/3 · …` per phase.
 
 `ModuleConfig.vue` also `provide()`s the module's reactive
 `pipelineProgress`; `ModuleUploadsSection.vue` injects it and threads

--- a/docs/src/implementation-plans/1219-stuck-jobs-and-pipeline-progress.md
+++ b/docs/src/implementation-plans/1219-stuck-jobs-and-pipeline-progress.md
@@ -1,0 +1,115 @@
+---
+status: delivered
+issue: 1219
+last_updated: 2026-05-19
+title: "1219 Stuck ingestion/recalc jobs + premature pipeline 'success'"
+summary: "Stage incident: a zombie emission_recalc row tripped uq_emission_recalc_active, the IntegrityError poisoned the runner's job_session, and the job never reached FINISHED — self-propagating the stall. Fixes runner session resilience, adds dedup to the csv/api fan-out, and makes pipeline completion server-authoritative with a 3-phase UI."
+---
+
+# 1219 — Stuck jobs + premature pipeline success
+
+## Context
+
+On **stage** (2026-05-19) a CSV equipment ingest (job 112) wrote its
+50 072 rows, then crashed in the post-success fan-out with
+`UniqueViolation: uq_emission_recalc_active (4, 10, 2025)`.
+
+The duplicate key was a symptom. Root cause chain:
+
+1. A prior `emission_recalc` for `(4,10,2025)` was stuck in an active
+   state (zombie) — its work done but its row never finalized.
+2. `uq_emission_recalc_active` is partial over
+   `state IN (NOT_STARTED, QUEUED, RUNNING)`; the zombie permanently
+   blocks new recalcs for that scope.
+3. The failing INSERT raised `IntegrityError` on the runner's
+   `job_session`; the runner never rolled it back, so the next query
+   (`get_job_by_id`) raised `PendingRollbackError`, escaped the
+   handler `except`, and `finish_job` was never called → job 112 also
+   stuck. The defect self-propagates.
+4. Separately, the UI showed a module green as soon as the parent
+   upload finished — before recalc/aggregation children ran.
+
+Root cause #3 is the single defect that both creates zombies and
+spreads the stall. Adjacent to [#1057 follow-ups](310-d-architecture-followups.md)
+(referenced, not superseded).
+
+## What shipped
+
+### Fix 1 — runner survives a poisoned `job_session` (core)
+
+`backend/app/tasks/runner.py`: the handler-exception block now
+`await job_session.rollback()` before the preempt-check / `finish_job`.
+Every handler failure now durably writes `FINISHED + ERROR` (visible
+in the UI) instead of stranding the job `RUNNING`.
+
+### Fix 2 / 2b — dedup + owned-child count on the csv/api fan-out
+
+`backend/app/tasks/ingestion_tasks.py`:
+`_chain_emission_recalc_for_data_ingest` now passes
+`dedup_config=EMISSION_RECALC_DEDUP` (mirrors the factor path) — a
+pre-existing active recalc is a logged no-op, not an uncaught
+`IntegrityError`. Both fan-out helpers now count only children they
+actually created (`chain_job` returning non-`None`); a dedup-skipped
+target is owned by an earlier pipeline and excluded from
+`recalc_jobs_chained`.
+
+### Fix 3 — server-authoritative completion + 3-phase UI
+
+`backend/app/services/pipeline_progress.py` (`compute_pipeline_progress`):
+derives phase/done/error from the _expected_ fan-out recorded in job
+meta (`recalc_jobs_chained`, `aggregation_job_id`), not from a
+possibly-incomplete snapshot. Phases: **data → emissions →
+aggregation**. `done` ⇔ phase 3 satisfied **or** any job
+`FINISHED+ERROR`.
+
+Wired into `data_sync.py`: the SSE stream closes on `progress.done`
+and ships `progress` in every payload; `GET /sync/pipelines/{id}`
+gained a `progress` field.
+
+Frontend: `pipelineStream.ts` carries `progress`; `isFinishedFor`
+trusts `progress.done` / `closed` (the old "all snapshot jobs
+FINISHED" heuristic is gone); `ModuleConfig.vue` shows
+`Step N/3 · …` per phase.
+
+`ModuleConfig.vue` also `provide()`s the module's reactive
+`pipelineProgress`; `ModuleUploadsSection.vue` injects it and threads
+it through `UploadCardData` / `UploadCardFactors` into the shared
+`UploadCard.vue`, which renders the live `Step N/3 · …` phase line per
+card while the pipeline runs (hidden once done/errored). The pipeline
+is module-scoped, so every card in a module reflects the same phase —
+a single SSE subscription, no per-card streams.
+
+> **Intentional edge case:** if every recalc target was dedup-skipped
+> (an earlier active pipeline owns them), `recalc_jobs_chained == 0`,
+> so the badge advances to "Aggregated" once the parent finishes. The
+> recalc work _is_ dispatched — under the owning pipeline's id.
+
+### Remediation (manual, post-deploy on stage)
+
+Use `POST /v1/sync/jobs/{id}/cancel` (immediate `FINISHED+ERROR`, no
+stale wait) on the zombie recalc + job 112 and any 30-min-stale
+siblings. Inspect first:
+
+```sql
+SELECT id, job_type, state, module_type_id, data_entry_type_id, year, locked_at
+FROM data_ingestion_jobs
+WHERE state IN ('NOT_STARTED','QUEUED','RUNNING')
+  AND (locked_at IS NULL OR locked_at < now() - interval '30 minutes')
+ORDER BY id;
+```
+
+## Verification
+
+- `backend`: `uv run pytest tests/unit/tasks/test_runner.py
+tests/unit/tasks/test_ingestion_handlers.py
+tests/unit/services/test_pipeline_progress.py tests/unit/tasks/test_chain.py`
+  — 52 pass. The Fix-1 regression test simulates the
+  `PendingRollbackError` state and is verified to fail when the
+  rollback is reverted.
+- `frontend`: `tsc` clean; lint clean. Issue-#1219 Playwright case in
+  `tests/integration/pipeline-diagnostic-tooltip.spec.ts` (runs in CI
+  — needs the preview build).
+- Pre-existing unrelated flake:
+  `test_reference_data.py::test_reference_ingest_handler_is_registered`
+  fails only under combined-suite ordering on clean `dev` (registry
+  snapshot); passes in isolation. Out of scope.

--- a/docs/src/implementation-plans/344-frontend-error-monitoring.md
+++ b/docs/src/implementation-plans/344-frontend-error-monitoring.md
@@ -1,0 +1,68 @@
+---
+status: delivered
+issue: 344
+last_updated: 2026-05-19
+title: "Frontend Error Monitoring via Self-Hosted GlitchTip"
+summary: Wire @sentry/vue to EPFL's self-hosted GlitchTip with runtime DSN injection under a read-only root filesystem.
+---
+
+# Frontend Error Monitoring via Self-Hosted GlitchTip
+
+Backfilled after delivery (work shipped without a plan-mode file).
+Records the delivered shape so future work builds on it. User-facing
+operation lives in
+[Frontend Error Monitoring](../frontend/error-monitoring.md) — this
+plan does not restate it.
+
+## Goal
+
+Capture uncaught frontend errors, server 5xx responses, and a route
+performance sample in a Sentry-compatible tracker, without shipping
+per-environment secrets in the bundle or breaking the hardened
+read-only pod.
+
+## Constraints
+
+- **One bundle, many environments.** The same image ships to
+  dev/stage/prod, so the DSN must be injected at runtime, not built in.
+- **`readOnlyRootFilesystem: true`.** Nothing may write to the image
+  filesystem at startup.
+- **Performance budget.** The Sentry SDK (~900 KiB) must not regress
+  the Lighthouse score gated in CI.
+- **No hosted Sentry.** Error data stays on EPFL infrastructure
+  (GlitchTip at `enac-it-glitchtip.epfl.ch`).
+
+## Delivered design
+
+1. **Runtime config resolution** — `src/config/runtime.ts` reads
+   `window.injectedEnvVariable` first, falling back to build-time
+   `process.env`. `||` (not `??`) so an empty pod env disables Sentry
+   instead of crashing init.
+2. **Runtime DSN injection** — `docker/entrypoint.sh` writes `APP_*`
+   env vars to `/tmp/injectEnv.js` at container startup; `nginx.conf`
+   aliases `/injectEnv.js` to `/tmp` with no-cache headers. `/tmp` is
+   a writable `emptyDir`, satisfying the read-only root.
+3. **Lazy SDK** — `@sentry/vue` is dynamic-imported in
+   `src/boot/sentry.ts` and `src/api/http.ts`, keeping the SDK off the
+   critical path; with no DSN the chunk never loads.
+4. **Four capture paths** — Vue `errorHandler`, `window` `error`,
+   `unhandledrejection`, and HTTP 5xx via `captureMessage`. Noise
+   (ResizeObserver, aborts) is filtered; `tracesSampleRate: 0.05`.
+5. **Helm wiring** — `helm/values.yaml` `frontend.env` exposes
+   `APP_SENTRY_DSN` (empty default) and `APP_ENVIRONMENT`; real values
+   are set per cluster in the ops repo. `docker-compose.yml` mirrors
+   the read-only fs + tmpfs so regressions surface locally.
+
+## Known tradeoff
+
+Source maps are disabled (`sourcemap: false`) to hold the bundle
+budget — GlitchTip stack traces are minified (line:column only).
+Revisiting with hidden source maps + a CI upload step is a possible
+follow-up.
+
+## Outcome
+
+Delivered across commits `d557b7e2`, `ad543124`, `13934f78`,
+`8778dbd4`, `c0a9cb85`, `43bbeea0`. Lighthouse CI threshold lowered to
+0.6 temporarily (`c0a9cb85`) pending a minification fix for the CI
+run; revisit before raising it back.

--- a/docs/src/infra/01-overview.md
+++ b/docs/src/infra/01-overview.md
@@ -311,6 +311,9 @@ spec:
 
 ## Monitoring & Observability
 
+Client-side JavaScript errors are tracked separately in self-hosted
+GlitchTip — see [Frontend Error Monitoring](../frontend/error-monitoring.md).
+
 ### Prometheus Metrics
 
 **Backend metrics** (`/metrics` endpoint):

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -26,7 +26,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
-    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs", specifier = ">=1.6.1,<1.7.0" },
     { name = "mkdocs-awesome-pages-plugin", specifier = ">=2.9.3" },
     { name = "mkdocs-gen-files", specifier = ">=0.5.0" },
     { name = "mkdocs-git-authors-plugin", specifier = ">=0.10.0" },

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -322,7 +322,7 @@ function recalculateScopeRects() {
             style: {
               fill: '#000000',
               text: t('charts-additional-category'),
-              font: '11px SuisseIntl',
+              font: 'italic 11px SuisseIntl',
             },
             silent: true,
           },

--- a/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { inject } from 'vue';
+import { computed, inject, type ComputedRef } from 'vue';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
 import { useModuleConfig } from 'src/composables/useModuleConfig';
 import { useRecalculation } from 'src/composables/useRecalculation';
 import {
@@ -32,6 +33,16 @@ const { recalcTypeRunning, getRecalcStatus, triggerTypeRecalculation } =
   useRecalculation({
     selectedYear: props.selectedYear,
   });
+
+// Issue #1219 — the module's authoritative pipeline progress, provided
+// by ModuleConfig (the single SSE subscriber). Shared by every card in
+// the module: the recalc/aggregation pipeline is module-scoped.
+const injectedPipelineProgress = inject<
+  ComputedRef<PipelineProgress | null>
+>('pipelineProgress');
+const pipelineProgress = computed<PipelineProgress | null>(
+  () => injectedPipelineProgress?.value ?? null,
+);
 
 const backofficeStore = useBackofficeDataManagement();
 
@@ -80,6 +91,7 @@ async function handleCancelJob(jobId: number) {
           <UploadCardFactors
             v-if="getImportRow(common).hasFactors"
             :row="getImportRow(common)"
+            :pipeline-progress="pipelineProgress"
             :on-download="downloadLastCsv"
             @upload="(row) => openDataEntryDialog(row, TargetType.FACTORS)"
             @recalculate="() => triggerTypeRecalculation(common)"
@@ -88,6 +100,7 @@ async function handleCancelJob(jobId: number) {
           <UploadCardData
             v-if="getImportRow(common).hasData"
             :row="getImportRow(common)"
+            :pipeline-progress="pipelineProgress"
             :recalc-running="
               recalcTypeRunning[
                 `${common.moduleTypeId}-${common.dataEntryTypeId}`

--- a/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
@@ -77,6 +77,14 @@ async function handleCancelJob(jobId: number) {
           {{ $t(common.labelKey) }}
         </div>
         <div class="row q-pb-md" style="gap: 1rem">
+          <UploadCardFactors
+            v-if="getImportRow(common).hasFactors"
+            :row="getImportRow(common)"
+            :on-download="downloadLastCsv"
+            @upload="(row) => openDataEntryDialog(row, TargetType.FACTORS)"
+            @recalculate="() => triggerTypeRecalculation(common)"
+            @cancel="handleCancelJob"
+          />
           <UploadCardData
             v-if="getImportRow(common).hasData"
             :row="getImportRow(common)"
@@ -88,14 +96,6 @@ async function handleCancelJob(jobId: number) {
             :recalc-status="getRecalcStatus(common)"
             :on-download="downloadLastCsv"
             @upload="(row) => openDataEntryDialog(row, TargetType.DATA_ENTRIES)"
-            @recalculate="() => triggerTypeRecalculation(common)"
-            @cancel="handleCancelJob"
-          />
-          <UploadCardFactors
-            v-if="getImportRow(common).hasFactors"
-            :row="getImportRow(common)"
-            :on-download="downloadLastCsv"
-            @upload="(row) => openDataEntryDialog(row, TargetType.FACTORS)"
             @recalculate="() => triggerTypeRecalculation(common)"
             @cancel="handleCancelJob"
           />

--- a/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
@@ -37,9 +37,8 @@ const { recalcTypeRunning, getRecalcStatus, triggerTypeRecalculation } =
 // Issue #1219 — the module's authoritative pipeline progress, provided
 // by ModuleConfig (the single SSE subscriber). Shared by every card in
 // the module: the recalc/aggregation pipeline is module-scoped.
-const injectedPipelineProgress = inject<
-  ComputedRef<PipelineProgress | null>
->('pipelineProgress');
+const injectedPipelineProgress =
+  inject<ComputedRef<PipelineProgress | null>>('pipelineProgress');
 const pipelineProgress = computed<PipelineProgress | null>(
   () => injectedPipelineProgress?.value ?? null,
 );

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -11,6 +11,7 @@ import type {
   SyncJobResponse,
 } from 'src/stores/backofficeDataManagement';
 import type { RecalculationStatusEntry } from 'src/stores/yearConfig';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
 
 interface Props {
   title: string;
@@ -28,6 +29,8 @@ interface Props {
   hasRecalcButton?: boolean;
   recalcStatus?: RecalculationStatusEntry;
   recalcRunning?: boolean;
+  /** Issue #1219 — module-scoped pipeline progress (null when idle). */
+  pipelineProgress?: PipelineProgress | null;
   hasComputedFactorButton?: boolean;
   computedFactorRunning?: boolean;
   isComputedFactorDisabled?: boolean;
@@ -46,6 +49,7 @@ const props = withDefaults(defineProps<Props>(), {
   hasRecalcButton: false,
   recalcStatus: undefined,
   recalcRunning: false,
+  pipelineProgress: null,
   hasComputedFactorButton: false,
   computedFactorRunning: false,
   isComputedFactorDisabled: false,
@@ -79,6 +83,22 @@ const apiRowsInserted = computed<number | undefined>(() => {
   const meta = props.apiJob?.meta as Record<string, unknown> | undefined;
   const inserted = meta?.inserted;
   return typeof inserted === 'number' ? inserted : undefined;
+});
+
+// Issue #1219 — live recalc-pipeline phase for this card. The pipeline
+// is module-scoped, so every card in the module reflects the same
+// phase while it runs (Data → Emissions → Aggregation). Hidden once
+// the pipeline is done or errored (the error surfaces via lastJob).
+const PIPELINE_PHASE_LABEL_KEYS: Record<string, string> = {
+  data: 'data_management_pipeline_phase_data',
+  emissions: 'data_management_pipeline_phase_emissions',
+  aggregation: 'data_management_pipeline_phase_aggregation',
+};
+
+const pipelinePhaseLabelKey = computed<string | null>(() => {
+  const p = props.pipelineProgress;
+  if (!p || p.done || p.has_error) return null;
+  return PIPELINE_PHASE_LABEL_KEYS[p.phase_label] ?? null;
 });
 
 function handleUpload() {
@@ -240,6 +260,16 @@ function handleCancel() {
           @click="handleCancel"
         />
       </div>
+    </div>
+
+    <!-- Issue #1219 — live recalc-pipeline phase (module-scoped) -->
+    <div
+      v-if="pipelinePhaseLabelKey"
+      class="row items-center text-caption q-mt-xs text-grey-7"
+      data-testid="pipeline-phase"
+    >
+      <q-spinner-rings color="grey" size="sm" class="q-mr-xs" />
+      <span>{{ $t(pipelinePhaseLabelKey) }}</span>
     </div>
 
     <!-- API ingestion status (success: small inline line; error: banner below) -->

--- a/frontend/src/components/molecules/data-management/UploadCardData.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardData.vue
@@ -6,6 +6,7 @@ import {
 } from 'src/stores/backofficeDataManagement';
 import type { ImportRow } from 'src/stores/backofficeDataManagement';
 import type { RecalculationStatusEntry } from 'src/stores/yearConfig';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
 import UploadCard from './UploadCard.vue';
 
 interface Props {
@@ -13,6 +14,8 @@ interface Props {
   isDisabled?: boolean;
   recalcRunning?: boolean;
   recalcStatus?: RecalculationStatusEntry;
+  /** Issue #1219 — module-scoped pipeline progress (null when idle). */
+  pipelineProgress?: PipelineProgress | null;
   onDownload?: (row: ImportRow, targetType: TargetType) => void;
 }
 
@@ -20,6 +23,7 @@ const props = withDefaults(defineProps<Props>(), {
   isDisabled: false,
   recalcRunning: false,
   recalcStatus: undefined,
+  pipelineProgress: null,
   onDownload: undefined,
 });
 
@@ -59,6 +63,7 @@ function handleRecalculate(item: ImportRow) {
     :has-recalc-button="row.hasFactors"
     :recalc-status="recalcStatus"
     :recalc-running="recalcRunning"
+    :pipeline-progress="pipelineProgress"
     @upload="handleUpload"
     @download="handleDownload"
     @recalculate="handleRecalculate"

--- a/frontend/src/components/molecules/data-management/UploadCardFactors.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardFactors.vue
@@ -7,6 +7,7 @@ import {
   IngestionState,
 } from 'src/stores/backofficeDataManagement';
 import type { ImportRow } from 'src/stores/backofficeDataManagement';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
 import UploadCard from './UploadCard.vue';
 
 interface Props {
@@ -15,6 +16,8 @@ interface Props {
   isDisabled?: boolean;
   computedFactorRunning?: boolean;
   anyComputedFactorRunning?: boolean;
+  /** Issue #1219 — module-scoped pipeline progress (null when idle). */
+  pipelineProgress?: PipelineProgress | null;
   onDownload?: (row: ImportRow, targetType: TargetType) => void;
 }
 
@@ -23,6 +26,7 @@ const props = withDefaults(defineProps<Props>(), {
   isDisabled: false,
   computedFactorRunning: false,
   anyComputedFactorRunning: false,
+  pipelineProgress: null,
   onDownload: undefined,
 });
 
@@ -77,6 +81,7 @@ function handleComputeFactors(item: ImportRow) {
     :last-job="row.lastFactorJob"
     :target-type="TargetType.FACTORS"
     :has-recalc-button="true"
+    :pipeline-progress="pipelineProgress"
     :has-computed-factor-button="hasComputedFactor"
     :computed-factor-running="computedFactorRunning"
     :is-computed-factor-disabled="props.anyComputedFactorRunning"

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -6,6 +6,7 @@ import { useRecalculation } from 'src/composables/useRecalculation';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { usePipelineStateStore } from 'src/stores/pipelineState';
 import { usePipelineStream } from 'src/composables/usePipelineStream';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
 import {
   TargetType,
   type ImportRow,
@@ -38,7 +39,7 @@ const { getModuleTypeIdFromName, isModuleEnabled, isModuleIncomplete } =
 // unified ``pipelineStateStore`` keyed by ``(module_type_id, year)``
 // — the SSE composable is responsible for the live state of that
 // pipeline once we know its id.
-const { subscribe, unsubscribe, isFinishedFor, hasErrorFor } =
+const { subscribe, unsubscribe, isFinishedFor, progressFor, hasErrorFor } =
   usePipelineStream();
 
 const currentPipelineId = computed<string | null>(() =>
@@ -83,6 +84,32 @@ const hasRecalcFailure = computed<boolean>(() => {
   if (!id) return false;
   return hasErrorFor(id).value;
 });
+
+// Issue #1219 — the badge now shows which of the 3 pipeline phases is
+// running (Data → Emissions → Aggregation) instead of a bare
+// "Recalculating…".  Falls back to the generic label in the brief
+// window before the first authoritative ``progress`` payload lands.
+const PHASE_LABEL_KEYS: Record<string, string> = {
+  data: 'data_management_pipeline_phase_data',
+  emissions: 'data_management_pipeline_phase_emissions',
+  aggregation: 'data_management_pipeline_phase_aggregation',
+};
+
+// Issue #1219 — the module owns the single pipeline SSE subscription;
+// expose its authoritative progress to the per-upload cards (provided
+// below) so each card shows the live recalc phase, not just whether
+// its own upload job is RUNNING.
+const pipelineProgress = computed<PipelineProgress | null>(() => {
+  const id = currentPipelineId.value;
+  return id ? progressFor(id).value : null;
+});
+
+const recalcBadgeLabelKey = computed<string>(
+  () =>
+    (pipelineProgress.value &&
+      PHASE_LABEL_KEYS[pipelineProgress.value.phase_label]) ??
+    'data_management_pipeline_recalculating',
+);
 
 // Plan 310-D — contextual recalculation button.
 //
@@ -223,6 +250,7 @@ provide('handleJobCompleted', handleJobCompleted);
 provide('handleJobProgressing', handleJobProgressing);
 provide('recalcTypeRunning', recalcTypeRunning);
 provide('triggerTypeRecalculation', triggerTypeRecalculation);
+provide('pipelineProgress', pipelineProgress);
 </script>
 
 <template>
@@ -288,8 +316,8 @@ provide('triggerTypeRecalculation', triggerTypeRecalculation);
               color="info"
               class="text-weight-medium cursor-help"
               tabindex="0"
-              :aria-label="$t('data_management_pipeline_recalculating')"
-              :label="$t('data_management_pipeline_recalculating')"
+              :aria-label="$t(recalcBadgeLabelKey)"
+              :label="$t(recalcBadgeLabelKey)"
               @focus="recalcTooltip?.show()"
               @blur="recalcTooltip?.hide()"
             >

--- a/frontend/src/composables/usePipelineStream.ts
+++ b/frontend/src/composables/usePipelineStream.ts
@@ -207,6 +207,7 @@ export function usePipelineStream() {
     // Re-export the store's reactive accessors so callers can compute
     // badge state without a separate ``useStore()`` call.
     isFinishedFor: (id: string) => store.isFinishedFor(id),
+    progressFor: (id: string) => store.progressFor(id),
     hasErrorFor: (id: string) => store.hasErrorFor(id),
     failedStatusMessagesFor: (id: string) => store.failedStatusMessagesFor(id),
     jobsFor: (id: string) => store.jobsFor(id),

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -617,6 +617,18 @@ export default {
     en: 'Last recalc failed',
     fr: 'Échec du dernier recalcul',
   },
+  data_management_pipeline_phase_data: {
+    en: 'Step 1/3 · Inserting data…',
+    fr: 'Étape 1/3 · Insertion des données…',
+  },
+  data_management_pipeline_phase_emissions: {
+    en: 'Step 2/3 · Recalculating emissions…',
+    fr: 'Étape 2/3 · Recalcul des émissions…',
+  },
+  data_management_pipeline_phase_aggregation: {
+    en: 'Step 3/3 · Aggregating…',
+    fr: 'Étape 3/3 · Agrégation…',
+  },
   data_management_recalculate_retry: {
     en: 'Retry recalculation',
     fr: 'Relancer le recalcul',

--- a/frontend/src/pages/app/WorkspaceSetupPage.vue
+++ b/frontend/src/pages/app/WorkspaceSetupPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
-import { useTimelineStore, useModuleStore } from 'src/stores/modules';
+import { useTimelineStore } from 'src/stores/modules';
+import { useYearConfigStore } from 'src/stores/yearConfig';
 import type { Unit } from 'src/stores/workspace';
 import { useRouter, useRoute } from 'vue-router';
 import LabSelectorItem from 'src/components/organisms/workspace-selector/LabSelectorItem.vue';
@@ -13,7 +14,7 @@ import { MODULES_LIST } from 'src/constant/modules';
 
 const workspaceStore = useWorkspaceStore();
 const timelineStore = useTimelineStore();
-const moduleStore = useModuleStore();
+const yearConfigStore = useYearConfigStore();
 const router = useRouter();
 const route = useRoute();
 
@@ -22,26 +23,23 @@ const selectedWorkspace = ref<'calculator' | 'simulator' | null>(null);
 // --- COMPUTED ---
 const unitsWithRoles = computed(() => workspaceStore.units);
 
-const yearsCount = computed(
-  () => workspaceStore.availableCarbonReportYears.length,
-);
-const hasMultipleYears = computed(
-  () => workspaceStore.availableCarbonReportYears.length > 1,
-);
-
+// Intersection: years globally opened (year-configuration `is_started`) AND
+// having a carbon report for this unit. tCO₂-eq comes from that report's
+// pre-computed `stats.total` (stored in kg, hence /1000).
 const yearRows = computed<YearData[]>(() => {
-  const emissionsMap = new Map<number, number>();
-  for (const row of moduleStore.state.yearlyValidatedEmissions) {
-    const year = row.year;
-    const tonnes = row.total_tonnes_co2eq;
-    emissionsMap.set(year, tonnes);
-  }
-  return workspaceStore.availableCarbonReportYears.map((year) => ({
-    year,
-    tco2eq: emissionsMap.get(year) ?? null,
-    status: workspaceStore.carbonReportForYear(year) ? 'complete' : 'missing',
-  }));
+  const startedYears = yearConfigStore.startedYears;
+  return workspaceStore.carbonReports
+    .filter((report) => startedYears.has(report.year))
+    .map((report) => ({
+      year: report.year,
+      tco2eq: report.stats?.total != null ? report.stats.total / 1000 : null,
+      status: 'complete',
+    }))
+    .sort((a, b) => a.year - b.year);
 });
+
+const yearsCount = computed(() => yearRows.value.length);
+const hasMultipleYears = computed(() => yearRows.value.length > 1);
 
 const selectedUnitAffiliations = computed(() => {
   const unit = workspaceStore.selectedUnit;
@@ -85,10 +83,7 @@ const handleUnitSelect = async (unit: Unit) => {
   workspaceStore.setUnit(unit);
   workspaceStore.setYear(null);
   selectedWorkspace.value = null;
-  await Promise.all([
-    workspaceStore.fetchCarbonReportsForUnit(unit.id),
-    moduleStore.getYearlyValidatedEmissions(unit.id),
-  ]);
+  await workspaceStore.fetchCarbonReportsForUnit(unit.id);
   // Show real module progress for the most recent report straight away
   const reports = workspaceStore.carbonReports;
   if (reports.length > 0) {
@@ -157,7 +152,11 @@ const reset = () => {
 onMounted(async () => {
   workspaceStore.reset();
   timelineStore.reset();
-  await workspaceStore.getUnits();
+  // Configured years are global (not unit-scoped) — fetch once per mount.
+  await Promise.all([
+    workspaceStore.getUnits(),
+    yearConfigStore.fetchConfiguredYears(),
+  ]);
 });
 </script>
 

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -35,11 +35,6 @@ interface ValidatedTotalsResponse {
   total_fte: number;
 }
 
-interface YearlyValidatedEmission {
-  year: number;
-  total_tonnes_co2eq: number;
-}
-
 export interface EmbodiedEnergyCategoryEntry {
   category: string;
   kg_co2eq: number;
@@ -302,9 +297,6 @@ export const useModuleStore = defineStore('modules', () => {
     validatedTotals: ValidatedTotalsResponse | null;
     loadingValidatedTotals: boolean;
     errorValidatedTotals: string | null;
-    yearlyValidatedEmissions: YearlyValidatedEmission[];
-    loadingYearlyValidatedEmissions: boolean;
-    errorYearlyValidatedEmissions: string | null;
     emissionBreakdown: EmissionBreakdownResponse | null;
     loadingEmissionBreakdown: boolean;
     errorEmissionBreakdown: string | null;
@@ -338,9 +330,6 @@ export const useModuleStore = defineStore('modules', () => {
     validatedTotals: null,
     loadingValidatedTotals: false,
     errorValidatedTotals: null,
-    yearlyValidatedEmissions: [],
-    loadingYearlyValidatedEmissions: false,
-    errorYearlyValidatedEmissions: null,
     emissionBreakdown: null,
     loadingEmissionBreakdown: false,
     errorEmissionBreakdown: null,
@@ -953,26 +942,6 @@ export const useModuleStore = defineStore('modules', () => {
     }
   }
 
-  async function getYearlyValidatedEmissions(unitId: number) {
-    state.loadingYearlyValidatedEmissions = true;
-    state.errorYearlyValidatedEmissions = null;
-    try {
-      const path = `unit/${encodeURIComponent(unitId)}/yearly-validated-emissions`;
-      const data = await api.get(path).json<YearlyValidatedEmission[]>();
-      state.yearlyValidatedEmissions = data;
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        state.errorYearlyValidatedEmissions = err.message ?? 'Unknown error';
-        state.yearlyValidatedEmissions = [];
-      } else {
-        state.errorYearlyValidatedEmissions = 'Unknown error';
-        state.yearlyValidatedEmissions = [];
-      }
-    } finally {
-      state.loadingYearlyValidatedEmissions = false;
-    }
-  }
-
   async function getItBreakdown(
     carbonReportId: number,
     excludeModules: number[] = [],
@@ -1037,7 +1006,6 @@ export const useModuleStore = defineStore('modules', () => {
     getTopClassBreakdown,
     getValidatedTotals,
     invalidateValidatedTotals,
-    getYearlyValidatedEmissions,
     getEmissionBreakdown,
     invalidateEmissionBreakdown,
     refreshEmissionBreakdownIfNeeded,

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -40,12 +40,33 @@ export interface PipelineJob {
 }
 
 /**
+ * Server-authoritative pipeline phase/done/error (Issue #1219).
+ * Mirrors the backend ``PipelineProgressResponse`` /
+ * ``app.services.pipeline_progress.PipelineProgress``.  The frontend
+ * trusts ``done`` here instead of inferring it from a
+ * possibly-incomplete job snapshot (the parent upload finishes before
+ * its recalc/aggregation children are even INSERTed).
+ */
+export interface PipelineProgress {
+  phase: number;
+  phases_total: number;
+  phase_label: 'data' | 'emissions' | 'aggregation';
+  done: boolean;
+  has_error: boolean;
+}
+
+/**
  * The wire payload of an ``event: pipeline-update`` SSE message.
  * Backend SSE endpoint: ``GET /v1/sync/pipelines/{pipeline_id}/stream``.
  */
 export interface PipelineUpdate {
   pipeline_id: string;
   jobs: PipelineJob[];
+  /**
+   * Authoritative progress (Issue #1219).  Present on every stream
+   * payload; the one-shot ``PipelineSnapshot`` seed carries it too.
+   */
+  progress?: PipelineProgress;
   /** Terminal marker — backend sets it on the very last event. */
   stream_closed?: boolean;
 }
@@ -60,10 +81,13 @@ export interface PipelineUpdate {
 export interface PipelineSnapshot {
   pipeline_id: string;
   jobs: PipelineJob[];
+  progress?: PipelineProgress;
 }
 
 interface PipelineEntry {
   jobs: PipelineJob[];
+  /** Latest authoritative progress, or null until the first payload. */
+  progress: PipelineProgress | null;
   /** ``true`` once a ``stream_closed: true`` payload has arrived. */
   closed: boolean;
   /** Refcount of mounted subscribers (composables). */
@@ -95,10 +119,17 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
   function applyUpdate(payload: PipelineUpdate): void {
     const entry = entries[payload.pipeline_id] ?? {
       jobs: [],
+      progress: null,
       closed: false,
       subscriberCount: 0,
     };
     entry.jobs = payload.jobs;
+    // Only overwrite progress when the payload carries it.  A
+    // snapshot-only seed (legacy / transient) must not wipe an
+    // authoritative progress we already received from the stream.
+    if (payload.progress !== undefined) {
+      entry.progress = payload.progress;
+    }
     if (payload.stream_closed) {
       entry.closed = true;
     }
@@ -125,6 +156,7 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
   function acquire(pipelineId: string): number {
     const entry = entries[pipelineId] ?? {
       jobs: [],
+      progress: null,
       closed: false,
       subscriberCount: 0,
     };
@@ -162,9 +194,14 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
   }
 
   /**
-   * Reactive ``isFinished`` — true when every job in the snapshot is
-   * FINISHED, OR when the stream's terminal ``stream_closed: true``
-   * marker arrived.  Empty pipelines (no jobs yet) are NOT finished.
+   * Reactive ``isFinished`` — Issue #1219: server-authoritative.
+   * True only when the backend says the *whole pipeline* is done
+   * (``progress.done``) or sent its terminal ``stream_closed: true``.
+   *
+   * The old "every job in the snapshot is FINISHED" heuristic is
+   * deliberately gone: it fired in the window where the parent upload
+   * was FINISHED but its recalc/aggregation children had not been
+   * INSERTed yet, flashing the module green on a half-done pipeline.
    */
   function isFinishedFor(pipelineId: string): ComputedRef<boolean> {
     return computed(() => {
@@ -172,14 +209,18 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
       if (!entry) {
         return false;
       }
-      if (entry.closed) {
-        return true;
-      }
-      if (entry.jobs.length === 0) {
-        return false;
-      }
-      return entry.jobs.every((j) => j.state === FINISHED);
+      return entry.closed || entry.progress?.done === true;
     });
+  }
+
+  /**
+   * Reactive authoritative progress for the 3-phase badge, or null
+   * until the first payload lands.
+   */
+  function progressFor(
+    pipelineId: string,
+  ): ComputedRef<PipelineProgress | null> {
+    return computed(() => entries[pipelineId]?.progress ?? null);
   }
 
   /**
@@ -225,6 +266,7 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
     clear,
     jobsFor,
     isFinishedFor,
+    progressFor,
     hasErrorFor,
     failedStatusMessagesFor,
   };

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -145,6 +145,12 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
     applyUpdate({
       pipeline_id: snapshot.pipeline_id,
       jobs: snapshot.jobs,
+      // Issue #1219 — forward the one-shot endpoint's authoritative
+      // progress so the badge/card show the phase immediately on
+      // subscribe, not only after the first ~2s SSE poll. Without
+      // this the seed wipes nothing (applyUpdate skips undefined) but
+      // leaves progress null until the stream catches up.
+      progress: snapshot.progress,
     });
   }
 
@@ -195,13 +201,21 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
 
   /**
    * Reactive ``isFinished`` — Issue #1219: server-authoritative.
-   * True only when the backend says the *whole pipeline* is done
-   * (``progress.done``) or sent its terminal ``stream_closed: true``.
+   * True when the backend says the *whole pipeline* is done
+   * (``progress.done``), sent its terminal ``stream_closed: true``,
+   * OR any job is FINISHED+ERROR.
    *
-   * The old "every job in the snapshot is FINISHED" heuristic is
-   * deliberately gone: it fired in the window where the parent upload
-   * was FINISHED but its recalc/aggregation children had not been
-   * INSERTed yet, flashing the module green on a half-done pipeline.
+   * The old "every job in the snapshot is FINISHED" *success*
+   * heuristic is deliberately gone: it fired in the window where the
+   * parent upload was FINISHED but its recalc/aggregation children
+   * had not been INSERTed yet, flashing the module green on a
+   * half-done pipeline.
+   *
+   * The FINISHED+ERROR clause is kept (and matches the backend's own
+   * ``done ⇔ phase3 OR any FINISHED+ERROR`` rule): a broken chain
+   * spawns no further children, so an error is unambiguously terminal
+   * regardless of fan-out completeness — the failure badge must show
+   * even before / without an authoritative ``progress`` payload.
    */
   function isFinishedFor(pipelineId: string): ComputedRef<boolean> {
     return computed(() => {
@@ -209,7 +223,11 @@ export const usePipelineStreamStore = defineStore('pipelineStream', () => {
       if (!entry) {
         return false;
       }
-      return entry.closed || entry.progress?.done === true;
+      return (
+        entry.closed ||
+        entry.progress?.done === true ||
+        entry.jobs.some((j) => j.state === FINISHED && j.result === ERROR)
+      );
     });
   }
 

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -4,8 +4,6 @@ import type { PersistenceOptions } from 'pinia-plugin-persistedstate';
 import { ref, computed } from 'vue';
 import { api } from 'src/api/http';
 
-export const WORKSPACE_DEFAULT_YEAR = 2025;
-
 export interface Unit {
   id: number;
   name: string;
@@ -36,12 +34,18 @@ interface SelectedParams {
   year: number;
   unit: string; // unit id-name string
 }
+export interface CarbonReportStats {
+  // Pre-computed aggregate written by the backend. `total` is in kg CO2eq.
+  total?: number | null;
+  [key: string]: unknown;
+}
 export interface CarbonReport {
   id: number;
   unit_id: number;
   year: number;
   reference_year?: number | null;
   carbon_project_id: number;
+  stats?: CarbonReportStats | null;
 }
 
 export const useWorkspaceStore = defineStore(
@@ -103,20 +107,6 @@ export const useWorkspaceStore = defineStore(
         carbonReportsLoading.value = false;
       }
     }
-
-    // Compute year range for selection (min year in DB or WORKSPACE_DEFAULT_YEAR, up to N-1)
-    const availableCarbonReportYears = computed(() => {
-      const currentYear = new Date().getFullYear();
-      const yearsInDb = carbonReports.value.map((inv) => inv.year);
-      const minDbYear =
-        yearsInDb.length > 0 ? Math.min(...yearsInDb) : WORKSPACE_DEFAULT_YEAR;
-      const startYear =
-        minDbYear < WORKSPACE_DEFAULT_YEAR ? minDbYear : WORKSPACE_DEFAULT_YEAR;
-      const maxYear = currentYear - 1;
-      const years: number[] = [];
-      for (let y = startYear; y <= maxYear; y++) years.push(y);
-      return years;
-    });
 
     // Helper: does carbon report exist for year?
     function carbonReportForYear(year: number) {
@@ -324,7 +314,6 @@ export const useWorkspaceStore = defineStore(
       carbonReportsError,
       selectedCarbonReport,
       fetchCarbonReportsForUnit,
-      availableCarbonReportYears,
       carbonReportForYear,
       createCarbonReport,
       selectCarbonReportForYear,

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -120,6 +120,13 @@ export interface YearConfigurationResponse {
   pipeline_id?: string | null;
 }
 
+/** Lightweight row from `GET /year-configuration/` (workspace year selector). */
+export interface YearConfigurationListItem {
+  year: number;
+  is_started: boolean;
+  updated_at: string;
+}
+
 interface YearConfigurationCreate {
   is_started?: boolean;
   config?: Partial<YearConfig>;
@@ -146,6 +153,29 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
   const loading = ref(false);
   /** True when the backend returned 404 — no configuration exists yet for this year. */
   const notFound = ref(false);
+  /** All year-configuration rows visible to the caller (workspace year selector). */
+  const configuredYears = ref<YearConfigurationListItem[]>([]);
+
+  /**
+   * Set of years that are globally open (`is_started`). The list endpoint
+   * already filters these for regular users; admins receive every row, so we
+   * re-filter client-side to keep the meaning identical for both.
+   */
+  const startedYears = computed(
+    () =>
+      new Set(
+        configuredYears.value.filter((y) => y.is_started).map((y) => y.year),
+      ),
+  );
+
+  /** Fetch the list of year-configuration rows (global, not unit-scoped). */
+  async function fetchConfiguredYears(): Promise<YearConfigurationListItem[]> {
+    const rows = (await api
+      .get('year-configuration/')
+      .json()) as YearConfigurationListItem[];
+    configuredYears.value = rows;
+    return rows;
+  }
 
   // Methods
   async function fetchConfig(
@@ -519,7 +549,9 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     config,
     loading,
     notFound,
+    configuredYears,
     // Computed
+    startedYears,
     anyModuleIncomplete,
     isReductionObjectiveIncomplete,
     unifiedModuleConfig,
@@ -541,6 +573,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     getModuleUncertaintyTag,
     // Methods
     fetchConfig,
+    fetchConfiguredYears,
     createConfig,
     updateConfig,
     openForUsers,

--- a/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
+++ b/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
@@ -281,6 +281,79 @@ test.describe('data-management — pipeline observability + a11y (Unit 11)', () 
     await expect(page.getByText(RECALCULATING_LABEL)).toHaveCount(0);
   });
 
+  test('Issue #1219: badge follows server-authoritative progress, not snapshot', async ({
+    page,
+  }) => {
+    // Regression for the core UX bug: the parent upload job is
+    // FINISHED but the pipeline as a whole is NOT — recalc/aggregation
+    // children have not been INSERTed yet. The OLD "every job in the
+    // snapshot is FINISHED" heuristic flashed the module green here.
+    // With the authoritative ``progress`` contract the badge must stay
+    // up (showing the current phase) until ``progress.done``.
+    const EMISSIONS_PHASE_LABEL = 'Step 2/3 · Recalculating emissions…';
+
+    activePipelines.set({ [HEADCOUNT_MODULE_TYPE_ID]: PIPELINE_UUID });
+    await gotoDataManagement(page, year);
+
+    const badge = page.getByText(RECALCULATING_LABEL).first();
+    await expect(badge).toBeVisible();
+    await waitForSsePipe(page, PIPELINE_UUID);
+
+    // Parent FINISHED, but progress says phase 2 / not done. Badge
+    // must NOT clear, and must now show the phase label.
+    await dispatchPipelineUpdate(page, PIPELINE_UUID, {
+      pipeline_id: PIPELINE_UUID,
+      jobs: [
+        {
+          id: 1,
+          job_type: 'csv_ingest',
+          state: 'FINISHED',
+          result: 'OK',
+          status_message: null,
+          started_at: new Date(Date.now() - 5000).toISOString(),
+          finished_at: new Date().toISOString(),
+        },
+      ],
+      progress: {
+        phase: 2,
+        phases_total: 3,
+        phase_label: 'emissions',
+        done: false,
+        has_error: false,
+      },
+    });
+
+    await expect(page.getByText(EMISSIONS_PHASE_LABEL)).toBeVisible();
+
+    // Now the backend reports the whole pipeline done (no
+    // stream_closed needed — ``progress.done`` is authoritative).
+    activePipelines.set({});
+    await dispatchPipelineUpdate(page, PIPELINE_UUID, {
+      pipeline_id: PIPELINE_UUID,
+      jobs: [
+        {
+          id: 1,
+          job_type: 'csv_ingest',
+          state: 'FINISHED',
+          result: 'OK',
+          status_message: null,
+          started_at: new Date(Date.now() - 5000).toISOString(),
+          finished_at: new Date().toISOString(),
+        },
+      ],
+      progress: {
+        phase: 3,
+        phases_total: 3,
+        phase_label: 'aggregation',
+        done: true,
+        has_error: false,
+      },
+    });
+
+    await expect(page.getByText(EMISSIONS_PHASE_LABEL)).toHaveCount(0);
+    await expect(page.getByText(RECALCULATING_LABEL)).toHaveCount(0);
+  });
+
   test('keyboard a11y: focus opens tooltip, blur closes it (F-C1 regression gate)', async ({
     page,
   }) => {


### PR DESCRIPTION
- **chore(docs): updated release instructions**
- **fix: make chart text italic**
- **fix(workspace-setup): source year list from started config × unit reports**
- **chore(docs): block mkdocs version to 1.6.x**
- **chore(frontend): invert factors and data for common**
- **docs(344): document frontend GlitchTip error monitoring + backfill plan**
- **fix(#1219): unstick ingestion jobs + server-authoritative pipeline progress**
- **fix(#1219): seed progress + keep FINISHED+ERROR terminal in isFinishedFor**
- **docs(#1219): tidy plan-doc sentence after merge of seed/error-clause notes**
