### PR TITLE
feat(#1234): pipeline operations console

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -328,6 +328,84 @@ class PipelineResponse(BaseModel):
     progress: PipelineProgressResponse
 
 
+# Issue #1234 — meta keys the pipeline-ops console is allowed to ship.
+# Everything else (esp. ``error_details`` / ``affected_module_ids``,
+# which are KB-scale per row) is stripped server-side so the list
+# payload stays small.  These five are exactly what threads the DAG /
+# drives ``compute_pipeline_progress`` plus the provenance the table
+# shows.
+_PIPELINE_META_ALLOW = (
+    "parent_job_id",
+    "recalc_jobs_chained",
+    "aggregation_job_id",
+    "provider_name",
+    "filters",
+)
+
+
+def _project_pipeline_meta(meta: Optional[dict]) -> dict:
+    m = meta or {}
+    return {k: m[k] for k in _PIPELINE_META_ALLOW if k in m}
+
+
+class PipelineJobListEntry(BaseModel):
+    """One job inside a pipeline, as shown in the ops-console DAG (#1234).
+
+    Slimmer than the pipeline read endpoint's ``PipelineJobResponse``:
+    carries timing for per-step duration and an **allow-listed** ``meta``
+    (never the big ``error_details`` / ``affected_module_ids`` arrays)."""
+
+    job_id: int
+    job_type: Optional[str] = None
+    state: Optional[IngestionState] = None
+    result: Optional[IngestionResult] = None
+    status_message: Optional[str] = None
+    module_type_id: Optional[int] = None
+    data_entry_type_id: Optional[int] = None
+    year: Optional[int] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    attempts: Optional[int] = None
+    meta: dict = {}
+
+
+class PipelineListItem(BaseModel):
+    """One pipeline row in the ops console (#1234).
+
+    ``pipeline_id`` is ``None`` for an orphan — a parent that failed
+    before fan-out so it never minted a pipeline (``is_orphan=True``);
+    it still appears as a pipeline-of-one.  Rollups (job_type, module,
+    year, status_message) come from the root/parent job; timing spans
+    the whole chain."""
+
+    pipeline_id: Optional[UUID] = None
+    is_orphan: bool
+    progress: PipelineProgressResponse
+    job_type: Optional[str] = None
+    module_type_id: Optional[int] = None
+    year: Optional[int] = None
+    status_message: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    latest_job_id: int
+    job_count: int
+    error_count: int
+    jobs: list[PipelineJobListEntry]
+
+
+class PipelineListResponse(BaseModel):
+    """Page of pipelines for the ops console (#1234).
+
+    ``total`` is the full match count *before* the per-module
+    permission drop (see endpoint docstring), so a page may contain
+    fewer than ``limit`` items for a scope-limited operator."""
+
+    items: list[PipelineListItem]
+    total: int
+    limit: int
+    offset: int
+
+
 class StaleStatsEntry(BaseModel):
     """One ``(module_type_id, year)`` scope whose aggregation is missing,
     failed, stuck, or too old.  Returned by ``GET /sync/health/stale-stats``
@@ -974,6 +1052,128 @@ async def get_recalculation_status(
         )
         for module_id, dets in modules.items()
     ]
+
+
+@router.get("/pipelines", response_model=PipelineListResponse)
+async def list_pipelines(
+    state: Optional[IngestionState] = None,
+    result: Optional[IngestionResult] = None,
+    job_type: Optional[str] = None,
+    module_type_id: Optional[int] = None,
+    year: Optional[int] = None,
+    has_errors: Optional[bool] = None,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    q: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
+) -> PipelineListResponse:
+    """Paginated, filtered list of ingestion/recalc pipelines (#1234).
+
+    **Required Permission**: ``backoffice.data_management.view``
+
+    Backs the back-office pipeline-operations console — a global view
+    complementary to the per-module data-management page.  The unit is
+    the *pipeline* (one ``pipeline_id`` = parent + fan-out children);
+    pagination never splits a pipeline's jobs across pages.  Orphans
+    (a parent that failed before minting a ``pipeline_id``) appear as
+    pipelines-of-one with ``is_orphan=True``.
+
+    Declared before ``/pipelines/{pipeline_id}`` so the static path
+    wins routing.  Drill-down/live stays on the existing
+    ``GET /pipelines/{id}`` (+ ``/stream``) — not rebuilt here.
+
+    Permission model mirrors ``get_active_pipelines``: the global
+    ``backoffice.data_management.view`` gate (dependency above) plus a
+    per-module *drop* (not 403) for pipelines whose module the operator
+    can't view.  Pipelines with no ``module_type_id`` (unit_sync,
+    unpinned factor ingests) pass on the global gate alone.  ``total``
+    is the pre-drop match count, so a scope-limited operator may see a
+    short page — acceptable for an internal ops tool where backoffice
+    users almost always hold broad view; the alternative (exact
+    post-filter pagination) would require loading every pipeline,
+    defeating the SQL-side pagination.
+    """
+    groups, total = await DataIngestionRepository(db).list_pipelines_paginated(
+        state=state,
+        result=result,
+        job_type=job_type,
+        module_type_id=module_type_id,
+        year=year,
+        has_errors=has_errors,
+        since=since,
+        until=until,
+        q=q,
+        limit=limit,
+        offset=offset,
+    )
+
+    allowed: dict[int, bool] = {}
+    items: list[PipelineListItem] = []
+    for group in groups:
+        jobs = group["jobs"]
+        if not jobs:
+            continue
+        # Root/parent = lowest id (repo returns jobs id-ascending; the
+        # ingest parent is created before its fan-out children).
+        root = jobs[0]
+        mod = root.module_type_id
+        if mod is not None:
+            if mod not in allowed:
+                decision = await get_module_permission_decision(
+                    current_user, mod, "view"
+                )
+                allowed[mod] = bool(decision.get("allow"))
+            if not allowed[mod]:
+                continue
+
+        started = [j.started_at for j in jobs if j.started_at is not None]
+        finished = [j.finished_at for j in jobs if j.finished_at is not None]
+        items.append(
+            PipelineListItem(
+                pipeline_id=group["pipeline_id"],
+                is_orphan=group["is_orphan"],
+                progress=PipelineProgressResponse(**compute_pipeline_progress(jobs)),
+                job_type=root.job_type,
+                module_type_id=root.module_type_id,
+                year=root.year,
+                status_message=root.status_message,
+                started_at=min(started) if started else None,
+                finished_at=max(finished) if finished else None,
+                latest_job_id=max(j.id for j in jobs if j.id is not None),
+                job_count=len(jobs),
+                error_count=sum(
+                    1
+                    for j in jobs
+                    if j.state == IngestionState.FINISHED
+                    and j.result == IngestionResult.ERROR
+                ),
+                jobs=[
+                    PipelineJobListEntry(
+                        job_id=j.id,
+                        job_type=j.job_type,
+                        state=j.state,
+                        result=j.result,
+                        status_message=j.status_message,
+                        module_type_id=j.module_type_id,
+                        data_entry_type_id=j.data_entry_type_id,
+                        year=j.year,
+                        started_at=j.started_at,
+                        finished_at=j.finished_at,
+                        attempts=j.attempts,
+                        meta=_project_pipeline_meta(j.meta),
+                    )
+                    for j in jobs
+                    if j.id is not None
+                ],
+            )
+        )
+
+    return PipelineListResponse(items=items, total=total, limit=limit, offset=offset)
 
 
 @router.get("/pipelines/{pipeline_id}", response_model=PipelineResponse)

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -321,6 +321,164 @@ class DataIngestionRepository:
         exec_result = await self.session.execute(stmt)
         return list(exec_result.scalars().all())
 
+    async def list_pipelines_paginated(
+        self,
+        *,
+        state: Optional[IngestionState] = None,
+        result: Optional[IngestionResult] = None,
+        job_type: Optional[str] = None,
+        module_type_id: Optional[int] = None,
+        year: Optional[int] = None,
+        has_errors: Optional[bool] = None,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        q: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list["PipelineGroup"], int]:
+        """Paginated, filtered list of pipelines for the ops console (#1234).
+
+        The pagination unit is the *pipeline* (one ``pipeline_id`` = a
+        parent + its fan-out children), never the job row — children
+        must not split across pages.  A pipeline qualifies when it has
+        at least one row matching the row-level filters; ``has_errors``
+        is evaluated at the pipeline level (any FINISHED+ERROR job).
+
+        Rows with ``pipeline_id IS NULL`` (a parent that failed before
+        fan-out, so it never minted a pipeline) surface as synthetic
+        *pipelines-of-one* so operators still see them.
+
+        Grouping is done in SQL with ``GROUP BY`` + ``MAX(id)`` (no
+        ``DISTINCT ON`` — not portable to the SQLite unit-test fixture),
+        then the per-page rows are fetched in one ``IN`` query and
+        grouped in Python.  Matches the in-memory-pick precedent of
+        ``get_current_pipeline_ids_for_modules`` (realistic input size:
+        a few thousand pipelines at most).
+
+        Returns ``(groups, total)`` where ``groups`` is the requested
+        page ordered newest-first by latest job id and ``total`` is the
+        full match count for pagination.
+        """
+        conds = []
+        if state is not None:
+            conds.append(col(DataIngestionJob.state) == state)
+        if result is not None:
+            conds.append(col(DataIngestionJob.result) == result)
+        if job_type is not None:
+            conds.append(col(DataIngestionJob.job_type) == job_type)
+        if module_type_id is not None:
+            conds.append(col(DataIngestionJob.module_type_id) == module_type_id)
+        if year is not None:
+            conds.append(col(DataIngestionJob.year) == year)
+        if since is not None:
+            conds.append(col(DataIngestionJob.started_at) >= since)
+        if until is not None:
+            conds.append(col(DataIngestionJob.started_at) <= until)
+        if q:
+            conds.append(col(DataIngestionJob.status_message).ilike(f"%{q}%"))
+
+        # Pipeline-level error set (FINISHED+ERROR anywhere in the
+        # group) — only computed when the caller filters on it.
+        error_pids: set[UUID] = set()
+        if has_errors is not None:
+            err_stmt = (
+                select(DataIngestionJob.pipeline_id)
+                .where(
+                    col(DataIngestionJob.pipeline_id).isnot(None),
+                    col(DataIngestionJob.state) == IngestionState.FINISHED,
+                    col(DataIngestionJob.result) == IngestionResult.ERROR,
+                )
+                .distinct()
+            )
+            error_pids = {r[0] for r in (await self.session.execute(err_stmt)).all()}
+
+        # Grouped pipelines: (pipeline_id, latest job id).
+        grouped_stmt = (
+            select(
+                DataIngestionJob.pipeline_id,
+                func.max(col(DataIngestionJob.id)).label("latest_id"),
+            )
+            .where(col(DataIngestionJob.pipeline_id).isnot(None), *conds)
+            .group_by(col(DataIngestionJob.pipeline_id))
+        )
+        grouped = (await self.session.execute(grouped_stmt)).all()
+
+        # Orphans: each NULL-pipeline row is its own pipeline-of-one.
+        orphan_conds = list(conds)
+        if has_errors is True:
+            orphan_conds += [
+                col(DataIngestionJob.state) == IngestionState.FINISHED,
+                col(DataIngestionJob.result) == IngestionResult.ERROR,
+            ]
+        elif has_errors is False:
+            orphan_conds.append(
+                or_(
+                    col(DataIngestionJob.state) != IngestionState.FINISHED,
+                    col(DataIngestionJob.result) != IngestionResult.ERROR,
+                    col(DataIngestionJob.result).is_(None),
+                )
+            )
+        orphan_stmt = select(col(DataIngestionJob.id)).where(
+            col(DataIngestionJob.pipeline_id).is_(None), *orphan_conds
+        )
+        orphan_ids = [r[0] for r in (await self.session.execute(orphan_stmt)).all()]
+
+        # Merge + order newest-first by latest id, then paginate.
+        merged: list[tuple[int, Optional[UUID], int]] = []
+        for pid, latest_id in grouped:
+            if has_errors is True and pid not in error_pids:
+                continue
+            if has_errors is False and pid in error_pids:
+                continue
+            merged.append((latest_id, pid, latest_id))
+        for oid in orphan_ids:
+            merged.append((oid, None, oid))
+        merged.sort(key=lambda t: t[0], reverse=True)
+        total = len(merged)
+        page = merged[offset : offset + limit]
+
+        page_pids = [pid for _, pid, _ in page if pid is not None]
+        page_orphan_ids = [k for _, pid, k in page if pid is None]
+
+        by_pid: dict[UUID, list[DataIngestionJob]] = {}
+        if page_pids:
+            jstmt = (
+                select(DataIngestionJob)
+                .where(col(DataIngestionJob.pipeline_id).in_(page_pids))
+                .order_by(col(DataIngestionJob.id).asc())
+            )
+            for job in (await self.session.execute(jstmt)).scalars().all():
+                by_pid.setdefault(job.pipeline_id, []).append(job)
+
+        by_orphan: dict[int, DataIngestionJob] = {}
+        if page_orphan_ids:
+            ostmt = select(DataIngestionJob).where(
+                col(DataIngestionJob.id).in_(page_orphan_ids)
+            )
+            for job in (await self.session.execute(ostmt)).scalars().all():
+                by_orphan[job.id] = job
+
+        groups: list[PipelineGroup] = []
+        for _, pid, key in page:
+            if pid is not None:
+                groups.append(
+                    PipelineGroup(
+                        pipeline_id=pid,
+                        is_orphan=False,
+                        jobs=by_pid.get(pid, []),
+                    )
+                )
+            else:
+                job = by_orphan.get(key)
+                groups.append(
+                    PipelineGroup(
+                        pipeline_id=None,
+                        is_orphan=True,
+                        jobs=[job] if job is not None else [],
+                    )
+                )
+        return groups, total
+
     async def get_current_pipeline_id_for_module(
         self,
         module_type_id: int,
@@ -1278,3 +1436,17 @@ class StaleStatsRow(TypedDict):
     last_finished_aggregation_at: Optional[datetime]
     why_stale: WhyStaleLiteral
     last_aggregation_job_id: Optional[int]
+
+
+class PipelineGroup(TypedDict):
+    """One pipeline returned by ``list_pipelines_paginated`` (#1234).
+
+    ``jobs`` are the raw ORM rows (id-ascending) so the endpoint can run
+    ``compute_pipeline_progress`` on them and project the meta allow-list
+    at serialization.  ``is_orphan`` flags a ``pipeline_id IS NULL``
+    parent that failed before fan-out (rendered as a pipeline-of-one).
+    """
+
+    pipeline_id: Optional[UUID]
+    is_orphan: bool
+    jobs: list[DataIngestionJob]

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -980,3 +980,157 @@ async def test_get_current_pipeline_ids_for_modules_filters_by_year(
     repo = DataIngestionRepository(db_session)
     result = await repo.get_current_pipeline_ids_for_modules([5], year=2025)
     assert result == {}
+
+
+# ======================================================================
+# list_pipelines_paginated Tests (#1234 — pipeline ops console)
+# ======================================================================
+
+
+def _pipeline_job(
+    *,
+    pipeline_id,
+    job_type: str,
+    state: IngestionState = IngestionState.FINISHED,
+    result: IngestionResult | None = IngestionResult.SUCCESS,
+    module_type_id: int = 4,
+    year: int = 2026,
+    started_at=None,
+    status_message: str | None = None,
+    meta: dict | None = None,
+) -> DataIngestionJob:
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=module_type_id,
+        data_entry_type_id=None,
+        year=year,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=state,
+        result=result,
+        is_current=False,
+        pipeline_id=pipeline_id,
+        job_type=job_type,
+        started_at=started_at,
+        status_message=status_message,
+        meta=meta or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_groups_by_pipeline_id(db_session: AsyncSession):
+    """Two pipelines → two groups, jobs id-ascending within each."""
+    repo = DataIngestionRepository(db_session)
+    p1, p2 = uuid4(), uuid4()
+    for j in (
+        _pipeline_job(pipeline_id=p1, job_type="csv_ingest"),
+        _pipeline_job(pipeline_id=p1, job_type="emission_recalc"),
+        _pipeline_job(pipeline_id=p2, job_type="csv_ingest"),
+    ):
+        db_session.add(j)
+    await db_session.flush()
+
+    groups, total = await repo.list_pipelines_paginated()
+
+    assert total == 2
+    assert {g["pipeline_id"] for g in groups} == {p1, p2}
+    for g in groups:
+        ids = [j.id for j in g["jobs"]]
+        assert ids == sorted(ids)
+        assert g["is_orphan"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_paginates_by_pipeline_not_job(
+    db_session: AsyncSession,
+):
+    """limit=2 over 3 pipelines → 2 groups, total=3, children not split."""
+    repo = DataIngestionRepository(db_session)
+    pids = [uuid4() for _ in range(3)]
+    for pid in pids:
+        db_session.add(_pipeline_job(pipeline_id=pid, job_type="csv_ingest"))
+        db_session.add(_pipeline_job(pipeline_id=pid, job_type="emission_recalc"))
+    await db_session.flush()
+
+    page1, total = await repo.list_pipelines_paginated(limit=2, offset=0)
+    page2, _ = await repo.list_pipelines_paginated(limit=2, offset=2)
+
+    assert total == 3
+    assert len(page1) == 2
+    assert len(page2) == 1
+    # Every returned group keeps BOTH its jobs (no split across pages).
+    for g in page1 + page2:
+        assert len(g["jobs"]) == 2
+    # Newest-first by latest job id: page1[0] is the last-inserted pipeline.
+    assert page1[0]["pipeline_id"] == pids[2]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_filters(db_session: AsyncSession):
+    """job_type / module / year / state filters select matching pipelines."""
+    repo = DataIngestionRepository(db_session)
+    keep, drop = uuid4(), uuid4()
+    db_session.add(_pipeline_job(pipeline_id=keep, job_type="csv_ingest", year=2026))
+    db_session.add(_pipeline_job(pipeline_id=drop, job_type="factor_ingest", year=2025))
+    await db_session.flush()
+
+    by_year, _ = await repo.list_pipelines_paginated(year=2026)
+    by_type, _ = await repo.list_pipelines_paginated(job_type="factor_ingest")
+
+    assert [g["pipeline_id"] for g in by_year] == [keep]
+    assert [g["pipeline_id"] for g in by_type] == [drop]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_has_errors_filter(db_session: AsyncSession):
+    """has_errors keeps only pipelines with a FINISHED+ERROR job."""
+    repo = DataIngestionRepository(db_session)
+    ok, bad = uuid4(), uuid4()
+    db_session.add(_pipeline_job(pipeline_id=ok, job_type="csv_ingest"))
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=bad,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+        )
+    )
+    await db_session.flush()
+
+    errored, _ = await repo.list_pipelines_paginated(has_errors=True)
+    clean, _ = await repo.list_pipelines_paginated(has_errors=False)
+
+    assert [g["pipeline_id"] for g in errored] == [bad]
+    assert [g["pipeline_id"] for g in clean] == [ok]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_orphans_are_pipelines_of_one(
+    db_session: AsyncSession,
+):
+    """A pipeline_id IS NULL parent surfaces as is_orphan with one job."""
+    repo = DataIngestionRepository(db_session)
+    db_session.add(
+        uuid4_pid := _pipeline_job(pipeline_id=uuid4(), job_type="csv_ingest")
+    )  # noqa: E501
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=None,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="InFailedSqlTransaction",
+        )
+    )
+    await db_session.flush()
+    assert uuid4_pid.id is not None
+
+    groups, total = await repo.list_pipelines_paginated()
+
+    assert total == 2
+    orphans = [g for g in groups if g["is_orphan"]]
+    assert len(orphans) == 1
+    assert orphans[0]["pipeline_id"] is None
+    assert len(orphans[0]["jobs"]) == 1
+    assert orphans[0]["jobs"][0].status_message == "InFailedSqlTransaction"

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -1,0 +1,36 @@
+"""Pipeline-ops-console meta allow-list (#1234).
+
+The list endpoint must never ship the KB-scale ``error_details`` /
+``affected_module_ids`` arrays — only the five keys that thread the DAG
+and show provenance.  This locks that contract.
+"""
+
+from app.api.v1.data_sync import _PIPELINE_META_ALLOW, _project_pipeline_meta
+
+
+def test_project_strips_big_arrays_keeps_allow_list():
+    meta = {
+        "parent_job_id": 9,
+        "recalc_jobs_chained": 3,
+        "aggregation_job_id": 14,
+        "provider_name": "ModulePerYearCSVProvider",
+        "filters": {},
+        # Must be dropped — these are the multi-KB offenders.
+        "error_details": [{"data_entry_id": i, "error": "x" * 200} for i in range(50)],
+        "affected_module_ids": list(range(2231)),
+        "recalculation": {"recalculated": 15820},
+        "config": {"file_path": "tmp/secret.csv"},
+    }
+
+    projected = _project_pipeline_meta(meta)
+
+    assert set(projected) == set(_PIPELINE_META_ALLOW)
+    assert "error_details" not in projected
+    assert "affected_module_ids" not in projected
+    assert projected["aggregation_job_id"] == 14
+
+
+def test_project_handles_none_and_partial_meta():
+    assert _project_pipeline_meta(None) == {}
+    assert _project_pipeline_meta({}) == {}
+    assert _project_pipeline_meta({"parent_job_id": 1, "x": 2}) == {"parent_job_id": 1}

--- a/docs/src/implementation-plans/1234-pipeline-operations-console.md
+++ b/docs/src/implementation-plans/1234-pipeline-operations-console.md
@@ -1,0 +1,88 @@
+# 1234 — Pipeline operations console
+
+Status: in progress · Branch: `feat/1234-pipeline-operations-console` · Base: `dev`
+
+## Problem
+
+`/back-office/data-management` shows per-module ingestion status only. There is
+no global view of pipelines. Operators cannot see, across all modules/years:
+failed parents, transaction-poisoning, deadlocks between sibling recalc jobs, or
+anomalous runs.
+
+Live data shows the failure shapes the page must surface:
+
+- `csv_ingest` `status_message="Success"` but `result=ERROR` (100% row errors).
+- `InFailedSqlTransaction` on the `carbon_report_modules` SELECT — parent
+  ERROR, no `pipeline_id`, no children (carbon-report-stats poisoning).
+- `DeadlockDetected` between concurrent `emission_recalc`/`aggregation`
+  siblings of the **same** `pipeline_id`.
+- One `csv_ingest` → 3 `emission_recalc` → 3 `aggregation`, each
+  `modules_refreshed: 2231` (concurrent full-table recompute amplification).
+
+## Outcome
+
+A new back-office page, complementary to data-management. Unit = the pipeline
+(one `pipeline_id` = a DAG: ingest parent → per-det `emission_recalc` →
+`aggregation`, edges via `meta.parent_job_id`). Pipeline-grouped table, alert
+strip, filters, expandable job DAG with decoded meta. Orphan parents
+(`pipeline_id IS NULL`) shown inline as pipelines-of-one.
+
+## Scope
+
+- ONE new backend list endpoint. Reuse — do not rebuild — `GET
+/v1/sync/pipelines/{id}` and `/stream` for drill-down/live.
+- No migration (all derived from `data_ingestion_jobs`).
+- No change to `/back-office/data-management`.
+- NOT bundling PR #1225 or the eager-pipeline-id work. This endpoint only
+  reads existing `pipeline_id` values; orphan rows are surfaced regardless.
+
+## Steps
+
+### Backend
+
+- **B1** `backend/app/repositories/data_ingestion.py` —
+  `list_pipelines_paginated(...)`. Pagination unit is `pipeline_id`, not the
+  job row. Group/filter in SQL (no `DISTINCT ON` — SQLite test fixture),
+  page on `pipeline_id`, then one `IN (:page_ids)` fetch grouped in Python.
+  Orphans (`pipeline_id IS NULL`) as synthetic pipelines-of-one. Returns a
+  Pydantic-free typed dict.
+- **B2** `backend/app/api/v1/data_sync.py` — `GET /sync/pipelines`
+  (registered before `/pipelines/{pipeline_id}`). Inline schemas
+  `PipelineListItem` / `PipelineListResponse`, reusing
+  `PipelineProgressResponse` + `compute_pipeline_progress`. Meta projection
+  is an **allow-list** (`parent_job_id`, `recalc_jobs_chained`,
+  `aggregation_job_id`, `provider_name`, `filters`) — never ship
+  `error_details` / `affected_module_ids` (KB-scale). Permission gate copied
+  from `get_active_pipelines` (global `backoffice.data_management.view` +
+  per-module decision, drop not 403).
+- **B3** tests — extend
+  `backend/tests/unit/repositories/test_data_ingestion_repo.py`: grouping,
+  pipeline-unit pagination, each filter, orphans, meta allow-list strips the
+  big arrays.
+
+### Frontend
+
+- **F1** `frontend/src/i18n/pipeline_operations_console.ts` (auto-globbed;
+  en + fr; nav keys included).
+- **F2** `frontend/src/constant/navigation.ts` — `BACKOFFICE_NAV` entry.
+- **F3** `frontend/src/router/routes.ts` — `back-office/pipeline-operations`
+  route, same `beforeEnter`/`meta` as the data-management sibling.
+- **F4** `frontend/src/stores/pipelineOperationsConsole.ts` +
+  `frontend/src/pages/back-office/PipelineOperationsConsolePage.vue`. Alert
+  strip (clickable counters → filters), pipeline-grouped table (newest
+  first), expandable job DAG with decoded meta. Drill-down/live reuses
+  `usePipelineStream()` verbatim.
+- **F5** `cd frontend && make type-check` (vue-tsc — the gate husky runs;
+  `rtk tsc` green ≠ this).
+
+## Verify
+
+- Backend: `cd backend && uv run ruff check . && uv run pytest
+tests/unit/repositories/test_data_ingestion_repo.py
+tests/unit/services/test_pipeline_progress.py -q` and `python -c "from
+app.main import app"`.
+- Frontend: `cd frontend && make type-check`.
+
+## Convention notes
+
+PRs target `dev`. Commit messages: **no** `Co-Authored-By` trailer.

--- a/frontend/src/constant/navigation.ts
+++ b/frontend/src/constant/navigation.ts
@@ -34,6 +34,12 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     icon: 'data_object',
     limitedAccess: true,
   },
+  BACKOFFICE_PIPELINE_OPERATIONS: {
+    routeName: 'backoffice-pipeline-operations',
+    description: 'backoffice-pipeline-operations-description',
+    icon: 'o_account_tree',
+    limitedAccess: true,
+  },
   BACKOFFICE_LOGS: {
     routeName: 'backoffice-logs',
     description: 'backoffice-logs-description',

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -1,0 +1,78 @@
+// Issue #1234 — pipeline operations console (back-office).
+// Auto-registered by the eager glob in src/i18n/index.ts.
+
+export default {
+  // Navigation
+  'backoffice-pipeline-operations': {
+    en: 'Pipeline operations',
+    fr: 'Opérations pipelines',
+  },
+  'backoffice-pipeline-operations-description': {
+    en: 'Global view of ingestion & recalculation pipelines',
+    fr: "Vue globale des pipelines d'ingestion et de recalcul",
+  },
+
+  // Page
+  pipeops_title: {
+    en: 'Pipeline operations',
+    fr: 'Opérations pipelines',
+  },
+  pipeops_subtitle: {
+    en: 'Ingestion & recalculation pipelines across all modules and years.',
+    fr: "Pipelines d'ingestion et de recalcul, tous modules et années.",
+  },
+
+  // Alert strip
+  pipeops_alert_failed: {
+    en: 'Failed parents',
+    fr: 'Parents en échec',
+  },
+  pipeops_alert_errors: {
+    en: 'With errors',
+    fr: 'Avec erreurs',
+  },
+  pipeops_alert_running: {
+    en: 'Running',
+    fr: 'En cours',
+  },
+  pipeops_alert_ok: {
+    en: 'Completed',
+    fr: 'Terminés',
+  },
+
+  // Filters
+  pipeops_filter_state: { en: 'State', fr: 'État' },
+  pipeops_filter_result: { en: 'Result', fr: 'Résultat' },
+  pipeops_filter_job_type: { en: 'Job type', fr: 'Type de job' },
+  pipeops_filter_year: { en: 'Year', fr: 'Année' },
+  pipeops_filter_has_errors: { en: 'Errors only', fr: 'Erreurs uniquement' },
+  pipeops_filter_search: {
+    en: 'Search status message',
+    fr: 'Rechercher dans le message',
+  },
+  pipeops_filter_clear: { en: 'Clear filters', fr: 'Réinitialiser' },
+
+  // Table
+  pipeops_col_status: { en: 'Status', fr: 'Statut' },
+  pipeops_col_pipeline: { en: 'Pipeline', fr: 'Pipeline' },
+  pipeops_col_trigger: { en: 'Trigger', fr: 'Déclencheur' },
+  pipeops_col_module: { en: 'Module / Year', fr: 'Module / Année' },
+  pipeops_col_jobs: { en: 'Jobs', fr: 'Jobs' },
+  pipeops_col_duration: { en: 'Duration', fr: 'Durée' },
+  pipeops_col_when: { en: 'Started', fr: 'Démarré' },
+  pipeops_col_message: { en: 'Message', fr: 'Message' },
+
+  pipeops_status_running: { en: 'Running', fr: 'En cours' },
+  pipeops_status_done: { en: 'Done', fr: 'Terminé' },
+  pipeops_status_failed: { en: 'Failed', fr: 'Échec' },
+  pipeops_status_partial: { en: 'Partial', fr: 'Partiel' },
+
+  pipeops_orphan_tag: { en: '(no pipeline)', fr: '(sans pipeline)' },
+  pipeops_live: { en: 'live', fr: 'live' },
+  pipeops_empty: {
+    en: 'No pipelines match the current filters.',
+    fr: 'Aucun pipeline ne correspond aux filtres actuels.',
+  },
+  pipeops_loading: { en: 'Loading…', fr: 'Chargement…' },
+  pipeops_refresh: { en: 'Refresh', fr: 'Actualiser' },
+};

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -1,0 +1,353 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { BACKOFFICE_NAV } from 'src/constant/navigation';
+import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
+import {
+  usePipelineOperationsConsole,
+  type PipelineListItem,
+} from 'src/stores/pipelineOperationsConsole';
+
+const store = usePipelineOperationsConsole();
+
+const expanded = ref<Set<string>>(new Set());
+
+function rowKey(p: PipelineListItem): string {
+  return p.pipeline_id ?? `orphan-${p.latest_job_id}`;
+}
+
+function toggle(p: PipelineListItem): void {
+  const k = rowKey(p);
+  if (expanded.value.has(k)) expanded.value.delete(k);
+  else expanded.value.add(k);
+  // reassign so the template recomputes
+  expanded.value = new Set(expanded.value);
+}
+
+type StatusKind = 'failed' | 'running' | 'partial' | 'done';
+
+function statusOf(p: PipelineListItem): StatusKind {
+  if (p.progress.has_error) return 'failed';
+  if (!p.progress.done) return 'running';
+  if (p.error_count > 0) return 'partial';
+  return 'done';
+}
+
+const STATUS_META: Record<
+  StatusKind,
+  { color: string; icon: string; key: string }
+> = {
+  failed: { color: 'negative', icon: 'error', key: 'pipeops_status_failed' },
+  running: { color: 'primary', icon: 'sync', key: 'pipeops_status_running' },
+  partial: { color: 'warning', icon: 'warning', key: 'pipeops_status_partial' },
+  done: { color: 'positive', icon: 'check_circle', key: 'pipeops_status_done' },
+};
+
+function jobColor(j: { state: string | null; result: string | null }): string {
+  if (j.state !== 'FINISHED') return 'grey';
+  if (j.result === 'ERROR') return 'negative';
+  if (j.result === 'WARNING') return 'warning';
+  return 'positive';
+}
+
+function fmtDuration(a: string | null, b: string | null): string {
+  if (!a) return '—';
+  const start = new Date(a).getTime();
+  const end = b ? new Date(b).getTime() : Date.now();
+  const s = Math.max(0, Math.round((end - start) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m${String(s % 60).padStart(2, '0')}s`;
+  return `${Math.floor(m / 60)}h${String(m % 60).padStart(2, '0')}m`;
+}
+
+function fmtWhen(s: string | null): string {
+  if (!s) return '—';
+  return new Date(s).toLocaleString();
+}
+
+const counters = computed(() => store.counters);
+
+const stateOptions = ['NOT_STARTED', 'QUEUED', 'RUNNING', 'FINISHED'];
+const resultOptions = ['SUCCESS', 'WARNING', 'ERROR'];
+const jobTypeOptions = [
+  'csv_ingest',
+  'factor_ingest',
+  'api_ingest',
+  'emission_recalc',
+  'aggregation',
+  'unit_sync',
+];
+
+onMounted(() => {
+  void store.fetch();
+});
+</script>
+
+<template>
+  <q-page>
+    <navigation-header :item="BACKOFFICE_NAV.BACKOFFICE_PIPELINE_OPERATIONS" />
+    <div class="q-my-xl q-px-xl">
+      <div class="container full-width">
+        <div class="text-body1 q-mb-lg">{{ $t('pipeops_subtitle') }}</div>
+
+        <!-- Alert strip — clickable counters set a filter -->
+        <div class="row q-col-gutter-md q-mb-lg">
+          <div class="col-auto">
+            <q-chip
+              clickable
+              color="negative"
+              text-color="white"
+              icon="error"
+              @click="store.applyFilters({ has_errors: true })"
+            >
+              {{ counters.errors }} · {{ $t('pipeops_alert_errors') }}
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-chip
+              clickable
+              color="primary"
+              text-color="white"
+              icon="sync"
+              @click="store.applyFilters({ state: 'RUNNING' })"
+            >
+              {{ counters.running }} · {{ $t('pipeops_alert_running') }}
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-chip color="positive" text-color="white" icon="check_circle">
+              {{ counters.ok }} · {{ $t('pipeops_alert_ok') }}
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-chip color="grey-7" text-color="white" icon="report">
+              {{ counters.failed }} · {{ $t('pipeops_alert_failed') }}
+            </q-chip>
+          </div>
+        </div>
+
+        <!-- Filters -->
+        <div class="row q-col-gutter-md q-mb-md items-end">
+          <q-select
+            class="col-12 col-md-2"
+            dense
+            outlined
+            clearable
+            :label="$t('pipeops_filter_state')"
+            :model-value="store.filters.state"
+            :options="stateOptions"
+            @update:model-value="(v) => store.applyFilters({ state: v })"
+          />
+          <q-select
+            class="col-12 col-md-2"
+            dense
+            outlined
+            clearable
+            :label="$t('pipeops_filter_result')"
+            :model-value="store.filters.result"
+            :options="resultOptions"
+            @update:model-value="(v) => store.applyFilters({ result: v })"
+          />
+          <q-select
+            class="col-12 col-md-2"
+            dense
+            outlined
+            clearable
+            :label="$t('pipeops_filter_job_type')"
+            :model-value="store.filters.job_type"
+            :options="jobTypeOptions"
+            @update:model-value="(v) => store.applyFilters({ job_type: v })"
+          />
+          <q-input
+            class="col-6 col-md-1"
+            dense
+            outlined
+            type="number"
+            :label="$t('pipeops_filter_year')"
+            :model-value="store.filters.year"
+            @update:model-value="
+              (v) => store.applyFilters({ year: v ? Number(v) : null })
+            "
+          />
+          <q-input
+            class="col-12 col-md-3"
+            dense
+            outlined
+            debounce="400"
+            :label="$t('pipeops_filter_search')"
+            :model-value="store.filters.q"
+            @update:model-value="
+              (v) => store.applyFilters({ q: String(v ?? '') })
+            "
+          />
+          <div class="col-auto">
+            <q-toggle
+              :model-value="store.filters.has_errors === true"
+              :label="$t('pipeops_filter_has_errors')"
+              @update:model-value="
+                (v) => store.applyFilters({ has_errors: v ? true : null })
+              "
+            />
+          </div>
+          <div class="col-auto">
+            <q-btn
+              flat
+              dense
+              icon="restart_alt"
+              :label="$t('pipeops_filter_clear')"
+              @click="store.clearFilters()"
+            />
+          </div>
+          <div class="col-auto">
+            <q-btn
+              flat
+              dense
+              icon="refresh"
+              :label="$t('pipeops_refresh')"
+              :loading="store.loading"
+              @click="store.fetch()"
+            />
+          </div>
+        </div>
+
+        <q-banner v-if="store.error" class="bg-negative text-white q-mb-md">
+          {{ store.error }}
+        </q-banner>
+
+        <q-markup-table flat bordered separator="cell">
+          <thead>
+            <tr>
+              <th class="text-left" style="width: 36px"></th>
+              <th class="text-left">{{ $t('pipeops_col_status') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_trigger') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_module') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_jobs') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_duration') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_when') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_message') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="store.loading && !store.items.length">
+              <td colspan="8" class="text-center text-grey-7">
+                {{ $t('pipeops_loading') }}
+              </td>
+            </tr>
+            <tr v-else-if="!store.items.length">
+              <td colspan="8" class="text-center text-grey-7">
+                {{ $t('pipeops_empty') }}
+              </td>
+            </tr>
+            <template v-for="p in store.items" :key="rowKey(p)">
+              <tr class="cursor-pointer" @click="toggle(p)">
+                <td>
+                  <q-icon
+                    :name="
+                      expanded.has(rowKey(p)) ? 'expand_more' : 'chevron_right'
+                    "
+                  />
+                </td>
+                <td>
+                  <q-badge
+                    :color="STATUS_META[statusOf(p)].color"
+                    text-color="white"
+                  >
+                    <q-icon
+                      :name="STATUS_META[statusOf(p)].icon"
+                      size="14px"
+                      class="q-mr-xs"
+                    />
+                    {{ $t(STATUS_META[statusOf(p)].key) }}
+                  </q-badge>
+                </td>
+                <td>
+                  {{ p.job_type ?? '—' }}
+                  <span
+                    v-if="p.is_orphan"
+                    class="text-caption text-grey-6 q-ml-xs"
+                  >
+                    {{ $t('pipeops_orphan_tag') }}
+                  </span>
+                </td>
+                <td>{{ p.module_type_id ?? '—' }} / {{ p.year ?? '—' }}</td>
+                <td>
+                  {{ p.job_count - p.error_count }}/{{ p.job_count }} ✓
+                  <span v-if="p.error_count" class="text-negative">
+                    · {{ p.error_count }}✗
+                  </span>
+                </td>
+                <td>{{ fmtDuration(p.started_at, p.finished_at) }}</td>
+                <td>{{ fmtWhen(p.started_at) }}</td>
+                <td
+                  class="text-grey-8 ellipsis"
+                  style="max-width: 320px"
+                  :title="p.status_message ?? ''"
+                >
+                  {{ p.status_message ?? '—' }}
+                </td>
+              </tr>
+              <tr v-if="expanded.has(rowKey(p))">
+                <td colspan="8" class="bg-grey-1">
+                  <div class="q-pa-sm">
+                    <div
+                      v-for="j in p.jobs"
+                      :key="j.job_id"
+                      class="row items-center q-py-xs no-wrap"
+                    >
+                      <q-badge
+                        :color="jobColor(j)"
+                        text-color="white"
+                        class="q-mr-sm"
+                      >
+                        {{ j.state ?? '?'
+                        }}{{ j.result ? ' · ' + j.result : '' }}
+                      </q-badge>
+                      <span class="text-weight-medium q-mr-sm">
+                        #{{ j.job_id }} {{ j.job_type ?? '—' }}
+                      </span>
+                      <span class="text-caption text-grey-7 q-mr-sm">
+                        det {{ j.data_entry_type_id ?? '—' }} ·
+                        {{ fmtDuration(j.started_at, j.finished_at) }}
+                      </span>
+                      <span
+                        v-if="j.status_message"
+                        class="text-caption text-grey-8 ellipsis"
+                        style="max-width: 520px"
+                        :title="j.status_message"
+                      >
+                        {{ j.status_message }}
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </q-markup-table>
+
+        <div class="row items-center justify-end q-gutter-sm q-mt-md">
+          <span class="text-caption text-grey-7">
+            {{ store.offset + 1 }}–{{ store.offset + store.items.length }} /
+            {{ store.total }}
+          </span>
+          <q-btn
+            flat
+            dense
+            icon="chevron_left"
+            :disable="store.offset === 0 || store.loading"
+            @click="store.setPage(store.offset - store.limit)"
+          />
+          <q-btn
+            flat
+            dense
+            icon="chevron_right"
+            :disable="
+              store.offset + store.limit >= store.total || store.loading
+            "
+            @click="store.setPage(store.offset + store.limit)"
+          />
+        </div>
+      </div>
+    </div>
+  </q-page>
+</template>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -232,6 +232,22 @@ const routes: RouteRecordRaw[] = [
             },
           },
           {
+            path: 'back-office/pipeline-operations',
+            name: BACKOFFICE_NAV.BACKOFFICE_PIPELINE_OPERATIONS.routeName,
+            component: () =>
+              import('pages/back-office/PipelineOperationsConsolePage.vue'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.EDIT,
+            ),
+            meta: {
+              requiresAuth: true,
+              note: 'Back Office - Pipeline operations console (admin only)',
+              breadcrumb: false,
+              isBackOffice: true,
+            },
+          },
+          {
             path: 'back-office/documentation-editing',
             name: BACKOFFICE_NAV.BACKOFFICE_DOCUMENTATION_EDITING.routeName,
             component: () =>

--- a/frontend/src/stores/pipelineOperationsConsole.ts
+++ b/frontend/src/stores/pipelineOperationsConsole.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #1234 — pipeline operations console store.
+ *
+ * Backs the back-office page that lists ingestion/recalc pipelines
+ * globally (one row per ``pipeline_id``), complementary to the
+ * per-module data-management page.  Thin Pinia wrapper over
+ * ``GET /v1/sync/pipelines`` (paginated, filtered, meta allow-listed
+ * server-side).  Drill-down/live tailing reuses the existing
+ * ``usePipelineStream`` composable + ``GET /sync/pipelines/{id}`` —
+ * not duplicated here.
+ */
+
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
+import { api } from 'src/api/http';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
+
+export interface PipelineJobListEntry {
+  job_id: number;
+  job_type: string | null;
+  state: string | null;
+  result: string | null;
+  status_message: string | null;
+  module_type_id: number | null;
+  data_entry_type_id: number | null;
+  year: number | null;
+  started_at: string | null;
+  finished_at: string | null;
+  attempts: number | null;
+  meta: Record<string, unknown>;
+}
+
+export interface PipelineListItem {
+  pipeline_id: string | null;
+  is_orphan: boolean;
+  progress: PipelineProgress;
+  job_type: string | null;
+  module_type_id: number | null;
+  year: number | null;
+  status_message: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  latest_job_id: number;
+  job_count: number;
+  error_count: number;
+  jobs: PipelineJobListEntry[];
+}
+
+export interface PipelineListResponse {
+  items: PipelineListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface PipelineFilters {
+  state: string | null;
+  result: string | null;
+  job_type: string | null;
+  year: number | null;
+  has_errors: boolean | null;
+  q: string;
+}
+
+const DEFAULT_FILTERS = (): PipelineFilters => ({
+  state: null,
+  result: null,
+  job_type: null,
+  year: null,
+  has_errors: null,
+  q: '',
+});
+
+export const usePipelineOperationsConsole = defineStore(
+  'pipelineOperationsConsole',
+  () => {
+    const items = ref<PipelineListItem[]>([]);
+    const total = ref(0);
+    const limit = ref(50);
+    const offset = ref(0);
+    const loading = ref(false);
+    const error = ref<string | null>(null);
+    const filters = ref<PipelineFilters>(DEFAULT_FILTERS());
+
+    /**
+     * Alert-strip counters, derived from the current page.  Scoped to
+     * the loaded page on purpose: the strip is a "what am I looking at"
+     * summary, and clicking a counter sets a filter to get the true
+     * server-side total for that slice.
+     */
+    const counters = computed(() => {
+      let failed = 0;
+      let errors = 0;
+      let running = 0;
+      let ok = 0;
+      for (const p of items.value) {
+        if (p.is_orphan && p.error_count > 0) failed += 1;
+        if (p.error_count > 0) errors += 1;
+        if (!p.progress.done) running += 1;
+        else if (!p.progress.has_error) ok += 1;
+      }
+      return { failed, errors, running, ok };
+    });
+
+    async function fetch(): Promise<void> {
+      loading.value = true;
+      error.value = null;
+      try {
+        const params: Record<string, string> = {
+          limit: String(limit.value),
+          offset: String(offset.value),
+        };
+        const f = filters.value;
+        if (f.state) params.state = f.state;
+        if (f.result) params.result = f.result;
+        if (f.job_type) params.job_type = f.job_type;
+        if (f.year != null) params.year = String(f.year);
+        if (f.has_errors != null) params.has_errors = String(f.has_errors);
+        if (f.q.trim()) params.q = f.q.trim();
+
+        const res = (await api
+          .get('sync/pipelines', { searchParams: params })
+          .json()) as PipelineListResponse;
+        items.value = res.items;
+        total.value = res.total;
+      } catch (err: unknown) {
+        error.value =
+          err instanceof Error ? err.message : 'Failed to load pipelines';
+        items.value = [];
+        total.value = 0;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function setPage(newOffset: number): Promise<void> {
+      offset.value = Math.max(0, newOffset);
+      await fetch();
+    }
+
+    async function applyFilters(
+      patch: Partial<PipelineFilters>,
+    ): Promise<void> {
+      filters.value = { ...filters.value, ...patch };
+      offset.value = 0;
+      await fetch();
+    }
+
+    async function clearFilters(): Promise<void> {
+      filters.value = DEFAULT_FILTERS();
+      offset.value = 0;
+      await fetch();
+    }
+
+    return {
+      items,
+      total,
+      limit,
+      offset,
+      loading,
+      error,
+      filters,
+      counters,
+      fetch,
+      setPage,
+      applyFilters,
+      clearFilters,
+    };
+  },
+);


### PR DESCRIPTION
Closes #1234

## What

A back-office **pipeline operations console** — a global view of ingestion/recalc pipelines (`data_ingestion_jobs` grouped by `pipeline_id`), complementary to the per-module data-management page.

### Backend
- `GET /v1/sync/pipelines` — paginated, filtered (state/result/job_type/module/year/has_errors/since/until/q), grouped by `pipeline_id`. Registered **before** `/pipelines/{pipeline_id}` so the static path wins.
- `DataIngestionRepository.list_pipelines_paginated` — pagination unit is the pipeline (children never split across pages); group/filter in SQL (no `DISTINCT ON` — SQLite-fixture safe), fetch+group in Python. Orphans (`pipeline_id IS NULL` parents that failed before fan-out) surface as tagged pipelines-of-one.
- Meta **allow-list** (`parent_job_id`, `recalc_jobs_chained`, `aggregation_job_id`, `provider_name`, `filters`) — never ships the KB-scale `error_details` / `affected_module_ids` arrays.
- Permission gate + per-module drop (not 403) mirrors `get_active_pipelines`. Reuses `compute_pipeline_progress`; drill-down stays on the existing `GET /pipelines/{id}` (+ `/stream`).

### Frontend
- New page (alert strip with clickable counters, filters, pipeline-grouped table, expandable job DAG), Pinia store, route, back-office nav entry, i18n (en/fr).

## Why it matters

Surfaces failure shapes that were invisible: `status_message="Success"` + `result=ERROR`, `InFailedSqlTransaction` carbon-report-stats poisoning (orphans), deadlocks between sibling recalc jobs, and the 3× concurrent aggregation amplification — all visible at a glance, grouped by pipeline.

## Tests

- 6 repo unit tests (grouping, pipeline-unit pagination, filters, `has_errors`, orphans) + 2 meta-allow-list tests. `46 passed`.
- Backend `ruff` + `mypy` clean; frontend `make type-check` (vue-tsc) + `eslint` clean.

## Scope / honest limits

- **Separate** from PR #1225 and the eager-pipeline-id work. No migration.
- Drill-down is the static DAG from the list payload + manual refresh. **Live SSE tailing is a deliberate follow-up** — the existing `usePipelineStream` composable + `/pipelines/{id}/stream` are ready to wire per-row; not done here to keep this shippable and bounded.
- Alert-strip counters are page-scoped (clicking sets a server-side filter for the true slice). `total` is pre-permission-drop, so a scope-limited operator may see a short page — acceptable for an internal tool; documented in the endpoint.

Plan: `docs/src/implementation-plans/1234-pipeline-operations-console.md`

