### PR TITLE
feat: alter box 2 in reuslt page modules

### DIFF
--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -762,46 +762,64 @@ const getUncertainty = (
                         }}</template>
                       </BigNumber>
                       <BigNumber
-                        :title="
-                          $t('results_module_carbon_footprint', {
-                            module: $t(module),
-                          })
-                        "
+                        :title="$t('results_unit_carbon_footprint')"
                         :number="
                           formatPercentChange(
                             getModuleResult(module)!.year_comparison_percentage,
                           )
                         "
                         :unit="
-                          $t('results_compared_to', {
-                            year: (currentYear - 1).toString(),
-                          })
+                          resultsSummary.unit_totals
+                            .year_comparison_percentage == null
+                            ? $t('results_no_comparison_year_available')
+                            : $t('results_compared_to', {
+                                year: (currentYear - 1).toString(),
+                              })
                         "
                         :color="
-                          getModuleResult(module)!.year_comparison_percentage ==
-                          null
+                          resultsSummary.unit_totals
+                            .year_comparison_percentage == null
                             ? undefined
-                            : getModuleResult(module)!
-                                  .year_comparison_percentage! < 0
+                            : resultsSummary.unit_totals
+                                  .year_comparison_percentage < 0
                               ? 'positive'
                               : 'negative'
                         "
                         :comparison="
-                          $t('results_compared_to_value_of', {
-                            value: `${getModuleConfig(module)?.totalFormatter(
-                              getModuleResult(module)!
-                                .previous_year_total_tonnes_co2eq,
-                            )}${$t('results_units_tonnes')}`,
-                          })
+                          resultsSummary.unit_totals
+                            .year_comparison_percentage == null
+                            ? undefined
+                            : $t('results_compared_to_value_of', {
+                                value: `${$nOrDash(
+                                  resultsSummary.unit_totals
+                                    .previous_year_total_tonnes_co2eq,
+                                  {
+                                    options: {
+                                      minimumFractionDigits: 1,
+                                      maximumFractionDigits: 1,
+                                    },
+                                  },
+                                )}${$t('results_units_tonnes')}`,
+                              })
                         "
-                        :comparison-highlight="`${getModuleConfig(
-                          module,
-                        ).totalFormatter(
-                          getModuleResult(module)!
-                            .previous_year_total_tonnes_co2eq,
-                        )}${$t('results_units_tonnes')}`"
+                        :comparison-highlight="
+                          resultsSummary.unit_totals
+                            .year_comparison_percentage == null
+                            ? undefined
+                            : `${$nOrDash(
+                                resultsSummary.unit_totals
+                                  .previous_year_total_tonnes_co2eq,
+                                {
+                                  options: {
+                                    minimumFractionDigits: 1,
+                                    maximumFractionDigits: 1,
+                                  },
+                                },
+                              )}${$t('results_units_tonnes')}`
+                        "
                       >
                       </BigNumber>
+
                       <BigNumber
                         :title="
                           resultsSummary.unit_totals.total_fte == null


### PR DESCRIPTION
## What does this change?

Updates the year-over-year comparison `BigNumber` card in the Results page to use unit-level totals (`resultsSummary.unit_totals`) instead of per-module data. Switches the title to the generic `results_unit_carbon_footprint` label, guards all comparison props against a `null` `year_comparison_percentage`, and formats the previous year value with `$nOrDash` (1 decimal place) instead of the module-specific `totalFormatter`.

## Why is this needed?

The card was incorrectly sourcing its comparison data from the individual module result rather than the unit totals, causing it to display wrong values in box 2. The null guard also prevents a crash/misleading display when no previous year data is available.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #992 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
