### PR TITLE
feat: make sciper field mandatory

### DIFF
--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -69,6 +69,7 @@ const memberFields: ModuleField[] = [
     labelKey: 'headcount-member-form-field-user-institutional-id-label',
     type: 'text',
     sortable: false,
+    required: true,
     ratio: '1/4',
   },
   {


### PR DESCRIPTION
## What does this change?

Marks the SCIPER (user institutional ID) field as `required: true` in the headcount member form config.

## Why is this needed?

The field was optional, allowing members to be saved without a SCIPER, which caused a bug in headcount FTE calculations that depend on it being present.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #1194 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
