### PR TITLE
feat: make references mandatory in backoffice configuration

### DIFF
--- a/frontend/src/constant/backoffice-module-config.ts
+++ b/frontend/src/constant/backoffice-module-config.ts
@@ -13,6 +13,8 @@ export type SubmoduleConfig = {
   headerIcon?: string;
   descriptionKey?: string;
   factorsOnly?: true;
+  mandatoryData?: boolean;
+  mandatoryReference?: boolean;
 };
 
 export const MODULE_SUBMODULES: Partial<
@@ -40,6 +42,8 @@ export const MODULE_SUBMODULES: Partial<
       moduleTypeId: 2,
       dataEntryTypeId: 21,
       other: 'data_management_other_train_stations',
+      mandatoryData: false,
+      mandatoryReference: true,
     },
     {
       key: 'plane',
@@ -48,6 +52,8 @@ export const MODULE_SUBMODULES: Partial<
       dataEntryTypeId: 20,
       hasApi: true,
       other: 'data_management_other_airports',
+      mandatoryData: false,
+      mandatoryReference: true,
     },
   ],
   [MODULES.Buildings]: [
@@ -57,6 +63,8 @@ export const MODULE_SUBMODULES: Partial<
       moduleTypeId: 3,
       dataEntryTypeId: 30,
       other: 'data_management_other_institution_rooms',
+      mandatoryData: false,
+      mandatoryReference: true,
     },
     {
       key: 'energy_combustion',

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -456,12 +456,9 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
       const job = subConfig?.latest_factor_job ?? mod?.latest_common_factor_job;
       if (!job || job.result !== 0) return true;
     }
-    if (sub.other) {
+    if (sub.mandatoryData) {
       const dataJob = subConfig?.latest_data_job ?? mod?.latest_common_data_job;
       const dataOk = !!dataJob && dataJob.result === 0;
-      // Submodules with both CSV and API data sources (e.g. plane) accept
-      // either path — admins choose one or the other, so requiring both would
-      // mark every API-only or CSV-only setup as incomplete.
       if (sub.hasApi) {
         const apiJob = subConfig?.latest_api_data_job;
         const apiOk = !!apiJob && apiJob.result === 0;
@@ -469,6 +466,10 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
       } else if (!dataOk) {
         return true;
       }
+    }
+    if (sub.mandatoryReference) {
+      const refJob = subConfig?.latest_reference_job;
+      if (!refJob || refJob.result !== 0) return true;
     }
     if (!sub.noData && !sub.dataEntryTypeId) {
       const job = mod?.latest_common_data_job;


### PR DESCRIPTION
## What does this change?

Replaces the implicit `sub.other` check for data/reference completeness with two explicit boolean flags — `mandatoryData` and `mandatoryReference` — on `SubmoduleConfig`. Adds a dedicated completeness check for reference jobs (`latest_reference_job`). Updates the train station, plane, and institution room submodules to use `mandatoryReference: true` (and `mandatoryData: false`). Also relaxes the mkdocs version pin and renames the `clean` Makefile target to `clean-docs`.

## Why is this needed?

The old `sub.other` flag was doing double duty: it implicitly required both a successful data job and (indirectly) signalled reference-data requirements, which made the logic hard to follow and easy to break. Submodules like `plane` that support both CSV and API sources needed special-case comments to explain why only one path was required. By splitting the concern into `mandatoryData` and `mandatoryReference`, each requirement is declared explicitly in the config and checked independently in the store — making it straightforward to add new submodule types without touching the completeness logic.

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [x] 🧹 Code cleanup