### PR TITLE
feat: correct subcategories in main charts

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -409,6 +409,7 @@ async def get_stats_by_class(
 _MODULE_TOP_CLASS_GROUP_FIELD: dict[ModuleTypeEnum, str] = {
     ModuleTypeEnum.equipment_electric_consumption: "equipment_class",
     ModuleTypeEnum.purchase: "purchase_institutional_code",
+    ModuleTypeEnum.research_facilities: "researchfacility_name",
 }
 
 # Maps module type → JSON data field to use as the human-readable label

--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -371,6 +371,23 @@ async def get_it_breakdown(
             report_year=report_year,
         )
 
+    rf_crm_id = crm_by_type.get(ModuleTypeEnum.research_facilities.value)
+    if (
+        rf_crm_id is not None
+        and ModuleTypeEnum.research_facilities.value not in exclude_set
+    ):
+        top_class_detail[
+            "research_facilities_it"
+        ] = await emission_svc.get_top_class_breakdown(
+            carbon_report_module_id=rf_crm_id,
+            data_entry_types=[
+                DataEntryTypeEnum.research_facilities,
+                DataEntryTypeEnum.mice_and_fish_animal_facilities,
+            ],
+            group_by_field="researchfacility_name",
+            report_year=report_year,
+        )
+
     emission_rows_no_qty: list[tuple[int, int, float]] = [
         (module_type_id, emission_type_id, kg_co2eq)
         for module_type_id, emission_type_id, kg_co2eq, _add in emission_rows

--- a/backend/app/models/data_entry_emission.py
+++ b/backend/app/models/data_entry_emission.py
@@ -206,6 +206,9 @@ class EmissionType(int, Enum):
     research_facilities = 100000
     research_facilities__facilities = 100100
     research_facilities__animal = 100200
+    research_facilities__animal__mice = 10020001
+    research_facilities__animal__fish = 10020002
+    research_facilities__it_facilities = 100300
 
     # -------------------------------------------------------------------------
     # External Clouds & AI
@@ -472,6 +475,15 @@ _PARENT_MAP: dict[int, int] = {
         EmissionType.research_facilities.value
     ),
     EmissionType.research_facilities__animal.value: (
+        EmissionType.research_facilities.value
+    ),
+    EmissionType.research_facilities__animal__mice.value: (
+        EmissionType.research_facilities__animal.value
+    ),
+    EmissionType.research_facilities__animal__fish.value: (
+        EmissionType.research_facilities__animal.value
+    ),
+    EmissionType.research_facilities__it_facilities.value: (
         EmissionType.research_facilities.value
     ),
     # external
@@ -886,6 +898,18 @@ _SCOPE_CATEGORY_MAP: dict[int, EmissionMeta] = {
         "category": EmissionCategory.research_facilities,
     },
     EmissionType.research_facilities__animal.value: {
+        "scope": Scope.scope3,
+        "category": EmissionCategory.research_facilities,
+    },
+    EmissionType.research_facilities__it_facilities.value: {
+        "scope": Scope.scope3,
+        "category": EmissionCategory.research_facilities,
+    },
+    EmissionType.research_facilities__animal__mice.value: {
+        "scope": Scope.scope3,
+        "category": EmissionCategory.research_facilities,
+    },
+    EmissionType.research_facilities__animal__fish.value: {
         "scope": Scope.scope3,
         "category": EmissionCategory.research_facilities,
     },

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -760,6 +760,7 @@ class DataEntryEmissionRepository:
         top_n: int = 3,
         label_field: str | None = None,
         report_year: int | None = None,
+        emission_type_ids: List[int] | None = None,
     ) -> List[Dict[str, Any]]:
         """Aggregate emissions by data entry type and a grouping field.
 
@@ -816,6 +817,11 @@ class DataEntryEmissionRepository:
                 ),
                 col(DataEntryEmission.kg_co2eq).isnot(None),
                 col(DataEntryEmission.kg_co2eq) > 0,
+                *(
+                    [col(DataEntryEmission.emission_type_id).in_(emission_type_ids)]
+                    if emission_type_ids is not None
+                    else []
+                ),
             )
             .group_by(*group_by_columns)
             .cte("ranked")

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -781,6 +781,7 @@ class DataEntryEmissionService:
         top_n: int = 3,
         label_field: str | None = None,
         report_year: int | None = None,
+        emission_type_ids: list[int] | None = None,
     ) -> list[dict]:
         """Get emissions aggregated by subcategory and a grouping field.
 
@@ -793,6 +794,7 @@ class DataEntryEmissionService:
             top_n=top_n,
             label_field=label_field,
             report_year=report_year,
+            emission_type_ids=emission_type_ids,
         )
 
     async def get_travel_evolution_over_time(

--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -127,13 +127,10 @@ DATA_ENTRY_TO_EMISSION_TYPES: dict[DataEntryTypeEnum, list[EmissionType] | None]
     DataEntryTypeEnum.vehicles: [EmissionType.purchases__vehicles],
     DataEntryTypeEnum.other_purchases: [EmissionType.purchases__other],
     DataEntryTypeEnum.additional_purchases: None,
-    # --- Research Facilities -------------------------------------------------
-    DataEntryTypeEnum.research_facilities: [
-        EmissionType.research_facilities__facilities
-    ],
-    DataEntryTypeEnum.mice_and_fish_animal_facilities: [
-        EmissionType.research_facilities__animal
-    ],
+    # --- Research Facilities — resolved at runtime (researchfacility_name) --
+    DataEntryTypeEnum.research_facilities: None,  # → _resolve_research_facilities()
+    # → _resolve_animal_facilities()
+    DataEntryTypeEnum.mice_and_fish_animal_facilities: None,
     # --- External Clouds — resolved at runtime (sub_kind key) ----------------
     DataEntryTypeEnum.external_clouds: None,  # → _resolve_clouds()
     # --- External AI ---------------------------------------------------------
@@ -284,6 +281,27 @@ def _resolve_combustion(data: dict) -> list[EmissionType] | None:
     return [EmissionType.buildings__combustion]
 
 
+# SCITAS and RCP are EPFL's IT infrastructure research facilities.
+# Their entries route to it_facilities rather than the general facilities type.
+_IT_RESEARCH_FACILITY_NAMES: frozenset[str] = frozenset({"scitas", "rcp"})
+
+
+def _resolve_research_facilities(data: dict) -> list[EmissionType]:
+    name = (data.get("researchfacility_name") or "").strip().lower()
+    if name in _IT_RESEARCH_FACILITY_NAMES:
+        return [EmissionType.research_facilities__it_facilities]
+    return [EmissionType.research_facilities__facilities]
+
+
+def _resolve_animal_facilities(data: dict) -> list[EmissionType]:
+    facility_type = (data.get("researchfacility_type") or "").strip().lower()
+    if facility_type == "mice":
+        return [EmissionType.research_facilities__animal__mice]
+    if facility_type == "fish":
+        return [EmissionType.research_facilities__animal__fish]
+    return [EmissionType.research_facilities__animal]
+
+
 _ADDITIONAL_PURCHASES_MAP: dict[str, EmissionType] = {
     "ln2": EmissionType.purchases__additional__ln2,
 }
@@ -351,6 +369,8 @@ _RUNTIME_RESOLVERS = {
     DataEntryTypeEnum.process_emissions: _resolve_process_emissions,
     DataEntryTypeEnum.member: _resolve_headcount_factor,
     DataEntryTypeEnum.student: _resolve_headcount_factor,
+    DataEntryTypeEnum.research_facilities: _resolve_research_facilities,
+    DataEntryTypeEnum.mice_and_fish_animal_facilities: _resolve_animal_facilities,
 }
 
 

--- a/backend/app/utils/it_breakdown.py
+++ b/backend/app/utils/it_breakdown.py
@@ -66,6 +66,9 @@ _IT_RESEARCH_TYPES: frozenset[EmissionType] = frozenset(
         EmissionType.research_facilities,
         EmissionType.research_facilities__facilities,
         EmissionType.research_facilities__animal,
+        EmissionType.research_facilities__animal__mice,
+        EmissionType.research_facilities__animal__fish,
+        EmissionType.research_facilities__it_facilities,
     ]
 )
 

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -37,7 +37,9 @@ const LABEL_KEY_MAP: Record<string, string> = {
   n2o: 'process-emissions.category.n2o',
   refrigerants: 'process-emissions.category.refrigerant',
   // buildings
+  combustion: 'charts-energy-combustion-subcategory',
   heating_thermal: 'charts-heating-thermal-subcategory',
+  heating_elec: 'charts-heating-elec-subcategory',
   lighting: 'charts-lighting-subcategory',
   cooling: 'charts-cooling-subcategory',
   ventilation: 'charts-ventilation-subcategory',
@@ -64,7 +66,11 @@ const LABEL_KEY_MAP: Record<string, string> = {
   additional: 'charts-additional-purchases-subcategory',
   // research facilities
   facilities: 'charts-research-facilities-subcategory',
+  it_facilities: 'charts-research-it-facilities-subcategory',
   animal: 'charts-research-animal-subcategory',
+  mice_and_fish_animal_facilities: 'charts-research-animal-subcategory',
+  mice: 'charts-animal-mice-subcategory',
+  fish: 'charts-animal-fish-subcategory',
   // professional travel
   plane: 'charts-plane-subcategory',
   train: 'charts-train-subcategory',
@@ -129,7 +135,7 @@ const chartOption = computed((): EChartsOption => {
       itemStyle: {
         color: cat.color,
         borderColor: '#fff',
-        borderWidth: 0,
+        borderWidth: 1,
       },
       label: {
         show: pct >= 0.09,

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -74,6 +74,8 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   goods_and_services: 'charts-services-subcategory',
   plane: 'charts-plane-subcategory',
   train: 'charts-train-subcategory',
+  class_1: 'charts-class-1-subcategory',
+  class_2: 'charts-class-2-subcategory',
   clouds: 'charts-clouds-subcategory',
   ai: 'charts-ai-subcategory',
   provider: 'charts-ai-provider-subcategory',
@@ -88,7 +90,11 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   virtualisation: 'charts-virtualisation-subcategory',
   calcul: 'charts-calcul-subcategory',
   facilities: 'charts-research-facilities-subcategory',
+  it_facilities: 'charts-research-it-facilities-subcategory',
   animal: 'charts-research-animal-subcategory',
+  mice_and_fish_animal_facilities: 'charts-research-animal-subcategory',
+  mice: 'charts-animal-mice-subcategory',
+  fish: 'charts-animal-fish-subcategory',
   rest: 'charts-rest-subcategory',
   'new-env': 'charts-new-env-subcategory',
   'new-tech': 'charts-new-tech-subcategory',
@@ -109,11 +115,34 @@ const props = defineProps<{
   printMode?: boolean;
 }>();
 
-const { t } = useI18n();
+const { t, te } = useI18n();
 const isPrintMode = usePrintMode();
 const colorblindStore = useColorblindStore();
 
 const categoryKeyPrefixes = Object.keys(CATEGORY_LABEL_MAP);
+
+// Defines left-to-right stacking order for room-type segments within each buildings bar.
+const ROOM_TYPE_SEGMENT_ORDER = [
+  'laboratories',
+  'office',
+  'archives',
+  'libraries',
+  'auditoriums',
+  'miscellaneous',
+];
+
+function sortSegmentKeys(keys: string[]): string[] {
+  return keys.slice().sort((a, b) => {
+    const aSuffix = a.split('_').pop() ?? a;
+    const bSuffix = b.split('_').pop() ?? b;
+    const aIdx = ROOM_TYPE_SEGMENT_ORDER.indexOf(aSuffix);
+    const bIdx = ROOM_TYPE_SEGMENT_ORDER.indexOf(bSuffix);
+    if (aIdx === -1 && bIdx === -1) return 0;
+    if (aIdx === -1) return 1;
+    if (bIdx === -1) return -1;
+    return aIdx - bIdx;
+  });
+}
 
 /**
  * Build the horizontal bar chart data from the category rows.
@@ -196,7 +225,7 @@ const chartData = computed(() => {
 
     return {
       bars,
-      segmentKeys: Array.from(segmentKeysSet),
+      segmentKeys: sortSegmentKeys(Array.from(segmentKeysSet)),
       barKey: 'xx_category',
       barCategoryMap,
       barLabelMap,
@@ -259,7 +288,7 @@ const chartData = computed(() => {
 
   return {
     bars,
-    segmentKeys: Array.from(segmentKeysSet),
+    segmentKeys: sortSegmentKeys(Array.from(segmentKeysSet)),
     barKey: 'xx_category',
     barCategoryMap,
     barLabelMap,
@@ -271,7 +300,8 @@ function translateSubcategory(key: string): string {
   const override = segmentLabelOverrides.get(key);
   if (override) {
     const i18nKey = SUBCATEGORY_LABEL_MAP[override];
-    return i18nKey ? t(i18nKey) : override;
+    if (i18nKey) return t(i18nKey);
+    return te(override) ? t(override) : override;
   }
 
   // `key` is a dataset dimension name. To keep segment dimensions unique across
@@ -287,7 +317,8 @@ function translateSubcategory(key: string): string {
 
   const subcategoryKey = key.slice(categoryPrefix.length + 1);
   const i18nKey = SUBCATEGORY_LABEL_MAP[subcategoryKey];
-  return i18nKey ? t(i18nKey) : subcategoryKey;
+  if (i18nKey) return t(i18nKey);
+  return te(subcategoryKey) ? t(subcategoryKey) : subcategoryKey;
 }
 
 function translateBar(categoryKey: string, barName: string): string {

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -716,7 +716,7 @@ const chartOption = computed((): EChartsOption => {
   const seriesArray = [
     // Process Emissions — YY subcategories
     {
-      name: 'CO₂',
+      name: t('process-emissions.category.co2'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -731,7 +731,7 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
-      name: 'CH4',
+      name: t('process-emissions.category.ch4'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -746,7 +746,7 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
-      name: 'N2O',
+      name: t('process-emissions.category.n2o'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -761,7 +761,7 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
-      name: 'Refrigerants',
+      name: t('process-emissions.category.refrigerant'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -822,21 +822,6 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
-      name: t('charts-lighting-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'lighting' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'buildings_room',
-          'lighting',
-          colors.value.lilac.darker,
-        ),
-      },
-      label: { show: false },
-    },
-    {
       name: t('charts-cooling-subcategory'),
       type: 'bar' as const,
       stack: 'total',
@@ -862,6 +847,21 @@ const chartOption = computed((): EChartsOption => {
           'buildings_room',
           'ventilation',
           colors.value.lilac.default,
+        ),
+      },
+      label: { show: false },
+    },
+    {
+      name: t('charts-lighting-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'lighting' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'buildings_room',
+          'lighting',
+          colors.value.lilac.darker,
         ),
       },
       label: { show: false },
@@ -1091,7 +1091,7 @@ const chartOption = computed((): EChartsOption => {
       },
       label: { show: false },
     },
-    // Research Facilities — subcategories: facilities, animal
+    // Research Facilities — subcategories: facilities, it_facilities, animal
     {
       name: t('charts-research-facilities-subcategory'),
       type: 'bar' as const,
@@ -1103,6 +1103,21 @@ const chartOption = computed((): EChartsOption => {
           'research_facilities',
           'facilities',
           colors.value.paleYellowGreen.darker,
+        ),
+      },
+      label: { show: false },
+    },
+    {
+      name: t('charts-research-it-facilities-subcategory'),
+      type: 'bar' as const,
+      stack: 'total',
+      animation: true,
+      encode: { x: 'category', y: 'it_facilities' },
+      itemStyle: {
+        color: getSubcategoryColor(
+          'research_facilities',
+          'it_facilities',
+          colors.value.paleYellowGreen.default,
         ),
       },
       label: { show: false },
@@ -1295,6 +1310,7 @@ const chartOption = computed((): EChartsOption => {
         'calcul',
         'ai_provider',
         'facilities',
+        'it_facilities',
         'animal',
         'commuting',
         'food',

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -289,7 +289,7 @@ const barChartOption = computed<EChartsOption>(() => {
     itemStyle: {
       color: segmentColorMap.value[segKey] ?? '#999',
       borderColor: '#fff',
-      borderWidth: 0.5,
+      borderWidth: 1,
     },
     barWidth: 60,
     label: { show: false },

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -208,6 +208,7 @@ const activeButtonStyle = computed((): Record<string, string> => {
 const TOP_CLASS_MODULES: Module[] = [
   MODULES.EquipmentElectricConsumption,
   MODULES.Purchase,
+  MODULES.ResearchFacilities,
 ];
 
 const moduleStore = useModuleStore();

--- a/frontend/src/composables/useEmissionTreemap.ts
+++ b/frontend/src/composables/useEmissionTreemap.ts
@@ -61,7 +61,7 @@ export function normalizeParentKey(
 export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
   process_emissions: ['co2', 'ch4', 'n2o', 'refrigerants'],
   buildings_energy_combustion: ['combustion', 'heating_thermal'],
-  buildings_room: ['heating_elec', 'lighting', 'cooling', 'ventilation'],
+  buildings_room: ['heating_elec', 'cooling', 'ventilation', 'lighting'],
   equipment: ['scientific', 'it', 'other'],
   external_cloud_and_ai: ['clouds', 'ai'],
   purchases: [
@@ -74,7 +74,7 @@ export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
     'other_purchases',
     'additional',
   ],
-  research_facilities: ['facilities', 'animal'],
+  research_facilities: ['facilities', 'it_facilities', 'animal'],
   professional_travel: ['plane', 'train'],
 };
 

--- a/frontend/src/composables/useEquipmentClassOptions.ts
+++ b/frontend/src/composables/useEquipmentClassOptions.ts
@@ -1,4 +1,5 @@
 import { reactive, ref, watch, type Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useFactorsStore } from 'src/stores/factors';
 import { AllSubmoduleTypes } from 'src/constant/modules';
 
@@ -36,6 +37,8 @@ export function useEquipmentClassOptions<
   config: FieldConfig = {},
   year?: Ref<string | number | undefined>,
 ) {
+  const { t, te } = useI18n();
+
   const classFieldId = config.classFieldId ?? '';
   const subClassFieldId = config.subClassFieldId ?? '';
 
@@ -69,7 +72,11 @@ export function useEquipmentClassOptions<
     if (!sub) return;
     loadingClasses.value = true;
     try {
-      dynamicOptions[classOptionId] = await store.fetchClassOptions(sub);
+      const rawClasses = await store.fetchClassOptions(sub);
+      dynamicOptions[classOptionId] = rawClasses.map((o) => ({
+        label: te(o.label) ? t(o.label) : o.label,
+        value: o.value,
+      }));
     } catch {
       dynamicOptions[classOptionId] = [];
     } finally {
@@ -88,7 +95,11 @@ export function useEquipmentClassOptions<
     loadingSubclasses.value = true;
     subclassLoadError.value = false;
     try {
-      const options = await store.fetchSubclassOptions(sub, cls);
+      const rawOptions = await store.fetchSubclassOptions(sub, cls);
+      const options = rawOptions.map((o) => ({
+        label: te(o.label) ? t(o.label) : o.label,
+        value: o.value,
+      }));
       // Ensure the currently selected subclass (if any) is present in the
       // options, even if the backend map does not include it (for example
       // when legacy data has subclasses but no dedicated power-factor row).

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -401,9 +401,9 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
   (): Record<string, Record<string, string>> => ({
     buildings_room: {
       heating_elec: colors.value.lilac.dark,
-      lighting: colors.value.lilac.default,
-      cooling: colors.value.lilac.light,
-      ventilation: colors.value.lilac.lighter,
+      cooling: colors.value.lilac.default,
+      ventilation: colors.value.lilac.light,
+      lighting: colors.value.lilac.lighter,
       heating_thermal: colors.value.lilac.lighter,
       office: colors.value.lilac.darker,
       laboratories: colors.value.lilac.dark,
@@ -450,6 +450,7 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
     },
     research_facilities: {
       facilities: colors.value.paleYellowGreen.darker,
+      it_facilities: colors.value.paleYellowGreen.default,
       animal: colors.value.paleYellowGreen.dark,
     },
     purchases: (() => {

--- a/frontend/src/constant/module-config/buildings.ts
+++ b/frontend/src/constant/module-config/buildings.ts
@@ -49,12 +49,12 @@ const roomFields: ModuleField[] = [
     // See: https://github.com/EPFL-ENAC/co2-calculator/issues/173
     optionLabelsAreKeys: true,
     options: [
-      { value: 'office', label: 'buildings-room-type-office' },
-      { value: 'miscellaneous', label: 'buildings-room-type-miscellaneous' },
       { value: 'laboratories', label: 'buildings-room-type-laboratories' },
+      { value: 'office', label: 'buildings-room-type-office' },
       { value: 'archives', label: 'buildings-room-type-archives' },
       { value: 'libraries', label: 'buildings-room-type-libraries' },
       { value: 'auditoriums', label: 'buildings-room-type-auditoriums' },
+      { value: 'miscellaneous', label: 'buildings-room-type-miscellaneous' },
     ],
   },
   {

--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -171,9 +171,10 @@ const trainFields: ModuleField[] = [
     hideIn: {
       table: true,
     },
+    optionLabelsAreKeys: true,
     options: [
-      { value: 'first', label: 'Class 1' },
-      { value: 'second', label: 'Class 2' },
+      { value: 'first', label: 'class_1' },
+      { value: 'second', label: 'class_2' },
     ],
   },
 ];

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -511,7 +511,7 @@ export default {
   },
   data_management_submodule_it_equipment: {
     en: 'IT Equipment',
-    fr: 'Équipements informatiques',
+    fr: 'Équipements IT',
   },
   data_management_submodule_consumables_accessories: {
     en: 'Consumables & Accessories',
@@ -534,8 +534,8 @@ export default {
     fr: 'Autres achats',
   },
   data_management_submodule_additional_purchases: {
-    en: 'Additional Purchases',
-    fr: 'Achats supplémentaires',
+    en: 'Centralized Purchases',
+    fr: 'Achats Centralisés',
   },
   data_management_submodule_research_facilities: {
     en: 'Research Facilities',

--- a/frontend/src/i18n/equipment_electric_consumption.ts
+++ b/frontend/src/i18n/equipment_electric_consumption.ts
@@ -89,15 +89,15 @@ Si la puissance moyenne active ou standby de votre équipement est différente d
   },
   [`${MODULES.EquipmentElectricConsumption}-scientific`]: {
     en: 'Scientific Equipment',
-    fr: 'Équipement scientifique',
+    fr: 'Équipements scientifiques',
   },
   [`${MODULES.EquipmentElectricConsumption}-it`]: {
     en: 'IT Equipment',
-    fr: 'Équipement informatique',
+    fr: 'Équipements IT',
   },
   [`${MODULES.EquipmentElectricConsumption}-other`]: {
     en: 'Other Equipment',
-    fr: 'Autre équipement',
+    fr: 'Autres équipements',
   },
   [`${MODULES.EquipmentElectricConsumption}-scientific-equipment-table-title`]:
     {
@@ -106,11 +106,11 @@ Si la puissance moyenne active ou standby de votre équipement est différente d
     },
   [`${MODULES.EquipmentElectricConsumption}-it-equipment-table-title`]: {
     en: 'IT equipment ({count}) | IT equipments ({count})',
-    fr: 'Équipement informatique ({count}) | Équipements informatiques ({count})',
+    fr: 'Équipements IT ({count}) | Équipements IT ({count})',
   },
   [`${MODULES.EquipmentElectricConsumption}-other-equipment-table-title`]: {
     en: 'Other equipment ({count}) | Other equipments ({count})',
-    fr: 'Autre équipement ({count}) | Autres équipements ({count})',
+    fr: 'Autres équipements ({count}) | Autres équipements ({count})',
   },
   [`${MODULES.EquipmentElectricConsumption}-scientific-form-title`]: {
     en: 'Add Scientific Equipment',

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -172,12 +172,12 @@ export default {
   },
   // Class keys
   class_1: {
-    en: 'Class 1',
-    fr: 'Classe 1',
+    en: '1st class',
+    fr: '1ère classe',
   },
   class_2: {
-    en: 'Class 2',
-    fr: 'Classe 2',
+    en: '2nd class',
+    fr: '2ème classe',
   },
   first: {
     en: 'First',

--- a/frontend/src/i18n/purchase.ts
+++ b/frontend/src/i18n/purchase.ts
@@ -141,13 +141,13 @@ export default {
       fr: 'Ajouter un autre achat',
     },
   [`${MODULES.Purchase}-${SUBMODULE_PURCHASE_TYPES.AdditionalPurchases}`]: {
-    en: 'Additional Purchase | Additional Purchases',
-    fr: 'Achat supplémentaire | Achats supplémentaires',
+    en: 'Additional purchase | Additional purchases',
+    fr: 'Achats centralisés | achats centralisés',
   },
   [`${MODULES.Purchase}.${SUBMODULE_PURCHASE_TYPES.AdditionalPurchases}-table-title`]:
     {
-      en: 'Additional Purchases ({count})',
-      fr: 'Achats supplémentaires ({count})',
+      en: 'Centralized purchases ({count})',
+      fr: 'Achats centralisés ({count})',
     },
 
   [`${MODULES.Purchase}-${SUBMODULE_PURCHASE_TYPES.ScientificEquipmentPurchases}-table-title-info-tooltip`]:

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -422,8 +422,8 @@ export default {
     fr: 'Emissions de combustion d’énergie',
   },
   'charts-energy-combustion-subcategory': {
-    en: 'Energy combustion emissions',
-    fr: "Émissions de combustion d'énergie",
+    en: 'Decentralized heating',
+    fr: 'Chauffage décentralisé',
   },
   'charts-lighting-subcategory': {
     en: 'Lighting',
@@ -438,32 +438,32 @@ export default {
     fr: 'Ventilation',
   },
   'charts-heating-elec-subcategory': {
-    en: 'Heating (electric)',
+    en: 'Heating (electric.)',
     fr: 'Chauffage (électrique)',
   },
   'charts-heating-thermal-subcategory': {
-    en: 'Heating (thermal)',
-    fr: 'Chauffage (thermique)',
+    en: 'Centralized heating',
+    fr: 'Chauffage centralisé',
   },
   'charts-office-subcategory': {
     en: 'Office',
     fr: 'Bureau',
   },
   'charts-laboratories-subcategory': {
-    en: 'Laboratories',
-    fr: 'Laboratoires',
+    en: 'Laboratory',
+    fr: 'Laboratoire',
   },
   'charts-archives-subcategory': {
     en: 'Archives',
     fr: 'Archives',
   },
   'charts-libraries-subcategory': {
-    en: 'Libraries',
-    fr: 'Bibliothèques',
+    en: 'Library',
+    fr: 'Bibliothèque',
   },
   'charts-auditoriums-subcategory': {
-    en: 'Auditoriums',
-    fr: 'Auditoires',
+    en: 'Auditorium',
+    fr: 'Auditoire',
   },
   'charts-miscellaneous-subcategory': {
     en: 'Miscellaneous',
@@ -570,8 +570,8 @@ export default {
     fr: 'Achat',
   },
   'charts-bio-chemicals-subcategory': {
-    en: 'Bio-chemicals',
-    fr: 'Bio-chimiques',
+    en: 'Bio & chemical products',
+    fr: 'Produits biologiques et chimiques',
   },
   'charts-consumables-subcategory': {
     en: 'Consumables',
@@ -590,12 +590,12 @@ export default {
     fr: 'Véhicules',
   },
   'charts-additional-purchases-subcategory': {
-    en: 'Additional purchases',
-    fr: 'Achats supplémentaires',
+    en: 'Centralized purchases',
+    fr: 'Achats centralisés',
   },
   'charts-other-equipment-subcategory': {
     en: 'Other equipment',
-    fr: 'Autre équipement',
+    fr: 'Autres équipements',
   },
   'charts-other-purchases-subcategory': {
     en: 'Other purchases',
@@ -618,12 +618,12 @@ export default {
     fr: 'Avion',
   },
   'charts-class-1-subcategory': {
-    en: 'Class 1',
-    fr: 'Classe 1',
+    en: '1st class',
+    fr: '1ère classe',
   },
   'charts-class-2-subcategory': {
-    en: 'Class 2',
-    fr: 'Classe 2',
+    en: '2nd class',
+    fr: '2ème classe',
   },
   'charts-first-class-subcategory': {
     en: 'First',
@@ -638,8 +638,8 @@ export default {
     fr: 'Éco',
   },
   'charts-clouds-subcategory': {
-    en: 'Clouds',
-    fr: 'Clouds',
+    en: 'External clouds',
+    fr: 'Clouds externes',
   },
   'charts-ai-subcategory': {
     en: 'AI',
@@ -651,7 +651,7 @@ export default {
   },
   'charts-scientific-subcategory': {
     en: 'Scientific equipment',
-    fr: 'Équipement scientifique',
+    fr: 'Équipements scientifiques',
   },
   'charts-stockage-subcategory': {
     en: 'Cloud storage',
@@ -699,7 +699,19 @@ export default {
   },
   'charts-research-animal-subcategory': {
     en: 'Animal facilities',
-    fr: 'Infrastructures pour animaux',
+    fr: 'Animalerie',
+  },
+  'charts-research-it-facilities-subcategory': {
+    en: 'IT facilities',
+    fr: 'Infrastructures IT',
+  },
+  'charts-animal-mice-subcategory': {
+    en: 'Mice',
+    fr: 'Souris',
+  },
+  'charts-animal-fish-subcategory': {
+    en: 'Fish',
+    fr: 'Poisson',
   },
   'charts-rest-subcategory': {
     en: 'Rest',
@@ -707,7 +719,7 @@ export default {
   },
   'charts-equipment-it': {
     en: 'IT Equipment',
-    fr: 'IT Équipement',
+    fr: 'Équipements IT',
   },
   'charts-buildings-it': {
     en: 'IT',


### PR DESCRIPTION
## What does this change?

Adds granular L2 subcategories for research facilities and several other modules, and corrects subcategory ordering and labelling throughout the main charts:

**Research facilities (backend + frontend):**
- Splits `research_facilities` entries into three runtime-resolved emission types: `facilities`, `it_facilities` (SCITAS/RCP), and `animal` (with `mice`/`fish` sub-types).
- Adds `_resolve_research_facilities` and `_resolve_animal_facilities` runtime resolvers.
- Adds `it_facilities` to the top-class breakdown endpoint and the IT breakdown stats.
- Adds new `EmissionType` entries and wires them into the parent map, scope/category map, and IT rollup set.

**Buildings:**
- Reorders `buildings_room` subcategories: `heating_elec → cooling → ventilation → lighting` (was `heating_elec → lighting → cooling → ventilation`).
- Fixes `ModuleCarbonFootprintChart` series definitions that had `lighting` and `cooling`/`ventilation` swapped.
- Reorders room type options in the form (laboratories first, miscellaneous last).
- Renames "Energy combustion emissions" → "Decentralized heating" and "Heating (thermal)" → "Centralized heating".

**Professional travel:** switches train class option labels to i18n keys (`class_1`/`class_2`), renames to "1st class" / "2nd class".

**Purchases:** renames "Additional Purchases" → "Centralized Purchases" across labels, chart keys, and i18n.

**General chart improvements:**
- Adds `sortSegmentKeys` in `EmissionTypeBreakdownChart` to enforce consistent left-to-right stacking of room-type segments.
- Falls back to `te(key) ? t(key) : key` in subcategory translation helpers so unknown keys degrade gracefully.
- Translates equipment class/subclass option labels through i18n in `useEquipmentClassOptions`.
- Adds `ResearchFacilities` to `TOP_CLASS_MODULES`.
- Increases chart border widths from 0/0.5 to 1px for visual clarity.
- Various FR terminology fixes (pluralisation, "Équipements IT", "Animalerie", "Clouds externes", etc.).

## Why is this needed?

The charts were grouping all research facility emissions into two flat buckets (`facilities` / `animal`), hiding the distinction between general research infrastructure and EPFL's IT research facilities (SCITAS/RCP). Several subcategory orderings were also wrong (buildings room types, series stack order), labels were inconsistent or inaccurate, and train class labels were hardcoded strings instead of translated keys.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Related issues

- Closes #1188 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
