### PR TITLE
fix(tests): realign integration suite with recent FK + Phase-5B changes

### DIFF
--- a/backend/tests/integration/services/data_ingestion/conftest.py
+++ b/backend/tests/integration/services/data_ingestion/conftest.py
@@ -88,6 +88,7 @@ from app.models.module_type import ALL_MODULE_TYPE_IDS
 from app.models.unit import Unit
 from app.models.user import UserProvider
 from app.models.year_configuration import YearConfiguration
+from app.repositories.data_ingestion import DataIngestionRepository
 
 PG_IMAGE = "postgres:16-alpine"
 PG_CONTAINER_NAME = "test-data-ingestion-postgres"
@@ -267,6 +268,52 @@ class SeededYear:
     reports_by_unit: dict[int, CarbonReport] = field(default_factory=dict)
     modules_by_unit_and_type: dict[tuple[int, int], CarbonReportModule] = field(
         default_factory=dict
+    )
+
+
+async def seed_jobs_with_pipelines(
+    session: AsyncSession, *jobs: DataIngestionJob
+) -> None:
+    """Seed one or more ``DataIngestionJob`` rows + their ``pipelines`` parents.
+
+    Convenience wrapper for tests that ``session.add(DataIngestionJob(...))``
+    directly (i.e. bypass the repo).  Calls ``ensure_pipeline_for_job`` for
+    each job first so the FK constraint (#1236 Phase 2) is satisfied, then
+    adds each job to the session.  Does NOT commit — the caller still owns
+    the transaction boundary.
+    """
+    for job in jobs:
+        await ensure_pipeline_for_job(session, job)
+    for job in jobs:
+        session.add(job)
+
+
+async def ensure_pipeline_for_job(session: AsyncSession, job: DataIngestionJob) -> None:
+    """Idempotently seed the ``pipelines`` row matching ``job.pipeline_id``.
+
+    Mirrors what the production mint sites do via
+    ``DataIngestionRepository.ensure_pipeline_exists`` — required since
+    #1236 Phase 2 added the FK ``data_ingestion_jobs.pipeline_id →
+    pipelines.id``.  Tests that hand-build a ``DataIngestionJob`` with a
+    ``pipeline_id`` and ``session.add`` it directly (i.e. bypassing the
+    repo) must seed the parent row first, else the INSERT trips
+    ``ForeignKeyViolationError``.
+
+    No-op when ``job.pipeline_id is None`` (legacy / not-yet-stamped
+    jobs are still allowed by the column).
+    """
+    if job.pipeline_id is None:
+        return
+    repo = DataIngestionRepository(session)
+    await repo.ensure_pipeline_exists(
+        job.pipeline_id,
+        kind=job.job_type,
+        entity_type=job.entity_type.value if job.entity_type is not None else None,
+        ingestion_method=(
+            job.ingestion_method.value if job.ingestion_method is not None else None
+        ),
+        module_type_id=job.module_type_id,
+        year=job.year,
     )
 
 
@@ -664,6 +711,11 @@ async def dispatch_csv_and_wait(
                 "year": year,
             },
         )
+        # #1236 Phase 2 — the FK forces the ``pipelines`` row to exist
+        # before the ``data_ingestion_jobs`` INSERT flushes.  Mirrors the
+        # production mint-site discipline (see
+        # ``ensure_pipeline_exists`` callers in ``app/api/v1/data_sync.py``).
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -694,8 +746,14 @@ async def dispatch_csv_and_wait(
         row.  Without the data-session commit, every chained handler
         would silently drop its domain writes — Units 2-11's
         ``assert_stats_match`` calls would then read pre-handler state.
-        On exception we roll back the data session and re-raise; the
-        helper's caller is the test, which should fail loudly.
+
+        On handler exception we mirror production ``app.tasks.runner``:
+        roll back the data session, then write FINISHED+ERROR with the
+        exception string as ``status_message``.  This is the
+        fail-fast path #1236 adds for ``_guard_factors_required`` etc.
+        — tests that exercise it (``test_csv_ingest_matrix_pg.py``
+        ``factors_state=absent``) need to see the FINISHED+ERROR row
+        rather than an exception bubbling out of the helper.
         """
         async with session_factory() as job_session:
             row = await job_session.get(DataIngestionJob, job_id)
@@ -703,18 +761,26 @@ async def dispatch_csv_and_wait(
                 return
             handler = get_handler(row.job_type)
             async with session_factory() as data_session:
+                handler_failed = False
                 try:
                     meta = await handler(row, job_session, data_session)
-                except Exception:
+                except Exception as exc:
                     await data_session.rollback()
-                    raise
-                await data_session.commit()
+                    await job_session.rollback()
+                    handler_failed = True
+                    meta = {
+                        "status_message": str(exc),
+                        "result": IngestionResult.ERROR,
+                    }
+                else:
+                    await data_session.commit()
             row.state = IngestionState.FINISHED
             row.result = meta.get("result", IngestionResult.SUCCESS)
             row.status_message = meta.get("status_message", "")
-            existing_meta = dict(row.meta or {})
-            existing_meta.update({k: v for k, v in meta.items() if k != "result"})
-            row.meta = existing_meta
+            if not handler_failed:
+                existing_meta = dict(row.meta or {})
+                existing_meta.update({k: v for k, v in meta.items() if k != "result"})
+                row.meta = existing_meta
             job_session.add(row)
             await job_session.commit()
 

--- a/backend/tests/integration/services/data_ingestion/test_active_pipelines_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_active_pipelines_endpoint_pg.py
@@ -42,6 +42,8 @@ from app.models.data_ingestion import (
 )
 from app.models.user import UserProvider
 
+from .conftest import seed_jobs_with_pipelines
+
 
 @pytest_asyncio.fixture
 async def pg_app(pg_dsn, monkeypatch):
@@ -73,31 +75,18 @@ async def pg_app(pg_dsn, monkeypatch):
 
     monkeypatch.setattr("app.core.security.is_permitted", _allow)
 
-    # ``/sync/active-pipelines`` carries TWO permission layers.  The
-    # tests in this file pin RESPONSE-SHAPE behaviour (mapping shape,
-    # sparse passthrough, year filter, etc.) — they are NOT testing
-    # the security filter.  We bypass it here by mocking it to allow.
-    # The security filter itself is asserted in a separate test
-    # (``test_active_pipelines_returns_403_for_user_without_permission``)
-    # that deliberately bypasses this fixture to exercise the real gate.
+    # ``/sync/active-pipelines`` is gated by a single layer now:
+    # ``require_permission("backoffice.data_management", "view")`` —
+    # cleared by mocking ``is_permitted`` above.
     #
-    # Layer 1 (global): ``require_permission("backoffice.data_management",
-    # "view")`` — cleared by mocking ``is_permitted`` above.
-    # Layer 2 (per-module): the endpoint loops the requested modules and
-    # calls ``get_module_permission_decision(user, module_id, "view")``
-    # for each, dropping disallowed entries from the response.  The
-    # default test user (a bare ``MagicMock``) holds zero module-level
-    # permissions, so without this mock every requested module gets
-    # filtered out and the endpoint returns ``{}``.  This is the
-    # security guard added in PR #1079 V1 to stop pipeline UUIDs from
-    # leaking across modules a caller can't read.
-    async def _allow_module_decision(*_args, **_kwargs):
-        return {"allow": True}
-
-    monkeypatch.setattr(
-        "app.api.v1.data_sync.get_module_permission_decision",
-        _allow_module_decision,
-    )
+    # The endpoint used to also run a per-module
+    # ``get_module_permission_decision`` filter, which was dropped in
+    # commit b8b48d17 (fix #1234) because ``calco2.backoffice.metier`` is
+    # global-scope on the data-management page and holds the global perm
+    # but not per-module perms — so every module was being filtered out,
+    # leaving the 'Recalculating…' badge silently broken.  Re-introduction
+    # is gated on #459 (sub-perimeter scoping by institutional_id, not by
+    # module enumeration); don't re-add a per-module mock here.
 
     yield {"factory": Sf}
 
@@ -139,15 +128,14 @@ async def test_active_pipelines_returns_mapping_for_requested_modules(pg_app):
     pipeline_b = uuid4()
 
     async with Sf() as session:
-        session.add(
+        await seed_jobs_with_pipelines(
+            session,
             _make_active_pipeline_job(
                 module_type_id=1, year=2025, pipeline_id=pipeline_a
-            )
-        )
-        session.add(
+            ),
             _make_active_pipeline_job(
                 module_type_id=2, year=2025, pipeline_id=pipeline_b
-            )
+            ),
         )
         await session.commit()
 
@@ -173,18 +161,17 @@ async def test_active_pipelines_omits_modules_without_active_pipeline(pg_app):
     Sf = pg_app["factory"]
 
     async with Sf() as session:
-        # Only module 1 has an active pipeline.
-        session.add(
-            _make_active_pipeline_job(module_type_id=1, year=2025, pipeline_id=uuid4())
-        )
-        # Module 2 has a FINISHED pipeline (excluded by the helper).
-        session.add(
+        await seed_jobs_with_pipelines(
+            session,
+            # Only module 1 has an active pipeline.
+            _make_active_pipeline_job(module_type_id=1, year=2025, pipeline_id=uuid4()),
+            # Module 2 has a FINISHED pipeline (excluded by the helper).
             _make_active_pipeline_job(
                 module_type_id=2,
                 year=2025,
                 pipeline_id=uuid4(),
                 state=IngestionState.FINISHED,
-            )
+            ),
         )
         await session.commit()
 
@@ -211,8 +198,9 @@ async def test_active_pipelines_filters_by_year(pg_app):
 
     async with Sf() as session:
         # Active pipeline but for 2024 — the request asks for 2025.
-        session.add(
-            _make_active_pipeline_job(module_type_id=1, year=2024, pipeline_id=uuid4())
+        await seed_jobs_with_pipelines(
+            session,
+            _make_active_pipeline_job(module_type_id=1, year=2024, pipeline_id=uuid4()),
         )
         await session.commit()
 
@@ -309,89 +297,11 @@ async def test_active_pipelines_returns_403_for_user_without_permission(
     assert resp.status_code == 403, resp.text
 
 
-@pytest.mark.asyncio
-async def test_active_pipelines_filters_per_module_by_decision(pg_dsn, monkeypatch):
-    """Per-module sparse-passthrough deny — the security guard added in
-    PR #1079 V1.
-
-    The global gate (``backoffice.data_management.view``) passes; the
-    per-module ``get_module_permission_decision`` denies module 1 and
-    allows module 2.  The endpoint must drop module 1 from the response
-    while keeping module 2 — proving the per-module filter actually
-    runs and isn't accidentally short-circuited by the global gate.
-
-    Without this test, a regression that inverts the
-    ``decision.get("allow")`` check (e.g. typo, default, refactor) would
-    be invisible to CI: ``pg_app``'s blanket allow-mock hides it, and
-    the global-gate test above only exercises ``is_permitted``.
-    """
-    engine = create_async_engine(pg_dsn, future=True)
-    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-
-    pipeline_a = uuid4()
-    pipeline_b = uuid4()
-    async with Sf() as session:
-        session.add(
-            _make_active_pipeline_job(
-                module_type_id=1, year=2025, pipeline_id=pipeline_a
-            )
-        )
-        session.add(
-            _make_active_pipeline_job(
-                module_type_id=2, year=2025, pipeline_id=pipeline_b
-            )
-        )
-        await session.commit()
-
-    async def override_get_db():
-        async with Sf() as session:
-            yield session
-
-    fake_user = MagicMock()
-    fake_user.id = 1
-    fake_user.email = "test@example.com"
-    fake_user.institutional_id = "TEST-USER"
-
-    app.dependency_overrides[deps_module.get_db] = override_get_db
-    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
-    app.dependency_overrides[security_module.get_current_active_user] = lambda: (
-        fake_user
-    )
-
-    # Pass the global gate so the per-module filter is what gates the
-    # response.
-    async def _allow_global(*_args, **_kwargs):
-        return True
-
-    monkeypatch.setattr("app.core.security.is_permitted", _allow_global)
-
-    # Per-module filter: deny module 1, allow module 2.
-    async def _per_module_decision(_user, module_id, _action):
-        return {"allow": int(module_id) != 1}
-
-    monkeypatch.setattr(
-        "app.api.v1.data_sync.get_module_permission_decision",
-        _per_module_decision,
-    )
-
-    try:
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            resp = await client.get(
-                "/v1/sync/active-pipelines",
-                params={"year": 2025, "modules": "1,2"},
-            )
-    finally:
-        app.dependency_overrides.clear()
-        await engine.dispose()
-
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert "1" not in body, (
-        f"module 1 was denied per-module but appears in response: {body}"
-    )
-    assert body.get("2") == str(pipeline_b), (
-        f"module 2 was allowed but missing or wrong in response: {body}"
-    )
+# NOTE: ``test_active_pipelines_filters_per_module_by_decision`` was
+# removed alongside commit b8b48d17 (fix #1234).  That commit dropped the
+# endpoint's per-module ``get_module_permission_decision`` pre-filter —
+# the test pinned a behaviour that no longer exists.  Coverage for the
+# replacement contract ("no per-module pre-filter, forwards module ids
+# straight to the repo, ``get_module_permission_decision`` is NOT
+# called") lives in ``tests/unit/v1/test_active_pipelines_endpoint.py``.
+# Re-introduction is gated on #459 (sub-perimeter scoping).

--- a/backend/tests/integration/services/data_ingestion/test_active_pipelines_year_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_active_pipelines_year_endpoint_pg.py
@@ -33,6 +33,8 @@ from app.models.data_ingestion import (
 )
 from app.models.user import UserProvider
 
+from .conftest import seed_jobs_with_pipelines
+
 
 @pytest_asyncio.fixture
 async def pg_app(pg_dsn, monkeypatch):
@@ -109,7 +111,9 @@ async def test_year_level_active_pipelines_returns_running_pipeline_id(pg_app):
     pipeline = uuid4()
 
     async with Sf() as session:
-        session.add(_make_year_level_job(year=2025, pipeline_id=pipeline))
+        await seed_jobs_with_pipelines(
+            session, _make_year_level_job(year=2025, pipeline_id=pipeline)
+        )
         await session.commit()
 
     async with httpx.AsyncClient(
@@ -130,12 +134,13 @@ async def test_year_level_active_pipelines_omits_finished(pg_app):
     Sf = pg_app["factory"]
 
     async with Sf() as session:
-        session.add(
+        await seed_jobs_with_pipelines(
+            session,
             _make_year_level_job(
                 year=2025,
                 pipeline_id=uuid4(),
                 state=IngestionState.FINISHED,
-            )
+            ),
         )
         await session.commit()
 
@@ -157,7 +162,9 @@ async def test_year_level_active_pipelines_filters_by_year(pg_app):
     Sf = pg_app["factory"]
 
     async with Sf() as session:
-        session.add(_make_year_level_job(year=2024, pipeline_id=uuid4()))
+        await seed_jobs_with_pipelines(
+            session, _make_year_level_job(year=2024, pipeline_id=uuid4())
+        )
         await session.commit()
 
     async with httpx.AsyncClient(
@@ -216,7 +223,8 @@ async def test_year_level_active_pipelines_omits_module_scoped(pg_app):
     Sf = pg_app["factory"]
 
     async with Sf() as session:
-        session.add(
+        await seed_jobs_with_pipelines(
+            session,
             DataIngestionJob(
                 entity_type=EntityType.MODULE_PER_YEAR,
                 module_type_id=1,
@@ -229,7 +237,7 @@ async def test_year_level_active_pipelines_omits_module_scoped(pg_app):
                 pipeline_id=uuid4(),
                 job_type="aggregation",
                 meta={},
-            )
+            ),
         )
         await session.commit()
 
@@ -253,13 +261,14 @@ async def test_year_level_active_pipelines_dedupes_pipeline_ids(pg_app):
 
     async with Sf() as session:
         # Two jobs in the same pipeline (e.g. parent + a fan-out child).
-        session.add(_make_year_level_job(year=2025, pipeline_id=shared_pipeline))
-        session.add(
+        await seed_jobs_with_pipelines(
+            session,
+            _make_year_level_job(year=2025, pipeline_id=shared_pipeline),
             _make_year_level_job(
                 year=2025,
                 pipeline_id=shared_pipeline,
                 state=IngestionState.QUEUED,
-            )
+            ),
         )
         await session.commit()
 

--- a/backend/tests/integration/services/data_ingestion/test_aggregation_dedup_chain_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_aggregation_dedup_chain_pg.py
@@ -31,6 +31,8 @@ from app.models.data_ingestion import (
 from app.models.user import UserProvider
 from app.tasks._chain import chain_job
 
+from .conftest import ensure_pipeline_for_job
+
 
 async def _install_dedup_index(engine) -> None:
     """Create the ``uq_aggregation_active`` partial unique index that
@@ -84,6 +86,7 @@ async def test_dedup_active_creates_single_row_for_concurrent_chains(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -148,6 +151,7 @@ async def test_dedup_active_allows_new_row_after_first_finishes(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -208,6 +212,8 @@ async def test_dedup_active_does_not_collide_across_modules_or_years(pg_dsn):
         parent_a = _parent_job(module_type_id=5, year=2025)
         parent_b = _parent_job(module_type_id=6, year=2025)  # diff module
         parent_c = _parent_job(module_type_id=5, year=2026)  # diff year
+        for parent in (parent_a, parent_b, parent_c):
+            await ensure_pipeline_for_job(session, parent)
         session.add_all([parent_a, parent_b, parent_c])
         await session.commit()
         await session.refresh(parent_a)
@@ -250,6 +256,7 @@ async def test_dedup_active_skips_run_job_dispatch_on_collision(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)

--- a/backend/tests/integration/services/data_ingestion/test_csv_ingest_matrix_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_csv_ingest_matrix_pg.py
@@ -20,9 +20,14 @@ Each test is one falsifiable hypothesis under the cartesian product
    provider's ``_get_source_from_entity_type`` pin).
 2. With factors pre-loaded → ``data_entry_emissions`` rows exist with
    ``kg_co2eq`` matching the factor formula.
-3. Without factors → ``data_entry_emissions`` rows are zero/empty
-   (``primary_factor_id is None`` on every entry; the chain still
-   drives to FINISHED — recalc handles "no factors" gracefully).
+3. Without factors → fail-fast: parent reaches FINISHED+ERROR with a
+   single-line ``status_message`` naming the missing-factor cause, no
+   children are dispatched, and no DataEntry/emissions/stats are
+   written.  Replaces the older "absent factors → graceful FINISHED+
+   SUCCESS, no emissions" contract retired by #1236 (commit 503bfe5b
+   added ``_guard_factors_required`` + the ``_FACTOR_INFERRED_MODULES``
+   short-circuit so the operator sees one explanation rather than
+   50 000 row-level "no matching factor" errors).
 4. The targeted module's CRM has a dict-shaped ``stats`` payload
    for module types that appear in ``MODULE_TYPE_TO_EMISSION_ROOTS``
    (proves the aggregation chain committed); for module types
@@ -405,13 +410,58 @@ async def test_csv_ingest_standard_module(
             year=year,
         )
 
-        # The parent must terminate cleanly.  ``WARNING`` is the partial
-        # success bucket; we don't expect skips on a 2-row trimmed CSV
-        # with a fully seeded tree, so assert SUCCESS strictly.
+        # The parent always reaches FINISHED.  For ``factors_state=absent``
+        # the new fail-fast guard (#1236, commit 503bfe5b) refuses ingest
+        # up-front so the result flips to ERROR with a single-line
+        # status_message — the operator sees one explanation instead of
+        # 50 000 row-level "no matching factor" errors.  For
+        # ``pre_loaded`` we expect SUCCESS strictly.
         assert parent.state == IngestionState.FINISHED, (
             f"parent did not FINISH: state={parent.state} "
             f"status={parent.status_message}"
         )
+
+        if factors_state == "absent":
+            # Fail-fast contract: parent terminates ERROR, no children
+            # are dispatched, and no DataEntry/emissions/stats are
+            # written.  Pinning the absence of side-effects guards
+            # against a regression where the guard misses + lets every
+            # row error individually.
+            assert parent.result == IngestionResult.ERROR, (
+                f"factors_state=absent must trip the fail-fast guard; "
+                f"got result={parent.result}, status={parent.status_message!r}"
+            )
+            assert "factor" in (parent.status_message or "").lower(), (
+                f"absent-factors error should name the missing-factor cause; "
+                f"got status_message={parent.status_message!r}"
+            )
+            recalc_children = [c for c in children if c.job_type == "emission_recalc"]
+            assert recalc_children == [], (
+                f"fail-fast must skip the chain fan-out; got recalc "
+                f"children={[c.id for c in recalc_children]}"
+            )
+
+            async with Sf() as s:
+                target_entries = await _read_data_entries(
+                    s, carbon_report_module_id=target_crm.id
+                )
+            assert target_entries == [], (
+                f"fail-fast must not persist DataEntry rows; got "
+                f"{len(target_entries)} rows on the target CRM."
+            )
+
+            async with Sf() as s:
+                sibling_entries = await _read_data_entries(
+                    s, carbon_report_module_id=sibling_crm.id
+                )
+            assert sibling_entries == [], (
+                f"sibling unit's CRM (module_type={spec.module_type.name}) "
+                f"received DataEntries despite fail-fast on the target. "
+                f"got {len(sibling_entries)} rows."
+            )
+            return
+
+        # ── pre_loaded path ──────────────────────────────────────────
         assert parent.result == IngestionResult.SUCCESS, (
             f"parent reported {parent.result}: {parent.status_message}"
         )
@@ -443,49 +493,34 @@ async def test_csv_ingest_standard_module(
 
         entry_ids = [e.id for e in target_entries if e.id is not None]
 
-        # ── 6. Assertions 2 & 3 — kg_co2eq math (or its absence).
+        # ── 6. Assertion 2 — kg_co2eq math.
         async with Sf() as s:
             emissions = await _read_emissions_for_entries(s, data_entry_ids=entry_ids)
 
-        if factors_state == "pre_loaded":
-            assert emissions, (
-                "expected data_entry_emissions when factors are pre-loaded; "
-                "the recalc chain should have written one row per (entry, "
-                "emission_type)"
+        assert emissions, (
+            "expected data_entry_emissions when factors are pre-loaded; "
+            "the recalc chain should have written one row per (entry, "
+            "emission_type)"
+        )
+        # Pin assertion 2: at least one emission row carries the
+        # formula-derived kg.  Tolerance accommodates float math
+        # (process_emissions=150.0 exact; equipment uses
+        # WEEKS_PER_YEAR which is float).
+        kg_values = [e.kg_co2eq for e in emissions if e.kg_co2eq is not None]
+        assert any(
+            kg == pytest.approx(spec.expected_kg_first_row, rel=1e-2)
+            for kg in kg_values
+        ), (
+            f"no emission row matched the expected formula output "
+            f"{spec.expected_kg_first_row} (rel=1e-2); "
+            f"persisted kg values: {kg_values}"
+        )
+        # Pin: every entry has a primary_factor_id (factor was found).
+        for entry in target_entries:
+            assert entry.data.get("primary_factor_id") is not None, (
+                f"entry id={entry.id} missing primary_factor_id "
+                f"despite factors_state=pre_loaded"
             )
-            # Pin assertion 2: at least one emission row carries the
-            # formula-derived kg.  Tolerance accommodates float math
-            # (process_emissions=150.0 exact; equipment uses
-            # WEEKS_PER_YEAR which is float).
-            kg_values = [e.kg_co2eq for e in emissions if e.kg_co2eq is not None]
-            assert any(
-                kg == pytest.approx(spec.expected_kg_first_row, rel=1e-2)
-                for kg in kg_values
-            ), (
-                f"no emission row matched the expected formula output "
-                f"{spec.expected_kg_first_row} (rel=1e-2); "
-                f"persisted kg values: {kg_values}"
-            )
-            # Pin: every entry has a primary_factor_id (factor was found).
-            for entry in target_entries:
-                assert entry.data.get("primary_factor_id") is not None, (
-                    f"entry id={entry.id} missing primary_factor_id "
-                    f"despite factors_state=pre_loaded"
-                )
-        else:
-            # No factors → no formula → no emission rows AND no
-            # primary_factor_id stamped on the entries.
-            assert emissions == [], (
-                f"expected zero emissions when factors are absent; "
-                f"got {len(emissions)} rows: "
-                f"{[(e.data_entry_id, e.kg_co2eq) for e in emissions]}"
-            )
-            for entry in target_entries:
-                assert entry.data.get("primary_factor_id") is None, (
-                    f"entry id={entry.id} stamped primary_factor_id="
-                    f"{entry.data.get('primary_factor_id')!r} despite "
-                    f"factors_state=absent"
-                )
 
         # ── 7. Assertion 4 — CRM stats committed (shape-only).
         # ``CarbonReportModuleService.recompute_stats`` early-returns

--- a/backend/tests/integration/services/data_ingestion/test_emission_recalc_dedup_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_emission_recalc_dedup_pg.py
@@ -32,6 +32,8 @@ from app.models.data_ingestion import (
 from app.models.user import UserProvider
 from app.tasks._chain import EMISSION_RECALC_DEDUP, chain_job
 
+from .conftest import ensure_pipeline_for_job
+
 
 async def _install_emission_recalc_dedup_index(engine) -> None:
     """Create the ``uq_emission_recalc_active`` partial unique index that
@@ -100,6 +102,7 @@ async def test_back_to_back_factor_reuploads_collapse_to_one_recalc(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_factor_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -168,6 +171,7 @@ async def test_dedup_releases_after_first_recalc_finishes(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_factor_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -236,6 +240,8 @@ async def test_dedup_does_not_collide_across_dets_or_years(pg_dsn):
         parent_c = _parent_factor_job(
             module_type_id=5, data_entry_type_id=11, year=2026
         )  # different year
+        for parent in (parent_a, parent_b, parent_c):
+            await ensure_pipeline_for_job(session, parent)
         session.add_all([parent_a, parent_b, parent_c])
         await session.commit()
         await session.refresh(parent_a)
@@ -278,6 +284,7 @@ async def test_dedup_skips_run_job_dispatch_on_collision(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_factor_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -331,6 +338,7 @@ async def test_dedup_config_rejects_null_scope_keys(pg_dsn):
 
     async with Sf() as session:
         parent = _parent_factor_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)

--- a/backend/tests/integration/services/data_ingestion/test_foundation_smoke.py
+++ b/backend/tests/integration/services/data_ingestion/test_foundation_smoke.py
@@ -28,12 +28,10 @@ import dataclasses
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from sqlalchemy import select as sa_select
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.carbon_report import CarbonReportModule
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import (
     IngestionMethod,
@@ -192,7 +190,12 @@ async def test_dispatch_csv_and_wait_drives_full_chain(pg_dsn_with_310b) -> None
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with Sf() as s:
-        seeded = await seeded_year_with_units(s, year=2025, n_units=1)
+        # Tree must exist so the chain has CRMs to scan during the
+        # aggregation grandchild — the return value is unused now that
+        # stats are no longer asserted (Phase 4A.3 of #1236 rescoped
+        # aggregation to ``affected_module_ids``, which is empty for
+        # the stub provider; see the assertions below).
+        await seeded_year_with_units(s, year=2025, n_units=1)
 
     csv_path = csv_fixture_path("headcount", "data")
 
@@ -223,28 +226,30 @@ async def test_dispatch_csv_and_wait_drives_full_chain(pg_dsn_with_310b) -> None
         f"expected emission_recalc child; got job_types={job_types}"
     )
 
-    # ``assert_stats_match`` against the CRM the recalc/aggregation
-    # touched: the headcount module for the seeded unit.  After the
-    # aggregation child runs, the CRM's ``stats`` column MUST be a
-    # dict — aggregation runs even on empty data and writes a
-    # zero-shape stats payload.  A ``None`` here would mean
-    # ``data_session`` never committed (regression of the
-    # ``_run_one_job`` commit fix).
-    unit_id = seeded.units[0].id
-    crm = seeded.modules_by_unit_and_type[(unit_id, int(ModuleTypeEnum.headcount))]
-    async with Sf() as s:
-        result = await s.execute(
-            sa_select(CarbonReportModule).where(CarbonReportModule.id == crm.id)
+    # Chain-wiring smoke: the aggregation grandchild ran and reached a
+    # FINISHED+SUCCESS terminal state.  We deliberately do NOT assert
+    # the CRM ``stats`` payload is non-null here — Phase 4A.3 (#1236)
+    # rescoped the aggregation handler to ``meta.config.affected_module_ids``,
+    # and the stub provider inserts no rows, so the workflow's
+    # ``affected_module_ids`` is empty and the aggregation correctly
+    # writes stats for zero modules.  The stats math is covered by
+    # ``test_full_dag_pipeline_pg.py`` (real workflow + real CRM update);
+    # this smoke just pins that every link in the chain runs to
+    # completion against the test PG session factory (a regression of
+    # ``_run_one_job``'s data-session commit would show up as the
+    # aggregation child stuck mid-state, not as a None stats).
+    aggregation_children = [c for c in children if c.job_type == "aggregation"]
+    assert aggregation_children, (
+        f"expected aggregation grandchild; got job_types="
+        f"{[c.job_type for c in children]}"
+    )
+    for agg in aggregation_children:
+        assert agg.state == IngestionState.FINISHED, (
+            f"aggregation child stuck mid-state: state={agg.state}, "
+            f"status={agg.status_message!r}"
         )
-        fresh = result.scalar_one()
-        assert isinstance(fresh.stats, dict), (
-            f"aggregation should leave stats as a dict; got {fresh.stats!r}. "
-            "Most likely cause: dispatch_csv_and_wait._run_one_job stopped "
-            "committing data_session — handlers' domain writes never "
-            "persisted past their session scope."
+        assert agg.result == IngestionResult.SUCCESS, (
+            f"aggregation child reported {agg.result}: {agg.status_message!r}"
         )
-        # Empty subset asserts the dict shape; Units 2-11 will pin
-        # specific keys + numerics.
-        await assert_stats_match(s, crm.id, {})
 
     await engine.dispose()

--- a/backend/tests/integration/services/data_ingestion/test_full_dag_pipeline_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_full_dag_pipeline_pg.py
@@ -34,6 +34,8 @@ from app.models.data_ingestion import (
 )
 from app.models.user import UserProvider
 
+from .conftest import ensure_pipeline_for_job
+
 
 async def _install_dedup_index(engine) -> None:
     """Install ``uq_aggregation_active`` so the aggregation chain's
@@ -95,6 +97,7 @@ async def test_full_dag_csv_ingest_chains_emission_recalc_chains_aggregation(pg_
     # 1. Persist the parent csv_ingest job.
     async with Sf() as session:
         parent = _csv_ingest_parent()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -293,6 +296,7 @@ async def test_aggregation_chains_on_warning_with_partial_failure(pg_dsn):
     #    here).
     async with Sf() as session:
         parent = _emission_recalc_parent()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
         await session.refresh(parent)
@@ -337,7 +341,11 @@ async def test_aggregation_chains_on_warning_with_partial_failure(pg_dsn):
 
     # Sanity: the handler reported WARNING (the branch the bug skipped).
     assert meta["result"] == IngestionResult.WARNING
-    assert meta["aggregation_job_id"] is not None
+    # Phase 5B (#1236) — ``aggregation_job_id`` is no longer threaded
+    # through meta; the aggregation row is the source of truth.  The
+    # contract asserted here is "aggregation chained" — checked below
+    # by the row count under the parent's pipeline_id.
+    assert "aggregation_job_id" not in meta
 
     # The aggregation child exists in the DB, carries the parent's
     # pipeline_id, and is module-scoped to (module=5, year=2025).
@@ -351,7 +359,6 @@ async def test_aggregation_chains_on_warning_with_partial_failure(pg_dsn):
 
     assert len(aggregation_rows) == 1
     aggregation = aggregation_rows[0]
-    assert aggregation.id == meta["aggregation_job_id"]
     assert aggregation.module_type_id == 5
     assert aggregation.data_entry_type_id is None
     assert aggregation.year == 2025

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
@@ -32,6 +32,7 @@ Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
 
 import asyncio
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -58,6 +59,7 @@ from app.models.data_ingestion import (
 from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
 from app.models.unit import Unit
+from app.models.year_configuration import YearConfiguration
 from app.schemas.data_entry import DataEntryResponse
 from app.services.data_entry_emission_service import DataEntryEmissionService
 
@@ -191,18 +193,26 @@ async def _wait_for_child_recalc_job(
     Sf, parent_job_id: int, *, timeout: float = POLL_TIMEOUT_SECONDS
 ) -> DataIngestionJob:
     """Find the recalc child job spawned by the factor_ingest handler's
-    fan-out (Plan 310-C: ``_chain.chain_job`` stamps ``parent_job_id``
-    at ``meta.parent_job_id``).  Falls back to the legacy
-    ``meta.config.parent_job_id`` location for backward-compatibility
-    with rows pre-310C."""
+    fan-out.
+
+    Phase 5B (#1236) retired ``meta.parent_job_id`` — children are now
+    tied to their parent only by the shared ``pipeline_id``.  Look the
+    parent up by ``parent_job_id`` to read its ``pipeline_id``, then
+    match the emission_recalc child by that.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         async with Sf() as s:
+            parent = await s.get(DataIngestionJob, parent_job_id)
+            if parent is None or parent.pipeline_id is None:
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                continue
             rows = (
                 (
                     await s.execute(
                         select(DataIngestionJob).where(
-                            col(DataIngestionJob.job_type) == "emission_recalc"
+                            col(DataIngestionJob.job_type) == "emission_recalc",
+                            col(DataIngestionJob.pipeline_id) == parent.pipeline_id,
                         )
                     )
                 )
@@ -210,14 +220,10 @@ async def _wait_for_child_recalc_job(
                 .all()
             )
             for row in rows:
-                meta = row.meta or {}
-                if (
-                    meta.get("parent_job_id") == parent_job_id
-                    or meta.get("config", {}).get("parent_job_id") == parent_job_id
-                ):
-                    if row.state == IngestionState.FINISHED:
-                        return row
-                    break  # found the row but not done yet
+                if row.state == IngestionState.FINISHED:
+                    return row
+                # Found the row but not done yet — fall through to the sleep
+                # so we re-poll instead of giving up.
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
     raise AssertionError(
         f"Child recalc job for parent={parent_job_id} did not reach FINISHED "
@@ -244,6 +250,22 @@ async def test_factor_reupload_endpoint_recomputes_emission_via_recalc_task(
     tmp_path: Path = pg_app["tmp_path"]
 
     # ── 1. Seed the carbon-report graph + factor v1 + data entry ───────
+    # ``/v1/sync/dispatch`` (#1234-followup) refuses uploads for a year
+    # whose ``unit_sync`` pipeline hasn't finished SUCCESS — gated by
+    # ``year_configuration.configuration_completed``.  This test stages
+    # the post-provisioned graph by hand (CarbonReports / CRMs already
+    # exist below), so we stamp the marker explicitly to mirror what
+    # ``unit_sync_handler`` would have written on a real run.
+    async with Sf() as s:
+        s.add(
+            YearConfiguration(
+                year=2025,
+                is_started=True,
+                configuration_completed=datetime.now(timezone.utc),
+            )
+        )
+        await s.commit()
+
     async with Sf() as s:
         unit = Unit(
             institutional_code="TEST-310B",

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_recalc_fanout_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_recalc_fanout_pg.py
@@ -39,6 +39,8 @@ from app.models.module_type import ModuleTypeEnum
 from app.models.user import UserProvider
 from app.tasks.ingestion_tasks import _chain_recalc_for_stale
 
+from .conftest import ensure_pipeline_for_job
+
 
 def _multi_type_factor_job() -> DataIngestionJob:
     """Mirrors the production case: a finished, current FACTORS job for
@@ -73,6 +75,7 @@ async def test_fanout_creates_one_child_per_det_for_multitype_parent(pg_dsn):
 
     async with Sf() as session:
         parent = _multi_type_factor_job()
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
 
@@ -130,9 +133,13 @@ async def test_fanout_creates_one_child_per_det_for_multitype_parent(pg_dsn):
         assert landed_dets == expected_dets, (
             f"Expected one recalc per det {expected_dets}, got {landed_dets}"
         )
+        # Phase 5B (#1236) — ``meta.parent_job_id`` was retired in
+        # favour of pipeline-scoped traversal (parent = lowest-id job
+        # in the pipeline; see ``compute_pipeline_progress._find_root``).
+        # Pin the new contract: every fan-out child inherits the
+        # parent's pipeline_id.
         for r in rows:
-            assert r.meta is not None
-            assert r.meta["parent_job_id"] is not None
+            assert r.pipeline_id == parent.pipeline_id
 
     await engine.dispose()
 
@@ -148,6 +155,7 @@ async def test_fanout_creates_single_child_for_single_type_parent(pg_dsn):
     async with Sf() as session:
         parent = _multi_type_factor_job()
         parent.data_entry_type_id = DataEntryTypeEnum.it.value
+        await ensure_pipeline_for_job(session, parent)
         session.add(parent)
         await session.commit()
 

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_endpoint_pg.py
@@ -44,6 +44,8 @@ from app.models.data_ingestion import (
 )
 from app.models.user import UserProvider
 
+from .conftest import ensure_pipeline_for_job
+
 
 @pytest_asyncio.fixture
 async def pg_app(pg_dsn, monkeypatch):
@@ -141,6 +143,9 @@ async def test_get_pipeline_returns_ordered_jobs(pg_app):
         parent = _make_parent_factor_job(pipeline_id)
         child_a = _make_child_data_entries_job(pipeline_id, data_entry_type_id=2)
         child_b = _make_child_data_entries_job(pipeline_id, data_entry_type_id=3)
+        # Pipeline row is shared — seed it once before the first INSERT
+        # so the FK on ``data_ingestion_jobs.pipeline_id`` is satisfied.
+        await ensure_pipeline_for_job(session, parent)
         # Insert sequentially so ids are deterministic (parent first).
         session.add(parent)
         await session.flush()
@@ -170,10 +175,13 @@ async def test_get_pipeline_returns_ordered_jobs(pg_app):
     )
 
     # Verify the parent shape — proves enum and Optional columns serialise.
+    # ``state`` / ``result`` use the enum NAME (PipelineJobResponse
+    # field_serializer) so frontend string comparisons hold; the int
+    # enums (``target_type``) keep their numeric value.
     parent_row = jobs[0]
     assert parent_row["job_type"] == "factor_ingest"
-    assert parent_row["state"] == IngestionState.FINISHED.value
-    assert parent_row["result"] == IngestionResult.SUCCESS.value
+    assert parent_row["state"] == IngestionState.FINISHED.name
+    assert parent_row["result"] == IngestionResult.SUCCESS.name
     assert parent_row["target_type"] == TargetType.FACTORS.value
     assert parent_row["module_type_id"] == 1
     assert parent_row["data_entry_type_id"] == 1
@@ -202,6 +210,9 @@ async def test_get_pipeline_does_not_leak_jobs_from_other_pipelines(pg_app):
         # Different combo so the partial unique is_current index doesn't trip.
         theirs.module_type_id = 2
         theirs.data_entry_type_id = 2
+        # Two distinct pipeline_ids — seed both ``pipelines`` rows first.
+        await ensure_pipeline_for_job(session, ours)
+        await ensure_pipeline_for_job(session, theirs)
         session.add_all([ours, theirs])
         await session.commit()
 

--- a/backend/tests/integration/services/data_ingestion/test_sync_pipeline_stream_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_pipeline_stream_endpoint_pg.py
@@ -45,6 +45,8 @@ from app.models.data_ingestion import (
 )
 from app.models.user import UserProvider
 
+from .conftest import ensure_pipeline_for_job
+
 
 @pytest_asyncio.fixture
 async def pg_app(pg_dsn, monkeypatch):
@@ -155,7 +157,9 @@ async def test_pipeline_stream_returns_403_for_user_without_permission(
 
     pipeline_id = uuid4()
     async with Sf() as session:
-        session.add(_make_pending_factor_job(pipeline_id))
+        job = _make_pending_factor_job(pipeline_id)
+        await ensure_pipeline_for_job(session, job)
+        session.add(job)
         await session.commit()
 
     async def override_get_db():
@@ -219,7 +223,9 @@ async def test_list_jobs_by_pipeline_id_reflects_cross_session_updates(pg_dsn):
     # Seed: a NOT_STARTED parent job — the kind the SSE consumer sees
     # before the runner picks it up.
     async with Sf() as seed_session:
-        seed_session.add(_make_pending_factor_job(pipeline_id))
+        job = _make_pending_factor_job(pipeline_id)
+        await ensure_pipeline_for_job(seed_session, job)
+        seed_session.add(job)
         await seed_session.commit()
 
     try:
@@ -294,7 +300,9 @@ async def test_disconnect_releases_pool_slot(pg_dsn, monkeypatch):
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     pipeline_id = uuid4()
     async with Sf() as session:
-        session.add(_make_pending_factor_job(pipeline_id))
+        job = _make_pending_factor_job(pipeline_id)
+        await ensure_pipeline_for_job(session, job)
+        session.add(job)
         await session.commit()
 
     # Patch the SSE handler's SessionLocal at the imported-module attribute.
@@ -409,7 +417,9 @@ async def test_cross_tenant_pipeline_returns_403(pg_dsn, monkeypatch):
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     pipeline_id = uuid4()
     async with Sf() as session:
-        session.add(_make_pending_factor_job(pipeline_id))
+        job = _make_pending_factor_job(pipeline_id)
+        await ensure_pipeline_for_job(session, job)
+        session.add(job)
         await session.commit()
 
     async def override_get_db():

--- a/backend/tests/integration/v1/test_year_configuration_list.py
+++ b/backend/tests/integration/v1/test_year_configuration_list.py
@@ -141,11 +141,22 @@ def test_admin_sees_all_years(client, monkeypatch, db_with_two_years):
 
 def test_response_excludes_heavy_config_blob(client, monkeypatch, db_with_two_years):
     """List rows are intentionally lightweight — no ``config`` or
-    ``recalculation_status`` payload (callers use ``GET /{year}`` for those)."""
+    ``recalculation_status`` payload (callers use ``GET /{year}`` for those).
+
+    ``configuration_completed`` (a scalar timestamp added by #1234-followup
+    so the dispatch gate can read it without a follow-up call) is in
+    scope — it's the lightweight marker, not the heavy blob this test
+    guards against.
+    """
     _, factory = db_with_two_years
     _wire(monkeypatch, factory, is_admin=True)
 
     r = client.get(URL)
     assert r.status_code == 200, r.text
     row = r.json()[0]
-    assert set(row.keys()) == {"year", "is_started", "updated_at"}
+    assert set(row.keys()) == {
+        "year",
+        "is_started",
+        "configuration_completed",
+        "updated_at",
+    }


### PR DESCRIPTION
## Why

`make test-cov-xml-integration` is no longer in the commit hooks (intentional — `make test` runs unit only), so ~80 commits' worth of behavior changes had silently broken the integration suite: **52 failed + 5 errored** out of 218. All four root causes are *already shipped* in production code; the tests just hadn't been updated.

## What

Four buckets:

| Bucket | Root cause | Fix |
|---|---|---|
| **A** (51 tests) | #1236 Phase-2 FK `data_ingestion_jobs.pipeline_id → pipelines.id` (commit c517f032) — tests `session.add(DataIngestionJob(...))` directly without the parent `pipelines` row tripped `ForeignKeyViolationError` | New `ensure_pipeline_for_job` + `seed_jobs_with_pipelines` helpers in `conftest.py`; `dispatch_csv_and_wait` calls them inline; 9 direct-insert tests updated |
| **B** (5 tests) | `get_module_permission_decision` removed from `app.api.v1.data_sync` (commit b8b48d17 / #1234) — fixture monkeypatch on the missing symbol → `AttributeError` | Drop the stale monkeypatch from `pg_app`. Delete `test_active_pipelines_filters_per_module_by_decision` — it pinned behavior intentionally retired; replacement coverage is `tests/unit/v1/test_active_pipelines_endpoint.py` |
| **C** (1 test) | `YearConfigurationListItem` gained `configuration_completed` (#1234-followup) | Add the key to the heavy-blob assertion set |
| **D** (1 test) | `/v1/sync/dispatch` gates on `year_configuration.configuration_completed` (commit 6ed3aab8) | Seed `YearConfiguration(year=2025, configuration_completed=...)` in the factor-reupload test setup |

**Phase-5B (#1236) tail-end follow-ons** surfaced once the FK bucket unblocked:

- `meta.parent_job_id` retired → `_wait_for_child_recalc_job` looks up parent by id, matches child by shared `pipeline_id`
- `meta.aggregation_job_id` retired → `test_aggregation_chains_on_warning_with_partial_failure` reads aggregation row from DB
- `PipelineJobResponse` serialises `state`/`result` as enum NAME (frontend string compare) — assertions switched to `.name`

**Two further casualties** from related #1236 phases:

- Aggregation rescoped to `meta.config.affected_module_ids` (Phase 4A.3) — stub provider inserts zero rows so `affected_module_ids` is empty; `test_foundation_smoke` pins chain wiring via the aggregation child's terminal state instead of stats payload
- `_guard_factors_required` fail-fast for empty `factors_map` (commit 503bfe5b) — `test_csv_ingest_matrix_pg.py` `factors_state=absent` now asserts FINISHED+ERROR + factor-naming `status_message` + no side-effects (no entries, no emissions, no child dispatch)

## Watchout for future authors

`dispatch_csv_and_wait._run_one_job` now mirrors production `app.tasks.runner`'s exception path: on handler raise it writes `FINISHED+ERROR` with the exception string as `status_message` rather than re-raising. Required for bucket-D-style fail-fast tests to be observable. No existing caller used `pytest.raises(...)` around `dispatch_csv_and_wait` (suite-verified) but worth flagging.

## Verification

- `tests/integration`: **218 passed** (was 161 passed, 52 failed, 5 errors)
- `tests/unit`: **1442 passed**
- `ruff` + `mypy` clean on the changed files

**No production code touched** — every change is in `tests/`.