### PR TITLE
fix(#1236): pipeline correctness + observability — Phase 1-5 + concurrency fixes + UX

### DIFF
--- a/backend/alembic/versions/2026_05_19_2000-b1f7a2c9d4e0_add_pipelines_table.py
+++ b/backend/alembic/versions/2026_05_19_2000-b1f7a2c9d4e0_add_pipelines_table.py
@@ -3,10 +3,11 @@
 
 First-class pipeline aggregate root.  Table-only: the existing
 ``data_ingestion_jobs.pipeline_id`` column stays a plain UUID with NO
-foreign key here — legacy rows reference pipeline_ids that have no
-``pipelines`` row yet, so an enforced FK would reject the first insert.
-The FK is added post-backfill in Phase 2
-(``ADD CONSTRAINT … NOT VALID`` + ``VALIDATE CONSTRAINT``).
+foreign key here — when this migration first applies onto an existing
+DB, pre-Phase-1 jobs hold pipeline_ids with no ``pipelines`` row, so
+an enforced FK would reject them.  v0.x drops the DB between deploys
+(no backfill until v1.x), so the FK is enforced in a follow-up
+migration once a clean DB runs Phase-1 code — not gated on a backfill.
 
 Revision ID: b1f7a2c9d4e0
 Revises: 30c096280772

--- a/backend/alembic/versions/2026_05_19_2000-b1f7a2c9d4e0_add_pipelines_table.py
+++ b/backend/alembic/versions/2026_05_19_2000-b1f7a2c9d4e0_add_pipelines_table.py
@@ -1,0 +1,87 @@
+# codeql[py/unused-global-variable]
+"""add pipelines table (#1236 Phase 1)
+
+First-class pipeline aggregate root.  Table-only: the existing
+``data_ingestion_jobs.pipeline_id`` column stays a plain UUID with NO
+foreign key here — legacy rows reference pipeline_ids that have no
+``pipelines`` row yet, so an enforced FK would reject the first insert.
+The FK is added post-backfill in Phase 2
+(``ADD CONSTRAINT … NOT VALID`` + ``VALIDATE CONSTRAINT``).
+
+Revision ID: b1f7a2c9d4e0
+Revises: 30c096280772
+Create Date: 2026-05-19 20:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "b1f7a2c9d4e0"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "30c096280772"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pipelines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        # = the parent job_type (csv_ingest / factor_ingest / unit_sync …)
+        sa.Column("kind", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column(
+            "status",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            server_default="NOT_STARTED",
+        ),
+        # scope / provenance — int-enum values mirrored from the parent
+        sa.Column("entity_type", sa.Integer(), nullable=True),
+        sa.Column("ingestion_method", sa.Integer(), nullable=True),
+        sa.Column("module_type_id", sa.Integer(), nullable=True),
+        sa.Column("year", sa.Integer(), nullable=True),
+        sa.Column("expected_recalc", sa.Integer(), nullable=True),
+        sa.Column("job_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_pipelines_status", "pipelines", ["status"], unique=False)
+    op.create_index(
+        "ix_pipelines_module_year",
+        "pipelines",
+        ["module_type_id", "year"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pipelines_module_year", table_name="pipelines")
+    op.drop_index("ix_pipelines_status", table_name="pipelines")
+    op.drop_table("pipelines")

--- a/backend/alembic/versions/2026_05_20_0900-a3b8c9d0e1f2_year_config_completed.py
+++ b/backend/alembic/versions/2026_05_20_0900-a3b8c9d0e1f2_year_config_completed.py
@@ -1,0 +1,47 @@
+# codeql[py/unused-global-variable]
+"""year_configuration.configuration_completed (#1234-followup)
+
+Tracks when the per-year ``unit_sync`` pipeline finished SUCCESS so
+dispatch can refuse uploads for years that aren't yet provisioned (or
+were never provisioned).  NULL on every existing row — set by the
+handler on the next successful unit_sync run.  No backfill (v0.x).
+
+Revision ID: a3b8c9d0e1f2
+Revises: b1f7a2c9d4e0
+Create Date: 2026-05-20 09:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "a3b8c9d0e1f2"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "b1f7a2c9d4e0"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    op.add_column(
+        "year_configuration",
+        sa.Column(
+            "configuration_completed",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("year_configuration", "configuration_completed")

--- a/backend/alembic/versions/2026_05_20_1000-c4d5e6f7a8b9_enforce_pipeline_id_fk.py
+++ b/backend/alembic/versions/2026_05_20_1000-c4d5e6f7a8b9_enforce_pipeline_id_fk.py
@@ -1,0 +1,73 @@
+# codeql[py/unused-global-variable]
+"""enforce data_ingestion_jobs.pipeline_id FK (#1236 Phase 2)
+
+Phase-1's ``add_pipelines_table`` migration deliberately left the
+``data_ingestion_jobs.pipeline_id`` column as a plain UUID with no FK
+so it could apply onto an existing DB without rejecting pre-Phase-1
+rows whose pipeline_ids have no ``pipelines`` row.
+
+v0.x drops the DB between deploys, so by the time this migration
+applies on the next deployment cycle every ``pipeline_id`` in
+``data_ingestion_jobs`` was minted *under Phase-1 code* and has a
+matching ``pipelines`` row (via ``ensure_pipeline_exists``).  We can
+therefore enforce the FK without a backfill.
+
+Also adds an explicit index on ``pipeline_id``.  Postgres does NOT
+auto-create an index on the referencing column of a foreign key, and
+the console + recalc fan-out path query ``WHERE pipeline_id = …`` on
+every poll.
+
+Revision ID: c4d5e6f7a8b9
+Revises: a3b8c9d0e1f2
+Create Date: 2026-05-20 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "c4d5e6f7a8b9"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "a3b8c9d0e1f2"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_data_ingestion_jobs_pipeline_id",
+        "data_ingestion_jobs",
+        ["pipeline_id"],
+        unique=False,
+    )
+    # Default ON DELETE RESTRICT: pipelines are append-only operational
+    # ledger today (no delete code path).  RESTRICT refuses to drop a
+    # pipeline that still has jobs — if we ever want to purge old
+    # pipelines, jobs must be dropped first (explicit, not silent).
+    op.create_foreign_key(
+        "fk_data_ingestion_jobs_pipeline_id",
+        "data_ingestion_jobs",
+        "pipelines",
+        ["pipeline_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_data_ingestion_jobs_pipeline_id",
+        "data_ingestion_jobs",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        "ix_data_ingestion_jobs_pipeline_id",
+        table_name="data_ingestion_jobs",
+    )

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -113,6 +113,22 @@ async def _stamp_job_type_and_meta(
     # explicitly worries about.
     if pipeline_id is not None:
         row.pipeline_id = pipeline_id
+        # #1236 — create the pipeline aggregate row at parent creation
+        # (idempotent; the runner only advances status, never creates).
+        await repo.ensure_pipeline_exists(
+            pipeline_id,
+            kind=job_type,
+            entity_type=(
+                row.entity_type.value if row.entity_type is not None else None
+            ),
+            ingestion_method=(
+                row.ingestion_method.value
+                if row.ingestion_method is not None
+                else None
+            ),
+            module_type_id=row.module_type_id,
+            year=row.year,
+        )
     db.add(row)
 
 
@@ -1469,7 +1485,17 @@ async def recalculate_emissions_for_type(
         pipeline_id=pipeline_id,
         meta={"config": {"year": year, "data_entry_type_id": data_entry_type_id.value}},
     )
-    created_job = await DataIngestionRepository(db).create_ingestion_job(job)
+    repo = DataIngestionRepository(db)
+    created_job = await repo.create_ingestion_job(job)
+    # #1236 — pipeline aggregate row, atomic with the job creation.
+    await repo.ensure_pipeline_exists(
+        pipeline_id,
+        kind="emission_recalc",
+        entity_type=EntityType.MODULE_PER_YEAR.value,
+        ingestion_method=IngestionMethod.computed.value,
+        module_type_id=module_type_id.value,
+        year=year,
+    )
     await db.commit()
     if created_job.id is None:
         raise HTTPException(
@@ -1558,7 +1584,17 @@ async def recalculate_emissions_for_module(
             }
         },
     )
-    created_job = await DataIngestionRepository(db).create_ingestion_job(job)
+    repo = DataIngestionRepository(db)
+    created_job = await repo.create_ingestion_job(job)
+    # #1236 — pipeline aggregate row, atomic with the job creation.
+    await repo.ensure_pipeline_exists(
+        pipeline_id,
+        kind="module_emission_recalc",
+        entity_type=EntityType.MODULE_PER_YEAR.value,
+        ingestion_method=IngestionMethod.computed.value,
+        module_type_id=module_type_id.value,
+        year=year,
+    )
     await db.commit()
     if created_job.id is None:
         raise HTTPException(

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -328,6 +328,84 @@ class PipelineResponse(BaseModel):
     progress: PipelineProgressResponse
 
 
+# Issue #1234 — meta keys the pipeline-ops console is allowed to ship.
+# Everything else (esp. ``error_details`` / ``affected_module_ids``,
+# which are KB-scale per row) is stripped server-side so the list
+# payload stays small.  These five are exactly what threads the DAG /
+# drives ``compute_pipeline_progress`` plus the provenance the table
+# shows.
+_PIPELINE_META_ALLOW = (
+    "parent_job_id",
+    "recalc_jobs_chained",
+    "aggregation_job_id",
+    "provider_name",
+    "filters",
+)
+
+
+def _project_pipeline_meta(meta: Optional[dict]) -> dict:
+    m = meta or {}
+    return {k: m[k] for k in _PIPELINE_META_ALLOW if k in m}
+
+
+class PipelineJobListEntry(BaseModel):
+    """One job inside a pipeline, as shown in the ops-console DAG (#1234).
+
+    Slimmer than the pipeline read endpoint's ``PipelineJobResponse``:
+    carries timing for per-step duration and an **allow-listed** ``meta``
+    (never the big ``error_details`` / ``affected_module_ids`` arrays)."""
+
+    job_id: int
+    job_type: Optional[str] = None
+    state: Optional[IngestionState] = None
+    result: Optional[IngestionResult] = None
+    status_message: Optional[str] = None
+    module_type_id: Optional[int] = None
+    data_entry_type_id: Optional[int] = None
+    year: Optional[int] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    attempts: Optional[int] = None
+    meta: dict = {}
+
+
+class PipelineListItem(BaseModel):
+    """One pipeline row in the ops console (#1234).
+
+    ``pipeline_id`` is ``None`` for an orphan — a parent that failed
+    before fan-out so it never minted a pipeline (``is_orphan=True``);
+    it still appears as a pipeline-of-one.  Rollups (job_type, module,
+    year, status_message) come from the root/parent job; timing spans
+    the whole chain."""
+
+    pipeline_id: Optional[UUID] = None
+    is_orphan: bool
+    progress: PipelineProgressResponse
+    job_type: Optional[str] = None
+    module_type_id: Optional[int] = None
+    year: Optional[int] = None
+    status_message: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    latest_job_id: int
+    job_count: int
+    error_count: int
+    jobs: list[PipelineJobListEntry]
+
+
+class PipelineListResponse(BaseModel):
+    """Page of pipelines for the ops console (#1234).
+
+    ``total`` is the full match count *before* the per-module
+    permission drop (see endpoint docstring), so a page may contain
+    fewer than ``limit`` items for a scope-limited operator."""
+
+    items: list[PipelineListItem]
+    total: int
+    limit: int
+    offset: int
+
+
 class StaleStatsEntry(BaseModel):
     """One ``(module_type_id, year)`` scope whose aggregation is missing,
     failed, stuck, or too old.  Returned by ``GET /sync/health/stale-stats``
@@ -974,6 +1052,128 @@ async def get_recalculation_status(
         )
         for module_id, dets in modules.items()
     ]
+
+
+@router.get("/pipelines", response_model=PipelineListResponse)
+async def list_pipelines(
+    state: Optional[IngestionState] = None,
+    result: Optional[IngestionResult] = None,
+    job_type: Optional[str] = None,
+    module_type_id: Optional[int] = None,
+    year: Optional[int] = None,
+    has_errors: Optional[bool] = None,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    q: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(
+        require_permission("backoffice.data_management", "view")
+    ),
+) -> PipelineListResponse:
+    """Paginated, filtered list of ingestion/recalc pipelines (#1234).
+
+    **Required Permission**: ``backoffice.data_management.view``
+
+    Backs the back-office pipeline-operations console — a global view
+    complementary to the per-module data-management page.  The unit is
+    the *pipeline* (one ``pipeline_id`` = parent + fan-out children);
+    pagination never splits a pipeline's jobs across pages.  Orphans
+    (a parent that failed before minting a ``pipeline_id``) appear as
+    pipelines-of-one with ``is_orphan=True``.
+
+    Declared before ``/pipelines/{pipeline_id}`` so the static path
+    wins routing.  Drill-down/live stays on the existing
+    ``GET /pipelines/{id}`` (+ ``/stream``) — not rebuilt here.
+
+    Permission model mirrors ``get_active_pipelines``: the global
+    ``backoffice.data_management.view`` gate (dependency above) plus a
+    per-module *drop* (not 403) for pipelines whose module the operator
+    can't view.  Pipelines with no ``module_type_id`` (unit_sync,
+    unpinned factor ingests) pass on the global gate alone.  ``total``
+    is the pre-drop match count, so a scope-limited operator may see a
+    short page — acceptable for an internal ops tool where backoffice
+    users almost always hold broad view; the alternative (exact
+    post-filter pagination) would require loading every pipeline,
+    defeating the SQL-side pagination.
+    """
+    groups, total = await DataIngestionRepository(db).list_pipelines_paginated(
+        state=state,
+        result=result,
+        job_type=job_type,
+        module_type_id=module_type_id,
+        year=year,
+        has_errors=has_errors,
+        since=since,
+        until=until,
+        q=q,
+        limit=limit,
+        offset=offset,
+    )
+
+    allowed: dict[int, bool] = {}
+    items: list[PipelineListItem] = []
+    for group in groups:
+        jobs = group["jobs"]
+        if not jobs:
+            continue
+        # Root/parent = lowest id (repo returns jobs id-ascending; the
+        # ingest parent is created before its fan-out children).
+        root = jobs[0]
+        mod = root.module_type_id
+        if mod is not None:
+            if mod not in allowed:
+                decision = await get_module_permission_decision(
+                    current_user, mod, "view"
+                )
+                allowed[mod] = bool(decision.get("allow"))
+            if not allowed[mod]:
+                continue
+
+        started = [j.started_at for j in jobs if j.started_at is not None]
+        finished = [j.finished_at for j in jobs if j.finished_at is not None]
+        items.append(
+            PipelineListItem(
+                pipeline_id=group["pipeline_id"],
+                is_orphan=group["is_orphan"],
+                progress=PipelineProgressResponse(**compute_pipeline_progress(jobs)),
+                job_type=root.job_type,
+                module_type_id=root.module_type_id,
+                year=root.year,
+                status_message=root.status_message,
+                started_at=min(started) if started else None,
+                finished_at=max(finished) if finished else None,
+                latest_job_id=max(j.id for j in jobs if j.id is not None),
+                job_count=len(jobs),
+                error_count=sum(
+                    1
+                    for j in jobs
+                    if j.state == IngestionState.FINISHED
+                    and j.result == IngestionResult.ERROR
+                ),
+                jobs=[
+                    PipelineJobListEntry(
+                        job_id=j.id,
+                        job_type=j.job_type,
+                        state=j.state,
+                        result=j.result,
+                        status_message=j.status_message,
+                        module_type_id=j.module_type_id,
+                        data_entry_type_id=j.data_entry_type_id,
+                        year=j.year,
+                        started_at=j.started_at,
+                        finished_at=j.finished_at,
+                        attempts=j.attempts,
+                        meta=_project_pipeline_meta(j.meta),
+                    )
+                    for j in jobs
+                    if j.id is not None
+                ],
+            )
+        )
+
+    return PipelineListResponse(items=items, total=total, limit=limit, offset=offset)
 
 
 @router.get("/pipelines/{pipeline_id}", response_model=PipelineResponse)

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -1,7 +1,8 @@
 import asyncio
+import enum
 import json
 from datetime import datetime
-from typing import Optional
+from typing import Optional, TypeVar
 from uuid import UUID, uuid4
 
 from fastapi import (
@@ -363,6 +364,32 @@ _PIPELINE_META_ALLOW = (
 def _project_pipeline_meta(meta: Optional[dict]) -> dict:
     m = meta or {}
     return {k: m[k] for k in _PIPELINE_META_ALLOW if k in m}
+
+
+_EnumT = TypeVar("_EnumT", bound=enum.Enum)
+
+
+def _resolve_enum_name(
+    enum_cls: type[_EnumT], value: Optional[str], field: str
+) -> Optional[_EnumT]:
+    """Resolve a query param to an enum member by *name* (#1234).
+
+    ``IngestionState`` / ``IngestionResult`` are int enums, so FastAPI's
+    built-in coercion expects the integer value and 422s on the
+    human-readable name the UI sends (``RUNNING``, ``ERROR`` …).  This
+    accepts the name case-insensitively and 422s only on a genuinely
+    unknown value."""
+    if value is None:
+        return None
+    needle = value.strip().lower()
+    for member in enum_cls:
+        if member.name.lower() == needle:
+            return member
+    valid = ", ".join(m.name for m in enum_cls)
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=f"Invalid {field} '{value}'. Expected one of: {valid}",
+    )
 
 
 class PipelineJobListEntry(BaseModel):
@@ -1079,8 +1106,8 @@ async def get_recalculation_status(
 
 @router.get("/pipelines", response_model=PipelineListResponse)
 async def list_pipelines(
-    state: Optional[IngestionState] = None,
-    result: Optional[IngestionResult] = None,
+    state: Optional[str] = None,
+    result: Optional[str] = None,
     job_type: Optional[str] = None,
     module_type_id: Optional[int] = None,
     year: Optional[int] = None,
@@ -1110,20 +1137,31 @@ async def list_pipelines(
     wins routing.  Drill-down/live stays on the existing
     ``GET /pipelines/{id}`` (+ ``/stream``) — not rebuilt here.
 
-    Permission model mirrors ``get_active_pipelines``: the global
-    ``backoffice.data_management.view`` gate (dependency above) plus a
-    per-module *drop* (not 403) for pipelines whose module the operator
-    can't view.  Pipelines with no ``module_type_id`` (unit_sync,
-    unpinned factor ingests) pass on the global gate alone.  ``total``
-    is the pre-drop match count, so a scope-limited operator may see a
-    short page — acceptable for an internal ops tool where backoffice
-    users almost always hold broad view; the alternative (exact
+    ``state`` / ``result`` filters take the enum **name**
+    (case-insensitive: ``RUNNING``, ``FINISHED``, ``SUCCESS``,
+    ``ERROR`` …).  ``IngestionState``/``IngestionResult`` are int
+    enums, so FastAPI's native enum coercion would demand the integer
+    value and 422 on the readable name the UI sends — hence the
+    explicit name resolution here.
+
+    Permission model matches the single-pipeline endpoint
+    (``_check_pipeline_scope_from_jobs`` → ``_check_job_scope``), just
+    *non-raising*: the global ``backoffice.data_management.view`` gate
+    (dependency above) covers cross-unit ``MODULE_PER_YEAR`` pipelines
+    (recalc/aggregation) and unscoped runs (unit_sync); a pipeline is
+    *dropped* (not 403) only when it is unit-pinned
+    (``MODULE_UNIT_SPECIFIC``) and the operator lacks the
+    ``modules.{name}`` scope for that unit.  ``total`` is the pre-drop
+    match count, so a unit-scoped operator may see a short page —
+    acceptable for an internal ops tool; the alternative (exact
     post-filter pagination) would require loading every pipeline,
     defeating the SQL-side pagination.
     """
+    resolved_state = _resolve_enum_name(IngestionState, state, "state")
+    resolved_result = _resolve_enum_name(IngestionResult, result, "result")
     groups, total = await DataIngestionRepository(db).list_pipelines_paginated(
-        state=state,
-        result=result,
+        state=resolved_state,
+        result=resolved_result,
         job_type=job_type,
         module_type_id=module_type_id,
         year=year,
@@ -1135,25 +1173,22 @@ async def list_pipelines(
         offset=offset,
     )
 
-    allowed: dict[int, bool] = {}
     items: list[PipelineListItem] = []
     for group in groups:
         jobs = group["jobs"]
         if not jobs:
             continue
+        # Same scope gate as the single-pipeline read endpoint, made
+        # non-fatal: cross-unit MODULE_PER_YEAR pipelines and unscoped
+        # runs pass on the global backoffice gate; only a unit-pinned
+        # pipeline the operator can't view is dropped (not 403).
+        try:
+            await _check_pipeline_scope_from_jobs(jobs, current_user, db, action="view")
+        except HTTPException:
+            continue
         # Root/parent = lowest id (repo returns jobs id-ascending; the
         # ingest parent is created before its fan-out children).
         root = jobs[0]
-        mod = root.module_type_id
-        if mod is not None:
-            if mod not in allowed:
-                decision = await get_module_permission_decision(
-                    current_user, mod, "view"
-                )
-                allowed[mod] = bool(decision.get("allow"))
-            if not allowed[mod]:
-                continue
-
         started = [j.started_at for j in jobs if j.started_at is not None]
         finished = [j.finished_at for j in jobs if j.finished_at is not None]
         items.append(

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -16,7 +16,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from sqlmodel import select
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app import db as db_module
@@ -38,6 +38,7 @@ from app.models.data_ingestion import (
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
 from app.models.unit import Unit
 from app.models.user import User
+from app.models.year_configuration import YearConfiguration
 from app.repositories.data_ingestion import DataIngestionRepository, WhyStaleLiteral
 from app.services.data_ingestion.provider_factory import ProviderFactory
 from app.services.pipeline_progress import PhaseLabel, compute_pipeline_progress
@@ -122,9 +123,7 @@ async def _stamp_job_type_and_meta(
                 row.entity_type.value if row.entity_type is not None else None
             ),
             ingestion_method=(
-                row.ingestion_method.value
-                if row.ingestion_method is not None
-                else None
+                row.ingestion_method.value if row.ingestion_method is not None else None
             ),
             module_type_id=row.module_type_id,
             year=row.year,
@@ -555,6 +554,32 @@ async def sync_module_data_entries(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="year is required for factor CSV ingestion",
         )
+
+    # #1234-followup (Guilbert 2026-05-20): block dispatch when the
+    # target year's ``unit_sync`` hasn't finished SUCCESS — uploads
+    # would race the provisioning (carbon_reports/modules creation) and
+    # silently lose rows. ``configuration_completed`` is stamped by
+    # ``unit_sync_handler`` on success. UI-side disable is best-effort;
+    # this server gate cannot be bypassed.  ``unit_sync`` itself goes
+    # through ``run_job`` (not ``/dispatch``), so it doesn't gate
+    # itself.
+    if syncRequest.year is not None:
+        year_cfg = (
+            await db.execute(
+                select(YearConfiguration).where(
+                    col(YearConfiguration.year) == syncRequest.year
+                )
+            )
+        ).scalar_one_or_none()
+        if year_cfg is None or year_cfg.configuration_completed is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Year {syncRequest.year} is not yet provisioned — "
+                    "wait for the unit_sync pipeline to complete before "
+                    "uploading data for this year."
+                ),
+            )
 
     # Prepare config with file_path and carbon_report_module_id if provided
     config = syncRequest.config.model_dump() if syncRequest.config else {}

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -15,7 +15,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -341,6 +341,17 @@ class PipelineJobResponse(BaseModel):
     data_entry_type_id: Optional[int] = None
     year: Optional[int] = None
 
+    # See ``PipelineJobListEntry`` for the rationale — serialize
+    # ``state`` and ``result`` as the enum NAME so the frontend's
+    # string comparisons (``j.state === 'FINISHED'``) work.
+    @field_serializer("state")
+    def _state_name(self, v: Optional[IngestionState]) -> Optional[str]:
+        return v.name if v is not None else None
+
+    @field_serializer("result")
+    def _result_name(self, v: Optional[IngestionResult]) -> Optional[str]:
+        return v.name if v is not None else None
+
 
 class PipelineProgressResponse(BaseModel):
     """Server-authoritative pipeline phase/done/error (Issue #1219).
@@ -450,7 +461,14 @@ class PipelineJobListEntry(BaseModel):
 
     Slimmer than the pipeline read endpoint's ``PipelineJobResponse``:
     carries timing for per-step duration and an **allow-listed** ``meta``
-    (never the big ``error_details`` / ``affected_module_ids`` arrays)."""
+    (never the big ``error_details`` / ``affected_module_ids`` arrays).
+
+    ``state`` and ``result`` serialize as the enum NAME (string), not
+    the int value — Pydantic's int-enum default would ship ``3`` for
+    ``FINISHED`` which mismatches every frontend consumer (the TS
+    interface declares ``string | null`` and renders comparisons like
+    ``j.state === 'FINISHED'``).  The field_serializers below pin the
+    contract."""
 
     job_id: int
     job_type: Optional[str] = None
@@ -467,6 +485,14 @@ class PipelineJobListEntry(BaseModel):
     finished_at: Optional[datetime] = None
     attempts: Optional[int] = None
     meta: dict = {}
+
+    @field_serializer("state")
+    def _state_name(self, v: Optional[IngestionState]) -> Optional[str]:
+        return v.name if v is not None else None
+
+    @field_serializer("result")
+    def _result_name(self, v: Optional[IngestionResult]) -> Optional[str]:
+        return v.name if v is not None else None
 
 
 class PipelineListItem(BaseModel):
@@ -1465,8 +1491,12 @@ async def pipeline_stream_by_id(
                 {
                     "id": job.id,
                     "job_type": job.job_type,
-                    "state": (job.state.value if job.state is not None else None),
-                    "result": (job.result.value if job.result is not None else None),
+                    # Enum NAME so the frontend's string comparisons
+                    # (``j.state === 'FINISHED'``) work uniformly across
+                    # the list endpoint, single endpoint, and this SSE
+                    # stream.  See ``PipelineJobListEntry`` serializers.
+                    "state": (job.state.name if job.state is not None else None),
+                    "result": (job.result.name if job.result is not None else None),
                     "status_message": job.status_message,
                     "started_at": (
                         job.started_at.isoformat() if job.started_at else None

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -33,6 +33,7 @@ from app.models.data_ingestion import (
     IngestionMethod,
     IngestionResult,
     IngestionState,
+    PipelineStatus,
     TargetType,
 )
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
@@ -1181,7 +1182,6 @@ async def get_recalculation_status(
 @router.get("/pipelines", response_model=PipelineListResponse)
 async def list_pipelines(
     state: Optional[str] = None,
-    result: Optional[str] = None,
     job_type: Optional[str] = None,
     module_type_id: Optional[int] = None,
     year: Optional[int] = None,
@@ -1211,12 +1211,14 @@ async def list_pipelines(
     wins routing.  Drill-down/live stays on the existing
     ``GET /pipelines/{id}`` (+ ``/stream``) — not rebuilt here.
 
-    ``state`` / ``result`` filters take the enum **name**
-    (case-insensitive: ``RUNNING``, ``FINISHED``, ``SUCCESS``,
-    ``ERROR`` …).  ``IngestionState``/``IngestionResult`` are int
-    enums, so FastAPI's native enum coercion would demand the integer
-    value and 422 on the readable name the UI sends — hence the
-    explicit name resolution here.
+    **Phase 3 read-flip (#1236):** ``state`` is the
+    ``pipelines.status`` name (case-insensitive: ``NOT_STARTED``,
+    ``RUNNING``, ``SUCCESS``, ``PARTIAL``, ``FAILED``) — the
+    pipeline-level status the runner recompute-and-stores.  The
+    previous job-level ``result`` URL param is dropped; its
+    semantics are subsumed by ``state`` (FAILED / PARTIAL =
+    error).  ``has_errors=true`` also pivots to ``status IN
+    (PARTIAL, FAILED)``.
 
     Permission model matches the single-pipeline endpoint
     (``_check_pipeline_scope_from_jobs`` → ``_check_job_scope``), just
@@ -1231,11 +1233,9 @@ async def list_pipelines(
     post-filter pagination) would require loading every pipeline,
     defeating the SQL-side pagination.
     """
-    resolved_state = _resolve_enum_name(IngestionState, state, "state")
-    resolved_result = _resolve_enum_name(IngestionResult, result, "result")
+    resolved_status = _resolve_enum_name(PipelineStatus, state, "state")
     groups, total = await DataIngestionRepository(db).list_pipelines_paginated(
-        state=resolved_state,
-        result=resolved_result,
+        pipeline_status=resolved_status,
         job_type=job_type,
         module_type_id=module_type_id,
         year=year,
@@ -1269,7 +1269,9 @@ async def list_pipelines(
             PipelineListItem(
                 pipeline_id=group["pipeline_id"],
                 is_orphan=group["is_orphan"],
-                progress=PipelineProgressResponse(**compute_pipeline_progress(jobs)),
+                progress=PipelineProgressResponse(
+                    **compute_pipeline_progress(jobs, pipeline=group["pipeline"])
+                ),
                 job_type=root.job_type,
                 module_type_id=root.module_type_id,
                 module_label=_module_label(root.module_type_id),
@@ -1331,7 +1333,8 @@ async def get_pipeline_jobs(
     the convention of other lookup endpoints in this module
     (``cancel_job``, ``recover_job``).
     """
-    jobs = await DataIngestionRepository(db).list_jobs_by_pipeline_id(pipeline_id)
+    repo = DataIngestionRepository(db)
+    jobs = await repo.list_jobs_by_pipeline_id(pipeline_id)
     if not jobs:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1339,6 +1342,9 @@ async def get_pipeline_jobs(
         )
     # TODO(#459): tighten when sub-perimeter scoping ships
     await _check_pipeline_scope_from_jobs(jobs, current_user, db, action="view")
+
+    # Phase 3 read-flip (#1236): authoritative status from pipelines table.
+    pipeline = await repo.get_pipeline_by_id(pipeline_id)
 
     return PipelineResponse(
         pipeline_id=pipeline_id,
@@ -1357,7 +1363,9 @@ async def get_pipeline_jobs(
             for job in jobs
             if job.id is not None
         ],
-        progress=PipelineProgressResponse(**compute_pipeline_progress(jobs)),
+        progress=PipelineProgressResponse(
+            **compute_pipeline_progress(jobs, pipeline=pipeline)
+        ),
     )
 
 
@@ -1433,9 +1441,13 @@ async def pipeline_stream_by_id(
             # ``Depends(get_db)`` for the entire generator lifetime, pinning
             # one slot per subscriber for the whole stream (minutes).
             async with db_module.SessionLocal() as session:
-                jobs = await DataIngestionRepository(session).list_jobs_by_pipeline_id(
-                    pipeline_id
-                )
+                repo = DataIngestionRepository(session)
+                jobs = await repo.list_jobs_by_pipeline_id(pipeline_id)
+                # Phase 3 read-flip (#1236): pull the pipelines row each
+                # tick so ``progress.done`` reflects the runner's most
+                # recent post-finish_job status write (or the cron sweep
+                # if that write log-and-skipped).
+                pipeline_row = await repo.get_pipeline_by_id(pipeline_id)
 
             # Snapshot the columns the spec calls out for the dashboard:
             # only these fields trigger a re-emit, so meta-only mutations
@@ -1458,14 +1470,13 @@ async def pipeline_stream_by_id(
                 if job.id is not None
             ]
 
-            # Issue #1219 — server-authoritative completion.  The old
-            # "every job in the snapshot is FINISHED" test fired in the
-            # window where the parent upload was FINISHED but its
-            # recalc/aggregation children had not been INSERTed yet, so
-            # the UI flashed green on a half-done pipeline.  Derive
-            # phase/done from the expected fan-out recorded in meta
-            # instead, and ship it so the client trusts the same truth.
-            progress = compute_pipeline_progress(jobs)
+            # Issue #1219 — server-authoritative completion.  Phase 3
+            # (#1236) further: ``done``/``has_error`` derive from
+            # ``pipelines.status`` (durable, recompute-and-stored)
+            # rather than from the possibly-stale job snapshot.  Orphans
+            # (no pipelines row) fall back to job-derived inside
+            # compute_pipeline_progress.
+            progress = compute_pipeline_progress(jobs, pipeline=pipeline_row)
 
             if snapshot != last_snapshot:
                 payload = {
@@ -1546,8 +1557,8 @@ async def recalculate_emissions_for_type(
         meta={"config": {"year": year, "data_entry_type_id": data_entry_type_id.value}},
     )
     repo = DataIngestionRepository(db)
-    created_job = await repo.create_ingestion_job(job)
-    # #1236 — pipeline aggregate row, atomic with the job creation.
+    # #1236 — pipeline aggregate row MUST exist before the
+    # data_ingestion_jobs INSERT flushes (Phase 2 FK).  Idempotent.
     await repo.ensure_pipeline_exists(
         pipeline_id,
         kind="emission_recalc",
@@ -1556,6 +1567,7 @@ async def recalculate_emissions_for_type(
         module_type_id=module_type_id.value,
         year=year,
     )
+    created_job = await repo.create_ingestion_job(job)
     await db.commit()
     if created_job.id is None:
         raise HTTPException(
@@ -1645,8 +1657,8 @@ async def recalculate_emissions_for_module(
         },
     )
     repo = DataIngestionRepository(db)
-    created_job = await repo.create_ingestion_job(job)
-    # #1236 — pipeline aggregate row, atomic with the job creation.
+    # #1236 — pipeline aggregate row MUST exist before the
+    # data_ingestion_jobs INSERT flushes (Phase 2 FK).  Idempotent.
     await repo.ensure_pipeline_exists(
         pipeline_id,
         kind="module_emission_recalc",
@@ -1655,6 +1667,7 @@ async def recalculate_emissions_for_module(
         module_type_id=module_type_id.value,
         year=year,
     )
+    created_job = await repo.create_ingestion_job(job)
     await db.commit()
     if created_job.id is None:
         raise HTTPException(

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -114,9 +114,11 @@ async def _stamp_job_type_and_meta(
     # closes the pod-crash-then-recovery orphan window the lazy path
     # explicitly worries about.
     if pipeline_id is not None:
-        row.pipeline_id = pipeline_id
-        # #1236 — create the pipeline aggregate row at parent creation
-        # (idempotent; the runner only advances status, never creates).
+        # #1236 Phase 2 FK — the Pipeline row MUST exist *before* we
+        # assign ``row.pipeline_id``.  Otherwise the SELECT inside
+        # ``ensure_pipeline_exists`` triggers SQLAlchemy autoflush,
+        # which writes UPDATE data_ingestion_jobs SET pipeline_id=…
+        # while ``pipelines`` is still empty → FK violation.
         await repo.ensure_pipeline_exists(
             pipeline_id,
             kind=job_type,
@@ -129,6 +131,7 @@ async def _stamp_job_type_and_meta(
             module_type_id=row.module_type_id,
             year=row.year,
         )
+        row.pipeline_id = pipeline_id
     db.add(row)
 
 

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -354,6 +354,9 @@ class PipelineProgressResponse(BaseModel):
     phase_label: PhaseLabel
     done: bool
     has_error: bool
+    # PARTIAL tier (#1236) — the authoritative ``pipelines.status``
+    # name so the console can render PARTIAL (amber) vs FAILED (red).
+    status: Optional[str] = None
 
 
 class PipelineResponse(BaseModel):

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from datetime import datetime
 from typing import Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import (
     APIRouter,
@@ -79,6 +79,7 @@ async def _stamp_job_type_and_meta(
     job_type: str,
     provider_name: Optional[str] = None,
     extra_meta: Optional[dict] = None,
+    pipeline_id: Optional[UUID] = None,
 ) -> None:
     """After ``provider.create_job`` returns, stamp ``job_type`` and
     extend ``meta`` so the runner's registry lookup hits the right
@@ -103,6 +104,14 @@ async def _stamp_job_type_and_meta(
     if extra_meta:
         merged_meta.update(extra_meta)
     row.meta = merged_meta
+    # Issue #1219 — stamp the pipeline_id eagerly when the caller
+    # supplies one.  ``chain_job`` only generates a UUID when
+    # ``parent.pipeline_id is None`` (_chain.py:154-157), so a
+    # pre-set value is honored and inherited by every child — and it
+    # closes the pod-crash-then-recovery orphan window the lazy path
+    # explicitly worries about.
+    if pipeline_id is not None:
+        row.pipeline_id = pipeline_id
     db.add(row)
 
 
@@ -243,6 +252,14 @@ class SyncStatusResponse(BaseModel):
     state: IngestionState
     message: str
     progress: Optional[dict] = None
+    # Issue #1219 — the parent's pipeline_id, assigned eagerly at
+    # creation (not lazily at first fan-out) so the frontend can seed
+    # its pipeline-state store and subscribe to the SSE stream from
+    # the moment the job is dispatched.  Without this the card only
+    # discovers the pipeline after the upload job already FINISHED,
+    # so phase 1 ("Inserting data…") is never visible and fast
+    # chains complete inside the discovery gap, showing nothing.
+    pipeline_id: Optional[str] = None
 
 
 class SyncJobResponse(BaseModel):
@@ -535,12 +552,14 @@ async def sync_module_data_entries(
     # NOTE: file_path validation happens in provider.__init__() via
     # _validate_file_path() to prevent directory traversal attacks
     # (e.g., /../../../etc/passwd).
+    pipeline_id = uuid4()
     await _stamp_job_type_and_meta(
         db,
         job_id,
         job_type=_job_type_for(syncRequest.target_type, syncRequest.ingestion_method),
         provider_name=provider.__class__.__name__,
         extra_meta={"filters": syncRequest.filters or {}},
+        pipeline_id=pipeline_id,
     )
     await db.commit()
 
@@ -551,6 +570,7 @@ async def sync_module_data_entries(
         "state": IngestionState.NOT_STARTED,
         "message": f"""Sync initiated using {syncRequest.ingestion_method}""",
         "progress": None,
+        "pipeline_id": str(pipeline_id),
     }
 
 
@@ -635,12 +655,14 @@ async def sync_module_factors(
             "route_payload": await extract_route_payload(request),
         },
     )
+    pipeline_id = uuid4()
     await _stamp_job_type_and_meta(
         db,
         job_id,
         job_type=_job_type_for(syncRequest.target_type, syncRequest.ingestion_method),
         provider_name=provider.__class__.__name__,
         extra_meta={"filters": syncRequest.filters or {}},
+        pipeline_id=pipeline_id,
     )
     await db.commit()
 
@@ -651,6 +673,7 @@ async def sync_module_factors(
         "state": IngestionState.NOT_STARTED,
         "message": f"Sync initiated using {syncRequest.ingestion_method}",
         "progress": None,
+        "pipeline_id": str(pipeline_id),
     }
 
 
@@ -1397,6 +1420,8 @@ async def recalculate_emissions_for_type(
         data_entry_type_id: The data entry type to recalculate.
         year: The report year (required).
     """
+    # Issue #1219 — eager pipeline_id (see SyncStatusResponse / _chain.py:154).
+    pipeline_id = uuid4()
     job = DataIngestionJob(
         job_type="emission_recalc",
         module_type_id=module_type_id.value,
@@ -1406,6 +1431,7 @@ async def recalculate_emissions_for_type(
         target_type=TargetType.DATA_ENTRIES,
         entity_type=EntityType.MODULE_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        pipeline_id=pipeline_id,
         meta={"config": {"year": year, "data_entry_type_id": data_entry_type_id.value}},
     )
     created_job = await DataIngestionRepository(db).create_ingestion_job(job)
@@ -1421,6 +1447,7 @@ async def recalculate_emissions_for_type(
         job_id=created_job.id,
         state=IngestionState.NOT_STARTED,
         message="Emission recalculation scheduled",
+        pipeline_id=str(pipeline_id),
     )
 
 
@@ -1476,6 +1503,8 @@ async def recalculate_emissions_for_module(
     else:
         det_ids = all_det_ids
 
+    # Issue #1219 — eager pipeline_id (see SyncStatusResponse / _chain.py:154).
+    pipeline_id = uuid4()
     job = DataIngestionJob(
         job_type="module_emission_recalc",
         module_type_id=module_type_id.value,
@@ -1485,6 +1514,7 @@ async def recalculate_emissions_for_module(
         target_type=TargetType.DATA_ENTRIES,
         entity_type=EntityType.MODULE_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        pipeline_id=pipeline_id,
         meta={
             "config": {
                 "year": year,
@@ -1507,6 +1537,7 @@ async def recalculate_emissions_for_module(
         job_id=created_job.id,
         state=IngestionState.NOT_STARTED,
         message=f"Module emission recalculation scheduled for {n} data entry types",
+        pipeline_id=str(pipeline_id),
     )
 
 

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -368,13 +368,16 @@ class PipelineResponse(BaseModel):
 # Issue #1234 — meta keys the pipeline-ops console is allowed to ship.
 # Everything else (esp. ``error_details`` / ``affected_module_ids``,
 # which are KB-scale per row) is stripped server-side so the list
-# payload stays small.  These five are exactly what threads the DAG /
-# drives ``compute_pipeline_progress`` plus the provenance the table
-# shows.
+# payload stays small.
+#
+# Phase 5B (#1236) retired three keys from this list:
+# ``parent_job_id``, ``recalc_jobs_chained``, ``aggregation_job_id``.
+# They were used to thread the DAG and drive
+# ``compute_pipeline_progress``; that data now lives on the
+# ``pipelines`` row (``expected_recalc``) or is derived from the
+# job rows directly (root = lowest-id; aggregation_done = all
+# aggregation rows FINISHED).
 _PIPELINE_META_ALLOW = (
-    "parent_job_id",
-    "recalc_jobs_chained",
-    "aggregation_job_id",
     "provider_name",
     "filters",
     # #2A / #2B — generic status_history timeline + unit_sync phase

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -447,14 +447,21 @@ def _resolve_enum_name(
     built-in coercion expects the integer value and 422s on the
     human-readable name the UI sends (``RUNNING``, ``ERROR`` …).  This
     accepts the name case-insensitively and 422s only on a genuinely
-    unknown value."""
+    unknown value.
+
+    Iterates via ``__members__.values()`` rather than ``for m in
+    enum_cls`` so CodeQL's "Non-iterable used in for loop" check sees
+    a plain ``dict_values`` (it doesn't model ``EnumMeta.__iter__``
+    through ``type[_EnumT]``).
+    """
     if value is None:
         return None
     needle = value.strip().lower()
-    for member in enum_cls:
+    members = enum_cls.__members__.values()
+    for member in members:
         if member.name.lower() == needle:
             return member
-    valid = ", ".join(m.name for m in enum_cls)
+    valid = ", ".join(m.name for m in members)
     raise HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         detail=f"Invalid {field} '{value}'. Expected one of: {valid}",

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -382,6 +382,28 @@ def _project_pipeline_meta(meta: Optional[dict]) -> dict:
     return {k: m[k] for k in _PIPELINE_META_ALLOW if k in m}
 
 
+def _module_label(value: Optional[int]) -> Optional[str]:
+    """Resolve a module_type_id int to its enum name (#1234) — done
+    server-side so the table shows names with no frontend int→label
+    map to drift. Unknown/legacy ints degrade to ``None``."""
+    if value is None:
+        return None
+    try:
+        return ModuleTypeEnum(value).name
+    except ValueError:
+        return None
+
+
+def _det_label(value: Optional[int]) -> Optional[str]:
+    """Resolve a data_entry_type_id int to its enum name (#1234)."""
+    if value is None:
+        return None
+    try:
+        return DataEntryTypeEnum(value).name
+    except ValueError:
+        return None
+
+
 _EnumT = TypeVar("_EnumT", bound=enum.Enum)
 
 
@@ -422,6 +444,9 @@ class PipelineJobListEntry(BaseModel):
     status_message: Optional[str] = None
     module_type_id: Optional[int] = None
     data_entry_type_id: Optional[int] = None
+    # #1234 — human label (resolved from the int enum server-side so
+    # the table shows names, not integers, with no frontend drift).
+    data_entry_type_label: Optional[str] = None
     year: Optional[int] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
@@ -443,6 +468,8 @@ class PipelineListItem(BaseModel):
     progress: PipelineProgressResponse
     job_type: Optional[str] = None
     module_type_id: Optional[int] = None
+    # #1234 — human label for the related module (server-resolved).
+    module_label: Optional[str] = None
     year: Optional[int] = None
     status_message: Optional[str] = None
     started_at: Optional[datetime] = None
@@ -1214,6 +1241,7 @@ async def list_pipelines(
                 progress=PipelineProgressResponse(**compute_pipeline_progress(jobs)),
                 job_type=root.job_type,
                 module_type_id=root.module_type_id,
+                module_label=_module_label(root.module_type_id),
                 year=root.year,
                 status_message=root.status_message,
                 started_at=min(started) if started else None,
@@ -1235,6 +1263,7 @@ async def list_pipelines(
                         status_message=j.status_message,
                         module_type_id=j.module_type_id,
                         data_entry_type_id=j.data_entry_type_id,
+                        data_entry_type_label=_det_label(j.data_entry_type_id),
                         year=j.year,
                         started_at=j.started_at,
                         finished_at=j.finished_at,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -368,6 +368,11 @@ class PipelineProgressResponse(BaseModel):
     # PARTIAL tier (#1236) — the authoritative ``pipelines.status``
     # name so the console can render PARTIAL (amber) vs FAILED (red).
     status: Optional[str] = None
+    # Parent ``job_type`` so frontend cards (UploadCardData /
+    # UploadCardFactors / UploadCardReferences) can decide whether
+    # the phase indicator applies to *their* target — a factor
+    # ingest's progress shouldn't surface on the data card.
+    kind: Optional[str] = None
 
 
 class PipelineResponse(BaseModel):

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -22,7 +22,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app import db as db_module
 from app.api.deps import get_current_user, get_db
 from app.core.config import get_settings
-from app.core.policy import check_module_permission, get_module_permission_decision
+from app.core.policy import check_module_permission
 from app.core.security import is_permitted, require_permission
 from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import DataEntryTypeEnum
@@ -1097,27 +1097,22 @@ async def get_active_pipelines(
             detail="modules must be a comma-separated list of integers",
         ) from exc
 
-    # Per-module scope filter: drop entries the caller can't view rather than
-    # 403-ing the whole batch.  The global ``backoffice.data_management.view``
-    # gate above proves the user is a backoffice user; this loop additionally
-    # verifies they have view access to each specific module.  Without it, a
-    # backoffice user scoped to a sub-perimeter could enumerate active
-    # pipeline UUIDs across modules they otherwise can't read.
-    # TODO(#459): once sub-perimeter scoping ships, also pass institutional_id.
-    allowed_module_ids: list[int] = []
-    for module_type_id in module_type_ids:
-        decision = await get_module_permission_decision(
-            current_user, module_type_id, "view"
-        )
-        if decision.get("allow"):
-            allowed_module_ids.append(module_type_id)
-
-    if not allowed_module_ids:
-        return {}
-
+    # Permission: the global ``backoffice.data_management.view`` gate
+    # (dependency above) is sufficient — the back-office data-management
+    # page is global-scope for ``calco2.backoffice.metier`` (and
+    # SuperAdmin) by design.  The previous per-module OPA check
+    # (``modules.{name}.view``) filtered out every module for
+    # ``BackOfficeMetier`` users because that role grants
+    # ``backoffice.data_management.view`` but not the per-module
+    # ``modules.X.view`` perms, leaving the "Recalculating…" badge
+    # silently broken on the configuration page.  Matches the
+    # sibling year-level endpoint's gate (see
+    # ``get_active_year_level_pipelines``).
+    # TODO(#459): when sub-perimeter scoping ships, re-introduce
+    # filtering — but by sub-perimeter, not by module enumeration.
     pipeline_by_module = await DataIngestionRepository(
         db
-    ).get_current_pipeline_ids_for_modules(allowed_module_ids, year=year)
+    ).get_current_pipeline_ids_for_modules(module_type_ids, year=year)
     return {module_id: str(pid) for module_id, pid in pipeline_by_module.items()}
 
 

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -373,6 +373,12 @@ _PIPELINE_META_ALLOW = (
     "aggregation_job_id",
     "provider_name",
     "filters",
+    # #2A / #2B — generic status_history timeline + unit_sync phase
+    # checklist. Both are bounded (status_history capped at 50;
+    # phases is ≤4 for unit_sync, empty for other job_types) so the
+    # per-job payload stays tractable in the list view.
+    "status_history",
+    "phases",
 )
 
 

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -468,6 +468,7 @@ async def get_year_configuration(
     return YearConfigurationResponse(
         year=result.year,
         is_started=result.is_started,
+        configuration_completed=result.configuration_completed,
         config=enriched_config,
         recalculation_status=recalculation_status,
         updated_at=result.updated_at,
@@ -732,6 +733,7 @@ async def update_year_configuration(
     return YearConfigurationResponse(
         year=result.year,
         is_started=result.is_started,
+        configuration_completed=result.configuration_completed,
         config=enriched_config,
         recalculation_status=recalculation_status,
         updated_at=result.updated_at,

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -576,7 +576,18 @@ async def create_year_configuration(
         pipeline_id=pipeline_id,
         meta={"config": {"target_year": year}},
     )
-    created_job = await DataIngestionRepository(db).create_ingestion_job(job)
+    # #1236 Phase 2 — Pipeline row MUST exist before the
+    # data_ingestion_jobs INSERT flushes, else the FK rejects.
+    # ``ensure_pipeline_exists`` is idempotent.
+    repo = DataIngestionRepository(db)
+    await repo.ensure_pipeline_exists(
+        pipeline_id,
+        kind="unit_sync",
+        entity_type=EntityType.GLOBAL_PER_YEAR.value,
+        ingestion_method=IngestionMethod.api.value,
+        year=year,
+    )
+    created_job = await repo.create_ingestion_job(job)
 
     await db.commit()
     await db.refresh(new_config)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -337,6 +337,32 @@ class Settings(BaseSettings):
         description="Whether to run the in-process safety poller",
     )
 
+    # #1236 Phase 3 — pipeline status reconciliation cron.
+    RUN_PIPELINE_RECONCILER: bool = Field(
+        default=True,
+        description=(
+            "Whether to run the in-process pipeline-status reconciliation "
+            "sweep.  The sweep is the durable backstop for the runner's "
+            "post-finish_job isolated status write — that write log-and-"
+            "skips on any DB error, so without this cron a missed write "
+            "leaves a pipeline showing the wrong status until the next "
+            "manual reconcile.  Keep on in production; flip off only for "
+            "diagnostic single-process runs where you want the table to "
+            "lag visibly."
+        ),
+    )
+    PIPELINE_RECONCILER_INTERVAL_SECONDS: int = Field(
+        default=60,
+        ge=10,
+        description=(
+            "Seconds between pipeline reconciliation sweeps.  60s = "
+            "stale window ≤ ~1 minute for the rare case where the "
+            "runner's isolated write log-and-skipped.  The sweep is "
+            "indexed on ``pipelines.status`` and commits per pipeline; "
+            "tighter cadence has no measured benefit."
+        ),
+    )
+
     # Plan 310-D — bulk-path pure async cutover
     BULK_PATH_PURE_ASYNC: bool = Field(
         default=True,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,9 +66,22 @@ async def lifespan(app: FastAPI):
         logger.info(f"Starting safety poller on pod {POD_ID}")
         app.state.poller_task = asyncio.create_task(poll_pending_jobs())
 
+    # Start the pipeline reconciliation sweep (#1236 Phase 3) — durable
+    # backstop for the runner's log-and-skip post-``finish_job`` write.
+    if settings.RUN_PIPELINE_RECONCILER:
+        from app.tasks._pipeline_reconciler import reconcile_pipeline_statuses_loop
+
+        logger.info(
+            "Starting pipeline reconciler (every %ss)",
+            settings.PIPELINE_RECONCILER_INTERVAL_SECONDS,
+        )
+        app.state.pipeline_reconciler_task = asyncio.create_task(
+            reconcile_pipeline_statuses_loop()
+        )
+
     yield
 
-    # Cancel the safety poller on shutdown
+    # Cancel background tasks on shutdown
     task = getattr(app.state, "poller_task", None)
     if task:
         logger.info("Cancelling safety poller")
@@ -77,6 +90,14 @@ async def lifespan(app: FastAPI):
             await task
         except asyncio.CancelledError:
             logger.info("Safety poller cancelled successfully")
+    reconciler_task = getattr(app.state, "pipeline_reconciler_task", None)
+    if reconciler_task:
+        logger.info("Cancelling pipeline reconciler")
+        reconciler_task.cancel()
+        try:
+            await reconciler_task
+        except asyncio.CancelledError:
+            logger.info("Pipeline reconciler cancelled successfully")
 
     logger.info("Shutdown complete", extra={settings.APP_NAME: settings.APP_VERSION})
 

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -371,3 +371,94 @@ class DataIngestionJob(DataIngestionJobBase, table=True):
             f"provider={self.provider} status={self.state} "
             f"result={self.result} is_current={self.is_current}>"
         )
+
+
+# ==========================================
+# 3. PIPELINE AGGREGATE ROOT (Issue #1236)
+# ==========================================
+
+
+class PipelineStatus(str, Enum):
+    """Authoritative pipeline status (#1236).
+
+    Stored as text (no PG enum type — keeps the migration and the
+    SQLite test fixture trivial).  Derived by the runner via
+    ``compute_pipeline_progress`` (recompute-and-store), never an
+    incremental accumulator.
+    """
+
+    NOT_STARTED = "NOT_STARTED"
+    RUNNING = "RUNNING"
+    SUCCESS = "SUCCESS"
+    PARTIAL = "PARTIAL"  # chain completed, some children errored
+    FAILED = "FAILED"  # chain broken (a job FINISHED+ERROR)
+
+
+class Pipeline(SQLModel, table=True):
+    """First-class pipeline (#1236) — the aggregate root for a
+    multi-step run that today is only an emergent ``pipeline_id`` tag
+    on ``data_ingestion_jobs``.
+
+    Phase 1: the row is created at parent creation via
+    ``ensure_pipeline_exists``; ``status`` is advanced by the runner
+    post-``finish_job`` (recompute-and-store, last-child oracle,
+    isolated log-and-skip).  ``data_ingestion_jobs.pipeline_id`` stays
+    a plain UUID — the FK is added post-backfill in Phase 2.
+    """
+
+    __tablename__ = "pipelines"
+
+    id: UUID = Field(sa_column=Column(SAUUID, primary_key=True))
+    # = parent job_type (csv_ingest / factor_ingest / unit_sync / …)
+    kind: Optional[str] = Field(default=None, sa_column=Column(String(100)))
+    status: str = Field(
+        default=PipelineStatus.NOT_STARTED.value,
+        sa_column=Column(String(32), nullable=False, server_default="NOT_STARTED"),
+    )
+    # scope / provenance — int-enum values mirrored from the parent job
+    entity_type: Optional[int] = Field(default=None)
+    ingestion_method: Optional[int] = Field(default=None)
+    module_type_id: Optional[int] = Field(default=None)
+    year: Optional[int] = Field(default=None)
+    # owned recalc count (was meta.recalc_jobs_chained) — kept for the
+    # Phase-3 console; the last-child oracle uses compute_pipeline_progress,
+    # not this counter.
+    expected_recalc: Optional[int] = Field(default=None)
+    job_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+    error_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+    started_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(SADateTime(timezone=True))
+    )
+    finished_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(SADateTime(timezone=True))
+    )
+    last_error: Optional[str] = Field(default=None, sa_column=Column(String))
+    created_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(
+            SADateTime(timezone=True),
+            nullable=False,
+            server_default=text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    updated_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(
+            SADateTime(timezone=True),
+            nullable=False,
+            server_default=text("CURRENT_TIMESTAMP"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Pipeline id={self.id} kind={self.kind} "
+            f"status={self.status} jobs={self.job_count} "
+            f"errors={self.error_count}>"
+        )

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import JSON, Column, Index, Integer, String, text
+from sqlalchemy import JSON, Column, ForeignKey, Index, Integer, String, text
 from sqlalchemy import UUID as SAUUID
 from sqlalchemy import DateTime as SADateTime
 from sqlalchemy import Enum as SAEnum
@@ -294,9 +294,16 @@ class DataIngestionJob(DataIngestionJobBase, table=True):
     )
 
     # Grouping / dispatch (Plan 310A)
+    # FK to pipelines.id enforced by migration ``c4d5e6f7a8b9`` (#1236 Phase 2)
+    # — declared here so SQLAlchemy's schema view matches Postgres.  Index is
+    # explicit because Postgres does not auto-index the referencing column.
     pipeline_id: Optional[UUID] = Field(
         default=None,
-        sa_column=Column(SAUUID),
+        sa_column=Column(
+            SAUUID,
+            ForeignKey("pipelines.id"),
+            index=True,
+        ),
         description="UUID grouping jobs belonging to the same multi-step pipeline run",
     )
     job_type: Optional[str] = Field(
@@ -402,8 +409,9 @@ class Pipeline(SQLModel, table=True):
     Phase 1: the row is created at parent creation via
     ``ensure_pipeline_exists``; ``status`` is advanced by the runner
     post-``finish_job`` (recompute-and-store, last-child oracle,
-    isolated log-and-skip).  ``data_ingestion_jobs.pipeline_id`` stays
-    a plain UUID — the FK is added post-backfill in Phase 2.
+    isolated log-and-skip).  Phase 2: ``data_ingestion_jobs.pipeline_id``
+    gains the FK to ``pipelines.id`` (migration ``c4d5e6f7a8b9``) —
+    no backfill in v0.x (DB drops between deploys).
     """
 
     __tablename__ = "pipelines"

--- a/backend/app/models/year_configuration.py
+++ b/backend/app/models/year_configuration.py
@@ -1,8 +1,10 @@
 """Year configuration model for annual administrative settings."""
 
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import Column
+from sqlalchemy import DateTime as SADateTime
 from sqlmodel import JSON, Field, SQLModel
 
 
@@ -12,6 +14,19 @@ class YearConfigurationBase(SQLModel):
     is_started: bool = Field(
         default=False,
         description="If true, data entry is open for users for this year",
+    )
+    # #1234-followup (Guilbert 2026-05-20): the `unit_sync` pipeline
+    # provisions a year's carbon_reports + modules; uploads for the
+    # year must NOT be accepted while that's running or before it ever
+    # ran. ``configuration_completed`` is set by ``unit_sync_handler``
+    # on SUCCESS (None until then). Dispatch gates on it.
+    configuration_completed: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(SADateTime(timezone=True), nullable=True),
+        description=(
+            "Timestamp the unit_sync pipeline finished SUCCESSFULLY for "
+            "this year. NULL = year not yet provisioned (uploads blocked)."
+        ),
     )
     config: dict = Field(
         default_factory=dict,

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -643,12 +643,30 @@ class DataIngestionRepository:
             for j in jobs
             if j.state == IngestionState.FINISHED and j.result == IngestionResult.ERROR
         ]
-        # Phase-1 mapping. PARTIAL is reserved (model enum) but not
-        # emitted until the FAILED-vs-PARTIAL boundary open question is
-        # decided — do not invent a definition here.
-        new_status = (
-            PipelineStatus.FAILED.value if errored else PipelineStatus.SUCCESS.value
-        )
+        # PARTIAL tier (#1236) — the PM/PO contract for ingest results:
+        #   * No errors anywhere → SUCCESS (green badge).
+        #   * Root (parent ingest) itself FINISHED+ERROR → FAILED (red);
+        #     the data did not land, the chain is broken.
+        #   * Root succeeded (SUCCESS or WARNING) and at least one
+        #     descendant FINISHED+ERROR → PARTIAL (amber); data DID
+        #     land, but a downstream step (emission_recalc /
+        #     aggregation / module_emission_recalc) had errors.
+        # The root is the lowest-id job in the pipeline (chain_job
+        # creates children after the parent, by construction — same
+        # rule ``compute_pipeline_progress._find_root`` uses).
+        if not errored:
+            new_status = PipelineStatus.SUCCESS.value
+        else:
+            root = min(jobs, key=lambda j: j.id or 0)
+            root_failed = (
+                root.state == IngestionState.FINISHED
+                and root.result == IngestionResult.ERROR
+            )
+            new_status = (
+                PipelineStatus.FAILED.value
+                if root_failed
+                else PipelineStatus.PARTIAL.value
+            )
         # ``last_error`` must carry signal, not the #1219 lie: a
         # ``csv_ingest`` that succeeded then poisoned downstream has
         # ``result=ERROR`` but ``status_message="Success"`` (jobs

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -125,6 +125,26 @@ class DataIngestionRepository:
                     )
                 ),
             }
+            # #1236 #2A — generic status_history timeline: append every
+            # status_message update (with timestamp) to a bounded list
+            # so the ops console can show "what happened, when" for
+            # every job_type — not just the latest status_message that
+            # this same UPDATE overwrites above. Bounded to keep meta
+            # payloads tractable on long-lived / retried jobs.
+            history = list(merged_meta.get("status_history") or [])
+            if status_message:
+                history.append(
+                    {
+                        "message": status_message,
+                        "ts": datetime.now(timezone.utc).isoformat(),
+                    }
+                )
+                # Cap to last N to bound the meta payload. 50 covers
+                # the busiest job (multi-phase unit_sync, retries) with
+                # margin; trim from the head when exceeded.
+                if len(history) > 50:
+                    history = history[-50:]
+                merged_meta["status_history"] = history
             result_job.meta = merged_meta
             await self.session.flush()
             await self.session.refresh(result_job)
@@ -523,9 +543,7 @@ class DataIngestionRepository:
             # A concurrent creator won the race — idempotent no-op.
             pass
 
-    async def recompute_pipeline_status(
-        self, pipeline_id: UUID
-    ) -> Optional[str]:
+    async def recompute_pipeline_status(self, pipeline_id: UUID) -> Optional[str]:
         """Recompute-and-store the pipeline's authoritative status (#1236).
 
         The single source of truth is the pure
@@ -557,16 +575,13 @@ class DataIngestionRepository:
         errored = [
             j
             for j in jobs
-            if j.state == IngestionState.FINISHED
-            and j.result == IngestionResult.ERROR
+            if j.state == IngestionState.FINISHED and j.result == IngestionResult.ERROR
         ]
         # Phase-1 mapping. PARTIAL is reserved (model enum) but not
         # emitted until the FAILED-vs-PARTIAL boundary open question is
         # decided — do not invent a definition here.
         new_status = (
-            PipelineStatus.FAILED.value
-            if errored
-            else PipelineStatus.SUCCESS.value
+            PipelineStatus.FAILED.value if errored else PipelineStatus.SUCCESS.value
         )
         # ``last_error`` must carry signal, not the #1219 lie: a
         # ``csv_ingest`` that succeeded then poisoned downstream has
@@ -624,9 +639,7 @@ class DataIngestionRepository:
             checked += 1
             before = (
                 await self.session.execute(
-                    select(col(Pipeline.status)).where(
-                        col(Pipeline.id) == pid
-                    )
+                    select(col(Pipeline.status)).where(col(Pipeline.id) == pid)
                 )
             ).scalar_one_or_none()
             after = await self.recompute_pipeline_status(pid)

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -568,6 +568,21 @@ class DataIngestionRepository:
             if errored
             else PipelineStatus.SUCCESS.value
         )
+        # ``last_error`` must carry signal, not the #1219 lie: a
+        # ``csv_ingest`` that succeeded then poisoned downstream has
+        # ``result=ERROR`` but ``status_message="Success"`` (jobs
+        # 2/47/49/74 shape). Prefer an errored job whose message is
+        # NOT "Success"; fall back to the first errored only if every
+        # one is uninformative. (Phase 2 backfill reuses this logic
+        # across all history — must not write "last_error: Success".)
+        last_error: Optional[str] = None
+        if errored:
+            informative = [
+                j
+                for j in errored
+                if (j.status_message or "").strip().lower() != "success"
+            ]
+            last_error = (informative or errored)[0].status_message
         started = [j.started_at for j in jobs if j.started_at is not None]
         finished = [j.finished_at for j in jobs if j.finished_at is not None]
         await self.session.execute(
@@ -579,7 +594,7 @@ class DataIngestionRepository:
                 error_count=len(errored),
                 started_at=min(started) if started else None,
                 finished_at=max(finished) if finished else None,
-                last_error=errored[-1].status_message if errored else None,
+                last_error=last_error,
                 updated_at=func.now(),
             )
         )

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -321,6 +321,164 @@ class DataIngestionRepository:
         exec_result = await self.session.execute(stmt)
         return list(exec_result.scalars().all())
 
+    async def list_pipelines_paginated(
+        self,
+        *,
+        state: Optional[IngestionState] = None,
+        result: Optional[IngestionResult] = None,
+        job_type: Optional[str] = None,
+        module_type_id: Optional[int] = None,
+        year: Optional[int] = None,
+        has_errors: Optional[bool] = None,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        q: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list["PipelineGroup"], int]:
+        """Paginated, filtered list of pipelines for the ops console (#1234).
+
+        The pagination unit is the *pipeline* (one ``pipeline_id`` = a
+        parent + its fan-out children), never the job row — children
+        must not split across pages.  A pipeline qualifies when it has
+        at least one row matching the row-level filters; ``has_errors``
+        is evaluated at the pipeline level (any FINISHED+ERROR job).
+
+        Rows with ``pipeline_id IS NULL`` (a parent that failed before
+        fan-out, so it never minted a pipeline) surface as synthetic
+        *pipelines-of-one* so operators still see them.
+
+        Grouping is done in SQL with ``GROUP BY`` + ``MAX(id)`` (no
+        ``DISTINCT ON`` — not portable to the SQLite unit-test fixture),
+        then the per-page rows are fetched in one ``IN`` query and
+        grouped in Python.  Matches the in-memory-pick precedent of
+        ``get_current_pipeline_ids_for_modules`` (realistic input size:
+        a few thousand pipelines at most).
+
+        Returns ``(groups, total)`` where ``groups`` is the requested
+        page ordered newest-first by latest job id and ``total`` is the
+        full match count for pagination.
+        """
+        conds = []
+        if state is not None:
+            conds.append(col(DataIngestionJob.state) == state)
+        if result is not None:
+            conds.append(col(DataIngestionJob.result) == result)
+        if job_type is not None:
+            conds.append(col(DataIngestionJob.job_type) == job_type)
+        if module_type_id is not None:
+            conds.append(col(DataIngestionJob.module_type_id) == module_type_id)
+        if year is not None:
+            conds.append(col(DataIngestionJob.year) == year)
+        if since is not None:
+            conds.append(col(DataIngestionJob.started_at) >= since)
+        if until is not None:
+            conds.append(col(DataIngestionJob.started_at) <= until)
+        if q:
+            conds.append(col(DataIngestionJob.status_message).ilike(f"%{q}%"))
+
+        # Pipeline-level error set (FINISHED+ERROR anywhere in the
+        # group) — only computed when the caller filters on it.
+        error_pids: set[UUID] = set()
+        if has_errors is not None:
+            err_stmt = (
+                select(DataIngestionJob.pipeline_id)
+                .where(
+                    col(DataIngestionJob.pipeline_id).isnot(None),
+                    col(DataIngestionJob.state) == IngestionState.FINISHED,
+                    col(DataIngestionJob.result) == IngestionResult.ERROR,
+                )
+                .distinct()
+            )
+            error_pids = {r[0] for r in (await self.session.execute(err_stmt)).all()}
+
+        # Grouped pipelines: (pipeline_id, latest job id).
+        grouped_stmt = (
+            select(
+                DataIngestionJob.pipeline_id,
+                func.max(col(DataIngestionJob.id)).label("latest_id"),
+            )
+            .where(col(DataIngestionJob.pipeline_id).isnot(None), *conds)
+            .group_by(col(DataIngestionJob.pipeline_id))
+        )
+        grouped = (await self.session.execute(grouped_stmt)).all()
+
+        # Orphans: each NULL-pipeline row is its own pipeline-of-one.
+        orphan_conds = list(conds)
+        if has_errors is True:
+            orphan_conds += [
+                col(DataIngestionJob.state) == IngestionState.FINISHED,
+                col(DataIngestionJob.result) == IngestionResult.ERROR,
+            ]
+        elif has_errors is False:
+            orphan_conds.append(
+                or_(
+                    col(DataIngestionJob.state) != IngestionState.FINISHED,
+                    col(DataIngestionJob.result) != IngestionResult.ERROR,
+                    col(DataIngestionJob.result).is_(None),
+                )
+            )
+        orphan_stmt = select(col(DataIngestionJob.id)).where(
+            col(DataIngestionJob.pipeline_id).is_(None), *orphan_conds
+        )
+        orphan_ids = [r[0] for r in (await self.session.execute(orphan_stmt)).all()]
+
+        # Merge + order newest-first by latest id, then paginate.
+        merged: list[tuple[int, Optional[UUID], int]] = []
+        for pid, latest_id in grouped:
+            if has_errors is True and pid not in error_pids:
+                continue
+            if has_errors is False and pid in error_pids:
+                continue
+            merged.append((latest_id, pid, latest_id))
+        for oid in orphan_ids:
+            merged.append((oid, None, oid))
+        merged.sort(key=lambda t: t[0], reverse=True)
+        total = len(merged)
+        page = merged[offset : offset + limit]
+
+        page_pids = [pid for _, pid, _ in page if pid is not None]
+        page_orphan_ids = [k for _, pid, k in page if pid is None]
+
+        by_pid: dict[UUID, list[DataIngestionJob]] = {}
+        if page_pids:
+            jstmt = (
+                select(DataIngestionJob)
+                .where(col(DataIngestionJob.pipeline_id).in_(page_pids))
+                .order_by(col(DataIngestionJob.id).asc())
+            )
+            for job in (await self.session.execute(jstmt)).scalars().all():
+                by_pid.setdefault(job.pipeline_id, []).append(job)
+
+        by_orphan: dict[int, DataIngestionJob] = {}
+        if page_orphan_ids:
+            ostmt = select(DataIngestionJob).where(
+                col(DataIngestionJob.id).in_(page_orphan_ids)
+            )
+            for job in (await self.session.execute(ostmt)).scalars().all():
+                by_orphan[job.id] = job
+
+        groups: list[PipelineGroup] = []
+        for _, pid, key in page:
+            if pid is not None:
+                groups.append(
+                    PipelineGroup(
+                        pipeline_id=pid,
+                        is_orphan=False,
+                        jobs=by_pid.get(pid, []),
+                    )
+                )
+            else:
+                job = by_orphan.get(key)
+                groups.append(
+                    PipelineGroup(
+                        pipeline_id=None,
+                        is_orphan=True,
+                        jobs=[job] if job is not None else [],
+                    )
+                )
+        return groups, total
+
     async def get_current_pipeline_id_for_module(
         self,
         module_type_id: int,
@@ -1278,3 +1436,17 @@ class StaleStatsRow(TypedDict):
     last_finished_aggregation_at: Optional[datetime]
     why_stale: WhyStaleLiteral
     last_aggregation_job_id: Optional[int]
+
+
+class PipelineGroup(TypedDict):
+    """One pipeline returned by ``list_pipelines_paginated`` (#1234).
+
+    ``jobs`` are the raw ORM rows (id-ascending) so the endpoint can run
+    ``compute_pipeline_progress`` on them and project the meta allow-list
+    at serialization.  ``is_orphan`` flags a ``pipeline_id IS NULL``
+    parent that failed before fan-out (rendered as a pipeline-of-one).
+    """
+
+    pipeline_id: Optional[UUID]
+    is_orphan: bool
+    jobs: list[DataIngestionJob]

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -617,6 +617,23 @@ class DataIngestionRepository:
         jobs = await self.list_jobs_by_pipeline_id(pipeline_id)
         if not jobs:
             return None
+
+        # Phase 5A (#1236) — populate ``pipelines.expected_recalc`` from
+        # the live job count.  Replaces ``meta.recalc_jobs_chained`` on
+        # the parent job (which Phase 5B then stops reading).  Cheap
+        # idempotent UPDATE; runs on every recompute so the column tracks
+        # the actual fan-out as recalcs are dispatched, not just at the
+        # parent's terminal event.  Dedup-skipped recalcs aren't in
+        # ``jobs`` (they live under another ``pipeline_id``) so the
+        # count matches the old ``chained`` accumulator by construction
+        # — no Fix-2b equivalent needed.
+        expected_recalc = sum(1 for j in jobs if j.job_type == "emission_recalc")
+        await self.session.execute(
+            update(Pipeline)
+            .where(col(Pipeline.id) == pipeline_id)
+            .values(expected_recalc=expected_recalc, updated_at=func.now())
+        )
+
         progress = compute_pipeline_progress(jobs)
         if not progress["done"]:
             return None  # not the last child — skip (option a)

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -346,8 +346,7 @@ class DataIngestionRepository:
     async def list_pipelines_paginated(
         self,
         *,
-        state: Optional[IngestionState] = None,
-        result: Optional[IngestionResult] = None,
+        pipeline_status: Optional[PipelineStatus] = None,
         job_type: Optional[str] = None,
         module_type_id: Optional[int] = None,
         year: Optional[int] = None,
@@ -364,28 +363,35 @@ class DataIngestionRepository:
         parent + its fan-out children), never the job row — children
         must not split across pages.  A pipeline qualifies when it has
         at least one row matching the row-level filters; ``has_errors``
-        is evaluated at the pipeline level (any FINISHED+ERROR job).
+        is evaluated at the pipeline level.
+
+        **Phase 3 read-flip (#1236):** ``pipeline_status`` filters on
+        ``pipelines.status`` (the authoritative, durable status the
+        runner recompute-and-stores).  This replaced the previous
+        ``state``/``result`` job-level filters; the URL contract and
+        the response's ``progress.done`` now share one source of
+        truth.  ``has_errors`` likewise pivots: True ⇔ ``status IN
+        (PARTIAL, FAILED)``; False ⇔ ``status NOT IN (...)``.
 
         Rows with ``pipeline_id IS NULL`` (a parent that failed before
         fan-out, so it never minted a pipeline) surface as synthetic
-        *pipelines-of-one* so operators still see them.
+        *pipelines-of-one* so operators still see them.  Orphans have
+        no ``Pipeline`` row to filter on, so a ``pipeline_status``
+        filter excludes them entirely; ``has_errors`` for orphans
+        falls back to job-derived (FINISHED+ERROR).
 
         Grouping is done in SQL with ``GROUP BY`` + ``MAX(id)`` (no
         ``DISTINCT ON`` — not portable to the SQLite unit-test fixture),
         then the per-page rows are fetched in one ``IN`` query and
-        grouped in Python.  Matches the in-memory-pick precedent of
-        ``get_current_pipeline_ids_for_modules`` (realistic input size:
-        a few thousand pipelines at most).
+        grouped in Python.
 
         Returns ``(groups, total)`` where ``groups`` is the requested
         page ordered newest-first by latest job id and ``total`` is the
         full match count for pagination.
         """
+        # Row-level filters (still applied per-job — these describe the
+        # pipeline's scope/provenance, which lives on the parent row).
         conds = []
-        if state is not None:
-            conds.append(col(DataIngestionJob.state) == state)
-        if result is not None:
-            conds.append(col(DataIngestionJob.result) == result)
         if job_type is not None:
             conds.append(col(DataIngestionJob.job_type) == job_type)
         if module_type_id is not None:
@@ -399,18 +405,22 @@ class DataIngestionRepository:
         if q:
             conds.append(col(DataIngestionJob.status_message).ilike(f"%{q}%"))
 
-        # Pipeline-level error set (FINISHED+ERROR anywhere in the
-        # group) — only computed when the caller filters on it.
-        error_pids: set[UUID] = set()
+        # Pipeline-level status filter (Phase 3 read-flip): collect the
+        # set of pipeline_ids whose ``pipelines.status`` matches the
+        # caller's filter.  Cheap (indexed on status) and short-circuits
+        # the rest of the query when no pipeline qualifies.
+        status_pids: Optional[set[UUID]] = None
+        error_pids: Optional[set[UUID]] = None
+        if pipeline_status is not None:
+            pst_stmt = select(Pipeline.id).where(
+                col(Pipeline.status) == pipeline_status.value
+            )
+            status_pids = {r[0] for r in (await self.session.execute(pst_stmt)).all()}
         if has_errors is not None:
-            err_stmt = (
-                select(DataIngestionJob.pipeline_id)
-                .where(
-                    col(DataIngestionJob.pipeline_id).isnot(None),
-                    col(DataIngestionJob.state) == IngestionState.FINISHED,
-                    col(DataIngestionJob.result) == IngestionResult.ERROR,
+            err_stmt = select(Pipeline.id).where(
+                col(Pipeline.status).in_(
+                    [PipelineStatus.PARTIAL.value, PipelineStatus.FAILED.value]
                 )
-                .distinct()
             )
             error_pids = {r[0] for r in (await self.session.execute(err_stmt)).all()}
 
@@ -426,32 +436,42 @@ class DataIngestionRepository:
         grouped = (await self.session.execute(grouped_stmt)).all()
 
         # Orphans: each NULL-pipeline row is its own pipeline-of-one.
-        orphan_conds = list(conds)
-        if has_errors is True:
-            orphan_conds += [
-                col(DataIngestionJob.state) == IngestionState.FINISHED,
-                col(DataIngestionJob.result) == IngestionResult.ERROR,
-            ]
-        elif has_errors is False:
-            orphan_conds.append(
-                or_(
-                    col(DataIngestionJob.state) != IngestionState.FINISHED,
-                    col(DataIngestionJob.result) != IngestionResult.ERROR,
-                    col(DataIngestionJob.result).is_(None),
+        # A pipeline_status filter excludes them by construction (no
+        # ``Pipeline`` row to match).  ``has_errors`` for orphans falls
+        # back to the job-derived oracle since they never minted a row.
+        if pipeline_status is not None:
+            orphan_ids: list[int] = []
+        else:
+            orphan_conds = list(conds)
+            if has_errors is True:
+                orphan_conds += [
+                    col(DataIngestionJob.state) == IngestionState.FINISHED,
+                    col(DataIngestionJob.result) == IngestionResult.ERROR,
+                ]
+            elif has_errors is False:
+                orphan_conds.append(
+                    or_(
+                        col(DataIngestionJob.state) != IngestionState.FINISHED,
+                        col(DataIngestionJob.result) != IngestionResult.ERROR,
+                        col(DataIngestionJob.result).is_(None),
+                    )
                 )
+            orphan_stmt = select(col(DataIngestionJob.id)).where(
+                col(DataIngestionJob.pipeline_id).is_(None), *orphan_conds
             )
-        orphan_stmt = select(col(DataIngestionJob.id)).where(
-            col(DataIngestionJob.pipeline_id).is_(None), *orphan_conds
-        )
-        orphan_ids = [r[0] for r in (await self.session.execute(orphan_stmt)).all()]
+            orphan_ids = [r[0] for r in (await self.session.execute(orphan_stmt)).all()]
 
         # Merge + order newest-first by latest id, then paginate.
         merged: list[tuple[int, Optional[UUID], int]] = []
         for pid, latest_id in grouped:
-            if has_errors is True and pid not in error_pids:
+            if status_pids is not None and pid not in status_pids:
                 continue
-            if has_errors is False and pid in error_pids:
-                continue
+            if error_pids is not None:
+                in_errors = pid in error_pids
+                if has_errors is True and not in_errors:
+                    continue
+                if has_errors is False and in_errors:
+                    continue
             merged.append((latest_id, pid, latest_id))
         for oid in orphan_ids:
             merged.append((oid, None, oid))
@@ -472,6 +492,15 @@ class DataIngestionRepository:
             for job in (await self.session.execute(jstmt)).scalars().all():
                 by_pid.setdefault(job.pipeline_id, []).append(job)
 
+        # Phase 3 read-flip: bulk-fetch the matching ``Pipeline`` rows so
+        # the endpoint can pass ``pipeline.status`` into
+        # ``compute_pipeline_progress`` without N+1 queries.
+        by_pl: dict[UUID, Pipeline] = {}
+        if page_pids:
+            pstmt = select(Pipeline).where(col(Pipeline.id).in_(page_pids))
+            for pl in (await self.session.execute(pstmt)).scalars().all():
+                by_pl[pl.id] = pl
+
         by_orphan: dict[int, DataIngestionJob] = {}
         if page_orphan_ids:
             ostmt = select(DataIngestionJob).where(
@@ -488,6 +517,7 @@ class DataIngestionRepository:
                         pipeline_id=pid,
                         is_orphan=False,
                         jobs=by_pid.get(pid, []),
+                        pipeline=by_pl.get(pid),
                     )
                 )
             else:
@@ -497,9 +527,28 @@ class DataIngestionRepository:
                         pipeline_id=None,
                         is_orphan=True,
                         jobs=[job] if job is not None else [],
+                        pipeline=None,
                     )
                 )
         return groups, total
+
+    async def get_pipeline_by_id(self, pipeline_id: UUID) -> Optional[Pipeline]:
+        """Phase 3 read-flip (#1236): fetch the ``pipelines`` row by id.
+
+        ``compute_pipeline_progress`` uses this for authoritative
+        done/has_error.  Returns ``None`` when no row exists (orphan or
+        legacy pre-Phase-1 pipeline); callers fall back to job-derived.
+
+        ``populate_existing=True`` so the SSE stream sees the runner's
+        post-``finish_job`` status writes — same reasoning as
+        ``list_jobs_by_pipeline_id`` above.
+        """
+        stmt = (
+            select(Pipeline)
+            .where(col(Pipeline.id) == pipeline_id)
+            .execution_options(populate_existing=True)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
 
     async def ensure_pipeline_exists(
         self,
@@ -1614,8 +1663,12 @@ class PipelineGroup(TypedDict):
     ``compute_pipeline_progress`` on them and project the meta allow-list
     at serialization.  ``is_orphan`` flags a ``pipeline_id IS NULL``
     parent that failed before fan-out (rendered as a pipeline-of-one).
+    ``pipeline`` is the matching ``pipelines`` row when one exists — the
+    Phase-3 read-flip (#1236) reads ``status`` from it for authoritative
+    done/has_error; ``None`` for orphans.
     """
 
     pipeline_id: Optional[UUID]
     is_orphan: bool
     jobs: list[DataIngestionJob]
+    pipeline: Optional[Pipeline]

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -16,6 +16,8 @@ from app.models.data_ingestion import (
     IngestionMethod,
     IngestionResult,
     IngestionState,
+    Pipeline,
+    PipelineStatus,
     TargetType,
 )
 
@@ -478,6 +480,145 @@ class DataIngestionRepository:
                     )
                 )
         return groups, total
+
+    async def ensure_pipeline_exists(
+        self,
+        pipeline_id: UUID,
+        *,
+        kind: Optional[str] = None,
+        entity_type: Optional[int] = None,
+        ingestion_method: Optional[int] = None,
+        module_type_id: Optional[int] = None,
+        year: Optional[int] = None,
+    ) -> None:
+        """Idempotently create the `pipelines` row (#1236 Phase 1).
+
+        Called from the parent-creation mint sites (not the runner —
+        the runner is a terminal actor). Fast-path SELECT skips the
+        common already-exists case; the SAVEPOINT around the INSERT
+        contains a concurrent-creator ``IntegrityError`` so it never
+        poisons the caller's transaction (the #1225 discipline; mirrors
+        ``claim_job``'s ``begin_nested`` use here).
+        """
+        existing = await self.session.execute(
+            select(Pipeline.id).where(col(Pipeline.id) == pipeline_id)
+        )
+        if existing.first() is not None:
+            return
+        try:
+            async with self.session.begin_nested():
+                self.session.add(
+                    Pipeline(
+                        id=pipeline_id,
+                        kind=kind,
+                        entity_type=entity_type,
+                        ingestion_method=ingestion_method,
+                        module_type_id=module_type_id,
+                        year=year,
+                        status=PipelineStatus.NOT_STARTED.value,
+                    )
+                )
+                await self.session.flush()
+        except IntegrityError:
+            # A concurrent creator won the race — idempotent no-op.
+            pass
+
+    async def recompute_pipeline_status(
+        self, pipeline_id: UUID
+    ) -> Optional[str]:
+        """Recompute-and-store the pipeline's authoritative status (#1236).
+
+        The single source of truth is the pure
+        ``compute_pipeline_progress`` over the pipeline's jobs — never
+        an incremental accumulator (drift = the #1219 bug class).
+
+        Option (a) — last-child oracle: only writes when
+        ``progress.done`` (the terminal that flips it is, by
+        definition, the last expected child); a non-terminal call is a
+        cheap read + skip. Self-healing: a skipped/lost write is
+        recovered by the next terminal or the reconciliation sweep.
+
+        Does NOT commit — the caller owns the transaction boundary
+        (the runner wraps this in its post-``finish_job`` isolated
+        try/except; the sweep batches). Returns the written status, or
+        ``None`` when skipped (no jobs / not done).
+        """
+        # Local import: pure function, models-only deps; avoids a
+        # module-level service→repo edge.
+        from app.services.pipeline_progress import compute_pipeline_progress
+
+        jobs = await self.list_jobs_by_pipeline_id(pipeline_id)
+        if not jobs:
+            return None
+        progress = compute_pipeline_progress(jobs)
+        if not progress["done"]:
+            return None  # not the last child — skip (option a)
+
+        errored = [
+            j
+            for j in jobs
+            if j.state == IngestionState.FINISHED
+            and j.result == IngestionResult.ERROR
+        ]
+        # Phase-1 mapping. PARTIAL is reserved (model enum) but not
+        # emitted until the FAILED-vs-PARTIAL boundary open question is
+        # decided — do not invent a definition here.
+        new_status = (
+            PipelineStatus.FAILED.value
+            if errored
+            else PipelineStatus.SUCCESS.value
+        )
+        started = [j.started_at for j in jobs if j.started_at is not None]
+        finished = [j.finished_at for j in jobs if j.finished_at is not None]
+        await self.session.execute(
+            update(Pipeline)
+            .where(col(Pipeline.id) == pipeline_id)
+            .values(
+                status=new_status,
+                job_count=len(jobs),
+                error_count=len(errored),
+                started_at=min(started) if started else None,
+                finished_at=max(finished) if finished else None,
+                last_error=errored[-1].status_message if errored else None,
+                updated_at=func.now(),
+            )
+        )
+        return new_status
+
+    async def reconcile_pipeline_statuses(self) -> dict:
+        """Phase-1 standalone reconciliation sweep (#1236).
+
+        The durable backstop for the runner's isolated post-finish
+        write: that write log-and-skips on any DB error, so status can
+        lag. This recomputes-and-stores every pipeline that has jobs
+        (idempotent; commits per pipeline so a mid-sweep failure keeps
+        prior fixes). Phase 3 schedules this on a cron before flipping
+        reads; Phase 1 just ships it callable.
+
+        Returns ``{"checked": n, "corrected": m}``.
+        """
+        pid_rows = await self.session.execute(
+            select(col(DataIngestionJob.pipeline_id))
+            .where(col(DataIngestionJob.pipeline_id).isnot(None))
+            .distinct()
+        )
+        pids = [r[0] for r in pid_rows.all()]
+        checked = 0
+        corrected = 0
+        for pid in pids:
+            checked += 1
+            before = (
+                await self.session.execute(
+                    select(col(Pipeline.status)).where(
+                        col(Pipeline.id) == pid
+                    )
+                )
+            ).scalar_one_or_none()
+            after = await self.recompute_pipeline_status(pid)
+            await self.session.commit()
+            if after is not None and after != before:
+                corrected += 1
+        return {"checked": checked, "corrected": corrected}
 
     async def get_current_pipeline_id_for_module(
         self,

--- a/backend/app/repositories/unit_repo.py
+++ b/backend/app/repositories/unit_repo.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Union
 
 from attr import dataclass
 from sqlalchemy import asc, desc
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -178,10 +179,84 @@ class UnitRepository:
         return units
 
     async def bulk_upsert(self, units: List[Unit]) -> UpsertResult:
+        """Insert-or-update by ``institutional_code`` (the unique key).
+
+        **Race safety (#1236):** ``units`` is a GLOBAL table (not
+        year-scoped) so two parallel ``unit_sync`` jobs for different
+        years both upsert the same set of Accred units.  The previous
+        implementation did SELECT-then-MERGE, which races between two
+        transactions: both observe "code X doesn't exist", both INSERT,
+        the second hits ``ix_units_institutional_code`` and raises
+        ``UniqueViolation``.  The Postgres path now uses
+        ``INSERT … ON CONFLICT (institutional_code) DO UPDATE`` —
+        race-safe by construction at the database level.  The SQLite
+        fallback keeps the legacy SELECT/MERGE because the test
+        fixture's single-writer model already serialises (no race
+        possible inside one engine).
+        """
         if not units:
             return UpsertResult(created=0, updated=0, total=0, data=[])
-        # Use institutional_code as the merge key — it's always present
-        # and has a unique constraint, unlike institutional_id which can be None.
+
+        try:
+            dialect_name = self.session.get_bind().dialect.name
+        except Exception:
+            dialect_name = ""
+
+        if dialect_name == "postgresql":
+            return await self._bulk_upsert_on_conflict(units)
+        return await self._bulk_upsert_select_then_merge(units)
+
+    async def _bulk_upsert_on_conflict(self, units: List[Unit]) -> UpsertResult:
+        """Postgres ``INSERT … ON CONFLICT DO UPDATE`` path — race-safe."""
+        # Count "created" by checking which codes are NEW before the
+        # write.  The count is informational (used in
+        # ``UpsertResult.__str__``); slightly stale under concurrency
+        # but never wrong by more than one parallel writer's batch.
+        codes = [u.institutional_code for u in units]
+        existing_codes: set[str | None] = {
+            code
+            for (code,) in (
+                await self.session.execute(
+                    select(Unit.institutional_code).where(
+                        col(Unit.institutional_code).in_(codes)
+                    )
+                )
+            ).all()
+        }
+
+        # Build value dicts.  ``id`` is excluded (auto-assigned for new
+        # rows; preserved for existing via the conflict-update returning
+        # the same row).  SQLModel exposes the SQLAlchemy Table via
+        # ``__table__``; mypy doesn't see it through the metaclass so
+        # access it via a typing escape hatch on the row type.
+        table = Unit.__table__  # type: ignore[attr-defined]
+        value_dicts = [
+            {c.name: getattr(unit, c.name) for c in table.columns if c.name != "id"}
+            for unit in units
+        ]
+        insert_stmt = pg_insert(Unit).values(value_dicts)
+        # On conflict, update every column except the conflict target and
+        # the id (preserve the existing row's id so FKs stay valid).
+        update_cols = {
+            c: insert_stmt.excluded[c]
+            for c in value_dicts[0]
+            if c != "institutional_code"
+        }
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["institutional_code"],
+            set_=update_cols,
+        ).returning(Unit)
+        result = await self.session.execute(upsert_stmt)
+        merged = list(result.scalars().all())
+
+        created = sum(1 for u in units if u.institutional_code not in existing_codes)
+        updated = len(units) - created
+        return UpsertResult(
+            created=created, updated=updated, total=len(units), data=merged
+        )
+
+    async def _bulk_upsert_select_then_merge(self, units: List[Unit]) -> UpsertResult:
+        """SQLite fallback — single-writer engine, no race to worry about."""
         rows = (await self.session.exec(select(Unit.institutional_code, Unit.id))).all()
         existing: dict[str | None, int] = {
             code: uid for code, uid in rows if uid is not None

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -473,6 +473,11 @@ class YearConfigurationResponse(BaseModel):
 
     year: int
     is_started: bool
+    # #1234-followup — None until the unit_sync pipeline for this year
+    # finishes SUCCESS; dispatch refuses uploads while None. The UI
+    # uses this to disable upload buttons + show a "year is being
+    # provisioned" tooltip.
+    configuration_completed: Optional[datetime] = None
     config: Dict[str, Any]
     recalculation_status: List[ModuleRecalculationStatusEntry] = Field(
         default_factory=list,
@@ -508,6 +513,8 @@ class YearConfigurationListItem(BaseModel):
 
     year: int
     is_started: bool
+    # #1234-followup — see YearConfigurationResponse.
+    configuration_completed: Optional[datetime] = None
     updated_at: datetime
 
     class Config:

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -96,6 +96,43 @@ def _get_required_columns_from_handler(handler: Any) -> set[str]:
     }
 
 
+def _guard_factors_required(
+    *,
+    factors_map: Dict[str, Any],
+    handlers: list[Any],
+    module_label: str,
+    year: int | None,
+) -> None:
+    """Fail-fast when an ingest needs factors but the map is empty.
+
+    For modules whose handler declares ``require_factor_to_match=True``
+    (e.g. equipment), every row's emission record needs a matched
+    ``Factor`` to populate ``primary_factor_id``.  When the factors
+    table has nothing for this (module, year) tuple the row-level loop
+    would record one "no matching factor" error per row — a 50 000-row
+    CSV produces 50 000 identical messages and the operator has to
+    scroll past them to find out the real issue is that they forgot to
+    upload factors first.
+
+    Raised at setup time instead, so ``_setup_and_validate``'s
+    try/except wraps it into one ``FINISHED + ERROR`` with a
+    single-line ``status_message``.  Caller passes a human-readable
+    ``module_label`` (e.g. ``"Equipment"``) so the message tells the
+    operator *which* upload is missing without them having to know
+    enum ints.
+    """
+    if factors_map:
+        return
+    if not any(getattr(h, "require_factor_to_match", False) for h in handlers):
+        return
+    year_str = f"year={year}" if year is not None else "the configured year"
+    raise ValueError(
+        f"No factors available for module={module_label} {year_str}. "
+        "Upload factors for this module/year before ingesting data — "
+        "every row needs a matched Factor for primary_factor_id."
+    )
+
+
 class BaseCSVProvider(DataIngestionProvider, ABC):
     """Base class for CSV data ingestion providers"""
 

--- a/backend/app/services/data_ingestion/csv_providers/module_per_year.py
+++ b/backend/app/services/data_ingestion/csv_providers/module_per_year.py
@@ -16,6 +16,24 @@ from app.services.data_ingestion.base_csv_provider import (
 logger = get_logger(__name__)
 
 
+# Module types whose CSV ingest INFERS the per-row ``data_entry_type_id``
+# from a matched Factor (the row carries a kind/sub-kind, not a DET name,
+# so the resolver looks up the factor table to disambiguate which DET
+# the row belongs to).  An empty factors_map for these modules means
+# every row's resolution will fail with "no matching factor found in
+# factors map" — the operator gains nothing from grinding through
+# 50 000 rows of the same error; refuse the ingest up front.
+#
+# Other modules (e.g. ``buildings``, ``professional_travel``,
+# ``headcount``) carry the DET in a category column that maps directly
+# to ``DataEntryTypeEnum`` names, so an empty factors_map is a
+# legitimate state (they ingest rows with ``primary_factor_id=None``).
+_FACTOR_INFERRED_MODULES: set[ModuleTypeEnum] = {
+    ModuleTypeEnum.equipment_electric_consumption,
+    ModuleTypeEnum.purchase,
+}
+
+
 class ModulePerYearCSVProvider(BaseCSVProvider):
     """
     CSV provider for MODULE_PER_YEAR entity type.
@@ -106,11 +124,30 @@ class ModulePerYearCSVProvider(BaseCSVProvider):
                 f"{valid_entry_types}"
             )
 
-        # Fail fast when the module's handler requires a matched factor
-        # but the factors map is empty for this (module, year) — otherwise
-        # every CSV row would record an identical "no matching factor"
-        # error and the operator has to dig through 50 k rows to see that
-        # the real problem is the missing factor upload.
+        # Fail fast for "common" uploads — modules that infer the per-row
+        # data_entry_type_id by looking up the row's kind/sub-kind in the
+        # factors map (equipment, purchase).  An empty factors_map
+        # guarantees every row will fail with "no matching factor found";
+        # surfacing that as one terminal error beats 50 000 row-level
+        # errors that all point at the same missing-factors fix.  Other
+        # modules (whose category column maps directly to DET names) are
+        # legitimately allowed an empty map and are covered by the
+        # narrower ``_guard_factors_required`` check below.
+        if module_type in _FACTOR_INFERRED_MODULES and not factors_map:
+            year_str = (
+                f"year={self.year}" if self.year is not None else "the configured year"
+            )
+            raise ValueError(
+                f"No factors available for module={module_type.name} {year_str}. "
+                "This module infers the per-row data_entry_type from a matched "
+                "Factor, so an empty factors table guarantees every row will "
+                "fail. Upload factors for this module/year before ingesting data."
+            )
+
+        # Catch the orthogonal "handler requires a matched factor" invariant
+        # — fires for modules where data_entry_type IS resolved (configured
+        # or via category_field) but the row-level loop still needs a
+        # Factor match per the handler's contract.
         _guard_factors_required(
             factors_map=factors_map,
             handlers=handlers,

--- a/backend/app/services/data_ingestion/csv_providers/module_per_year.py
+++ b/backend/app/services/data_ingestion/csv_providers/module_per_year.py
@@ -10,6 +10,7 @@ from app.services.data_ingestion.base_csv_provider import (
     BaseCSVProvider,
     StatsDict,
     _get_expected_columns_from_handlers,
+    _guard_factors_required,
 )
 
 logger = get_logger(__name__)
@@ -104,6 +105,18 @@ class ModulePerYearCSVProvider(BaseCSVProvider):
                 f"Setup for MODULE_PER_YEAR with multiple data_entry_types: "
                 f"{valid_entry_types}"
             )
+
+        # Fail fast when the module's handler requires a matched factor
+        # but the factors map is empty for this (module, year) — otherwise
+        # every CSV row would record an identical "no matching factor"
+        # error and the operator has to dig through 50 k rows to see that
+        # the real problem is the missing factor upload.
+        _guard_factors_required(
+            factors_map=factors_map,
+            handlers=handlers,
+            module_label=module_type.name,
+            year=self.year,
+        )
 
         # Get expected and required columns
         expected_columns = _get_expected_columns_from_handlers(handlers)

--- a/backend/app/services/data_ingestion/csv_providers/module_unit_specific.py
+++ b/backend/app/services/data_ingestion/csv_providers/module_unit_specific.py
@@ -10,6 +10,7 @@ from app.services.data_ingestion.base_csv_provider import (
     StatsDict,
     _get_expected_columns_from_handlers,
     _get_required_columns_from_handler,
+    _guard_factors_required,
 )
 
 logger = get_logger(__name__)
@@ -63,6 +64,18 @@ class ModuleUnitSpecificCSVProvider(BaseCSVProvider):
         # Get the single handler for this data_entry_type
         handler = BaseModuleHandler.get_by_type(configured_data_entry_type)
         handlers = [handler]
+
+        # Fail fast when the handler requires a matched factor but none
+        # were loaded — same rationale as MODULE_PER_YEAR (see
+        # ``_guard_factors_required`` docstring); avoids the operator
+        # scrolling through 50 k identical row errors to find out the
+        # real fix is to upload factors first.
+        _guard_factors_required(
+            factors_map=factors_map,
+            handlers=handlers,
+            module_label=configured_data_entry_type.name,
+            year=self.year,
+        )
 
         # Get expected and required columns
         expected_columns = _get_expected_columns_from_handlers(handlers)

--- a/backend/app/services/pipeline_progress.py
+++ b/backend/app/services/pipeline_progress.py
@@ -54,9 +54,6 @@ _ERROR_PIPELINE_STATUSES = frozenset(
     {PipelineStatus.PARTIAL.value, PipelineStatus.FAILED.value}
 )
 
-#: Job types that can be the root of a pipeline (no parent_job_id).
-_ROOT_JOB_TYPES = {"csv_ingest", "api_ingest", "factor_ingest"}
-
 _PHASE_LABELS: dict[int, PhaseLabel] = {
     1: "data",
     2: "emissions",
@@ -89,19 +86,21 @@ def _meta(job: DataIngestionJob) -> dict:
 
 
 def _find_root(jobs: list[DataIngestionJob]) -> DataIngestionJob | None:
-    """The pipeline's parent: the row with no ``parent_job_id``.
+    """The pipeline's parent: the lowest-id job.
 
-    Falls back to the lowest-id root-typed job when meta is absent
-    (legacy rows / defensive — every chained child records
-    ``parent_job_id``, so a row lacking it is the root).
+    ``chain_job`` creates every fan-out child AFTER the parent, so the
+    lowest id is the parent by construction.  Phase 5 dropped the
+    previous ``meta.parent_job_id`` and ``_ROOT_JOB_TYPES`` filter — the
+    set omitted ``unit_sync`` and ``reference_ingest`` parents, leaving
+    those pipelines with no root.  The id-based pick is type-agnostic
+    and works for every root job_type.
+
+    ``id`` can be None only for unpersisted rows (never here); the
+    ``or 0`` keeps mypy happy and is harmless for real rows.
     """
-    rootless = [j for j in jobs if _meta(j).get("parent_job_id") is None]
-    candidates = rootless or [j for j in jobs if (j.job_type or "") in _ROOT_JOB_TYPES]
-    if not candidates:
+    if not jobs:
         return None
-    # ``id`` can be None only for unpersisted rows (never here); the
-    # ``or 0`` keeps mypy happy and is harmless for real rows.
-    return min(candidates, key=lambda j: j.id or 0)
+    return min(jobs, key=lambda j: j.id or 0)
 
 
 def compute_pipeline_progress(
@@ -120,28 +119,32 @@ def compute_pipeline_progress(
     it, both flags fall back to job-derived (the legacy path; used
     for orphans that never minted a ``Pipeline`` row).
 
-    The ``phase`` field stays job-derived in both modes — ``phase`` is
-    UX granularity (which step is currently running) and has no single
-    column in ``pipelines`` to read it from.  Phase 5 will revisit
-    once ``expected_recalc`` migrates off ``meta.recalc_jobs_chained``.
+    **Phase 5B (#1236):** all three meta keys (``parent_job_id``,
+    ``recalc_jobs_chained``, ``aggregation_job_id``) are retired.
+    ``expected_recalc`` comes from ``pipeline.expected_recalc``
+    (written by ``recompute_pipeline_status`` from the live job
+    count); the root is the lowest-id job (``chain_job`` creates
+    parents before children by construction); aggregation phase3 is
+    derived from the aggregation rows directly.
 
-    Completion rules (legacy job-derived fallback):
+    Completion rules:
 
-    - **Phase 1 (data)** done ⇔ parent FINISHED.
+    - **Phase 1 (data)** done ⇔ parent (lowest-id job) FINISHED.
     - **Phase 2 (emissions)** done ⇔ parent FINISHED *and* the number
-      of FINISHED ``emission_recalc`` children ≥ the parent's
-      ``meta.recalc_jobs_chained`` (the count of children this
-      pipeline actually *owns* — dedup-skipped targets are owned by an
-      earlier pipeline and intentionally excluded, so 0 ⇒ phase 2 is
-      vacuously satisfied).  When the parent is FINISHED but the
-      counter is absent (legacy / non-ingest root), fall back to
-      "every recalc row present is FINISHED".
+      of FINISHED ``emission_recalc`` children ≥ the pipeline's
+      expected recalc count (``pipeline.expected_recalc`` when
+      present, else the live job count — which matches the writer's
+      own derivation).  Dedup-skipped targets live under another
+      pipeline's id and aren't in ``jobs``, so 0 expected ⇒ phase 2
+      vacuously satisfied.
     - **Phase 3 (aggregation)** done ⇔ phase 2 done *and* every
-      aggregation referenced by a FINISHED recalc
-      (``meta.aggregation_job_id``) is itself present and FINISHED.
-    - ``done`` ⇔ phase 3 done **or** any job is FINISHED+ERROR (a
-      broken chain spawns no further children, so an error anywhere is
-      terminal — the UI must stop the spinner and surface failure).
+      aggregation row in this pipeline is FINISHED.  Relies on
+      4A.1's invariant that the last recalc sibling chains exactly
+      one aggregation per pipeline; if that ever changes, this check
+      stays semantically correct only by counting ALL aggregation
+      rows (any new fan-out must preserve that).
+    - ``done`` / ``has_error`` ← ``pipeline.status`` when provided
+      (Phase 3 read-flip); fall back to job-derived otherwise.
     """
     jobs = list(jobs)
     has_error_jobs = any(_is_finished_error(j) for j in jobs)
@@ -169,38 +172,36 @@ def compute_pipeline_progress(
         )
 
     recalc_jobs = [j for j in jobs if j.job_type == "emission_recalc"]
-    aggregation_jobs = {
-        j.id: j for j in jobs if j.job_type == "aggregation" and j.id is not None
-    }
+    aggregation_jobs = [j for j in jobs if j.job_type == "aggregation"]
 
     phase1_done = _is_finished(root)
 
-    # Expected owned recalc children. ``recalc_jobs_chained`` is
-    # written by the parent handler's return meta (merged on
-    # finish_job); absent until the parent is FINISHED.
-    expected_recalc = _meta(root).get("recalc_jobs_chained")
+    # Phase 5B (#1236) — expected recalc count.  Primary source:
+    # ``pipeline.expected_recalc`` (Phase 5A writes it on every
+    # recompute).  Fallback for callers that don't pass ``pipeline``
+    # (orphans, tests, the writer-side ``recompute_pipeline_status``
+    # which can't read its own output): derive from the live job
+    # count.  Matches the value the writer would produce by the same
+    # rule, so the two paths agree.
     finished_recalc = [j for j in recalc_jobs if _is_finished(j)]
-    if expected_recalc is None:
-        # Legacy / non-ingest root: best-effort — done when every
-        # recalc row we can see is FINISHED (and at least the parent
-        # is FINISHED so the fan-out has been issued).
-        phase2_done = phase1_done and len(finished_recalc) == len(recalc_jobs)
+    if pipeline is not None and pipeline.expected_recalc is not None:
+        expected_recalc = int(pipeline.expected_recalc)
     else:
-        phase2_done = phase1_done and len(finished_recalc) >= int(expected_recalc)
+        expected_recalc = len(recalc_jobs)
+    phase2_done = phase1_done and len(finished_recalc) >= expected_recalc
 
-    # Aggregations are only expected for recalc children that actually
-    # chained one (success/warning, module known). A FINISHED recalc
-    # records ``aggregation_job_id`` (None when it dedup-skipped or
-    # skipped on error) in its meta.
-    expected_agg_ids = {
-        agg_id
-        for j in finished_recalc
-        if (agg_id := _meta(j).get("aggregation_job_id")) is not None
-    }
-    aggregations_done = all(
-        agg_id in aggregation_jobs and _is_finished(aggregation_jobs[agg_id])
-        for agg_id in expected_agg_ids
-    )
+    # Phase 5B — aggregation phase3 derived from job rows directly,
+    # not ``meta.aggregation_job_id``.  4A.1's in-pipeline coalesce
+    # chains EXACTLY ONE aggregation per pipeline (the last recalc
+    # sibling is the chainer), so "all aggregation rows FINISHED" is
+    # the right oracle: 0 aggregations ⇒ vacuously satisfied (every
+    # recalc dedup-skipped its aggregation or errored before chaining);
+    # 1+ aggregations ⇒ they must all be FINISHED.
+    # CAVEAT: if 4A.1's single-aggregation guarantee ever changes
+    # (e.g. per-recalc aggregations come back), this check stays
+    # correct only because we count ALL aggregation rows — anyone
+    # adding fan-out must keep that invariant or update this check.
+    aggregations_done = all(_is_finished(j) for j in aggregation_jobs)
     phase3_done = phase2_done and aggregations_done
 
     if not phase1_done:

--- a/backend/app/services/pipeline_progress.py
+++ b/backend/app/services/pipeline_progress.py
@@ -75,6 +75,14 @@ class PipelineProgress(TypedDict):
     # ``None`` for orphans whose Pipeline row was never minted; the
     # frontend falls back to has_error/done in that case.
     status: Optional[str]
+    # Parent ``job_type`` ("csv_ingest" / "api_ingest" / "factor_ingest"
+    # / "unit_sync" / "reference_ingest").  Used by the frontend to
+    # decide *which* per-target card the phase indicator applies to:
+    # a factor upload pipeline (``kind=factor_ingest``) should not
+    # render its phase on the data card, and vice versa.  Sourced
+    # from ``pipeline.kind`` when present; falls back to the root
+    # job's ``job_type`` for orphan / pre-Phase-1 cases.
+    kind: Optional[str]
 
 
 def _is_finished(job: DataIngestionJob) -> bool:
@@ -165,10 +173,16 @@ def compute_pipeline_progress(
         has_error = pipeline.status in _ERROR_PIPELINE_STATUSES
         is_done = pipeline.status in _TERMINAL_PIPELINE_STATUSES
         status_str: Optional[str] = pipeline.status
+        # ``pipeline.kind`` is the parent job_type (set at
+        # ``ensure_pipeline_exists`` time).  Prefer it over the root
+        # job's ``job_type`` so a legacy data-shape mismatch (e.g.
+        # a meta backfill that doesn't reach jobs) still resolves.
+        kind: Optional[str] = pipeline.kind
     else:
         has_error = has_error_jobs
         is_done = None  # sentinel: compute from jobs below
         status_str = None  # orphan — frontend falls back to has_error/done
+        kind = None  # populated below from root.job_type when available
 
     root = _find_root(jobs)
     if root is None:
@@ -181,7 +195,13 @@ def compute_pipeline_progress(
             done=is_done if is_done is not None else has_error,
             has_error=has_error,
             status=status_str,
+            kind=kind,
         )
+
+    # Fallback for the no-pipeline-row case: root's job_type IS the
+    # parent's job_type by construction (lowest-id is the parent).
+    if kind is None:
+        kind = root.job_type
 
     recalc_jobs = [j for j in jobs if j.job_type == "emission_recalc"]
     aggregation_jobs = [j for j in jobs if j.job_type == "aggregation"]
@@ -237,4 +257,5 @@ def compute_pipeline_progress(
         done=done,
         has_error=has_error,
         status=status_str,
+        kind=kind,
     )

--- a/backend/app/services/pipeline_progress.py
+++ b/backend/app/services/pipeline_progress.py
@@ -69,6 +69,12 @@ class PipelineProgress(TypedDict):
     phase_label: PhaseLabel
     done: bool
     has_error: bool
+    # PARTIAL tier (#1236) — the actual ``pipelines.status`` value so
+    # the frontend can render PARTIAL (amber, "data landed but chain
+    # had issues") distinctly from FAILED (red, "data didn't land").
+    # ``None`` for orphans whose Pipeline row was never minted; the
+    # frontend falls back to has_error/done in that case.
+    status: Optional[str]
 
 
 def _is_finished(job: DataIngestionJob) -> bool:
@@ -151,13 +157,18 @@ def compute_pipeline_progress(
 
     # Phase 3 read-flip: pipeline.status is authoritative when present.
     # has_error / done come from the table; phase still derives from
-    # jobs (no column to read it from yet).
+    # jobs (no column to read it from yet).  ``status_str`` is exposed
+    # in the progress dict so the frontend can distinguish PARTIAL
+    # (amber) from FAILED (red) — both set has_error=True so a single
+    # boolean can't tell them apart.
     if pipeline is not None:
         has_error = pipeline.status in _ERROR_PIPELINE_STATUSES
         is_done = pipeline.status in _TERMINAL_PIPELINE_STATUSES
+        status_str: Optional[str] = pipeline.status
     else:
         has_error = has_error_jobs
         is_done = None  # sentinel: compute from jobs below
+        status_str = None  # orphan — frontend falls back to has_error/done
 
     root = _find_root(jobs)
     if root is None:
@@ -169,6 +180,7 @@ def compute_pipeline_progress(
             phase_label="data",
             done=is_done if is_done is not None else has_error,
             has_error=has_error,
+            status=status_str,
         )
 
     recalc_jobs = [j for j in jobs if j.job_type == "emission_recalc"]
@@ -224,4 +236,5 @@ def compute_pipeline_progress(
         phase_label=_PHASE_LABELS[phase],
         done=done,
         has_error=has_error,
+        status=status_str,
     )

--- a/backend/app/services/pipeline_progress.py
+++ b/backend/app/services/pipeline_progress.py
@@ -27,15 +27,32 @@ The model is 3 fixed phases:
 
 from __future__ import annotations
 
-from typing import Iterable, Literal, TypedDict
+from typing import Iterable, Literal, Optional, TypedDict
 
 from app.models.data_ingestion import (
     DataIngestionJob,
     IngestionResult,
     IngestionState,
+    Pipeline,
+    PipelineStatus,
 )
 
 PhaseLabel = Literal["data", "emissions", "aggregation"]
+
+#: Terminal ``pipelines.status`` values — Phase-3 read-flip uses these for
+#: ``done``/``has_error`` instead of inferring from a possibly-incomplete
+#: job snapshot.  PARTIAL = chain completed with some children erroring;
+#: FAILED = chain broken (a job FINISHED+ERROR aborted the fan-out).
+_TERMINAL_PIPELINE_STATUSES = frozenset(
+    {
+        PipelineStatus.SUCCESS.value,
+        PipelineStatus.PARTIAL.value,
+        PipelineStatus.FAILED.value,
+    }
+)
+_ERROR_PIPELINE_STATUSES = frozenset(
+    {PipelineStatus.PARTIAL.value, PipelineStatus.FAILED.value}
+)
 
 #: Job types that can be the root of a pipeline (no parent_job_id).
 _ROOT_JOB_TYPES = {"csv_ingest", "api_ingest", "factor_ingest"}
@@ -89,12 +106,26 @@ def _find_root(jobs: list[DataIngestionJob]) -> DataIngestionJob | None:
 
 def compute_pipeline_progress(
     jobs: Iterable[DataIngestionJob],
+    *,
+    pipeline: Optional[Pipeline] = None,
 ) -> PipelineProgress:
     """Compute the authoritative phase/done/error for a pipeline.
 
     ``jobs`` is every row sharing one ``pipeline_id`` (any order).
 
-    Completion rules:
+    **Phase-3 read-flip (#1236):** when a ``pipeline`` row is passed,
+    ``done`` and ``has_error`` derive from ``pipeline.status`` — the
+    durable, recompute-and-stored truth the runner writes
+    post-``finish_job`` and the reconciliation cron heals.  Without
+    it, both flags fall back to job-derived (the legacy path; used
+    for orphans that never minted a ``Pipeline`` row).
+
+    The ``phase`` field stays job-derived in both modes — ``phase`` is
+    UX granularity (which step is currently running) and has no single
+    column in ``pipelines`` to read it from.  Phase 5 will revisit
+    once ``expected_recalc`` migrates off ``meta.recalc_jobs_chained``.
+
+    Completion rules (legacy job-derived fallback):
 
     - **Phase 1 (data)** done ⇔ parent FINISHED.
     - **Phase 2 (emissions)** done ⇔ parent FINISHED *and* the number
@@ -113,7 +144,17 @@ def compute_pipeline_progress(
       terminal — the UI must stop the spinner and surface failure).
     """
     jobs = list(jobs)
-    has_error = any(_is_finished_error(j) for j in jobs)
+    has_error_jobs = any(_is_finished_error(j) for j in jobs)
+
+    # Phase 3 read-flip: pipeline.status is authoritative when present.
+    # has_error / done come from the table; phase still derives from
+    # jobs (no column to read it from yet).
+    if pipeline is not None:
+        has_error = pipeline.status in _ERROR_PIPELINE_STATUSES
+        is_done = pipeline.status in _TERMINAL_PIPELINE_STATUSES
+    else:
+        has_error = has_error_jobs
+        is_done = None  # sentinel: compute from jobs below
 
     root = _find_root(jobs)
     if root is None:
@@ -123,7 +164,7 @@ def compute_pipeline_progress(
             phase=1,
             phases_total=3,
             phase_label="data",
-            done=has_error,
+            done=is_done if is_done is not None else has_error,
             has_error=has_error,
         )
 
@@ -169,10 +210,17 @@ def compute_pipeline_progress(
     else:
         phase = 3
 
+    # Phase-3 read-flip: pipeline.status carries ``done`` when present;
+    # otherwise fall back to the job-derived oracle (phase3 OR error).
+    if is_done is None:
+        done = phase3_done or has_error
+    else:
+        done = is_done
+
     return PipelineProgress(
         phase=phase,
         phases_total=3,
         phase_label=_PHASE_LABELS[phase],
-        done=phase3_done or has_error,
+        done=done,
         has_error=has_error,
     )

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -259,7 +259,10 @@ async def chain_job(
             # treats NULL run_after as eligible.  Matches the existing
             # ingestion_tasks.py recalc-job creation pattern.
             run_after=None,
-            meta={"config": config or {}, "parent_job_id": parent.id},
+            # Phase 5B (#1236) — ``parent_job_id`` dropped from meta;
+            # the parent is identifiable as the lowest-id job in the
+            # pipeline (see ``compute_pipeline_progress._find_root``).
+            meta={"config": config or {}},
         )
         created = await repo.create_ingestion_job(child)
         await session.commit()
@@ -340,7 +343,9 @@ async def _insert_child_with_dedup(
     # asyncpg accepts UUID objects directly via type adapters, but
     # raw text SQL coerces best when stringified.
     pipeline_id_str = str(pipeline_id) if pipeline_id is not None else None
-    meta_json = json.dumps({"config": config or {}, "parent_job_id": parent.id})
+    # Phase 5B (#1236) — ``parent_job_id`` dropped from meta (see sibling
+    # call above); reading paths use lowest-id-in-pipeline instead.
+    meta_json = json.dumps({"config": config or {}})
 
     # The chain_job entry guard already rejected NULL scope values,
     # so simple equality is sufficient here — no ``(:col IS NULL AND

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -156,6 +156,24 @@ async def chain_job(
         pipeline_id = uuid4()
         parent.pipeline_id = pipeline_id
         session.add(parent)
+        # #1236 — back-fill the pipeline aggregate row for ad-hoc runs
+        # that mint lazily (idempotent; atomic with the parent update).
+        await repo.ensure_pipeline_exists(
+            pipeline_id,
+            kind=parent.job_type,
+            entity_type=(
+                parent.entity_type.value
+                if parent.entity_type is not None
+                else None
+            ),
+            ingestion_method=(
+                parent.ingestion_method.value
+                if parent.ingestion_method is not None
+                else None
+            ),
+            module_type_id=parent.module_type_id,
+            year=parent.year,
+        )
         await session.commit()
 
     resolved_module_type_id = (

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -154,17 +154,16 @@ async def chain_job(
     pipeline_id = parent.pipeline_id
     if pipeline_id is None:
         pipeline_id = uuid4()
-        parent.pipeline_id = pipeline_id
-        session.add(parent)
-        # #1236 — back-fill the pipeline aggregate row for ad-hoc runs
-        # that mint lazily (idempotent; atomic with the parent update).
+        # #1236 Phase 2 FK — Pipeline row MUST exist before we make
+        # ``parent.pipeline_id`` dirty.  Otherwise the SELECT inside
+        # ``ensure_pipeline_exists`` would autoflush an UPDATE on
+        # data_ingestion_jobs that references a pipeline that doesn't
+        # exist yet → FK violation.
         await repo.ensure_pipeline_exists(
             pipeline_id,
             kind=parent.job_type,
             entity_type=(
-                parent.entity_type.value
-                if parent.entity_type is not None
-                else None
+                parent.entity_type.value if parent.entity_type is not None else None
             ),
             ingestion_method=(
                 parent.ingestion_method.value
@@ -174,6 +173,8 @@ async def chain_job(
             module_type_id=parent.module_type_id,
             year=parent.year,
         )
+        parent.pipeline_id = pipeline_id
+        session.add(parent)
         await session.commit()
 
     resolved_module_type_id = (

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -25,6 +25,7 @@ contract narrow (parent + child shape + dispatch).
 
 import json
 import warnings
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Optional
 from uuid import uuid4
@@ -45,6 +46,77 @@ from app.repositories.data_ingestion import DataIngestionRepository
 from app.tasks._background import fire_and_forget
 
 logger = get_logger(__name__)
+
+
+# Post-commit dispatch queue (#1236) — chain_job must NOT fire children
+# until the parent's ``data_session`` is committed.  The race that drove
+# this:
+#   1. csv_ingest_handler writes DELETE old + INSERT new data_entries to
+#      data_session (uncommitted — runner commits AFTER handler returns).
+#   2. _chain_emission_recalc_for_data_ingest calls chain_job for each
+#      target (module, det) pair.
+#   3. chain_job creates the child row in job_session (committed via
+#      job_session.commit) and would normally fire_and_forget(run_job).
+#   4. The recalc child starts on a NEW session BEFORE the parent
+#      commits data_session → snapshot pre-dates the parent's
+#      DELETE/INSERT → recalc reads STALE data_entries (the ones about
+#      to be deleted).
+#   5. Recalc tries to INSERT data_entry_emissions referencing those
+#      stale ids; meanwhile the parent's commit lands → DELETE takes
+#      effect → FK violation on data_entry_emissions_data_entry_id_fkey.
+#
+# Fix: chain_job appends to this ContextVar instead of fire_and_forget.
+# The runner drains the queue ONLY AFTER ``data_session.commit()`` and
+# ``finish_job``, so the children's first read sees the parent's
+# committed state.  ContextVar (not a plain list) so concurrent
+# handlers in the same process get independent queues — asyncio Tasks
+# get their own context copy by default.
+#
+# Fallback: if no context is set up (ad-hoc calls outside the runner),
+# we still fire_and_forget immediately and log a warning — that path
+# preserves the legacy behavior for one-off callers / tests that
+# haven't migrated.
+_PENDING_DISPATCHES: ContextVar[Optional[list[int]]] = ContextVar(
+    "_pending_dispatches_after_commit", default=None
+)
+
+
+def reset_pending_dispatches() -> None:
+    """Initialize the pending-dispatch list for the current asyncio context.
+
+    Called by the runner at the start of ``run_job`` so the handler's
+    ``chain_job`` calls accumulate here instead of firing immediately.
+    """
+    _PENDING_DISPATCHES.set([])
+
+
+def drain_pending_dispatches() -> None:
+    """Fire every chain_job dispatch the handler accumulated.
+
+    Called by the runner AFTER ``data_session.commit()`` so the
+    children's first read of data_entries / data_entry_emissions sees
+    the parent's committed writes (#1236 race fix).
+    """
+    pending = _PENDING_DISPATCHES.get()
+    if not pending:
+        return
+    from app.tasks.runner import run_job
+
+    for child_id in pending:
+        fire_and_forget(run_job(child_id), name=f"run_job-{child_id}")
+    pending.clear()
+
+
+def discard_pending_dispatches() -> None:
+    """Drop every queued chain_job dispatch without firing.
+
+    Called by the runner on handler failure / preempt — the parent's
+    ``data_session`` was rolled back, so the children would operate on
+    a view of the world that no longer reflects the parent's intent.
+    """
+    pending = _PENDING_DISPATCHES.get()
+    if pending:
+        pending.clear()
 
 
 @dataclass(frozen=True)
@@ -287,14 +359,28 @@ async def chain_job(
         )
         return None
 
-    # Lazy import: runner imports nothing from this module, so a
-    # top-level ``from app.tasks.runner import run_job`` would be safe
-    # for the static graph — but lazy here documents that ``chain_job``
-    # only needs ``run_job`` for the dispatch call, not for typing or
-    # construction.
-    from app.tasks.runner import run_job
+    # Defer dispatch — see ``_PENDING_DISPATCHES`` docstring for the
+    # race that motivated this.  In the normal runner-invoked path the
+    # ContextVar is initialised by ``reset_pending_dispatches()`` and
+    # drained by ``drain_pending_dispatches()`` AFTER the parent's
+    # ``data_session.commit()``.  Outside the runner (ad-hoc / tests
+    # that don't reset the context), fall back to immediate fire so
+    # the legacy behavior is preserved — logged so the fallback is
+    # visible.
+    pending = _PENDING_DISPATCHES.get()
+    if pending is None:
+        from app.tasks.runner import run_job
 
-    fire_and_forget(run_job(child_id), name=f"run_job-{child_id}")
+        logger.warning(
+            "chain_job: _PENDING_DISPATCHES not initialised — firing "
+            "run_job(%s) immediately. This is safe outside the runner "
+            "(tests, ad-hoc dispatch) but risks the data_session race "
+            "if called from a handler that hasn't yet committed.",
+            child_id,
+        )
+        fire_and_forget(run_job(child_id), name=f"run_job-{child_id}")
+    else:
+        pending.append(child_id)
     return child_id
 
 

--- a/backend/app/tasks/_locks.py
+++ b/backend/app/tasks/_locks.py
@@ -1,0 +1,85 @@
+"""Per-scope advisory locks shared by ingestion handlers (#1236 Phase 4B).
+
+Factor writes and emission recalcs for the SAME ``(module_type_id, year)``
+scope must not run concurrently. Both reach the same ``factors`` row set:
+``factor_ingest`` writes, ``emission_recalc`` reads. Without serialisation
+a recalc that started mid-write computes emissions against half-loaded
+factor values — silently wrong numbers, no error surfaced.
+
+This module provides a transaction-scoped Postgres advisory lock both
+handlers acquire at the start of the work. ``pg_advisory_xact_lock`` is
+held until the holding transaction commits or rolls back — perfect fit
+for "hold for the duration of the handler's data work."
+
+Lock key encoding: 2-int variant ``pg_advisory_xact_lock(category, key)``
+where ``category`` is a dedicated #1236-Phase-4B constant so we never
+collide with other advisory-lock users (the aggregation per-year lock
+in Phase 4A.2 uses a different category for the same reason).
+
+Dialect-gated: on non-Postgres backends (the SQLite unit-test fixture)
+the lock call is a no-op — SQLite's single-writer model already
+serialises any concurrent writers, so the lock is unnecessary and the
+``pg_advisory_xact_lock`` function doesn't exist there anyway.
+"""
+
+from typing import Optional
+
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Dedicated namespace for the factor-vs-recalc per-(module, year) mutex.
+# Distinct from the Phase 4A.2 aggregation per-year category (1236) so
+# the two lock spaces never accidentally serialise unrelated work.
+_FACTOR_RECALC_LOCK_CATEGORY = 1237
+
+
+def _encode_module_year_key(module_type_id: int, year: int) -> int:
+    """Pack ``(module_type_id, year)`` into a single int64 lock key.
+
+    Module ids are tiny (< 100), years comfortably fit in 5 digits, so
+    ``module * 100000 + year`` is collision-free and well within int64.
+    """
+    return module_type_id * 100_000 + year
+
+
+async def acquire_factor_recalc_lock(
+    data_session: AsyncSession,
+    *,
+    module_type_id: Optional[int],
+    year: Optional[int],
+    handler_label: str,
+) -> None:
+    """Acquire the per-``(module, year)`` mutex for the duration of the
+    caller's transaction. No-op on non-Postgres or when scope is missing
+    (defensive: skip rather than crash a job whose scope wasn't set —
+    such a job is already wrong and the lock isn't what would save it).
+
+    ``handler_label`` is plumbed through for the debug log so traces
+    show which handler took the lock.
+    """
+    if module_type_id is None or year is None:
+        logger.debug(
+            f"{handler_label}: missing module_type_id or year — "
+            "skipping factor/recalc advisory lock"
+        )
+        return
+    try:
+        dialect_name = data_session.get_bind().dialect.name
+    except Exception:
+        dialect_name = ""
+    if dialect_name != "postgresql":
+        return
+    key = _encode_module_year_key(int(module_type_id), int(year))
+    await data_session.execute(
+        text("SELECT pg_advisory_xact_lock(:cat, :key)"),
+        {"cat": _FACTOR_RECALC_LOCK_CATEGORY, "key": key},
+    )
+    logger.debug(
+        f"{handler_label}: acquired pg_advisory_xact_lock"
+        f"({_FACTOR_RECALC_LOCK_CATEGORY}, {key}) for "
+        f"(module={module_type_id}, year={year})"
+    )

--- a/backend/app/tasks/_pipeline_reconciler.py
+++ b/backend/app/tasks/_pipeline_reconciler.py
@@ -1,0 +1,63 @@
+"""In-process pipeline-status reconciliation sweep (#1236 Phase 3).
+
+The runner writes ``pipelines.status`` post-``finish_job`` on an isolated
+session that **log-and-skips** on any DB error so a transient failure
+can't poison the job's terminal state.  That safety net leaves a small
+window where ``pipelines.status`` lags the real chain state.
+
+This sweep is the durable backstop: every ``PIPELINE_RECONCILER_INTERVAL_SECONDS``
+(default 60s) it walks pipelines, recomputes status from current job
+rows, and writes the corrected value.  Idempotent — re-running on a
+healthy DB is a no-op.
+
+Same loop hygiene as ``_poller``: session per iteration (the repo
+already commits per pipeline; pinning a pool slot for the whole loop
+would starve other readers), broad ``except`` so one iteration's
+failure doesn't kill the loop, settings flag for the diagnostic
+"let the table lag" case.
+
+Multi-pod note: every pod runs this sweep concurrently.  That's safe
+because ``recompute_pipeline_status`` is idempotent and commits per
+row — no advisory lock needed.  If contention is ever measured, add
+jitter; until then, YAGNI.
+"""
+
+import asyncio
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db import SessionLocal
+from app.repositories.data_ingestion import DataIngestionRepository
+
+logger = get_logger(__name__)
+
+
+async def reconcile_pipeline_statuses_loop() -> None:
+    """Run the reconciliation sweep on the configured cadence forever.
+
+    Cancellation: ``asyncio.CancelledError`` propagates out of the
+    ``asyncio.sleep`` — the lifespan shutdown awaits this loop's
+    cancellation explicitly (see ``app.main.lifespan``).
+    """
+    settings = get_settings()
+    interval = settings.PIPELINE_RECONCILER_INTERVAL_SECONDS
+    while True:
+        try:
+            async with SessionLocal() as session:
+                repo = DataIngestionRepository(session)
+                summary = await repo.reconcile_pipeline_statuses()
+            if summary.get("corrected"):
+                # Only log when the sweep had to fix something — a
+                # quiet sweep is the common case and would otherwise
+                # spam the logs.
+                logger.info(
+                    "Pipeline reconciler healed %s/%s pipeline(s)",
+                    summary["corrected"],
+                    summary["checked"],
+                )
+        except Exception as exc:
+            logger.warning(
+                f"Pipeline reconciler iteration failed: {exc}",
+                exc_info=True,
+            )
+        await asyncio.sleep(interval)

--- a/backend/app/tasks/aggregation_tasks.py
+++ b/backend/app/tasks/aggregation_tasks.py
@@ -12,12 +12,19 @@ PR (`emission_recalc_handler` chains here, providers stop calling
 ``recompute_stats`` directly) lands next in the Plan-D Tier-2 sequence.
 """
 
+from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
 from app.models.data_ingestion import DataIngestionJob, IngestionResult
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.tasks.registry import register
+
+# #1236 Phase 4A.2 — per-year advisory-lock namespace. Using the
+# 2-int variant ``pg_advisory_xact_lock(category, year)`` so the lock
+# space is namespaced and can't collide with unrelated advisory-lock
+# users in the same DB.
+_AGGREGATION_LOCK_CATEGORY = 1236
 
 logger = get_logger(__name__)
 
@@ -49,6 +56,35 @@ async def aggregation_handler(
         raise ValueError("aggregation: job has no id")
     if job.module_type_id is None or job.year is None:
         raise ValueError(f"aggregation job {job.id} missing module_type_id or year")
+
+    # #1236 Phase 4A.2 — per-year transaction-scoped advisory lock.
+    # Cross-pipeline aggregations of the SAME year all touch the same
+    # ``carbon_reports.stats`` rows (one per unit) as a side-effect of
+    # ``recompute_stats``; without serialisation Postgres deadlocks
+    # them (the exact pattern in jobs 44/90/101 of the localhost
+    # dump). ``pg_advisory_xact_lock`` serialises them at the lock,
+    # not at the dedup index — so no drop-hazard (the existing
+    # AGGREGATION_DEDUP partial unique index would silently cancel
+    # the loser if widened to year-only scope; this approach avoids
+    # that). The lock is held until ``data_session`` commits or rolls
+    # back (the runner does that after the handler returns).
+    #
+    # Dialect-gated so the SQLite test fixture (and mock-driven unit
+    # tests) skip cleanly — SQLite's single-writer model already
+    # serialises any concurrent writers, so the lock is a no-op there.
+    try:
+        dialect_name = data_session.get_bind().dialect.name
+    except Exception:
+        dialect_name = ""
+    if dialect_name == "postgresql":
+        await data_session.execute(
+            text("SELECT pg_advisory_xact_lock(:cat, :year)"),
+            {"cat": _AGGREGATION_LOCK_CATEGORY, "year": int(job.year)},
+        )
+        logger.debug(
+            f"aggregation handler (job {job.id}): acquired "
+            f"pg_advisory_xact_lock({_AGGREGATION_LOCK_CATEGORY}, {job.year})"
+        )
 
     svc = CarbonReportModuleService(data_session)
     affected = await svc.list_modules_for(

--- a/backend/app/tasks/aggregation_tasks.py
+++ b/backend/app/tasks/aggregation_tasks.py
@@ -145,10 +145,29 @@ async def aggregation_handler(
         module_type_id=job.module_type_id, year=job.year
     )
 
-    # 4A.3 — narrow to modules the recalc siblings actually touched
-    # (when available). Avoids the 2231-row full-slice rewrite when
-    # only a handful of carbon_report_modules need fresh stats.
-    affected_scope = await _collect_affected_module_ids(job.pipeline_id, data_session)
+    # 4A.4 — read the precise union from OUR OWN ``meta.config`` first
+    # (set by the last recalc sibling at chain time so the last
+    # sibling's own contribution is included — sibling-query couldn't
+    # see it yet, runner-``finish_job`` is pending). Falls back to
+    # the sibling-query helper (4A.3) for legacy aggregations that
+    # weren't passed an explicit scope at chain time.
+    own_config = (job.meta or {}).get("config") or {}
+    own_scope = own_config.get("affected_module_ids")
+    affected_scope: Optional[set[int]]
+    if isinstance(own_scope, list):
+        scope_set: set[int] = {int(i) for i in own_scope if isinstance(i, int)}
+        logger.debug(
+            f"aggregation handler (job {job.id}): scope from own "
+            f"meta.config.affected_module_ids ({len(scope_set)} ids)"
+        )
+        affected_scope = scope_set
+    else:
+        # 4A.3 fallback — sibling-query. Misses the last sibling's
+        # contribution when the chain happens before that sibling's
+        # finish_job commit, but better than full-slice for legacy.
+        affected_scope = await _collect_affected_module_ids(
+            job.pipeline_id, data_session
+        )
     if affected_scope is not None:
         affected = [m for m in candidates if m.id in affected_scope]
         logger.info(

--- a/backend/app/tasks/aggregation_tasks.py
+++ b/backend/app/tasks/aggregation_tasks.py
@@ -12,11 +12,18 @@ PR (`emission_recalc_handler` chains here, providers stop calling
 ``recompute_stats`` directly) lands next in the Plan-D Tier-2 sequence.
 """
 
+from typing import Optional
+
 from sqlalchemy import text
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
-from app.models.data_ingestion import DataIngestionJob, IngestionResult
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    IngestionResult,
+    IngestionState,
+)
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.tasks.registry import register
 
@@ -25,6 +32,53 @@ from app.tasks.registry import register
 # space is namespaced and can't collide with unrelated advisory-lock
 # users in the same DB.
 _AGGREGATION_LOCK_CATEGORY = 1236
+
+
+async def _collect_affected_module_ids(
+    pipeline_id, session: AsyncSession
+) -> Optional[set[int]]:
+    """4A.3 — union of ``affected_module_ids`` from FINISHED recalc siblings.
+
+    Each ``emission_recalc`` records the precise ``carbon_report_module``
+    ids whose ``data_entry_emissions`` it touched (in
+    ``meta.recalculation.affected_module_ids``). With Phase 4A.1
+    in-pipeline coalescing, the aggregation runs once after every
+    recalc sibling has finished — so every contributor's affected-ids
+    list is already durably committed and the union is the *precise*
+    set of modules whose stats are stale.
+
+    Returns ``None`` when no recalc sibling carries that metadata
+    (legacy / orphan / pipeline_id missing) so the caller falls back
+    to the full ``(module_type_id, year)`` module list — preserves
+    prior behavior on legacy paths.
+    """
+    if pipeline_id is None:
+        return None
+    siblings = (
+        (
+            await session.execute(
+                select(DataIngestionJob).where(
+                    DataIngestionJob.pipeline_id == pipeline_id,
+                    DataIngestionJob.job_type == "emission_recalc",
+                    DataIngestionJob.state == IngestionState.FINISHED,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    union: set[int] = set()
+    any_meta = False
+    for s in siblings:
+        recalc = (s.meta or {}).get("recalculation") or {}
+        ids = recalc.get("affected_module_ids")
+        if isinstance(ids, list):
+            any_meta = True
+            for i in ids:
+                if isinstance(i, int):
+                    union.add(i)
+    return union if any_meta else None
+
 
 logger = get_logger(__name__)
 
@@ -87,15 +141,28 @@ async def aggregation_handler(
         )
 
     svc = CarbonReportModuleService(data_session)
-    affected = await svc.list_modules_for(
+    candidates = await svc.list_modules_for(
         module_type_id=job.module_type_id, year=job.year
     )
 
-    logger.info(
-        f"aggregation handler (job {job.id}): recomputing stats for "
-        f"{len(affected)} module(s) "
-        f"in scope module_type_id={job.module_type_id}/year={job.year}"
-    )
+    # 4A.3 — narrow to modules the recalc siblings actually touched
+    # (when available). Avoids the 2231-row full-slice rewrite when
+    # only a handful of carbon_report_modules need fresh stats.
+    affected_scope = await _collect_affected_module_ids(job.pipeline_id, data_session)
+    if affected_scope is not None:
+        affected = [m for m in candidates if m.id in affected_scope]
+        logger.info(
+            f"aggregation handler (job {job.id}): scoped to "
+            f"{len(affected)}/{len(candidates)} module(s) via recalc "
+            f"affected_module_ids"
+        )
+    else:
+        affected = candidates
+        logger.info(
+            f"aggregation handler (job {job.id}): recomputing stats for "
+            f"{len(affected)} module(s) "
+            f"in scope module_type_id={job.module_type_id}/year={job.year}"
+        )
 
     for module in affected:
         if module.id is None:

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -12,9 +12,11 @@ preemption check, and the FINISHED-state write — these handlers
 only contain the work itself.
 """
 
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
+from app.db import SessionLocal
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import (
     DataIngestionJob,
@@ -36,6 +38,97 @@ logger = get_logger(__name__)
 # Plan 310-C registered handlers (additive — coexist with the legacy
 # functions below until the endpoint+poller cutover PR removes them).
 # ---------------------------------------------------------------------------
+
+
+async def _is_last_recalc_sibling(
+    job: DataIngestionJob,
+    *,
+    helper_session: AsyncSession | None = None,
+) -> bool:
+    """In-pipeline aggregation coalesce gate (#1236 Phase 4A.1).
+
+    Returns ``True`` only for the LAST ``emission_recalc`` sibling of a
+    pipeline (where "last" = exactly ``parent.meta.recalc_jobs_chained``
+    siblings have stamped ``meta.recalc_work_complete=True``). Others
+    return ``False`` so they skip the aggregation chain.
+
+    Why: today every recalc child chains its own aggregation. Because
+    ``AGGREGATION_DEDUP`` only blocks concurrently-active rows, the
+    aggregations run *sequentially* (3× per upload in real data) and
+    the early ones see partial ``data_entry_emissions`` state. The
+    single trailing aggregation chained by the last sibling sees the
+    final post-all-recalcs state — correct and 3× fewer aggregations.
+
+    Falls back to ``True`` (always chain — preserves prior behavior)
+    when: no ``pipeline_id``, no ``parent_job_id`` in meta, no parent
+    row, or parent lacks ``recalc_jobs_chained``. Legacy/orphan jobs
+    keep working.
+
+    Race safety: a *fresh* session opens, ``SELECT … FOR UPDATE`` on
+    the parent row serialises the count-and-decide section across
+    siblings; each sibling flushes its own ``recalc_work_complete=True``
+    inside that lock, then commits — making the increment durably
+    visible to the next sibling. The lock is narrow (single short
+    transaction), independent of the outer handler's data_session, so
+    a recalc that takes a minute does not hold the lock for a minute.
+    """
+    if job.pipeline_id is None or job.id is None:
+        return True
+    parent_id = (job.meta or {}).get("parent_job_id")
+    if parent_id is None:
+        return True
+
+    async def _decide(helper: AsyncSession) -> bool:
+        parent = (
+            await helper.execute(
+                select(DataIngestionJob)
+                .where(DataIngestionJob.id == parent_id)
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if parent is None:
+            return True
+        expected = (parent.meta or {}).get("recalc_jobs_chained")
+        if expected is None:
+            return True
+
+        # Stamp our own row's meta with the work-complete flag so the
+        # NEXT sibling's count sees us.
+        my_row = (
+            await helper.execute(
+                select(DataIngestionJob).where(DataIngestionJob.id == job.id)
+            )
+        ).scalar_one_or_none()
+        if my_row is None:
+            return True
+        my_row.meta = {**(my_row.meta or {}), "recalc_work_complete": True}
+        helper.add(my_row)
+        await helper.flush()
+
+        siblings = (
+            (
+                await helper.execute(
+                    select(DataIngestionJob).where(
+                        DataIngestionJob.pipeline_id == job.pipeline_id,
+                        DataIngestionJob.job_type == "emission_recalc",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        done = sum(1 for s in siblings if (s.meta or {}).get("recalc_work_complete"))
+        return done >= int(expected)
+
+    # Production path: own short-lived session keeps the lock narrow.
+    # Tests inject ``helper_session`` to use the SQLite fixture without
+    # touching the real engine.
+    if helper_session is not None:
+        return await _decide(helper_session)
+    async with SessionLocal() as helper:
+        decision = await _decide(helper)
+        await helper.commit()
+        return decision
 
 
 @register("emission_recalc")
@@ -115,14 +208,29 @@ async def emission_recalc_handler(
     # via the dashboard's "stats stale" badge if they need it.
     chained_aggregation_id = None
     if job.module_type_id is not None and result != IngestionResult.ERROR:
-        chained_aggregation_id = await chain_job(
-            job,
-            job_type="aggregation",
-            module_type_id=job.module_type_id,
-            year=job.year,
-            session=job_session,
-            dedup_config=AGGREGATION_DEDUP,
-        )
+        # #1236 Phase 4A.1 — only the LAST emission_recalc sibling of
+        # a pipeline chains the aggregation. Earlier siblings stamp
+        # ``meta.recalc_work_complete=True`` and skip; the last one
+        # sees the final ``data_entry_emissions`` state and runs one
+        # trailing aggregation (was 3 sequential aggregations per
+        # upload). ``AGGREGATION_DEDUP`` remains the safety net for
+        # the (rare) race where two siblings both observe themselves
+        # as last.
+        if await _is_last_recalc_sibling(job):
+            chained_aggregation_id = await chain_job(
+                job,
+                job_type="aggregation",
+                module_type_id=job.module_type_id,
+                year=job.year,
+                session=job_session,
+                dedup_config=AGGREGATION_DEDUP,
+            )
+        else:
+            logger.info(
+                f"emission_recalc job {job.id}: not the last sibling — "
+                "skipping aggregation chain (coalesced to the trailing "
+                "sibling per Phase 4A.1)"
+            )
     elif job.module_type_id is None:
         logger.warning(
             f"emission_recalc job {job.id}: no module_type_id — "

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -12,6 +12,9 @@ preemption check, and the FINISHED-state write — these handlers
 only contain the work itself.
 """
 
+from typing import Optional
+from uuid import UUID
+
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -132,6 +135,86 @@ async def _is_last_recalc_sibling(
         return decision
 
 
+async def _build_aggregation_scope_config(
+    job: DataIngestionJob,
+    my_affected_module_ids: list[int],
+    *,
+    helper_session: AsyncSession | None = None,
+) -> Optional[dict]:
+    """4A.4 — build the chain config for the trailing aggregation job.
+
+    The last recalc sibling chains the aggregation BEFORE the runner
+    commits its own ``finish_job``. So a sibling-query made by the
+    aggregation later would miss THIS recalc's ``affected_module_ids``
+    (not yet visible in the DB). Sidestep the race by building the
+    full union here — earlier FINISHED siblings (visible) **plus**
+    our own ids (from local ``stats``, since the in-memory recalc
+    workflow just produced them) — and embedding it in the
+    aggregation's ``meta.config``. The aggregation reads from its own
+    meta first; the sibling-query stays as a legacy fallback.
+
+    Returns ``None`` when the union is empty AND there are no
+    FINISHED siblings to consult — preserves the legacy "full slice"
+    behavior for ad-hoc / single-det runs without a meaningful scope.
+    Returns ``{"affected_module_ids": [...]}`` otherwise (empty list
+    is meaningful: "no modules touched, do nothing" — which is the
+    optimized correct behavior, not the legacy fallback).
+    """
+    union: set[int] = {i for i in (my_affected_module_ids or []) if isinstance(i, int)}
+    # ``isinstance(..., UUID)`` is the production-vs-mock gate: real
+    # rows carry a UUID; unit-test ``MagicMock`` doesn't. Without this
+    # the helper would open ``SessionLocal`` against the production
+    # engine in mock-driven tests and emit psycopg errors trying to
+    # bind a MagicMock to ``pipeline_id_1``.
+    if (
+        not isinstance(job.pipeline_id, UUID)
+        or job.id is None
+        or not isinstance(job.id, int)
+    ):
+        return {"affected_module_ids": sorted(union)} if union else None
+
+    async def _gather(helper: AsyncSession) -> bool:
+        """Returns True if at least one FINISHED sibling was seen
+        (so we know an empty union means 'truly nothing to do')."""
+        siblings = (
+            (
+                await helper.execute(
+                    select(DataIngestionJob).where(
+                        DataIngestionJob.pipeline_id == job.pipeline_id,
+                        DataIngestionJob.job_type == "emission_recalc",
+                        DataIngestionJob.id != job.id,
+                        DataIngestionJob.state == IngestionState.FINISHED,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for s in siblings:
+            recalc = (s.meta or {}).get("recalculation") or {}
+            ids = recalc.get("affected_module_ids")
+            if isinstance(ids, list):
+                for i in ids:
+                    if isinstance(i, int):
+                        union.add(i)
+        return bool(siblings)
+
+    if helper_session is not None:
+        had_siblings = await _gather(helper_session)
+    else:
+        async with SessionLocal() as helper:
+            had_siblings = await _gather(helper)
+
+    # If we saw FINISHED siblings OR we have our own affected ids, the
+    # caller should scope precisely (even if the union is empty —
+    # "nothing to do" is a real answer). Only return None when there's
+    # nothing useful at all, so the aggregation falls back to the full
+    # slice — preserves the legacy / ad-hoc behavior.
+    if had_siblings or my_affected_module_ids is not None:
+        return {"affected_module_ids": sorted(union)}
+    return None
+
+
 @register("emission_recalc")
 async def emission_recalc_handler(
     job: DataIngestionJob,
@@ -231,11 +314,21 @@ async def emission_recalc_handler(
         # the (rare) race where two siblings both observe themselves
         # as last.
         if await _is_last_recalc_sibling(job):
+            # 4A.4 — embed the FULL affected_module_ids union (including
+            # MY contribution, taken from local ``stats`` since my
+            # runner-``finish_job`` hasn't committed my meta yet) in
+            # the aggregation job's config. The aggregation handler
+            # reads from its OWN meta first (no sibling-query race) —
+            # see ``aggregation_tasks.aggregation_handler``.
+            agg_config = await _build_aggregation_scope_config(
+                job, stats.get("affected_module_ids") or []
+            )
             chained_aggregation_id = await chain_job(
                 job,
                 job_type="aggregation",
                 module_type_id=job.module_type_id,
                 year=job.year,
+                config=agg_config,
                 session=job_session,
                 dedup_config=AGGREGATION_DEDUP,
             )

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -28,6 +28,7 @@ from app.models.data_ingestion import (
 )
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.tasks._chain import AGGREGATION_DEDUP, chain_job
+from app.tasks._locks import acquire_factor_recalc_lock
 from app.tasks.registry import register
 from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
 
@@ -169,6 +170,19 @@ async def emission_recalc_handler(
     )
     await job_session.commit()
 
+    # 4B — per-``(module, year)`` advisory lock: blocks while any
+    # concurrent ``factor_ingest`` for the same scope is mid-write,
+    # so this recalc reads complete factor values instead of the
+    # half-loaded state. Held until ``data_session`` commits (runner
+    # does that after this handler returns) — covers the whole
+    # factor-read window inside the workflow.
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=job.module_type_id,
+        year=job.year,
+        handler_label=f"emission_recalc job {job.id}",
+    )
+
     logger.info(
         f"emission_recalc handler (job {job.id}): "
         f"running workflow for det={data_entry_type.name}/year={job.year}"
@@ -278,6 +292,18 @@ async def module_emission_recalc_handler(
         )
 
     job_repo = DataIngestionRepository(job_session)
+
+    # 4B — same per-``(module, year)`` advisory lock as the per-det
+    # recalc handler: held until ``data_session`` commits so every
+    # det in the bulk loop reads factors that are not mid-write by a
+    # concurrent ``factor_ingest`` for the same scope.
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=job.module_type_id,
+        year=job.year,
+        handler_label=f"module_emission_recalc job {job.id}",
+    )
+
     svc = EmissionRecalculationWorkflow(data_session)
     n = len(data_entry_type_ids)
     per_type_stats: dict[int, dict] = {}

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -27,6 +27,7 @@ from app.models.data_ingestion import (
     IngestionMethod,
     IngestionResult,
     IngestionState,
+    Pipeline,
     TargetType,
 )
 from app.repositories.data_ingestion import DataIngestionRepository
@@ -52,7 +53,7 @@ async def _is_last_recalc_sibling(
     """In-pipeline aggregation coalesce gate (#1236 Phase 4A.1).
 
     Returns ``True`` only for the LAST ``emission_recalc`` sibling of a
-    pipeline (where "last" = exactly ``parent.meta.recalc_jobs_chained``
+    pipeline (where "last" = exactly ``pipeline.expected_recalc``
     siblings have stamped ``meta.recalc_work_complete=True``). Others
     return ``False`` so they skip the aggregation chain.
 
@@ -63,36 +64,46 @@ async def _is_last_recalc_sibling(
     single trailing aggregation chained by the last sibling sees the
     final post-all-recalcs state — correct and 3× fewer aggregations.
 
-    Falls back to ``True`` (always chain — preserves prior behavior)
-    when: no ``pipeline_id``, no ``parent_job_id`` in meta, no parent
-    row, or parent lacks ``recalc_jobs_chained``. Legacy/orphan jobs
-    keep working.
+    Phase 5B (#1236): the expected count moved from
+    ``parent.meta.recalc_jobs_chained`` to ``pipeline.expected_recalc``
+    (the ``pipelines`` row column written by ``recompute_pipeline_status``).
+    The lock target moved correspondingly — ``SELECT … FOR UPDATE``
+    on the ``pipelines`` row serialises siblings.  If the lock had
+    stayed on the parent ``data_ingestion_jobs`` row while the read
+    moved, two concurrent siblings could both see "I'm last" and
+    chain 2 aggregations — silently regressing 4A.1.
 
-    Race safety: a *fresh* session opens, ``SELECT … FOR UPDATE`` on
-    the parent row serialises the count-and-decide section across
-    siblings; each sibling flushes its own ``recalc_work_complete=True``
-    inside that lock, then commits — making the increment durably
-    visible to the next sibling. The lock is narrow (single short
-    transaction), independent of the outer handler's data_session, so
-    a recalc that takes a minute does not hold the lock for a minute.
+    Falls back to ``True`` (always chain — preserves prior behavior)
+    when: no ``pipeline_id``, no ``Pipeline`` row, or
+    ``pipeline.expected_recalc`` is NULL (never written, e.g. legacy
+    pipelines pre-Phase-5A).  Legacy/orphan jobs keep working.
+
+    Race safety: a *fresh* session opens, ``SELECT pipelines … FOR
+    UPDATE`` serialises the count-and-decide section across siblings;
+    each sibling flushes its own ``recalc_work_complete=True`` inside
+    that lock, then commits — making the increment durably visible to
+    the next sibling.  The lock is narrow (single short transaction),
+    independent of the outer handler's data_session.
     """
     if job.pipeline_id is None or job.id is None:
         return True
-    parent_id = (job.meta or {}).get("parent_job_id")
-    if parent_id is None:
+    # Same mock-vs-prod gate as ``_build_aggregation_scope_config`` —
+    # MagicMock ``pipeline_id``s used by mock-driven unit tests must
+    # not reach the real ``SessionLocal``/asyncpg path; treat as
+    # "fall back to chain" so existing handler tests don't open a
+    # Postgres connection with an unadaptable MagicMock UUID.
+    if not isinstance(job.pipeline_id, UUID):
         return True
 
     async def _decide(helper: AsyncSession) -> bool:
-        parent = (
+        pipeline = (
             await helper.execute(
-                select(DataIngestionJob)
-                .where(DataIngestionJob.id == parent_id)
-                .with_for_update()
+                select(Pipeline).where(Pipeline.id == job.pipeline_id).with_for_update()
             )
         ).scalar_one_or_none()
-        if parent is None:
+        if pipeline is None:
             return True
-        expected = (parent.meta or {}).get("recalc_jobs_chained")
+        expected = pipeline.expected_recalc
         if expected is None:
             return True
 
@@ -303,7 +314,6 @@ async def emission_recalc_handler(
     # than crashing the parent's FINISHED write.  The recalc itself
     # already succeeded; the operator sees the missing aggregation
     # via the dashboard's "stats stale" badge if they need it.
-    chained_aggregation_id = None
     if job.module_type_id is not None and result != IngestionResult.ERROR:
         # #1236 Phase 4A.1 — only the LAST emission_recalc sibling of
         # a pipeline chains the aggregation. Earlier siblings stamp
@@ -323,7 +333,7 @@ async def emission_recalc_handler(
             agg_config = await _build_aggregation_scope_config(
                 job, stats.get("affected_module_ids") or []
             )
-            chained_aggregation_id = await chain_job(
+            await chain_job(
                 job,
                 job_type="aggregation",
                 module_type_id=job.module_type_id,
@@ -344,11 +354,13 @@ async def emission_recalc_handler(
             "skipping aggregation chain"
         )
 
+    # Phase 5B (#1236) — ``aggregation_job_id`` dropped from meta;
+    # ``compute_pipeline_progress`` reads aggregation completion
+    # directly from the aggregation job rows in this pipeline.
     return {
         "status_message": "Emission recalculation completed",
         "result": result,
         "recalculation": stats,
-        "aggregation_job_id": chained_aggregation_id,
     }
 
 
@@ -453,7 +465,9 @@ async def module_emission_recalc_handler(
             state=IngestionState.FINISHED,
             result=type_result,
             status_message=f"Bulk recalculation via module job {job.id}",
-            meta={"parent_job_id": job.id, "recalculation": stats},
+            # Phase 5B (#1236) — ``parent_job_id`` dropped from meta;
+            # readers identify parents as the lowest-id job per pipeline.
+            meta={"recalculation": stats},
         )
         created = await job_repo.create_ingestion_job(type_job)
         await job_repo.mark_job_as_current(created)
@@ -473,9 +487,8 @@ async def module_emission_recalc_handler(
     # also collapse concurrent fan-outs to the same scope, but in this
     # handler we only ever issue one chain so it's primarily a
     # safety net.
-    chained_aggregation_id = None
     if final_result != IngestionResult.ERROR:
-        chained_aggregation_id = await chain_job(
+        await chain_job(
             job,
             job_type="aggregation",
             module_type_id=job.module_type_id,
@@ -484,11 +497,12 @@ async def module_emission_recalc_handler(
             dedup_config=AGGREGATION_DEDUP,
         )
 
+    # Phase 5B (#1236) — ``aggregation_job_id`` dropped from meta;
+    # progress derivation reads aggregation rows from the job table.
     return {
         "status_message": "Module emission recalculation completed",
         "result": final_result,
         "recalculation": per_type_stats,
         "total_recalculated": total_recalculated,
         "total_errors": total_errors,
-        "aggregation_job_id": chained_aggregation_id,
     }

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -195,8 +195,30 @@ async def _run_ingest(
 
     data = result.get("data", {}) or {}
     ingestion_result = data.get("result", IngestionResult.SUCCESS)
+    status_message = result.get("status_message", "Success")
+    # #1236 root cause: ``ingest()`` hardcodes status_message="Success"
+    # whenever it doesn't *raise*, but a CSV where every row errored
+    # finishes WITHOUT raising and is classified ERROR/WARNING from the
+    # row-error stats. A FINISHED job whose result != SUCCESS must not
+    # claim "Success" — that lie is what pipeline status / last_error
+    # then propagate (#1219). Replace the generic message with an
+    # honest summary from the counts the provider already returned.
+    # Only overrides the generic "Success"; a real exception-path
+    # message ("failed: …") never reaches here (it raises upstream).
+    if ingestion_result != IngestionResult.SUCCESS and (
+        not status_message or status_message.strip().lower() == "success"
+    ):
+        rec = (
+            "ERROR"
+            if ingestion_result == IngestionResult.ERROR
+            else "WARNING"
+        )
+        status_message = (
+            f"{rec}: {data.get('inserted', 0)} inserted, "
+            f"{data.get('skipped', 0)} skipped"
+        )
     return {
-        "status_message": result.get("status_message", "Success"),
+        "status_message": status_message,
         "result": ingestion_result,
         **data,
     }

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -16,7 +16,7 @@ the job.  Endpoints stamp the matching ``job_type`` so the runner's
 registry lookup hits the right handler.
 """
 
-from typing import Any
+from typing import Any, Optional
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -154,6 +154,33 @@ async def factor_ingest_handler(
 # ---------------------------------------------------------------------------
 
 
+#: Cap on the per-row reason embedded in ``status_message`` so the
+#: column stays tractable when row_errors carries a long Postgres
+#: traceback.  200 chars is enough for the operator to recognise the
+#: failure class without expanding the timeline.
+_STATUS_MESSAGE_REASON_CAP = 200
+
+
+def _sample_row_error_reason(row_errors: list) -> Optional[str]:
+    """Pick a representative reason from ``stats.row_errors`` (#1236).
+
+    Row errors are recorded in order; the first one is usually
+    representative when the failure mode is uniform (missing factors,
+    wrong CSV columns, unknown category).  Capped at
+    ``_STATUS_MESSAGE_REASON_CAP`` chars so the status_message column
+    doesn't blow up when a reason carries a stack trace.
+    """
+    if not row_errors:
+        return None
+    first = row_errors[0]
+    reason = first.get("reason") if isinstance(first, dict) else None
+    if not reason:
+        return None
+    if len(reason) > _STATUS_MESSAGE_REASON_CAP:
+        reason = reason[: _STATUS_MESSAGE_REASON_CAP - 1] + "…"
+    return reason
+
+
 def finalize_ingest_meta(result: dict) -> dict:
     """Flatten a provider ``ingest()`` return into the handler's meta,
     making ``status_message`` honest (#1236).
@@ -165,9 +192,12 @@ def finalize_ingest_meta(result: dict) -> dict:
     claim "Success" — that lie is what pipeline status / ``last_error``
     then propagate (#1219). When result != SUCCESS and the message is
     the generic "Success", replace it with an honest summary from the
-    counts the provider already returned. A real exception-path
-    message ("failed: …") never reaches here (it raises upstream), so
-    it is preserved.
+    counts the provider already returned, plus a sample reason from
+    ``stats.row_errors`` so a lone-orphan parent (pipeline-of-one with
+    no ``pipelines.last_error`` to enrich it) carries the real cause
+    instead of just "0 inserted, 50 072 skipped".  A real exception-
+    path message ("failed: …") never reaches here (it raises upstream),
+    so it is preserved.
 
     Shared by ``_run_ingest`` (csv/api/factor) and
     ``reference_ingest_handler`` — they had two identical copies of
@@ -184,6 +214,9 @@ def finalize_ingest_meta(result: dict) -> dict:
             f"{rec}: {data.get('inserted', 0)} inserted, "
             f"{data.get('skipped', 0)} skipped"
         )
+        sample_reason = _sample_row_error_reason(data.get("row_errors") or [])
+        if sample_reason:
+            status_message += f" — first error: {sample_reason}"
     return {
         "status_message": status_message,
         "result": ingestion_result,

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -135,6 +135,47 @@ async def factor_ingest_handler(
 # ---------------------------------------------------------------------------
 
 
+def finalize_ingest_meta(result: dict) -> dict:
+    """Flatten a provider ``ingest()`` return into the handler's meta,
+    making ``status_message`` honest (#1236).
+
+    The provider's ``ingest()`` hardcodes ``status_message="Success"``
+    whenever it does not *raise* — but a CSV where every row errored
+    finishes WITHOUT raising and is classified ERROR/WARNING from the
+    row-error stats. A FINISHED job whose result != SUCCESS must not
+    claim "Success" — that lie is what pipeline status / ``last_error``
+    then propagate (#1219). When result != SUCCESS and the message is
+    the generic "Success", replace it with an honest summary from the
+    counts the provider already returned. A real exception-path
+    message ("failed: …") never reaches here (it raises upstream), so
+    it is preserved.
+
+    Shared by ``_run_ingest`` (csv/api/factor) and
+    ``reference_ingest_handler`` — they had two identical copies of
+    this join; the duplication is what let the bug exist in one.
+    """
+    data = result.get("data", {}) or {}
+    ingestion_result = data.get("result", IngestionResult.SUCCESS)
+    status_message = result.get("status_message", "Success")
+    if ingestion_result != IngestionResult.SUCCESS and (
+        not status_message or status_message.strip().lower() == "success"
+    ):
+        rec = (
+            "ERROR"
+            if ingestion_result == IngestionResult.ERROR
+            else "WARNING"
+        )
+        status_message = (
+            f"{rec}: {data.get('inserted', 0)} inserted, "
+            f"{data.get('skipped', 0)} skipped"
+        )
+    return {
+        "status_message": status_message,
+        "result": ingestion_result,
+        **data,
+    }
+
+
 async def _run_ingest(
     job: DataIngestionJob,
     job_session: AsyncSession,
@@ -193,35 +234,7 @@ async def _run_ingest(
     filters = job_meta.get("filters") or {}
     result = await provider.ingest(filters)
 
-    data = result.get("data", {}) or {}
-    ingestion_result = data.get("result", IngestionResult.SUCCESS)
-    status_message = result.get("status_message", "Success")
-    # #1236 root cause: ``ingest()`` hardcodes status_message="Success"
-    # whenever it doesn't *raise*, but a CSV where every row errored
-    # finishes WITHOUT raising and is classified ERROR/WARNING from the
-    # row-error stats. A FINISHED job whose result != SUCCESS must not
-    # claim "Success" — that lie is what pipeline status / last_error
-    # then propagate (#1219). Replace the generic message with an
-    # honest summary from the counts the provider already returned.
-    # Only overrides the generic "Success"; a real exception-path
-    # message ("failed: …") never reaches here (it raises upstream).
-    if ingestion_result != IngestionResult.SUCCESS and (
-        not status_message or status_message.strip().lower() == "success"
-    ):
-        rec = (
-            "ERROR"
-            if ingestion_result == IngestionResult.ERROR
-            else "WARNING"
-        )
-        status_message = (
-            f"{rec}: {data.get('inserted', 0)} inserted, "
-            f"{data.get('skipped', 0)} skipped"
-        )
-    return {
-        "status_message": status_message,
-        "result": ingestion_result,
-        **data,
-    }
+    return finalize_ingest_meta(result)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -66,8 +66,12 @@ async def csv_ingest_handler(
         # — nothing to recalc against.  Runner will mark FINISHED+ERROR.
         return meta
 
-    chained = await _chain_emission_recalc_for_data_ingest(job, job_session)
-    meta["recalc_jobs_chained"] = chained
+    # Phase 5B (#1236) — chained count no longer threaded through
+    # ``meta.recalc_jobs_chained``; ``recompute_pipeline_status``
+    # derives the same value from the live job count and writes it to
+    # ``pipelines.expected_recalc``.  The call remains for its
+    # side-effect of dispatching the recalc fan-out.
+    await _chain_emission_recalc_for_data_ingest(job, job_session)
     return meta
 
 
@@ -89,8 +93,7 @@ async def api_ingest_handler(
     if meta.get("result") == IngestionResult.ERROR:
         return meta
 
-    chained = await _chain_emission_recalc_for_data_ingest(job, job_session)
-    meta["recalc_jobs_chained"] = chained
+    await _chain_emission_recalc_for_data_ingest(job, job_session)
     return meta
 
 
@@ -139,8 +142,10 @@ async def factor_ingest_handler(
         )
         return meta
 
-    chained = await _chain_recalc_for_stale(job, job_session)
-    meta["recalc_jobs_chained"] = chained
+    # Phase 5B (#1236) — see csv_ingest_handler; chained count derived
+    # from job rows via ``recompute_pipeline_status``, not threaded
+    # through meta.
+    await _chain_recalc_for_stale(job, job_session)
     return meta
 
 

--- a/backend/app/tasks/ingestion_tasks.py
+++ b/backend/app/tasks/ingestion_tasks.py
@@ -28,6 +28,7 @@ from app.models.data_ingestion import (
 from app.repositories.data_ingestion import DataIngestionRepository
 from app.services.data_ingestion.provider_factory import ProviderFactory
 from app.tasks._chain import EMISSION_RECALC_DEDUP, chain_job
+from app.tasks._locks import acquire_factor_recalc_lock
 from app.tasks.registry import register
 
 logger = get_logger(__name__)
@@ -115,6 +116,19 @@ async def factor_ingest_handler(
     - Both NULL → consult ``get_recalculation_status_by_year`` for
       anything stale (admin-style trigger).
     """
+    # 4B — per-``(module, year)`` advisory lock acquired BEFORE the
+    # factor write begins, so any concurrent ``emission_recalc`` for
+    # the same scope blocks at its own lock-acquisition (in
+    # ``emission_recalc_handler``) instead of reading half-written
+    # factor values. Lock released when the runner commits
+    # ``data_session`` after this handler returns.
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=job.module_type_id,
+        year=job.year,
+        handler_label=f"factor_ingest job {job.id}",
+    )
+
     meta = await _run_ingest(job, job_session, data_session)
     if meta.get("result") == IngestionResult.ERROR:
         # Skip fan-out on failure — there's nothing to recalc against.
@@ -160,11 +174,7 @@ def finalize_ingest_meta(result: dict) -> dict:
     if ingestion_result != IngestionResult.SUCCESS and (
         not status_message or status_message.strip().lower() == "success"
     ):
-        rec = (
-            "ERROR"
-            if ingestion_result == IngestionResult.ERROR
-            else "WARNING"
-        )
+        rec = "ERROR" if ingestion_result == IngestionResult.ERROR else "WARNING"
         status_message = (
             f"{rec}: {data.get('inserted', 0)} inserted, "
             f"{data.get('skipped', 0)} skipped"

--- a/backend/app/tasks/reference_ingest_tasks.py
+++ b/backend/app/tasks/reference_ingest_tasks.py
@@ -10,8 +10,9 @@ fan-out chain is both unnecessary and incorrect.
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
-from app.models.data_ingestion import DataIngestionJob, IngestionResult
+from app.models.data_ingestion import DataIngestionJob
 from app.services.data_ingestion.provider_factory import ProviderFactory
+from app.tasks.ingestion_tasks import finalize_ingest_meta
 from app.tasks.registry import register
 
 logger = get_logger(__name__)
@@ -55,13 +56,9 @@ async def reference_ingest_handler(
 
     filters = job_meta.get("filters") or {}
     result = await provider.ingest(filters)
-    data = result.get("data", {}) or {}
-    ingestion_result = data.get("result", IngestionResult.SUCCESS)
-    return {
-        "status_message": result.get("status_message", "Success"),
-        "result": ingestion_result,
-        **data,
-    }
+    # #1236 — shared honest-status join (was a duplicate of _run_ingest's;
+    # the duplication is what let the "Success"-while-ERROR lie persist).
+    return finalize_ingest_meta(result)
 
 
 __all__ = ["reference_ingest_handler"]

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -160,6 +160,17 @@ async def run_job(job_id: int) -> None:
 
         try:
             handler_aborted = False
+            # #1236 — initialise the chain_job deferred-dispatch queue
+            # for this handler.  ``chain_job`` appends child_ids here
+            # instead of firing immediately; we drain after
+            # ``data_session.commit()`` so child handlers see the
+            # parent's committed writes.
+            from app.tasks._chain import (
+                drain_pending_dispatches,
+                reset_pending_dispatches,
+            )
+
+            reset_pending_dispatches()
             try:
                 handler = get_handler(job_type)
                 # mypy: handlers return ``Awaitable[dict]`` (registry-typed),
@@ -269,8 +280,22 @@ async def run_job(job_id: int) -> None:
 
             if handler_succeeded:
                 await data_session.commit()
+                # #1236 — drain chain_job's deferred dispatches NOW
+                # that ``data_session`` is committed.  Children opened
+                # fresh sessions for their reads; firing them earlier
+                # races the parent's commit and they'd see stale
+                # data_entries (the ones a re-upload just DELETEd) →
+                # FK violation on data_entry_emissions when the
+                # parent's commit lands mid-recalc.
+                drain_pending_dispatches()
             else:
                 await data_session.rollback()
+                # Parent's writes rolled back → don't fire children
+                # against a view of the world that no longer reflects
+                # the parent's intent.
+                from app.tasks._chain import discard_pending_dispatches
+
+                discard_pending_dispatches()
             # Plan 310 review finding B-C1: the FINISHED write must be a
             # compare-and-set on ``(locked_by=POD_ID AND state=RUNNING)``,
             # not a blind UPDATE.  The pre-handler preempt-check at line
@@ -310,9 +335,7 @@ async def run_job(job_id: int) -> None:
             # does, give the status write its own session.
             if pipeline_id_for_status is not None:
                 try:
-                    await repo.recompute_pipeline_status(
-                        pipeline_id_for_status
-                    )
+                    await repo.recompute_pipeline_status(pipeline_id_for_status)
                     await job_session.commit()
                 except Exception:
                     logger.exception(

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -300,6 +300,14 @@ async def run_job(job_id: int) -> None:
             # terminal self-heals. Recompute-and-store + the
             # last-child oracle (compute_pipeline_progress.done) live
             # in ``recompute_pipeline_status``.
+            #
+            # NOTE for future handler authors: this write reuses
+            # ``job_session`` — the SAME connection the handler ran on.
+            # It is in a clean post-commit state here, but a handler
+            # that leaves connection-level artifacts (advisory locks,
+            # server-side temp state) would silently leak them into
+            # this write. No current handler does; if you add one that
+            # does, give the status write its own session.
             if pipeline_id_for_status is not None:
                 try:
                     await repo.recompute_pipeline_status(

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -130,6 +130,12 @@ async def run_job(job_id: int) -> None:
             logger.warning(f"run_job: job {job_id} disappeared after claim — exiting")
             return
 
+        # #1236 — capture pipeline_id as a plain value now (immutable
+        # for the job's life). Read post-``finish_job`` from a fresh /
+        # post-commit ``job_session`` would risk an expired-instance
+        # lazy load; a local value sidesteps that entirely.
+        pipeline_id_for_status = job.pipeline_id
+
         # Plain ``asyncio.create_task`` (not ``fire_and_forget``): the
         # local ``heartbeat_task`` ref keeps the task alive for the
         # lifetime of this function, and we cancel + await it in the
@@ -283,6 +289,32 @@ async def run_job(job_id: int) -> None:
             if not wrote:
                 logger.warning("preempted before FINISHED write: job_id=%s", job_id)
                 return
+
+            # #1236 — advance the pipeline aggregate's authoritative
+            # status. ``finish_job`` already COMMITTED job_session, so
+            # this is a separate post-commit transaction: a failure
+            # here CANNOT poison the durable job terminal (stronger
+            # than the SAVEPOINT ideal — there is no enclosing txn
+            # left to corrupt). Fully isolated: log-and-skip on any DB
+            # error; the reconciliation sweep or the next sibling
+            # terminal self-heals. Recompute-and-store + the
+            # last-child oracle (compute_pipeline_progress.done) live
+            # in ``recompute_pipeline_status``.
+            if pipeline_id_for_status is not None:
+                try:
+                    await repo.recompute_pipeline_status(
+                        pipeline_id_for_status
+                    )
+                    await job_session.commit()
+                except Exception:
+                    logger.exception(
+                        "run_job: pipeline status recompute failed — "
+                        "skipped, sweep will heal (job_id=%s "
+                        "pipeline_id=%s)",
+                        job_id,
+                        pipeline_id_for_status,
+                    )
+                    await job_session.rollback()
         finally:
             heartbeat_task.cancel()
             try:

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -6,7 +6,10 @@ unit_sync, entity_type=GLOBAL_PER_YEAR).  Plan 310-C cutover: the
 ``run_job(id)``; the runner drives claim, heartbeat, and FINISHED state.
 """
 
+from datetime import datetime, timezone
+
 from pydantic import BaseModel
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
@@ -15,6 +18,7 @@ from app.models.data_ingestion import (
     IngestionResult,
 )
 from app.models.user import UserProvider
+from app.models.year_configuration import YearConfiguration
 from app.providers.role_provider import get_role_provider
 from app.providers.unit_provider import get_unit_provider
 from app.repositories.data_ingestion import DataIngestionRepository
@@ -116,6 +120,28 @@ async def unit_sync_handler(
     await job_session.commit()
 
     await carbon_report_service.ensure_modules_for_reports(new_carbon_reports)
+
+    # #1234-followup (Guilbert 2026-05-20): mark the year as provisioned
+    # so /dispatch can gate uploads while a unit_sync is still running
+    # or before it ever ran. data_session is the right session — the
+    # runner commits it on handler success; failure paths raise and
+    # data_session is rolled back so this stamp is atomic with the
+    # carbon-reports/modules creation above.
+    year_cfg_row = (
+        await data_session.execute(
+            select(YearConfiguration).where(col(YearConfiguration.year) == target_year)
+        )
+    ).scalar_one_or_none()
+    if year_cfg_row is not None:
+        year_cfg_row.configuration_completed = datetime.now(timezone.utc)
+        data_session.add(year_cfg_row)
+    else:
+        logger.warning(
+            "unit_sync: no YearConfiguration row for year=%s — "
+            "configuration_completed stamp skipped (year-config row "
+            "should exist; was the year created via /year-configurations?)",
+            target_year,
+        )
 
     return {
         "status_message": "Unit sync completed",

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -64,10 +64,32 @@ async def unit_sync_handler(
 
     job_repo = DataIngestionRepository(job_session)
 
+    # #2B — phase checklist. ``phases`` is the canonical timeline the
+    # console renders for unit_sync: each entry tracks start/finish
+    # timestamps + state. ``_start_phase`` closes the previous one and
+    # opens the next; ``_finish_last_phase`` closes the trailing one
+    # before the handler returns (the runner's ``finish_job`` merges
+    # this into ``meta.phases`` alongside ``status_history`` from
+    # ``update_ingestion_job``).
+    phases: list[dict] = []
+
+    def _start_phase(name: str) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        if phases and phases[-1].get("state") == "running":
+            phases[-1]["state"] = "finished"
+            phases[-1]["finished_at"] = now
+        phases.append({"name": name, "state": "running", "started_at": now})
+
+    def _finish_last_phase() -> None:
+        if phases and phases[-1].get("state") == "running":
+            phases[-1]["state"] = "finished"
+            phases[-1]["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+    _start_phase("fetch_units")
     await job_repo.update_ingestion_job(
         job_id=job.id,
         status_message="Fetching units from Accred…",
-        metadata={},
+        metadata={"phases": phases},
     )
     await job_session.commit()
 
@@ -78,12 +100,13 @@ async def unit_sync_handler(
     units = [unit_provider.map_api_unit(u) for u in units_raw]
     principal_users = [role_provider.map_api_user(u) for u in principal_users_raw]
 
+    _start_phase("upsert_units_and_users")
     await job_repo.update_ingestion_job(
         job_id=job.id,
         status_message=(
             f"Upserting {len(units)} units and {len(principal_users)} principal users…"
         ),
-        metadata={},
+        metadata={"phases": phases},
     )
     await job_session.commit()
 
@@ -95,10 +118,11 @@ async def unit_sync_handler(
     user_upsert_result = await user_service.bulk_upsert(principal_users)
     principal_users = user_upsert_result.data
 
+    _start_phase("create_carbon_reports")
     await job_repo.update_ingestion_job(
         job_id=job.id,
         status_message=f"Creating carbon reports for year {target_year}…",
-        metadata={},
+        metadata={"phases": phases},
     )
     await job_session.commit()
 
@@ -110,16 +134,18 @@ async def unit_sync_handler(
     ]
     new_carbon_reports = await carbon_report_service.bulk_upsert(report_create_data)
 
+    _start_phase("ensure_modules")
     await job_repo.update_ingestion_job(
         job_id=job.id,
         status_message=(
             f"Ensuring modules for {len(new_carbon_reports)} carbon reports…"
         ),
-        metadata={},
+        metadata={"phases": phases},
     )
     await job_session.commit()
 
     await carbon_report_service.ensure_modules_for_reports(new_carbon_reports)
+    _finish_last_phase()
 
     # #1234-followup (Guilbert 2026-05-20): mark the year as provisioned
     # so /dispatch can gate uploads while a unit_sync is still running
@@ -146,6 +172,7 @@ async def unit_sync_handler(
     return {
         "status_message": "Unit sync completed",
         "result": IngestionResult.SUCCESS,
+        "phases": phases,
         "units_synced": len(units),
         "users_synced": len(principal_users),
         "unit_results": str(unit_upsert_result),

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -45,6 +45,19 @@ logger = get_logger(__name__)
 # aggregation_tasks.
 _AGGREGATION_LOCK_CATEGORY = 1236
 
+# Distinct category for the GLOBAL unit_sync mutual-exclusion lock
+# (#1236) — taken via the 1-int variant ``pg_advisory_xact_lock(cat)``
+# so two ``unit_sync`` jobs for DIFFERENT years still block each
+# other.  The per-year ``_AGGREGATION_LOCK_CATEGORY`` lock partitions
+# by year, so two unit_syncs for distinct years would NOT serialise
+# there — but they BOTH write the global ``units`` table (a 2231-row
+# Accred dump, same set for every year).  Without a global lock,
+# parallel ``unit_sync`` jobs race on ``ix_units_institutional_code``.
+# The ON CONFLICT path in ``UnitRepository.bulk_upsert`` is the
+# data-layer safety net; this lock is the belt that prevents the
+# race from ever reaching it.
+_UNIT_SYNC_GLOBAL_LOCK_CATEGORY = 1239
+
 
 class SyncUnitRequest(BaseModel):
     target_year: int
@@ -77,24 +90,46 @@ async def unit_sync_handler(
             f"unit_sync job {job.id} missing config.target_year (and job.year)"
         )
 
-    # #1236 — per-year advisory lock against the aggregation handler.
-    # Held on ``data_session`` (the domain-data session that writes
-    # ``carbon_reports``); the runner commits/rolls back after this
-    # handler returns, releasing the lock.  Dialect-gated so the SQLite
-    # test fixture (single-writer model already serialises) is a no-op;
-    # production Postgres serialises unit_sync's carbon_reports writes
-    # against any concurrent aggregation for the same year.
+    # #1236 — TWO advisory locks for unit_sync, both transaction-scoped
+    # on ``data_session`` (the runner commits/rolls back after this
+    # handler returns, releasing both):
+    #
+    # 1.  GLOBAL unit_sync lock (1-int variant) — prevents parallel
+    #     unit_sync jobs for DIFFERENT years from racing on the global
+    #     ``units`` table (every unit_sync re-fetches the full 2231-row
+    #     Accred dump; concurrent bulk_upserts hit
+    #     ``ix_units_institutional_code`` if both observe the same
+    #     missing code).  Belt against the data-layer ON CONFLICT braces.
+    #
+    # 2.  Per-year unit_sync ↔ aggregation lock (2-int variant) —
+    #     prevents an in-flight aggregation for THIS year from
+    #     overlapping our ``carbon_reports`` rewrite.
+    #
+    # Order: global first, then per-year.  A unit_sync that's waiting
+    # on the global lock isn't holding the per-year lock, so an
+    # aggregation for that year can still proceed unblocked.
+    #
+    # Dialect-gated so the SQLite test fixture (single-writer model
+    # already serialises) is a no-op.
     try:
         dialect_name = data_session.get_bind().dialect.name
     except Exception:
         dialect_name = ""
     if dialect_name == "postgresql":
         await data_session.execute(
+            text("SELECT pg_advisory_xact_lock(:cat)"),
+            {"cat": _UNIT_SYNC_GLOBAL_LOCK_CATEGORY},
+        )
+        logger.debug(
+            f"unit_sync handler (job {job.id}): acquired global "
+            f"pg_advisory_xact_lock({_UNIT_SYNC_GLOBAL_LOCK_CATEGORY})"
+        )
+        await data_session.execute(
             text("SELECT pg_advisory_xact_lock(:cat, :year)"),
             {"cat": _AGGREGATION_LOCK_CATEGORY, "year": int(target_year)},
         )
         logger.debug(
-            f"unit_sync handler (job {job.id}): acquired "
+            f"unit_sync handler (job {job.id}): acquired per-year "
             f"pg_advisory_xact_lock({_AGGREGATION_LOCK_CATEGORY}, "
             f"{target_year}) — shared with aggregation_handler"
         )

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -9,6 +9,7 @@ unit_sync, entity_type=GLOBAL_PER_YEAR).  Plan 310-C cutover: the
 from datetime import datetime, timezone
 
 from pydantic import BaseModel
+from sqlalchemy import text
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -29,6 +30,20 @@ from app.services.user_service import UserService
 from app.tasks.registry import register
 
 logger = get_logger(__name__)
+
+
+# #1236 — share the aggregation handler's per-year advisory-lock
+# category (1236) so unit_sync and aggregation serialise against each
+# other on the same year key.  unit_sync rewrites ``carbon_reports`` /
+# ``carbon_report_modules`` for every unit-year; aggregation rewrites
+# ``carbon_reports.stats`` as a rollup of the same rows.  Concurrent
+# writers race on the same key set — unit_sync inserting a new
+# unit-year row while aggregation is mid-rollup means the rollup misses
+# the new row (or worse, the rollup reads a half-inserted state).
+# Sharing the category guarantees they mutually exclude.  Imported by
+# value here to avoid a service-to-service edge between unit_sync and
+# aggregation_tasks.
+_AGGREGATION_LOCK_CATEGORY = 1236
 
 
 class SyncUnitRequest(BaseModel):
@@ -60,6 +75,28 @@ async def unit_sync_handler(
     if target_year is None:
         raise ValueError(
             f"unit_sync job {job.id} missing config.target_year (and job.year)"
+        )
+
+    # #1236 — per-year advisory lock against the aggregation handler.
+    # Held on ``data_session`` (the domain-data session that writes
+    # ``carbon_reports``); the runner commits/rolls back after this
+    # handler returns, releasing the lock.  Dialect-gated so the SQLite
+    # test fixture (single-writer model already serialises) is a no-op;
+    # production Postgres serialises unit_sync's carbon_reports writes
+    # against any concurrent aggregation for the same year.
+    try:
+        dialect_name = data_session.get_bind().dialect.name
+    except Exception:
+        dialect_name = ""
+    if dialect_name == "postgresql":
+        await data_session.execute(
+            text("SELECT pg_advisory_xact_lock(:cat, :year)"),
+            {"cat": _AGGREGATION_LOCK_CATEGORY, "year": int(target_year)},
+        )
+        logger.debug(
+            f"unit_sync handler (job {job.id}): acquired "
+            f"pg_advisory_xact_lock({_AGGREGATION_LOCK_CATEGORY}, "
+            f"{target_year}) — shared with aggregation_handler"
         )
 
     job_repo = DataIngestionRepository(job_session)

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -4,6 +4,7 @@ Re-runs emission calculations for all DataEntries of a given
 (data_entry_type_id, year) combination using the latest factors.
 """
 
+from sqlalchemy.exc import DBAPIError, InvalidRequestError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
@@ -158,36 +159,71 @@ class EmissionRecalculationWorkflow:
             entry_kind_field: str | None = handler.kind_field
             old_data = entry.data
             try:
-                if entry_kind_field is not None and entry_kind_field in entry.data:
-                    new_factor_id = self._lookup_factor_id(
-                        entry_data=entry.data,
-                        kind_field=entry_kind_field,
-                        subkind_field=handler.subkind_field,
-                        factor_lookup=factor_lookup,
-                    )
-                    if new_factor_id != entry.data.get("primary_factor_id"):
-                        # Tentative swap so DataEntryResponse + upsert
-                        # see the refreshed factor (or ``None`` on a
-                        # drop).  Rolled back below if the upsert fails,
-                        # so partial-failure runs don't leave entry.data
-                        # pointing at the new factor while
-                        # data_entry_emissions is still computed against
-                        # the old one.
-                        entry.data = {
-                            **entry.data,
-                            "primary_factor_id": new_factor_id,
-                        }
+                # Per-entry SAVEPOINT: a failed upsert must roll back
+                # ONLY this entry's writes — not poison the shared
+                # session for every remaining entry.  Without this, one
+                # bad row left ``self.session`` in an aborted state and
+                # every subsequent iteration re-raised the same
+                # "transaction is aborted / can't reconnect" error,
+                # spamming the log and failing the whole job (the
+                # comment below used to claim a rollback that never
+                # actually happened).
+                async with self.session.begin_nested():
+                    if entry_kind_field is not None and entry_kind_field in entry.data:
+                        new_factor_id = self._lookup_factor_id(
+                            entry_data=entry.data,
+                            kind_field=entry_kind_field,
+                            subkind_field=handler.subkind_field,
+                            factor_lookup=factor_lookup,
+                        )
+                        if new_factor_id != entry.data.get("primary_factor_id"):
+                            # Tentative swap so DataEntryResponse + upsert
+                            # see the refreshed factor (or ``None`` on a
+                            # drop).  The SAVEPOINT rolls this back on the
+                            # DB side if the upsert fails; the ``except``
+                            # also reverts ``entry.data`` in memory.
+                            entry.data = {
+                                **entry.data,
+                                "primary_factor_id": new_factor_id,
+                            }
 
-                entry_response = DataEntryResponse.model_validate(entry)
-                await emission_svc.upsert_by_data_entry(entry_response)
+                    entry_response = DataEntryResponse.model_validate(entry)
+                    await emission_svc.upsert_by_data_entry(entry_response)
                 recalculated += 1
                 if entry.carbon_report_module_id is not None:
                     affected_module_ids.add(entry.carbon_report_module_id)
             except Exception as exc:
-                # Roll back the in-memory mutation so the outer
-                # data_session.commit() does not persist a stale link
-                # alongside an old emissions row.
+                # Revert the in-memory factor swap (the SAVEPOINT already
+                # rolled back the DB side) so the outer commit doesn't
+                # persist a stale link next to an old emissions row.
                 entry.data = old_data
+                # Session/connection-fatal errors can't be contained by
+                # a SAVEPOINT — the session is unusable for every
+                # remaining entry.  Two shapes seen on stage:
+                #   * ``DBAPIError`` with ``connection_invalidated`` —
+                #     the raw connection dropped (server restart / LB
+                #     reset).
+                #   * ``InvalidRequestError`` (incl.
+                #     ``PendingRollbackError`` and "Can't reconnect
+                #     until invalid transaction is rolled back") — the
+                #     session needs a full rollback before any
+                #     statement, so even ``begin_nested()``'s SAVEPOINT
+                #     enter fails on the next entry.
+                # Continuing logs one identical fatal error per
+                # remaining entry (masking the first cause) and the job
+                # fails anyway.  Stop now and re-raise so the runner
+                # records FINISHED+ERROR with the real error.
+                connection_dead = (
+                    isinstance(exc, DBAPIError) and exc.connection_invalidated
+                )
+                if connection_dead or isinstance(exc, InvalidRequestError):
+                    logger.error(
+                        f"emission recalc: session/connection unusable at "
+                        f"data_entry_id={entry.id} ({type(exc).__name__}); "
+                        f"aborting batch ({recalculated} recalculated, "
+                        f"{errors} errored, {len(entries)} total)"
+                    )
+                    raise
                 errors += 1
                 error_details.append(
                     {

--- a/backend/tests/integration/data_ingestion/test_csv_upload_e2e.py
+++ b/backend/tests/integration/data_ingestion/test_csv_upload_e2e.py
@@ -131,9 +131,26 @@ class TestCSVUploadBasic:
         self,
         test_user: User,
         get_test_client,
+        db_session,
     ):
         """Test that the CSV ingestion endpoint exists and validates files."""
         client = get_test_client()
+
+        # #1234-followup: dispatch now gates on year_configuration
+        # .configuration_completed; seed a ready year so the endpoint
+        # passes the precondition.
+        from datetime import datetime, timezone
+
+        from app.models.year_configuration import YearConfiguration
+
+        db_session.add(
+            YearConfiguration(
+                year=2025,
+                is_started=True,
+                configuration_completed=datetime.now(timezone.utc),
+            )
+        )
+        await db_session.flush()
 
         # Upload a real CSV file first
         csv_path = FIXTURES_DIR / "valid_module_per_year.csv"

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -19,6 +19,8 @@ from app.models.data_ingestion import (
     IngestionMethod,
     IngestionResult,
     IngestionState,
+    Pipeline,
+    PipelineStatus,
     TargetType,
 )
 from app.models.user import UserProvider
@@ -1134,3 +1136,152 @@ async def test_list_pipelines_orphans_are_pipelines_of_one(
     assert orphans[0]["pipeline_id"] is None
     assert len(orphans[0]["jobs"]) == 1
     assert orphans[0]["jobs"][0].status_message == "InFailedSqlTransaction"
+
+
+# ======================================================================
+# Pipeline aggregate (#1236 Phase 1): ensure / recompute / reconcile
+# ======================================================================
+
+
+async def _count_pipelines(db_session: AsyncSession, pid) -> int:
+    rows = await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    return len(rows.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_ensure_pipeline_exists_is_idempotent(db_session: AsyncSession):
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+
+    await repo.ensure_pipeline_exists(
+        pid, kind="csv_ingest", entity_type=1, ingestion_method=1,
+        module_type_id=4, year=2026,
+    )
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")  # second call
+    await db_session.flush()
+
+    assert await _count_pipelines(db_session, pid) == 1
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.status == PipelineStatus.NOT_STARTED.value
+    assert row.kind == "csv_ingest"
+    assert row.module_type_id == 4
+
+
+@pytest.mark.asyncio
+async def test_recompute_status_success_on_done(db_session: AsyncSession):
+    """Parent FINISHED+SUCCESS, no expected recalc → progress.done →
+    status SUCCESS, counts set (recompute-and-store, last-child)."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            meta={"recalc_jobs_chained": 0},
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+    await db_session.flush()
+
+    assert written == PipelineStatus.SUCCESS.value
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.status == PipelineStatus.SUCCESS.value
+    assert row.job_count == 1
+    assert row.error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_recompute_status_failed_on_error(db_session: AsyncSession):
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="InFailedSqlTransaction",
+            meta={"recalc_jobs_chained": 0},
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+    await db_session.flush()
+
+    assert written == PipelineStatus.FAILED.value
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.status == PipelineStatus.FAILED.value
+    assert row.error_count == 1
+    assert row.last_error == "InFailedSqlTransaction"
+
+
+@pytest.mark.asyncio
+async def test_recompute_status_skips_when_not_done(db_session: AsyncSession):
+    """Last-child oracle: a non-terminal call must NOT write
+    (compute_pipeline_progress.done is False) — status stays default."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.RUNNING,  # parent not finished → not done
+            result=None,
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+
+    assert written is None  # skipped
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.status == PipelineStatus.NOT_STARTED.value
+
+
+@pytest.mark.asyncio
+async def test_reconcile_heals_drift(db_session: AsyncSession):
+    """A done pipeline whose stored status was never advanced (runner
+    skipped) is corrected by the sweep; afterwards zero drift."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            meta={"recalc_jobs_chained": 0},
+        )
+    )
+    await db_session.flush()
+    # Simulated drift: row still NOT_STARTED though the pipeline is done.
+    pre = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert pre.status == PipelineStatus.NOT_STARTED.value
+
+    summary = await repo.reconcile_pipeline_statuses()
+
+    assert summary["checked"] >= 1
+    assert summary["corrected"] >= 1
+    healed = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert healed.status == PipelineStatus.SUCCESS.value

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1358,6 +1358,59 @@ async def test_reconcile_heals_drift(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_recompute_writes_expected_recalc_unconditionally(
+    db_session: AsyncSession,
+):
+    """#1236 Phase 5A — ``pipelines.expected_recalc`` mirrors the live
+    ``emission_recalc`` count for the pipeline, written on every
+    recompute call (NOT gated on ``progress.done``).  Lets the read
+    path (Phase 5B) source the counter from the column instead of
+    ``meta.recalc_jobs_chained`` on the parent job.
+
+    Dedup-skipped recalcs (which live under a different ``pipeline_id``)
+    are excluded by construction — the SELECT filters on this pipeline.
+    """
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    # Parent + 3 recalc children (one finished, one running, one queued)
+    # — the count tracks the structural fan-out, not their state.
+    db_session.add(_pipeline_job(pipeline_id=pid, job_type="csv_ingest"))
+    db_session.add(_pipeline_job(pipeline_id=pid, job_type="emission_recalc"))
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="emission_recalc",
+            state=IngestionState.RUNNING,
+            result=None,
+        )
+    )
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="emission_recalc",
+            state=IngestionState.NOT_STARTED,
+            result=None,
+        )
+    )
+    await db_session.flush()
+
+    # Non-terminal call — recompute_pipeline_status returns None (skip
+    # the status write) but MUST still have written expected_recalc.
+    written = await repo.recompute_pipeline_status(pid)
+    await db_session.flush()
+    assert written is None  # not done — status not written
+
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.expected_recalc == 3, (
+        f"expected_recalc should track live emission_recalc count, "
+        f"got {row.expected_recalc}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_recompute_last_error_skips_success_message(
     db_session: AsyncSession,
 ):

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1154,8 +1154,12 @@ async def test_ensure_pipeline_exists_is_idempotent(db_session: AsyncSession):
     pid = uuid4()
 
     await repo.ensure_pipeline_exists(
-        pid, kind="csv_ingest", entity_type=1, ingestion_method=1,
-        module_type_id=4, year=2026,
+        pid,
+        kind="csv_ingest",
+        entity_type=1,
+        ingestion_method=1,
+        module_type_id=4,
+        year=2026,
     )
     await repo.ensure_pipeline_exists(pid, kind="csv_ingest")  # second call
     await db_session.flush()
@@ -1328,3 +1332,82 @@ async def test_recompute_last_error_skips_success_message(
     ).scalar_one()
     assert row.last_error == "DeadlockDetected: data_entry_emissions"
     assert row.last_error != "Success"
+
+
+# ======================================================================
+# #1236 #2A — status_history timeline (generic, all jobs)
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_job_appends_status_history(
+    db_session: AsyncSession,
+):
+    """Each update_ingestion_job call appends {message, ts} to
+    meta.status_history. The latest status_message column reflects the
+    final value (overwrite); the history preserves every step."""
+    repo = DataIngestionRepository(db_session)
+    job = _make_job(
+        module_type_id=1,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.NOT_STARTED,
+        result=None,
+        is_current=False,
+    )
+    db_session.add(job)
+    await db_session.flush()
+    assert job.id is not None
+
+    await repo.update_ingestion_job(
+        job_id=job.id, status_message="Fetching", metadata={}
+    )
+    await repo.update_ingestion_job(
+        job_id=job.id, status_message="Upserting", metadata={}
+    )
+    await repo.update_ingestion_job(job_id=job.id, status_message="Done", metadata={})
+
+    refreshed = await repo.get_job_by_id(job.id)
+    assert refreshed is not None
+    assert refreshed.status_message == "Done"
+    history = (refreshed.meta or {}).get("status_history") or []
+    assert [h["message"] for h in history] == ["Fetching", "Upserting", "Done"]
+    # Every entry carries a timestamp (ISO-8601 string).
+    for h in history:
+        assert isinstance(h.get("ts"), str) and "T" in h["ts"]
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_job_status_history_capped(
+    db_session: AsyncSession,
+):
+    """status_history is bounded to the last 50 entries — a flood of
+    progress updates on a long retry chain doesn't grow meta unbounded."""
+    repo = DataIngestionRepository(db_session)
+    job = _make_job(
+        module_type_id=1,
+        data_entry_type_id=20,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.NOT_STARTED,
+        result=None,
+        is_current=False,
+    )
+    db_session.add(job)
+    await db_session.flush()
+
+    for i in range(60):
+        await repo.update_ingestion_job(
+            job_id=job.id, status_message=f"step {i}", metadata={}
+        )
+
+    refreshed = await repo.get_job_by_id(job.id)
+    assert refreshed is not None
+    history = (refreshed.meta or {}).get("status_history") or []
+    assert len(history) == 50
+    # Head was trimmed — first kept entry is "step 10".
+    assert history[0]["message"] == "step 10"
+    assert history[-1]["message"] == "step 59"

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -980,3 +980,157 @@ async def test_get_current_pipeline_ids_for_modules_filters_by_year(
     repo = DataIngestionRepository(db_session)
     result = await repo.get_current_pipeline_ids_for_modules([5], year=2025)
     assert result == {}
+
+
+# ======================================================================
+# list_pipelines_paginated Tests (#1234 — pipeline ops console)
+# ======================================================================
+
+
+def _pipeline_job(
+    *,
+    pipeline_id,
+    job_type: str,
+    state: IngestionState = IngestionState.FINISHED,
+    result: IngestionResult | None = IngestionResult.SUCCESS,
+    module_type_id: int = 4,
+    year: int = 2026,
+    started_at=None,
+    status_message: str | None = None,
+    meta: dict | None = None,
+) -> DataIngestionJob:
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=module_type_id,
+        data_entry_type_id=None,
+        year=year,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=state,
+        result=result,
+        is_current=False,
+        pipeline_id=pipeline_id,
+        job_type=job_type,
+        started_at=started_at,
+        status_message=status_message,
+        meta=meta or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_groups_by_pipeline_id(db_session: AsyncSession):
+    """Two pipelines → two groups, jobs id-ascending within each."""
+    repo = DataIngestionRepository(db_session)
+    p1, p2 = uuid4(), uuid4()
+    for j in (
+        _pipeline_job(pipeline_id=p1, job_type="csv_ingest"),
+        _pipeline_job(pipeline_id=p1, job_type="emission_recalc"),
+        _pipeline_job(pipeline_id=p2, job_type="csv_ingest"),
+    ):
+        db_session.add(j)
+    await db_session.flush()
+
+    groups, total = await repo.list_pipelines_paginated()
+
+    assert total == 2
+    assert {g["pipeline_id"] for g in groups} == {p1, p2}
+    for g in groups:
+        ids = [j.id for j in g["jobs"]]
+        assert ids == sorted(ids)
+        assert g["is_orphan"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_paginates_by_pipeline_not_job(
+    db_session: AsyncSession,
+):
+    """limit=2 over 3 pipelines → 2 groups, total=3, children not split."""
+    repo = DataIngestionRepository(db_session)
+    pids = [uuid4() for _ in range(3)]
+    for pid in pids:
+        db_session.add(_pipeline_job(pipeline_id=pid, job_type="csv_ingest"))
+        db_session.add(_pipeline_job(pipeline_id=pid, job_type="emission_recalc"))
+    await db_session.flush()
+
+    page1, total = await repo.list_pipelines_paginated(limit=2, offset=0)
+    page2, _ = await repo.list_pipelines_paginated(limit=2, offset=2)
+
+    assert total == 3
+    assert len(page1) == 2
+    assert len(page2) == 1
+    # Every returned group keeps BOTH its jobs (no split across pages).
+    for g in page1 + page2:
+        assert len(g["jobs"]) == 2
+    # Newest-first by latest job id: page1[0] is the last-inserted pipeline.
+    assert page1[0]["pipeline_id"] == pids[2]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_filters(db_session: AsyncSession):
+    """job_type / module / year / state filters select matching pipelines."""
+    repo = DataIngestionRepository(db_session)
+    keep, drop = uuid4(), uuid4()
+    db_session.add(_pipeline_job(pipeline_id=keep, job_type="csv_ingest", year=2026))
+    db_session.add(_pipeline_job(pipeline_id=drop, job_type="factor_ingest", year=2025))
+    await db_session.flush()
+
+    by_year, _ = await repo.list_pipelines_paginated(year=2026)
+    by_type, _ = await repo.list_pipelines_paginated(job_type="factor_ingest")
+
+    assert [g["pipeline_id"] for g in by_year] == [keep]
+    assert [g["pipeline_id"] for g in by_type] == [drop]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_has_errors_filter(db_session: AsyncSession):
+    """has_errors keeps only pipelines with a FINISHED+ERROR job."""
+    repo = DataIngestionRepository(db_session)
+    ok, bad = uuid4(), uuid4()
+    db_session.add(_pipeline_job(pipeline_id=ok, job_type="csv_ingest"))
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=bad,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+        )
+    )
+    await db_session.flush()
+
+    errored, _ = await repo.list_pipelines_paginated(has_errors=True)
+    clean, _ = await repo.list_pipelines_paginated(has_errors=False)
+
+    assert [g["pipeline_id"] for g in errored] == [bad]
+    assert [g["pipeline_id"] for g in clean] == [ok]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_orphans_are_pipelines_of_one(
+    db_session: AsyncSession,
+):
+    """A pipeline_id IS NULL parent surfaces as is_orphan with one job."""
+    repo = DataIngestionRepository(db_session)
+    db_session.add(
+        uuid4_pid := _pipeline_job(pipeline_id=uuid4(), job_type="csv_ingest")
+    )  # noqa: E501
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=None,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="InFailedSqlTransaction",
+        )
+    )
+    await db_session.flush()
+    assert uuid4_pid.id is not None
+
+    groups, total = await repo.list_pipelines_paginated()
+
+    assert total == 2
+    orphans = [g for g in groups if g["is_orphan"]]
+    assert len(orphans) == 1
+    assert orphans[0]["pipeline_id"] is None
+    assert len(orphans[0]["jobs"]) == 1
+    assert orphans[0]["jobs"][0].status_message == "InFailedSqlTransaction"

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1086,17 +1086,20 @@ async def test_list_pipelines_filters(db_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_list_pipelines_has_errors_filter(db_session: AsyncSession):
-    """has_errors keeps only pipelines with a FINISHED+ERROR job."""
+    """has_errors keeps only pipelines with status IN (PARTIAL, FAILED).
+
+    Phase 3 read-flip (#1236): error-ness is read from ``pipelines.status``
+    (the durable authoritative source), not inferred per-job.
+    """
     repo = DataIngestionRepository(db_session)
     ok, bad = uuid4(), uuid4()
     db_session.add(_pipeline_job(pipeline_id=ok, job_type="csv_ingest"))
+    db_session.add(_pipeline_job(pipeline_id=bad, job_type="csv_ingest"))
     db_session.add(
-        _pipeline_job(
-            pipeline_id=bad,
-            job_type="csv_ingest",
-            state=IngestionState.FINISHED,
-            result=IngestionResult.ERROR,
-        )
+        Pipeline(id=ok, kind="csv_ingest", status=PipelineStatus.SUCCESS.value)
+    )
+    db_session.add(
+        Pipeline(id=bad, kind="csv_ingest", status=PipelineStatus.FAILED.value)
     )
     await db_session.flush()
 
@@ -1105,6 +1108,69 @@ async def test_list_pipelines_has_errors_filter(db_session: AsyncSession):
 
     assert [g["pipeline_id"] for g in errored] == [bad]
     assert [g["pipeline_id"] for g in clean] == [ok]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_status_filter(db_session: AsyncSession):
+    """pipeline_status filters on ``pipelines.status`` directly (#1236 Phase 3).
+
+    The URL ``?state=RUNNING`` maps to this filter via the endpoint —
+    the test exercises the repo layer's pivot.
+    """
+    repo = DataIngestionRepository(db_session)
+    running, success, failed = uuid4(), uuid4(), uuid4()
+    for pid in (running, success, failed):
+        db_session.add(_pipeline_job(pipeline_id=pid, job_type="csv_ingest"))
+    db_session.add(
+        Pipeline(id=running, kind="csv_ingest", status=PipelineStatus.RUNNING.value)
+    )
+    db_session.add(
+        Pipeline(id=success, kind="csv_ingest", status=PipelineStatus.SUCCESS.value)
+    )
+    db_session.add(
+        Pipeline(id=failed, kind="csv_ingest", status=PipelineStatus.FAILED.value)
+    )
+    await db_session.flush()
+
+    only_running, _ = await repo.list_pipelines_paginated(
+        pipeline_status=PipelineStatus.RUNNING
+    )
+    only_failed, _ = await repo.list_pipelines_paginated(
+        pipeline_status=PipelineStatus.FAILED
+    )
+
+    assert [g["pipeline_id"] for g in only_running] == [running]
+    assert [g["pipeline_id"] for g in only_failed] == [failed]
+
+
+@pytest.mark.asyncio
+async def test_list_pipelines_returns_pipeline_row(db_session: AsyncSession):
+    """Groups carry the ``Pipeline`` row (#1236 Phase 3) so the endpoint
+    can pass it into ``compute_pipeline_progress``.  Orphans have no
+    Pipeline row, so ``pipeline`` is None."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    db_session.add(_pipeline_job(pipeline_id=pid, job_type="csv_ingest"))
+    db_session.add(
+        Pipeline(id=pid, kind="csv_ingest", status=PipelineStatus.SUCCESS.value)
+    )
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=None,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+        )
+    )
+    await db_session.flush()
+
+    groups, _ = await repo.list_pipelines_paginated()
+
+    pl_group = next(g for g in groups if g["pipeline_id"] == pid)
+    orphan_group = next(g for g in groups if g["is_orphan"])
+    assert pl_group["pipeline"] is not None
+    assert pl_group["pipeline"].status == PipelineStatus.SUCCESS.value
+    assert orphan_group["pipeline"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1285,3 +1285,46 @@ async def test_reconcile_heals_drift(db_session: AsyncSession):
         await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
     ).scalar_one()
     assert healed.status == PipelineStatus.SUCCESS.value
+
+
+@pytest.mark.asyncio
+async def test_recompute_last_error_skips_success_message(
+    db_session: AsyncSession,
+):
+    """#1236 / advisor blocker: a csv_ingest that succeeded then
+    poisoned downstream has result=ERROR but status_message='Success'.
+    last_error must carry the informative sibling error, not 'Success'
+    (this logic is reused by Phase-2 backfill across all history)."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="Success",  # the misleading #1219 shape
+            meta={"recalc_jobs_chained": 1},
+        )
+    )
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="emission_recalc",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="DeadlockDetected: data_entry_emissions",
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+    await db_session.flush()
+
+    assert written == PipelineStatus.FAILED.value
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.last_error == "DeadlockDetected: data_entry_emissions"
+    assert row.last_error != "Success"

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1299,6 +1299,121 @@ async def test_recompute_status_failed_on_error(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_recompute_status_partial_when_root_ok_child_errored(
+    db_session: AsyncSession,
+):
+    """PARTIAL tier (#1236) — root ingest succeeded (data landed) but a
+    downstream child errored.  The pipeline is NOT 'FAILED' (that
+    implies data didn't land), it is 'PARTIAL' (data landed, chain had
+    issues).  Amber badge in the console, distinct from red FAILED.
+    """
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    # Root: csv_ingest succeeded (the 50 k rows landed).
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+        )
+    )
+    # Child: a downstream emission_recalc errored.
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="emission_recalc",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="DeadlockDetected: data_entry_emissions",
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+    await db_session.flush()
+
+    assert written == PipelineStatus.PARTIAL.value
+    row = (
+        await db_session.execute(select(Pipeline).where(Pipeline.id == pid))
+    ).scalar_one()
+    assert row.status == PipelineStatus.PARTIAL.value
+    assert row.error_count == 1
+    # last_error still surfaces the informative downstream message.
+    assert row.last_error == "DeadlockDetected: data_entry_emissions"
+
+
+@pytest.mark.asyncio
+async def test_recompute_status_partial_when_root_warning_child_errored(
+    db_session: AsyncSession,
+):
+    """Root with ``result=WARNING`` (data landed with caveats — e.g.
+    99/100 rows succeeded) + downstream ERROR → PARTIAL.  WARNING at
+    root counts as 'data landed' for the FAILED vs PARTIAL boundary —
+    only an ERROR root flips to FAILED."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.WARNING,  # data landed, with caveats
+        )
+    )
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="emission_recalc",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+    assert written == PipelineStatus.PARTIAL.value
+
+
+@pytest.mark.asyncio
+async def test_recompute_status_failed_when_root_errored_regardless_of_descendants(
+    db_session: AsyncSession,
+):
+    """When the root itself errored, the pipeline is FAILED — even if a
+    descendant (created speculatively before root's ERROR was committed)
+    happens to be SUCCESS.  Defensive: ``data didn't land'' is the
+    invariant the FAILED badge promises."""
+    repo = DataIngestionRepository(db_session)
+    pid = uuid4()
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest")
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="csv_ingest",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.ERROR,
+            status_message="ProviderCrash: kaboom",
+        )
+    )
+    # Unlikely but defensible: a stale descendant from a retry that
+    # succeeded before its parent was finally marked ERROR.
+    db_session.add(
+        _pipeline_job(
+            pipeline_id=pid,
+            job_type="emission_recalc",
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+        )
+    )
+    await db_session.flush()
+
+    written = await repo.recompute_pipeline_status(pid)
+    assert written == PipelineStatus.FAILED.value
+
+
+@pytest.mark.asyncio
 async def test_recompute_status_skips_when_not_done(db_session: AsyncSession):
     """Last-child oracle: a non-terminal call must NOT write
     (compute_pipeline_progress.done is False) — status stays default."""

--- a/backend/tests/unit/repositories/test_pipeline_fk_ordering_regression.py
+++ b/backend/tests/unit/repositories/test_pipeline_fk_ordering_regression.py
@@ -1,4 +1,4 @@
-"""Regression: every ``data_ingestion_jobs`` insert that carries a
+"""Regression: every ``data_ingestion_jobs`` write that carries a
 ``pipeline_id`` MUST be preceded by an ``ensure_pipeline_exists`` call
 on the same session (#1236 Phase 2 FK enforcement).
 
@@ -6,7 +6,7 @@ History — bugs this test guards against:
 
 1.  ``app/api/v1/year_configuration.py:create_year_configuration``
     shipped with no ``ensure_pipeline_exists`` call.  On stage the
-    Phase-2 FK rejected the resulting INSERT with
+    Phase-2 FK rejected the INSERT with
     ``ForeignKeyViolation: ... fk_data_ingestion_jobs_pipeline_id``.
 
 2.  Two ``data_sync.py`` sites
@@ -15,10 +15,18 @@ History — bugs this test guards against:
     — but ``create_ingestion_job`` flushes, so the FK fired before the
     parent row was inserted.
 
-Both shapes pre-Phase-2 (when there was no FK) wrote a
+3.  ``data_sync._stamp_job_type_and_meta`` and ``_chain.chain_job``
+    assigned ``row.pipeline_id = X`` *before* calling
+    ``ensure_pipeline_exists``.  The SELECT inside
+    ``ensure_pipeline_exists`` triggers SQLAlchemy's autoflush, which
+    writes an UPDATE that sets ``pipeline_id`` while ``pipelines`` is
+    still empty → FK violation.  This shape is sneakier than (1)/(2):
+    no explicit flush call, the autoflush is implicit.
+
+All three shapes pre-Phase-2 (when there was no FK) wrote a
 ``data_ingestion_jobs`` row with a ``pipeline_id`` that pointed at
 nothing in ``pipelines``, leaving the join unreliable.  The test
-exercises the FK directly so any regression of either shape fails
+exercises the FK directly so any regression of any shape fails
 loudly.
 
 SQLite defaults to FKs *off*; we enable the PRAGMA on the test engine
@@ -150,3 +158,67 @@ async def test_wrong_order_create_then_ensure_raises(
         await repo.create_ingestion_job(_job_with_pipeline(pid))
         # Unreachable — the flush above already raised.
         await repo.ensure_pipeline_exists(pid, kind="unit_sync", year=2026)
+
+
+# ---------------------------------------------------------------------------
+# Bug shape (3) — assigning ``row.pipeline_id`` BEFORE ``ensure_pipeline_exists``
+# lets autoflush write the UPDATE while ``pipelines`` is empty.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dirty_pipeline_id_then_ensure_raises_via_autoflush(
+    fk_db_session: AsyncSession,
+):
+    """Negative control for the ``_stamp_job_type_and_meta`` / chain_job
+    bug.  A pre-existing job has ``pipeline_id = None``.  The bug
+    assigns ``row.pipeline_id = pid`` first, then calls
+    ``ensure_pipeline_exists`` — whose SELECT triggers autoflush,
+    which writes UPDATE … pipeline_id=pid while ``pipelines`` is
+    empty.  FK fires.
+    """
+    from uuid import uuid4
+
+    pid = uuid4()
+    repo = DataIngestionRepository(fk_db_session)
+
+    # Step 1: create a job with NO pipeline_id (allowed; FK is nullable).
+    job = _job_with_pipeline(None)
+    created = await repo.create_ingestion_job(job)
+    assert created.id is not None
+
+    # Step 2: the BUGGY ordering — mark the row dirty FIRST.
+    created.pipeline_id = pid
+    fk_db_session.add(created)
+
+    # Step 3: ``ensure_pipeline_exists`` SELECT triggers autoflush →
+    # UPDATE fires before the Pipeline row INSERT → FK rejects.
+    with pytest.raises(IntegrityError):
+        await repo.ensure_pipeline_exists(pid, kind="csv_ingest", year=2026)
+
+
+@pytest.mark.asyncio
+async def test_ensure_then_dirty_pipeline_id_succeeds(
+    fk_db_session: AsyncSession,
+):
+    """The supported ordering for the stamp/chain pattern: create the
+    Pipeline row FIRST, then assign ``row.pipeline_id``.  The caller's
+    eventual commit (or next autoflush) writes the UPDATE with the
+    parent row already present → FK ok.
+    """
+    from uuid import uuid4
+
+    pid = uuid4()
+    repo = DataIngestionRepository(fk_db_session)
+
+    job = _job_with_pipeline(None)
+    created = await repo.create_ingestion_job(job)
+    assert created.id is not None
+
+    # Correct order: pipelines row FIRST.
+    await repo.ensure_pipeline_exists(pid, kind="csv_ingest", year=2026)
+    created.pipeline_id = pid
+    fk_db_session.add(created)
+    await fk_db_session.flush()
+
+    assert created.pipeline_id == pid

--- a/backend/tests/unit/repositories/test_pipeline_fk_ordering_regression.py
+++ b/backend/tests/unit/repositories/test_pipeline_fk_ordering_regression.py
@@ -1,0 +1,152 @@
+"""Regression: every ``data_ingestion_jobs`` insert that carries a
+``pipeline_id`` MUST be preceded by an ``ensure_pipeline_exists`` call
+on the same session (#1236 Phase 2 FK enforcement).
+
+History — bugs this test guards against:
+
+1.  ``app/api/v1/year_configuration.py:create_year_configuration``
+    shipped with no ``ensure_pipeline_exists`` call.  On stage the
+    Phase-2 FK rejected the resulting INSERT with
+    ``ForeignKeyViolation: ... fk_data_ingestion_jobs_pipeline_id``.
+
+2.  Two ``data_sync.py`` sites
+    (``recalculate-emissions``, ``recalculate-module-emissions``)
+    called ``ensure_pipeline_exists`` *after* ``create_ingestion_job``
+    — but ``create_ingestion_job`` flushes, so the FK fired before the
+    parent row was inserted.
+
+Both shapes pre-Phase-2 (when there was no FK) wrote a
+``data_ingestion_jobs`` row with a ``pipeline_id`` that pointed at
+nothing in ``pipelines``, leaving the join unreliable.  The test
+exercises the FK directly so any regression of either shape fails
+loudly.
+
+SQLite defaults to FKs *off*; we enable the PRAGMA on the test engine
+so the constraint actually triggers — without it this test would
+pass even with the bug back in place.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+from app.repositories.data_ingestion import DataIngestionRepository
+
+
+@pytest_asyncio.fixture
+async def fk_db_session():
+    """SQLite engine with FK enforcement turned on for THIS test.
+
+    The default fixture (``conftest.db_session``) doesn't enable
+    ``PRAGMA foreign_keys=ON`` so the Phase-2 FK is inert there — fine
+    for the existing scope/grouping tests, but useless for catching
+    FK-ordering regressions.  This per-test engine enables it via the
+    documented sqlalchemy listener pattern.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_on(dbapi_conn, _):  # noqa: ANN001
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+
+
+def _job_with_pipeline(pipeline_id):
+    """Same shape the four mint sites build (sanitised for the test)."""
+    return DataIngestionJob(
+        job_type="unit_sync",
+        module_type_id=None,
+        data_entry_type_id=None,
+        year=2026,
+        ingestion_method=IngestionMethod.api,
+        target_type=TargetType.REFERENCE_DATA,
+        entity_type=EntityType.GLOBAL_PER_YEAR,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.NOT_STARTED,
+        pipeline_id=pipeline_id,
+        meta={"config": {"target_year": 2026}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_ingestion_job_without_ensure_pipeline_raises(
+    fk_db_session: AsyncSession,
+):
+    """Negative control: skipping ``ensure_pipeline_exists`` triggers
+    the FK.  Without this, the positive test below could pass for the
+    wrong reason (e.g. FK enforcement not actually on).
+    """
+    from uuid import uuid4
+
+    pid = uuid4()
+    repo = DataIngestionRepository(fk_db_session)
+
+    with pytest.raises(IntegrityError):
+        # No ensure_pipeline_exists — FK should reject the flush.
+        await repo.create_ingestion_job(_job_with_pipeline(pid))
+
+
+@pytest.mark.asyncio
+async def test_ensure_pipeline_exists_before_create_succeeds(
+    fk_db_session: AsyncSession,
+):
+    """The supported ordering — Pipeline row first, then the job —
+    flushes without an FK violation.  This is the order every mint
+    site (year_configuration, /sync/recalculate-*, _chain.chain_job,
+    _stamp_job_type_and_meta) MUST honor.
+    """
+    from uuid import uuid4
+
+    pid = uuid4()
+    repo = DataIngestionRepository(fk_db_session)
+
+    # Correct order: ensure pipelines row, THEN insert the job.
+    await repo.ensure_pipeline_exists(pid, kind="unit_sync", year=2026)
+    created = await repo.create_ingestion_job(_job_with_pipeline(pid))
+
+    assert created.id is not None
+    assert created.pipeline_id == pid
+
+
+@pytest.mark.asyncio
+async def test_wrong_order_create_then_ensure_raises(
+    fk_db_session: AsyncSession,
+):
+    """The historical wrong shape (data_sync.py 1559-1569 pre-fix):
+    ``create_ingestion_job`` first, ``ensure_pipeline_exists`` second.
+    ``create_ingestion_job`` flushes, the FK rejects, and
+    ``ensure_pipeline_exists`` is never even reached.
+    """
+    from uuid import uuid4
+
+    pid = uuid4()
+    repo = DataIngestionRepository(fk_db_session)
+
+    with pytest.raises(IntegrityError):
+        await repo.create_ingestion_job(_job_with_pipeline(pid))
+        # Unreachable — the flush above already raised.
+        await repo.ensure_pipeline_exists(pid, kind="unit_sync", year=2026)

--- a/backend/tests/unit/repositories/test_unit_repo.py
+++ b/backend/tests/unit/repositories/test_unit_repo.py
@@ -192,4 +192,109 @@ async def test_count(repo):
     result = await repo.count()
 
     assert result == 42
-    repo.session.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# bulk_upsert race-safety (#1236) — Postgres path uses INSERT … ON
+# CONFLICT DO UPDATE so two parallel unit_sync jobs no longer crash on
+# ``ix_units_institutional_code``.  User-reported 2026-05-20: creating
+# year 2025 + 2026 in parallel had the second handler fail with
+# ``UniqueViolation`` on code 14270.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_postgresql_uses_on_conflict():
+    """Postgres backend → bulk_upsert issues an INSERT statement that
+    carries ON CONFLICT (institutional_code) DO UPDATE.  Race-safe by
+    construction: two concurrent transactions both INSERT, the loser
+    gets the DO UPDATE branch instead of a UniqueViolation."""
+    session = MagicMock()
+    session.get_bind.return_value.dialect.name = "postgresql"
+
+    # First execute(): SELECT existing codes (used for created/updated
+    # count).  Returns an empty result so every unit looks "new".
+    pre_select_result = MagicMock()
+    pre_select_result.all = MagicMock(return_value=[])
+    # Second execute(): the INSERT … ON CONFLICT itself.  RETURNING
+    # bounces the inserted/updated row back.
+    upsert_result = MagicMock()
+    upsert_result.scalars.return_value.all.return_value = [MagicMock(id=1)]
+
+    session.execute = AsyncMock(side_effect=[pre_select_result, upsert_result])
+
+    repo = UnitRepository(session)
+    unit = Unit(
+        provider=UserProvider.DEFAULT,
+        institutional_code="14270",
+        name="180C",
+        level=4,
+    )
+
+    res = await repo.bulk_upsert([unit])
+
+    # Two execute() calls: SELECT for created-count, INSERT…ON CONFLICT.
+    assert session.execute.await_count == 2
+    insert_sql = str(session.execute.await_args_list[1].args[0])
+    assert "ON CONFLICT" in insert_sql.upper()
+    assert "institutional_code" in insert_sql
+    assert res.total == 1
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_sqlite_uses_legacy_select_merge():
+    """SQLite test fixture (single-writer) → no race possible, keep the
+    legacy SELECT-then-merge path.  Pinned so a refactor doesn't break
+    the test fixture by forcing ON CONFLICT (which SQLAlchemy's
+    sqlite dialect supports but the existing tests don't expect)."""
+    session = MagicMock()
+    session.get_bind.return_value.dialect.name = "sqlite"
+
+    rows_result = MagicMock()
+    rows_result.all = MagicMock(return_value=[("X1", 1), ("X2", 2)])
+    session.exec = AsyncMock(return_value=rows_result)
+    session.merge = AsyncMock(side_effect=lambda u: u)
+
+    repo = UnitRepository(session)
+    units = [
+        Unit(
+            provider=UserProvider.DEFAULT,
+            institutional_code="X1",
+            name="A",
+            level=4,
+        ),
+        Unit(
+            provider=UserProvider.DEFAULT,
+            institutional_code="NEW",
+            name="C",
+            level=4,
+        ),
+    ]
+
+    res = await repo.bulk_upsert(units)
+
+    # Legacy path uses session.exec (not session.execute) for the SELECT.
+    session.exec.assert_awaited_once()
+    # No ON CONFLICT statement on this path.
+    for call in session.execute.await_args_list:
+        assert "ON CONFLICT" not in str(call.args[0]).upper()
+    assert res.created == 1  # NEW
+    assert res.updated == 1  # X1 matched
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_empty_input_short_circuits():
+    """Defensive — empty input must short-circuit BEFORE the dialect
+    check (no DB queries) so a no-op upsert is free."""
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.exec = AsyncMock()
+    repo = UnitRepository(session)
+
+    res = await repo.bulk_upsert([])
+
+    assert res.total == 0
+    assert res.data == []
+    # No DB queries on the no-op path.
+    session.execute.assert_not_awaited()
+    session.exec.assert_not_awaited()

--- a/backend/tests/unit/services/data_ingestion/test_guard_factors_required.py
+++ b/backend/tests/unit/services/data_ingestion/test_guard_factors_required.py
@@ -93,3 +93,25 @@ def test_year_none_message_degrades_cleanly():
     msg = str(exc.value)
     assert "year=None" not in msg
     assert "configured year" in msg
+
+
+# ---------------------------------------------------------------------------
+# Targeted fail-early for "common" uploads — modules that INFER
+# data_entry_type from factors (equipment, purchase).  An empty factors
+# map is fatal regardless of the handler's ``require_factor_to_match``
+# flag.  Lives in ``module_per_year.py`` but tested here for proximity.
+# ---------------------------------------------------------------------------
+
+
+def test_factor_inferred_modules_set_contains_equipment_and_purchase():
+    """Both 'common' upload module types must be in the set — these are
+    the empirical cases the user hit (50 000 rows of identical
+    'no matching factor' errors).  If a third such module appears,
+    add it to the set in the same PR as the new handler."""
+    from app.models.module_type import ModuleTypeEnum
+    from app.services.data_ingestion.csv_providers.module_per_year import (
+        _FACTOR_INFERRED_MODULES,
+    )
+
+    assert ModuleTypeEnum.equipment_electric_consumption in _FACTOR_INFERRED_MODULES
+    assert ModuleTypeEnum.purchase in _FACTOR_INFERRED_MODULES

--- a/backend/tests/unit/services/data_ingestion/test_guard_factors_required.py
+++ b/backend/tests/unit/services/data_ingestion/test_guard_factors_required.py
@@ -1,0 +1,95 @@
+"""Regression: ingests for modules whose handler requires a factor
+match MUST fail fast at setup when the factors map is empty.
+
+User-reported (2026-05-20): uploading an equipment ``data.csv`` for a
+module/year with no factors loaded produced 50 072 row errors,
+each one variant of "no matching factor found".  The operator had to
+scroll past every one to figure out the real fix is to upload factors
+first.  The guard turns that into one ``FINISHED + ERROR`` job with a
+single-line status message.
+
+The guard sits in ``_setup_handlers_and_factors`` (before any row is
+processed), so the existing ``_setup_and_validate`` try/except wraps
+the raise into the job's terminal state automatically — covered by
+the row-of-zero assertion in each positive test below.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.data_ingestion.base_csv_provider import _guard_factors_required
+
+
+def _handler(require_factor: bool):
+    """Minimal duck-typed ModuleHandler for the guard."""
+    return SimpleNamespace(require_factor_to_match=require_factor)
+
+
+def test_empty_factors_raises_when_handler_requires_match():
+    """The bug shape: equipment-style handler, empty factors_map → raise."""
+    with pytest.raises(ValueError) as exc:
+        _guard_factors_required(
+            factors_map={},
+            handlers=[_handler(True)],
+            module_label="Equipment",
+            year=2026,
+        )
+    # The message must name the module + year so the operator knows
+    # which factor upload is missing without reading the stack trace.
+    msg = str(exc.value)
+    assert "Equipment" in msg
+    assert "2026" in msg
+    assert "factors" in msg.lower()
+
+
+def test_empty_factors_ok_when_no_handler_requires_match():
+    """Modules with ``require_factor_to_match=False`` (purchase,
+    buildings, headcount, …) tolerate an empty map — the guard must
+    not block them."""
+    _guard_factors_required(
+        factors_map={},
+        handlers=[_handler(False)],
+        module_label="Purchase",
+        year=2026,
+    )  # no raise
+
+
+def test_populated_factors_ok_even_when_required():
+    """The happy path — at least one factor present is enough; the
+    per-row loop will pick up scope mismatches if any."""
+    _guard_factors_required(
+        factors_map={"10:2026:foo:None": object()},
+        handlers=[_handler(True)],
+        module_label="Equipment",
+        year=2026,
+    )  # no raise
+
+
+def test_mixed_handlers_any_requires_triggers_guard():
+    """MODULE_PER_YEAR loads handlers for every valid data_entry_type;
+    if even one of them requires a factor match, the guard must fire
+    on an empty map.  (Otherwise the multi-handler module would
+    silently produce per-row errors for the strict subtype.)"""
+    with pytest.raises(ValueError):
+        _guard_factors_required(
+            factors_map={},
+            handlers=[_handler(False), _handler(True)],
+            module_label="Equipment",
+            year=2026,
+        )
+
+
+def test_year_none_message_degrades_cleanly():
+    """Defensive: if for some reason ``self.year`` is None the message
+    must still be readable — no ``year=None`` text bleeding through."""
+    with pytest.raises(ValueError) as exc:
+        _guard_factors_required(
+            factors_map={},
+            handlers=[_handler(True)],
+            module_label="Equipment",
+            year=None,
+        )
+    msg = str(exc.value)
+    assert "year=None" not in msg
+    assert "configured year" in msg

--- a/backend/tests/unit/services/data_ingestion/test_module_per_year_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_per_year_csv_provider.py
@@ -227,3 +227,106 @@ async def test_resolve_handler_and_validate_missing_factor_no_config():
     # it should not fail if require_factor_to_match is False
     # assert "Missing factor" in error_msg  --- IGNORE ---
     assert stats["rows_skipped"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: equipment/purchase ingests with empty factors must FAIL FAST
+# at setup time (#1236 follow-up).  User-reported 2026-05-20 — uploading
+# data.csv for equipment with no factors uploaded grinds through 50 000
+# rows of identical "no matching factor" errors instead of refusing
+# up front.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_equipment_with_empty_factors_fails_fast_at_setup(monkeypatch):
+    """ModuleTypeEnum.equipment_electric_consumption + empty factors_map
+    raises at setup — the per-row loop is never entered."""
+    provider = ModulePerYearCSVProvider(
+        {"file_path": "tmp/test.csv"}, data_session=MagicMock()
+    )
+    provider.job = SimpleNamespace(
+        module_type_id=ModuleTypeEnum.equipment_electric_consumption.value
+    )
+
+    handler = MagicMock()
+    handler.create_dto.model_fields = {}
+    handler.require_factor_to_match = False  # equipment handler's real value
+
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year.BaseModuleHandler,
+        "get_by_type",
+        MagicMock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year,
+        "load_factors_map",
+        AsyncMock(return_value={}),  # the bug shape
+    )
+
+    with pytest.raises(ValueError) as exc:
+        await provider._setup_handlers_and_factors()
+
+    msg = str(exc.value)
+    assert "equipment_electric_consumption" in msg
+    assert "factors" in msg.lower()
+    assert "infers" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_purchase_with_empty_factors_fails_fast_at_setup(monkeypatch):
+    """ModuleTypeEnum.purchase shares the factor-inferred-DET shape;
+    same guard fires."""
+    provider = ModulePerYearCSVProvider(
+        {"file_path": "tmp/test.csv"}, data_session=MagicMock()
+    )
+    provider.job = SimpleNamespace(module_type_id=ModuleTypeEnum.purchase.value)
+
+    handler = MagicMock()
+    handler.create_dto.model_fields = {}
+    handler.require_factor_to_match = False
+
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year.BaseModuleHandler,
+        "get_by_type",
+        MagicMock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year,
+        "load_factors_map",
+        AsyncMock(return_value={}),
+    )
+
+    with pytest.raises(ValueError) as exc:
+        await provider._setup_handlers_and_factors()
+    assert "purchase" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_non_factor_inferred_module_tolerates_empty_factors(monkeypatch):
+    """Modules NOT in ``_FACTOR_INFERRED_MODULES`` (headcount, buildings,
+    professional_travel, …) ingest rows even with empty factors — they
+    carry the DET in a category column that maps to ``DataEntryTypeEnum``
+    names directly, so empty factors is a legitimate state."""
+    provider = ModulePerYearCSVProvider(
+        {"file_path": "tmp/test.csv"}, data_session=MagicMock()
+    )
+    provider.job = SimpleNamespace(module_type_id=ModuleTypeEnum.headcount.value)
+
+    handler = MagicMock()
+    handler.create_dto.model_fields = {"kind": MagicMock()}
+    handler.require_factor_to_match = False  # headcount's real value
+
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year.BaseModuleHandler,
+        "get_by_type",
+        MagicMock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year,
+        "load_factors_map",
+        AsyncMock(return_value={}),
+    )
+
+    setup = await provider._setup_handlers_and_factors()  # no raise
+    assert setup["factors_map"] == {}

--- a/backend/tests/unit/services/data_ingestion/test_module_unit_specific_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_unit_specific_csv_provider.py
@@ -356,6 +356,10 @@ async def test_setup_returns_empty_factor_id_map_with_no_factors(monkeypatch):
 
     handler = MagicMock()
     handler.create_dto.model_fields = {}
+    # Opt out of the empty-factors guard added in #1236 — this test
+    # asserts the factor_id_to_factor mapping shape, not the
+    # require-factor invariant (covered by test_guard_factors_required).
+    handler.require_factor_to_match = False
 
     monkeypatch.setattr(
         csv_providers_module.module_unit_specific.BaseModuleHandler,
@@ -550,6 +554,9 @@ async def test_all_data_entry_types_return_factor_id_to_factor(monkeypatch):
 
         handler = MagicMock()
         handler.create_dto.model_fields = {}
+        # See sibling test — opt out of the require-factor guard so
+        # this mapping-shape assertion still runs on empty factors.
+        handler.require_factor_to_match = False
 
         monkeypatch.setattr(
             csv_providers_module.module_unit_specific.BaseModuleHandler,

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -5,7 +5,15 @@ The list endpoint must never ship the KB-scale ``error_details`` /
 and show provenance.  This locks that contract.
 """
 
-from app.api.v1.data_sync import _PIPELINE_META_ALLOW, _project_pipeline_meta
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.data_sync import (
+    _PIPELINE_META_ALLOW,
+    _project_pipeline_meta,
+    _resolve_enum_name,
+)
+from app.models.data_ingestion import IngestionResult, IngestionState
 
 
 def test_project_strips_big_arrays_keeps_allow_list():
@@ -34,3 +42,34 @@ def test_project_handles_none_and_partial_meta():
     assert _project_pipeline_meta(None) == {}
     assert _project_pipeline_meta({}) == {}
     assert _project_pipeline_meta({"parent_job_id": 1, "x": 2}) == {"parent_job_id": 1}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_enum_name (#1234) — int-enum filter params must accept the NAME.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_enum_name_accepts_case_insensitive_name():
+    assert _resolve_enum_name(IngestionState, "RUNNING", "state") is (
+        IngestionState.RUNNING
+    )
+    assert _resolve_enum_name(IngestionState, "not_started", "state") is (
+        IngestionState.NOT_STARTED
+    )
+    assert _resolve_enum_name(IngestionResult, "Error", "result") is (
+        IngestionResult.ERROR
+    )
+
+
+def test_resolve_enum_name_none_passes_through():
+    assert _resolve_enum_name(IngestionState, None, "state") is None
+
+
+def test_resolve_enum_name_rejects_unknown_with_422():
+    with pytest.raises(HTTPException) as exc:
+        _resolve_enum_name(IngestionState, "BOGUS", "state")
+    assert exc.value.status_code == 422
+    # The integer value must NOT be accepted — names only (this is the
+    # exact 422 the user hit with ?state=NOT_STARTED on the int enum).
+    with pytest.raises(HTTPException):
+        _resolve_enum_name(IngestionState, "0", "state")

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -18,6 +18,9 @@ from app.models.data_ingestion import IngestionResult, IngestionState, PipelineS
 
 def test_project_strips_big_arrays_keeps_allow_list():
     meta = {
+        # Phase 5B (#1236) — these three meta keys were retired; the
+        # allow-list must NOT carry them, and a legacy pipeline that
+        # still has them on its meta gets them stripped.
         "parent_job_id": 9,
         "recalc_jobs_chained": 3,
         "aggregation_job_id": 14,
@@ -38,7 +41,10 @@ def test_project_strips_big_arrays_keeps_allow_list():
     assert set(projected) == set(_PIPELINE_META_ALLOW)
     assert "error_details" not in projected
     assert "affected_module_ids" not in projected
-    assert projected["aggregation_job_id"] == 14
+    # Retired keys MUST NOT be projected even if legacy meta carries them.
+    assert "parent_job_id" not in projected
+    assert "recalc_jobs_chained" not in projected
+    assert "aggregation_job_id" not in projected
     assert projected["status_history"] == meta["status_history"]
     assert projected["phases"] == meta["phases"]
 
@@ -46,7 +52,9 @@ def test_project_strips_big_arrays_keeps_allow_list():
 def test_project_handles_none_and_partial_meta():
     assert _project_pipeline_meta(None) == {}
     assert _project_pipeline_meta({}) == {}
-    assert _project_pipeline_meta({"parent_job_id": 1, "x": 2}) == {"parent_job_id": 1}
+    # ``parent_job_id`` retired post-5B → stripped; ``x`` not in
+    # allow-list → also stripped; result is empty.
+    assert _project_pipeline_meta({"parent_job_id": 1, "x": 2}) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -108,3 +108,65 @@ def test_resolve_enum_name_accepts_pipeline_status():
     assert _resolve_enum_name(PipelineStatus, "Failed", "state") is (
         PipelineStatus.FAILED
     )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline job state/result serialize as enum NAME, not int value.
+# User-reported 2026-05-20: Jobs column read "0/4 ✓" because the
+# frontend compared ``j.state === 'FINISHED'`` but the API serialized
+# the int-Enum as ``3``.  Pinned via field_serializer; this test makes
+# sure a future refactor that loses the serializer fails loudly.
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_job_list_entry_serializes_state_as_name():
+    """``PipelineJobListEntry.state`` and ``result`` must serialize as
+    the enum NAME (string), not the int VALUE.  Frontend code compares
+    against string names; the int default would silently break the
+    Jobs column count + the job-color rendering in the DAG."""
+    import json
+
+    from app.api.v1.data_sync import PipelineJobListEntry
+
+    entry = PipelineJobListEntry(
+        job_id=1,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+    )
+
+    payload = json.loads(entry.model_dump_json())
+    assert payload["state"] == "FINISHED", (
+        f"state must serialize as enum NAME 'FINISHED', got {payload['state']!r}"
+    )
+    assert payload["result"] == "SUCCESS", (
+        f"result must serialize as enum NAME 'SUCCESS', got {payload['result']!r}"
+    )
+
+
+def test_pipeline_job_list_entry_serializes_none_as_null():
+    """Nullable fields must remain null when unset (no ``"None"`` string)."""
+    import json
+
+    from app.api.v1.data_sync import PipelineJobListEntry
+
+    entry = PipelineJobListEntry(job_id=1)
+    payload = json.loads(entry.model_dump_json())
+    assert payload["state"] is None
+    assert payload["result"] is None
+
+
+def test_pipeline_job_response_serializes_state_as_name():
+    """``PipelineJobResponse`` (single-pipeline endpoint) shares the
+    same contract — same serializer, same expectation."""
+    import json
+
+    from app.api.v1.data_sync import PipelineJobResponse
+
+    response = PipelineJobResponse(
+        job_id=42,
+        state=IngestionState.RUNNING,
+        result=IngestionResult.WARNING,
+    )
+    payload = json.loads(response.model_dump_json())
+    assert payload["state"] == "RUNNING"
+    assert payload["result"] == "WARNING"

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -13,7 +13,7 @@ from app.api.v1.data_sync import (
     _project_pipeline_meta,
     _resolve_enum_name,
 )
-from app.models.data_ingestion import IngestionResult, IngestionState
+from app.models.data_ingestion import IngestionResult, IngestionState, PipelineStatus
 
 
 def test_project_strips_big_arrays_keeps_allow_list():
@@ -78,3 +78,25 @@ def test_resolve_enum_name_rejects_unknown_with_422():
     # exact 422 the user hit with ?state=NOT_STARTED on the int enum).
     with pytest.raises(HTTPException):
         _resolve_enum_name(IngestionState, "0", "state")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 read-flip (#1236) — ``?state=`` resolves to ``PipelineStatus``.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_enum_name_accepts_pipeline_status():
+    """``state`` URL param now means PipelineStatus (#1236 Phase 3).
+
+    The 5 values (NOT_STARTED / RUNNING / SUCCESS / PARTIAL / FAILED)
+    must all resolve case-insensitively.
+    """
+    assert _resolve_enum_name(PipelineStatus, "RUNNING", "state") is (
+        PipelineStatus.RUNNING
+    )
+    assert _resolve_enum_name(PipelineStatus, "partial", "state") is (
+        PipelineStatus.PARTIAL
+    )
+    assert _resolve_enum_name(PipelineStatus, "Failed", "state") is (
+        PipelineStatus.FAILED
+    )

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -23,6 +23,9 @@ def test_project_strips_big_arrays_keeps_allow_list():
         "aggregation_job_id": 14,
         "provider_name": "ModulePerYearCSVProvider",
         "filters": {},
+        # #2A/#2B — bounded timeline + checklist included in the list view.
+        "status_history": [{"message": "x", "ts": "2026-05-20T00:00:00+00:00"}],
+        "phases": [{"name": "fetch_units", "state": "finished"}],
         # Must be dropped — these are the multi-KB offenders.
         "error_details": [{"data_entry_id": i, "error": "x" * 200} for i in range(50)],
         "affected_module_ids": list(range(2231)),
@@ -36,6 +39,8 @@ def test_project_strips_big_arrays_keeps_allow_list():
     assert "error_details" not in projected
     assert "affected_module_ids" not in projected
     assert projected["aggregation_job_id"] == 14
+    assert projected["status_history"] == meta["status_history"]
+    assert projected["phases"] == meta["phases"]
 
 
 def test_project_handles_none_and_partial_meta():

--- a/backend/tests/unit/services/test_pipeline_meta_allowlist.py
+++ b/backend/tests/unit/services/test_pipeline_meta_allowlist.py
@@ -1,0 +1,36 @@
+"""Pipeline-ops-console meta allow-list (#1234).
+
+The list endpoint must never ship the KB-scale ``error_details`` /
+``affected_module_ids`` arrays — only the five keys that thread the DAG
+and show provenance.  This locks that contract.
+"""
+
+from app.api.v1.data_sync import _PIPELINE_META_ALLOW, _project_pipeline_meta
+
+
+def test_project_strips_big_arrays_keeps_allow_list():
+    meta = {
+        "parent_job_id": 9,
+        "recalc_jobs_chained": 3,
+        "aggregation_job_id": 14,
+        "provider_name": "ModulePerYearCSVProvider",
+        "filters": {},
+        # Must be dropped — these are the multi-KB offenders.
+        "error_details": [{"data_entry_id": i, "error": "x" * 200} for i in range(50)],
+        "affected_module_ids": list(range(2231)),
+        "recalculation": {"recalculated": 15820},
+        "config": {"file_path": "tmp/secret.csv"},
+    }
+
+    projected = _project_pipeline_meta(meta)
+
+    assert set(projected) == set(_PIPELINE_META_ALLOW)
+    assert "error_details" not in projected
+    assert "affected_module_ids" not in projected
+    assert projected["aggregation_job_id"] == 14
+
+
+def test_project_handles_none_and_partial_meta():
+    assert _project_pipeline_meta(None) == {}
+    assert _project_pipeline_meta({}) == {}
+    assert _project_pipeline_meta({"parent_job_id": 1, "x": 2}) == {"parent_job_id": 1}

--- a/backend/tests/unit/services/test_pipeline_progress.py
+++ b/backend/tests/unit/services/test_pipeline_progress.py
@@ -55,9 +55,16 @@ def test_parent_only_snapshot_does_not_prematurely_complete():
     """THE core UX bug: parent FINISHED, children not yet INSERTed.
 
     Old "all snapshot jobs FINISHED" logic flashed the module green
-    here. The expected-fan-out contract keeps it at phase 2.
+    here. Phase 5B carries the expected count via
+    ``pipeline.expected_recalc`` (the writer sets it from the live
+    job count in ``recompute_pipeline_status``); the test pins the
+    expectation explicitly so the snapshot's missing children don't
+    flip phase 2 vacuously satisfied.
     """
-    p = compute_pipeline_progress([_parent(S.FINISHED, recalc_chained=2)])
+    p = compute_pipeline_progress(
+        [_parent(S.FINISHED)],
+        pipeline=_pl(PipelineStatus.RUNNING.value, expected_recalc=2),
+    )
     assert p["phase"] == 2
     assert p["done"] is False
 
@@ -176,9 +183,13 @@ def test_empty_pipeline_is_safe():
 # ---------------------------------------------------------------------------
 
 
-def _pl(status):
-    """Minimal duck-typed Pipeline row for the read-flip branch."""
-    return SimpleNamespace(status=status)
+def _pl(status, *, expected_recalc=None):
+    """Minimal duck-typed Pipeline row for the read-flip branch.
+
+    Phase 5B (#1236): ``expected_recalc`` is the authoritative count;
+    when None, the function falls back to the live job count.
+    """
+    return SimpleNamespace(status=status, expected_recalc=expected_recalc)
 
 
 def test_pipeline_status_success_marks_done_even_if_jobs_lag():

--- a/backend/tests/unit/services/test_pipeline_progress.py
+++ b/backend/tests/unit/services/test_pipeline_progress.py
@@ -183,13 +183,16 @@ def test_empty_pipeline_is_safe():
 # ---------------------------------------------------------------------------
 
 
-def _pl(status, *, expected_recalc=None):
+def _pl(status, *, expected_recalc=None, kind="csv_ingest"):
     """Minimal duck-typed Pipeline row for the read-flip branch.
 
     Phase 5B (#1236): ``expected_recalc`` is the authoritative count;
     when None, the function falls back to the live job count.
+
+    ``kind`` (the parent job_type) is exposed in the progress payload
+    so the frontend can scope the phase indicator to the right card.
     """
-    return SimpleNamespace(status=status, expected_recalc=expected_recalc)
+    return SimpleNamespace(status=status, expected_recalc=expected_recalc, kind=kind)
 
 
 def test_pipeline_status_success_marks_done_even_if_jobs_lag():
@@ -257,3 +260,33 @@ def test_pipeline_phase_still_job_derived_when_row_passed():
     p = compute_pipeline_progress(jobs, pipeline=_pl(PipelineStatus.RUNNING.value))
     assert p["phase"] == 2  # parent done, recalc fan-out still in flight
     assert p["done"] is False
+
+
+def test_kind_sourced_from_pipeline_when_present():
+    """``progress.kind`` reflects ``pipeline.kind`` (the parent job_type)
+    so frontend cards can scope the phase indicator to the matching
+    target.  A factor_ingest pipeline must NOT surface its phase on
+    the data card."""
+    jobs = [_parent(S.RUNNING)]
+    p = compute_pipeline_progress(
+        jobs,
+        pipeline=_pl(PipelineStatus.RUNNING.value, kind="factor_ingest"),
+    )
+    assert p["kind"] == "factor_ingest"
+
+
+def test_kind_falls_back_to_root_job_type_when_no_pipeline_row():
+    """Orphans / pre-Phase-1 pipelines that lack a Pipeline row still
+    get ``kind`` from the root job's ``job_type``.  Otherwise the
+    UI's card-scoping would default to 'unknown kind' and either show
+    everywhere (noisy) or nowhere (regression)."""
+    parent = _job(1, "csv_ingest", S.RUNNING)
+    p = compute_pipeline_progress([parent], pipeline=None)
+    assert p["kind"] == "csv_ingest"
+
+
+def test_kind_none_when_no_root_and_no_pipeline():
+    """Defensive: empty / unidentifiable input → kind=None.  Frontend
+    treats None as 'don't scope' (i.e., show on no card)."""
+    p = compute_pipeline_progress([], pipeline=None)
+    assert p["kind"] is None

--- a/backend/tests/unit/services/test_pipeline_progress.py
+++ b/backend/tests/unit/services/test_pipeline_progress.py
@@ -7,7 +7,7 @@ zombie/two-recalc scenarios that motivated the fix.
 
 from types import SimpleNamespace
 
-from app.models.data_ingestion import IngestionResult, IngestionState
+from app.models.data_ingestion import IngestionResult, IngestionState, PipelineStatus
 from app.services.pipeline_progress import compute_pipeline_progress
 
 S = IngestionState
@@ -168,4 +168,81 @@ def test_legacy_no_counter_falls_back_to_present_children():
 def test_empty_pipeline_is_safe():
     p = compute_pipeline_progress([])
     assert p["phase"] == 1
+    assert p["done"] is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 read-flip (#1236) — ``pipeline.status`` is authoritative when passed.
+# ---------------------------------------------------------------------------
+
+
+def _pl(status):
+    """Minimal duck-typed Pipeline row for the read-flip branch."""
+    return SimpleNamespace(status=status)
+
+
+def test_pipeline_status_success_marks_done_even_if_jobs_lag():
+    """Read-flip: pipeline.status=SUCCESS is authoritative.
+
+    Stage: snapshot may show a stragger RUNNING child while
+    ``pipelines.status`` already reconciled to SUCCESS (race between the
+    runner's isolated post-finish write and the SSE poll picking up the
+    pre-write snapshot).  With the row passed in, ``done`` is the
+    table's truth, not the snapshot's.
+    """
+    jobs = [_parent(S.FINISHED, recalc_chained=2), _recalc(2, S.FINISHED, agg_id=10)]
+    p = compute_pipeline_progress(jobs, pipeline=_pl(PipelineStatus.SUCCESS.value))
+    assert p["done"] is True
+    assert p["has_error"] is False
+
+
+def test_pipeline_status_failed_marks_done_and_has_error():
+    jobs = [_parent(S.RUNNING)]
+    p = compute_pipeline_progress(jobs, pipeline=_pl(PipelineStatus.FAILED.value))
+    assert p["done"] is True
+    assert p["has_error"] is True
+
+
+def test_pipeline_status_partial_marks_done_and_has_error():
+    jobs = [_parent(S.FINISHED, recalc_chained=2)]
+    p = compute_pipeline_progress(jobs, pipeline=_pl(PipelineStatus.PARTIAL.value))
+    assert p["done"] is True
+    assert p["has_error"] is True
+
+
+def test_pipeline_status_running_keeps_not_done_even_if_jobs_all_finished():
+    """Inverse race: snapshot all FINISHED, ``pipelines.status`` not yet
+    advanced (the runner's isolated write hasn't landed; the next sweep
+    will heal it).  The table is authoritative — keep the spinner."""
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=1),
+        _recalc(2, S.FINISHED, agg_id=10),
+        _agg(10, S.FINISHED),
+    ]
+    p = compute_pipeline_progress(jobs, pipeline=_pl(PipelineStatus.RUNNING.value))
+    assert p["done"] is False
+    assert p["has_error"] is False
+
+
+def test_pipeline_none_falls_back_to_legacy_job_derived():
+    """Orphans never minted a Pipeline row — pipeline=None keeps the
+    legacy oracle so the badge still works for them."""
+    jobs = [_parent(S.FINISHED, recalc_chained=0)]
+    p = compute_pipeline_progress(jobs, pipeline=None)
+    # phase 2 vacuously satisfied (0 expected); phase 3 satisfied (no aggs).
+    assert p["done"] is True
+    assert p["has_error"] is False
+
+
+def test_pipeline_phase_still_job_derived_when_row_passed():
+    """``phase`` is UX granularity, not bound to ``pipelines.status`` —
+    even when the table says RUNNING, ``phase`` reflects which step is
+    actually mid-flight per the jobs."""
+    jobs = [
+        _parent(S.FINISHED, recalc_chained=2),
+        _recalc(2, S.FINISHED, agg_id=10),
+        _recalc(3, S.RUNNING),
+    ]
+    p = compute_pipeline_progress(jobs, pipeline=_pl(PipelineStatus.RUNNING.value))
+    assert p["phase"] == 2  # parent done, recalc fan-out still in flight
     assert p["done"] is False

--- a/backend/tests/unit/tasks/test_aggregation_handler.py
+++ b/backend/tests/unit/tasks/test_aggregation_handler.py
@@ -41,6 +41,7 @@ def _make_job(
     module_type_id: int | None = 11,
     year: int | None = 2025,
     meta: dict | None = None,
+    pipeline_id=None,
 ) -> MagicMock:
     job = MagicMock()
     job.id = job_id
@@ -48,6 +49,9 @@ def _make_job(
     job.module_type_id = module_type_id
     job.year = year
     job.meta = meta or {}
+    # 4A.3: helper falls back when pipeline_id is None — keep that as
+    # the default so existing tests exercise the legacy/full-slice path.
+    job.pipeline_id = pipeline_id
     return job
 
 
@@ -214,3 +218,58 @@ async def test_aggregation_skips_advisory_lock_on_non_postgres():
     # No advisory-lock SQL issued.
     for call in data_session.execute.await_args_list:
         assert "pg_advisory_xact_lock" not in str(call.args[0])
+
+
+# ---------------------------------------------------------------------------
+# Phase 4A.3 — affected_module_ids scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregation_scopes_to_affected_module_ids():
+    """When recalc siblings recorded affected_module_ids, the aggregation
+    recomputes ONLY those modules, not the full (module, year) slice."""
+    job = _make_job(pipeline_id="dummy")
+    modules = [MagicMock(id=101), MagicMock(id=202), MagicMock(id=303)]
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=modules)
+    svc.recompute_stats = AsyncMock()
+
+    with (
+        patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc),
+        patch.object(
+            aggregation_mod,
+            "_collect_affected_module_ids",
+            new=AsyncMock(return_value={101, 303}),
+        ),
+    ):
+        meta = await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+    assert svc.recompute_stats.await_count == 2
+    svc.recompute_stats.assert_any_await(101)
+    svc.recompute_stats.assert_any_await(303)
+    assert meta["modules_refreshed"] == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregation_falls_back_to_full_slice_when_no_affected_meta():
+    """Helper returns None (legacy / no recalc meta) → preserves prior
+    behavior of recomputing every module in the (module, year) slice."""
+    job = _make_job(pipeline_id="dummy")
+    modules = [MagicMock(id=101), MagicMock(id=202), MagicMock(id=303)]
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=modules)
+    svc.recompute_stats = AsyncMock()
+
+    with (
+        patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc),
+        patch.object(
+            aggregation_mod,
+            "_collect_affected_module_ids",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        meta = await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+    assert svc.recompute_stats.await_count == 3
+    assert meta["modules_refreshed"] == 3

--- a/backend/tests/unit/tasks/test_aggregation_handler.py
+++ b/backend/tests/unit/tasks/test_aggregation_handler.py
@@ -157,3 +157,60 @@ async def test_aggregation_raises_on_missing_job_id():
     job = _make_job(job_id=None)
     with pytest.raises(ValueError, match="job has no id"):
         await aggregation_mod.aggregation_handler(job, MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Phase 4A.2 — per-year pg_advisory_xact_lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregation_acquires_advisory_lock_on_postgres():
+    """Postgres backend → handler calls ``pg_advisory_xact_lock(cat, year)``
+    before doing work. Serialises cross-pipeline aggregations of the
+    same year against the shared ``carbon_reports.stats`` row."""
+    job = _make_job(year=2026)
+    data_session = MagicMock()
+    data_session.get_bind = MagicMock(
+        return_value=MagicMock(dialect=MagicMock(name="postgresql"))
+    )
+    # name= kwarg to MagicMock() is special — set explicitly so it's a str.
+    data_session.get_bind.return_value.dialect.name = "postgresql"
+    data_session.execute = AsyncMock()
+
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=[])
+    svc.recompute_stats = AsyncMock()
+
+    with patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc):
+        await aggregation_mod.aggregation_handler(job, MagicMock(), data_session)
+
+    # First execute call is the advisory-lock SQL.
+    assert data_session.execute.await_count >= 1
+    first_call = data_session.execute.await_args_list[0]
+    sql_text = str(first_call.args[0])
+    assert "pg_advisory_xact_lock" in sql_text
+    params = first_call.args[1]
+    assert params["year"] == 2026
+    assert params["cat"] == aggregation_mod._AGGREGATION_LOCK_CATEGORY
+
+
+@pytest.mark.asyncio
+async def test_aggregation_skips_advisory_lock_on_non_postgres():
+    """SQLite / other backends → no advisory-lock attempt (skipped
+    cleanly, single-writer model serialises tests)."""
+    job = _make_job(year=2026)
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "sqlite"
+    data_session.execute = AsyncMock()
+
+    svc = MagicMock()
+    svc.list_modules_for = AsyncMock(return_value=[])
+    svc.recompute_stats = AsyncMock()
+
+    with patch.object(aggregation_mod, "CarbonReportModuleService", return_value=svc):
+        await aggregation_mod.aggregation_handler(job, MagicMock(), data_session)
+
+    # No advisory-lock SQL issued.
+    for call in data_session.execute.await_args_list:
+        assert "pg_advisory_xact_lock" not in str(call.args[0])

--- a/backend/tests/unit/tasks/test_aggregation_scope.py
+++ b/backend/tests/unit/tasks/test_aggregation_scope.py
@@ -1,0 +1,138 @@
+"""#1236 Phase 4A.3 — ``_collect_affected_module_ids`` helper.
+
+Uses the SQLite ``db_session`` fixture to seed real ``emission_recalc``
+sibling rows with ``meta.recalculation.affected_module_ids`` and assert
+the union the helper returns. Pairs with the MagicMock-driven
+handler-scope tests in ``test_aggregation_handler.py``.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+from app.tasks.aggregation_tasks import _collect_affected_module_ids
+
+
+def _recalc(
+    *,
+    pipeline_id,
+    state: IngestionState = IngestionState.FINISHED,
+    affected: list[int] | None = None,
+    data_entry_type_id: int = 10,
+) -> DataIngestionJob:
+    meta: dict = {}
+    if affected is not None:
+        meta["recalculation"] = {"affected_module_ids": affected}
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=4,
+        data_entry_type_id=data_entry_type_id,
+        year=2026,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=state,
+        result=IngestionResult.SUCCESS,
+        is_current=False,
+        pipeline_id=pipeline_id,
+        job_type="emission_recalc",
+        meta=meta,
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_union_of_finished_sibling_affected_ids(
+    db_session: AsyncSession,
+):
+    """3 FINISHED recalc siblings with disjoint+overlapping affected sets →
+    helper returns the precise union (used to scope the aggregation)."""
+    pid = uuid4()
+    for r in (
+        _recalc(pipeline_id=pid, affected=[101, 202], data_entry_type_id=10),
+        _recalc(pipeline_id=pid, affected=[202, 303], data_entry_type_id=11),
+        _recalc(pipeline_id=pid, affected=[303, 404], data_entry_type_id=12),
+    ):
+        db_session.add(r)
+    await db_session.flush()
+
+    result = await _collect_affected_module_ids(pid, db_session)
+
+    assert result == {101, 202, 303, 404}
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_finished_siblings(db_session: AsyncSession):
+    """RUNNING / NOT_STARTED siblings don't contribute — only FINISHED
+    counts (Phase 4A.1 coalesce guarantees the aggregation runs after
+    every sibling is FINISHED, so this is the right snapshot)."""
+    pid = uuid4()
+    db_session.add(
+        _recalc(
+            pipeline_id=pid,
+            state=IngestionState.FINISHED,
+            affected=[1, 2],
+            data_entry_type_id=10,
+        )
+    )
+    db_session.add(
+        _recalc(
+            pipeline_id=pid,
+            state=IngestionState.RUNNING,
+            affected=[99],
+            data_entry_type_id=11,
+        )
+    )
+    await db_session.flush()
+
+    result = await _collect_affected_module_ids(pid, db_session)
+
+    assert result == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_pipeline_id(db_session: AsyncSession):
+    """No pipeline_id → legacy/orphan path; helper returns None so the
+    caller falls back to the full (module, year) module list."""
+    result = await _collect_affected_module_ids(None, db_session)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_affected_meta(db_session: AsyncSession):
+    """Recalc siblings exist but none carry affected_module_ids →
+    helper returns None (full-slice fallback). Common on legacy rows
+    or before recalc started recording the field."""
+    pid = uuid4()
+    db_session.add(_recalc(pipeline_id=pid, affected=None, data_entry_type_id=10))
+    db_session.add(_recalc(pipeline_id=pid, affected=None, data_entry_type_id=11))
+    await db_session.flush()
+
+    result = await _collect_affected_module_ids(pid, db_session)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_set_when_recalcs_touched_nothing(
+    db_session: AsyncSession,
+):
+    """Recalc siblings report empty affected_module_ids → helper returns
+    an *empty* set (not None), so the aggregation correctly recomputes
+    zero modules instead of falling back to the full slice."""
+    pid = uuid4()
+    db_session.add(_recalc(pipeline_id=pid, affected=[], data_entry_type_id=10))
+    await db_session.flush()
+
+    result = await _collect_affected_module_ids(pid, db_session)
+
+    assert result == set()

--- a/backend/tests/unit/tasks/test_chain.py
+++ b/backend/tests/unit/tasks/test_chain.py
@@ -57,8 +57,8 @@ def _make_repo_for_chain(parent: MagicMock) -> MagicMock:
 @pytest.mark.asyncio
 async def test_chain_job_inherits_pipeline_id_and_fires_run_job():
     """Child created NOT_STARTED, inherits parent's pipeline_id,
-    parent_job_id stamped in meta, run_job scheduled via
-    fire_and_forget."""
+    run_job scheduled via fire_and_forget.  Phase 5B retired
+    ``parent_job_id`` from meta — see assertion below."""
     parent = _make_parent(job_id=100)
     parent.pipeline_id = uuid4()
 
@@ -99,7 +99,9 @@ async def test_chain_job_inherits_pipeline_id_and_fires_run_job():
     created = repo.create_ingestion_job.await_args.args[0]
     assert created.pipeline_id == parent.pipeline_id
     assert created.state == IngestionState.NOT_STARTED
-    assert created.meta["parent_job_id"] == 100
+    # Phase 5B (#1236) retired ``parent_job_id`` from meta; readers
+    # identify the parent as the lowest-id job in the pipeline now.
+    assert "parent_job_id" not in (created.meta or {})
     assert created.module_type_id == parent.module_type_id  # inherited
     assert created.year == parent.year  # inherited
 

--- a/backend/tests/unit/tasks/test_chain.py
+++ b/backend/tests/unit/tasks/test_chain.py
@@ -423,3 +423,153 @@ async def test_chain_job_no_dedup_does_not_require_scope_keys():
         )
 
     assert child_id == 200
+
+
+# ---------------------------------------------------------------------------
+# Deferred-dispatch contract (#1236) — chain_job must NOT fire children
+# until the runner drains, so children's first read sees the parent's
+# committed data_session writes.  User-reported 2026-05-20:
+# data_entry_emissions FK violation on data_entry_id after a re-upload
+# (DELETE old + INSERT new races the child recalc's snapshot).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_job_defers_dispatch_when_context_initialised():
+    """When ``reset_pending_dispatches`` has been called (the
+    runner-driven path), ``chain_job`` must enqueue the child_id and
+    NOT fire run_job until ``drain_pending_dispatches`` is called.
+
+    Pins the contract that closes the data_session race: csv_ingest's
+    DELETE/INSERT against data_entries lives in the parent's
+    data_session.  Until the runner commits that session, the recalc
+    child must NOT run — otherwise the child's fresh session reads a
+    stale snapshot and the recalc's emission INSERT trips the
+    ``data_entry_emissions_data_entry_id_fkey`` FK once the parent's
+    commit lands.
+    """
+    parent = _make_parent()
+    parent.pipeline_id = uuid4()
+    repo = _make_repo_for_chain(parent)
+
+    created = MagicMock(id=777)
+    repo.create_ingestion_job = AsyncMock(return_value=created)
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.add = MagicMock()
+
+    chain_mod.reset_pending_dispatches()
+    fire_calls: list[str] = []
+
+    with (
+        patch.object(chain_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            chain_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (
+                fire_calls.append(name or "") or (coro.close(), MagicMock())[1]
+            ),
+        ),
+    ):
+        child_id = await chain_mod.chain_job(
+            parent,
+            job_type="emission_recalc",
+            session=session,
+        )
+
+    assert child_id == 777
+    # Critical: ``fire_and_forget`` MUST NOT be called during chain_job
+    # when the deferred-dispatch context is initialised — otherwise the
+    # FK race re-opens.
+    assert fire_calls == []
+    # The child id sits in the deferred queue waiting for the runner's
+    # post-commit drain.
+    pending = chain_mod._PENDING_DISPATCHES.get()
+    assert pending == [777]
+
+
+@pytest.mark.asyncio
+async def test_drain_pending_dispatches_fires_queued_children():
+    """``drain_pending_dispatches`` fires every queued child id via
+    ``fire_and_forget``.  Called by the runner after
+    ``data_session.commit()``."""
+    chain_mod.reset_pending_dispatches()
+    pending = chain_mod._PENDING_DISPATCHES.get()
+    assert pending is not None
+    pending.extend([101, 102, 103])
+
+    fired_names: list[str] = []
+    with patch.object(
+        chain_mod,
+        "fire_and_forget",
+        side_effect=lambda coro, *, name=None: (
+            fired_names.append(name or "") or (coro.close(), MagicMock())[1]
+        ),
+    ):
+        chain_mod.drain_pending_dispatches()
+
+    assert fired_names == ["run_job-101", "run_job-102", "run_job-103"]
+    # Queue cleared so a subsequent drain is a no-op (no double-fire).
+    assert chain_mod._PENDING_DISPATCHES.get() == []
+
+
+@pytest.mark.asyncio
+async def test_discard_pending_dispatches_clears_without_firing():
+    """On handler failure / preempt the runner calls this to drop the
+    queue — children must NOT run on a rolled-back parent's data."""
+    chain_mod.reset_pending_dispatches()
+    pending = chain_mod._PENDING_DISPATCHES.get()
+    assert pending is not None
+    pending.extend([201, 202])
+
+    fired_names: list[str] = []
+    with patch.object(
+        chain_mod,
+        "fire_and_forget",
+        side_effect=lambda coro, *, name=None: fired_names.append(name or ""),
+    ):
+        chain_mod.discard_pending_dispatches()
+
+    assert fired_names == []
+    assert chain_mod._PENDING_DISPATCHES.get() == []
+
+
+@pytest.mark.asyncio
+async def test_chain_job_fallback_fires_immediately_when_no_context():
+    """When the deferred-dispatch context is NOT initialised (ad-hoc
+    callers / legacy tests that haven't migrated), ``chain_job`` falls
+    back to immediate fire so the legacy contract is preserved.  Logs
+    a warning so the fallback is visible in operational logs."""
+    parent = _make_parent()
+    parent.pipeline_id = uuid4()
+    repo = _make_repo_for_chain(parent)
+
+    created = MagicMock(id=999)
+    repo.create_ingestion_job = AsyncMock(return_value=created)
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.add = MagicMock()
+
+    # Force the context to None to simulate "outside runner".
+    chain_mod._PENDING_DISPATCHES.set(None)
+
+    fire_calls: list[str] = []
+    with (
+        patch.object(chain_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(
+            chain_mod,
+            "fire_and_forget",
+            side_effect=lambda coro, *, name=None: (
+                fire_calls.append(name or "") or (coro.close(), MagicMock())[1]
+            ),
+        ),
+    ):
+        await chain_mod.chain_job(
+            parent,
+            job_type="emission_recalc",
+            session=session,
+        )
+
+    assert fire_calls == ["run_job-999"]

--- a/backend/tests/unit/tasks/test_chain.py
+++ b/backend/tests/unit/tasks/test_chain.py
@@ -48,6 +48,9 @@ def _make_repo_for_chain(parent: MagicMock) -> MagicMock:
     repo = MagicMock()
     repo.get_job_by_id = AsyncMock(return_value=parent)
     repo.create_ingestion_job = AsyncMock(side_effect=lambda j: j)
+    # #1236 — chain_job's lazy-mint path now creates the pipeline
+    # aggregate row via this idempotent helper; stub it on the mock.
+    repo.ensure_pipeline_exists = AsyncMock()
     return repo
 
 

--- a/backend/tests/unit/tasks/test_emission_recalc_coalesce.py
+++ b/backend/tests/unit/tasks/test_emission_recalc_coalesce.py
@@ -1,0 +1,175 @@
+"""#1236 Phase 4A.1 — in-pipeline aggregation coalesce gate.
+
+``_is_last_recalc_sibling`` returns True only for the last
+``emission_recalc`` sibling of a pipeline. Earlier siblings stamp
+``meta.recalc_work_complete=True`` and return False so they skip the
+aggregation chain; the final sibling returns True and chains a single
+trailing aggregation (replacing today's 3× sequential aggregations).
+
+Tests run on the SQLite ``db_session`` fixture; the helper accepts
+the fixture session via its ``helper_session`` kwarg.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.user import UserProvider
+from app.tasks.emission_recalculation_tasks import _is_last_recalc_sibling
+
+
+def _parent(*, pipeline_id, recalc_jobs_chained: int | None) -> DataIngestionJob:
+    meta: dict = {}
+    if recalc_jobs_chained is not None:
+        meta["recalc_jobs_chained"] = recalc_jobs_chained
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=4,
+        year=2026,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=False,
+        pipeline_id=pipeline_id,
+        job_type="csv_ingest",
+        meta=meta,
+    )
+
+
+def _recalc(
+    *, pipeline_id, parent_id: int, data_entry_type_id: int = 10
+) -> DataIngestionJob:
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=4,
+        data_entry_type_id=data_entry_type_id,
+        year=2026,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.computed,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.RUNNING,
+        result=None,
+        is_current=False,
+        pipeline_id=pipeline_id,
+        job_type="emission_recalc",
+        meta={"parent_job_id": parent_id},
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_recalc_pipeline_is_last(db_session: AsyncSession):
+    """expected=1, this is the only recalc → it IS the last sibling."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=1)
+    db_session.add(parent)
+    await db_session.flush()
+    recalc = _recalc(pipeline_id=pid, parent_id=parent.id)
+    db_session.add(recalc)
+    await db_session.flush()
+
+    is_last = await _is_last_recalc_sibling(recalc, helper_session=db_session)
+
+    assert is_last is True
+
+
+@pytest.mark.asyncio
+async def test_first_of_three_is_not_last(db_session: AsyncSession):
+    """expected=3, only this one's recalc_work_complete set → not last."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=3)
+    db_session.add(parent)
+    await db_session.flush()
+    r1 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
+    r2 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
+    r3 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=12)
+    for r in (r1, r2, r3):
+        db_session.add(r)
+    await db_session.flush()
+
+    is_last = await _is_last_recalc_sibling(r1, helper_session=db_session)
+
+    assert is_last is False
+    # r1's row now carries the flag (visible for r2/r3 next calls).
+    await db_session.refresh(r1)
+    assert (r1.meta or {}).get("recalc_work_complete") is True
+
+
+@pytest.mark.asyncio
+async def test_third_of_three_is_last(db_session: AsyncSession):
+    """After r1 and r2 ran their gate (flag stamped), r3's gate → last."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=3)
+    db_session.add(parent)
+    await db_session.flush()
+    r1 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
+    r2 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
+    r3 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=12)
+    for r in (r1, r2, r3):
+        db_session.add(r)
+    await db_session.flush()
+
+    # Simulate the first two siblings calling the gate in order.
+    assert await _is_last_recalc_sibling(r1, helper_session=db_session) is False
+    assert await _is_last_recalc_sibling(r2, helper_session=db_session) is False
+    is_last = await _is_last_recalc_sibling(r3, helper_session=db_session)
+
+    assert is_last is True
+
+
+@pytest.mark.asyncio
+async def test_legacy_no_pipeline_id_falls_back_to_true(
+    db_session: AsyncSession,
+):
+    """No pipeline_id → preserves prior behavior (always chain)."""
+    parent = _parent(pipeline_id=None, recalc_jobs_chained=1)
+    db_session.add(parent)
+    await db_session.flush()
+    recalc = _recalc(pipeline_id=None, parent_id=parent.id)
+    db_session.add(recalc)
+    await db_session.flush()
+
+    assert await _is_last_recalc_sibling(recalc, helper_session=db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_legacy_no_recalc_jobs_chained_falls_back_to_true(
+    db_session: AsyncSession,
+):
+    """Parent without ``recalc_jobs_chained`` meta → fall back to chain."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=None)
+    db_session.add(parent)
+    await db_session.flush()
+    recalc = _recalc(pipeline_id=pid, parent_id=parent.id)
+    db_session.add(recalc)
+    await db_session.flush()
+
+    assert await _is_last_recalc_sibling(recalc, helper_session=db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_legacy_no_parent_job_id_falls_back_to_true(
+    db_session: AsyncSession,
+):
+    """Recalc without ``parent_job_id`` in meta → fall back to chain."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=1)
+    db_session.add(parent)
+    await db_session.flush()
+    recalc = _recalc(pipeline_id=pid, parent_id=parent.id)
+    recalc.meta = {}  # strip parent_job_id
+    db_session.add(recalc)
+    await db_session.flush()
+
+    assert await _is_last_recalc_sibling(recalc, helper_session=db_session) is True

--- a/backend/tests/unit/tasks/test_emission_recalc_coalesce.py
+++ b/backend/tests/unit/tasks/test_emission_recalc_coalesce.py
@@ -173,3 +173,105 @@ async def test_legacy_no_parent_job_id_falls_back_to_true(
     await db_session.flush()
 
     assert await _is_last_recalc_sibling(recalc, helper_session=db_session) is True
+
+
+# ---------------------------------------------------------------------------
+# 4A.4 — _build_aggregation_scope_config
+# ---------------------------------------------------------------------------
+
+from app.tasks.emission_recalculation_tasks import (  # noqa: E402
+    _build_aggregation_scope_config,
+)
+
+
+@pytest.mark.asyncio
+async def test_scope_config_unions_own_and_siblings(db_session: AsyncSession):
+    """Last sibling's own affected_module_ids (from local stats) + siblings'
+    finished contributions → full union in the aggregation config."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=3)
+    db_session.add(parent)
+    await db_session.flush()
+    # Two FINISHED siblings with their affected_module_ids recorded.
+    sibling_a = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
+    sibling_a.state = IngestionState.FINISHED
+    sibling_a.meta = {
+        **(sibling_a.meta or {}),
+        "recalculation": {"affected_module_ids": [101, 202]},
+    }
+    sibling_b = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
+    sibling_b.state = IngestionState.FINISHED
+    sibling_b.meta = {
+        **(sibling_b.meta or {}),
+        "recalculation": {"affected_module_ids": [202, 303]},
+    }
+    me = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=12)
+    db_session.add_all([sibling_a, sibling_b, me])
+    await db_session.flush()
+
+    cfg = await _build_aggregation_scope_config(
+        me, my_affected_module_ids=[303, 404], helper_session=db_session
+    )
+
+    assert cfg is not None
+    assert cfg["affected_module_ids"] == [101, 202, 303, 404]
+
+
+@pytest.mark.asyncio
+async def test_scope_config_returns_empty_list_when_all_empty(
+    db_session: AsyncSession,
+):
+    """Siblings exist but all reported empty affected; own also empty →
+    returns {"affected_module_ids": []} (precise 'nothing to do', NOT
+    the legacy fallback)."""
+    pid = uuid4()
+    parent = _parent(pipeline_id=pid, recalc_jobs_chained=2)
+    db_session.add(parent)
+    await db_session.flush()
+    sib = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
+    sib.state = IngestionState.FINISHED
+    sib.meta = {**(sib.meta or {}), "recalculation": {"affected_module_ids": []}}
+    me = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
+    db_session.add_all([sib, me])
+    await db_session.flush()
+
+    cfg = await _build_aggregation_scope_config(
+        me, my_affected_module_ids=[], helper_session=db_session
+    )
+
+    assert cfg == {"affected_module_ids": []}
+
+
+@pytest.mark.asyncio
+async def test_scope_config_returns_none_when_no_info(db_session: AsyncSession):
+    """No siblings, no own ids, no pipeline_id → returns None so the
+    aggregation falls back to the full slice (legacy behavior)."""
+    me = _recalc(pipeline_id=None, parent_id=1, data_entry_type_id=10)
+    me.meta = {}  # no parent_job_id either
+    db_session.add(me)
+    await db_session.flush()
+
+    cfg = await _build_aggregation_scope_config(
+        me, my_affected_module_ids=[], helper_session=db_session
+    )
+
+    assert cfg is None
+
+
+@pytest.mark.asyncio
+async def test_scope_config_uses_only_own_when_no_real_pipeline(
+    db_session: AsyncSession,
+):
+    """Mock-style pipeline_id (not a real UUID) → helper short-circuits
+    using just the caller's local affected_module_ids. Keeps mock-driven
+    unit tests off the real SessionLocal path in production code."""
+    # Simulate a non-UUID pipeline_id (e.g., test mock).
+    me = _recalc(pipeline_id=None, parent_id=1)  # pipeline_id=None → same code path
+    db_session.add(me)
+    await db_session.flush()
+
+    cfg = await _build_aggregation_scope_config(
+        me, my_affected_module_ids=[7, 8, 9], helper_session=db_session
+    )
+
+    assert cfg == {"affected_module_ids": [7, 8, 9]}

--- a/backend/tests/unit/tasks/test_emission_recalc_coalesce.py
+++ b/backend/tests/unit/tasks/test_emission_recalc_coalesce.py
@@ -21,16 +21,38 @@ from app.models.data_ingestion import (
     IngestionMethod,
     IngestionResult,
     IngestionState,
+    Pipeline,
+    PipelineStatus,
     TargetType,
 )
 from app.models.user import UserProvider
 from app.tasks.emission_recalculation_tasks import _is_last_recalc_sibling
 
 
-def _parent(*, pipeline_id, recalc_jobs_chained: int | None) -> DataIngestionJob:
-    meta: dict = {}
-    if recalc_jobs_chained is not None:
-        meta["recalc_jobs_chained"] = recalc_jobs_chained
+async def _seed_pipeline(
+    session: AsyncSession, *, pipeline_id, expected_recalc: int | None
+) -> None:
+    """Phase 5B (#1236) — coalesce gate reads ``expected`` from
+    ``pipelines.expected_recalc``, not ``parent.meta.recalc_jobs_chained``.
+    Tests seed both the Pipeline row and the parent job so the gate has
+    its full read environment.
+    """
+    if pipeline_id is None:
+        return
+    session.add(
+        Pipeline(
+            id=pipeline_id,
+            kind="csv_ingest",
+            status=PipelineStatus.RUNNING.value,
+            expected_recalc=expected_recalc,
+        )
+    )
+    await session.flush()
+
+
+def _parent(*, pipeline_id) -> DataIngestionJob:
+    """Parent ingest job — Phase 5B: no ``recalc_jobs_chained`` meta
+    (it's on ``pipelines.expected_recalc`` now)."""
     return DataIngestionJob(
         entity_type=EntityType.MODULE_PER_YEAR,
         module_type_id=4,
@@ -43,13 +65,13 @@ def _parent(*, pipeline_id, recalc_jobs_chained: int | None) -> DataIngestionJob
         is_current=False,
         pipeline_id=pipeline_id,
         job_type="csv_ingest",
-        meta=meta,
+        meta={},
     )
 
 
-def _recalc(
-    *, pipeline_id, parent_id: int, data_entry_type_id: int = 10
-) -> DataIngestionJob:
+def _recalc(*, pipeline_id, data_entry_type_id: int = 10) -> DataIngestionJob:
+    """Recalc child — Phase 5B: no ``parent_job_id`` meta (root is
+    identifiable by lowest-id job in the pipeline)."""
     return DataIngestionJob(
         entity_type=EntityType.MODULE_PER_YEAR,
         module_type_id=4,
@@ -63,7 +85,7 @@ def _recalc(
         is_current=False,
         pipeline_id=pipeline_id,
         job_type="emission_recalc",
-        meta={"parent_job_id": parent_id},
+        meta={},
     )
 
 
@@ -71,10 +93,9 @@ def _recalc(
 async def test_single_recalc_pipeline_is_last(db_session: AsyncSession):
     """expected=1, this is the only recalc → it IS the last sibling."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=1)
-    db_session.add(parent)
-    await db_session.flush()
-    recalc = _recalc(pipeline_id=pid, parent_id=parent.id)
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=1)
+    db_session.add(_parent(pipeline_id=pid))
+    recalc = _recalc(pipeline_id=pid)
     db_session.add(recalc)
     await db_session.flush()
 
@@ -87,12 +108,11 @@ async def test_single_recalc_pipeline_is_last(db_session: AsyncSession):
 async def test_first_of_three_is_not_last(db_session: AsyncSession):
     """expected=3, only this one's recalc_work_complete set → not last."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=3)
-    db_session.add(parent)
-    await db_session.flush()
-    r1 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
-    r2 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
-    r3 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=12)
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=3)
+    db_session.add(_parent(pipeline_id=pid))
+    r1 = _recalc(pipeline_id=pid, data_entry_type_id=10)
+    r2 = _recalc(pipeline_id=pid, data_entry_type_id=11)
+    r3 = _recalc(pipeline_id=pid, data_entry_type_id=12)
     for r in (r1, r2, r3):
         db_session.add(r)
     await db_session.flush()
@@ -109,12 +129,11 @@ async def test_first_of_three_is_not_last(db_session: AsyncSession):
 async def test_third_of_three_is_last(db_session: AsyncSession):
     """After r1 and r2 ran their gate (flag stamped), r3's gate → last."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=3)
-    db_session.add(parent)
-    await db_session.flush()
-    r1 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
-    r2 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
-    r3 = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=12)
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=3)
+    db_session.add(_parent(pipeline_id=pid))
+    r1 = _recalc(pipeline_id=pid, data_entry_type_id=10)
+    r2 = _recalc(pipeline_id=pid, data_entry_type_id=11)
+    r3 = _recalc(pipeline_id=pid, data_entry_type_id=12)
     for r in (r1, r2, r3):
         db_session.add(r)
     await db_session.flush()
@@ -132,10 +151,10 @@ async def test_legacy_no_pipeline_id_falls_back_to_true(
     db_session: AsyncSession,
 ):
     """No pipeline_id → preserves prior behavior (always chain)."""
-    parent = _parent(pipeline_id=None, recalc_jobs_chained=1)
+    parent = _parent(pipeline_id=None)
     db_session.add(parent)
     await db_session.flush()
-    recalc = _recalc(pipeline_id=None, parent_id=parent.id)
+    recalc = _recalc(pipeline_id=None)
     db_session.add(recalc)
     await db_session.flush()
 
@@ -143,15 +162,16 @@ async def test_legacy_no_pipeline_id_falls_back_to_true(
 
 
 @pytest.mark.asyncio
-async def test_legacy_no_recalc_jobs_chained_falls_back_to_true(
+async def test_legacy_pipeline_without_expected_recalc_falls_back_to_true(
     db_session: AsyncSession,
 ):
-    """Parent without ``recalc_jobs_chained`` meta → fall back to chain."""
+    """Pipeline row exists but ``expected_recalc`` is NULL (e.g. legacy
+    pre-Phase-5A pipelines) → coalesce gate falls back to True so the
+    aggregation chain still fires (preserves prior behavior)."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=None)
-    db_session.add(parent)
-    await db_session.flush()
-    recalc = _recalc(pipeline_id=pid, parent_id=parent.id)
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=None)
+    db_session.add(_parent(pipeline_id=pid))
+    recalc = _recalc(pipeline_id=pid)
     db_session.add(recalc)
     await db_session.flush()
 
@@ -159,20 +179,57 @@ async def test_legacy_no_recalc_jobs_chained_falls_back_to_true(
 
 
 @pytest.mark.asyncio
-async def test_legacy_no_parent_job_id_falls_back_to_true(
+async def test_legacy_no_pipeline_row_falls_back_to_true(
     db_session: AsyncSession,
 ):
-    """Recalc without ``parent_job_id`` in meta → fall back to chain."""
+    """Pipeline row missing entirely (pre-Phase-1 legacy / dropped row)
+    → gate falls back to True so the aggregation chain still fires."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=1)
-    db_session.add(parent)
-    await db_session.flush()
-    recalc = _recalc(pipeline_id=pid, parent_id=parent.id)
-    recalc.meta = {}  # strip parent_job_id
+    # NO _seed_pipeline call — Pipeline row absent.
+    db_session.add(_parent(pipeline_id=pid))
+    recalc = _recalc(pipeline_id=pid)
     db_session.add(recalc)
     await db_session.flush()
 
     assert await _is_last_recalc_sibling(recalc, helper_session=db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_siblings_yield_exactly_one_last(
+    db_session: AsyncSession,
+):
+    """LOCK-DOWN test for 4A.1 (#1236 Phase 5B advisor blocker).
+
+    Two siblings both call the gate against the SAME ``pipeline_id``.
+    The lock moved from parent-job to pipeline row in Phase 5B; if the
+    lock target moved wrong (e.g. lock on parent stayed while the read
+    of ``expected_recalc`` migrated to pipelines), BOTH siblings could
+    see "done >= expected" and chain their own aggregation — silently
+    regressing the coalesce to N aggregations per pipeline.
+
+    With correct serialisation, exactly one of the two returns True
+    (the second caller, after the first stamped its own flag).
+    """
+    pid = uuid4()
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=2)
+    db_session.add(_parent(pipeline_id=pid))
+    r1 = _recalc(pipeline_id=pid, data_entry_type_id=10)
+    r2 = _recalc(pipeline_id=pid, data_entry_type_id=11)
+    db_session.add_all([r1, r2])
+    await db_session.flush()
+
+    # Sequential calls on the shared session (the production gate opens
+    # its own short-lived session and SELECT … FOR UPDATEs the pipeline
+    # row to serialise; here we exercise the predicate logic with the
+    # injected helper_session so the order-independence assertion holds
+    # via the recalc_work_complete flag — see test_third_of_three).
+    a = await _is_last_recalc_sibling(r1, helper_session=db_session)
+    b = await _is_last_recalc_sibling(r2, helper_session=db_session)
+
+    assert (a, b).count(True) == 1, (
+        f"Exactly ONE sibling must be 'last' — got {(a, b)} "
+        "(if both True, 4A.1's single-aggregation guarantee is broken)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -189,23 +246,22 @@ async def test_scope_config_unions_own_and_siblings(db_session: AsyncSession):
     """Last sibling's own affected_module_ids (from local stats) + siblings'
     finished contributions → full union in the aggregation config."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=3)
-    db_session.add(parent)
-    await db_session.flush()
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=3)
+    db_session.add(_parent(pipeline_id=pid))
     # Two FINISHED siblings with their affected_module_ids recorded.
-    sibling_a = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
+    sibling_a = _recalc(pipeline_id=pid, data_entry_type_id=10)
     sibling_a.state = IngestionState.FINISHED
     sibling_a.meta = {
         **(sibling_a.meta or {}),
         "recalculation": {"affected_module_ids": [101, 202]},
     }
-    sibling_b = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
+    sibling_b = _recalc(pipeline_id=pid, data_entry_type_id=11)
     sibling_b.state = IngestionState.FINISHED
     sibling_b.meta = {
         **(sibling_b.meta or {}),
         "recalculation": {"affected_module_ids": [202, 303]},
     }
-    me = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=12)
+    me = _recalc(pipeline_id=pid, data_entry_type_id=12)
     db_session.add_all([sibling_a, sibling_b, me])
     await db_session.flush()
 
@@ -225,13 +281,12 @@ async def test_scope_config_returns_empty_list_when_all_empty(
     returns {"affected_module_ids": []} (precise 'nothing to do', NOT
     the legacy fallback)."""
     pid = uuid4()
-    parent = _parent(pipeline_id=pid, recalc_jobs_chained=2)
-    db_session.add(parent)
-    await db_session.flush()
-    sib = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=10)
+    await _seed_pipeline(db_session, pipeline_id=pid, expected_recalc=2)
+    db_session.add(_parent(pipeline_id=pid))
+    sib = _recalc(pipeline_id=pid, data_entry_type_id=10)
     sib.state = IngestionState.FINISHED
     sib.meta = {**(sib.meta or {}), "recalculation": {"affected_module_ids": []}}
-    me = _recalc(pipeline_id=pid, parent_id=parent.id, data_entry_type_id=11)
+    me = _recalc(pipeline_id=pid, data_entry_type_id=11)
     db_session.add_all([sib, me])
     await db_session.flush()
 
@@ -246,8 +301,8 @@ async def test_scope_config_returns_empty_list_when_all_empty(
 async def test_scope_config_returns_none_when_no_info(db_session: AsyncSession):
     """No siblings, no own ids, no pipeline_id → returns None so the
     aggregation falls back to the full slice (legacy behavior)."""
-    me = _recalc(pipeline_id=None, parent_id=1, data_entry_type_id=10)
-    me.meta = {}  # no parent_job_id either
+    me = _recalc(pipeline_id=None, data_entry_type_id=10)
+    me.meta = {}
     db_session.add(me)
     await db_session.flush()
 
@@ -265,8 +320,7 @@ async def test_scope_config_uses_only_own_when_no_real_pipeline(
     """Mock-style pipeline_id (not a real UUID) → helper short-circuits
     using just the caller's local affected_module_ids. Keeps mock-driven
     unit tests off the real SessionLocal path in production code."""
-    # Simulate a non-UUID pipeline_id (e.g., test mock).
-    me = _recalc(pipeline_id=None, parent_id=1)  # pipeline_id=None → same code path
+    me = _recalc(pipeline_id=None)  # pipeline_id=None → same code path
     db_session.add(me)
     await db_session.flush()
 

--- a/backend/tests/unit/tasks/test_factor_recalc_lock.py
+++ b/backend/tests/unit/tasks/test_factor_recalc_lock.py
@@ -1,0 +1,115 @@
+"""#1236 Phase 4B — ``acquire_factor_recalc_lock`` helper.
+
+Per-``(module, year)`` advisory lock used by ``factor_ingest_handler``
+and ``emission_recalc_handler`` (+ ``module_emission_recalc_handler``)
+to serialise factor writes vs concurrent recalcs of the same scope.
+
+Tests pin: lock IS attempted on Postgres with the right
+``(category, key)`` pair; SKIPPED on non-Postgres backends; SKIPPED
+when scope is missing (defensive).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.tasks._locks import (
+    _FACTOR_RECALC_LOCK_CATEGORY,
+    _encode_module_year_key,
+    acquire_factor_recalc_lock,
+)
+
+
+def test_encode_module_year_key_is_collision_free():
+    """Distinct (module, year) pairs hash to distinct keys."""
+    seen: dict[int, tuple[int, int]] = {}
+    for module in (1, 2, 4, 7, 8, 99):
+        for year in (2023, 2024, 2025, 2026):
+            key = _encode_module_year_key(module, year)
+            assert key not in seen, (
+                f"collision: ({module},{year}) and {seen[key]} → {key}"
+            )
+            seen[key] = (module, year)
+
+
+@pytest.mark.asyncio
+async def test_acquires_lock_on_postgres():
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "postgresql"
+    data_session.execute = AsyncMock()
+
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=4,
+        year=2026,
+        handler_label="test",
+    )
+
+    data_session.execute.assert_awaited_once()
+    args = data_session.execute.await_args
+    sql_text = str(args.args[0])
+    assert "pg_advisory_xact_lock" in sql_text
+    params = args.args[1]
+    assert params["cat"] == _FACTOR_RECALC_LOCK_CATEGORY
+    assert params["key"] == _encode_module_year_key(4, 2026)
+
+
+@pytest.mark.asyncio
+async def test_skips_lock_on_non_postgres():
+    """SQLite / other → single-writer model already serialises; no-op."""
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "sqlite"
+    data_session.execute = AsyncMock()
+
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=4,
+        year=2026,
+        handler_label="test",
+    )
+
+    data_session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_lock_when_module_type_id_missing():
+    """Defensive: job without scope shouldn't crash the handler at the
+    lock step — skip and let the handler's own scope validation raise."""
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "postgresql"
+    data_session.execute = AsyncMock()
+
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=None,
+        year=2026,
+        handler_label="test",
+    )
+
+    data_session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_lock_when_year_missing():
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "postgresql"
+    data_session.execute = AsyncMock()
+
+    await acquire_factor_recalc_lock(
+        data_session,
+        module_type_id=4,
+        year=None,
+        handler_label="test",
+    )
+
+    data_session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lock_category_distinct_from_aggregation_lock():
+    """4B's category must not collide with 4A.2's aggregation lock —
+    they're in the same advisory-lock namespace and accidental
+    collisions would cross-serialise unrelated work."""
+    from app.tasks.aggregation_tasks import _AGGREGATION_LOCK_CATEGORY
+
+    assert _FACTOR_RECALC_LOCK_CATEGORY != _AGGREGATION_LOCK_CATEGORY

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -603,20 +603,22 @@ async def test_unit_sync_acquires_advisory_lock_on_postgres():
     ):
         await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
 
-    # The advisory lock is the FIRST data_session.execute call; the
-    # year-config lookup follows.
-    assert data_session.execute.await_count >= 1
-    first_call = data_session.execute.await_args_list[0]
-    sql_text = str(first_call.args[0])
-    assert "pg_advisory_xact_lock" in sql_text
-    params = first_call.args[1]
-    assert params["year"] == 2026
+    # Look up the per-year lock call (the global lock fires first; this
+    # test pins the per-year one — the order is locked down separately
+    # in ``test_unit_sync_acquires_global_lock_before_per_year_lock``).
+    per_year_call = next(
+        call
+        for call in data_session.execute.await_args_list
+        if "pg_advisory_xact_lock" in str(call.args[0])
+        and "year" in (call.args[1] if len(call.args) > 1 else {})
+    )
+    assert per_year_call.args[1]["year"] == 2026
     # Must share the aggregation handler's category — that's the
     # whole point of this commit.  Pin it as 1236 explicitly so a
     # future refactor that splits the categories has to update this
     # test, not silently break the mutual exclusion.
-    assert params["cat"] == 1236
-    assert params["cat"] == unit_sync_mod._AGGREGATION_LOCK_CATEGORY
+    assert per_year_call.args[1]["cat"] == 1236
+    assert per_year_call.args[1]["cat"] == unit_sync_mod._AGGREGATION_LOCK_CATEGORY
 
 
 @pytest.mark.asyncio
@@ -668,6 +670,83 @@ def test_unit_sync_lock_category_matches_aggregation():
     assert (
         unit_sync_mod._AGGREGATION_LOCK_CATEGORY
         == aggregation_tasks._AGGREGATION_LOCK_CATEGORY
+    )
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_acquires_global_lock_before_per_year_lock():
+    """User-reported 2026-05-20: creating year 2026 + 2025 in parallel
+    crashed the second handler with ``UniqueViolation`` on
+    ``ix_units_institutional_code`` (code 14270).  ``units`` is a
+    GLOBAL table; the per-year lock partitions by year, so different
+    years didn't mutually exclude — both transactions raced on the
+    ``units`` bulk_upsert.  Fix: a GLOBAL 1-int advisory lock takes
+    precedence over the per-year lock.
+
+    This test pins the order (global → per-year) and the category
+    distinctness so a refactor can't silently break the mutual
+    exclusion."""
+    job = _make_job(job_type="unit_sync", meta={"config": {"target_year": 2026}})
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "postgresql"
+    _no_year_cfg = MagicMock()
+    _no_year_cfg.scalar_one_or_none = MagicMock(return_value=None)
+    data_session.execute = AsyncMock(return_value=_no_year_cfg)
+
+    stubs = _stub_unit_sync_deps()
+
+    with (
+        patch.object(
+            unit_sync_mod, "DataIngestionRepository", return_value=stubs["repo"]
+        ),
+        patch.object(
+            unit_sync_mod, "get_unit_provider", return_value=stubs["unit_provider"]
+        ),
+        patch.object(
+            unit_sync_mod, "get_role_provider", return_value=stubs["role_provider"]
+        ),
+        patch.object(unit_sync_mod, "UnitService", return_value=stubs["unit_service"]),
+        patch.object(unit_sync_mod, "UserService", return_value=stubs["user_service"]),
+        patch.object(
+            unit_sync_mod,
+            "CarbonReportService",
+            return_value=stubs["carbon_report_service"],
+        ),
+    ):
+        await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
+
+    # Two advisory locks in order: global first, per-year second.
+    lock_calls = [
+        call
+        for call in data_session.execute.await_args_list
+        if "pg_advisory_xact_lock" in str(call.args[0])
+    ]
+    assert len(lock_calls) == 2, (
+        f"expected 2 advisory-lock calls (global + per-year), got {len(lock_calls)}"
+    )
+    # Global lock fires FIRST and uses the 1-int variant (no year param).
+    first_params = lock_calls[0].args[1]
+    assert first_params["cat"] == 1239
+    assert first_params["cat"] == unit_sync_mod._UNIT_SYNC_GLOBAL_LOCK_CATEGORY
+    assert "year" not in first_params, (
+        "global lock must use the 1-int variant — passing a year would "
+        "partition the keyspace and break mutual exclusion across years"
+    )
+    # Per-year lock follows with the year-2026 key.
+    second_params = lock_calls[1].args[1]
+    assert second_params["cat"] == 1236
+    assert second_params["year"] == 2026
+
+
+def test_unit_sync_global_lock_category_distinct_from_aggregation():
+    """Global unit_sync lock MUST live in a different category from the
+    per-year aggregation lock — they protect different invariants and
+    must not partition each other's keyspace."""
+    assert (
+        unit_sync_mod._UNIT_SYNC_GLOBAL_LOCK_CATEGORY
+        != unit_sync_mod._AGGREGATION_LOCK_CATEGORY
     )
 
 

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -402,6 +402,13 @@ async def test_unit_sync_handler_runs_full_chain_and_returns_summary():
     job_session = MagicMock()
     job_session.commit = AsyncMock()
     data_session = MagicMock()
+    # #1234-followup: handler now stamps configuration_completed via a
+    # data_session.execute(select(YearConfiguration)…); stub it to
+    # return "no row" so the handler hits its log-and-skip branch and
+    # the rest of the test exercises the unit-sync chain as before.
+    _no_year_cfg = MagicMock()
+    _no_year_cfg.scalar_one_or_none = MagicMock(return_value=None)
+    data_session.execute = AsyncMock(return_value=_no_year_cfg)
 
     repo = MagicMock()
     repo.update_ingestion_job = AsyncMock()
@@ -458,6 +465,13 @@ async def test_unit_sync_handler_falls_back_to_job_year_when_config_missing():
     job_session = MagicMock()
     job_session.commit = AsyncMock()
     data_session = MagicMock()
+    # #1234-followup: handler now stamps configuration_completed via a
+    # data_session.execute(select(YearConfiguration)…); stub it to
+    # return "no row" so the handler hits its log-and-skip branch and
+    # the rest of the test exercises the unit-sync chain as before.
+    _no_year_cfg = MagicMock()
+    _no_year_cfg.scalar_one_or_none = MagicMock(return_value=None)
+    data_session.execute = AsyncMock(return_value=_no_year_cfg)
 
     repo = MagicMock()
     repo.update_ingestion_job = AsyncMock()

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -171,7 +171,7 @@ async def test_emission_recalc_handler_chains_aggregation_with_dedup_on_success(
     # for the dedup INSERT lives on the job-progress session, not the
     # data_session that the workflow scrubbed and committed).
     assert chain_kwargs["session"] is job_session
-    assert meta["aggregation_job_id"] == 999
+    assert "aggregation_job_id" not in meta  # Phase 5B retired
     crm_svc_factory.assert_not_called()
 
 
@@ -218,7 +218,7 @@ async def test_emission_recalc_handler_chains_aggregation_on_warning():
     assert chain_kwargs["year"] == job.year
     assert chain_kwargs["dedup_config"] is AGGREGATION_DEDUP
     assert meta["result"] == IngestionResult.WARNING
-    assert meta["aggregation_job_id"] == 777
+    assert "aggregation_job_id" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio
@@ -324,7 +324,7 @@ async def test_module_emission_recalc_iterates_all_types():
     assert meta["result"] == IngestionResult.SUCCESS
     assert meta["total_recalculated"] == 6
     assert meta["total_errors"] == 0
-    assert meta["aggregation_job_id"] == 555
+    assert "aggregation_job_id" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -454,6 +454,16 @@ async def test_unit_sync_handler_runs_full_chain_and_returns_summary():
     assert meta["units_synced"] == 2
     assert meta["carbon_reports_created"] == 2
     assert meta["carbon_report_year"] == 2025
+    # #2B — phase checklist: 4 phases recorded, all finished.
+    phases = meta.get("phases") or []
+    assert [p["name"] for p in phases] == [
+        "fetch_units",
+        "upsert_units_and_users",
+        "create_carbon_reports",
+        "ensure_modules",
+    ]
+    assert all(p["state"] == "finished" for p in phases)
+    assert all("started_at" in p and "finished_at" in p for p in phases)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -525,6 +525,153 @@ async def test_unit_sync_handler_raises_when_no_target_year_anywhere():
 
 
 # ---------------------------------------------------------------------------
+# unit_sync ↔ aggregation concurrency safety (#1236) — both rewrite
+# ``carbon_reports`` for the same (unit, year); the SAME advisory-lock
+# category (1236) makes them mutually exclude on the year key.
+# ---------------------------------------------------------------------------
+
+
+def _stub_unit_sync_deps():
+    """Minimal stub bundle to drive ``unit_sync_handler`` through to
+    completion in a test — same shape as the full-chain test above,
+    pared down so the lock tests stay focused on the lock SQL."""
+    unit_provider = MagicMock()
+    unit_provider.fetch_all_units = AsyncMock(return_value=([], []))
+    unit_provider.map_api_unit = MagicMock(side_effect=lambda u: MagicMock())
+
+    role_provider = MagicMock()
+    role_provider.map_api_user = MagicMock(return_value=MagicMock())
+
+    unit_service = MagicMock()
+    unit_service.bulk_upsert = AsyncMock(return_value=MagicMock(data=[]))
+
+    user_service = MagicMock()
+    user_service.bulk_upsert = AsyncMock(return_value=MagicMock(data=[]))
+
+    carbon_report_service = MagicMock()
+    carbon_report_service.bulk_upsert = AsyncMock(return_value=[])
+    carbon_report_service.ensure_modules_for_reports = AsyncMock()
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+
+    return {
+        "unit_provider": unit_provider,
+        "role_provider": role_provider,
+        "unit_service": unit_service,
+        "user_service": user_service,
+        "carbon_report_service": carbon_report_service,
+        "repo": repo,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_acquires_advisory_lock_on_postgres():
+    """Postgres backend → handler calls
+    ``pg_advisory_xact_lock(_AGGREGATION_LOCK_CATEGORY, year)`` BEFORE
+    any carbon_reports write.  Shared category with the aggregation
+    handler (same number, 1236) so the two mutually exclude on the
+    same year key."""
+    job = _make_job(job_type="unit_sync", meta={"config": {"target_year": 2026}})
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "postgresql"
+    _no_year_cfg = MagicMock()
+    _no_year_cfg.scalar_one_or_none = MagicMock(return_value=None)
+    data_session.execute = AsyncMock(return_value=_no_year_cfg)
+
+    stubs = _stub_unit_sync_deps()
+
+    with (
+        patch.object(
+            unit_sync_mod, "DataIngestionRepository", return_value=stubs["repo"]
+        ),
+        patch.object(
+            unit_sync_mod, "get_unit_provider", return_value=stubs["unit_provider"]
+        ),
+        patch.object(
+            unit_sync_mod, "get_role_provider", return_value=stubs["role_provider"]
+        ),
+        patch.object(unit_sync_mod, "UnitService", return_value=stubs["unit_service"]),
+        patch.object(unit_sync_mod, "UserService", return_value=stubs["user_service"]),
+        patch.object(
+            unit_sync_mod,
+            "CarbonReportService",
+            return_value=stubs["carbon_report_service"],
+        ),
+    ):
+        await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
+
+    # The advisory lock is the FIRST data_session.execute call; the
+    # year-config lookup follows.
+    assert data_session.execute.await_count >= 1
+    first_call = data_session.execute.await_args_list[0]
+    sql_text = str(first_call.args[0])
+    assert "pg_advisory_xact_lock" in sql_text
+    params = first_call.args[1]
+    assert params["year"] == 2026
+    # Must share the aggregation handler's category — that's the
+    # whole point of this commit.  Pin it as 1236 explicitly so a
+    # future refactor that splits the categories has to update this
+    # test, not silently break the mutual exclusion.
+    assert params["cat"] == 1236
+    assert params["cat"] == unit_sync_mod._AGGREGATION_LOCK_CATEGORY
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_skips_advisory_lock_on_non_postgres():
+    """SQLite / other → no advisory-lock attempt (single-writer model
+    serialises tests; lock is a no-op).  Mirrors the aggregation
+    handler's dialect-gate."""
+    job = _make_job(job_type="unit_sync", meta={"config": {"target_year": 2026}})
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+    data_session.get_bind.return_value.dialect.name = "sqlite"
+    _no_year_cfg = MagicMock()
+    _no_year_cfg.scalar_one_or_none = MagicMock(return_value=None)
+    data_session.execute = AsyncMock(return_value=_no_year_cfg)
+
+    stubs = _stub_unit_sync_deps()
+
+    with (
+        patch.object(
+            unit_sync_mod, "DataIngestionRepository", return_value=stubs["repo"]
+        ),
+        patch.object(
+            unit_sync_mod, "get_unit_provider", return_value=stubs["unit_provider"]
+        ),
+        patch.object(
+            unit_sync_mod, "get_role_provider", return_value=stubs["role_provider"]
+        ),
+        patch.object(unit_sync_mod, "UnitService", return_value=stubs["unit_service"]),
+        patch.object(unit_sync_mod, "UserService", return_value=stubs["user_service"]),
+        patch.object(
+            unit_sync_mod,
+            "CarbonReportService",
+            return_value=stubs["carbon_report_service"],
+        ),
+    ):
+        await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
+
+    for call in data_session.execute.await_args_list:
+        assert "pg_advisory_xact_lock" not in str(call.args[0])
+
+
+def test_unit_sync_lock_category_matches_aggregation():
+    """Pin the invariant: unit_sync and aggregation MUST share the same
+    category number, otherwise their advisory locks live in disjoint
+    keyspaces and the mutual exclusion is silently broken."""
+    from app.tasks import aggregation_tasks
+
+    assert (
+        unit_sync_mod._AGGREGATION_LOCK_CATEGORY
+        == aggregation_tasks._AGGREGATION_LOCK_CATEGORY
+    )
+
+
+# ---------------------------------------------------------------------------
 # bootstrap.py — every shipped handler MUST be registered after bootstrap
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/tasks/test_ingestion_handlers.py
+++ b/backend/tests/unit/tasks/test_ingestion_handlers.py
@@ -159,6 +159,103 @@ async def test_csv_ingest_error_result_does_not_report_success():
     assert meta["status_message"] == "ERROR: 0 inserted, 50072 skipped"
 
 
+# ---------------------------------------------------------------------------
+# Lone-orphan ``last_error`` improvement (#1236 follow-up) —
+# ``finalize_ingest_meta`` enriches the honest summary with the first
+# row_error's reason so a pipeline-of-one parent doesn't surface as just
+# "ERROR: 0 inserted, 50 072 skipped" with no clue WHY.
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_ingest_meta_enriches_with_first_row_error_reason():
+    """Every row failed with the same reason → status_message carries
+    a sample of that reason so the operator doesn't have to expand the
+    timeline to find the cause."""
+    result = {
+        "status_message": "Success",  # the ingest() lie
+        "data": {
+            "result": IngestionResult.ERROR,
+            "inserted": 0,
+            "skipped": 50072,
+            "row_errors": [
+                {
+                    "row": 1,
+                    "reason": (
+                        "No matching factor found in factors map "
+                        "(kind=Monitors, subkind=None)"
+                    ),
+                },
+                {"row": 2, "reason": "same"},
+            ],
+        },
+    }
+
+    meta = ingest_mod.finalize_ingest_meta(result)
+
+    assert meta["status_message"].startswith(
+        "ERROR: 0 inserted, 50072 skipped — first error: "
+    )
+    assert "kind=Monitors" in meta["status_message"]
+
+
+def test_finalize_ingest_meta_caps_long_reason():
+    """A 600-char reason (e.g. a Postgres traceback) must not bloat the
+    status_message column — capped at ~200 chars with an ellipsis."""
+    long_reason = "x" * 600
+    result = {
+        "status_message": "Success",
+        "data": {
+            "result": IngestionResult.ERROR,
+            "inserted": 0,
+            "skipped": 50000,
+            "row_errors": [{"row": 1, "reason": long_reason}],
+        },
+    }
+
+    meta = ingest_mod.finalize_ingest_meta(result)
+    suffix = meta["status_message"].split("first error: ", 1)[1]
+
+    # 200-char cap (199 chars + "…"); proves the message stays small
+    # even when the underlying reason is multi-KB.
+    assert len(suffix) <= 201
+    assert suffix.endswith("…")
+
+
+def test_finalize_ingest_meta_no_row_errors_keeps_short_summary():
+    """When row_errors is absent (e.g. setup-time fail-fast guard fired
+    before the row loop), the message keeps the count-only summary —
+    no spurious 'first error: None' appended."""
+    result = {
+        "status_message": "Success",
+        "data": {
+            "result": IngestionResult.ERROR,
+            "inserted": 0,
+            "skipped": 0,
+        },
+    }
+    meta = ingest_mod.finalize_ingest_meta(result)
+    assert meta["status_message"] == "ERROR: 0 inserted, 0 skipped"
+    assert "first error" not in meta["status_message"]
+
+
+def test_finalize_ingest_meta_success_path_preserved():
+    """A genuine SUCCESS keeps its original status_message regardless
+    of row_errors content (defensive: row_errors should be empty on
+    SUCCESS, but if a provider still recorded warnings we don't lie
+    about a failure)."""
+    result = {
+        "status_message": "Success",
+        "data": {
+            "result": IngestionResult.SUCCESS,
+            "inserted": 100,
+            "skipped": 0,
+            "row_errors": [{"row": 99, "reason": "warn"}],
+        },
+    }
+    meta = ingest_mod.finalize_ingest_meta(result)
+    assert meta["status_message"] == "Success"
+
+
 @pytest.mark.asyncio
 async def test_api_ingest_handler_uses_same_path():
     """``api_ingest_handler`` shares ``_run_ingest`` — same contract."""

--- a/backend/tests/unit/tasks/test_ingestion_handlers.py
+++ b/backend/tests/unit/tasks/test_ingestion_handlers.py
@@ -151,9 +151,7 @@ async def test_csv_ingest_error_result_does_not_report_success():
         ),
         patch.object(ingest_mod, "chain_job", new_callable=AsyncMock),
     ):
-        meta = await ingest_mod.csv_ingest_handler(
-            job, MagicMock(), MagicMock()
-        )
+        meta = await ingest_mod.csv_ingest_handler(job, MagicMock(), MagicMock())
 
     assert meta["result"] == IngestionResult.ERROR
     assert meta["status_message"] != "Success"
@@ -257,7 +255,7 @@ async def test_factor_ingest_handler_chains_recalc_for_single_type():
     assert chain_kwargs["module_type_id"] == 5
     assert chain_kwargs["data_entry_type_id"] == 11
     assert chain_kwargs["year"] == 2025
-    assert meta["recalc_jobs_chained"] == 1
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
     assert meta["upsert_count"] == 3
 
 
@@ -309,7 +307,7 @@ async def test_factor_ingest_handler_chains_per_det_for_multitype_upload():
     assert mock_chain.await_count == len(expected_dets)
     chained_dets = {c.kwargs["data_entry_type_id"] for c in mock_chain.await_args_list}
     assert chained_dets == set(expected_dets)
-    assert meta["recalc_jobs_chained"] == len(expected_dets)
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio
@@ -450,7 +448,7 @@ async def test_factor_ingest_handler_consults_repo_when_module_and_det_both_null
     chain_kwargs = mock_chain.await_args.kwargs
     assert chain_kwargs["module_type_id"] == 1
     assert chain_kwargs["data_entry_type_id"] == 10
-    assert meta["recalc_jobs_chained"] == 1
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio
@@ -545,7 +543,7 @@ async def test_csv_ingest_handler_chains_recalc_for_single_det():
     assert chain_kwargs["module_type_id"] == 5
     assert chain_kwargs["data_entry_type_id"] == 11
     assert chain_kwargs["year"] == 2025
-    assert meta["recalc_jobs_chained"] == 1
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio
@@ -580,7 +578,7 @@ async def test_csv_ingest_handler_chains_per_det_for_multitype_upload():
     assert mock_chain.await_count == len(expected_dets)
     chained_dets = {c.kwargs["data_entry_type_id"] for c in mock_chain.await_args_list}
     assert chained_dets == set(expected_dets)
-    assert meta["recalc_jobs_chained"] == len(expected_dets)
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio
@@ -627,7 +625,7 @@ async def test_api_ingest_handler_chains_recalc_on_success():
         meta = await ingest_mod.api_ingest_handler(job, MagicMock(), MagicMock())
 
     mock_chain.assert_awaited_once()
-    assert meta["recalc_jobs_chained"] == 1
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
 
 
 @pytest.mark.asyncio
@@ -697,7 +695,7 @@ async def test_csv_ingest_handler_skips_fan_out_when_module_type_id_missing():
         meta = await ingest_mod.csv_ingest_handler(job, MagicMock(), MagicMock())
 
     mock_chain.assert_not_awaited()
-    assert meta["recalc_jobs_chained"] == 0
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
     assert meta["result"] == IngestionResult.SUCCESS
 
 
@@ -777,5 +775,5 @@ async def test_csv_ingest_fan_out_counts_only_owned_children():
 
     # All dets attempted, but only the one owned child counts.
     assert mock_chain.await_count == len(expected_dets)
-    assert meta["recalc_jobs_chained"] == 1
+    assert "recalc_jobs_chained" not in meta  # Phase 5B retired
     assert meta["result"] == IngestionResult.SUCCESS

--- a/backend/tests/unit/tasks/test_ingestion_handlers.py
+++ b/backend/tests/unit/tasks/test_ingestion_handlers.py
@@ -119,6 +119,49 @@ async def test_csv_ingest_handler_resolves_provider_and_returns_meta():
 
 
 @pytest.mark.asyncio
+async def test_csv_ingest_error_result_does_not_report_success():
+    """#1236 root cause: ``ingest()`` hardcodes status_message='Success'
+    when it doesn't raise, but a CSV where every row errored finishes
+    WITHOUT raising and is classified ERROR. A FINISHED job whose
+    result != SUCCESS must NOT claim 'Success' (jobs 2/49/50/51 shape).
+    """
+    job = _make_job(meta={"provider_name": "FakeCSV", "config": {}})
+    fake_provider = MagicMock()
+    fake_provider.set_job_id = AsyncMock()
+    fake_provider.ingest = AsyncMock(
+        return_value={
+            "status_message": "Success",  # the hardcoded ingest() lie
+            "data": {
+                "result": IngestionResult.ERROR,
+                "inserted": 0,
+                "skipped": 50072,
+            },
+        }
+    )
+
+    class FakeProviderClass:
+        def __new__(cls, *args, **kwargs):
+            return fake_provider
+
+    with (
+        patch.object(
+            ingest_mod.ProviderFactory,
+            "get_provider_class",
+            return_value=FakeProviderClass,
+        ),
+        patch.object(ingest_mod, "chain_job", new_callable=AsyncMock),
+    ):
+        meta = await ingest_mod.csv_ingest_handler(
+            job, MagicMock(), MagicMock()
+        )
+
+    assert meta["result"] == IngestionResult.ERROR
+    assert meta["status_message"] != "Success"
+    assert "Success" not in meta["status_message"]
+    assert meta["status_message"] == "ERROR: 0 inserted, 50072 skipped"
+
+
+@pytest.mark.asyncio
 async def test_api_ingest_handler_uses_same_path():
     """``api_ingest_handler`` shares ``_run_ingest`` — same contract."""
     job = _make_job(meta={"provider_name": "FakeAPI"})

--- a/backend/tests/unit/tasks/test_pipeline_reconciler.py
+++ b/backend/tests/unit/tasks/test_pipeline_reconciler.py
@@ -1,0 +1,119 @@
+"""#1236 Phase 3 — pipeline reconciliation cron loop.
+
+Covers the loop-hygiene contract that makes the sweep safe under the
+"runner missed the post-finish write" hazard the cron exists to heal:
+
+- The loop awaits the sweep, then ``asyncio.sleep(interval)``.
+- A raised exception from one iteration does NOT kill the loop.
+- ``CancelledError`` from ``sleep`` propagates so the lifespan shutdown
+  can await the loop cleanly.
+- A quiet sweep (corrected=0) does NOT spam logs.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _short_interval():
+    """Force a tiny sleep so the loop cycles fast under test."""
+    with patch("app.tasks._pipeline_reconciler.get_settings") as gs:
+        gs.return_value = MagicMock(PIPELINE_RECONCILER_INTERVAL_SECONDS=0)
+        yield
+
+
+@pytest.mark.asyncio
+async def test_loop_calls_reconcile_and_sleeps():
+    """Happy path — one full iteration, then sleep."""
+    from app.tasks._pipeline_reconciler import reconcile_pipeline_statuses_loop
+
+    sleep_called = asyncio.Event()
+
+    async def fake_sleep(*_a, **_kw):
+        sleep_called.set()
+        raise asyncio.CancelledError()  # break out after one tick
+
+    with (
+        patch("app.tasks._pipeline_reconciler.DataIngestionRepository") as repo_cls,
+        patch("app.tasks._pipeline_reconciler.SessionLocal") as session_cls,
+        patch("app.tasks._pipeline_reconciler.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        repo_cls.return_value.reconcile_pipeline_statuses = AsyncMock(
+            return_value={"checked": 3, "corrected": 1}
+        )
+        # Async context manager mock for ``async with SessionLocal() as session``.
+        session_cls.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        session_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with pytest.raises(asyncio.CancelledError):
+            await reconcile_pipeline_statuses_loop()
+
+    assert sleep_called.is_set()
+    repo_cls.return_value.reconcile_pipeline_statuses.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_sweep_exception():
+    """A raised exception from ``reconcile_pipeline_statuses`` does NOT
+    kill the loop — the next iteration runs as usual."""
+    from app.tasks._pipeline_reconciler import reconcile_pipeline_statuses_loop
+
+    call_count = {"n": 0}
+
+    async def boom_then_ok(*_):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("transient DB error")
+        return {"checked": 0, "corrected": 0}
+
+    async def fake_sleep(*_a, **_kw):
+        # Break out after the SECOND iteration so we prove the loop
+        # survived the first iteration's exception.
+        if call_count["n"] >= 2:
+            raise asyncio.CancelledError()
+
+    with (
+        patch("app.tasks._pipeline_reconciler.DataIngestionRepository") as repo_cls,
+        patch("app.tasks._pipeline_reconciler.SessionLocal") as session_cls,
+        patch("app.tasks._pipeline_reconciler.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        repo_cls.return_value.reconcile_pipeline_statuses = AsyncMock(
+            side_effect=boom_then_ok
+        )
+        session_cls.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        session_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with pytest.raises(asyncio.CancelledError):
+            await reconcile_pipeline_statuses_loop()
+
+    assert call_count["n"] == 2, "loop must continue past the first exception"
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_info_log_on_quiet_sweep(caplog):
+    """corrected=0 → no INFO log (otherwise the cron would spam at 60s
+    cadence in steady state)."""
+    from app.tasks._pipeline_reconciler import reconcile_pipeline_statuses_loop
+
+    async def fake_sleep(*_a, **_kw):
+        raise asyncio.CancelledError()
+
+    with (
+        patch("app.tasks._pipeline_reconciler.DataIngestionRepository") as repo_cls,
+        patch("app.tasks._pipeline_reconciler.SessionLocal") as session_cls,
+        patch("app.tasks._pipeline_reconciler.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        repo_cls.return_value.reconcile_pipeline_statuses = AsyncMock(
+            return_value={"checked": 100, "corrected": 0}
+        )
+        session_cls.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        session_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with caplog.at_level("INFO", logger="app.tasks._pipeline_reconciler"):
+            with pytest.raises(asyncio.CancelledError):
+                await reconcile_pipeline_statuses_loop()
+
+    healed_logs = [r for r in caplog.records if "healed" in r.message]
+    assert not healed_logs, "quiet sweeps must not log at INFO"

--- a/backend/tests/unit/v1/test_active_pipelines_endpoint.py
+++ b/backend/tests/unit/v1/test_active_pipelines_endpoint.py
@@ -1,0 +1,118 @@
+"""#1234 — ``GET /sync/active-pipelines`` endpoint unit tests.
+
+User-reported (2026-05-20) regression: the endpoint always returned
+``{}`` for ``calco2.backoffice.metier`` users because of an over-eager
+per-module OPA check (``modules.{name}.view``) that filtered out every
+module the role doesn't have a per-module perm for.  But that role is
+*global-scope by design* — it should see every module on the
+data-management page.
+
+The check was meant for a future sub-perimeter scoping (#459) but the
+current OPA policy doesn't grant ``modules.X.view`` to BackOfficeMetier,
+so the filter silently zero'd the response.  Removed: the global
+``backoffice.data_management.view`` gate is sufficient until #459
+ships a real sub-perimeter check.
+
+These tests pin the endpoint to forward ``module_type_ids`` straight
+through to the repo — no per-module pre-filter — so a future re-add of
+the bug fails loudly.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.v1 import data_sync as data_sync_mod
+
+
+@pytest.mark.asyncio
+async def test_active_pipelines_forwards_modules_without_per_module_opa_filter():
+    """Caller passes modules=[4] → endpoint forwards [4] to the repo
+    method, no per-module OPA permission check in between.  This is
+    the regression that broke BackOfficeMetier users on the
+    data-management page (always {}).
+    """
+    fake_db = MagicMock()
+    fake_user = MagicMock()
+    fake_repo = MagicMock()
+    fake_repo.get_current_pipeline_ids_for_modules = AsyncMock(
+        return_value={4: "pipeline-uuid-stub"}
+    )
+
+    with patch.object(data_sync_mod, "DataIngestionRepository", return_value=fake_repo):
+        result = await data_sync_mod.get_active_pipelines(
+            year=2026,
+            modules="4",
+            db=fake_db,
+            current_user=fake_user,
+        )
+
+    fake_repo.get_current_pipeline_ids_for_modules.assert_awaited_once_with(
+        [4], year=2026
+    )
+    # Result is module_id → pipeline_id (string-serialised UUID).
+    assert result == {4: "pipeline-uuid-stub"}
+
+
+@pytest.mark.asyncio
+async def test_active_pipelines_does_not_call_per_module_permission_check():
+    """Pin the absence of the OPA call.  If a refactor reintroduces
+    ``get_module_permission_decision`` in this endpoint without
+    sub-perimeter scoping, it'll silently regress to filtering out
+    every module for BackOfficeMetier — this test makes that loud."""
+    fake_db = MagicMock()
+    fake_user = MagicMock()
+    fake_repo = MagicMock()
+    fake_repo.get_current_pipeline_ids_for_modules = AsyncMock(return_value={})
+
+    # Patch the policy function so any accidental invocation is visible.
+    patched_decision = AsyncMock(return_value={"allow": True})
+    with (
+        patch.object(data_sync_mod, "DataIngestionRepository", return_value=fake_repo),
+        patch("app.core.policy.get_module_permission_decision", patched_decision),
+    ):
+        await data_sync_mod.get_active_pipelines(
+            year=2026,
+            modules="4,5,6",
+            db=fake_db,
+            current_user=fake_user,
+        )
+
+    # Endpoint must NOT call the per-module permission helper.
+    patched_decision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_pipelines_empty_modules_short_circuits():
+    """Empty ``modules`` query param returns ``{}`` without calling the
+    repo — defensive contract, unchanged by the fix."""
+    fake_db = MagicMock()
+    fake_user = MagicMock()
+    fake_repo = MagicMock()
+    fake_repo.get_current_pipeline_ids_for_modules = AsyncMock()
+
+    with patch.object(data_sync_mod, "DataIngestionRepository", return_value=fake_repo):
+        result = await data_sync_mod.get_active_pipelines(
+            year=2026, modules="", db=fake_db, current_user=fake_user
+        )
+
+    assert result == {}
+    fake_repo.get_current_pipeline_ids_for_modules.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_pipelines_invalid_module_id_raises_400():
+    """Non-integer module id → HTTP 400 (validation), unchanged by the fix."""
+    from fastapi import HTTPException
+
+    fake_db = MagicMock()
+    fake_user = MagicMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await data_sync_mod.get_active_pipelines(
+            year=2026,
+            modules="4,not-an-int",
+            db=fake_db,
+            current_user=fake_user,
+        )
+    assert exc.value.status_code == 400

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -141,6 +141,143 @@ async def test_recalculate_partial_error():
 
 
 @pytest.mark.asyncio
+async def test_recalculate_aborts_batch_on_connection_invalidated():
+    """A connection-invalidated DBAPIError aborts the whole batch
+    (re-raised) instead of looping the same fatal error per remaining
+    entry.  Regression for the stage incident where one dead-connection
+    failure produced one identical "transaction aborted / can't
+    reconnect" log line per remaining data_entry and a silently failed
+    job.  Re-raising lets the runner record FINISHED+ERROR with the
+    real cause (per-entry data errors still continue — see
+    test_recalculate_partial_error)."""
+    from sqlalchemy.exc import DBAPIError
+
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entries = [_make_mock_entry(1, 10), _make_mock_entry(2, 11)]
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryResponse"
+        ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
+
+        def _model_validate(entry):
+            m = MagicMock()
+            m.id = entry.id
+            return m
+
+        mock_response_cls.model_validate.side_effect = _model_validate
+
+        upsert_calls: list[int] = []
+
+        async def _upsert(entry_response):
+            upsert_calls.append(entry_response.id)
+            if entry_response.id == 1:
+                raise DBAPIError(
+                    "UPDATE data_entry_emissions ...",
+                    {},
+                    Exception("server closed the connection unexpectedly"),
+                    connection_invalidated=True,
+                )
+
+        mock_emission_cls.return_value.upsert_by_data_entry = _upsert
+
+        with pytest.raises(DBAPIError):
+            await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+
+    # Aborted at the first entry — the second was never attempted, so
+    # no error storm and no masking of the first cause.
+    assert upsert_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_recalculate_aborts_batch_on_pending_rollback():
+    """A ``PendingRollbackError`` / ``InvalidRequestError`` (the
+    "Can't reconnect until invalid transaction is rolled back" shape
+    actually seen in the stage storm) must also abort the batch — not
+    just ``DBAPIError.connection_invalidated``.  This is the case the
+    first version of the fix missed: once the session needs a full
+    rollback, every remaining entry (including ``begin_nested()``'s
+    SAVEPOINT enter) re-raises the same error."""
+    from sqlalchemy.exc import PendingRollbackError
+
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entries = [_make_mock_entry(1, 10), _make_mock_entry(2, 11)]
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryResponse"
+        ) as mock_response_cls,
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=entries
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
+
+        def _model_validate(entry):
+            m = MagicMock()
+            m.id = entry.id
+            return m
+
+        mock_response_cls.model_validate.side_effect = _model_validate
+
+        upsert_calls: list[int] = []
+
+        async def _upsert(entry_response):
+            upsert_calls.append(entry_response.id)
+            if entry_response.id == 1:
+                raise PendingRollbackError(
+                    "This Session's transaction has been rolled back "
+                    "due to a previous exception during flush."
+                )
+
+        mock_emission_cls.return_value.upsert_by_data_entry = _upsert
+
+        with pytest.raises(PendingRollbackError):
+            await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
+
+    assert upsert_calls == [1]
+
+
+@pytest.mark.asyncio
 async def test_recalculate_empty_result():
     """No data entries for the type/year → all counts are zero."""
     mock_session = MagicMock()

--- a/docs/code-review/1249-copilot-feedback-fix-1236-pipeline-correctness-observability-phase-1-5-concurrency-fixes-ux.md
+++ b/docs/code-review/1249-copilot-feedback-fix-1236-pipeline-correctness-observability-phase-1-5-concurrency-fixes-ux.md
@@ -92,6 +92,14 @@ Copilot reviewed 63 out of 63 changed files in this pull request and generated 3
 
 ---
 
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+Copilot reviewed 66 out of 66 changed files in this pull request and generated 6 comments.
+
+---
+
 ### File: `backend/app/api/v1/data_sync.py` (Line null) — github-advanced-security[bot]
 
 ## CodeQL / Non-iterable used in for loop
@@ -129,20 +137,44 @@ Import of module [app.tasks.ingestion_tasks](1) begins an import cycle.
 
 ## New inline imports were introduced inside run_job() for \_chain helpers. These don’t appear to be required for avoiding a circular dependency (runner already imports from app.tasks.\_chain elsewhere), and they make dependencies harder to audit and can hide import-time errors until runtime. Prefer moving these imports to the module top (or at least the top of run_job alongside the existing bootstrap_handlers import) so they’re explicit and consistent.
 
+### File: `frontend/src/components/molecules/data-management/UploadCard.vue` (Line 107) — Copilot
+
+## `TARGET_TO_KINDS[TargetType.DATA_ENTRIES]` only allows `csv_ingest`/`api_ingest`, but backend also creates pipelines with kind `emission_recalc` and `module_emission_recalc` for the “Recalculate” actions (see `POST /sync/recalculate-emissions/...`). With the current mapping, those pipelines won’t show phase progress / the amber in-progress indicator on the data cards, which contradicts the intent of seeding `pipeline_id` from the recalc responses. Add the recalc kinds to the DATA_ENTRIES allowed list (or switch to a broader rule for DATA_ENTRIES pipelines).
+
+### File: `docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md` (Line 5) — Copilot
+
+## This new implementation plan is missing the required YAML frontmatter (`---` block with at least `status`, `issue`, `last_updated`, `summary`). `docs/gen_indexes.py` groups implementation plans using that frontmatter; without it this page will fall under “Uncategorized” in the generated Implementation Plans index.
+
+### File: `docs/src/implementation-plans/1234-pipeline-operations-console.md` (Line 4) — Copilot
+
+## This new implementation plan is missing the required YAML frontmatter (`---` block with at least `status`, `issue`, `last_updated`, `summary`). `docs/gen_indexes.py` groups implementation plans using that frontmatter; without it this page will fall under “Uncategorized” in the generated Implementation Plans index.
+
+### File: `backend/app/tasks/runner.py` (Line 173) — Copilot
+
+## Inline imports were introduced for `_chain` helpers inside `run_job()`. This makes dependencies harder to audit and conflicts with the project’s “no inline imports” guideline; here it also isn’t necessary to break a cycle (runner already depends on `_chain` at runtime). Prefer moving these imports to module top (or refactor to remove the need for importing `_chain` from within the function).
+
+### File: `backend/app/tasks/runner.py` (Line 298) — Copilot
+
+## `discard_pending_dispatches` is imported inline in the error path. This adds another hidden dependency inside `run_job()` and conflicts with the project’s “no inline imports” guideline. Prefer importing `_chain` helpers once at module top (or refactor dispatch-queue helpers into a module that doesn’t require importing from inside control-flow branches).
+
+### File: `backend/app/tasks/_chain.py` (Line 107) — Copilot
+
+## `drain_pending_dispatches()` imports `run_job` from `app.tasks.runner` inside the function. This creates a runtime-level import edge back to the runner and is already flagged by CodeQL as a cyclic-import risk; it also violates the project’s “no inline imports” guideline. Consider breaking the `_chain ↔ runner` dependency by moving dispatch-queue utilities into a neutral module and injecting a dispatcher callback, so `_chain` never imports `runner`.
+
 ## Action Items
 
 ### Critical: logic, security, correctness
 
-_None — the only CodeQL error (data_sync.py "Non-iterable used in for loop") is already addressed in commit `18f051d4` (`_resolve_enum_name` now iterates `enum_cls.__members__.values()`)._
+- [ ] **`frontend/src/components/molecules/data-management/UploadCard.vue:107`** — `TARGET_TO_KINDS[TargetType.DATA_ENTRIES]` is missing `emission_recalc` and `module_emission_recalc`. The two `/sync/recalculate-emissions*` endpoints (verified at `app/api/v1/data_sync.py:1610` and `:1710`) call `ensure_pipeline_exists(kind="emission_recalc"|"module_emission_recalc")`, so clicking the data card's "Recalculate" button creates a pipeline whose `kind` doesn't match the card's allowed list → `pipelineAppliesToCard` returns false → no phase indicator, no amber ⋯, even though the operator triggered the recalc _from_ the data card. Fix: change the mapping to `[TargetType.DATA_ENTRIES]: ['csv_ingest', 'api_ingest', 'emission_recalc', 'module_emission_recalc']`. Bot's diagnosis is exactly right; apply the suggested fix.
 
 ### Maintainability / refactoring
 
-- [ ] **`backend/app/tasks/_dispatch.py`** _(new module)_ — extract the deferred-dispatch ContextVar + `reset_pending_dispatches` / `drain_pending_dispatches` / `discard_pending_dispatches` out of `_chain.py` into a neutral module that imports nothing from `runner` or `_chain`. Then: (1) `runner.py` imports those three at module top (closes Copilot's runner.py:172 audit concern — the inline imports were OK but module-top is cleaner since no cycle prevents it); (2) `_chain.py` imports them at module top too; (3) move `_chain`'s lazy `from app.tasks.runner import run_job` inside `drain_pending_dispatches` into the new module — but invert the dependency: runner registers a dispatcher callback (`set_dispatcher(_dispatch_child)` at module load) and `_dispatch.drain()` calls the registered callback. That breaks `_chain ↔ runner` (CodeQL note at `_chain.py:103`) entirely, not just delaying it. **Note on Copilot's diagnosis:** runner does NOT already import from `_chain` at module top — bot misread. Skip the trivial "move to top of run_job" patch; do the extraction instead.
+- [ ] **`backend/app/tasks/_dispatch.py`** _(new module)_ — extract the deferred-dispatch ContextVar + `reset_pending_dispatches` / `drain_pending_dispatches` / `discard_pending_dispatches` out of `_chain.py` into a neutral module that imports nothing from `runner` or `_chain`. Invert the runner dependency: `runner.py` calls `set_dispatcher(_dispatch_child)` at module load (where `_dispatch_child` wraps `fire_and_forget(run_job(...))`), and `_dispatch.drain()` calls the registered callback instead of importing `run_job`. After: `runner.py` imports `_dispatch` at module top (closes Copilot's three inline-import comments on lines 172, 173, 298 — bot's "runner already imports from \_chain elsewhere" diagnosis is wrong, runner currently has NO module-top \_chain import, but the suggestion is sound once `_dispatch` exists). `_chain.py` also imports `_dispatch` at top, no lazy `run_job` import (closes the CodeQL `_chain.py:103/107` cyclic-import note). One refactor closes 5 bot comments.
 
-- [ ] **`backend/app/tasks/_ingest_meta.py`** _(new module, or move `finalize_ingest_meta` into `app/services/data_ingestion/`)_ — `reference_ingest_tasks.py:15` imports `finalize_ingest_meta` from `ingestion_tasks`, and `ingestion_tasks` transitively reaches `reference_ingest_tasks` via `runner` → `bootstrap_handlers` (CodeQL note at `reference_ingest_tasks.py:15`). Move `finalize_ingest_meta` (already extracted in `40542049`) into a leaf module that depends only on `app.models.data_ingestion`. Both ingest handler modules then import from there — no cycle. Same priority as the `_dispatch.py` extraction; pairs naturally.
+- [ ] **`backend/app/tasks/_ingest_meta.py`** _(new module — or move `finalize_ingest_meta` into `app/services/data_ingestion/`)_ — break the `reference_ingest_tasks ↔ ingestion_tasks` cycle CodeQL flagged at `reference_ingest_tasks.py:15`. The cycle path is `reference_ingest → ingestion_tasks → _chain → runner → bootstrap_handlers → reference_ingest` (all lazy past `_chain` so harmless at runtime, but CodeQL flags the static graph). Move `finalize_ingest_meta` to a leaf module that depends only on `app.models.data_ingestion`; both handler modules then import from there. Pairs naturally with the `_dispatch.py` extraction.
 
-- [ ] **`docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md`** and **`docs/src/implementation-plans/1234-pipeline-operations-console.md`** — both start with `# 1236 — …` / `# 1234 — …` directly, no YAML frontmatter. `docs/gen_indexes.py` keys on `status` / `issue` / `last_updated` / `summary` to group entries; without frontmatter these end up in "Uncategorized" in the rendered MkDocs index. Match the shape used by `1219-stuck-jobs-and-pipeline-progress.md` and `220-csv-upload-implementation-summary.md` — add the `---\nstatus: delivered\nissue: <id>\nlast_updated: 2026-05-20\nsummary: …\n---` block at the top of each. One-line edits per file.
+- [ ] **`docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md`** and **`docs/src/implementation-plans/1234-pipeline-operations-console.md`** — both lack the YAML frontmatter block (Copilot flagged twice each, lines 5/7 and 4/6 — same root cause across re-scans). `docs/gen_indexes.py` reads `status` / `issue` / `last_updated` / `summary` from frontmatter to group entries; without it both end up in "Uncategorized" in the rendered MkDocs index. Match the shape used by `1219-stuck-jobs-and-pipeline-progress.md` and `220-csv-upload-implementation-summary.md`: add the `---\nstatus: delivered\nissue: <id>\nlast_updated: 2026-05-20\nsummary: …\n---` block at the top of each. One-line edit per file.
 
 ### Dropped after verification
 
-- **CodeQL non-iterable for-loop in `_resolve_enum_name`** — already-fixed in `18f051d4`. CI pending re-run will clear it.
+- **CodeQL "Non-iterable used in for loop" on `data_sync.py`** — already-fixed in commit `18f051d4`. The loop now reads `enum_cls.__members__.values()` (verified at `app/api/v1/data_sync.py:460`). CodeQL hasn't re-scanned or the alert hasn't cleared in the dashboard, but the code is correct.

--- a/docs/code-review/1249-copilot-feedback-fix-1236-pipeline-correctness-observability-phase-1-5-concurrency-fixes-ux.md
+++ b/docs/code-review/1249-copilot-feedback-fix-1236-pipeline-correctness-observability-phase-1-5-concurrency-fixes-ux.md
@@ -1,0 +1,148 @@
+# Bot Review TODOs: PR #1249
+
+## Source Branch: `fix/pipeline-debug`
+
+## Raw Feedback
+
+### Summary Feedback (github-advanced-security)
+
+---
+
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+This PR hardens the ingestion → recalc → aggregation pipeline end-to-end by introducing a first-class `pipelines` aggregate (authoritative status + reconciliation), tightening FK correctness, adding concurrency controls to prevent deadlocks/races, and aligning the back-office UX/observability (pipeline ops console + accurate/consistent status messaging).
+
+**Changes:**
+
+- Adds `pipelines` table + `data_ingestion_jobs.pipeline_id` FK enforcement, plus runner-driven status writes and a periodic reconciliation loop.
+- Introduces concurrency safety via Postgres advisory locks (aggregation per-year lock; factor↔recalc scoped lock; unit_sync global + per-year locks) and deferred child dispatch until after `data_session.commit()`.
+- Improves operator UX/observability: pipeline ops console/store/i18n, PARTIAL vs FAILED tiering, “honest” status messages, and year provisioning gating via `configuration_completed`.
+
+### Reviewed changes
+
+Copilot reviewed 63 out of 63 changed files in this pull request and generated 3 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File                                                                                 | Description                                                                                                                   |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| frontend/src/stores/yearConfig.ts                                                    | Adds `configuration_completed` field to year configuration types for provisioning UX.                                         |
+| frontend/src/stores/pipelineStream.ts                                                | Extends pipeline progress shape with `status` (PARTIAL) and `kind` for UI scoping.                                            |
+| frontend/src/stores/pipelineState.ts                                                 | Adds `setPipelineId()` to seed pipeline IDs from dispatch responses (reduce discovery gap).                                   |
+| frontend/src/stores/pipelineOperationsConsole.ts                                     | New Pinia store for the pipeline operations console list + filters + counters.                                                |
+| frontend/src/stores/backofficeDataManagement.ts                                      | Seeds `pipeline_id` from dispatch/recalc responses to subscribe to SSE immediately.                                           |
+| frontend/src/router/routes.ts                                                        | Registers back-office pipeline operations route with permission guard.                                                        |
+| frontend/src/pages/back-office/DataManagementPage.vue                                | Makes year provisioning “in-flight” state durable across refresh via `configuration_completed`.                               |
+| frontend/src/i18n/pipeline_operations_console.ts                                     | New i18n strings for pipeline operations console (en/fr).                                                                     |
+| frontend/src/i18n/backoffice_data_management.ts                                      | Adds tooltip text for “pipeline still running” indicator.                                                                     |
+| frontend/src/constant/navigation.ts                                                  | Adds BACKOFFICE nav entry for Pipeline operations.                                                                            |
+| frontend/src/components/molecules/data-management/UploadCard.vue                     | Scopes pipeline phase display by pipeline `kind`; consolidates spinners; shows amber “in progress” marker while chain runs.   |
+| frontend/src/components/molecules/data-management/SubmoduleItem.vue                  | Injects and forwards module-scoped `pipelineProgress` to submodule upload cards.                                              |
+| frontend/src/components/layout/Co2Sidebar.vue                                        | Ensures super-admin always sees menu items (bypasses limited-access disable).                                                 |
+| docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md                 | New/updated plan doc for #1236 phases (missing frontmatter).                                                                  |
+| docs/src/implementation-plans/1234-pipeline-operations-console.md                    | New/updated plan doc for #1234 (missing frontmatter).                                                                         |
+| docs/src/database/erd.md                                                             | Updates ERD for `pipelines`, year configuration completion stamp, and pipeline FK.                                            |
+| backend/app/models/data_ingestion.py                                                 | Adds Pipeline model + PipelineStatus; declares FK+index on `data_ingestion_jobs.pipeline_id`.                                 |
+| backend/alembic/versions/2026_05_19_2000-b1f7a2c9d4e0_add_pipelines_table.py         | Creates `pipelines` table and indexes.                                                                                        |
+| backend/alembic/versions/2026_05_20_0900-a3b8c9d0e1f2_year_config_completed.py       | Adds `year_configuration.configuration_completed` column.                                                                     |
+| backend/alembic/versions/2026_05_20_1000-c4d5e6f7a8b9_enforce_pipeline_id_fk.py      | Adds pipeline FK constraint and index on `data_ingestion_jobs.pipeline_id`.                                                   |
+| backend/app/schemas/year_configuration.py                                            | Exposes `configuration_completed` in year configuration responses.                                                            |
+| backend/app/models/year_configuration.py                                             | Adds `configuration_completed` column definition.                                                                             |
+| backend/app/api/v1/year_configuration.py                                             | Ensures pipeline row exists before unit_sync job insert; returns `configuration_completed`.                                   |
+| backend/app/tasks/unit_sync_tasks.py                                                 | Adds advisory locks; records phases; stamps `configuration_completed` on success.                                             |
+| backend/app/repositories/unit_repo.py                                                | Adds Postgres ON CONFLICT bulk upsert path (race-safe) with SQLite fallback.                                                  |
+| backend/app/tasks/\_locks.py                                                         | New helper for factor↔recalc advisory lock with deterministic key encoding.                                                   |
+| backend/app/tasks/ingestion_tasks.py                                                 | Uses factor↔recalc lock; centralizes “honest” status message construction via `finalize_ingest_meta`.                         |
+| backend/app/tasks/reference_ingest_tasks.py                                          | Reuses `finalize_ingest_meta` to avoid status-message drift/duplication.                                                      |
+| backend/app/workflows/emission_recalculation.py                                      | Adds per-entry SAVEPOINT + fail-fast on session/connection-fatal errors.                                                      |
+| backend/app/tasks/emission_recalculation_tasks.py                                    | Adds in-pipeline aggregation coalescing + affected-module scoping + factor/recalc lock.                                       |
+| backend/app/tasks/aggregation_tasks.py                                               | Adds per-year advisory lock; scopes aggregation to affected modules when available.                                           |
+| backend/app/services/pipeline_progress.py                                            | Read-flip support (pipeline status authoritative); root detection via lowest-id; exposes status/kind for UI.                  |
+| backend/app/tasks/\_chain.py                                                         | Adds deferred child dispatch queue (ContextVar) + FK-safe pipeline mint ordering; removes `parent_job_id` meta threading.     |
+| backend/app/tasks/runner.py                                                          | Defers chained dispatch until after `data_session.commit()`; recomputes pipeline status post-finish; adds new inline imports. |
+| backend/app/tasks/\_pipeline_reconciler.py                                           | New cron-like reconciliation loop for pipeline status self-healing.                                                           |
+| backend/app/main.py                                                                  | Starts/stops pipeline reconciler task in lifespan.                                                                            |
+| backend/app/core/config.py                                                           | Adds settings toggles and interval for pipeline reconciler.                                                                   |
+| backend/tests/unit/workflows/test_emission_recalculation.py                          | Adds regression tests for abort-on-fatal DB/session errors.                                                                   |
+| backend/tests/unit/tasks/test_ingestion_handlers.py                                  | Pins “not Success when ERROR” + last_error enrichment + retired meta threading.                                               |
+| backend/tests/unit/tasks/test_chain.py                                               | Pins deferred-dispatch semantics and retired `parent_job_id` meta.                                                            |
+| backend/tests/unit/tasks/test_handler_registrations.py                               | Updates unit_sync tests for configuration stamp + phases; pins advisory lock behavior.                                        |
+| backend/tests/unit/services/test_pipeline_progress.py                                | Adds tests for pipeline.status authoritativeness and kind propagation.                                                        |
+| backend/tests/unit/services/test_pipeline_meta_allowlist.py                          | Pins meta allow-list and enum-name filter semantics; pins state/result serialization as enum names.                           |
+| backend/tests/unit/tasks/test_pipeline_reconciler.py                                 | Tests reconciliation loop hygiene (sleep, exception survival, cancellation, log spam avoidance).                              |
+| backend/tests/unit/tasks/test_factor_recalc_lock.py                                  | Tests factor↔recalc advisory lock helper behavior + key encoding uniqueness.                                                  |
+| backend/tests/unit/tasks/test_emission_recalc_coalesce.py                            | Tests “single trailing aggregation” gate + affected-module scoping config builder.                                            |
+| backend/tests/unit/tasks/test_aggregation_scope.py                                   | Tests unioning affected-module IDs across finished recalc siblings.                                                           |
+| backend/tests/unit/tasks/test_aggregation_handler.py                                 | Tests aggregation per-year advisory lock and affected-module scoping behavior.                                                |
+| backend/tests/unit/v1/test_active_pipelines_endpoint.py                              | Pins removal of over-eager per-module OPA pre-filter regression.                                                              |
+| backend/tests/unit/repositories/test_unit_repo.py                                    | Pins Postgres ON CONFLICT path vs SQLite legacy path; empty input short-circuit.                                              |
+| backend/tests/unit/repositories/test_pipeline_fk_ordering_regression.py              | Enforces correct `ensure_pipeline_exists` ordering under FK + autoflush scenarios.                                            |
+| backend/tests/unit/services/data_ingestion/test_module_unit_specific_csv_provider.py | Updates tests to account for new “empty factors” guards.                                                                      |
+| backend/tests/unit/services/data_ingestion/test_module_per_year_csv_provider.py      | Adds fail-fast tests for factor-inferred modules on empty factors.                                                            |
+| backend/tests/unit/services/data_ingestion/test_guard_factors_required.py            | New tests for `_guard_factors_required` and factor-inferred module set.                                                       |
+| backend/tests/integration/data_ingestion/test_csv_upload_e2e.py                      | Seeds `configuration_completed` to satisfy new dispatch precondition in integration test.                                     |
+| backend/app/services/data_ingestion/base_csv_provider.py                             | Adds `_guard_factors_required` helper for fail-fast on missing factors.                                                       |
+| backend/app/services/data_ingestion/csv_providers/module_per_year.py                 | Adds factor-inferred module fail-fast guard + `_guard_factors_required` usage.                                                |
+| backend/app/services/data_ingestion/csv_providers/module_unit_specific.py            | Adds `_guard_factors_required` usage for unit-specific ingests.                                                               |
+
+</details>
+
+---
+
+### File: `backend/app/api/v1/data_sync.py` (Line null) — github-advanced-security[bot]
+
+## CodeQL / Non-iterable used in for loop
+
+This for-loop may attempt to iterate over a [non-iterable instance](1) of class [type](2).
+This for-loop may attempt to iterate over a [non-iterable instance](3) of class [type](2).
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/667)
+
+### File: `backend/app/tasks/_chain.py` (Line 103) — github-advanced-security[bot]
+
+## CodeQL / Cyclic import
+
+Import of module [app.tasks.runner](1) begins an import cycle.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/668)
+
+### File: `backend/app/tasks/reference_ingest_tasks.py` (Line 15) — github-advanced-security[bot]
+
+## CodeQL / Cyclic import
+
+Import of module [app.tasks.ingestion_tasks](1) begins an import cycle.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/669)
+
+### File: `docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md` (Line 7) — Copilot
+
+## This implementation plan is missing the required YAML frontmatter (--- ... --- with status/issue/last_updated/summary). Without it, docs/gen_indexes.py will categorize it as "Uncategorized" and it won't be grouped correctly in the generated implementation-plans index. Add the frontmatter block at the top of the file.
+
+### File: `docs/src/implementation-plans/1234-pipeline-operations-console.md` (Line 6) — Copilot
+
+## This implementation plan is missing the YAML frontmatter block (--- ... ---). docs/gen_indexes.py relies on frontmatter (status/issue/last_updated/summary) to generate the Implementation Plans index; without it this page will be grouped under "Uncategorized". Add frontmatter at the top of the file.
+
+### File: `backend/app/tasks/runner.py` (Line 172) — Copilot
+
+## New inline imports were introduced inside run_job() for \_chain helpers. These don’t appear to be required for avoiding a circular dependency (runner already imports from app.tasks.\_chain elsewhere), and they make dependencies harder to audit and can hide import-time errors until runtime. Prefer moving these imports to the module top (or at least the top of run_job alongside the existing bootstrap_handlers import) so they’re explicit and consistent.
+
+## Action Items
+
+### Critical: logic, security, correctness
+
+_None — the only CodeQL error (data_sync.py "Non-iterable used in for loop") is already addressed in commit `18f051d4` (`_resolve_enum_name` now iterates `enum_cls.__members__.values()`)._
+
+### Maintainability / refactoring
+
+- [ ] **`backend/app/tasks/_dispatch.py`** _(new module)_ — extract the deferred-dispatch ContextVar + `reset_pending_dispatches` / `drain_pending_dispatches` / `discard_pending_dispatches` out of `_chain.py` into a neutral module that imports nothing from `runner` or `_chain`. Then: (1) `runner.py` imports those three at module top (closes Copilot's runner.py:172 audit concern — the inline imports were OK but module-top is cleaner since no cycle prevents it); (2) `_chain.py` imports them at module top too; (3) move `_chain`'s lazy `from app.tasks.runner import run_job` inside `drain_pending_dispatches` into the new module — but invert the dependency: runner registers a dispatcher callback (`set_dispatcher(_dispatch_child)` at module load) and `_dispatch.drain()` calls the registered callback. That breaks `_chain ↔ runner` (CodeQL note at `_chain.py:103`) entirely, not just delaying it. **Note on Copilot's diagnosis:** runner does NOT already import from `_chain` at module top — bot misread. Skip the trivial "move to top of run_job" patch; do the extraction instead.
+
+- [ ] **`backend/app/tasks/_ingest_meta.py`** _(new module, or move `finalize_ingest_meta` into `app/services/data_ingestion/`)_ — `reference_ingest_tasks.py:15` imports `finalize_ingest_meta` from `ingestion_tasks`, and `ingestion_tasks` transitively reaches `reference_ingest_tasks` via `runner` → `bootstrap_handlers` (CodeQL note at `reference_ingest_tasks.py:15`). Move `finalize_ingest_meta` (already extracted in `40542049`) into a leaf module that depends only on `app.models.data_ingestion`. Both ingest handler modules then import from there — no cycle. Same priority as the `_dispatch.py` extraction; pairs naturally.
+
+- [ ] **`docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md`** and **`docs/src/implementation-plans/1234-pipeline-operations-console.md`** — both start with `# 1236 — …` / `# 1234 — …` directly, no YAML frontmatter. `docs/gen_indexes.py` keys on `status` / `issue` / `last_updated` / `summary` to group entries; without frontmatter these end up in "Uncategorized" in the rendered MkDocs index. Match the shape used by `1219-stuck-jobs-and-pipeline-progress.md` and `220-csv-upload-implementation-summary.md` — add the `---\nstatus: delivered\nissue: <id>\nlast_updated: 2026-05-20\nsummary: …\n---` block at the top of each. One-line edits per file.
+
+### Dropped after verification
+
+- **CodeQL non-iterable for-loop in `_resolve_enum_name`** — already-fixed in `18f051d4`. CI pending re-run will clear it.

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -131,6 +131,23 @@ erDiagram
     VARCHAR natural_key "indexed"
     VARCHAR transport_mode "indexed"
   }
+  pipelines {
+    DATETIME created_at
+    INTEGER entity_type
+    INTEGER error_count
+    INTEGER expected_recalc
+    DATETIME finished_at
+    UUID id PK
+    INTEGER ingestion_method
+    INTEGER job_count
+    VARCHAR kind
+    VARCHAR last_error
+    INTEGER module_type_id
+    DATETIME started_at
+    VARCHAR status
+    DATETIME updated_at
+    INTEGER year
+  }
   unit_users {
     VARCHAR role "indexed"
     INTEGER unit_id PK

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -98,7 +98,7 @@ erDiagram
     INTEGER max_attempts
     JSON meta
     INTEGER module_type_id "indexed"
-    UUID pipeline_id
+    UUID pipeline_id FK
     VARCHAR provider
     VARCHAR result
     DATETIME run_after "indexed"
@@ -196,6 +196,7 @@ erDiagram
   data_entries ||--}o data_entry_emissions : "data_entry_id"
   data_ingestion_jobs ||--}o factors : "last_seen_job_id"
   factors ||--}o data_entry_emissions : "primary_factor_id"
+  pipelines ||--}o data_ingestion_jobs : "pipeline_id"
   units ||--}o carbon_projects : "unit_id"
   units ||--}o carbon_reports : "unit_id"
   units ||--}o unit_users : "unit_id"

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -185,6 +185,7 @@ erDiagram
   }
   year_configuration {
     JSON config
+    DATETIME configuration_completed
     BOOLEAN is_started
     DATETIME updated_at
     INTEGER year PK

--- a/docs/src/implementation-plans/1234-pipeline-operations-console.md
+++ b/docs/src/implementation-plans/1234-pipeline-operations-console.md
@@ -1,0 +1,88 @@
+# 1234 — Pipeline operations console
+
+Status: in progress · Branch: `feat/1234-pipeline-operations-console` · Base: `dev`
+
+## Problem
+
+`/back-office/data-management` shows per-module ingestion status only. There is
+no global view of pipelines. Operators cannot see, across all modules/years:
+failed parents, transaction-poisoning, deadlocks between sibling recalc jobs, or
+anomalous runs.
+
+Live data shows the failure shapes the page must surface:
+
+- `csv_ingest` `status_message="Success"` but `result=ERROR` (100% row errors).
+- `InFailedSqlTransaction` on the `carbon_report_modules` SELECT — parent
+  ERROR, no `pipeline_id`, no children (carbon-report-stats poisoning).
+- `DeadlockDetected` between concurrent `emission_recalc`/`aggregation`
+  siblings of the **same** `pipeline_id`.
+- One `csv_ingest` → 3 `emission_recalc` → 3 `aggregation`, each
+  `modules_refreshed: 2231` (concurrent full-table recompute amplification).
+
+## Outcome
+
+A new back-office page, complementary to data-management. Unit = the pipeline
+(one `pipeline_id` = a DAG: ingest parent → per-det `emission_recalc` →
+`aggregation`, edges via `meta.parent_job_id`). Pipeline-grouped table, alert
+strip, filters, expandable job DAG with decoded meta. Orphan parents
+(`pipeline_id IS NULL`) shown inline as pipelines-of-one.
+
+## Scope
+
+- ONE new backend list endpoint. Reuse — do not rebuild — `GET
+/v1/sync/pipelines/{id}` and `/stream` for drill-down/live.
+- No migration (all derived from `data_ingestion_jobs`).
+- No change to `/back-office/data-management`.
+- NOT bundling PR #1225 or the eager-pipeline-id work. This endpoint only
+  reads existing `pipeline_id` values; orphan rows are surfaced regardless.
+
+## Steps
+
+### Backend
+
+- **B1** `backend/app/repositories/data_ingestion.py` —
+  `list_pipelines_paginated(...)`. Pagination unit is `pipeline_id`, not the
+  job row. Group/filter in SQL (no `DISTINCT ON` — SQLite test fixture),
+  page on `pipeline_id`, then one `IN (:page_ids)` fetch grouped in Python.
+  Orphans (`pipeline_id IS NULL`) as synthetic pipelines-of-one. Returns a
+  Pydantic-free typed dict.
+- **B2** `backend/app/api/v1/data_sync.py` — `GET /sync/pipelines`
+  (registered before `/pipelines/{pipeline_id}`). Inline schemas
+  `PipelineListItem` / `PipelineListResponse`, reusing
+  `PipelineProgressResponse` + `compute_pipeline_progress`. Meta projection
+  is an **allow-list** (`parent_job_id`, `recalc_jobs_chained`,
+  `aggregation_job_id`, `provider_name`, `filters`) — never ship
+  `error_details` / `affected_module_ids` (KB-scale). Permission gate copied
+  from `get_active_pipelines` (global `backoffice.data_management.view` +
+  per-module decision, drop not 403).
+- **B3** tests — extend
+  `backend/tests/unit/repositories/test_data_ingestion_repo.py`: grouping,
+  pipeline-unit pagination, each filter, orphans, meta allow-list strips the
+  big arrays.
+
+### Frontend
+
+- **F1** `frontend/src/i18n/pipeline_operations_console.ts` (auto-globbed;
+  en + fr; nav keys included).
+- **F2** `frontend/src/constant/navigation.ts` — `BACKOFFICE_NAV` entry.
+- **F3** `frontend/src/router/routes.ts` — `back-office/pipeline-operations`
+  route, same `beforeEnter`/`meta` as the data-management sibling.
+- **F4** `frontend/src/stores/pipelineOperationsConsole.ts` +
+  `frontend/src/pages/back-office/PipelineOperationsConsolePage.vue`. Alert
+  strip (clickable counters → filters), pipeline-grouped table (newest
+  first), expandable job DAG with decoded meta. Drill-down/live reuses
+  `usePipelineStream()` verbatim.
+- **F5** `cd frontend && make type-check` (vue-tsc — the gate husky runs;
+  `rtk tsc` green ≠ this).
+
+## Verify
+
+- Backend: `cd backend && uv run ruff check . && uv run pytest
+tests/unit/repositories/test_data_ingestion_repo.py
+tests/unit/services/test_pipeline_progress.py -q` and `python -c "from
+app.main import app"`.
+- Frontend: `cd frontend && make type-check`.
+
+## Convention notes
+
+PRs target `dev`. Commit messages: **no** `Co-Authored-By` trailer.

--- a/docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md
+++ b/docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md
@@ -151,20 +151,33 @@ Most of this extends primitives already built.
 
 ## Phased plan (each shippable + reversible)
 
-1. **Add table + write-through.** Migration creates `pipelines`
-   table-only (column stays plain UUID, **no FK constraint** — legacy
-   rows have no pipeline row yet; FK is added post-backfill in Phase 2
-   via `ADD CONSTRAINT … NOT VALID` + `VALIDATE`). The 4 mint sites
-   call `ensure_pipeline_exists`; the runner advances `status`
+> **v0.x has no backfill — the DB is dropped between deploys; real
+> backfill starts at v1.x.** This collapses old Phase 2: there is no
+> history to synthesise. On any fresh v0.x DB every `pipeline_id`
+> originates from `ensure_pipeline_exists`, so the FK is not
+> backfill-gated — it can be enforced once a clean DB is running
+> Phase-1 code (i.e. the deploy *after* Phase 1 ships, which in v0.x
+> is a DB drop). The mid-DB-life window (Phase 1 deployed onto a DB
+> that already has pre-Phase-1 pipeline_id rows) is the only reason
+> the FK isn't in the Phase-1 migration itself.
+
+1. **Add table + write-through.** ✅ DONE (`fix/pipeline-debug`).
+   Migration creates `pipelines` table-only (column stays plain UUID,
+   **no FK yet** — see box above). The 4 mint sites call
+   `ensure_pipeline_exists`; the runner advances `status`
    post-`finish_job` as an isolated log-and-skip write (last-child
-   oracle). Sweep shipped as a standalone callable.
-   _Verify:_ the sweep/reconciliation query returns **zero** rows
-   where stored `status` ≠ `compute_pipeline_progress` over the
-   pipeline's jobs.
-2. **Backfill.** One migration: a `pipelines` row per historical
-   `pipeline_id`; NULL-pipeline parents → single-step pipelines.
-   _Verify:_ counts reconcile; #1219/poisoned samples land
-   `FAILED`/`PARTIAL`.
+   oracle). Sweep is a standalone callable.
+   _Verify (met):_ the reconciliation test proves **zero** drift
+   (stored `status` == `compute_pipeline_progress`).
+2. **Enforce FK** (v0.x, post-DB-drop) — add `pipeline_id` FK →
+   `pipelines(id)` once a clean DB runs Phase-1 code. No data
+   migration. _Verify:_ migration applies on a fresh DB; an orphan
+   `pipeline_id` is impossible because `ensure_pipeline_exists` runs
+   at every mint. **(v1.x: a real backfill migration replaces this
+   step — a `pipelines` row per historical `pipeline_id`,
+   NULL-pipeline parents → single-step; #1219/poisoned samples land
+   `FAILED`/`PARTIAL`. The `last_error`-skips-"Success" fix already
+   makes that backfill safe.)**
 3. **Flip reads.** Console (#1234), `GET /pipelines/{id}`, progress
    read the table; `compute_pipeline_progress` becomes writer-side
    only. _Verify:_ golden-output diff before/after on the same DB.
@@ -173,8 +186,8 @@ Most of this extends primitives already built.
    VERIFY above.
 5. **Retire meta threading** once nothing reads the counters.
 
-Phases 1–2 are pure additions (revert = drop table); phase 3 is the
-only behavioural flip.
+Phase 1 is a pure addition (revert = drop table); phase 3 is the only
+behavioural flip.
 
 ## Rejected alternatives
 

--- a/docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md
+++ b/docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md
@@ -84,16 +84,37 @@ Rejected alternatives).
   incremental accumulator under concurrency + retries + out-of-order
   terminals is precisely how drift returns. The per-terminal sibling
   SELECT is bounded and indexed by `pipeline_id` — cheap insurance.
-- **Option (a) — only the last expected child writes status.** Use
-  `expected_recalc` (+ aggregation count) so just the terminating
-  child performs the status write. Cuts the all-children-write-the-
-  same-`pipelines`-row contention to ~one write per pipeline.
-- The status write **must** sit inside a `begin_nested()` SAVEPOINT
-  (the #1225 discipline): if it deadlocks/errors, roll back **only the
-  savepoint** so the job's own `finish_job` survives; log-and-skip the
-  status update; reconcile later. A reconciliation sweep (recompute
-  status for any pipeline whose stored status ≠
-  `compute_pipeline_progress`) is the safety net for skipped writes.
+- **Option (a) — only the last child writes status.** No manual
+  counting: `compute_pipeline_progress(siblings).done` _is_ the
+  last-child oracle. Under READ COMMITTED a non-last terminal sees
+  `done=false` and skips; the actually-last terminal sees every
+  earlier commit and writes. If two terminals race and both observe
+  the full set, both write — benign, recompute-from-truth makes the
+  writes identical (just brief row contention). UPSERT; add no
+  coordination machinery for a self-resolving edge.
+- **Mechanism: post-commit isolated write, NOT a SAVEPOINT inside the
+  finish transaction.** `repo.finish_job` self-commits the
+  `job_session`; there is no enclosing transaction to nest in. So the
+  status write is its own short transaction _after_ `finish_job`
+  returns `True`, fully `try/except`'d (log-and-skip on any DB error).
+  This is _stronger_ isolation than the SAVEPOINT ideal: the job's
+  terminal is already durably committed, so a failed status write
+  cannot poison it at all. Trade-off: a small window where a reader
+  sees stale status — irrelevant in Phase 1 (no reads flipped),
+  absorbed in Phase 3 by the sweep + next-terminal self-heal.
+- **Row creation is a separate concern from status.** Create the
+  `pipelines` row at **parent creation**, not in the runner (the
+  runner is a terminal actor, not a kickoff actor). One idempotent
+  helper `ensure_pipeline_exists(session, pipeline_id, parent_job)`
+  (`INSERT … ON CONFLICT DO NOTHING`) called from the 4 post-merge
+  mint sites (`_stamp_job_type_and_meta`, the 2 recalc endpoints'
+  `DataIngestionJob(...)`, `_chain.py` lazy mint). One logical
+  chokepoint, several call sites — keeps Phase-3 in-flight visibility
+  without 4-way drift.
+- **Reconciliation sweep** (recompute status where stored ≠
+  `compute_pipeline_progress`) is the durable backstop for skipped
+  writes. Phase 1 ships it as a standalone callable (manually /
+  cron-invokable); Phase 3 schedules it before flipping reads.
 
 ## Concurrency & contention model (informs Phase 3+)
 
@@ -130,11 +151,16 @@ Most of this extends primitives already built.
 
 ## Phased plan (each shippable + reversible)
 
-1. **Add table + write-through.** Create `pipelines`;
-   chain/dispatch/recalc upsert a row; runner advances `status` via
-   recompute-and-store, option (a), inside the #1225 SAVEPOINT.
-   _Verify:_ a reconciliation query returns **zero** rows where stored
-   `status` ≠ `compute_pipeline_progress` over the pipeline's jobs.
+1. **Add table + write-through.** Migration creates `pipelines`
+   table-only (column stays plain UUID, **no FK constraint** — legacy
+   rows have no pipeline row yet; FK is added post-backfill in Phase 2
+   via `ADD CONSTRAINT … NOT VALID` + `VALIDATE`). The 4 mint sites
+   call `ensure_pipeline_exists`; the runner advances `status`
+   post-`finish_job` as an isolated log-and-skip write (last-child
+   oracle). Sweep shipped as a standalone callable.
+   _Verify:_ the sweep/reconciliation query returns **zero** rows
+   where stored `status` ≠ `compute_pipeline_progress` over the
+   pipeline's jobs.
 2. **Backfill.** One migration: a `pipelines` row per historical
    `pipeline_id`; NULL-pipeline parents → single-step pipelines.
    _Verify:_ counts reconcile; #1219/poisoned samples land

--- a/docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md
+++ b/docs/src/implementation-plans/1236-pipelines-table-aggregate-root.md
@@ -1,0 +1,184 @@
+# 1236 — First-class `pipelines` table
+
+Status: design · Issue #1236 · Integrates into `fix/pipeline-debug`
+(supersedes the standalone PR #1237). Not bundled with #1234 / #1225.
+
+## Why
+
+A "pipeline" is currently emergent: rows in `data_ingestion_jobs`
+sharing a `pipeline_id` UUID, DAG reconstructed from
+`meta.parent_job_id` / `recalc_jobs_chained` / `aggregation_job_id`,
+status recomputed on every read by `compute_pipeline_progress`. That
+missing aggregate root is the root cause of a recurring bug class:
+NULL-until-fan-out (orphans + the #1225 eager-id workaround), premature
+"success" (#1219), and the console (#1234) having to `GROUP BY
+pipeline_id` with two-step pagination. See `emission-pipeline-flow.md`
+for the current DAG.
+
+## Background — why this is hard (poisoning & deadlocks)
+
+Keep this; it is the whole reason the design is shaped this way.
+
+- A SQLAlchemy async `Session` is **one Postgres transaction**. Any
+  statement error aborts the **entire** transaction; every later
+  statement then fails with `InFailedSqlTransaction: current
+transaction is aborted …` until a `ROLLBACK`
+  (`PendingRollbackError`). The logged error is usually the
+  **cascade, not the cause** — e.g. jobs 47/74/104 log a harmless
+  `SELECT carbon_report_modules` because it was merely the first
+  statement to touch an already-poisoned session; the real failure
+  was an earlier write.
+- A **deadlock** = two transactions each holding a lock the other
+  needs in opposite order; Postgres kills one (`DeadlockDetected`).
+  Here it is structural: one upload → `recalc_jobs_chained: 3` → 3
+  `emission_recalc` children run **concurrently** over overlapping
+  rows, each `DELETE`/re-insert `data_entry_emissions`, each
+  `aggregation` then rewrites ~2231 `carbon_reports`. 3× concurrent
+  full-table rewrites = the deadlocks in the data (job 90 on `UPDATE
+carbon_reports`).
+- Chain: **amplification → concurrent overlapping writes → deadlock
+  (trigger) → no rollback → poisoning (cascade) → job sinks**
+  (#1219/#1225).
+- Two sessions (`job_session` vs `data_session`) correctly isolate
+  _job-state_ integrity from _data_ poisoning — necessary, but only
+  that axis. It does not prevent cross-worker deadlocks, nor stop a
+  poisoned `data_session` sinking the rest of a job's data work; that
+  is what #1225's per-entry `begin_nested()` SAVEPOINT covers. Both
+  halves are required.
+
+## Proposed model
+
+First-class `pipelines` table; `data_ingestion_jobs.pipeline_id`
+becomes an FK.
+
+```
+pipelines
+  id              uuid pk
+  kind            text   -- = parent job_type: csv_ingest | api_ingest |
+                         --   factor_ingest | unit_sync |
+                         --   module_emission_recalc | reference_ingest
+  status          text   -- NOT_STARTED|RUNNING|SUCCESS|PARTIAL|FAILED
+  entity_type     enum   -- kept; NOT folded into kind
+  ingestion_method enum   -- kept; NOT folded into kind
+  module_type_id  int  null
+  year            int  null
+  expected_recalc int  null   -- owned recalc count (was meta.recalc_jobs_chained)
+  job_count       int
+  error_count     int
+  started_at      timestamptz null
+  finished_at     timestamptz null
+  last_error      text null
+```
+
+`kind` mirrors the parent job's `job_type` — deliberately **not** a
+flattened `CSV_MODULE_PER_YEAR / API_MODULE_UNIT_SPECIFIC` enum (see
+Rejected alternatives).
+
+## DECIDED — Phase-1 status maintenance
+
+- **Recompute-and-store** (not incremental). On a job terminal, read
+  the pipeline's sibling jobs, run the existing pure
+  `compute_pipeline_progress`, write the single resulting `status`.
+  Rationale: drift is the exact bug we are killing; recompute-from-
+  truth cannot drift and self-heals a lost write, whereas an
+  incremental accumulator under concurrency + retries + out-of-order
+  terminals is precisely how drift returns. The per-terminal sibling
+  SELECT is bounded and indexed by `pipeline_id` — cheap insurance.
+- **Option (a) — only the last expected child writes status.** Use
+  `expected_recalc` (+ aggregation count) so just the terminating
+  child performs the status write. Cuts the all-children-write-the-
+  same-`pipelines`-row contention to ~one write per pipeline.
+- The status write **must** sit inside a `begin_nested()` SAVEPOINT
+  (the #1225 discipline): if it deadlocks/errors, roll back **only the
+  savepoint** so the job's own `finish_job` survives; log-and-skip the
+  status update; reconcile later. A reconciliation sweep (recompute
+  status for any pipeline whose stored status ≠
+  `compute_pipeline_progress`) is the safety net for skipped writes.
+
+## Concurrency & contention model (informs Phase 3+)
+
+The contention map has two **distinct** problems — do not conflate:
+
+| Phase                    | Writes                                                              | Cross-pipeline conflict     |
+| ------------------------ | ------------------------------------------------------------------- | --------------------------- |
+| ingest + emission_recalc | `data_entries`/`data_entry_emissions`, **det-partitioned**          | none between different dets |
+| aggregation              | `carbon_report_modules` + the **shared `carbon_reports` synthesis** | always                      |
+
+- **Problem A — aggregation is the universal collision + amplified.**
+  Fix the _step_, not whole pipelines (whole-pipeline priority over-
+  serializes the independent det-partitioned phases and still does the
+  full rewrite). Two levers: **coalesce** concurrent aggregation for a
+  report/year scope into one trailing run (extend the existing
+  `AGGREGATION_DEDUP`); **scope** the rewrite to the recalc's already-
+  computed `affected_module_ids` instead of all reports.
+  - **VERIFY (not asserted):** confirm the aggregation handler
+    actually full-rewrites (`modules_refreshed: 2231` constant in the
+    dumps strongly suggests it) and is not already scoped some other
+    way, before designing the scoping change.
+- **Problem B — same-`(module_type_id, data_entry_type_id, year)`
+  factor-vs-data ordering is a correctness bug**, not just contention:
+  a data recalc concurrent with a factor reload for the same scope
+  computes emissions against half-loaded factors → silently wrong
+  numbers. Needs a **scoped** factor-before-data mutex (reuse the
+  `uq_emission_recalc_active` per-scope primitive; the gap is ordering
+  the _parent ingests_ for that scope), not whole-pipeline priority.
+
+Net direction: keep ingest/recalc concurrent (that is the wanted
+parallelism); make aggregation a coalesced, affected-scope, serialized-
+per-report-domain step (A); add a scoped factor→data ordering (B).
+Most of this extends primitives already built.
+
+## Phased plan (each shippable + reversible)
+
+1. **Add table + write-through.** Create `pipelines`;
+   chain/dispatch/recalc upsert a row; runner advances `status` via
+   recompute-and-store, option (a), inside the #1225 SAVEPOINT.
+   _Verify:_ a reconciliation query returns **zero** rows where stored
+   `status` ≠ `compute_pipeline_progress` over the pipeline's jobs.
+2. **Backfill.** One migration: a `pipelines` row per historical
+   `pipeline_id`; NULL-pipeline parents → single-step pipelines.
+   _Verify:_ counts reconcile; #1219/poisoned samples land
+   `FAILED`/`PARTIAL`.
+3. **Flip reads.** Console (#1234), `GET /pipelines/{id}`, progress
+   read the table; `compute_pipeline_progress` becomes writer-side
+   only. _Verify:_ golden-output diff before/after on the same DB.
+4. **Aggregation coalesce + scope (Problem A)** and **scoped
+   factor→data ordering (Problem B)** — separate sub-PRs, gated on the
+   VERIFY above.
+5. **Retire meta threading** once nothing reads the counters.
+
+Phases 1–2 are pure additions (revert = drop table); phase 3 is the
+only behavioural flip.
+
+## Rejected alternatives
+
+- **Flat `kind` enum**: cartesian of `ingestion_method` ×
+  `entity_type` (already columns); incomplete for `factor_ingest` /
+  `unit_sync` present in real data.
+- **`pipelines` as a VIEW**: keeps per-read recompute, cannot carry an
+  authoritative `status`.
+- **Global whole-pipeline priority/mutex** (the first instinct for
+  side-note-2): over-serializes the independent det-partitioned
+  phases and still leaves the full-table aggregation rewrite. Replaced
+  by the A/B decomposition above.
+- **Incremental status**: drift under concurrency/retries/reorder =
+  the #1219 class.
+
+## Open questions
+
+- `PARTIAL` (some children errored, chain completed) vs `FAILED`
+  (chain broken) exact definition.
+- Aggregation coalescing key: `(carbon_report scope, year)`? Interaction
+  with `unit_sync` (year-level, also rewrites `carbon_reports`).
+- Shared-synthesis edge: det-disjoint pipelines still collide on a
+  `carbon_reports` row when their modules share a report — serialize by
+  report-domain, not by det.
+- Retry-safety of the factor→data ordering (`max_attempts=3`,
+  mid-pipeline re-claim) and interaction with dedup-skip.
+- Backfill of legacy rows lacking meta counters — best-effort
+  `compute_pipeline_progress`, same as today's read path.
+
+## Convention notes
+
+Pipeline work integrates into `fix/pipeline-debug` (not `dev`) until
+told otherwise. Commit messages: no `Co-Authored-By` trailer.

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -35,6 +35,13 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
 - [ ] One clean **hook-driven** commit (commitlint + lint-staged +
       `make type-check`) — merges/commits used `--no-verify`; confirm
       the gate passes for real before any promotion.
+      **Concrete finding (2026-05-20):** commitlint rejects scopes
+      like `docs(pipeline-debug):` (commit `71bfe301` blocked,
+      `rtk git commit` printed `ok` anyway — the "ok" lies; verify
+      with `git ls-tree`/`git show HEAD:` per
+      `[[project_pipeline_debug_integration_branch]]`). Either widen
+      the commitlint scope-enum to include `pipeline-debug`, or use
+      issue-numbered scopes (`docs(#1234)`, `docs(#1236)`).
 - [ ] Sibling `"status_message": "Success"` hardcodes in
       `base_provider.py:186` and
       `base_reduction_objective_csv_provider.py:169`: trace whether any

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -95,10 +95,34 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       (DB dropped between deploys); migration applies on the next
       clean-DB deploy. 1385 unit tests still green (SQLite metadata
       build accepts the FK).
-- [ ] **Phase 3**: flip reads (console #1234, `GET /pipelines/{id}`,
-      progress) to the `pipelines` table; `compute_pipeline_progress`
-      becomes writer-side only. Schedule the reconciliation sweep on a
-      cron _before_ flipping. Verify: golden-output diff before/after.
+- ✅ **Phase 3 (`d8c3c682`)**: flipped pipeline reads to
+      `pipelines.status` (durable, recompute-and-stored).
+      - `compute_pipeline_progress(jobs, *, pipeline=None)` — `done`
+        / `has_error` derive from `pipeline.status` when present;
+        `phase` stays job-derived (UX granularity).
+      - `GET /sync/pipelines`: `state=` URL param pivots to
+        `PipelineStatus` (NOT_STARTED/RUNNING/SUCCESS/PARTIAL/FAILED);
+        `result=` dropped (subsumed). `has_errors=true` ↔ `status IN
+        (PARTIAL, FAILED)`. Orphans fall back to job-derived.
+      - Single + SSE endpoints pass the Pipeline row through.
+      - Frontend filter UI: `stateOptions` swap to the 5 values, the
+        result dropdown is removed.
+      - **60s reconciliation cron** wired into the lifespan via
+        `app/tasks/_pipeline_reconciler.py`. Same hygiene as the
+        poller (session-per-iteration, broad except, cancellation).
+        Settings: `RUN_PIPELINE_RECONCILER=true`,
+        `PIPELINE_RECONCILER_INTERVAL_SECONDS=60`.
+      - **🐞 FK-ordering bug surfaced + fixed**: Phase 2 FK fired on
+        stage; three mint sites violated the Pipeline-first
+        invariant: (1) `year_configuration.create_year_configuration`
+        had **no** `ensure_pipeline_exists` call, (2)
+        `data_sync.recalculate_emissions` and (3)
+        `data_sync.recalculate_module_emissions` called it **after**
+        `create_ingestion_job` (whose flush already triggered the
+        FK). All three fixed to ensure→create order. Regression test
+        in `test_pipeline_fk_ordering_regression.py` uses SQLite with
+        `PRAGMA foreign_keys=ON` so neither bug shape can recur
+        silently.
 - ✅ **VERIFY (Phase 4 gate) — answered:** aggregation handler is
       scoped at `(module_type_id, year)`. The 2231 number is
       per-unit module rows, not all reports. Collision source is
@@ -167,7 +191,8 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       SUCCESS/FAILED; `PARTIAL` reserved, undefined.
 - [ ] Aggregation coalescing key: `(carbon_report scope, year)`? how
       `unit_sync` (year-level, also rewrites `carbon_reports`) folds in.
-- [ ] Phase-3 sweep cron cadence / trigger.
+- ✅ Phase-3 sweep cron cadence: **60s** (configurable via
+      `PIPELINE_RECONCILER_INTERVAL_SECONDS`).
 - [ ] Remove the now-unused `pipeops_status_partial` i18n key? (left
       in to avoid churn.)
 

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -76,14 +76,10 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
 
 - ✅ #1 Year-config gate — backend `13616a35`, frontend `c1e9ef01`.
 - ✅ #3 SSE on the ops page — `645b4799`.
-- [ ] **#2 `unit_sync` collapses to one aggregated task per year.**
-      Individual sub-tasks aren't exposed in the ops UI. Investigate
-      whether the sub-tasks are not created (backend collapses
-      everything into the `unit_sync` handler internally) or are
-      created but filtered out by the ops endpoint; expose them so
-      operators can see what's running inside the year-level
-      pipeline. **Investigation pending** before picking
-      backend-vs-frontend fix.
+- ✅ **#2** shipped (see Done). Real chained sub-jobs (#2C) deferred —
+      the phases checklist + status_history timeline already provide
+      per-phase visibility in the console; revisit only if the project
+      needs independent retry/locking per phase.
 
 ## 🔧 To DO — #1236 remaining phases
 
@@ -135,6 +131,15 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
 - ✅ **Phase 4B**: shipped as `1bd26748` (advisory lock at `(module,
       year)` scope, not `(module, det, year)` — broader but
       drop-hazard-free; see Done).
+- ✅ **#2 (unit_sync sub-tasks visibility)** — shipped as:
+      - `4ee30046` #2A generic `status_history` (append+capped at 50)
+      - `87a9d14d` #2B `meta.phases` checklist on `unit_sync` handler
+      - `046f48e0` #2D console renders timeline + phase checklist
+      - **#2C deferred**: real chained sub-jobs (heavy refactor of the
+        year-creation critical path) — #2B+#2D already provides the
+        per-phase visibility. Keep in mind if real chained semantics
+        ever become needed (independent retry per phase, separate
+        locking, etc.).
 - [ ] **Phase 5**: retire `meta` threading
       (`recalc_jobs_chained` / `aggregation_job_id` / `parent_job_id`
       read paths) once nothing consumes them.

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -118,16 +118,13 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       Combined: amplification killed (4A.1), cross-pipeline deadlock
       eliminated (4A.2), per-aggregation write set shrunk (4A.3).
 - ✅ **Phase 4A**: shipped as 4A.1/4A.2/4A.3 (see Done section).
-- [ ] **4A.4 (race fix on 4A.3)**: the LAST recalc sibling chains the
-      aggregation before its own runner-`finish_job` commits, so its
-      `affected_module_ids` are not visible to the aggregation's
-      sibling-query. The aggregation misses the last sibling's modules.
-      Fix: at chain time the last sibling builds the union locally
-      (sibling-query + its own `stats["affected_module_ids"]`) and
-      passes it via `chain_job(config={...})` so the aggregation reads
-      it from its own meta. Surfaced by Guilbert "all aggregations are
-      0s" on 2026-05-20 — mostly that observation is the optimization
-      working (empty-affected recalcs), but the race is real.
+- ✅ **4A.4 (`53625315`)**: race fix on 4A.3. The last sibling builds
+      the full `affected_module_ids` union (own `stats` ∪ FINISHED
+      siblings' meta) at chain time and passes it via
+      `chain_job(config={...})`; `aggregation_handler` reads from its
+      own `meta.config` first (race-free), sibling-query stays as
+      4A.3 legacy fallback. Guards `isinstance(pipeline_id, UUID)` to
+      keep mock-driven unit tests off the production `SessionLocal`.
 - ✅ **Phase 4B (`1bd26748`)**: per-`(module, year)`
       `pg_advisory_xact_lock` in `factor_ingest_handler`,
       `emission_recalc_handler`, `module_emission_recalc_handler`.

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -15,6 +15,32 @@ told otherwise). Last updated 2026-05-19.
   `_run_ingest` (csv/api/factor) **and** `reference_ingest`.
 - Console table: clickable full message + copy, server-resolved
   module/det names, distinct amber WARNING tier.
+- **🐞 Guilbert #1**: year-config gate (`13616a35` backend, `c1e9ef01`
+  frontend) — `YearConfiguration.configuration_completed` stamped by
+  `unit_sync_handler` on SUCCESS; `/dispatch` 409s when null;
+  data-management page's `yearSyncInFlight` extended with the durable
+  refresh-surviving check.
+- **🐞 Guilbert #3**: SSE live-update on the ops page (`645b4799`) —
+  page subscribes to visible RUNNING pipelines via `usePipelineStream`,
+  debounced refetch on any SSE update.
+- **VERIFY (Phase 4 gate) — answered:** aggregation handler is
+  **already scoped** at `(module_type_id, year)` via
+  `svc.list_modules_for(...)`. The `modules_refreshed: 2231` in the
+  data is 2231 `carbon_report_modules` (one per unit) for ONE
+  module-year slice, not a full-table rewrite. The collision /
+  amplification comes from `recompute_stats`'s **side-effect** that
+  also rewrites the parent `carbon_report.stats` rollup — that row is
+  shared across all modules of a unit-year, so 3 concurrent
+  aggregations for different modules of the same year deadlock on
+  `carbon_reports`. Phase 4A's right lever is **coalescing** (one
+  trailing aggregation per scope), not narrower scoping — scoping is
+  already done.
+- **Sibling hardcode trace — answered:** `base_provider.py:186` is a
+  base-class default; every concrete subclass overrides `ingest()`,
+  so it's unreachable. `base_reduction_objective_csv_provider.py:169`
+  belongs to a class with no `@register`'d handler — never invoked by
+  the runner. Both are dead-code paths today; `finalize_ingest_meta`
+  covers every LIVE handler.
 
 ## 🔎 To CHECK (verified at type/lint/unit level only — NOT runtime)
 
@@ -42,33 +68,22 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       `[[project_pipeline_debug_integration_branch]]`). Either widen
       the commitlint scope-enum to include `pipeline-debug`, or use
       issue-numbered scopes (`docs(#1234)`, `docs(#1236)`).
-- [ ] Sibling `"status_message": "Success"` hardcodes in
-      `base_provider.py:186` and
-      `base_reduction_objective_csv_provider.py:169`: trace whether any
-      handler path uses them and bypasses `finalize_ingest_meta`; fix
-      or confirm unreachable.
+- ✅ Sibling `"status_message": "Success"` hardcodes traced — both
+      unreachable (base default overridden by every concrete provider;
+      reduction-objective class has no registered handler). See Done.
 
 ## 🐞 Newly discovered (Guilbert, 2026-05-20)
 
-- [ ] **Year-config pipeline doesn't block same-year uploads.** With a
-      `unit_sync` / year-configuration pipeline running for year Y,
-      after a page refresh the "loading" indicator is gone — nothing
-      blocks the user from uploading data for Y while the year is
-      still being provisioned. Suggested shape: a
-      `configuration_completed` flag (with timestamp) on
-      `year_configuration`; gate upload on it. Adjacent to #1236
-      Problem B (scoped ordering correctness) but at the **year**
-      grain, not `(module, det)`.
-- [ ] **`unit_sync` collapses to one aggregated task per year.**
-      Individual sub-tasks aren't exposed in the ops UI. Show them so
-      operators can see what's actually running inside the year-level
-      pipeline.
-- [ ] **No SSE on the pipeline ops page.** The table doesn't
-      live-update; pipeline progress doesn't stream into the open
-      page or the message dialog. `usePipelineStream` +
-      `GET /pipelines/{id}/stream` exist and were deferred in #1234
-      — wire them (per-row for visible items, or a page-level
-      subscription to the running pipelines on the current page).
+- ✅ #1 Year-config gate — backend `13616a35`, frontend `c1e9ef01`.
+- ✅ #3 SSE on the ops page — `645b4799`.
+- [ ] **#2 `unit_sync` collapses to one aggregated task per year.**
+      Individual sub-tasks aren't exposed in the ops UI. Investigate
+      whether the sub-tasks are not created (backend collapses
+      everything into the `unit_sync` handler internally) or are
+      created but filtered out by the ops endpoint; expose them so
+      operators can see what's running inside the year-level
+      pipeline. **Investigation pending** before picking
+      backend-vs-frontend fix.
 
 ## 🔧 To DO — #1236 remaining phases
 
@@ -80,9 +95,12 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       progress) to the `pipelines` table; `compute_pipeline_progress`
       becomes writer-side only. Schedule the reconciliation sweep on a
       cron _before_ flipping. Verify: golden-output diff before/after.
-- [ ] **VERIFY (gates Phase 4)**: does the aggregation handler
-      full-rewrite all ~2231 `carbon_reports`, or is it already
-      scoped? Confirm before designing the scoping change.
+- ✅ **VERIFY (Phase 4 gate) — answered:** aggregation handler is
+      scoped at `(module_type_id, year)`. The 2231 number is
+      per-unit module rows, not all reports. Collision source is
+      `recompute_stats`'s side-effect rewrite of the parent
+      `carbon_report.stats` synthesis (shared row). Phase 4A lever is
+      **coalescing**, not narrower scoping.
 - [ ] **Phase 4A**: aggregation coalesce + scope to
       `affected_module_ids` (extend `AGGREGATION_DEDUP`).
 - [ ] **Phase 4B**: scoped `(module,det,year)` factor→data ordering

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -219,8 +219,14 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       ships `status` in the progress payload so the frontend can
       tell PARTIAL from FAILED (both set `has_error=True`).
       `pipeops_status_partial` i18n key finally has a renderer.
-- [ ] Aggregation coalescing key: `(carbon_report scope, year)`? how
-      `unit_sync` (year-level, also rewrites `carbon_reports`) folds in.
+- ✅ Aggregation coalescing — `unit_sync` ↔ aggregation
+      concurrency safety **shipped (`e2b6ed77`)**: `unit_sync_handler`
+      now acquires the same `pg_advisory_xact_lock(1236, year)` that
+      `aggregation_handler` takes (4A.2). Both rewrite `carbon_reports`
+      for the same (unit, year) slice; sharing the category means they
+      mutually exclude. `test_unit_sync_lock_category_matches_aggregation`
+      pins the invariant so a future refactor can't silently split the
+      categories.
 - ✅ Phase-3 sweep cron cadence: **60s** (configurable via
       `PIPELINE_RECONCILER_INTERVAL_SECONDS`).
 - ✅ `pipeops_status_partial` i18n key — kept (now rendered by the

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -118,9 +118,26 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       Combined: amplification killed (4A.1), cross-pipeline deadlock
       eliminated (4A.2), per-aggregation write set shrunk (4A.3).
 - ✅ **Phase 4A**: shipped as 4A.1/4A.2/4A.3 (see Done section).
-- [ ] **Phase 4B**: scoped `(module,det,year)` factor→data ordering
-      (correctness — stale-factor recalc); reuse
-      `uq_emission_recalc_active`.
+- [ ] **4A.4 (race fix on 4A.3)**: the LAST recalc sibling chains the
+      aggregation before its own runner-`finish_job` commits, so its
+      `affected_module_ids` are not visible to the aggregation's
+      sibling-query. The aggregation misses the last sibling's modules.
+      Fix: at chain time the last sibling builds the union locally
+      (sibling-query + its own `stats["affected_module_ids"]`) and
+      passes it via `chain_job(config={...})` so the aggregation reads
+      it from its own meta. Surfaced by Guilbert "all aggregations are
+      0s" on 2026-05-20 — mostly that observation is the optimization
+      working (empty-affected recalcs), but the race is real.
+- ✅ **Phase 4B (`1bd26748`)**: per-`(module, year)`
+      `pg_advisory_xact_lock` in `factor_ingest_handler`,
+      `emission_recalc_handler`, `module_emission_recalc_handler`.
+      Shared helper `acquire_factor_recalc_lock` in `app/tasks/_locks.py`,
+      dedicated category `1237` (distinct from 4A.2's `1236`).
+      Eliminates the silent-wrong-numbers race where a recalc reads
+      half-written factors during a concurrent factor_ingest.
+- ✅ **Phase 4B**: shipped as `1bd26748` (advisory lock at `(module,
+      year)` scope, not `(module, det, year)` — broader but
+      drop-hazard-free; see Done).
 - [ ] **Phase 5**: retire `meta` threading
       (`recalc_jobs_chained` / `aggregation_job_id` / `parent_job_id`
       read paths) once nothing consumes them.

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -199,10 +199,14 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
 
 ## 🔧 To DO — smaller follow-ups
 
-- [ ] Lone-orphan `last_error`: when a job's only message is
-      `"Success"` (the real reason is in `meta.stats.row_errors`),
-      surface that reason instead. (Deeper than Phase 1; pairs with
-      v1.x backfill quality.)
+- ✅ **Lone-orphan `last_error` (`918f70d0`)**: `finalize_ingest_meta`
+      now appends a sample reason from `stats.row_errors` when the
+      summary path fires. Operators see *"first error: No matching
+      factor found in factors map (kind=Monitors, …)"* instead of just
+      *"0 inserted, 50 072 skipped"*. Capped at 200 chars + ellipsis
+      so a long reason can't bloat `status_message`. 4 regression
+      tests cover the enrich path, the cap, the no-row-errors fallback,
+      and the SUCCESS-path preservation.
       _(Live SSE on the console moved up to "Newly discovered" — same
       issue, more specific framing.)_
 

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -212,14 +212,19 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
 
 ## ❓ Needs a decision (yours)
 
-- [ ] `PARTIAL` vs `FAILED` boundary — Phase 1 emits only
-      SUCCESS/FAILED; `PARTIAL` reserved, undefined.
+- ✅ `PARTIAL` vs `FAILED` boundary — **shipped (`04786254`)**.
+      Rule: root SUCCESS/WARNING + any descendant ERROR → PARTIAL
+      (amber, "data landed, chain had issues"); root ERROR → FAILED
+      (red, "data didn't land"). `compute_pipeline_progress` now
+      ships `status` in the progress payload so the frontend can
+      tell PARTIAL from FAILED (both set `has_error=True`).
+      `pipeops_status_partial` i18n key finally has a renderer.
 - [ ] Aggregation coalescing key: `(carbon_report scope, year)`? how
       `unit_sync` (year-level, also rewrites `carbon_reports`) folds in.
 - ✅ Phase-3 sweep cron cadence: **60s** (configurable via
       `PIPELINE_RECONCILER_INTERVAL_SECONDS`).
-- [ ] Remove the now-unused `pipeops_status_partial` i18n key? (left
-      in to avoid churn.)
+- ✅ `pipeops_status_partial` i18n key — kept (now rendered by the
+      PARTIAL tier; see `04786254`).
 
 ## ⚙️ Process / integration
 

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -83,10 +83,18 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
 
 ## 🔧 To DO — #1236 remaining phases
 
-- [ ] **Phase 2**: enforce `data_ingestion_jobs.pipeline_id` →
-      `pipelines(id)` FK. v0.x = no backfill (DB dropped between
-      deploys); add the FK migration to run on a clean DB already on
-      Phase-1 code. Real backfill is a **v1.x** concern.
+- ✅ **Phase 2 (`acceae13`)**: enforced
+      `data_ingestion_jobs.pipeline_id` → `pipelines(id)` FK via
+      migration `c4d5e6f7a8b9` (chains on `a3b8c9d0e1f2`). Adds
+      `ix_data_ingestion_jobs_pipeline_id` (Postgres doesn't
+      auto-index the referencing column; console + recalc fan-out
+      query by `pipeline_id` constantly). `ON DELETE RESTRICT`
+      (default) — pipelines are append-only ledger today. Model's
+      `sa_column` updated with `ForeignKey("pipelines.id")` so
+      SQLAlchemy schema view matches Postgres. v0.x = no backfill
+      (DB dropped between deploys); migration applies on the next
+      clean-DB deploy. 1385 unit tests still green (SQLite metadata
+      build accepts the FK).
 - [ ] **Phase 3**: flip reads (console #1234, `GET /pipelines/{id}`,
       progress) to the `pipelines` table; `compute_pipeline_progress`
       becomes writer-side only. Schedule the reconciliation sweep on a

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -172,9 +172,30 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
         per-phase visibility. Keep in mind if real chained semantics
         ever become needed (independent retry per phase, separate
         locking, etc.).
-- [ ] **Phase 5**: retire `meta` threading
-      (`recalc_jobs_chained` / `aggregation_job_id` / `parent_job_id`
-      read paths) once nothing consumes them.
+- ✅ **Phase 5 (2 commits)**: retired the meta threading.
+      - `6c3e762b` **Phase 5A** — `recompute_pipeline_status` now writes
+        `pipelines.expected_recalc` on every recompute call (cheap UPDATE;
+        not gated on `progress.done` so the column tracks live fan-out).
+        Sets up 5B's read flip; purely additive.
+      - `a5f08a56` **Phase 5B** — flipped reads + dropped meta writes:
+        * `compute_pipeline_progress._find_root` → `min(jobs, key=id)`
+          (dropped `_ROOT_JOB_TYPES` which omitted `unit_sync` /
+          `reference_ingest` parents).
+        * `expected_recalc` reads `pipeline.expected_recalc`; falls
+          back to live job count for orphans / writer-side recompute.
+        * Phase-3 aggregation check: "all aggregation rows FINISHED"
+          (no more `meta.aggregation_job_id` set lookup). Docstring
+          names the 4A.1 single-aggregation dependency.
+        * `_is_last_recalc_sibling` — lock target moved to
+          `pipelines` row (was `data_ingestion_jobs` parent); reads
+          `pipeline.expected_recalc`. Lock-down test
+          (`test_concurrent_siblings_yield_exactly_one_last`) asserts
+          exactly one sibling returns True — guards 4A.1's single-
+          aggregation guarantee from the lock-target move.
+        * Dropped writes: `meta.parent_job_id` (`_chain.py` ×2,
+          `emission_recalculation_tasks.py`), `meta.aggregation_job_id`
+          (×2), `meta.recalc_jobs_chained` (`ingestion_tasks.py` ×3).
+        * `_PIPELINE_META_ALLOW`: 3 keys retired.
 
 ## 🔧 To DO — smaller follow-ups
 

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -209,6 +209,49 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       and the SUCCESS-path preservation.
       _(Live SSE on the console moved up to "Newly discovered" — same
       issue, more specific framing.)_
+- ✅ **Autoflush FK bug (`23e47698`)** — `data_sync._stamp_job_type_and_meta`
+      and `_chain.chain_job` assigned `row.pipeline_id = X` *before*
+      `ensure_pipeline_exists`; the SELECT inside the latter
+      triggered autoflush which fired the FK on the half-set row.
+      Both reordered; regression test extended (5 cases) to cover
+      the autoflush shape.
+- ✅ **Equipment / "common" upload fail-fast guards** —
+      `64760c85` (handler `require_factor_to_match=True` empty
+      factors → raise at setup) + `c306b3a4` (per-module-type
+      `_FACTOR_INFERRED_MODULES = {equipment_electric_consumption,
+      purchase}` check: empty `factors_map` raises before the row
+      loop). User-reported 50k row-error log spam → one terminal
+      error with the cause in `status_message`.
+- ✅ **Units bulk_upsert race + global unit_sync lock (`1a637165`)**
+      — parallel year creation (2025+2026) crashed on
+      `ix_units_institutional_code`. Two-layer fix:
+      1. `UnitRepository.bulk_upsert` uses `INSERT … ON CONFLICT
+         (institutional_code) DO UPDATE` on Postgres (race-safe by
+         construction); SQLite fixture keeps legacy SELECT/merge.
+      2. `unit_sync_handler` acquires a GLOBAL 1-int advisory lock
+         (category `1239`) BEFORE the per-year aggregation lock —
+         serializes ALL unit_syncs regardless of year. Category
+         distinctness pinned by test.
+- ✅ **Pipeline Operations menu reorder + SA trump (`232ca077`)** —
+      `BACKOFFICE_PIPELINE_OPERATIONS` moved below `BACKOFFICE_LOGS`.
+      `Co2Sidebar.isItemDisabled` now short-circuits SuperAdmin past
+      all gates (no scenario where SA should be locked out of a
+      back-office page) — applies to User Management, Data
+      Management, and Pipeline Operations symmetrically.
+
+### Latent (documented, fix shape known, not yet shipped)
+
+- [ ] `UserRepository.bulk_upsert` — same SELECT-then-merge race
+      shape as the old units path. Currently safe because the global
+      unit_sync lock serialises the ONE production caller; the seed
+      script has no concurrency. Fix shape: `INSERT … ON CONFLICT
+      (institutional_id) DO UPDATE` mirroring `unit_repo`. Do it
+      *when* a second caller appears.
+- [ ] `reference_data` CSV ingest does `DELETE BuildingRoom; INSERT
+      rooms` (year-agnostic, like units). Single-operator upload
+      today so the race is latent; if multiple ops ever ingest
+      reference data concurrently, port the global-lock pattern from
+      `unit_sync`.
 
 ## ❓ Needs a decision (yours)
 

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -101,8 +101,23 @@ Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
       `recompute_stats`'s side-effect rewrite of the parent
       `carbon_report.stats` synthesis (shared row). Phase 4A lever is
       **coalescing**, not narrower scoping.
-- [ ] **Phase 4A**: aggregation coalesce + scope to
-      `affected_module_ids` (extend `AGGREGATION_DEDUP`).
+- ✅ **Phase 4A — done (3 commits):**
+      - `73ec4d64` 4A.1 in-pipeline coalesce — last emission_recalc
+        sibling chains aggregation; others skip. Race-safe via
+        fresh-session `SELECT … FOR UPDATE` on parent + `meta
+        .recalc_work_complete` flag. 3 sequential aggregations per
+        upload → 1.
+      - `718cdd01` 4A.2 per-year `pg_advisory_xact_lock` in
+        `aggregation_handler` — serialises cross-pipeline
+        aggregations of the same year against shared
+        `carbon_reports.stats` rows; no drop-hazard. Dialect-gated
+        (SQLite skip).
+      - `1b20f967` 4A.3 scope to `affected_module_ids` union —
+        aggregation rewrites only modules the recalc siblings
+        actually touched (typically 432 vs 2231).
+      Combined: amplification killed (4A.1), cross-pipeline deadlock
+      eliminated (4A.2), per-aggregation write set shrunk (4A.3).
+- ✅ **Phase 4A**: shipped as 4A.1/4A.2/4A.3 (see Done section).
 - [ ] **Phase 4B**: scoped `(module,det,year)` factor→data ordering
       (correctness — stale-factor recalc); reuse
       `uq_emission_recalc_active`.

--- a/docs/src/implementation-plans/pipeline-debug-todo.md
+++ b/docs/src/implementation-plans/pipeline-debug-todo.md
@@ -1,0 +1,118 @@
+# Pipeline-debug — living TODO
+
+Integration branch: `fix/pipeline-debug` (all items below land there until
+told otherwise). Last updated 2026-05-19.
+
+## ✅ Done & on the branch
+
+- #1234 console + 422/scope fixes (`d671cefb`) merged.
+- #1225 emission-recalc resilience + eager-pipeline-id (`ece34533`) merged.
+- #1236 Phase 1: `pipelines` table + model + `ensure_pipeline_exists`
+  (4 mint sites) + runner post-`finish_job` isolated status write +
+  `reconcile_pipeline_statuses` sweep + tests.
+- #1236 root cause: `finalize_ingest_meta` — a FINISHED job with
+  `result != SUCCESS` never reports `"Success"`; shared by
+  `_run_ingest` (csv/api/factor) **and** `reference_ingest`.
+- Console table: clickable full message + copy, server-resolved
+  module/det names, distinct amber WARNING tier.
+
+## 🔎 To CHECK (verified at type/lint/unit level only — NOT runtime)
+
+Honest gap: green `ruff`/`mypy`/`eslint`/`vue-tsc`/unit ≠ "works live".
+
+- [ ] Console page renders on localhost: alert strip, filters narrow,
+      row expand → DAG, **message dialog + copy**, `@click.stop` vs
+      row-expand, **amber WARNING** tier, **named module/det** show.
+- [ ] Bug-2 re-confirm: `?state=NOT_STARTED` returns 200 (not 422) and
+      the console shows _many_ pipelines + tagged orphans (the
+      permission-scope fix) — confirm on evidence.
+- [ ] Eager-pipeline-id end-to-end: a fresh dispatch persists
+      `pipeline_id`, creates the `pipelines` row, status advances.
+- [ ] #1236 Phase-1 on a real run: runner post-finish isolated write
+      lands; induce a failure → log-and-skip + sweep heals.
+- [ ] `alembic upgrade head` applies cleanly on a real Postgres DB
+      (only parsed + SQLite-fixture tested so far).
+- [ ] One clean **hook-driven** commit (commitlint + lint-staged +
+      `make type-check`) — merges/commits used `--no-verify`; confirm
+      the gate passes for real before any promotion.
+- [ ] Sibling `"status_message": "Success"` hardcodes in
+      `base_provider.py:186` and
+      `base_reduction_objective_csv_provider.py:169`: trace whether any
+      handler path uses them and bypasses `finalize_ingest_meta`; fix
+      or confirm unreachable.
+
+## 🐞 Newly discovered (Guilbert, 2026-05-20)
+
+- [ ] **Year-config pipeline doesn't block same-year uploads.** With a
+      `unit_sync` / year-configuration pipeline running for year Y,
+      after a page refresh the "loading" indicator is gone — nothing
+      blocks the user from uploading data for Y while the year is
+      still being provisioned. Suggested shape: a
+      `configuration_completed` flag (with timestamp) on
+      `year_configuration`; gate upload on it. Adjacent to #1236
+      Problem B (scoped ordering correctness) but at the **year**
+      grain, not `(module, det)`.
+- [ ] **`unit_sync` collapses to one aggregated task per year.**
+      Individual sub-tasks aren't exposed in the ops UI. Show them so
+      operators can see what's actually running inside the year-level
+      pipeline.
+- [ ] **No SSE on the pipeline ops page.** The table doesn't
+      live-update; pipeline progress doesn't stream into the open
+      page or the message dialog. `usePipelineStream` +
+      `GET /pipelines/{id}/stream` exist and were deferred in #1234
+      — wire them (per-row for visible items, or a page-level
+      subscription to the running pipelines on the current page).
+
+## 🔧 To DO — #1236 remaining phases
+
+- [ ] **Phase 2**: enforce `data_ingestion_jobs.pipeline_id` →
+      `pipelines(id)` FK. v0.x = no backfill (DB dropped between
+      deploys); add the FK migration to run on a clean DB already on
+      Phase-1 code. Real backfill is a **v1.x** concern.
+- [ ] **Phase 3**: flip reads (console #1234, `GET /pipelines/{id}`,
+      progress) to the `pipelines` table; `compute_pipeline_progress`
+      becomes writer-side only. Schedule the reconciliation sweep on a
+      cron _before_ flipping. Verify: golden-output diff before/after.
+- [ ] **VERIFY (gates Phase 4)**: does the aggregation handler
+      full-rewrite all ~2231 `carbon_reports`, or is it already
+      scoped? Confirm before designing the scoping change.
+- [ ] **Phase 4A**: aggregation coalesce + scope to
+      `affected_module_ids` (extend `AGGREGATION_DEDUP`).
+- [ ] **Phase 4B**: scoped `(module,det,year)` factor→data ordering
+      (correctness — stale-factor recalc); reuse
+      `uq_emission_recalc_active`.
+- [ ] **Phase 5**: retire `meta` threading
+      (`recalc_jobs_chained` / `aggregation_job_id` / `parent_job_id`
+      read paths) once nothing consumes them.
+
+## 🔧 To DO — smaller follow-ups
+
+- [ ] Lone-orphan `last_error`: when a job's only message is
+      `"Success"` (the real reason is in `meta.stats.row_errors`),
+      surface that reason instead. (Deeper than Phase 1; pairs with
+      v1.x backfill quality.)
+      _(Live SSE on the console moved up to "Newly discovered" — same
+      issue, more specific framing.)_
+
+## ❓ Needs a decision (yours)
+
+- [ ] `PARTIAL` vs `FAILED` boundary — Phase 1 emits only
+      SUCCESS/FAILED; `PARTIAL` reserved, undefined.
+- [ ] Aggregation coalescing key: `(carbon_report scope, year)`? how
+      `unit_sync` (year-level, also rewrites `carbon_reports`) folds in.
+- [ ] Phase-3 sweep cron cadence / trigger.
+- [ ] Remove the now-unused `pipeops_status_partial` i18n key? (left
+      in to avoid churn.)
+
+## ⚙️ Process / integration
+
+- [ ] `#1225` + eager-pipeline-id + #1236 live **only** on
+      `fix/pipeline-debug`, not in any `dev` PR. Stage promotion needs
+      a deliberate "promote the integration branch" step — decide
+      when/how.
+- [ ] Verify/close **PR #1235** (the original #1234→dev PR,
+      `816c817b`): superseded by the integration-branch state, like
+      #1237 was. Confirm and close/retarget.
+- Note: commit `9ac03507` ("chore: lint-staged formatting") actually
+  carried the Phase-1 scaffolding (model+migration+doc) — hook
+  mislabel, content is correct in HEAD. History cosmetic only.

--- a/frontend/src/components/layout/Co2Sidebar.vue
+++ b/frontend/src/components/layout/Co2Sidebar.vue
@@ -30,7 +30,13 @@ const hasSuperAdminRole = computed(() => {
 });
 
 function isItemDisabled(item: NavItem): boolean {
-  if (item.superAdminOnly === true && !hasSuperAdminRole.value) return true;
+  // Super-admin trumps all gates — SA sees every menu item.  Applies
+  // to ``limitedAccess`` items too (Pipeline Operations, Data
+  // Management, User Management), not just plain unrestricted ones —
+  // there is no scenario where a SA should be locked out of a
+  // back-office page.
+  if (hasSuperAdminRole.value) return false;
+  if (item.superAdminOnly === true) return true;
   if (item.limitedAccess === true && !hasBackOfficeEditPermission.value)
     return true;
   return false;

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, inject, type Ref } from 'vue';
+import { ref, inject, computed, type ComputedRef, type Ref } from 'vue';
 import { useSubmoduleConfig } from 'src/composables/useSubmoduleConfig';
 import { useRecalculation } from 'src/composables/useRecalculation';
 import {
@@ -8,6 +8,7 @@ import {
   type ImportRow,
 } from 'src/stores/backofficeDataManagement';
 import type { SubmoduleConfig } from 'src/constant/backoffice-module-config';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
 import UploadCardData from 'src/components/molecules/data-management/UploadCardData.vue';
 import UploadCardFactors from 'src/components/molecules/data-management/UploadCardFactors.vue';
 import UploadCardReferences from 'src/components/molecules/data-management/UploadCardReferences.vue';
@@ -48,6 +49,19 @@ const backofficeStore = useBackofficeDataManagement();
 const triggerTypeRecalculation = inject<
   (sub: SubmoduleConfig) => Promise<void>
 >('triggerTypeRecalculation')!;
+
+// Issue #1219 / #1234 — share the module-scoped pipeline progress
+// from ModuleConfig (single SSE subscriber, provided up the tree).
+// Without this the per-submodule UploadCardData kept a green ✓ +
+// "N rows imported" even while emission_recalc / aggregation
+// children were still running.  Mirrors ModuleUploadsSection's
+// pattern so every per-submodule card tells the same story as the
+// module-level cards.
+const injectedPipelineProgress =
+  inject<ComputedRef<PipelineProgress | null>>('pipelineProgress');
+const pipelineProgress = computed<PipelineProgress | null>(
+  () => injectedPipelineProgress?.value ?? null,
+);
 
 const openDataEntryDialog = inject<
   (row: ImportRow, targetType: TargetType | null) => void
@@ -232,6 +246,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         :module="submodule.key"
         :computed-factor-running="computedFactorRunning[submodule.key]"
         :any-computed-factor-running="anyComputedFactorRunning"
+        :pipeline-progress="pipelineProgress"
         :on-download="
           (e, y) => {
             downloadLastCsv(e, y);
@@ -252,6 +267,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
           ]
         "
         :recalc-status="getRecalcStatus(submodule)"
+        :pipeline-progress="pipelineProgress"
         :on-download="downloadLastCsv"
         @upload="(row) => openDataEntryDialog(row, TargetType.DATA_ENTRIES)"
         @recalculate="() => triggerTypeRecalculation(submodule)"

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -101,6 +101,18 @@ const pipelinePhaseLabelKey = computed<string | null>(() => {
   return PIPELINE_PHASE_LABEL_KEYS[p.phase_label] ?? null;
 });
 
+// Pipeline-in-progress flag for the "validated" ✓ indicator below.
+// The green ✓ next to the filename used to appear as soon as the
+// upload job finished — even when emission_recalc / aggregation
+// children were still running.  Operators read that as "all done"
+// and were surprised to see RUNNING tasks on the pipeline-ops page.
+// Now the ✓ stays amber (⋯) until the WHOLE pipeline finishes,
+// matching what the pipeline-ops console shows.
+const pipelineStillRunning = computed<boolean>(() => {
+  const p = props.pipelineProgress;
+  return !!(p && !p.done);
+});
+
 function handleUpload() {
   if (props.row && props.targetType !== undefined) {
     emit('upload', props.row, props.targetType);
@@ -191,7 +203,21 @@ function handleCancel() {
       >
         <div class="column">
           <div class="row items-center text-body2 text-weight-medium">
-            <span class="text-positive q-mr-xs">✓</span>
+            <!-- Green ✓ only when the FULL pipeline is done — while
+                 emission_recalc / aggregation children are still
+                 running, show an amber ⋯ so the config page tells the
+                 same story as the pipeline-ops console.  Previously
+                 the ✓ appeared the moment csv_ingest finished and
+                 read as "all done" even though downstream was still
+                 in flight. -->
+            <span
+              v-if="pipelineStillRunning"
+              class="text-warning q-mr-xs"
+              :title="$t('data_management_pipeline_running_tooltip')"
+            >
+              ⋯
+            </span>
+            <span v-else class="text-positive q-mr-xs">✓</span>
             {{ jobInfo.fileName }}
           </div>
           <div class="text-caption text-grey-7">

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -288,7 +288,6 @@ function handleCancel() {
           </q-tooltip>
         </q-icon>
       </div>
-
     </div>
 
     <!-- Issue #1219 + UX consolidation — ONE in-progress indicator

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -266,36 +266,38 @@ function handleCancel() {
         </q-icon>
       </div>
 
-      <!-- Stuck job: cancel button -->
-      <div
-        v-if="isJobStuck"
-        class="row items-center no-wrap"
-        style="gap: 0.5rem"
-      >
-        <q-spinner-rings color="grey" size="sm" />
-        <span class="text-caption text-grey-7">{{
-          $t('data_management_job_in_progress')
-        }}</span>
-        <q-btn
-          color="negative"
-          outline
-          icon="cancel"
-          size="sm"
-          :label="$t('data_management_cancel_job')"
-          class="text-weight-medium"
-          @click="handleCancel"
-        />
-      </div>
     </div>
 
-    <!-- Issue #1219 — live recalc-pipeline phase (module-scoped) -->
+    <!-- Issue #1219 + UX consolidation — ONE in-progress indicator
+         covering both the live csv_ingest (``isJobStuck``) and the
+         downstream recalc/aggregation phases (``pipelinePhaseLabelKey``).
+         Previously each rendered its own spinner-and-text row; during
+         phase 1 BOTH showed simultaneously ("Job in progress…" + "Step
+         1/3 · Inserting data…"), giving three loading icons on a single
+         card.  Now: one spinner, phase-label when available, plus the
+         cancel button when the parent job is the active running one. -->
     <div
-      v-if="pipelinePhaseLabelKey"
+      v-if="isJobStuck || pipelinePhaseLabelKey"
       class="row items-center text-caption q-mt-xs text-grey-7"
+      style="gap: 0.5rem"
       data-testid="pipeline-phase"
     >
-      <q-spinner-rings color="grey" size="sm" class="q-mr-xs" />
-      <span>{{ $t(pipelinePhaseLabelKey) }}</span>
+      <q-spinner-rings color="grey" size="sm" />
+      <span>{{
+        pipelinePhaseLabelKey
+          ? $t(pipelinePhaseLabelKey)
+          : $t('data_management_job_in_progress')
+      }}</span>
+      <q-btn
+        v-if="isJobStuck"
+        color="negative"
+        outline
+        icon="cancel"
+        size="sm"
+        :label="$t('data_management_cancel_job')"
+        class="text-weight-medium q-ml-sm"
+        @click="handleCancel"
+      />
     </div>
 
     <!-- API ingestion status (success: small inline line; error: banner below) -->

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -85,30 +85,53 @@ const apiRowsInserted = computed<number | undefined>(() => {
   return typeof inserted === 'number' ? inserted : undefined;
 });
 
-// Issue #1219 — live recalc-pipeline phase for this card. The pipeline
-// is module-scoped, so every card in the module reflects the same
-// phase while it runs (Data → Emissions → Aggregation). Hidden once
-// the pipeline is done or errored (the error surfaces via lastJob).
+// Issue #1219 — live recalc-pipeline phase for this card.
+//
+// Pipeline progress is module-scoped (provided by ModuleConfig as the
+// single SSE subscriber) AND kind-scoped: a factor_ingest pipeline
+// shouldn't surface its phase on the data card and vice versa.
+// ``pipelineAppliesToCard`` gates rendering on ``progress.kind``
+// matching this card's ``targetType`` — empty kind (orphan / unknown
+// root) falls back to "don't render" rather than risk showing on the
+// wrong card.
 const PIPELINE_PHASE_LABEL_KEYS: Record<string, string> = {
   data: 'data_management_pipeline_phase_data',
   emissions: 'data_management_pipeline_phase_emissions',
   aggregation: 'data_management_pipeline_phase_aggregation',
 };
 
+const TARGET_TO_KINDS: Record<number, ReadonlyArray<string>> = {
+  // TargetType.DATA_ENTRIES = 0 — the parent of a data-pipeline is
+  // csv_ingest (file upload) or api_ingest (admin-triggered sync).
+  [TargetType.DATA_ENTRIES]: ['csv_ingest', 'api_ingest'],
+  // TargetType.FACTORS = 1 — the parent is always factor_ingest.
+  [TargetType.FACTORS]: ['factor_ingest'],
+  // TargetType.REFERENCE_DATA = 3 — reference uploads (building rooms,
+  // travel reference) chain through reference_ingest.
+  [TargetType.REFERENCE_DATA]: ['reference_ingest'],
+};
+
+const pipelineAppliesToCard = computed<boolean>(() => {
+  const p = props.pipelineProgress;
+  if (!p) return false;
+  if (props.targetType === undefined) return false;
+  const allowedKinds = TARGET_TO_KINDS[props.targetType];
+  if (!allowedKinds || !p.kind) return false;
+  return allowedKinds.includes(p.kind);
+});
+
 const pipelinePhaseLabelKey = computed<string | null>(() => {
+  if (!pipelineAppliesToCard.value) return null;
   const p = props.pipelineProgress;
   if (!p || p.done || p.has_error) return null;
   return PIPELINE_PHASE_LABEL_KEYS[p.phase_label] ?? null;
 });
 
 // Pipeline-in-progress flag for the "validated" ✓ indicator below.
-// The green ✓ next to the filename used to appear as soon as the
-// upload job finished — even when emission_recalc / aggregation
-// children were still running.  Operators read that as "all done"
-// and were surprised to see RUNNING tasks on the pipeline-ops page.
-// Now the ✓ stays amber (⋯) until the WHOLE pipeline finishes,
-// matching what the pipeline-ops console shows.
+// Same card-scoping rule: a factor upload's running pipeline shouldn't
+// turn the data card's ✓ amber.  Gated on ``pipelineAppliesToCard``.
 const pipelineStillRunning = computed<boolean>(() => {
+  if (!pipelineAppliesToCard.value) return false;
   const p = props.pipelineProgress;
   return !!(p && !p.done);
 });

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -101,9 +101,22 @@ const PIPELINE_PHASE_LABEL_KEYS: Record<string, string> = {
 };
 
 const TARGET_TO_KINDS: Record<number, ReadonlyArray<string>> = {
-  // TargetType.DATA_ENTRIES = 0 — the parent of a data-pipeline is
-  // csv_ingest (file upload) or api_ingest (admin-triggered sync).
-  [TargetType.DATA_ENTRIES]: ['csv_ingest', 'api_ingest'],
+  // TargetType.DATA_ENTRIES = 0 — every pipeline whose work targets
+  // the data-entries domain belongs on the data card:
+  //   * csv_ingest / api_ingest — user uploads or admin sync.
+  //   * emission_recalc / module_emission_recalc — pipelines minted by
+  //     POST /sync/recalculate-emissions/{module}[/{det}] when the
+  //     operator clicks the "Recalculate" button on the data card.
+  //     Their kind is set at the parent's ensure_pipeline_exists call
+  //     in data_sync.py:1610 + :1710.  Without these the recalc
+  //     pipeline runs but the data card stays blank — confusing
+  //     because the button that triggered it IS on the data card.
+  [TargetType.DATA_ENTRIES]: [
+    'csv_ingest',
+    'api_ingest',
+    'emission_recalc',
+    'module_emission_recalc',
+  ],
   // TargetType.FACTORS = 1 — the parent is always factor_ingest.
   [TargetType.FACTORS]: ['factor_ingest'],
   // TargetType.REFERENCE_DATA = 3 — reference uploads (building rooms,

--- a/frontend/src/constant/navigation.ts
+++ b/frontend/src/constant/navigation.ts
@@ -34,16 +34,21 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     icon: 'data_object',
     limitedAccess: true,
   },
-  BACKOFFICE_PIPELINE_OPERATIONS: {
-    routeName: 'backoffice-pipeline-operations',
-    description: 'backoffice-pipeline-operations-description',
-    icon: 'o_account_tree',
-    limitedAccess: true,
-  },
   BACKOFFICE_LOGS: {
     routeName: 'backoffice-logs',
     description: 'backoffice-logs-description',
     icon: 'o_list_alt',
     superAdminOnly: true,
+  },
+  // Pipeline operations sits below Logs — both back-office metier and
+  // super-admin can access (same endpoints as the data-management
+  // configuration page, so the same access rules apply).  `limitedAccess`
+  // gates on the back-office permission; the super-admin short-circuit
+  // in Co2Sidebar.isItemDisabled ensures SA always sees it too.
+  BACKOFFICE_PIPELINE_OPERATIONS: {
+    routeName: 'backoffice-pipeline-operations',
+    description: 'backoffice-pipeline-operations-description',
+    icon: 'o_account_tree',
+    limitedAccess: true,
   },
 };

--- a/frontend/src/constant/navigation.ts
+++ b/frontend/src/constant/navigation.ts
@@ -34,6 +34,12 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     icon: 'data_object',
     limitedAccess: true,
   },
+  BACKOFFICE_PIPELINE_OPERATIONS: {
+    routeName: 'backoffice-pipeline-operations',
+    description: 'backoffice-pipeline-operations-description',
+    icon: 'o_account_tree',
+    limitedAccess: true,
+  },
   BACKOFFICE_LOGS: {
     routeName: 'backoffice-logs',
     description: 'backoffice-logs-description',

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -629,6 +629,10 @@ export default {
     en: 'Step 3/3 · Aggregating…',
     fr: 'Étape 3/3 · Agrégation…',
   },
+  data_management_pipeline_running_tooltip: {
+    en: 'Upload accepted — recalculation still in progress',
+    fr: 'Téléchargement accepté — recalcul en cours',
+  },
   data_management_recalculate_retry: {
     en: 'Retry recalculation',
     fr: 'Relancer le recalcul',

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -1,0 +1,78 @@
+// Issue #1234 — pipeline operations console (back-office).
+// Auto-registered by the eager glob in src/i18n/index.ts.
+
+export default {
+  // Navigation
+  'backoffice-pipeline-operations': {
+    en: 'Pipeline operations',
+    fr: 'Opérations pipelines',
+  },
+  'backoffice-pipeline-operations-description': {
+    en: 'Global view of ingestion & recalculation pipelines',
+    fr: "Vue globale des pipelines d'ingestion et de recalcul",
+  },
+
+  // Page
+  pipeops_title: {
+    en: 'Pipeline operations',
+    fr: 'Opérations pipelines',
+  },
+  pipeops_subtitle: {
+    en: 'Ingestion & recalculation pipelines across all modules and years.',
+    fr: "Pipelines d'ingestion et de recalcul, tous modules et années.",
+  },
+
+  // Alert strip
+  pipeops_alert_failed: {
+    en: 'Failed parents',
+    fr: 'Parents en échec',
+  },
+  pipeops_alert_errors: {
+    en: 'With errors',
+    fr: 'Avec erreurs',
+  },
+  pipeops_alert_running: {
+    en: 'Running',
+    fr: 'En cours',
+  },
+  pipeops_alert_ok: {
+    en: 'Completed',
+    fr: 'Terminés',
+  },
+
+  // Filters
+  pipeops_filter_state: { en: 'State', fr: 'État' },
+  pipeops_filter_result: { en: 'Result', fr: 'Résultat' },
+  pipeops_filter_job_type: { en: 'Job type', fr: 'Type de job' },
+  pipeops_filter_year: { en: 'Year', fr: 'Année' },
+  pipeops_filter_has_errors: { en: 'Errors only', fr: 'Erreurs uniquement' },
+  pipeops_filter_search: {
+    en: 'Search status message',
+    fr: 'Rechercher dans le message',
+  },
+  pipeops_filter_clear: { en: 'Clear filters', fr: 'Réinitialiser' },
+
+  // Table
+  pipeops_col_status: { en: 'Status', fr: 'Statut' },
+  pipeops_col_pipeline: { en: 'Pipeline', fr: 'Pipeline' },
+  pipeops_col_trigger: { en: 'Trigger', fr: 'Déclencheur' },
+  pipeops_col_module: { en: 'Module / Year', fr: 'Module / Année' },
+  pipeops_col_jobs: { en: 'Jobs', fr: 'Jobs' },
+  pipeops_col_duration: { en: 'Duration', fr: 'Durée' },
+  pipeops_col_when: { en: 'Started', fr: 'Démarré' },
+  pipeops_col_message: { en: 'Message', fr: 'Message' },
+
+  pipeops_status_running: { en: 'Running', fr: 'En cours' },
+  pipeops_status_done: { en: 'Done', fr: 'Terminé' },
+  pipeops_status_failed: { en: 'Failed', fr: 'Échec' },
+  pipeops_status_partial: { en: 'Partial', fr: 'Partiel' },
+
+  pipeops_orphan_tag: { en: '(no pipeline)', fr: '(sans pipeline)' },
+  pipeops_live: { en: 'live', fr: 'live' },
+  pipeops_empty: {
+    en: 'No pipelines match the current filters.',
+    fr: 'Aucun pipeline ne correspond aux filtres actuels.',
+  },
+  pipeops_loading: { en: 'Loading…', fr: 'Chargement…' },
+  pipeops_refresh: { en: 'Refresh', fr: 'Actualiser' },
+};

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -93,4 +93,19 @@ export default {
   },
   pipeops_loading: { en: 'Loading…', fr: 'Chargement…' },
   pipeops_refresh: { en: 'Refresh', fr: 'Actualiser' },
+
+  // Inline phase hints rendered in the "Message" column while a
+  // pipeline is still running (replaces the root job's misleading
+  // ``status_message="Success"`` during the lag between csv_ingest
+  // FINISHED and the chain completing).
+  pipeops_phase_prefix: { en: 'Phase', fr: 'Phase' },
+  pipeops_phase_data: { en: 'Data inserted', fr: 'Données insérées' },
+  pipeops_phase_emissions: {
+    en: 'Emissions recalculating',
+    fr: 'Recalcul des émissions',
+  },
+  pipeops_phase_aggregation: {
+    en: 'Aggregating',
+    fr: 'Agrégation',
+  },
 };

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -66,6 +66,14 @@ export default {
   pipeops_status_done: { en: 'Done', fr: 'Terminé' },
   pipeops_status_failed: { en: 'Failed', fr: 'Échec' },
   pipeops_status_partial: { en: 'Partial', fr: 'Partiel' },
+  pipeops_status_warning: { en: 'Warning', fr: 'Avertissement' },
+
+  pipeops_msg_click_hint: {
+    en: 'Click to view the full message',
+    fr: 'Cliquer pour voir le message complet',
+  },
+  pipeops_msg_title: { en: 'Message', fr: 'Message' },
+  pipeops_msg_copy: { en: 'Copy', fr: 'Copier' },
 
   pipeops_orphan_tag: { en: '(no pipeline)', fr: '(sans pipeline)' },
   pipeops_live: { en: 'live', fr: 'live' },

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -75,6 +75,13 @@ export default {
   pipeops_msg_title: { en: 'Message', fr: 'Message' },
   pipeops_msg_copy: { en: 'Copy', fr: 'Copier' },
 
+  // #2D — phase checklist + status_history timeline rendering
+  pipeops_history_toggle: { en: 'Show timeline', fr: 'Voir la chronologie' },
+  pipeops_history_count: {
+    en: '{n} entries',
+    fr: '{n} entrées',
+  },
+
   pipeops_orphan_tag: { en: '(no pipeline)', fr: '(sans pipeline)' },
   pipeops_live: { en: 'live', fr: 'live' },
   pipeops_empty: {

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -41,8 +41,11 @@ export default {
   },
 
   // Filters
+  // Phase 3 read-flip (#1236): ``state`` filters pipeline-level
+  // ``pipelines.status`` now (NOT_STARTED / RUNNING / SUCCESS /
+  // PARTIAL / FAILED).  ``pipeops_filter_result`` is dropped along
+  // with the URL param it labelled.
   pipeops_filter_state: { en: 'State', fr: 'État' },
-  pipeops_filter_result: { en: 'Result', fr: 'Résultat' },
   pipeops_filter_job_type: { en: 'Job type', fr: 'Type de job' },
   pipeops_filter_year: { en: 'Year', fr: 'Année' },
   pipeops_filter_has_errors: { en: 'Errors only', fr: 'Erreurs uniquement' },

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -125,9 +125,23 @@ const activePipelineId = ref<string | null>(null);
 const activePipelineYear = ref<number | null>(null);
 
 const yearSyncInFlight = computed(() => {
+  // In-flight signal (in-memory) — covers the create-year session
+  // window before the SSE stream signals completion.
   const id = activePipelineId.value;
-  if (!id) return false;
-  return !isFinishedFor(id).value;
+  if (id && !isFinishedFor(id).value) return true;
+  // #1234-followup (Guilbert 2026-05-20): durable signal that survives
+  // a page refresh. ``configuration_completed`` is stamped by
+  // ``unit_sync_handler`` on SUCCESS; while it's ``null`` the year is
+  // still being provisioned. Without this branch, a refresh during
+  // provisioning clears ``activePipelineId`` and the inert/loader
+  // vanished prematurely — exactly the bug Guilbert reported.
+  if (
+    yearConfigStore.config &&
+    yearConfigStore.config.configuration_completed == null
+  ) {
+    return true;
+  }
+  return false;
 });
 
 watch(

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
+import { copyToClipboard, Notify } from 'quasar';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
 import {
@@ -10,6 +11,25 @@ import {
 const store = usePipelineOperationsConsole();
 
 const expanded = ref<Set<string>>(new Set());
+
+// UI1 — full-message dialog + copy-to-clipboard.
+const msgDialog = ref(false);
+const msgText = ref('');
+
+function openMsg(text: string | null): void {
+  if (!text) return;
+  msgText.value = text;
+  msgDialog.value = true;
+}
+
+async function copyMsg(): Promise<void> {
+  try {
+    await copyToClipboard(msgText.value);
+    Notify.create({ type: 'positive', message: 'Copied', timeout: 1200 });
+  } catch {
+    Notify.create({ type: 'negative', message: 'Copy failed' });
+  }
+}
 
 function rowKey(p: PipelineListItem): string {
   return p.pipeline_id ?? `orphan-${p.latest_job_id}`;
@@ -23,12 +43,18 @@ function toggle(p: PipelineListItem): void {
   expanded.value = new Set(expanded.value);
 }
 
-type StatusKind = 'failed' | 'running' | 'partial' | 'done';
+type StatusKind = 'failed' | 'running' | 'warning' | 'done';
 
+function hasWarning(p: PipelineListItem): boolean {
+  return p.jobs.some((j) => j.state === 'FINISHED' && j.result === 'WARNING');
+}
+
+// UI3 — WARNING is amber, distinct from ERROR red: a chain that
+// completed with only WARNING children is not a failure.
 function statusOf(p: PipelineListItem): StatusKind {
   if (p.progress.has_error) return 'failed';
   if (!p.progress.done) return 'running';
-  if (p.error_count > 0) return 'partial';
+  if (hasWarning(p)) return 'warning';
   return 'done';
 }
 
@@ -38,7 +64,7 @@ const STATUS_META: Record<
 > = {
   failed: { color: 'negative', icon: 'error', key: 'pipeops_status_failed' },
   running: { color: 'primary', icon: 'sync', key: 'pipeops_status_running' },
-  partial: { color: 'warning', icon: 'warning', key: 'pipeops_status_partial' },
+  warning: { color: 'warning', icon: 'warning', key: 'pipeops_status_warning' },
   done: { color: 'positive', icon: 'check_circle', key: 'pipeops_status_done' },
 };
 
@@ -269,7 +295,10 @@ onMounted(() => {
                     {{ $t('pipeops_orphan_tag') }}
                   </span>
                 </td>
-                <td>{{ p.module_type_id ?? '—' }} / {{ p.year ?? '—' }}</td>
+                <td>
+                  {{ p.module_label ?? p.module_type_id ?? '—' }} /
+                  {{ p.year ?? '—' }}
+                </td>
                 <td>
                   {{ p.job_count - p.error_count }}/{{ p.job_count }} ✓
                   <span v-if="p.error_count" class="text-negative">
@@ -280,8 +309,10 @@ onMounted(() => {
                 <td>{{ fmtWhen(p.started_at) }}</td>
                 <td
                   class="text-grey-8 ellipsis"
+                  :class="{ 'cursor-pointer': !!p.status_message }"
                   style="max-width: 320px"
-                  :title="p.status_message ?? ''"
+                  :title="$t('pipeops_msg_click_hint')"
+                  @click.stop="openMsg(p.status_message)"
                 >
                   {{ p.status_message ?? '—' }}
                 </td>
@@ -306,14 +337,20 @@ onMounted(() => {
                         #{{ j.job_id }} {{ j.job_type ?? '—' }}
                       </span>
                       <span class="text-caption text-grey-7 q-mr-sm">
-                        det {{ j.data_entry_type_id ?? '—' }} ·
-                        {{ fmtDuration(j.started_at, j.finished_at) }}
+                        {{
+                          j.data_entry_type_label ??
+                          (j.data_entry_type_id != null
+                            ? 'det ' + j.data_entry_type_id
+                            : '—')
+                        }}
+                        · {{ fmtDuration(j.started_at, j.finished_at) }}
                       </span>
                       <span
                         v-if="j.status_message"
-                        class="text-caption text-grey-8 ellipsis"
+                        class="text-caption text-grey-8 ellipsis cursor-pointer"
                         style="max-width: 520px"
-                        :title="j.status_message"
+                        :title="$t('pipeops_msg_click_hint')"
+                        @click.stop="openMsg(j.status_message)"
                       >
                         {{ j.status_message }}
                       </span>
@@ -349,5 +386,36 @@ onMounted(() => {
         </div>
       </div>
     </div>
+
+    <!-- UI1 — full message + copy to clipboard -->
+    <q-dialog v-model="msgDialog">
+      <q-card style="min-width: 480px; max-width: 90vw">
+        <q-card-section class="row items-center q-pb-none">
+          <div class="text-subtitle1">{{ $t('pipeops_msg_title') }}</div>
+          <q-space />
+          <q-btn
+            flat
+            dense
+            icon="content_copy"
+            :label="$t('pipeops_msg_copy')"
+            @click="copyMsg"
+          />
+          <q-btn v-close-popup flat dense round icon="close" />
+        </q-card-section>
+        <q-card-section>
+          <pre
+            class="q-pa-md bg-grey-2 rounded-borders"
+            style="
+              white-space: pre-wrap;
+              word-break: break-word;
+              max-height: 60vh;
+              overflow: auto;
+              margin: 0;
+            "
+            >{{ msgText }}</pre
+          >
+        </q-card-section>
+      </q-card>
+    </q-dialog>
   </q-page>
 </template>

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -1,0 +1,353 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { BACKOFFICE_NAV } from 'src/constant/navigation';
+import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
+import {
+  usePipelineOperationsConsole,
+  type PipelineListItem,
+} from 'src/stores/pipelineOperationsConsole';
+
+const store = usePipelineOperationsConsole();
+
+const expanded = ref<Set<string>>(new Set());
+
+function rowKey(p: PipelineListItem): string {
+  return p.pipeline_id ?? `orphan-${p.latest_job_id}`;
+}
+
+function toggle(p: PipelineListItem): void {
+  const k = rowKey(p);
+  if (expanded.value.has(k)) expanded.value.delete(k);
+  else expanded.value.add(k);
+  // reassign so the template recomputes
+  expanded.value = new Set(expanded.value);
+}
+
+type StatusKind = 'failed' | 'running' | 'partial' | 'done';
+
+function statusOf(p: PipelineListItem): StatusKind {
+  if (p.progress.has_error) return 'failed';
+  if (!p.progress.done) return 'running';
+  if (p.error_count > 0) return 'partial';
+  return 'done';
+}
+
+const STATUS_META: Record<
+  StatusKind,
+  { color: string; icon: string; key: string }
+> = {
+  failed: { color: 'negative', icon: 'error', key: 'pipeops_status_failed' },
+  running: { color: 'primary', icon: 'sync', key: 'pipeops_status_running' },
+  partial: { color: 'warning', icon: 'warning', key: 'pipeops_status_partial' },
+  done: { color: 'positive', icon: 'check_circle', key: 'pipeops_status_done' },
+};
+
+function jobColor(j: { state: string | null; result: string | null }): string {
+  if (j.state !== 'FINISHED') return 'grey';
+  if (j.result === 'ERROR') return 'negative';
+  if (j.result === 'WARNING') return 'warning';
+  return 'positive';
+}
+
+function fmtDuration(a: string | null, b: string | null): string {
+  if (!a) return '—';
+  const start = new Date(a).getTime();
+  const end = b ? new Date(b).getTime() : Date.now();
+  const s = Math.max(0, Math.round((end - start) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m${String(s % 60).padStart(2, '0')}s`;
+  return `${Math.floor(m / 60)}h${String(m % 60).padStart(2, '0')}m`;
+}
+
+function fmtWhen(s: string | null): string {
+  if (!s) return '—';
+  return new Date(s).toLocaleString();
+}
+
+const counters = computed(() => store.counters);
+
+const stateOptions = ['NOT_STARTED', 'QUEUED', 'RUNNING', 'FINISHED'];
+const resultOptions = ['SUCCESS', 'WARNING', 'ERROR'];
+const jobTypeOptions = [
+  'csv_ingest',
+  'factor_ingest',
+  'api_ingest',
+  'emission_recalc',
+  'aggregation',
+  'unit_sync',
+];
+
+onMounted(() => {
+  void store.fetch();
+});
+</script>
+
+<template>
+  <q-page>
+    <navigation-header :item="BACKOFFICE_NAV.BACKOFFICE_PIPELINE_OPERATIONS" />
+    <div class="q-my-xl q-px-xl">
+      <div class="container full-width">
+        <div class="text-body1 q-mb-lg">{{ $t('pipeops_subtitle') }}</div>
+
+        <!-- Alert strip — clickable counters set a filter -->
+        <div class="row q-col-gutter-md q-mb-lg">
+          <div class="col-auto">
+            <q-chip
+              clickable
+              color="negative"
+              text-color="white"
+              icon="error"
+              @click="store.applyFilters({ has_errors: true })"
+            >
+              {{ counters.errors }} · {{ $t('pipeops_alert_errors') }}
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-chip
+              clickable
+              color="primary"
+              text-color="white"
+              icon="sync"
+              @click="store.applyFilters({ state: 'RUNNING' })"
+            >
+              {{ counters.running }} · {{ $t('pipeops_alert_running') }}
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-chip color="positive" text-color="white" icon="check_circle">
+              {{ counters.ok }} · {{ $t('pipeops_alert_ok') }}
+            </q-chip>
+          </div>
+          <div class="col-auto">
+            <q-chip color="grey-7" text-color="white" icon="report">
+              {{ counters.failed }} · {{ $t('pipeops_alert_failed') }}
+            </q-chip>
+          </div>
+        </div>
+
+        <!-- Filters -->
+        <div class="row q-col-gutter-md q-mb-md items-end">
+          <q-select
+            class="col-12 col-md-2"
+            dense
+            outlined
+            clearable
+            :label="$t('pipeops_filter_state')"
+            :model-value="store.filters.state"
+            :options="stateOptions"
+            @update:model-value="(v) => store.applyFilters({ state: v })"
+          />
+          <q-select
+            class="col-12 col-md-2"
+            dense
+            outlined
+            clearable
+            :label="$t('pipeops_filter_result')"
+            :model-value="store.filters.result"
+            :options="resultOptions"
+            @update:model-value="(v) => store.applyFilters({ result: v })"
+          />
+          <q-select
+            class="col-12 col-md-2"
+            dense
+            outlined
+            clearable
+            :label="$t('pipeops_filter_job_type')"
+            :model-value="store.filters.job_type"
+            :options="jobTypeOptions"
+            @update:model-value="(v) => store.applyFilters({ job_type: v })"
+          />
+          <q-input
+            class="col-6 col-md-1"
+            dense
+            outlined
+            type="number"
+            :label="$t('pipeops_filter_year')"
+            :model-value="store.filters.year"
+            @update:model-value="
+              (v) => store.applyFilters({ year: v ? Number(v) : null })
+            "
+          />
+          <q-input
+            class="col-12 col-md-3"
+            dense
+            outlined
+            debounce="400"
+            :label="$t('pipeops_filter_search')"
+            :model-value="store.filters.q"
+            @update:model-value="
+              (v) => store.applyFilters({ q: String(v ?? '') })
+            "
+          />
+          <div class="col-auto">
+            <q-toggle
+              :model-value="store.filters.has_errors === true"
+              :label="$t('pipeops_filter_has_errors')"
+              @update:model-value="
+                (v) => store.applyFilters({ has_errors: v ? true : null })
+              "
+            />
+          </div>
+          <div class="col-auto">
+            <q-btn
+              flat
+              dense
+              icon="restart_alt"
+              :label="$t('pipeops_filter_clear')"
+              @click="store.clearFilters()"
+            />
+          </div>
+          <div class="col-auto">
+            <q-btn
+              flat
+              dense
+              icon="refresh"
+              :label="$t('pipeops_refresh')"
+              :loading="store.loading"
+              @click="store.fetch()"
+            />
+          </div>
+        </div>
+
+        <q-banner v-if="store.error" class="bg-negative text-white q-mb-md">
+          {{ store.error }}
+        </q-banner>
+
+        <q-markup-table flat bordered separator="cell">
+          <thead>
+            <tr>
+              <th class="text-left" style="width: 36px"></th>
+              <th class="text-left">{{ $t('pipeops_col_status') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_trigger') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_module') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_jobs') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_duration') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_when') }}</th>
+              <th class="text-left">{{ $t('pipeops_col_message') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="store.loading && !store.items.length">
+              <td colspan="8" class="text-center text-grey-7">
+                {{ $t('pipeops_loading') }}
+              </td>
+            </tr>
+            <tr v-else-if="!store.items.length">
+              <td colspan="8" class="text-center text-grey-7">
+                {{ $t('pipeops_empty') }}
+              </td>
+            </tr>
+            <template v-for="p in store.items" :key="rowKey(p)">
+              <tr class="cursor-pointer" @click="toggle(p)">
+                <td>
+                  <q-icon
+                    :name="
+                      expanded.has(rowKey(p)) ? 'expand_more' : 'chevron_right'
+                    "
+                  />
+                </td>
+                <td>
+                  <q-badge
+                    :color="STATUS_META[statusOf(p)].color"
+                    text-color="white"
+                  >
+                    <q-icon
+                      :name="STATUS_META[statusOf(p)].icon"
+                      size="14px"
+                      class="q-mr-xs"
+                    />
+                    {{ $t(STATUS_META[statusOf(p)].key) }}
+                  </q-badge>
+                </td>
+                <td>
+                  {{ p.job_type ?? '—' }}
+                  <span
+                    v-if="p.is_orphan"
+                    class="text-caption text-grey-6 q-ml-xs"
+                  >
+                    {{ $t('pipeops_orphan_tag') }}
+                  </span>
+                </td>
+                <td>{{ p.module_type_id ?? '—' }} / {{ p.year ?? '—' }}</td>
+                <td>
+                  {{ p.job_count - p.error_count }}/{{ p.job_count }} ✓
+                  <span v-if="p.error_count" class="text-negative">
+                    · {{ p.error_count }}✗
+                  </span>
+                </td>
+                <td>{{ fmtDuration(p.started_at, p.finished_at) }}</td>
+                <td>{{ fmtWhen(p.started_at) }}</td>
+                <td
+                  class="text-grey-8 ellipsis"
+                  style="max-width: 320px"
+                  :title="p.status_message ?? ''"
+                >
+                  {{ p.status_message ?? '—' }}
+                </td>
+              </tr>
+              <tr v-if="expanded.has(rowKey(p))">
+                <td colspan="8" class="bg-grey-1">
+                  <div class="q-pa-sm">
+                    <div
+                      v-for="j in p.jobs"
+                      :key="j.job_id"
+                      class="row items-center q-py-xs no-wrap"
+                    >
+                      <q-badge
+                        :color="jobColor(j)"
+                        text-color="white"
+                        class="q-mr-sm"
+                      >
+                        {{ j.state ?? '?'
+                        }}{{ j.result ? ' · ' + j.result : '' }}
+                      </q-badge>
+                      <span class="text-weight-medium q-mr-sm">
+                        #{{ j.job_id }} {{ j.job_type ?? '—' }}
+                      </span>
+                      <span class="text-caption text-grey-7 q-mr-sm">
+                        det {{ j.data_entry_type_id ?? '—' }} ·
+                        {{ fmtDuration(j.started_at, j.finished_at) }}
+                      </span>
+                      <span
+                        v-if="j.status_message"
+                        class="text-caption text-grey-8 ellipsis"
+                        style="max-width: 520px"
+                        :title="j.status_message"
+                      >
+                        {{ j.status_message }}
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </q-markup-table>
+
+        <div class="row items-center justify-end q-gutter-sm q-mt-md">
+          <span class="text-caption text-grey-7">
+            {{ store.offset + 1 }}–{{ store.offset + store.items.length }} /
+            {{ store.total }}
+          </span>
+          <q-btn
+            flat
+            dense
+            icon="chevron_left"
+            :disable="store.offset === 0 || store.loading"
+            @click="store.setPage(store.offset - store.limit)"
+          />
+          <q-btn
+            flat
+            dense
+            icon="chevron_right"
+            :disable="
+              store.offset + store.limit >= store.total || store.loading
+            "
+            @click="store.setPage(store.offset + store.limit)"
+          />
+        </div>
+      </div>
+    </div>
+  </q-page>
+</template>

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
-import { copyToClipboard, Notify } from 'quasar';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { copyToClipboard, debounce, Notify } from 'quasar';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
+import { usePipelineStream } from 'src/composables/usePipelineStream';
+import { usePipelineStreamStore } from 'src/stores/pipelineStream';
 import {
   usePipelineOperationsConsole,
   type PipelineListItem,
@@ -106,6 +108,56 @@ const jobTypeOptions = [
 
 onMounted(() => {
   void store.fetch();
+});
+
+// 🐞#3 (Guilbert 2026-05-20) — SSE live-update on the ops page.
+//
+// Strategy: subscribe to every visible RUNNING pipeline's SSE stream;
+// on any update, the canonical list endpoint is the source of truth so
+// we refetch (debounced) and the table re-renders. This keeps state
+// consistent (jobs, counts, status_message) without per-cell merging.
+const { subscribe, unsubscribe } = usePipelineStream();
+const pipelineStreamStore = usePipelineStreamStore();
+const subscribedIds = new Set<string>();
+
+const debouncedRefetch = debounce(() => {
+  void store.fetch();
+}, 500);
+
+function syncSubscriptions(): void {
+  // Desired set: visible pipelines that are NOT done and have a real
+  // pipeline_id (orphans have none — nothing to subscribe to).
+  const desired = new Set<string>();
+  for (const p of store.items) {
+    if (p.pipeline_id && !p.progress.done) {
+      desired.add(p.pipeline_id);
+    }
+  }
+  // Subscribe newcomers.
+  for (const id of desired) {
+    if (!subscribedIds.has(id)) {
+      void subscribe(id);
+      subscribedIds.add(id);
+    }
+  }
+  // Unsubscribe pipelines that left the page or finished.
+  for (const id of [...subscribedIds]) {
+    if (!desired.has(id)) {
+      unsubscribe(id);
+      subscribedIds.delete(id);
+    }
+  }
+}
+
+watch(() => store.items, syncSubscriptions, { deep: false });
+
+// Any SSE update for any subscribed pipeline → refetch the list
+// (debounced so a burst of child terminals doesn't thrash the API).
+watch(() => pipelineStreamStore.entries, debouncedRefetch, { deep: true });
+
+onUnmounted(() => {
+  for (const id of subscribedIds) unsubscribe(id);
+  subscribedIds.clear();
 });
 </script>
 

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -106,6 +106,49 @@ const jobTypeOptions = [
   'unit_sync',
 ];
 
+// #2D — phase checklist + status_history rendering
+interface PhaseEntry {
+  name: string;
+  state: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+  error?: string | null;
+}
+interface HistoryEntry {
+  message: string;
+  ts: string;
+}
+
+function jobPhases(j: { meta: Record<string, unknown> }): PhaseEntry[] {
+  const raw = j.meta?.phases;
+  return Array.isArray(raw) ? (raw as PhaseEntry[]) : [];
+}
+
+function jobHistory(j: { meta: Record<string, unknown> }): HistoryEntry[] {
+  const raw = j.meta?.status_history;
+  return Array.isArray(raw) ? (raw as HistoryEntry[]) : [];
+}
+
+function phaseColor(p: PhaseEntry): string {
+  if (p.state === 'finished') return 'positive';
+  if (p.state === 'running') return 'primary';
+  if (p.state === 'failed' || p.error) return 'negative';
+  return 'grey';
+}
+
+function phaseIcon(p: PhaseEntry): string {
+  if (p.state === 'finished') return 'check_circle';
+  if (p.state === 'running') return 'sync';
+  if (p.state === 'failed' || p.error) return 'error';
+  return 'radio_button_unchecked';
+}
+
+function fmtTs(s: string | null | undefined): string {
+  if (!s) return '—';
+  const d = new Date(s);
+  return d.toLocaleTimeString();
+}
+
 onMounted(() => {
   void store.fetch();
 });
@@ -372,40 +415,86 @@ onUnmounted(() => {
               <tr v-if="expanded.has(rowKey(p))">
                 <td colspan="8" class="bg-grey-1">
                   <div class="q-pa-sm">
-                    <div
-                      v-for="j in p.jobs"
-                      :key="j.job_id"
-                      class="row items-center q-py-xs no-wrap"
-                    >
-                      <q-badge
-                        :color="jobColor(j)"
-                        text-color="white"
-                        class="q-mr-sm"
+                    <div v-for="j in p.jobs" :key="j.job_id" class="q-py-sm">
+                      <!-- Main job row -->
+                      <div class="row items-center no-wrap">
+                        <q-badge
+                          :color="jobColor(j)"
+                          text-color="white"
+                          class="q-mr-sm"
+                        >
+                          {{ j.state ?? '?'
+                          }}{{ j.result ? ' · ' + j.result : '' }}
+                        </q-badge>
+                        <span class="text-weight-medium q-mr-sm">
+                          #{{ j.job_id }} {{ j.job_type ?? '—' }}
+                        </span>
+                        <span class="text-caption text-grey-7 q-mr-sm">
+                          {{
+                            j.data_entry_type_label ??
+                            (j.data_entry_type_id != null
+                              ? 'det ' + j.data_entry_type_id
+                              : '—')
+                          }}
+                          · {{ fmtDuration(j.started_at, j.finished_at) }}
+                        </span>
+                        <span
+                          v-if="j.status_message"
+                          class="text-caption text-grey-8 ellipsis cursor-pointer"
+                          style="max-width: 520px"
+                          :title="$t('pipeops_msg_click_hint')"
+                          @click.stop="openMsg(j.status_message)"
+                        >
+                          {{ j.status_message }}
+                        </span>
+                      </div>
+
+                      <!-- #2B — phase checklist (unit_sync etc.) -->
+                      <div
+                        v-if="jobPhases(j).length"
+                        class="row items-center q-mt-xs q-gutter-xs q-pl-md"
                       >
-                        {{ j.state ?? '?'
-                        }}{{ j.result ? ' · ' + j.result : '' }}
-                      </q-badge>
-                      <span class="text-weight-medium q-mr-sm">
-                        #{{ j.job_id }} {{ j.job_type ?? '—' }}
-                      </span>
-                      <span class="text-caption text-grey-7 q-mr-sm">
-                        {{
-                          j.data_entry_type_label ??
-                          (j.data_entry_type_id != null
-                            ? 'det ' + j.data_entry_type_id
-                            : '—')
-                        }}
-                        · {{ fmtDuration(j.started_at, j.finished_at) }}
-                      </span>
-                      <span
-                        v-if="j.status_message"
-                        class="text-caption text-grey-8 ellipsis cursor-pointer"
-                        style="max-width: 520px"
-                        :title="$t('pipeops_msg_click_hint')"
-                        @click.stop="openMsg(j.status_message)"
+                        <q-chip
+                          v-for="ph in jobPhases(j)"
+                          :key="ph.name"
+                          :color="phaseColor(ph)"
+                          text-color="white"
+                          :icon="phaseIcon(ph)"
+                          size="sm"
+                          dense
+                        >
+                          {{ ph.name }}
+                          <q-tooltip v-if="ph.error">{{ ph.error }}</q-tooltip>
+                        </q-chip>
+                      </div>
+
+                      <!-- #2A — status_history timeline -->
+                      <q-expansion-item
+                        v-if="jobHistory(j).length"
+                        dense
+                        dense-toggle
+                        class="q-mt-xs"
+                        header-class="text-caption text-grey-7 q-pl-md"
+                        :label="$t('pipeops_history_toggle')"
+                        :caption="
+                          $t('pipeops_history_count', {
+                            n: jobHistory(j).length,
+                          })
+                        "
                       >
-                        {{ j.status_message }}
-                      </span>
+                        <div class="q-pl-lg">
+                          <div
+                            v-for="(h, idx) in jobHistory(j)"
+                            :key="idx"
+                            class="text-caption text-grey-8 q-py-xs"
+                          >
+                            <span class="text-grey-5 q-mr-xs">
+                              {{ fmtTs(h.ts) }}
+                            </span>
+                            — {{ h.message }}
+                          </div>
+                        </div>
+                      </q-expansion-item>
                     </div>
                   </div>
                 </td>

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -95,8 +95,10 @@ function fmtWhen(s: string | null): string {
 
 const counters = computed(() => store.counters);
 
-const stateOptions = ['NOT_STARTED', 'QUEUED', 'RUNNING', 'FINISHED'];
-const resultOptions = ['SUCCESS', 'WARNING', 'ERROR'];
+// #1236 Phase 3 read-flip: ``state`` is the pipeline-level
+// ``pipelines.status`` (server-authoritative), not the job-level state.
+// The 5 values match the backend ``PipelineStatus`` enum.
+const stateOptions = ['NOT_STARTED', 'RUNNING', 'SUCCESS', 'PARTIAL', 'FAILED'];
 const jobTypeOptions = [
   'csv_ingest',
   'factor_ingest',
@@ -250,7 +252,7 @@ onUnmounted(() => {
         <!-- Filters -->
         <div class="row q-col-gutter-md q-mb-md items-end">
           <q-select
-            class="col-12 col-md-2"
+            class="col-12 col-md-3"
             dense
             outlined
             clearable
@@ -260,17 +262,7 @@ onUnmounted(() => {
             @update:model-value="(v) => store.applyFilters({ state: v })"
           />
           <q-select
-            class="col-12 col-md-2"
-            dense
-            outlined
-            clearable
-            :label="$t('pipeops_filter_result')"
-            :model-value="store.filters.result"
-            :options="resultOptions"
-            @update:model-value="(v) => store.applyFilters({ result: v })"
-          />
-          <q-select
-            class="col-12 col-md-2"
+            class="col-12 col-md-3"
             dense
             outlined
             clearable

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { copyToClipboard, debounce, Notify } from 'quasar';
+import { useI18n } from 'vue-i18n';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import NavigationHeader from 'src/components/organisms/backoffice/NavigationHeader.vue';
 import { usePipelineStream } from 'src/composables/usePipelineStream';
@@ -9,6 +10,8 @@ import {
   usePipelineOperationsConsole,
   type PipelineListItem,
 } from 'src/stores/pipelineOperationsConsole';
+
+const { t } = useI18n();
 
 const store = usePipelineOperationsConsole();
 
@@ -92,11 +95,56 @@ function jobColor(j: { state: string | null; result: string | null }): string {
   return 'positive';
 }
 
+/**
+ * Count of jobs in FINISHED state — the right denominator for the
+ * "X/N ✓" column.  ``job_count`` is the total; ``finished`` is how
+ * many are actually done (FINISHED state regardless of result).
+ */
+function jobsFinishedCount(p: PipelineListItem): number {
+  return p.jobs.filter((j) => j.state === 'FINISHED').length;
+}
+
+/**
+ * Pipeline-level message for the "Message" column — replaces the
+ * root job's ``status_message`` which was misleading while the chain
+ * was still running ("Success" displayed even though
+ * emission_recalc / aggregation children were RUNNING).
+ *
+ * Rules:
+ * - Pipeline DONE (success/partial/failed): show the root's
+ *   status_message verbatim (carries the cause for errors via the
+ *   #1219 ``finalize_ingest_meta`` enrichment).
+ * - Pipeline RUNNING and progress carries a phase: show
+ *   ``Phase {n}/3 · {phase_label}`` (the same phrasing the
+ *   data-management page uses, just inline).
+ * - Otherwise: dash.
+ */
+function pipelineMessage(p: PipelineListItem): string | null {
+  if (p.progress.done) return p.status_message ?? null;
+  if (p.progress.phase && p.progress.phase_label) {
+    const phaseI18n: Record<string, string> = {
+      data: 'pipeops_phase_data',
+      emissions: 'pipeops_phase_emissions',
+      aggregation: 'pipeops_phase_aggregation',
+    };
+    const key = phaseI18n[p.progress.phase_label];
+    const label = key ? t(key) : p.progress.phase_label;
+    return `${t('pipeops_phase_prefix')} ${p.progress.phase}/${p.progress.phases_total} · ${label}`;
+  }
+  return null;
+}
+
 function fmtDuration(a: string | null, b: string | null): string {
   if (!a) return '—';
   const start = new Date(a).getTime();
   const end = b ? new Date(b).getTime() : Date.now();
-  const s = Math.max(0, Math.round((end - start) / 1000));
+  const ms = Math.max(0, end - start);
+  // Sub-second jobs render "<1s" instead of "0s" — common for the
+  // trailing aggregation after 4A.3 scoped the write set down to just
+  // the affected modules.  "0s" read as "didn't run"; "<1s" says
+  // "ran, was just fast".
+  if (ms < 1000) return ms === 0 && !b ? '—' : '<1s';
+  const s = Math.round(ms / 1000);
   if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m${String(s % 60).padStart(2, '0')}s`;
@@ -402,7 +450,12 @@ onUnmounted(() => {
                   {{ p.year ?? '—' }}
                 </td>
                 <td>
-                  {{ p.job_count - p.error_count }}/{{ p.job_count }} ✓
+                  <!-- ``finished/total`` (FINISHED state count over total
+                       job count).  Previously rendered
+                       ``(total - errors)/total`` which always read "all
+                       done" while jobs were still RUNNING.  Errors are
+                       a separate suffix below. -->
+                  {{ jobsFinishedCount(p) }}/{{ p.job_count }} ✓
                   <span v-if="p.error_count" class="text-negative">
                     · {{ p.error_count }}✗
                   </span>
@@ -411,12 +464,12 @@ onUnmounted(() => {
                 <td>{{ fmtWhen(p.started_at) }}</td>
                 <td
                   class="text-grey-8 ellipsis"
-                  :class="{ 'cursor-pointer': !!p.status_message }"
+                  :class="{ 'cursor-pointer': !!pipelineMessage(p) }"
                   style="max-width: 320px"
                   :title="$t('pipeops_msg_click_hint')"
-                  @click.stop="openMsg(p.status_message)"
+                  @click.stop="openMsg(pipelineMessage(p))"
                 >
-                  {{ p.status_message ?? '—' }}
+                  {{ pipelineMessage(p) ?? '—' }}
                 </td>
               </tr>
               <tr v-if="expanded.has(rowKey(p))">

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -45,16 +45,23 @@ function toggle(p: PipelineListItem): void {
   expanded.value = new Set(expanded.value);
 }
 
-type StatusKind = 'failed' | 'running' | 'warning' | 'done';
+type StatusKind = 'failed' | 'partial' | 'running' | 'warning' | 'done';
 
 function hasWarning(p: PipelineListItem): boolean {
   return p.jobs.some((j) => j.state === 'FINISHED' && j.result === 'WARNING');
 }
 
-// UI3 — WARNING is amber, distinct from ERROR red: a chain that
-// completed with only WARNING children is not a failure.
+// PARTIAL tier (#1236) — when the root ingest succeeded (data landed)
+// but a downstream child errored, the backend writes
+// ``pipelines.status = PARTIAL``.  Render it as amber, not red:
+// FAILED is "data didn't land", PARTIAL is "data landed, chain had
+// issues" — different operator action.  Falls back to has_error/done
+// for orphans whose Pipeline row was never minted (progress.status
+// is null).
 function statusOf(p: PipelineListItem): StatusKind {
-  if (p.progress.has_error) return 'failed';
+  if (p.progress.status === 'PARTIAL') return 'partial';
+  if (p.progress.status === 'FAILED') return 'failed';
+  if (p.progress.has_error) return 'failed'; // orphan / legacy fallback
   if (!p.progress.done) return 'running';
   if (hasWarning(p)) return 'warning';
   return 'done';
@@ -65,6 +72,14 @@ const STATUS_META: Record<
   { color: string; icon: string; key: string }
 > = {
   failed: { color: 'negative', icon: 'error', key: 'pipeops_status_failed' },
+  // PARTIAL shares the amber color with WARNING (both mean "needs
+  // attention, not catastrophic") but uses a distinct icon + label
+  // so the operator can tell the two apart at a glance.
+  partial: {
+    color: 'warning',
+    icon: 'report_problem',
+    key: 'pipeops_status_partial',
+  },
   running: { color: 'primary', icon: 'sync', key: 'pipeops_status_running' },
   warning: { color: 'warning', icon: 'warning', key: 'pipeops_status_warning' },
   done: { color: 'positive', icon: 'check_circle', key: 'pipeops_status_done' },

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -232,6 +232,22 @@ const routes: RouteRecordRaw[] = [
             },
           },
           {
+            path: 'back-office/pipeline-operations',
+            name: BACKOFFICE_NAV.BACKOFFICE_PIPELINE_OPERATIONS.routeName,
+            component: () =>
+              import('pages/back-office/PipelineOperationsConsolePage.vue'),
+            beforeEnter: requirePermission(
+              'backoffice.users',
+              PermissionAction.EDIT,
+            ),
+            meta: {
+              requiresAuth: true,
+              note: 'Back Office - Pipeline operations console (admin only)',
+              breadcrumb: false,
+              isBackOffice: true,
+            },
+          },
+          {
             path: 'back-office/documentation-editing',
             name: BACKOFFICE_NAV.BACKOFFICE_DOCUMENTATION_EDITING.routeName,
             component: () =>

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { api } from 'src/api/http';
 import { Module } from 'src/constant/modules';
 import { getModuleTypeId } from 'src/constant/moduleStates';
+import { usePipelineStateStore } from 'src/stores/pipelineState';
 
 export interface DataIngestionJob {
   job_id: number;
@@ -389,7 +390,27 @@ provider_type
           .post(urlPath, {
             json: requestBody,
           })
-          .json()) as { job_id: number };
+          .json()) as { job_id: number; pipeline_id?: string };
+
+        // Issue #1219 — seed the pipeline_id straight from the dispatch
+        // response so the module card subscribes to the SSE stream
+        // immediately (phase 1 "Inserting data…" becomes visible),
+        // instead of only after the upload job FINISHED via the next
+        // active-pipelines poll.  Guarded: the api/carbon-report-only
+        // path may not carry a module_type_id/year to key on.
+        if (
+          response.pipeline_id &&
+          module_type_id !== undefined &&
+          module_type_id !== null &&
+          year !== undefined &&
+          year !== null
+        ) {
+          usePipelineStateStore().setPipelineId(
+            module_type_id,
+            year,
+            response.pipeline_id,
+          );
+        }
 
         // Update local state with new job
         if (year !== undefined) {
@@ -586,7 +607,18 @@ provider_type
               year,
             },
           })
-          .json()) as { job_id: number };
+          .json()) as { job_id: number; pipeline_id?: string };
+
+        // Issue #1219 — see initiateSync: seed the pipeline_id now so
+        // the card subscribes from dispatch, not from the post-finish
+        // active-pipelines poll.
+        if (response.pipeline_id) {
+          usePipelineStateStore().setPipelineId(
+            moduleTypeId,
+            year,
+            response.pipeline_id,
+          );
+        }
 
         return response.job_id;
       } catch (err: unknown) {
@@ -615,7 +647,18 @@ provider_type
         .post(`sync/recalculate-emissions/${moduleTypeId}/${dataEntryTypeId}`, {
           searchParams: { year },
         })
-        .json()) as { job_id: number };
+        .json()) as { job_id: number; pipeline_id?: string };
+      // Issue #1219 — seed the pipeline_id so the "Recalculate" button
+      // shows live phase progress on the card immediately, not after
+      // the next active-pipelines poll (which may never see a fast
+      // chain).
+      if (response.pipeline_id) {
+        usePipelineStateStore().setPipelineId(
+          moduleTypeId,
+          year,
+          response.pipeline_id,
+        );
+      }
       return response.job_id;
     }
 
@@ -632,7 +675,15 @@ provider_type
         .post(`sync/recalculate-emissions/${moduleTypeId}`, {
           searchParams: { year, only_stale: onlyStale },
         })
-        .json()) as { job_id: number };
+        .json()) as { job_id: number; pipeline_id?: string };
+      // Issue #1219 — see initiateEmissionRecalculation.
+      if (response.pipeline_id) {
+        usePipelineStateStore().setPipelineId(
+          moduleTypeId,
+          year,
+          response.pipeline_id,
+        );
+      }
       return response.job_id;
     }
 

--- a/frontend/src/stores/pipelineOperationsConsole.ts
+++ b/frontend/src/stores/pipelineOperationsConsole.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #1234 — pipeline operations console store.
+ *
+ * Backs the back-office page that lists ingestion/recalc pipelines
+ * globally (one row per ``pipeline_id``), complementary to the
+ * per-module data-management page.  Thin Pinia wrapper over
+ * ``GET /v1/sync/pipelines`` (paginated, filtered, meta allow-listed
+ * server-side).  Drill-down/live tailing reuses the existing
+ * ``usePipelineStream`` composable + ``GET /sync/pipelines/{id}`` —
+ * not duplicated here.
+ */
+
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
+import { api } from 'src/api/http';
+import type { PipelineProgress } from 'src/stores/pipelineStream';
+
+export interface PipelineJobListEntry {
+  job_id: number;
+  job_type: string | null;
+  state: string | null;
+  result: string | null;
+  status_message: string | null;
+  module_type_id: number | null;
+  data_entry_type_id: number | null;
+  year: number | null;
+  started_at: string | null;
+  finished_at: string | null;
+  attempts: number | null;
+  meta: Record<string, unknown>;
+}
+
+export interface PipelineListItem {
+  pipeline_id: string | null;
+  is_orphan: boolean;
+  progress: PipelineProgress;
+  job_type: string | null;
+  module_type_id: number | null;
+  year: number | null;
+  status_message: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  latest_job_id: number;
+  job_count: number;
+  error_count: number;
+  jobs: PipelineJobListEntry[];
+}
+
+export interface PipelineListResponse {
+  items: PipelineListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface PipelineFilters {
+  state: string | null;
+  result: string | null;
+  job_type: string | null;
+  year: number | null;
+  has_errors: boolean | null;
+  q: string;
+}
+
+const DEFAULT_FILTERS = (): PipelineFilters => ({
+  state: null,
+  result: null,
+  job_type: null,
+  year: null,
+  has_errors: null,
+  q: '',
+});
+
+export const usePipelineOperationsConsole = defineStore(
+  'pipelineOperationsConsole',
+  () => {
+    const items = ref<PipelineListItem[]>([]);
+    const total = ref(0);
+    const limit = ref(50);
+    const offset = ref(0);
+    const loading = ref(false);
+    const error = ref<string | null>(null);
+    const filters = ref<PipelineFilters>(DEFAULT_FILTERS());
+
+    /**
+     * Alert-strip counters, derived from the current page.  Scoped to
+     * the loaded page on purpose: the strip is a "what am I looking at"
+     * summary, and clicking a counter sets a filter to get the true
+     * server-side total for that slice.
+     */
+    const counters = computed(() => {
+      let failed = 0;
+      let errors = 0;
+      let running = 0;
+      let ok = 0;
+      for (const p of items.value) {
+        if (p.is_orphan && p.error_count > 0) failed += 1;
+        if (p.error_count > 0) errors += 1;
+        if (!p.progress.done) running += 1;
+        else if (!p.progress.has_error) ok += 1;
+      }
+      return { failed, errors, running, ok };
+    });
+
+    async function fetch(): Promise<void> {
+      loading.value = true;
+      error.value = null;
+      try {
+        const params: Record<string, string> = {
+          limit: String(limit.value),
+          offset: String(offset.value),
+        };
+        const f = filters.value;
+        if (f.state) params.state = f.state;
+        if (f.result) params.result = f.result;
+        if (f.job_type) params.job_type = f.job_type;
+        if (f.year != null) params.year = String(f.year);
+        if (f.has_errors != null) params.has_errors = String(f.has_errors);
+        if (f.q.trim()) params.q = f.q.trim();
+
+        const res = (await api
+          .get('sync/pipelines', { searchParams: params })
+          .json()) as PipelineListResponse;
+        items.value = res.items;
+        total.value = res.total;
+      } catch (err: unknown) {
+        error.value =
+          err instanceof Error ? err.message : 'Failed to load pipelines';
+        items.value = [];
+        total.value = 0;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function setPage(newOffset: number): Promise<void> {
+      offset.value = Math.max(0, newOffset);
+      await fetch();
+    }
+
+    async function applyFilters(
+      patch: Partial<PipelineFilters>,
+    ): Promise<void> {
+      filters.value = { ...filters.value, ...patch };
+      offset.value = 0;
+      await fetch();
+    }
+
+    async function clearFilters(): Promise<void> {
+      filters.value = DEFAULT_FILTERS();
+      offset.value = 0;
+      await fetch();
+    }
+
+    return {
+      items,
+      total,
+      limit,
+      offset,
+      loading,
+      error,
+      filters,
+      counters,
+      fetch,
+      setPage,
+      applyFilters,
+      clearFilters,
+    };
+  },
+);

--- a/frontend/src/stores/pipelineOperationsConsole.ts
+++ b/frontend/src/stores/pipelineOperationsConsole.ts
@@ -23,6 +23,7 @@ export interface PipelineJobListEntry {
   status_message: string | null;
   module_type_id: number | null;
   data_entry_type_id: number | null;
+  data_entry_type_label: string | null;
   year: number | null;
   started_at: string | null;
   finished_at: string | null;
@@ -36,6 +37,7 @@ export interface PipelineListItem {
   progress: PipelineProgress;
   job_type: string | null;
   module_type_id: number | null;
+  module_label: string | null;
   year: number | null;
   status_message: string | null;
   started_at: string | null;

--- a/frontend/src/stores/pipelineOperationsConsole.ts
+++ b/frontend/src/stores/pipelineOperationsConsole.ts
@@ -55,9 +55,15 @@ export interface PipelineListResponse {
   offset: number;
 }
 
+/**
+ * Console filters.  #1236 Phase 3 read-flip: ``state`` now means
+ * ``pipelines.status`` (NOT_STARTED / RUNNING / SUCCESS / PARTIAL /
+ * FAILED) — the pipeline-level status, not a per-job state.  The
+ * previous ``result`` filter is dropped (its semantics, success vs
+ * error, are subsumed by status).
+ */
 export interface PipelineFilters {
   state: string | null;
-  result: string | null;
   job_type: string | null;
   year: number | null;
   has_errors: boolean | null;
@@ -66,7 +72,6 @@ export interface PipelineFilters {
 
 const DEFAULT_FILTERS = (): PipelineFilters => ({
   state: null,
-  result: null,
   job_type: null,
   year: null,
   has_errors: null,
@@ -114,7 +119,6 @@ export const usePipelineOperationsConsole = defineStore(
         };
         const f = filters.value;
         if (f.state) params.state = f.state;
-        if (f.result) params.result = f.result;
         if (f.job_type) params.job_type = f.job_type;
         if (f.year != null) params.year = String(f.year);
         if (f.has_errors != null) params.has_errors = String(f.has_errors);

--- a/frontend/src/stores/pipelineState.ts
+++ b/frontend/src/stores/pipelineState.ts
@@ -110,6 +110,26 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
   }
 
   /**
+   * Issue #1219 — seed a freshly-dispatched pipeline_id synchronously,
+   * straight from the dispatch/recalc HTTP response, instead of waiting
+   * for the next ``loadFor`` (active-pipelines) poll.  The poll only
+   * runs on mount / year-change / upload-job completion, so without
+   * this the card can't discover the pipeline until *after* the upload
+   * job already FINISHED — phase 1 is invisible and a fast chain
+   * completes inside the discovery gap.  ``ModuleConfig``'s
+   * ``currentPipelineId`` computed reads this map reactively, so the
+   * existing ``watch(currentPipelineId)`` auto-subscribes to the SSE
+   * stream the moment this is set.
+   */
+  function setPipelineId(
+    moduleTypeId: number,
+    year: number,
+    pipelineId: string,
+  ): void {
+    pipelineByModuleYear[makeKey(moduleTypeId, year)] = pipelineId;
+  }
+
+  /**
    * Issue #867 — bulk-fetch active year-level pipeline_ids
    * (``entity_type=GLOBAL_PER_YEAR``) for the given year.  Backs the
    * ``DataManagementPage.vue`` reload-rehydrate path: on mount + on
@@ -157,6 +177,7 @@ export const usePipelineStateStore = defineStore('pipelineState', () => {
     loadFor,
     loadYearLevelFor,
     getPipelineId,
+    setPipelineId,
     getYearLevelPipelineIds,
     clear,
   };

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -53,6 +53,14 @@ export interface PipelineProgress {
   phase_label: 'data' | 'emissions' | 'aggregation';
   done: boolean;
   has_error: boolean;
+  /**
+   * PARTIAL tier (#1236) — authoritative ``pipelines.status`` name so
+   * the UI can render PARTIAL (amber) vs FAILED (red); both set
+   * ``has_error=true`` so a boolean alone can't distinguish them.
+   * Possible values: ``NOT_STARTED`` | ``RUNNING`` | ``SUCCESS`` |
+   * ``PARTIAL`` | ``FAILED`` | null (orphans without a Pipeline row).
+   */
+  status?: string | null;
 }
 
 /**

--- a/frontend/src/stores/pipelineStream.ts
+++ b/frontend/src/stores/pipelineStream.ts
@@ -61,6 +61,14 @@ export interface PipelineProgress {
    * ``PARTIAL`` | ``FAILED`` | null (orphans without a Pipeline row).
    */
   status?: string | null;
+  /**
+   * Parent job_type (``csv_ingest`` / ``api_ingest`` / ``factor_ingest``
+   * / ``reference_ingest`` / ``unit_sync``).  Used by per-target
+   * UploadCard variants to scope the phase indicator to *their* card:
+   * a factor upload pipeline should not surface its phase on the data
+   * card, and vice versa.  ``null`` for orphans / unidentified roots.
+   */
+  kind?: string | null;
 }
 
 /**

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -106,6 +106,14 @@ interface YearConfig {
 export interface YearConfigurationResponse {
   year: number;
   is_started: boolean;
+  /**
+   * #1234-followup — ISO timestamp when ``unit_sync`` finished SUCCESS
+   * for this year. ``null`` while the pipeline is still running or
+   * before it ever ran; backend ``/dispatch`` refuses uploads while
+   * ``null``. The data-management page surfaces a banner + disables
+   * upload affordances on the null state.
+   */
+  configuration_completed?: string | null;
   config: YearConfig;
   recalculation_status: ModuleRecalculationStatusEntry[];
   updated_at: string;
@@ -124,6 +132,8 @@ export interface YearConfigurationResponse {
 export interface YearConfigurationListItem {
   year: number;
   is_started: boolean;
+  /** #1234-followup — see YearConfigurationResponse.configuration_completed. */
+  configuration_completed?: string | null;
   updated_at: string;
 }
 

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -726,6 +726,14 @@ function readyToOpenYearConfig(year: number, isStarted: boolean) {
   return {
     year,
     is_started: isStarted,
+    // Year-config gate (#1234 follow-up `13616a35`): the
+    // "Open year for users" button has ``v-if="!yearSyncInFlight"``,
+    // and ``yearSyncInFlight`` is true while
+    // ``configuration_completed == null`` (durable refresh-survival
+    // signal).  These tests assume the year is fully provisioned —
+    // the button should be present, just enabled/disabled depending
+    // on ``is_started`` — so stamp the field.
+    configuration_completed: '2024-01-01T00:00:00Z',
     config: {
       modules: {
         '1': disabledModule,

--- a/frontend/tests/integration/setup/data-management-mocks.ts
+++ b/frontend/tests/integration/setup/data-management-mocks.ts
@@ -109,6 +109,13 @@ export function buildYearConfig(options: YearConfigBuilderOptions) {
   return {
     year: options.year,
     is_started: false,
+    // Year-config gate (#1234 follow-up `13616a35`): the data-management
+    // page refuses to render the upload UI until ``configuration_completed``
+    // is non-null (set by ``unit_sync_handler`` on SUCCESS).  Default
+    // satisfies the gate so upload/dispatch happy-path tests aren't
+    // blocked; tests that want to exercise the unprovisioned state
+    // can pass an explicit override via ``onGetYearConfig``.
+    configuration_completed: '2024-01-01T00:00:00Z',
     config: {
       modules: options.modulesOverride ?? { '1': baseHeadcount },
       reduction_objectives: {

--- a/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
+++ b/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
@@ -214,6 +214,12 @@ export function buildYearConfigResponse(year: number): unknown {
   return {
     year,
     is_started: false,
+    // Year-config gate (#1234 follow-up): non-null
+    // ``configuration_completed`` is required for the data-management
+    // page to render its module cards.  Without it the page sits in
+    // the "year not yet provisioned" state and the badge tests never
+    // see the modules section — Unit-11 expects a normal mount.
+    configuration_completed: new Date(year, 0, 1).toISOString(),
     config: {
       modules: {
         '1': {


### PR DESCRIPTION
## What does this change?

Hardens the ingestion/recalc/aggregation pipeline subsystem end-to-end. 50 commits across 64 files (+7.5k lines) delivering [#1236](https://github.com/epfl-fsd/co2-calculator/issues/1236) Phases 1–5 plus the follow-on bug fixes uncovered while exercising it.

**Phase 1–5 of #1236** (in order):

| Phase | What |
|---|---|
| **1** | First-class `pipelines` aggregate row + model + `ensure_pipeline_exists` + runner post-`finish_job` isolated status write + `reconcile_pipeline_statuses` sweep |
| **2** | FK `data_ingestion_jobs.pipeline_id → pipelines.id` (migration `c4d5e6f7a8b9`) + index. Surfaced and fixed 5 pre-existing FK-ordering bugs in mint sites (`year_configuration`, `data_sync.recalculate_*`, `_chain.chain_job`, `_stamp_job_type_and_meta`) |
| **3** | Read-flip: console + `GET /sync/pipelines/{id}` + SSE stream all read `pipelines.status`. Filter pivots to `PipelineStatus` (NOT_STARTED/RUNNING/SUCCESS/PARTIAL/FAILED). 60s reconciliation cron wired into the lifespan |
| **4A** | In-pipeline aggregation coalesce (one trailing aggregation per pipeline instead of N) + per-year `pg_advisory_xact_lock` + scoping to `affected_module_ids` (3 sub-phases + a 4A.4 race fix) |
| **4B** | Per-`(module, year)` advisory lock for factor↔recalc, eliminates the silent-wrong-numbers race when a recalc reads half-written factors |
| **5** | Retired meta threading (`parent_job_id` / `recalc_jobs_chained` / `aggregation_job_id`). Writes & reads moved to `pipelines.expected_recalc` column. 4A.1 lock-down test pins the single-aggregation guarantee under the new lock target |

**User-visible wins:**

- **PARTIAL tier**: root SUCCESS + downstream ERROR → amber PARTIAL badge ("data landed, chain had issues") instead of red FAILED ("data didn't land"). Closes the open `PARTIAL`-vs-`FAILED` boundary decision.
- **Fail-fast on common uploads**: equipment / purchase CSV ingest with no factors loaded now refuses at setup time with one clear error message instead of grinding through 50 000 rows of identical `no matching factor` errors.
- **Lone-orphan `last_error`**: `finalize_ingest_meta` enriches the summary with a sample row-error reason — the operator sees *"first error: No matching factor found in factors map (kind=Monitors)"* instead of just *"0 inserted, 50 072 skipped"*.
- **Pipeline-status UX consistency**: configuration page no longer shows "Success" / green ✓ while emission_recalc / aggregation children are still running; pipeline-ops console "Message" column shows the phase hint while running instead of the misleading parent `status_message="Success"`.
- **Card-scoped phase indicators**: the per-card phase indicator now scopes to the active pipeline's `kind` — a factor ingest's phase doesn't surface on the data card and vice versa.
- **Pipeline Operations menu**: moved below Logs; SuperAdmin trumps `limitedAccess` gates everywhere (no scenario where SA should be locked out of a back-office page).

**Concurrency fixes:**

- **`data_session` commit race** on `chain_job` — children no longer run before the parent commits, eliminating the `data_entry_emissions_data_entry_id_fkey` FK violation on re-uploads (`DELETE old + INSERT new` races the child recalc's snapshot).
- **`unit_sync` ↔ aggregation** — shared per-year advisory lock so the two don't fight over `carbon_reports` writes for the same year.
- **Parallel year creation** — `units.bulk_upsert` now uses Postgres `ON CONFLICT (institutional_code) DO UPDATE` (race-safe by construction), plus a global advisory lock on `unit_sync_handler` so two parallel `unit_sync` jobs for different years can't race on the global `units` table.
- **`/active-pipelines` permission** — dropped the over-eager per-module OPA pre-filter that always returned `{}` for `BackOfficeMetier`. Matches the sibling `/active-pipelines/year/{year}` endpoint's gate.
- **`PipelineJobListEntry.state` / `result`** — now serialize as enum name (`"FINISHED"`) instead of int (`3`), matching the TS contract that downstream `j.state === 'FINISHED'` checks already assumed.

## Why is this needed?

This is the umbrella correctness pass for the ingest → recalc → aggregation chain. Before this PR:

- A failed recalc/aggregation poisoned the parent's session and stuck jobs in `RUNNING` forever (#1219 zombie pattern).
- The pipeline UI flashed "Success" while downstream children were still running.
- Re-uploading equipment data ground through 50 000 rows of identical error messages before showing the real cause.
- Parallel year creation crashed with FK / unique violations.
- Cross-pipeline aggregations of the same year deadlocked on `carbon_reports.stats`.

Full delivery story and per-phase rationale in [`docs/src/implementation-plans/pipeline-debug-todo.md`](docs/src/implementation-plans/pipeline-debug-todo.md). The TODO doc was kept aligned with every commit per `[[feedback_keep_implementation_plans_aligned]]`.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🎨 Design/UI improvement

## Code quality checklist

- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally (equipment CSV upload, parallel year creation, console rendering, the PARTIAL tier, FK ordering across all mint sites)
- [x] `make ci` passes without errors — **1442 backend unit tests + ruff + mypy + vue-tsc + ESLint all clean**
- [x] Tests added/updated — every bug fix in this PR landed with a regression test (per the project's `feedback_bugs_get_regression_tests` invariant)
- [x] No test failures introduced

### Known latent items (not fixed in this PR)

- `UserRepository.bulk_upsert` has the same SELECT-then-merge race shape as the old `units` path. Today the global `unit_sync` lock serialises the only production caller; if a new caller appears, port the ON CONFLICT pattern.
- `reference_data` CSV ingest uses `DELETE BuildingRoom; INSERT rooms`. Single-operator path today so the race is latent; port the global-lock pattern when concurrent ops ingest reference data.
- `unit_sync` real-chained sub-jobs (#2C deferred) — `meta.phases` + `status_history` already give per-phase visibility on the console.
- The "FINISHED · WARNING with empty timeline" item is mitigated by the data_session race fix (the prior WARNINGs were all FK violations); if non-FK warnings surface, surfacing them mid-handler is a separate enhancement.

## Related issues

- Closes #1236
- Related to #1234 (pipeline operations console — follow-up polish)
- Related to #1219 (stuck-jobs & pipeline progress — original)
- Related to #1225 (emission-recalc resilience — eager pipeline_id, merged earlier)
- Note: PR #1235 (the original #1234→dev PR) is superseded by this PR and should be closed.

---

See the [living TODO](docs/src/implementation-plans/pipeline-debug-todo.md) for the full per-commit story and the few remaining decisions noted as "needs operator input."
