### PR TITLE
fix(emission-recalc): savepoint-isolate per-entry recalc; abort batch on dead/poisoned session

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from datetime import datetime
 from typing import Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import (
     APIRouter,
@@ -79,6 +79,7 @@ async def _stamp_job_type_and_meta(
     job_type: str,
     provider_name: Optional[str] = None,
     extra_meta: Optional[dict] = None,
+    pipeline_id: Optional[UUID] = None,
 ) -> None:
     """After ``provider.create_job`` returns, stamp ``job_type`` and
     extend ``meta`` so the runner's registry lookup hits the right
@@ -103,6 +104,14 @@ async def _stamp_job_type_and_meta(
     if extra_meta:
         merged_meta.update(extra_meta)
     row.meta = merged_meta
+    # Issue #1219 — stamp the pipeline_id eagerly when the caller
+    # supplies one.  ``chain_job`` only generates a UUID when
+    # ``parent.pipeline_id is None`` (_chain.py:154-157), so a
+    # pre-set value is honored and inherited by every child — and it
+    # closes the pod-crash-then-recovery orphan window the lazy path
+    # explicitly worries about.
+    if pipeline_id is not None:
+        row.pipeline_id = pipeline_id
     db.add(row)
 
 
@@ -243,6 +252,14 @@ class SyncStatusResponse(BaseModel):
     state: IngestionState
     message: str
     progress: Optional[dict] = None
+    # Issue #1219 — the parent's pipeline_id, assigned eagerly at
+    # creation (not lazily at first fan-out) so the frontend can seed
+    # its pipeline-state store and subscribe to the SSE stream from
+    # the moment the job is dispatched.  Without this the card only
+    # discovers the pipeline after the upload job already FINISHED,
+    # so phase 1 ("Inserting data…") is never visible and fast
+    # chains complete inside the discovery gap, showing nothing.
+    pipeline_id: Optional[str] = None
 
 
 class SyncJobResponse(BaseModel):
@@ -457,12 +474,14 @@ async def sync_module_data_entries(
     # NOTE: file_path validation happens in provider.__init__() via
     # _validate_file_path() to prevent directory traversal attacks
     # (e.g., /../../../etc/passwd).
+    pipeline_id = uuid4()
     await _stamp_job_type_and_meta(
         db,
         job_id,
         job_type=_job_type_for(syncRequest.target_type, syncRequest.ingestion_method),
         provider_name=provider.__class__.__name__,
         extra_meta={"filters": syncRequest.filters or {}},
+        pipeline_id=pipeline_id,
     )
     await db.commit()
 
@@ -473,6 +492,7 @@ async def sync_module_data_entries(
         "state": IngestionState.NOT_STARTED,
         "message": f"""Sync initiated using {syncRequest.ingestion_method}""",
         "progress": None,
+        "pipeline_id": str(pipeline_id),
     }
 
 
@@ -557,12 +577,14 @@ async def sync_module_factors(
             "route_payload": await extract_route_payload(request),
         },
     )
+    pipeline_id = uuid4()
     await _stamp_job_type_and_meta(
         db,
         job_id,
         job_type=_job_type_for(syncRequest.target_type, syncRequest.ingestion_method),
         provider_name=provider.__class__.__name__,
         extra_meta={"filters": syncRequest.filters or {}},
+        pipeline_id=pipeline_id,
     )
     await db.commit()
 
@@ -573,6 +595,7 @@ async def sync_module_factors(
         "state": IngestionState.NOT_STARTED,
         "message": f"Sync initiated using {syncRequest.ingestion_method}",
         "progress": None,
+        "pipeline_id": str(pipeline_id),
     }
 
 
@@ -1197,6 +1220,8 @@ async def recalculate_emissions_for_type(
         data_entry_type_id: The data entry type to recalculate.
         year: The report year (required).
     """
+    # Issue #1219 — eager pipeline_id (see SyncStatusResponse / _chain.py:154).
+    pipeline_id = uuid4()
     job = DataIngestionJob(
         job_type="emission_recalc",
         module_type_id=module_type_id.value,
@@ -1206,6 +1231,7 @@ async def recalculate_emissions_for_type(
         target_type=TargetType.DATA_ENTRIES,
         entity_type=EntityType.MODULE_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        pipeline_id=pipeline_id,
         meta={"config": {"year": year, "data_entry_type_id": data_entry_type_id.value}},
     )
     created_job = await DataIngestionRepository(db).create_ingestion_job(job)
@@ -1221,6 +1247,7 @@ async def recalculate_emissions_for_type(
         job_id=created_job.id,
         state=IngestionState.NOT_STARTED,
         message="Emission recalculation scheduled",
+        pipeline_id=str(pipeline_id),
     )
 
 
@@ -1276,6 +1303,8 @@ async def recalculate_emissions_for_module(
     else:
         det_ids = all_det_ids
 
+    # Issue #1219 — eager pipeline_id (see SyncStatusResponse / _chain.py:154).
+    pipeline_id = uuid4()
     job = DataIngestionJob(
         job_type="module_emission_recalc",
         module_type_id=module_type_id.value,
@@ -1285,6 +1314,7 @@ async def recalculate_emissions_for_module(
         target_type=TargetType.DATA_ENTRIES,
         entity_type=EntityType.MODULE_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        pipeline_id=pipeline_id,
         meta={
             "config": {
                 "year": year,
@@ -1307,6 +1337,7 @@ async def recalculate_emissions_for_module(
         job_id=created_job.id,
         state=IngestionState.NOT_STARTED,
         message=f"Module emission recalculation scheduled for {n} data entry types",
+        pipeline_id=str(pipeline_id),
     )
 
 

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -4,6 +4,7 @@ Re-runs emission calculations for all DataEntries of a given
 (data_entry_type_id, year) combination using the latest factors.
 """
 
+from sqlalchemy.exc import DBAPIError, InvalidRequestError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
@@ -158,36 +159,71 @@ class EmissionRecalculationWorkflow:
             entry_kind_field: str | None = handler.kind_field
             old_data = entry.data
             try:
-                if entry_kind_field is not None and entry_kind_field in entry.data:
-                    new_factor_id = self._lookup_factor_id(
-                        entry_data=entry.data,
-                        kind_field=entry_kind_field,
-                        subkind_field=handler.subkind_field,
-                        factor_lookup=factor_lookup,
-                    )
-                    if new_factor_id != entry.data.get("primary_factor_id"):
-                        # Tentative swap so DataEntryResponse + upsert
-                        # see the refreshed factor (or ``None`` on a
-                        # drop).  Rolled back below if the upsert fails,
-                        # so partial-failure runs don't leave entry.data
-                        # pointing at the new factor while
-                        # data_entry_emissions is still computed against
-                        # the old one.
-                        entry.data = {
-                            **entry.data,
-                            "primary_factor_id": new_factor_id,
-                        }
+                # Per-entry SAVEPOINT: a failed upsert must roll back
+                # ONLY this entry's writes — not poison the shared
+                # session for every remaining entry.  Without this, one
+                # bad row left ``self.session`` in an aborted state and
+                # every subsequent iteration re-raised the same
+                # "transaction is aborted / can't reconnect" error,
+                # spamming the log and failing the whole job (the
+                # comment below used to claim a rollback that never
+                # actually happened).
+                async with self.session.begin_nested():
+                    if entry_kind_field is not None and entry_kind_field in entry.data:
+                        new_factor_id = self._lookup_factor_id(
+                            entry_data=entry.data,
+                            kind_field=entry_kind_field,
+                            subkind_field=handler.subkind_field,
+                            factor_lookup=factor_lookup,
+                        )
+                        if new_factor_id != entry.data.get("primary_factor_id"):
+                            # Tentative swap so DataEntryResponse + upsert
+                            # see the refreshed factor (or ``None`` on a
+                            # drop).  The SAVEPOINT rolls this back on the
+                            # DB side if the upsert fails; the ``except``
+                            # also reverts ``entry.data`` in memory.
+                            entry.data = {
+                                **entry.data,
+                                "primary_factor_id": new_factor_id,
+                            }
 
-                entry_response = DataEntryResponse.model_validate(entry)
-                await emission_svc.upsert_by_data_entry(entry_response)
+                    entry_response = DataEntryResponse.model_validate(entry)
+                    await emission_svc.upsert_by_data_entry(entry_response)
                 recalculated += 1
                 if entry.carbon_report_module_id is not None:
                     affected_module_ids.add(entry.carbon_report_module_id)
             except Exception as exc:
-                # Roll back the in-memory mutation so the outer
-                # data_session.commit() does not persist a stale link
-                # alongside an old emissions row.
+                # Revert the in-memory factor swap (the SAVEPOINT already
+                # rolled back the DB side) so the outer commit doesn't
+                # persist a stale link next to an old emissions row.
                 entry.data = old_data
+                # Session/connection-fatal errors can't be contained by
+                # a SAVEPOINT — the session is unusable for every
+                # remaining entry.  Two shapes seen on stage:
+                #   * ``DBAPIError`` with ``connection_invalidated`` —
+                #     the raw connection dropped (server restart / LB
+                #     reset).
+                #   * ``InvalidRequestError`` (incl.
+                #     ``PendingRollbackError`` and "Can't reconnect
+                #     until invalid transaction is rolled back") — the
+                #     session needs a full rollback before any
+                #     statement, so even ``begin_nested()``'s SAVEPOINT
+                #     enter fails on the next entry.
+                # Continuing logs one identical fatal error per
+                # remaining entry (masking the first cause) and the job
+                # fails anyway.  Stop now and re-raise so the runner
+                # records FINISHED+ERROR with the real error.
+                connection_dead = (
+                    isinstance(exc, DBAPIError) and exc.connection_invalidated
+                )
+                if connection_dead or isinstance(exc, InvalidRequestError):
+                    logger.error(
+                        f"emission recalc: session/connection unusable at "
+                        f"data_entry_id={entry.id} ({type(exc).__name__}); "
+                        f"aborting batch ({recalculated} recalculated, "
+                        f"{errors} errored, {len(entries)} total)"
+                    )
+                    raise
                 errors += 1
                 error_details.append(
                     {

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -141,6 +141,143 @@ async def test_recalculate_partial_error():
 
 
 @pytest.mark.asyncio
+async def test_recalculate_aborts_batch_on_connection_invalidated():
+    """A connection-invalidated DBAPIError aborts the whole batch
+    (re-raised) instead of looping the same fatal error per remaining
+    entry.  Regression for the stage incident where one dead-connection
+    failure produced one identical "transaction aborted / can't
+    reconnect" log line per remaining data_entry and a silently failed
+    job.  Re-raising lets the runner record FINISHED+ERROR with the
+    real cause (per-entry data errors still continue — see
+    test_recalculate_partial_error)."""
+    from sqlalchemy.exc import DBAPIError
+
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entries = [_make_mock_entry(1, 10), _make_mock_entry(2, 11)]
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryResponse"
+        ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
+
+        def _model_validate(entry):
+            m = MagicMock()
+            m.id = entry.id
+            return m
+
+        mock_response_cls.model_validate.side_effect = _model_validate
+
+        upsert_calls: list[int] = []
+
+        async def _upsert(entry_response):
+            upsert_calls.append(entry_response.id)
+            if entry_response.id == 1:
+                raise DBAPIError(
+                    "UPDATE data_entry_emissions ...",
+                    {},
+                    Exception("server closed the connection unexpectedly"),
+                    connection_invalidated=True,
+                )
+
+        mock_emission_cls.return_value.upsert_by_data_entry = _upsert
+
+        with pytest.raises(DBAPIError):
+            await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+
+    # Aborted at the first entry — the second was never attempted, so
+    # no error storm and no masking of the first cause.
+    assert upsert_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_recalculate_aborts_batch_on_pending_rollback():
+    """A ``PendingRollbackError`` / ``InvalidRequestError`` (the
+    "Can't reconnect until invalid transaction is rolled back" shape
+    actually seen in the stage storm) must also abort the batch — not
+    just ``DBAPIError.connection_invalidated``.  This is the case the
+    first version of the fix missed: once the session needs a full
+    rollback, every remaining entry (including ``begin_nested()``'s
+    SAVEPOINT enter) re-raises the same error."""
+    from sqlalchemy.exc import PendingRollbackError
+
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entries = [_make_mock_entry(1, 10), _make_mock_entry(2, 11)]
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryResponse"
+        ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
+
+        def _model_validate(entry):
+            m = MagicMock()
+            m.id = entry.id
+            return m
+
+        mock_response_cls.model_validate.side_effect = _model_validate
+
+        upsert_calls: list[int] = []
+
+        async def _upsert(entry_response):
+            upsert_calls.append(entry_response.id)
+            if entry_response.id == 1:
+                raise PendingRollbackError(
+                    "This Session's transaction has been rolled back "
+                    "due to a previous exception during flush."
+                )
+
+        mock_emission_cls.return_value.upsert_by_data_entry = _upsert
+
+        with pytest.raises(PendingRollbackError):
+            await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+
+    assert upsert_calls == [1]
+
+
+@pytest.mark.asyncio
 async def test_recalculate_empty_result():
     """No data entries for the type/year → all counts are zero."""
     mock_session = MagicMock()

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { api } from 'src/api/http';
 import { Module } from 'src/constant/modules';
 import { getModuleTypeId } from 'src/constant/moduleStates';
+import { usePipelineStateStore } from 'src/stores/pipelineState';
 
 export interface DataIngestionJob {
   job_id: number;
@@ -389,7 +390,27 @@ provider_type
           .post(urlPath, {
             json: requestBody,
           })
-          .json()) as { job_id: number };
+          .json()) as { job_id: number; pipeline_id?: string };
+
+        // Issue #1219 — seed the pipeline_id straight from the dispatch
+        // response so the module card subscribes to the SSE stream
+        // immediately (phase 1 "Inserting data…" becomes visible),
+        // instead of only after the upload job FINISHED via the next
+        // active-pipelines poll.  Guarded: the api/carbon-report-only
+        // path may not carry a module_type_id/year to key on.
+        if (
+          response.pipeline_id &&
+          module_type_id !== undefined &&
+          module_type_id !== null &&
+          year !== undefined &&
+          year !== null
+        ) {
+          usePipelineStateStore().setPipelineId(
+            module_type_id,
+            year,
+            response.pipeline_id,
+          );
+        }
 
         // Update local state with new job
         if (year !== undefined) {
@@ -586,7 +607,18 @@ provider_type
               year,
             },
           })
-          .json()) as { job_id: number };
+          .json()) as { job_id: number; pipeline_id?: string };
+
+        // Issue #1219 — see initiateSync: seed the pipeline_id now so
+        // the card subscribes from dispatch, not from the post-finish
+        // active-pipelines poll.
+        if (response.pipeline_id) {
+          usePipelineStateStore().setPipelineId(
+            moduleTypeId,
+            year,
+            response.pipeline_id,
+          );
+        }
 
         return response.job_id;
       } catch (err: unknown) {
@@ -615,7 +647,18 @@ provider_type
         .post(`sync/recalculate-emissions/${moduleTypeId}/${dataEntryTypeId}`, {
           searchParams: { year },
         })
-        .json()) as { job_id: number };
+        .json()) as { job_id: number; pipeline_id?: string };
+      // Issue #1219 — seed the pipeline_id so the "Recalculate" button
+      // shows live phase progress on the card immediately, not after
+      // the next active-pipelines poll (which may never see a fast
+      // chain).
+      if (response.pipeline_id) {
+        usePipelineStateStore().setPipelineId(
+          moduleTypeId,
+          year,
+          response.pipeline_id,
+        );
+      }
       return response.job_id;
     }
 
@@ -632,7 +675,15 @@ provider_type
         .post(`sync/recalculate-emissions/${moduleTypeId}`, {
           searchParams: { year, only_stale: onlyStale },
         })
-        .json()) as { job_id: number };
+        .json()) as { job_id: number; pipeline_id?: string };
+      // Issue #1219 — see initiateEmissionRecalculation.
+      if (response.pipeline_id) {
+        usePipelineStateStore().setPipelineId(
+          moduleTypeId,
+          year,
+          response.pipeline_id,
+        );
+      }
       return response.job_id;
     }
 

--- a/frontend/src/stores/pipelineState.ts
+++ b/frontend/src/stores/pipelineState.ts
@@ -110,6 +110,26 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
   }
 
   /**
+   * Issue #1219 — seed a freshly-dispatched pipeline_id synchronously,
+   * straight from the dispatch/recalc HTTP response, instead of waiting
+   * for the next ``loadFor`` (active-pipelines) poll.  The poll only
+   * runs on mount / year-change / upload-job completion, so without
+   * this the card can't discover the pipeline until *after* the upload
+   * job already FINISHED — phase 1 is invisible and a fast chain
+   * completes inside the discovery gap.  ``ModuleConfig``'s
+   * ``currentPipelineId`` computed reads this map reactively, so the
+   * existing ``watch(currentPipelineId)`` auto-subscribes to the SSE
+   * stream the moment this is set.
+   */
+  function setPipelineId(
+    moduleTypeId: number,
+    year: number,
+    pipelineId: string,
+  ): void {
+    pipelineByModuleYear[makeKey(moduleTypeId, year)] = pipelineId;
+  }
+
+  /**
    * Issue #867 — bulk-fetch active year-level pipeline_ids
    * (``entity_type=GLOBAL_PER_YEAR``) for the given year.  Backs the
    * ``DataManagementPage.vue`` reload-rehydrate path: on mount + on
@@ -157,6 +177,7 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
     loadFor,
     loadYearLevelFor,
     getPipelineId,
+    setPipelineId,
     getYearLevelPipelineIds,
     clear,
   };


### PR DESCRIPTION
## Context

Surfaced on **stage** after #1219 unblocked the recalc chain. `EmissionRecalculationWorkflow.recalculate_for_data_entry_type` caught every per-entry exception and continued **without rolling back `self.session`**. One DB failure poisoned the shared session, so every remaining entry re-raised *"transaction is aborted / can't reconnect"* — a log storm (observed: `data_entry_id 19903..19922`) and a job that failed while masking the first cause. The in-code comment even claimed a rollback that never happened.

## Changes

- **Per-entry `SAVEPOINT`** (`session.begin_nested()`): a bad row is contained and the loop's intended "skip & continue" behaviour now actually works (it was broken — the session stayed poisoned).
- **Fast-abort on a session/connection-fatal error**: re-raise so the runner (via #1219 Fix 1) records `FINISHED+ERROR` with the real cause instead of one identical fatal error per remaining entry. Fatal = `DBAPIError.connection_invalidated` (dropped connection) **or** `InvalidRequestError` incl. `PendingRollbackError` / "can't reconnect" (session needs a full rollback — even `begin_nested()`'s SAVEPOINT-enter fails on the next entry; this is the shape the stage log actually shows).
- Two regression tests (`connection_invalidated`, `PendingRollbackError`), **both verified to fail without the fatal clause**. Existing 10 workflow tests still green (12 total).

## Scope / honest limits

- This makes the recalc loop **resilient** to a transient DB fault (fail fast + clean, no storm, job correctly ERRORs).
- It does **not** explain or prevent the *first* `UndefinedTable: relation "data_ingestion_jobs" does not exist` seen simultaneously across three independent sessions on stage — that points to a concurrent DDL/deploy window (consistent with "table exists now / migration worked"). Tracked as a separate **environmental** question, not addressed here.
- The aggregation→carbon-report-stats path (`recompute_stats`/`update_stats`) has the **same unguarded-flush anti-pattern** (the earlier `InFailedSqlTransaction` on `carbon_report_modules`). Same SAVEPOINT treatment warranted — deliberately **not bundled**; follow-up PR.

## Verification

`cd backend && uv run pytest tests/unit/workflows/test_emission_recalculation.py` → 12 passed. Lint clean. Gold-standard: reverting the fatal clause makes both new regression tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)