### PR TITLE
feat: change result by category subtitle

### DIFF
--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -220,8 +220,8 @@ export default {
     fr: 'Résultats par catégorie',
   },
   results_by_category_subtitle: {
-    en: 'Annual carbon footprint {year}',
-    fr: 'Bilan CO₂ annuel {year}',
+    en: 'Carbon footprint {year}',
+    fr: 'Empreinte carbone {year}',
   },
   results_equipment_distribution_title: {
     en: 'Equipment distribution',


### PR DESCRIPTION
## What does this change?

Updates the "results by category" subtitle i18n strings:
- EN: "Annual carbon footprint {year}" → "Carbon footprint {year}"
- FR: "Bilan CO₂ annuel {year}" → "Empreinte carbone {year}"

## Why is this needed?

The word "Annual" is redundant since the year is already shown in the subtitle. The French translation is also updated to use the more standard "Empreinte carbone" terminology.

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

Closes #1035 