### PR TITLE
fix: show rows_processed for successful api_data_job in UploadCardData

### DIFF
--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -79,11 +79,6 @@ const isJobStuck = computed(
 const apiJobInfo = computed(() => getJobInfo(props.apiJob));
 const hasApiErrorOrWarn = computed(() => hasErrorOrWarning(props.apiJob));
 const apiErrorDetails = computed(() => getErrorDetails(props.apiJob));
-const apiRowsInserted = computed<number | undefined>(() => {
-  const meta = props.apiJob?.meta as Record<string, unknown> | undefined;
-  const inserted = meta?.inserted;
-  return typeof inserted === 'number' ? inserted : undefined;
-});
 
 // Issue #1219 — live recalc-pipeline phase for this card.
 //
@@ -343,8 +338,8 @@ function handleCancel() {
     >
       <span class="text-positive q-mr-xs">✓</span>
       <span>{{ $t('data_management_api_ingestion') }}:</span>
-      <span v-if="apiRowsInserted !== undefined" class="q-ml-xs">
-        {{ apiRowsInserted }}
+      <span v-if="apiJobInfo.rowsProcessed !== undefined" class="q-ml-xs">
+        {{ apiJobInfo.rowsProcessed }}
         {{ $t('data_management_rows_imported') }}
       </span>
       <span v-if="apiJobInfo.timestamp" class="q-ml-xs">

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -553,6 +553,83 @@ test.describe('back-office data-management — happy paths', () => {
     await expect(apiBanner).toContainText(/Travel API ingestion failed/i);
   });
 
+  test('9b — UploadCardData renders rows_processed for a SUCCESSFUL api job (regression)', async ({
+    page,
+  }) => {
+    // Regression: the API success line previously read ``meta.inserted``
+    // via a local ``apiRowsInserted`` computed, but the backend's API
+    // ingest writes ``meta.rows_processed`` (same key as the CSV path's
+    // ``getJobInfo``).  Result: the rows count was always blank on a
+    // successful API ingestion.  The fix drops the local computed and
+    // reuses ``apiJobInfo.rowsProcessed``; this test pins the visible
+    // text so a regression re-surfaces loudly.
+    const apiSuccess = {
+      job_id: 300,
+      module_type_id: 1,
+      data_entry_type_id: 1,
+      year: 2024,
+      ingestion_method: 0, // API
+      target_type: 0,
+      state: 3,
+      result: 0,
+      status_message: 'Success',
+      meta: { rows_processed: 10475, timestamp: '2024-01-15T00:00:00Z' },
+    };
+
+    const yearConfigApiOnly = (year: number) => ({
+      ...buildYearConfig({ year }),
+      config: {
+        modules: {
+          '1': {
+            enabled: true,
+            uncertainty_tag: 'medium',
+            submodules: {
+              '1': {
+                enabled: true,
+                threshold: null,
+                latest_factor_job: apiSuccess,
+                latest_api_data_job: apiSuccess,
+              },
+            },
+          },
+        },
+        reduction_objectives: {
+          files: {
+            institutional_footprint: null,
+            population_projections: null,
+            unit_scenarios: null,
+          },
+          goals: [],
+          institutional_footprint: [],
+          population_projections: [],
+          unit_scenarios: [],
+        },
+      },
+    });
+
+    await mockBackend(page, {
+      onGetYearConfig: async (route, year) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(yearConfigApiOnly(year)),
+        });
+      },
+    });
+
+    await page.goto(DATA_MANAGEMENT_URL);
+    await expandHeadcountAndMember(page);
+
+    const apiSuccessLine = page.getByTestId('api-status-success').first();
+    await expect(apiSuccessLine).toBeVisible({ timeout: 10000 });
+    // The exact number must surface — proves the field-name fix
+    // (meta.rows_processed, not meta.inserted) is in place.
+    await expect(apiSuccessLine).toContainText(/10475/);
+    await expect(apiSuccessLine).toContainText(
+      /rows imported|lignes importées/i,
+    );
+  });
+
   test('8 — year-level reload-rehydrate (Issue #867): GET /sync/active-pipelines/year/{year} fires on mount and on year change', async ({
     page,
   }) => {


### PR DESCRIPTION
## What does this change?

`UploadCard.vue` had a local `apiRowsInserted` computed that read `apiJob.meta.inserted` — but the backend's API ingest writes `meta.rows_processed` (same key the CSV path uses via `getJobInfo`).  Result: a successful API ingestion's row count was always blank on the data card, even when meta clearly contained `"rows_processed": 10475`.

Drop the local computed and reuse `apiJobInfo.rowsProcessed` — symmetric with how the CSV path renders rows.

## Why is this needed?

User-reported: 10 475 rows imported via API ingestion, but the success line on the data card showed `✓ API ingestion: • 2024-01-15` with no row count.

## Type of change

- [x] 🐛 Bug fix

## Code quality checklist

- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [x] vue-tsc + ESLint clean
- [x] Tests added — new regression test `9b — UploadCardData renders rows_processed for a SUCCESSFUL api job` sits next to the existing test 9 (which covers the failure banner)
- [x] No test failures introduced

## Related issues

- Follow-up to #1249 (merged 2026-05-20) — small UX fix the equipment ingest case surfaced after merge.