### PR TITLE
feat: remove My unit carbon footprint per FTE tooltip

### DIFF
--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -846,9 +846,6 @@ const getUncertainty = (
                         :comparison-highlight="`${$nOrDash(2)}${$t('results_units_tonnes')}`"
                         color="negative"
                       >
-                        <template #tooltip>{{
-                          $t('results_paris_agreement_tooltip')
-                        }}</template>
                       </BigNumber>
                     </q-card>
                   </template>


### PR DESCRIPTION
## What does this change?

Removes the tooltip from the "My unit carbon footprint per FTE" `BigNumber` component on the Results page.

## Why is this needed?

The tooltip was displaying the Paris Agreement tooltip text (`results_paris_agreement_tooltip`) on a card where it didn't belong, likely a copy-paste mistake.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Related issues

- Closes #1033 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
