### PR TITLE
feat: update module carbon footprint chart ticks

### DIFF
--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -409,12 +409,12 @@ export default {
     fr: 'Emissions de procédés',
   },
   'charts-buildings-room-category': {
-    en: 'Buildings room',
-    fr: 'Salles des bâtiments',
+    en: 'Buildings',
+    fr: 'Bâtiments',
   },
   'charts-buildings-energy-combustion-category': {
-    en: 'Energy combustion emissions',
-    fr: 'Emissions de combustion d’énergie',
+    en: 'Thermal energy emissions',
+    fr: 'Emissions d’énergie thermique',
   },
   // Legacy key kept for backward compatibility with any existing references.
   'charts-building-energy-subcategory': {
@@ -507,7 +507,7 @@ export default {
   },
   'charts-commuting-category': {
     en: 'Commuting',
-    fr: 'Déplacements domicile-travail',
+    fr: 'Pendularité',
   },
   'charts-food-category': {
     en: 'Food',
@@ -542,8 +542,8 @@ export default {
     fr: 'Équipement',
   },
   'charts-external-cloud-category': {
-    en: 'External cloud',
-    fr: 'Cloud externe',
+    en: 'External clouds & AI',
+    fr: 'Clouds externes & IA',
   },
   'emission-type-breakdown-info-equipment': {
     en: 'The emissions considered here are those related to the energy required to operate the equipment (scientific, IT, etc.).',


### PR DESCRIPTION
## What does this change?

Updates chart category labels in the results i18n strings:
- "Buildings room" → "Buildings" / "Salles des bâtiments" → "Bâtiments"
- "Energy combustion emissions" → "Thermal energy emissions" / "Emissions de combustion d'énergie" → "Emissions d'énergie thermique"
- "Déplacements domicile-travail" → "Pendularité" (FR only)
- "External cloud" → "External clouds & AI" / "Cloud externe" → "Clouds externes & IA"

## Why is this needed?

The previous labels were either too technical, too verbose, or no longer accurately reflected the scope of the categories (notably, external cloud now covers AI workloads).

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup


## Related issues

- Closes #1166 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
