### PR TITLE
feat: change examples in Equipment names

### DIFF
--- a/frontend/src/constant/backoffice-module-config.ts
+++ b/frontend/src/constant/backoffice-module-config.ts
@@ -217,6 +217,7 @@ export const MODULE_COMMON_UPLOADS: Partial<
       key: 'equipment',
       labelKey: `${MODULES.EquipmentElectricConsumption}-common`,
       moduleTypeId: 4,
+      noData: true,
       headerIcon: 'o_folder_shared',
       descriptionKey: 'data_management_equipment_common_description',
     },

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -11,18 +11,22 @@ import {
   SUBMODULE_EQUIPMENT_TYPES,
 } from 'src/constant/modules';
 
+const nameField: ModuleField = {
+  id: 'name',
+  label: 'Equipment Name',
+  labelKey: `${MODULES.EquipmentElectricConsumption}.inputs.name`,
+  type: 'text',
+  required: true,
+  sortable: true,
+  align: 'left',
+  readOnly: false,
+  ratio: '1/1',
+};
+
 const baseModuleFields: ModuleField[] = [
   {
-    id: 'name',
-    label: 'Equipment Name',
-    labelKey: `${MODULES.EquipmentElectricConsumption}.inputs.name`,
-    type: 'text',
-    required: true,
-    placeholder: 'e.g., Agitator, Centrifuge',
-    sortable: true,
-    align: 'left',
-    readOnly: false,
-    ratio: '1/1',
+    ...nameField,
+    placeholder: `${MODULES.EquipmentElectricConsumption}.inputs.name-placeholder-scientific`,
   },
   {
     id: 'equipment_class',
@@ -157,10 +161,22 @@ const baseModuleFields: ModuleField[] = [
   },
 ];
 
-// remove subclass field for equipment-electric-consumption module
-const itmodulefields: ModuleField[] = baseModuleFields.filter(
-  (field) => field.id !== 'sub_class',
-);
+const otherModuleFields: ModuleField[] = [
+  {
+    ...nameField,
+    placeholder: `${MODULES.EquipmentElectricConsumption}.inputs.name-placeholder-other`,
+  },
+  ...baseModuleFields.slice(1),
+];
+
+// remove subclass field for IT equipment
+const itmodulefields: ModuleField[] = [
+  {
+    ...nameField,
+    placeholder: `${MODULES.EquipmentElectricConsumption}.inputs.name-placeholder-it`,
+  },
+  ...baseModuleFields.slice(1).filter((field) => field.id !== 'sub_class'),
+];
 
 export const equipmentElectricConsumption: ModuleConfig = {
   id: 'module_elec_001',
@@ -208,7 +224,7 @@ export const equipmentElectricConsumption: ModuleConfig = {
       tableNameKey:
         'equipment-electric-consumption-other-equipment-table-title',
       count: 4,
-      moduleFields: baseModuleFields,
+      moduleFields: otherModuleFields,
       hasFormTooltip: `${MODULES.EquipmentElectricConsumption}-other-form-title-info-tooltip`,
     },
   ],

--- a/frontend/src/i18n/equipment_electric_consumption.ts
+++ b/frontend/src/i18n/equipment_electric_consumption.ts
@@ -50,6 +50,19 @@ Si la puissance moyenne active ou standby de votre équipement est différente d
     en: 'Name',
     fr: 'Nom',
   },
+  [`${MODULES.EquipmentElectricConsumption}.inputs.name-placeholder-scientific`]:
+    {
+      en: 'e.g., Agitator, Centrifuge',
+      fr: 'ex. : Agitateur, Centrifugeuse',
+    },
+  [`${MODULES.EquipmentElectricConsumption}.inputs.name-placeholder-it`]: {
+    en: 'e.g., Laptop, Monitor',
+    fr: 'ex. : Ordinateur portable, Moniteur',
+  },
+  [`${MODULES.EquipmentElectricConsumption}.inputs.name-placeholder-other`]: {
+    en: 'e.g., Freezer, Fridge',
+    fr: 'ex. : Congélateur, Réfrigérateur',
+  },
   [`${MODULES.EquipmentElectricConsumption}.inputs.class`]: {
     en: 'Class',
     fr: 'Classe',


### PR DESCRIPTION
## What does this change?

Splits the equipment name field's placeholder into three context-specific variants — one per equipment type (scientific, IT, other) — with appropriate examples for each. Also extracts the shared `nameField` definition to avoid repetition, adds a dedicated `otherModuleFields` config, and updates the IT fields config to use the new placeholder. Adds `noData: true` to the equipment common upload config. New i18n keys added in both EN and FR.

## Why is this needed?

The previous placeholder ("e.g., Agitator, Centrifuge") was scientific-equipment-specific but was shown for all equipment types, including IT and other. Users filling in IT or general equipment forms were shown irrelevant examples, which was confusing.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup
## Related issues

- Closes #1182 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
