### PR TITLE
fix(#1266): provider-scope unit_sync + year_configuration

### DIFF
--- a/backend/alembic/versions/2026_05_22_1000-d6e7f8a9b0c1_year_configuration_provider_scope.py
+++ b/backend/alembic/versions/2026_05_22_1000-d6e7f8a9b0c1_year_configuration_provider_scope.py
@@ -1,0 +1,71 @@
+# codeql[py/unused-global-variable]
+"""year_configuration provider scope (#1266)
+
+Adds a ``provider`` column to ``year_configuration`` and pivots the
+primary key from ``(year)`` to ``(year, provider)`` so TEST and ACCRED
+users can each provision the same year independently.
+
+Existing rows are stamped ``DEFAULT`` (the dev-fallback value); production
+never lands here because v0.x drops the DB between deploys (no backfill
+until v1.x).  The server default lets the ALTER COLUMN ... SET NOT NULL
+succeed on any pre-existing rows in dev databases.
+
+Revision ID: d6e7f8a9b0c1
+Revises: c4d5e6f7a8b9
+Create Date: 2026-05-22 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+revision: str = "d6e7f8a9b0c1"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "c4d5e6f7a8b9"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    # The enum type ``user_provider_enum`` already exists (created by the
+    # initial migration for ``units`` / ``users`` / ``data_ingestion_jobs``);
+    # ``create_type=False`` tells Alembic to reference it, not recreate.
+    user_provider_enum = postgresql.ENUM(
+        "ACCRED",
+        "DEFAULT",
+        "TEST",
+        name="user_provider_enum",
+        create_type=False,
+    )
+    op.add_column(
+        "year_configuration",
+        sa.Column(
+            "provider",
+            user_provider_enum,
+            nullable=False,
+            server_default="DEFAULT",
+        ),
+    )
+    op.drop_constraint("year_configuration_pkey", "year_configuration", type_="primary")
+    op.create_primary_key(
+        "year_configuration_pkey",
+        "year_configuration",
+        ["year", "provider"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("year_configuration_pkey", "year_configuration", type_="primary")
+    op.create_primary_key("year_configuration_pkey", "year_configuration", ["year"])
+    op.drop_column("year_configuration", "provider")

--- a/backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py
+++ b/backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py
@@ -1,25 +1,30 @@
 # codeql[py/unused-global-variable]
 """year_configuration provider scope (#1266)
 
-Adds a ``provider`` column to ``year_configuration`` and pivots the
-primary key from ``(year)`` to ``(year, provider)`` so TEST and ACCRED
-users can each provision the same year independently.
+Adds ``provider`` to ``year_configuration`` and pivots the PK from
+``(year)`` to ``(year, provider)`` so TEST and ACCRED users can each
+provision the same year independently.
 
-Existing rows are stamped ``DEFAULT`` (the dev-fallback value); production
-never lands here because v0.x drops the DB between deploys (no backfill
-until v1.x).  The server default lets the ALTER COLUMN ... SET NOT NULL
-succeed on any pre-existing rows in dev databases.
+Existing rows get stamped ``DEFAULT`` via the server default; v0.x drops
+the DB between deploys (no backfill until v1.x) so production never
+lands on a stamped row.
 
-Revision ID: d6e7f8a9b0c1
+Autogenerate also detected 7 "removed indexes" (uq_aggregation_active,
+uq_emission_recalc_active, uq_factor_identity, uq_factor_identity_no_year,
+ix_locations_keywords, ix_pipelines_module_year, ix_pipelines_status) —
+all FALSE POSITIVES: those are partial / GIN / raw-SQL indexes declared
+in prior migrations but not in the SQLModel metadata, so each fresh
+autogenerate offers to drop them.  Stripped from this revision.
+
+Revision ID: 6293d5b22dc5
 Revises: c4d5e6f7a8b9
-Create Date: 2026-05-22 10:00:00.000000
+Create Date: 2026-05-22 11:42:31.915898
 
 """
 
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
@@ -31,28 +36,20 @@ __all__ = [
 ]
 
 
-revision: str = "d6e7f8a9b0c1"  # noqa: F841
+# revision identifiers, used by Alembic.
+revision: str = "6293d5b22dc5"  # noqa: F841
 down_revision: Union[str, Sequence[str], None] = "c4d5e6f7a8b9"  # noqa: F841
 branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
 depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
 
 
 def upgrade() -> None:
-    # The enum type ``user_provider_enum`` already exists (created by the
-    # initial migration for ``units`` / ``users`` / ``data_ingestion_jobs``);
-    # ``create_type=False`` tells Alembic to reference it, not recreate.
-    user_provider_enum = postgresql.ENUM(
-        "ACCRED",
-        "DEFAULT",
-        "TEST",
-        name="user_provider_enum",
-        create_type=False,
-    )
+    """Upgrade schema."""
     op.add_column(
         "year_configuration",
         sa.Column(
             "provider",
-            user_provider_enum,
+            sa.Enum("ACCRED", "DEFAULT", "TEST", name="user_provider_enum"),
             nullable=False,
             server_default="DEFAULT",
         ),
@@ -66,6 +63,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    """Downgrade schema."""
     op.drop_constraint("year_configuration_pkey", "year_configuration", type_="primary")
     op.create_primary_key("year_configuration_pkey", "year_configuration", ["year"])
     op.drop_column("year_configuration", "provider")

--- a/backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py
+++ b/backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py
@@ -63,7 +63,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
+    """Downgrade schema.
+
+    After this migration runs, the table can hold multiple rows per
+    ``year`` (one per provider). Re-creating a PK on ``year`` alone
+    would fail with a duplicate-key error. Drop every non-DEFAULT row
+    first so the surviving set is unique on ``year``. v0.x drops the
+    DB between deploys, so the data loss is acceptable on a
+    downgrade-then-redeploy.
+    """
+    op.execute("DELETE FROM year_configuration WHERE provider <> 'DEFAULT'")
     op.drop_constraint("year_configuration_pkey", "year_configuration", type_="primary")
     op.create_primary_key("year_configuration_pkey", "year_configuration", ["year"])
     op.drop_column("year_configuration", "provider")

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -1906,6 +1906,7 @@ async def recalculate_emissions_for_type(
         target_type=TargetType.DATA_ENTRIES,
         entity_type=EntityType.MODULE_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        provider=current_user.provider,
         pipeline_id=pipeline_id,
         meta={"config": {"year": year, "data_entry_type_id": data_entry_type_id.value}},
     )
@@ -2000,6 +2001,7 @@ async def recalculate_emissions_for_module(
         target_type=TargetType.DATA_ENTRIES,
         entity_type=EntityType.MODULE_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        provider=current_user.provider,
         pipeline_id=pipeline_id,
         meta={
             "config": {

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -2051,12 +2051,14 @@ async def sync_units_from_accred(
     db: AsyncSession = Depends(get_db),
 ):
     """
-    Sync units from Accred API.
+    Sync units from the caller's provider (Accred for ACCRED users,
+    fixture-backed for TEST users).
 
     Plan 310B Part 5 — creates a tracked DataIngestionJob (job_type=
     unit_sync, entity_type=GLOBAL_PER_YEAR) so progress is observable via
     the SSE stream and the job is recoverable on pod crash via the safety
-    poller.
+    poller. Provider is resolved from ``current_user.provider`` and stamped
+    on the job (#1266).
 
     **Required Permission**: `backoffice.data_management.sync`
 
@@ -2096,7 +2098,7 @@ async def sync_units_from_accred(
     return SyncStatusResponse(
         job_id=created.id,
         state=IngestionState.NOT_STARTED,
-        message="Unit sync from Accred API scheduled",
+        message=f"Unit sync from {current_user.provider.name} scheduled",
     )
 
 

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -753,7 +753,8 @@ async def sync_module_data_entries(
         year_cfg = (
             await db.execute(
                 select(YearConfiguration).where(
-                    col(YearConfiguration.year) == syncRequest.year
+                    col(YearConfiguration.year) == syncRequest.year,
+                    col(YearConfiguration.provider) == current_user.provider,
                 )
             )
         ).scalar_one_or_none()
@@ -761,9 +762,9 @@ async def sync_module_data_entries(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail=(
-                    f"Year {syncRequest.year} is not yet provisioned — "
-                    "wait for the unit_sync pipeline to complete before "
-                    "uploading data for this year."
+                    f"Year {syncRequest.year} is not yet provisioned for "
+                    f"provider {current_user.provider.name} — wait for the "
+                    "unit_sync pipeline to complete before uploading data."
                 ),
             )
 
@@ -2069,6 +2070,7 @@ async def sync_units_from_accred(
         target_type=TargetType.REFERENCE_DATA,
         entity_type=EntityType.GLOBAL_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        provider=current_user.provider,
         meta={"config": {"target_year": syncRequest.target_year}},
     )
     created = await DataIngestionRepository(db).create_ingestion_job(job)

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -335,14 +335,15 @@ async def create_audit_entry(
 ) -> None:
     """Create audit entry for year configuration change.
 
-    Args:
-        session: Database session.
-        year: Configuration year.
-        change_type: Type of change (CREATE/UPDATE/DELETE).
-        user: User making the change.
-        data_snapshot: Full configuration snapshot.
-        data_diff: Optional diff between old and new config.
+    ``YearConfiguration`` is keyed by ``(year, provider)``; the audit chain
+    must mirror that so two providers don't interleave their version
+    counters. Encode ``entity_id`` as ``year * 10 + provider.value`` —
+    ``UserProvider`` is 0/1/2 so this stays collision-free with adjacent
+    years. The ``data_snapshot`` always includes ``provider`` so the
+    encoded id is recoverable.
     """
+    entity_id = year * 10 + int(user.provider)
+
     # Calculate hash for integrity chain
     snapshot_str = str(data_snapshot)
     current_hash = hashlib.sha256(snapshot_str.encode()).hexdigest()
@@ -352,7 +353,7 @@ async def create_audit_entry(
     stmt = (
         select(AuditDocument)
         .where(col(AuditDocument.entity_type) == "year_configuration")
-        .where(col(AuditDocument.entity_id) == year)
+        .where(col(AuditDocument.entity_id) == entity_id)
         .where(col(AuditDocument.is_current))
         .order_by(col(AuditDocument.version).desc())
     )
@@ -370,7 +371,7 @@ async def create_audit_entry(
     # Create new audit entry
     audit_entry = AuditDocument(
         entity_type="year_configuration",
-        entity_id=year,
+        entity_id=entity_id,
         version=new_version,
         is_current=True,
         data_snapshot=data_snapshot,
@@ -409,7 +410,9 @@ async def list_year_configurations(
     """
     is_admin = await is_permitted(current_user, "backoffice.data_management", "view")
 
-    stmt = select(YearConfiguration)
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.provider) == current_user.provider
+    )
     if not is_admin:
         stmt = stmt.where(col(YearConfiguration.is_started).is_(True))
     stmt = stmt.order_by(col(YearConfiguration.year).desc())
@@ -446,7 +449,10 @@ async def get_year_configuration(
     Returns:
         Year configuration enriched with latest sync job per submodule.
     """
-    stmt = select(YearConfiguration).where(col(YearConfiguration.year) == year)
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == current_user.provider,
+    )
     result = (await db.exec(stmt)).first()
 
     if not result:
@@ -506,12 +512,18 @@ async def create_year_configuration(
             detail="Only backoffice data managers can create year configurations",
         )
 
-    stmt = select(YearConfiguration).where(col(YearConfiguration.year) == year)
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == current_user.provider,
+    )
     existing = (await db.exec(stmt)).first()
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Configuration for year {year} already exists",
+            detail=(
+                f"Configuration for year {year} provider "
+                f"{current_user.provider.name} already exists"
+            ),
         )
 
     config_data = (
@@ -530,6 +542,7 @@ async def create_year_configuration(
     # ``is_started: true``).  Callers may still override here.
     new_config = YearConfiguration(
         year=year,
+        provider=current_user.provider,
         is_started=payload.is_started
         if payload and payload.is_started is not None
         else False,
@@ -573,6 +586,7 @@ async def create_year_configuration(
         target_type=TargetType.REFERENCE_DATA,
         entity_type=EntityType.GLOBAL_PER_YEAR,
         state=IngestionState.NOT_STARTED,
+        provider=current_user.provider,
         pipeline_id=pipeline_id,
         meta={"config": {"target_year": year}},
     )
@@ -682,7 +696,10 @@ async def update_year_configuration(
                     ),
                 )
 
-    stmt = select(YearConfiguration).where(col(YearConfiguration.year) == year)
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == current_user.provider,
+    )
     result = (await db.exec(stmt)).first()
 
     if not result:
@@ -823,7 +840,10 @@ async def upload_reduction_objective_file(
     config_key = category_map[category]
 
     # Update configuration
-    stmt = select(YearConfiguration).where(col(YearConfiguration.year) == year)
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == current_user.provider,
+    )
     result = (await db.exec(stmt)).first()
 
     if not result:
@@ -945,7 +965,10 @@ async def check_emission_threshold(
         Whether threshold is exceeded and threshold value.
     """
     # Get configuration
-    stmt = select(YearConfiguration).where(col(YearConfiguration.year) == year)
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == current_user.provider,
+    )
     result = (await db.exec(stmt)).first()
 
     config = result.config if result else generate_default_year_config()

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -401,10 +401,12 @@ async def list_year_configurations(
 ):
     """List year configurations available to the caller.
 
-    Backoffice data managers see every row (admin-equivalent for this purpose);
-    everyone else only sees years where ``is_started`` is true. This is what
-    drives the workspace year selector — closed years stay hidden from regular
-    users until backoffice opens them.
+    Results are always scoped to ``current_user.provider`` — a TEST user
+    never sees ACCRED rows and vice versa. Backoffice data managers
+    additionally bypass the ``is_started`` filter (regular users only
+    see opened years). This is what drives the workspace year selector
+    — closed years stay hidden from regular users until backoffice
+    opens them.
 
     Sorted by year descending (latest first).
     """
@@ -551,6 +553,7 @@ async def create_year_configuration(
     db.add(new_config)
 
     snapshot = {
+        "provider": current_user.provider.name,
         "is_started": new_config.is_started,
         "config": new_config.config,
     }
@@ -710,6 +713,7 @@ async def update_year_configuration(
 
     # Get old snapshot for audit
     old_snapshot = {
+        "provider": current_user.provider.name,
         "is_started": result.is_started,
         "config": result.config,
     }
@@ -722,6 +726,7 @@ async def update_year_configuration(
     db.add(result)
 
     new_snapshot = {
+        "provider": current_user.provider.name,
         "is_started": result.is_started,
         "config": result.config,
     }
@@ -858,6 +863,7 @@ async def upload_reduction_objective_file(
     # Capture old state for audit diff before any mutation
     old_config = copy.deepcopy(result.config)
     old_snapshot = {
+        "provider": current_user.provider.name,
         "is_started": result.is_started,
         "config": old_config,
     }
@@ -902,6 +908,7 @@ async def upload_reduction_objective_file(
 
     # Create audit entry with diff
     new_snapshot = {
+        "provider": current_user.provider.name,
         "is_started": result.is_started,
         "config": result.config,
     }

--- a/backend/app/models/year_configuration.py
+++ b/backend/app/models/year_configuration.py
@@ -5,7 +5,10 @@ from typing import Optional
 
 from sqlalchemy import Column
 from sqlalchemy import DateTime as SADateTime
+from sqlalchemy import Enum as SAEnum
 from sqlmodel import JSON, Field, SQLModel
+
+from app.models.user import UserProvider
 
 
 class YearConfigurationBase(SQLModel):
@@ -15,17 +18,12 @@ class YearConfigurationBase(SQLModel):
         default=False,
         description="If true, data entry is open for users for this year",
     )
-    # #1234-followup (Guilbert 2026-05-20): the `unit_sync` pipeline
-    # provisions a year's carbon_reports + modules; uploads for the
-    # year must NOT be accepted while that's running or before it ever
-    # ran. ``configuration_completed`` is set by ``unit_sync_handler``
-    # on SUCCESS (None until then). Dispatch gates on it.
     configuration_completed: Optional[datetime] = Field(
         default=None,
         sa_column=Column(SADateTime(timezone=True), nullable=True),
         description=(
             "Timestamp the unit_sync pipeline finished SUCCESSFULLY for "
-            "this year. NULL = year not yet provisioned (uploads blocked)."
+            "this year/provider. NULL = not yet provisioned (uploads blocked)."
         ),
     )
     config: dict = Field(
@@ -36,21 +34,24 @@ class YearConfigurationBase(SQLModel):
 
 
 class YearConfiguration(YearConfigurationBase, table=True):
-    """Year configuration table for annual administrative settings.
+    """Year configuration table, scoped by (year, provider).
 
-    This table centralizes:
-    - Annual administrative settings (is_started)
-    - Emission thresholds per module/submodule
-    - Uncertainty levels
-    - Institutional reduction goals
-
-    The `config` JSONB column stores module configurations keyed by ModuleTypeEnum
-    and DataEntryTypeEnum for O(1) lookup in the calculation engine.
+    Each `UserProvider` has an independent row per year so TEST and ACCRED
+    can be provisioned and opened independently in the same database.
     """
 
     __tablename__ = "year_configuration"
 
     year: int = Field(primary_key=True, description="The reference year")
+    provider: UserProvider = Field(
+        default=UserProvider.DEFAULT.value,
+        sa_column=Column(
+            SAEnum(UserProvider, name="user_provider_enum", native_enum=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        description="Provider scope (accred, default, test)",
+    )
     updated_at: datetime = Field(
         default_factory=datetime.utcnow,
         sa_column_kwargs={"onupdate": datetime.utcnow},

--- a/backend/app/providers/unit_provider.py
+++ b/backend/app/providers/unit_provider.py
@@ -8,8 +8,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.models.unit import Unit
-from app.models.user import UserProvider
-from app.providers.test_fixtures import TEST_UNITS
+from app.models.user import RoleName, UserProvider
+from app.providers.test_fixtures import TEST_UNITS, TEST_USERS
 
 """
 Unit provider interface and implementations.
@@ -323,6 +323,20 @@ class TestUnitProvider(UnitProvider):
                 u.model_copy() for u in TEST_UNITS if u.institutional_id in unit_ids
             ]
         return [u.model_copy() for u in TEST_UNITS]
+
+    async def fetch_all_units(self) -> tuple[list[dict], list[dict]]:
+        """Return TEST fixtures shaped for ``unit_sync_handler``.
+
+        Round-trips through ``map_api_unit`` via ``Unit.model_dump()``.
+        Principal user is the one TEST_UNITS' ``principal_user_institutional_id``
+        points at — TEST_USERS[RoleName.CO2_USER_PRINCIPAL].
+        """
+        units_raw = [u.model_dump() for u in TEST_UNITS]
+        principal = TEST_USERS[RoleName.CO2_USER_PRINCIPAL]
+        return units_raw, [principal]
+
+    def map_api_unit(self, unit_raw: dict) -> Unit:
+        return Unit(**unit_raw)
 
 
 def get_unit_provider(

--- a/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
@@ -344,12 +344,20 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
         """Write the validated CSV rows into year_configuration.config."""
         if not self.year:
             raise ValueError("year is required")
+        if self.user is None:
+            raise ValueError(
+                "user is required to resolve the provider-scoped year_configuration"
+            )
 
-        stmt = select(YearConfiguration).where(col(YearConfiguration.year) == self.year)
+        stmt = select(YearConfiguration).where(
+            col(YearConfiguration.year) == self.year,
+            col(YearConfiguration.provider) == self.user.provider,
+        )
         result = (await self.data_session.exec(stmt)).first()
         if not result:
             raise ValueError(
-                f"No year_configuration found for year {self.year}. Create it first."
+                f"No year_configuration found for year {self.year} "
+                f"provider {self.user.provider.name}. Create it first."
             )
 
         # Ensure reduction_objectives structure exists

--- a/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
@@ -344,20 +344,32 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
         """Write the validated CSV rows into year_configuration.config."""
         if not self.year:
             raise ValueError("year is required")
-        if self.user is None:
+
+        # Provider resolution order: ``config["provider"]`` is the
+        # ``job.provider`` value spread by ``_run_ingest`` from
+        # ``job.__dict__``; ``self.user.provider`` covers the endpoint-
+        # driven path where the runner isn't in the loop. Neither
+        # present is a hard error — we can't write provider-scoped data
+        # without a provider.
+        provider = self.config.get("provider")
+        if provider is None and self.user is not None:
+            provider = self.user.provider
+        if provider is None:
             raise ValueError(
-                "user is required to resolve the provider-scoped year_configuration"
+                "provider is required to resolve the provider-scoped "
+                "year_configuration (neither job.provider in config nor "
+                "user.provider available)"
             )
 
         stmt = select(YearConfiguration).where(
             col(YearConfiguration.year) == self.year,
-            col(YearConfiguration.provider) == self.user.provider,
+            col(YearConfiguration.provider) == provider,
         )
         result = (await self.data_session.exec(stmt)).first()
         if not result:
             raise ValueError(
                 f"No year_configuration found for year {self.year} "
-                f"provider {self.user.provider.name}. Create it first."
+                f"provider {provider}. Create it first."
             )
 
         # Ensure reduction_objectives structure exists

--- a/backend/app/tasks/_chain.py
+++ b/backend/app/tasks/_chain.py
@@ -327,6 +327,12 @@ async def chain_job(
             state=IngestionState.NOT_STARTED,
             is_current=False,
             pipeline_id=pipeline_id,
+            # Inherit the parent's provider scope — every job in a
+            # pipeline shares the same provider (the user who triggered
+            # the root upload). Without this children default to DEFAULT
+            # and downstream provider-scoped reads (year_configuration,
+            # carbon_reports) miss the right rows.
+            provider=parent.provider,
             # ``None`` means "runnable immediately" — claim_job's WHERE
             # treats NULL run_after as eligible.  Matches the existing
             # ingestion_tasks.py recalc-job creation pattern.

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -533,6 +533,7 @@ async def module_emission_recalc_handler(
             state=IngestionState.FINISHED,
             result=type_result,
             status_message=f"Bulk recalculation via module job {job.id}",
+            provider=job.provider,
             # Phase 5B (#1236) — ``parent_job_id`` dropped from meta;
             # readers identify parents as the lowest-id job per pipeline.
             meta={"recalculation": stats},

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -166,7 +166,7 @@ async def unit_sync_handler(
     _start_phase("fetch_units")
     await job_repo.update_ingestion_job(
         job_id=job.id,
-        status_message="Fetching units from Accred…",
+        status_message=f"Fetching units from {job.provider.name}…",
         metadata={"phases": phases},
     )
     await job_session.commit()

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -90,6 +90,12 @@ async def unit_sync_handler(
             f"unit_sync job {job.id} missing config.target_year (and job.year)"
         )
 
+    if job.provider == UserProvider.DEFAULT:
+        raise ValueError(
+            f"unit_sync job {job.id}: UserProvider.DEFAULT has no unit "
+            f"source; check PROVIDER_PLUGIN and current_user.provider"
+        )
+
     # #1236 — TWO advisory locks for unit_sync, both transaction-scoped
     # on ``data_session`` (the runner commits/rolls back after this
     # handler returns, releasing both):
@@ -165,8 +171,8 @@ async def unit_sync_handler(
     )
     await job_session.commit()
 
-    unit_provider = get_unit_provider(UserProvider.ACCRED)
-    role_provider = get_role_provider(UserProvider.ACCRED)
+    unit_provider = get_unit_provider(job.provider)
+    role_provider = get_role_provider(job.provider)
     units_raw, principal_users_raw = await unit_provider.fetch_all_units()
 
     units = [unit_provider.map_api_unit(u) for u in units_raw]
@@ -227,7 +233,10 @@ async def unit_sync_handler(
     # carbon-reports/modules creation above.
     year_cfg_row = (
         await data_session.execute(
-            select(YearConfiguration).where(col(YearConfiguration.year) == target_year)
+            select(YearConfiguration).where(
+                col(YearConfiguration.year) == target_year,
+                col(YearConfiguration.provider) == job.provider,
+            )
         )
     ).scalar_one_or_none()
     if year_cfg_row is not None:
@@ -235,10 +244,11 @@ async def unit_sync_handler(
         data_session.add(year_cfg_row)
     else:
         logger.warning(
-            "unit_sync: no YearConfiguration row for year=%s — "
+            "unit_sync: no YearConfiguration row for year=%s provider=%s — "
             "configuration_completed stamp skipped (year-config row "
             "should exist; was the year created via /year-configuration?)",
             target_year,
+            job.provider,
         )
 
     return {

--- a/backend/tests/integration/services/data_ingestion/conftest.py
+++ b/backend/tests/integration/services/data_ingestion/conftest.py
@@ -354,9 +354,11 @@ async def seeded_year_with_units(
 
     # ── 1. Year configuration row (idempotent — a previous test on the
     #       same session may already have laid this year down).
-    existing_year = await session.get(YearConfiguration, year)
+    existing_year = await session.get(YearConfiguration, (year, UserProvider.DEFAULT))
     if existing_year is None:
-        session.add(YearConfiguration(year=year, is_started=True))
+        session.add(
+            YearConfiguration(year=year, provider=UserProvider.DEFAULT, is_started=True)
+        )
         await session.flush()
 
     units: list[Unit] = []

--- a/backend/tests/integration/services/data_ingestion/test_dispatch_copy_from_previous_year_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_dispatch_copy_from_previous_year_pg.py
@@ -82,6 +82,7 @@ async def pg_app(pg_dsn, monkeypatch, tmp_path):
     fake_user.id = 1
     fake_user.email = "test@example.com"
     fake_user.institutional_id = "TEST-COPY-FROM-PREV"
+    fake_user.provider = UserProvider.DEFAULT
 
     app.dependency_overrides[deps_module.get_db] = override_get_db
     app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user

--- a/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py
@@ -59,6 +59,7 @@ from app.models.data_ingestion import (
 from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
 from app.models.unit import Unit
+from app.models.user import UserProvider
 from app.models.year_configuration import YearConfiguration
 from app.schemas.data_entry import DataEntryResponse
 from app.services.data_entry_emission_service import DataEntryEmissionService
@@ -114,6 +115,7 @@ async def pg_app(pg_dsn_with_310b, monkeypatch, tmp_path):
     fake_user.id = 1
     fake_user.email = "test@example.com"
     fake_user.institutional_id = "TEST-310B"
+    fake_user.provider = UserProvider.DEFAULT
 
     app.dependency_overrides[deps_module.get_db] = override_get_db
     app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user

--- a/backend/tests/integration/services/data_ingestion/test_sync_units_endpoint_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sync_units_endpoint_pg.py
@@ -38,6 +38,7 @@ from app.models.data_ingestion import (
     IngestionState,
     TargetType,
 )
+from app.models.user import UserProvider
 
 
 @pytest_asyncio.fixture
@@ -54,6 +55,7 @@ async def pg_app(pg_dsn, monkeypatch):
     fake_user.id = 1
     fake_user.email = "test@example.com"
     fake_user.institutional_id = "TEST-USER"
+    fake_user.provider = UserProvider.DEFAULT
 
     app.dependency_overrides[deps_module.get_db] = override_get_db
     app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user

--- a/backend/tests/integration/services/data_ingestion/test_travel_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_travel_pg.py
@@ -121,9 +121,11 @@ async def _seed_year_unit_and_module(
     foundation helper's ``SEED-{suffix}-{i}`` shape.
     """
     # YearConfiguration may already exist if multiple tests share a session.
-    existing = await session.get(YearConfiguration, year)
+    existing = await session.get(YearConfiguration, (year, UserProvider.DEFAULT))
     if existing is None:
-        session.add(YearConfiguration(year=year, is_started=True))
+        session.add(
+            YearConfiguration(year=year, provider=UserProvider.DEFAULT, is_started=True)
+        )
         await session.flush()
 
     unit = Unit(

--- a/backend/tests/integration/v1/test_year_configuration_list.py
+++ b/backend/tests/integration/v1/test_year_configuration_list.py
@@ -18,6 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 import app.api.deps as deps_module
 from app.main import app
+from app.models.user import UserProvider
 from app.models.year_configuration import YearConfiguration
 
 URL = "/api/v1/year-configuration/"
@@ -45,6 +46,7 @@ async def db_with_two_years():
         session.add(
             YearConfiguration(
                 year=2024,
+                provider=UserProvider.DEFAULT,
                 is_started=True,
                 config={},
                 updated_at=datetime.utcnow(),
@@ -53,8 +55,49 @@ async def db_with_two_years():
         session.add(
             YearConfiguration(
                 year=2025,
+                provider=UserProvider.DEFAULT,
                 is_started=False,
                 config={},
+                updated_at=datetime.utcnow(),
+            )
+        )
+        await session.commit()
+
+        yield session, async_session
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_with_two_providers_same_year():
+    """Seed YearConfiguration(2026, ACCRED) and YearConfiguration(2026, TEST)
+    to verify per-provider isolation: list endpoint must only return the
+    row matching ``current_user.provider``.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        session.add(
+            YearConfiguration(
+                year=2026,
+                provider=UserProvider.ACCRED,
+                is_started=True,
+                config={"marker": "accred"},
+                updated_at=datetime.utcnow(),
+            )
+        )
+        session.add(
+            YearConfiguration(
+                year=2026,
+                provider=UserProvider.TEST,
+                is_started=True,
+                config={"marker": "test"},
                 updated_at=datetime.utcnow(),
             )
         )
@@ -77,17 +120,24 @@ def _clear_overrides():
     app.dependency_overrides.clear()
 
 
-def _user() -> MagicMock:
+def _user(provider: UserProvider = UserProvider.DEFAULT) -> MagicMock:
     u = MagicMock()
     u.id = 1
     u.email = "test@example.com"
     u.institutional_id = "11111"
+    u.provider = provider
     return u
 
 
-def _wire(monkeypatch, db_factory, *, is_admin: bool) -> None:
+def _wire(
+    monkeypatch,
+    db_factory,
+    *,
+    is_admin: bool,
+    provider: UserProvider = UserProvider.DEFAULT,
+) -> None:
     """Inject the seeded session and stub ``is_permitted`` to control the branch."""
-    app.dependency_overrides[deps_module.get_current_user] = lambda: _user()
+    app.dependency_overrides[deps_module.get_current_user] = lambda: _user(provider)
 
     async def override_get_db():
         async with db_factory() as session:
@@ -96,9 +146,9 @@ def _wire(monkeypatch, db_factory, *, is_admin: bool) -> None:
     app.dependency_overrides[deps_module.get_db] = override_get_db
 
     async def fake_is_permitted(user, path, action="view"):
-        # The endpoint only checks ``backoffice.data_management:view`` — bind
-        # the answer to the test parameter.
-        if path == "backoffice.data_management" and action == "view":
+        # The list endpoint checks ``view``; the create endpoint checks
+        # ``edit``. Both are gated on the same admin flag for this test.
+        if path == "backoffice.data_management" and action in {"view", "edit"}:
             return is_admin
         return False
 
@@ -160,3 +210,100 @@ def test_response_excludes_heavy_config_blob(client, monkeypatch, db_with_two_ye
         "configuration_completed",
         "updated_at",
     }
+
+
+def test_per_provider_isolation_for_same_year(
+    client, monkeypatch, db_with_two_providers_same_year
+):
+    """Two YearConfiguration rows share year=2026 across UserProvider.ACCRED
+    and UserProvider.TEST. A TEST user must only see the TEST row, and vice
+    versa — the list must NEVER conflate providers.
+    """
+    _, factory = db_with_two_providers_same_year
+
+    _wire(monkeypatch, factory, is_admin=True, provider=UserProvider.TEST)
+    r = client.get(URL)
+    assert r.status_code == 200, r.text
+    test_rows = r.json()
+    assert [row["year"] for row in test_rows] == [2026]
+
+    app.dependency_overrides.clear()
+
+    _wire(monkeypatch, factory, is_admin=True, provider=UserProvider.ACCRED)
+    r = client.get(URL)
+    assert r.status_code == 200, r.text
+    accred_rows = r.json()
+    assert [row["year"] for row in accred_rows] == [2026]
+    # Different providers, but neither response saw the *other* row;
+    # both responses returned exactly one row from a 2-row table.
+    assert len(test_rows) == 1 and len(accred_rows) == 1
+
+
+@pytest_asyncio.fixture
+async def db_with_only_accred_2026():
+    """Seed a single ACCRED row at year=2026. A TEST user POSTing the same
+    year must succeed (201, new TEST row) — the existence check at
+    create_year_configuration must be provider-scoped or it would 409.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        session.add(
+            YearConfiguration(
+                year=2026,
+                provider=UserProvider.ACCRED,
+                is_started=True,
+                config={"marker": "accred-existing"},
+                updated_at=datetime.utcnow(),
+            )
+        )
+        await session.commit()
+
+        yield session, async_session
+
+    await engine.dispose()
+
+
+def test_post_year_as_test_user_does_not_conflict_with_existing_accred_row(
+    client, monkeypatch, db_with_only_accred_2026
+):
+    """POST /v1/year-configuration/2026 as a TEST user must create the TEST
+    row even though an ACCRED row already exists at year=2026. The 409
+    existence check must be provider-scoped — otherwise non-ACCRED users
+    can never bootstrap their own years once ACCRED has been provisioned.
+    """
+    _, factory = db_with_only_accred_2026
+    _wire(monkeypatch, factory, is_admin=True, provider=UserProvider.TEST)
+
+    # The POST endpoint also enqueues a unit_sync DataIngestionJob and
+    # fires ``run_job`` — neither matters for this test's invariant
+    # (which is purely the existence-check scoping). Stub fire_and_forget
+    # so we don't spawn a coroutine that would crash on the unmocked
+    # runner.
+    def _consume_coro(coro, *_args, **_kwargs):
+        coro.close()
+        return None
+
+    monkeypatch.setattr("app.api.v1.year_configuration.fire_and_forget", _consume_coro)
+
+    r = client.post(URL + "2026")
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["year"] == 2026
+    assert body["is_started"] is False  # default; ACCRED's True must not leak
+
+    # Both rows must coexist — list as ACCRED user should still see the
+    # original row, list as TEST user should see the new one.
+    app.dependency_overrides.clear()
+    _wire(monkeypatch, factory, is_admin=True, provider=UserProvider.ACCRED)
+    r = client.get(URL)
+    assert r.status_code == 200, r.text
+    accred_rows = r.json()
+    assert len(accred_rows) == 1
+    assert accred_rows[0]["is_started"] is True  # ACCRED untouched

--- a/backend/tests/unit/providers/test_unit_provider.py
+++ b/backend/tests/unit/providers/test_unit_provider.py
@@ -337,6 +337,25 @@ class TestTestUnitProvider:
         units = await provider.get_units(unit_ids=["NONEXISTENT_ID_XYZ"])
         assert units == []
 
+    @pytest.mark.asyncio
+    async def test_fetch_all_units_returns_fixtures_round_trippable(self):
+        """``unit_sync_handler`` calls ``fetch_all_units`` then maps each
+        raw dict through ``map_api_unit``. The pair must round-trip TEST
+        fixtures back into ``Unit`` instances with ``provider=TEST``."""
+        from app.models.user import UserProvider as _UP
+        from app.providers.test_fixtures import TEST_UNITS
+
+        provider = TestUnitProvider()
+        units_raw, users_raw = await provider.fetch_all_units()
+        assert len(units_raw) == len(TEST_UNITS)
+        assert len(users_raw) == 1  # the principal user
+
+        mapped = [provider.map_api_unit(u) for u in units_raw]
+        assert all(u.provider == _UP.TEST for u in mapped)
+        assert {u.institutional_id for u in mapped} == {
+            u.institutional_id for u in TEST_UNITS
+        }
+
 
 # ---------------------------------------------------------------------------
 # get_unit_by_id (base class method)

--- a/backend/tests/unit/services/data_ingestion/csv_providers/test_reduction_objectives.py
+++ b/backend/tests/unit/services/data_ingestion/csv_providers/test_reduction_objectives.py
@@ -1,8 +1,11 @@
 """Tests for ModulePerYearReductionObjectivesApiProvider."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from app.models.data_ingestion import EntityType
+from app.models.user import UserProvider
 from app.services.data_ingestion.csv_providers.reduction_objectives import (
     ModulePerYearReductionObjectivesApiProvider,
 )
@@ -30,3 +33,91 @@ def test_resolve_handler_valid():
     handler = provider._resolve_handler()
     assert handler is not None
     assert handler.config_key == "institutional_footprint"
+
+
+# ---------------------------------------------------------------------------
+# Regression: ``_store_in_year_config`` must resolve provider from the
+# job context (config["provider"]) when invoked via the runner.
+#
+# The runner instantiates the CSV provider with ``user=None`` (job rows
+# have no ``user`` FK), so the provider cannot fall back to
+# ``self.user.provider``. The job's provider IS available via
+# ``config["provider"]`` because ``_run_ingest`` spreads ``job.__dict__``
+# into config. Earlier we required ``self.user`` to be non-None — that
+# broke reduction-objective CSV uploads in production
+# (#1266 follow-up: "ValueError: user is required to resolve the
+# provider-scoped year_configuration").
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_in_year_config_reads_provider_from_config_when_no_user():
+    """Runner path: ``user=None`` but ``config["provider"]`` is the job's
+    provider. The SELECT must filter by that provider; no ValueError."""
+    provider = _make_provider(
+        reduction_objective_type_id=0,
+        provider=UserProvider.TEST,
+    )
+    provider.user = None
+
+    yc_row = MagicMock()
+    yc_row.config = {}
+    exec_result = MagicMock()
+    exec_result.first = MagicMock(return_value=yc_row)
+    provider.data_session = MagicMock()
+    provider.data_session.exec = AsyncMock(return_value=exec_result)
+    provider.data_session.flush = AsyncMock()
+
+    # Should not raise — provider resolved from config["provider"].
+    await provider._store_in_year_config(
+        validated_rows=[{"x": 1}],
+        config_key="institutional_footprint",
+        filename="test.csv",
+    )
+    assert provider.data_session.exec.await_count == 1
+    # YC row's reduction_objectives slot was populated.
+    assert yc_row.config["reduction_objectives"]["institutional_footprint"] == [
+        {"x": 1}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_store_in_year_config_falls_back_to_user_provider():
+    """Endpoint-driven path: ``config["provider"]`` absent but
+    ``self.user.provider`` is set. Fallback must work."""
+    provider = _make_provider(reduction_objective_type_id=0)
+    user = MagicMock()
+    user.provider = UserProvider.ACCRED
+    provider.user = user
+
+    yc_row = MagicMock()
+    yc_row.config = {}
+    exec_result = MagicMock()
+    exec_result.first = MagicMock(return_value=yc_row)
+    provider.data_session = MagicMock()
+    provider.data_session.exec = AsyncMock(return_value=exec_result)
+    provider.data_session.flush = AsyncMock()
+
+    await provider._store_in_year_config(
+        validated_rows=[],
+        config_key="institutional_footprint",
+        filename="test.csv",
+    )
+    assert provider.data_session.exec.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_store_in_year_config_raises_when_provider_missing_everywhere():
+    """Neither ``config["provider"]`` nor ``self.user`` available — must
+    raise so callers see the bug instead of silently writing to a
+    DEFAULT-scoped row."""
+    provider = _make_provider(reduction_objective_type_id=0)
+    provider.user = None
+    provider.data_session = MagicMock()
+
+    with pytest.raises(ValueError, match="provider is required"):
+        await provider._store_in_year_config(
+            validated_rows=[],
+            config_key="institutional_footprint",
+            filename="test.csv",
+        )

--- a/backend/tests/unit/tasks/test_handler_registrations.py
+++ b/backend/tests/unit/tasks/test_handler_registrations.py
@@ -524,6 +524,72 @@ async def test_unit_sync_handler_raises_when_no_target_year_anywhere():
         await unit_sync_mod.unit_sync_handler(job, MagicMock(), MagicMock())
 
 
+@pytest.mark.asyncio
+async def test_unit_sync_handler_rejects_default_provider():
+    """UserProvider.DEFAULT has no unit source (no API, no fixture).
+    The handler must fail loudly rather than silently fall through."""
+    from app.models.user import UserProvider
+
+    job = _make_job(job_type="unit_sync", meta={"config": {"target_year": 2025}})
+    job.provider = UserProvider.DEFAULT
+    with pytest.raises(ValueError, match="UserProvider.DEFAULT has no unit source"):
+        await unit_sync_mod.unit_sync_handler(job, MagicMock(), MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_unit_sync_handler_passes_job_provider_to_factories():
+    """The handler must resolve unit/role providers from ``job.provider``,
+    not a hardcoded constant — otherwise TEST users see ACCRED units."""
+    from app.models.user import UserProvider
+
+    job = _make_job(job_type="unit_sync", meta={"config": {"target_year": 2025}})
+    job.provider = UserProvider.TEST
+
+    job_session = MagicMock()
+    job_session.commit = AsyncMock()
+    data_session = MagicMock()
+    _no_year_cfg = MagicMock()
+    _no_year_cfg.scalar_one_or_none = MagicMock(return_value=None)
+    data_session.execute = AsyncMock(return_value=_no_year_cfg)
+
+    repo = MagicMock()
+    repo.update_ingestion_job = AsyncMock()
+
+    unit_provider = MagicMock()
+    unit_provider.fetch_all_units = AsyncMock(return_value=([], []))
+    unit_provider.map_api_unit = MagicMock(side_effect=lambda u: MagicMock())
+    role_provider = MagicMock()
+    role_provider.map_api_user = MagicMock(return_value=MagicMock())
+
+    unit_service = MagicMock()
+    unit_service.bulk_upsert = AsyncMock(return_value=MagicMock(data=[]))
+    user_service = MagicMock()
+    user_service.bulk_upsert = AsyncMock(return_value=MagicMock(data=[]))
+    carbon_report_service = MagicMock()
+    carbon_report_service.bulk_upsert = AsyncMock(return_value=[])
+    carbon_report_service.ensure_modules_for_reports = AsyncMock()
+
+    get_unit_provider_mock = MagicMock(return_value=unit_provider)
+    get_role_provider_mock = MagicMock(return_value=role_provider)
+
+    with (
+        patch.object(unit_sync_mod, "DataIngestionRepository", return_value=repo),
+        patch.object(unit_sync_mod, "get_unit_provider", get_unit_provider_mock),
+        patch.object(unit_sync_mod, "get_role_provider", get_role_provider_mock),
+        patch.object(unit_sync_mod, "UnitService", return_value=unit_service),
+        patch.object(unit_sync_mod, "UserService", return_value=user_service),
+        patch.object(
+            unit_sync_mod,
+            "CarbonReportService",
+            return_value=carbon_report_service,
+        ),
+    ):
+        await unit_sync_mod.unit_sync_handler(job, job_session, data_session)
+
+    get_unit_provider_mock.assert_called_once_with(UserProvider.TEST)
+    get_role_provider_mock.assert_called_once_with(UserProvider.TEST)
+
+
 # ---------------------------------------------------------------------------
 # unit_sync ↔ aggregation concurrency safety (#1236) — both rewrite
 # ``carbon_reports`` for the same (unit, year); the SAME advisory-lock

--- a/backend/tests/unit/v1/test_audit.py
+++ b/backend/tests/unit/v1/test_audit.py
@@ -9,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.v1 import audit
 from app.main import app
 from app.models.audit import AuditChangeTypeEnum, AuditDocument
-from app.models.user import User
+from app.models.user import User, UserProvider
 
 app.include_router(audit.router, prefix="/api/v1/audit", tags=["audit"])
 
@@ -1576,3 +1576,31 @@ class TestExportAuditLogs:
             data = json.loads(response.text)
             assert data[0]["change_type"] == "DELETE"
             assert isinstance(data[0]["change_type"], str)
+
+
+# ============================================================================
+# year_configuration audit-id encoding invariant (#1266)
+# ============================================================================
+#
+# ``year_configuration.create_audit_entry`` encodes the audit ``entity_id``
+# as ``year * 10 + provider.value`` so the hash chain stays per-(year,
+# provider) without changing ``AuditDocument``'s schema (deferred to #1268).
+# That encoding only stays collision-free with adjacent years as long as
+# every ``UserProvider`` value fits in a single decimal digit. This test
+# pins that invariant so a future provider added past value 9 fails CI
+# instead of silently corrupting the audit chain across years.
+
+
+class TestYearConfigurationAuditEncoding:
+    def test_user_provider_values_fit_audit_id_encoding(self):
+        """``entity_id = year * 10 + provider.value`` requires every
+        UserProvider value to be a single decimal digit. If this fails,
+        the encoding overflows into the next year — see #1268 for the
+        proper fix (add ``AuditDocument.provider`` column)."""
+        max_value = max(p.value for p in UserProvider)
+        assert max_value < 10, (
+            f"UserProvider grew past value 9 (max={max_value}); "
+            f"year_configuration audit encoding now collides with the "
+            f"next year. See #1268 — replace the encoding with a real "
+            f"AuditDocument.provider column."
+        )

--- a/docs/code-review/1266-copilot-feedback-fix-1266-provider-scope-unit-sync-year-configuration.md
+++ b/docs/code-review/1266-copilot-feedback-fix-1266-provider-scope-unit-sync-year-configuration.md
@@ -1,0 +1,102 @@
+# Bot Review TODOs: PR #1267
+
+## Source Branch: `fix/1266-provider-scope-unit-sync-and-year-config`
+
+## Raw Feedback
+
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+This PR makes **unit sync** and **year configuration** provider-scoped end-to-end so multiple providers (e.g., TEST and ACCRED) can independently provision and open the same year within a shared database, preventing cross-provider interference.
+
+**Changes:**
+
+- Scope `YearConfiguration` by `(year, provider)` (composite PK) and update reads/writes across API/task/provider code paths to filter by provider.
+- Plumb `current_user.provider` into newly created `DataIngestionJob` rows and update `unit_sync_handler` to use `job.provider` (rejecting `DEFAULT`).
+- Add/update unit + integration tests to validate provider isolation and ensure the TEST provider can run unit sync using fixtures.
+
+### Reviewed changes
+
+Copilot reviewed 16 out of 16 changed files in this pull request and generated 4 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File                                                                                            | Description                                                                                                    |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| docs/src/database/erd.md                                                                        | Updates ERD to reflect provider being part of `year_configuration`’s primary key.                              |
+| backend/app/models/year_configuration.py                                                        | Adds `provider` to `YearConfiguration` and makes PK composite `(year, provider)`.                              |
+| backend/app/api/v1/year_configuration.py                                                        | Scopes year-configuration CRUD/listing and audit chain behavior by provider.                                   |
+| backend/app/api/v1/data_sync.py                                                                 | Scopes year-provisioning checks and unit-sync job creation by provider.                                        |
+| backend/app/tasks/unit_sync_tasks.py                                                            | Uses `job.provider` to resolve providers; stamps `configuration_completed` per provider.                       |
+| backend/app/providers/unit_provider.py                                                          | Implements TEST provider `fetch_all_units`/`map_api_unit` for unit_sync compatibility.                         |
+| backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py                    | Stores reduction objectives into provider-scoped `year_configuration`.                                         |
+| backend/tests/unit/tasks/test_handler_registrations.py                                          | Adds unit tests ensuring provider is used and DEFAULT is rejected in unit_sync.                                |
+| backend/tests/unit/providers/test_unit_provider.py                                              | Adds unit test validating TEST fixtures round-trip through `fetch_all_units`/`map_api_unit`.                   |
+| backend/tests/integration/v1/test_year_configuration_list.py                                    | Adds integration tests validating per-provider isolation for same year + provider-scoped POST existence check. |
+| backend/tests/integration/services/data_ingestion/test_travel_pg.py                             | Updates YearConfiguration lookups to use composite PK in PG integration tests.                                 |
+| backend/tests/integration/services/data_ingestion/conftest.py                                   | Updates seeding helper to use composite PK and set provider when creating YearConfiguration.                   |
+| backend/tests/integration/services/data_ingestion/test_sync_units_endpoint_pg.py                | Ensures mocked current_user includes `.provider` for provider-scoped queries/job creation.                     |
+| backend/tests/integration/services/data_ingestion/test_plan_310b_factor_reupload_endpoint_pg.py | Ensures mocked current_user includes `.provider` for provider-scoped queries/job creation.                     |
+| backend/tests/integration/services/data_ingestion/test_dispatch_copy_from_previous_year_pg.py   | Ensures mocked current_user includes `.provider` for provider-scoped queries/job creation.                     |
+
+</details>
+
+---
+
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+Copilot reviewed 19 out of 19 changed files in this pull request and generated 3 comments.
+
+---
+
+### File: `backend/app/api/v1/year_configuration.py` (Line 343) — Copilot
+
+The create_audit_entry docstring says the data_snapshot “always includes provider”, but the snapshots passed from create_year_configuration/update_year_configuration don’t include provider. Either include provider in the snapshot/diff payload or update the docstring to avoid misleading future readers about recoverability.
+
+---
+
+### File: `backend/app/api/v1/year_configuration.py` (Line 417) — Copilot
+
+## list_year_configurations() now filters by current_user.provider. The docstring above still says backoffice data managers “see every row”, which is no longer true across providers; update it to clarify results are provider-scoped (admins still bypass only the is_started filter).
+
+### File: `backend/app/tasks/unit_sync_tasks.py` (Line 175) — Copilot
+
+## unit_sync is now provider-scoped (job.provider drives provider selection), but the phase status_message still says “Fetching units from Accred…”. This will be misleading for TEST runs and any future providers; make status/progress messages (and ideally the handler docstring) provider-neutral or include the provider name dynamically.
+
+### File: `backend/app/api/v1/data_sync.py` (Line 2078) — Copilot
+
+## Since this endpoint now sets job.provider from current_user.provider (provider-scoped unit sync), the surrounding naming/text still hardcodes “Accred API” (function name/docstring and the SyncStatusResponse message below). That becomes misleading for TEST and any future providers; adjust the wording to be provider-agnostic or include the provider name dynamically.
+
+### File: `backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py` (Line 56) — Copilot
+
+The new `provider` column is created with `server_default="DEFAULT"`, which will also apply to _future_ inserts if a code path forgets to set `provider` (silently writing rows into the DEFAULT scope and breaking per-provider isolation). Consider a 2-step migration: add column nullable + server_default to backfill existing rows, then `ALTER COLUMN` to drop the server default (and keep it NOT NULL) once existing rows are stamped.
+
+---
+
+### File: `backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py` (Line 66) — Copilot
+
+`downgrade()` recreates a primary key on `year` only. After this migration, the table can legitimately contain multiple rows with the same `year` (one per provider), so the downgrade will fail with duplicate key errors. If downgrade support is required, add an explicit cleanup step (e.g., delete non-DEFAULT rows or error with a clear message) before recreating the single-column PK.
+
+---
+
+### File: `backend/app/api/v1/year_configuration.py` (Line 344) — Copilot
+
+## `create_audit_entry`’s docstring no longer follows the Args/Returns structure used throughout this module (e.g., `save_uploaded_file`). Since this helper has a non-trivial signature, consider restoring the parameter docs and adding the new provider-scoping explanation as an extra paragraph to keep documentation consistent and easier to maintain.
+
+## Action Items
+
+### Critical: logic, security, correctness
+
+- [ ] **`backend/alembic/versions/2026_05_22_1142-6293d5b22dc5_year_configuration_provider_scope_1266.py`** — `downgrade()` recreates a single-column PK on `year`, which fails with duplicate-key errors as soon as the DB carries rows for two providers at the same year (which is the entire reason this migration exists). Fix: in `downgrade()`, delete every row whose `provider != 'DEFAULT'` before `create_primary_key`, so the remaining set is unique on `year`. v0.x drops the DB between deploys so the data loss is acceptable; the alternative — raising a `RuntimeError` with a clear "manual cleanup required" message — is also acceptable. Either way, don't leave it silently broken.
+
+### Maintainability / refactoring
+
+- [ ] **`backend/app/tasks/unit_sync_tasks.py`** (line 169) and **`backend/app/api/v1/data_sync.py`** (lines 2044, 2054, 2099) — ACCRED-specific wording leaked into now-provider-agnostic code: `status_message="Fetching units from Accred…"`, function `sync_units_from_accred`, docstring `"Sync units from Accred API"`, response `message="Unit sync from Accred API scheduled"`. TEST runs surface misleading copy. Fix: parameterize each user-visible string with `job.provider.name` / `current_user.provider.name`. **Skip the function rename** — it's just a Python identifier (route is `POST /sync/units`), and renaming churns no contract but does churn imports.
+- [ ] **`backend/app/api/v1/year_configuration.py`** (line 343 docstring) — Claims `data_snapshot` "always includes provider" but the three call sites (lines 552-555, 724-727, 904-907) build snapshots with only `is_started` + `config`. Fix: add `"provider": current_user.provider.name` to all three snapshot dicts — makes the audit log self-describing and matches the docstring. (Alternative: correct the docstring. Adding the field is the more useful direction since the encoded `entity_id` alone is opaque to a human reader.)
+- [ ] **`backend/app/api/v1/year_configuration.py`** (line 402 docstring on `list_year_configurations`) — Says backoffice data managers "see every row"; post-change they only see every row _within their own provider scope_ (the `is_started` filter is what `is_admin` actually bypasses now). Fix: one-line docstring update — "Admins bypass the `is_started` filter; both views are scoped to `current_user.provider`."
+
+_Dropped as non-actionable: line 56 (`server_default="DEFAULT"`) — the bot's diagnosis is real (DB doesn't block forgotten `provider=`) but the suggested 2-step migration is overkill for v0.x (DB is dropped between deploys, no rows to backfill) and would diverge from the existing `units` / `users` / `data_ingestion_jobs` convention which uses the same pattern. Line 344 (docstring Args/Returns format) — pure style nitpick._

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -194,6 +194,7 @@ erDiagram
     JSON config
     DATETIME configuration_completed
     BOOLEAN is_started
+    VARCHAR provider PK
     DATETIME updated_at
     INTEGER year PK
   }


### PR DESCRIPTION
Related to #1266.

## What does this change?

Unit-sync and year-configuration are now provider-scoped end-to-end so TEST and ACCRED users can each get an independent open year in the same database.

| Layer | Change |
|---|---|
| **Job plumbing** | `POST /v1/sync/units` and `POST /v1/year-configuration/{year}` now set `job.provider = current_user.provider` on the `DataIngestionJob` they create. The `provider` column already existed (defaulted to DEFAULT) — endpoints just weren't populating it. |
| **`unit_sync_handler`** | Reads `job.provider` instead of hardcoded `UserProvider.ACCRED`. Rejects `UserProvider.DEFAULT` with a clear `ValueError` (DEFAULT is dev-fallback only — no upstream, no fixture). |
| **`YearConfiguration` model** | Composite PK `(year, provider)`. New `provider` column on the same `user_provider_enum` shared by `units` / `users` / `data_ingestion_jobs`. |
| **YC callers (8 sites)** | Router endpoints, dispatch gate, reduction-objective CSV provider, and `unit_sync_handler`'s `configuration_completed` stamp all filter by provider. |
| **`TestUnitProvider`** | Implements `fetch_all_units` + `map_api_unit` against `TEST_UNITS` / `TEST_USERS` fixtures. `TestRoleProvider.map_api_user` already worked via base inheritance since TEST_USERS uses User-native field names. |
| **Audit chain** | `entity_id = year * 10 + provider.value` so the hash chain stays per-`(year, provider)` instead of interleaving across providers. `UserProvider` is 0/1/2 so collision-free with adjacent years. |

## Why is this needed?

Today a TEST backoffice user clicking "Sync units" or creating a year fires the ACCRED pipeline, calls the real EPFL Accred API, and creates `carbon_reports` only for ACCRED units. The TEST user's units never get a `carbon_reports` row for `target_year`, so the year stays "closed" and the upload flow has nothing to write into. The `year_configuration` row is also shared — `configuration_completed` belongs to whichever provider finished sync last.

Full audit + reasoning in the [issue](https://github.com/EPFL-ENAC/co2-calculator/issues/1266).

## Model audit summary

Only `year_configuration` was missing scoping. `units` / `users` / `data_ingestion_jobs` already carry `provider`; downstream tables (`carbon_reports`, `carbon_report_modules`, `data_entries`, `data_entry_emissions`, `carbon_projects`) inherit it via FK chain to `units`. `factors` is flagged as an open follow-up (scientific reference data vs. per-provider fixture is a product call).

## Tests

- **Unit**: `test_unit_sync_handler_passes_job_provider_to_factories`, `test_unit_sync_handler_rejects_default_provider`, `test_fetch_all_units_returns_fixtures_round_trippable`.
- **Integration**: `test_per_provider_isolation_for_same_year` (GET / list endpoint), `test_post_year_as_test_user_does_not_conflict_with_existing_accred_row` (POST endpoint — proves the existence check is provider-scoped).
- Also patched 4 pre-existing integration tests whose `MagicMock` `current_user` lacked `.provider` (would have failed the new enum cast in the YC queries).
- `mypy` clean (183 source files); 1472 tests pass.

## Test plan

- [x] `uv run mypy app/` — clean
- [x] `uv run pytest backend/tests/unit/` — 1450 pass
- [x] `uv run pytest backend/tests/integration/v1/test_year_configuration_list.py` — 5 pass (includes 2 new cross-provider tests)
- [x] `uv run pytest backend/tests/integration/services/data_ingestion/` (the affected subset) — green
- [ ] **Manual smoke (TEST)**: log in as `CO2_BACKOFFICE_METIER` TEST user, create year 2027, watch the 4-phase SSE stream, verify `carbon_reports` for TEST units at 2025 in the DB and `YearConfiguration(year=2027, provider=TEST).configuration_completed` is set
- [ ] **Manual smoke (ACCRED)**: log in as ACCRED backoffice user, create year 2025 (independent row from TEST's), verify ACCRED units get reports and the ACCRED row is independently provisioned
- [ ] **Coexistence**: both rows visible in DB, neither overwrites the other

## Out of scope

- `factors` provider scoping (open product question — does TEST share ACCRED's factor set?).
- `DefaultUnitProvider.fetch_all_units` (DEFAULT is dev-fallback only; rejected at handler entry).
- Safety poller doesn't currently handle `unit_sync` recovery — independent gap.
- Extracting the duplicated `DataIngestionJob`-construction block in `data_sync.py` + `year_configuration.py` (existing TODO at `year_configuration.py:561-565`).

## Type of change

- [x] 🐛 Bug fix