### PR TITLE
feat: add ordering option in dropdowns

### DIFF
--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -318,6 +318,7 @@ interface Option {
 }
 type FieldValue = string | number | boolean | null | Option;
 import type { AllSubmoduleTypes, Module } from 'src/constant/modules';
+import { sortByOrder } from 'src/utils/options';
 
 const props = withDefaults(
   defineProps<{
@@ -442,9 +443,13 @@ const filteredOptionsMap = computed(() => {
             value: o.value,
           })) ?? []);
 
+    const orderedBaseOptions = inp.optionOrder
+      ? sortByOrder(baseOptions, inp.optionOrder)
+      : baseOptions;
+
     // If no conditionalOptions, return base options
     if (!inp.conditionalOptions) {
-      map[inp.id] = baseOptions;
+      map[inp.id] = orderedBaseOptions;
       return;
     }
 
@@ -461,7 +466,7 @@ const filteredOptionsMap = computed(() => {
 
       // If condition matches, filter to only show specified options
       if (fieldValue === when.value) {
-        map[inp.id] = baseOptions.filter((opt) =>
+        map[inp.id] = orderedBaseOptions.filter((opt) =>
           showOptions.includes(opt.value),
         );
         matched = true;
@@ -471,7 +476,7 @@ const filteredOptionsMap = computed(() => {
 
     // If no condition matches, show all options
     if (!matched) {
-      map[inp.id] = baseOptions;
+      map[inp.id] = orderedBaseOptions;
     }
   });
 

--- a/frontend/src/components/organisms/module/ModuleInlineSelect.vue
+++ b/frontend/src/components/organisms/module/ModuleInlineSelect.vue
@@ -33,6 +33,7 @@ import { useI18n } from 'vue-i18n';
 import { useEquipmentClassOptions } from 'src/composables/useEquipmentClassOptions';
 import type { Module, ConditionalSubmoduleProps } from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
+import { sortByOrder } from 'src/utils/options';
 
 const moduleStore = useModuleStore();
 
@@ -55,6 +56,7 @@ type CommonProps = {
   fieldId: string;
   optionsId: string;
   optionLabelKey?: string;
+  optionOrder?: string[];
   hint?: string;
   cols: TableViewColumnSubset[];
   unitId: number;
@@ -88,7 +90,7 @@ const { dynamicOptions, loadingClasses, loadingSubclasses } =
 const classOptions = computed(() => {
   const taxo = moduleStore.state.taxonomySubmodule[props.submoduleType ?? ''];
   const opts = dynamicOptions['kind'] ?? [];
-  return opts.map((opt) => {
+  const mapped = opts.map((opt) => {
     if (props.optionLabelKey) {
       return {
         value: opt.value,
@@ -106,6 +108,7 @@ const classOptions = computed(() => {
       label: kindNode ? kindNode.label : opt.label || opt.value,
     };
   });
+  return props.optionOrder ? sortByOrder(mapped, props.optionOrder) : mapped;
 });
 const subClassOptions = computed(() => {
   const taxo = moduleStore.state.taxonomySubmodule[props.submoduleType ?? ''];

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -140,6 +140,7 @@
               :field-id="col.field"
               :options-id="col.optionsId"
               :option-label-key="col.optionLabelKey"
+              :option-order="col.optionOrder"
               :cols="qCols"
               :module-type="moduleType"
               :submodule-type="submoduleType as any"
@@ -750,6 +751,7 @@ type TableViewColumn = {
   readOnlyDisplayField?: string;
   optionLabelsAreKeys?: boolean;
   optionLabelPrefix?: string;
+  optionOrder?: string[];
 };
 
 const qCols = computed<TableViewColumn[]>(() => {
@@ -803,6 +805,7 @@ const qCols = computed<TableViewColumn[]>(() => {
             readOnlyDisplayField: f.readOnlyDisplayField,
             optionLabelsAreKeys: f.optionLabelsAreKeys,
             optionLabelPrefix: f.optionLabelPrefix,
+            optionOrder: f.optionOrder,
           });
         });
       } else {
@@ -838,6 +841,7 @@ const qCols = computed<TableViewColumn[]>(() => {
           readOnlyDisplayField: f.readOnlyDisplayField,
           optionLabelsAreKeys: f.optionLabelsAreKeys,
           optionLabelPrefix: f.optionLabelPrefix,
+          optionOrder: f.optionOrder,
         });
       }
     });

--- a/frontend/src/constant/module-config/buildings.ts
+++ b/frontend/src/constant/module-config/buildings.ts
@@ -159,6 +159,14 @@ const energyCombustionFields: ModuleField[] = [
     ratio: '1/3',
     icon: 'o_local_fire_department',
     hideIn: { form: false },
+    optionOrder: [
+      'buildings_combustion_type_natural_gas',
+      'buildings_combustion_type_heating_oil',
+      'buildings_combustion_type_biomethane',
+      'buildings_combustion_type_pellets',
+      'buildings_combustion_type_forest_chips',
+      'buildings_combustion_type_wood_logs',
+    ],
   },
   {
     id: 'unit',

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -60,6 +60,7 @@ export interface ModuleField {
   defaultFrom?: 'total_fte';
   options?: Array<{ value: string; label: string }>;
   optionsId?: string; // ID to fetch options from store (kind or subkind)
+  optionOrder?: string[]; // Explicit ordering of options by value
   optionLabelKey?: string; // i18n key template; use {value} as placeholder, e.g. 'process-emissions.category.{value}', where {value} matches the normalized option value used by the translation keys
   appendFromFieldId?: string;
   // Flat configuration (preferred): used by both table and form where relevant

--- a/frontend/src/i18n/buildings.ts
+++ b/frontend/src/i18n/buildings.ts
@@ -204,15 +204,15 @@ export default {
   },
   buildings_combustion_type_pellets: {
     en: 'Pellets',
-    fr: 'Pellets',
+    fr: 'Granulés de bois',
   },
   buildings_combustion_type_forest_chips: {
     en: 'Forest chips',
-    fr: 'Copeaux de forêt',
+    fr: 'Plaquettes forestières',
   },
   buildings_combustion_type_wood_logs: {
     en: 'Wood logs',
-    fr: 'Bûches de bois',
+    fr: 'Bois bûche',
   },
 
   // Charts

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -483,7 +483,7 @@ export default {
   },
   'charts-pellets-subcategory': {
     en: 'Pellets',
-    fr: 'Pellets',
+    fr: 'Granulés de bois',
   },
   'charts-forest-chips-subcategory': {
     en: 'Forest Chips',
@@ -491,7 +491,7 @@ export default {
   },
   'charts-wood-logs-subcategory': {
     en: 'Wood Logs',
-    fr: 'Bûches',
+    fr: 'Bois bûche',
   },
   'charts-ln2-subcategory': {
     en: 'LN2',

--- a/frontend/src/stores/factors.ts
+++ b/frontend/src/stores/factors.ts
@@ -45,7 +45,7 @@ export const useFactorsStore = defineStore('factors', () => {
     submodule: AllSubmoduleTypes,
   ): Promise<Option[]> {
     const optionMap = await ensureSubclassOptionMap(submodule);
-    const classes = Object.keys(optionMap).sort();
+    const classes = Object.keys(optionMap);
     return classes.map((c) => ({ label: c, value: c }));
   }
 

--- a/frontend/src/utils/options.ts
+++ b/frontend/src/utils/options.ts
@@ -1,0 +1,13 @@
+export function sortByOrder<T extends { value: string }>(
+  options: T[],
+  order: string[],
+): T[] {
+  return [...options].sort((a, b) => {
+    const ai = order.indexOf(a.value);
+    const bi = order.indexOf(b.value);
+    if (ai === -1 && bi === -1) return 0;
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}


### PR DESCRIPTION
## What does this change?

Adds an `optionOrder` field to `ModuleField` that allows dropdown options to be sorted in an explicit, config-defined order rather than alphabetically. Introduces a `sortByOrder` utility and wires it through `ModuleForm`, `ModuleInlineSelect`, and `ModuleTable`. Applies the ordering to the buildings energy combustion type dropdown. Also removes the default alphabetical sort from the factors store so that `optionOrder` is the single source of truth. Fixes several French translations for wood-based fuel types (`Pellets` → `Granulés de bois`, `Bûches de bois` → `Bois bûche`, `Copeaux de forêt` → `Plaquettes forestières`) in both the form and results chart labels.

## Why is this needed?

Options in some dropdowns were being sorted alphabetically, which didn't match the logical or domain-expected order (e.g. most-common fuel types first). The French translations for wood fuels were also using informal or incorrect terminology.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #967 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
