### PR TITLE
docs(#459): draft implementation plan — backoffice ACCRED affiliation scoping

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -12,7 +12,7 @@ from typing import Any, Generator, List, NamedTuple, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
-from sqlmodel import desc, select
+from sqlmodel import col, desc, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_db
@@ -43,11 +43,12 @@ from app.core.constants import (
     ModuleStatus,
 )
 from app.core.logging import get_logger
-from app.core.security import require_permission
+from app.core.security import get_current_active_user
 from app.models.carbon_report import (
     CarbonReport,
 )
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES
+from app.models.unit import Unit
 from app.models.user import User
 from app.repositories.carbon_report_module_repo import (
     CarbonReportModuleRepository,
@@ -56,6 +57,11 @@ from app.schemas.backoffice import (
     PaginatedUnitReportingData,
     PaginationMeta,
     UnitReportingData,
+)
+from app.utils.scoping import (
+    build_affiliation_predicate,
+    gate_backoffice,
+    narrow_path_affiliation,
 )
 
 logger = get_logger(__name__)
@@ -238,19 +244,36 @@ async def list_backoffice_units(
         None,
         description="Sort order: 'asc' for ascending, 'desc' for descending",
     ),
-    current_user: User = Depends(require_permission("backoffice.users", "view")),
+    current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
     List units with their reporting completion status and outlier values.
     """
+    is_global, affiliations = gate_backoffice(current_user, "view")
+    scoped_path_affiliation = narrow_path_affiliation(
+        filters.path_affiliation, is_global, affiliations
+    )
+    # Scoped caller whose request resolves to no allowed affiliations → empty.
+    if not is_global and not scoped_path_affiliation:
+        return PaginatedUnitReportingData(
+            data=[],
+            pagination=PaginationMeta(
+                total=0, page=page, page_size=page_size, total_pages=0
+            ),
+            validated_units_count=0,
+            in_progress_units_count=0,
+            not_started_units_count=0,
+            total_units_count=0,
+        )
+
     carbon_report_module_repo = CarbonReportModuleRepository(db)
 
     if filters.years is None or len(filters.years) == 0:
         raise HTTPException(status_code=400, detail=ERROR_AT_LEAST_ONE_YEAR)
 
     result = await carbon_report_module_repo.get_reporting_overview(
-        path_affiliation=filters.path_affiliation,
+        path_affiliation=scoped_path_affiliation,
         path_lvl4=filters.path_lvl4,
         completion_status=filters.completion_status,
         search=filters.search,
@@ -321,10 +344,12 @@ async def export_reporting(
         description="Number of items per page",
     ),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_permission("backoffice.users", "export")),
+    current_user: User = Depends(get_current_active_user),
 ):
     """Export unit reporting data as CSV or JSON file download."""
-    # Get all matching records for export
+    gate_backoffice(current_user, "export")
+    # Get all matching records for export. The inner ``list_backoffice_units``
+    # applies the affiliation narrowing via its own ``gate_backoffice("view")``.
     reporting_data = await list_backoffice_units(
         filters=filters,
         page=page,
@@ -385,16 +410,26 @@ async def export_reporting(
 
 @router.get("/years")
 async def get_available_years(
-    current_user: User = Depends(require_permission("backoffice.users", "view")),
+    current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Get all available years from CarbonReport records in the database,
     sorted in descending order (latest first).
+
+    Affiliation-scoped backoffice users see only the years where reports
+    exist for units inside their affiliation (#459).
     """
-    result = await db.exec(
-        select(CarbonReport.year).distinct().order_by(desc(CarbonReport.year))
-    )
+    is_global, affiliations = gate_backoffice(current_user, "view")
+    stmt = select(CarbonReport.year).distinct()
+    if not is_global:
+        if not affiliations:
+            return {"years": [], "latest": ""}
+        stmt = stmt.join(Unit, col(CarbonReport.unit_id) == col(Unit.id)).where(
+            build_affiliation_predicate(affiliations)
+        )
+    stmt = stmt.order_by(desc(CarbonReport.year))
+    result = await db.exec(stmt)
     years = [str(y) for y in result.all()]
     if not years:
         return {"years": [], "latest": ""}
@@ -406,23 +441,30 @@ async def report_usage(
     filters: BackofficeFilters = Depends(get_backoffice_filters),
     format: str = Query("csv", description="Export format: csv or json"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_permission("backoffice.users", "export")),
+    current_user: User = Depends(get_current_active_user),
 ) -> StreamingResponse:
     if format not in {"csv", "json"}:
         raise HTTPException(status_code=400, detail=ERROR_INVALID_FORMAT)
 
-    try:
-        data = await CarbonReportModuleRepository(db).get_usage_report(
-            path_affiliation=filters.path_affiliation,
-            path_lvl4=filters.path_lvl4,
-            completion_status=filters.completion_status,
-            search=filters.search,
-            modules=filters.modules,
-            years=filters.years,
-        )
-    except ValueError as exc:
-        # Invalid filter values or other issues in query parameters
-        raise HTTPException(status_code=400, detail=str(exc))
+    is_global, affiliations = gate_backoffice(current_user, "export")
+    scoped_path_affiliation = narrow_path_affiliation(
+        filters.path_affiliation, is_global, affiliations
+    )
+    if not is_global and not scoped_path_affiliation:
+        data = []
+    else:
+        try:
+            data = await CarbonReportModuleRepository(db).get_usage_report(
+                path_affiliation=scoped_path_affiliation,
+                path_lvl4=filters.path_lvl4,
+                completion_status=filters.completion_status,
+                search=filters.search,
+                modules=filters.modules,
+                years=filters.years,
+            )
+        except ValueError as exc:
+            # Invalid filter values or other issues in query parameters
+            raise HTTPException(status_code=400, detail=str(exc))
 
     timestamp = datetime.now(timezone.utc).strftime(EXPORT_CSV_TIMESTAMP_FORMAT)
     if format == "json":
@@ -468,10 +510,16 @@ async def report_detailed(
     filters: BackofficeFilters = Depends(get_backoffice_filters),
     format: str = Query("csv", description="Export format: csv or json"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_permission("backoffice.users", "export")),
+    current_user: User = Depends(get_current_active_user),
 ) -> StreamingResponse:
     if format not in {"csv", "json"}:
         raise HTTPException(status_code=400, detail=ERROR_INVALID_FORMAT)
+
+    is_global, affiliations = gate_backoffice(current_user, "export")
+    scoped_path_affiliation = narrow_path_affiliation(
+        filters.path_affiliation, is_global, affiliations
+    )
+    scoped_caller_no_affiliations = not is_global and not scoped_path_affiliation
 
     timestamp = datetime.now(timezone.utc).strftime(EXPORT_CSV_TIMESTAMP_FORMAT)
 
@@ -480,10 +528,12 @@ async def report_detailed(
 
         for module_type, data_entry_types in MODULE_TYPE_TO_DATA_ENTRY_TYPES.items():
             for data_entry_type in data_entry_types:
+                if scoped_caller_no_affiliations:
+                    continue
                 try:
                     data = await CarbonReportModuleRepository(db).get_detailed_report(
                         data_entry_type=data_entry_type,
-                        path_affiliation=filters.path_affiliation,
+                        path_affiliation=scoped_path_affiliation,
                         path_lvl4=filters.path_lvl4,
                         completion_status=filters.completion_status,
                         search=filters.search,
@@ -551,22 +601,29 @@ async def report_results(
     filters: BackofficeFilters = Depends(get_backoffice_filters),
     format: str = Query("csv", description="Export format: csv or json"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_permission("backoffice.users", "export")),
+    current_user: User = Depends(get_current_active_user),
 ) -> StreamingResponse:
     if format not in {"csv", "json"}:
         raise HTTPException(status_code=400, detail=ERROR_INVALID_FORMAT)
 
-    try:
-        data = await CarbonReportModuleRepository(db).get_results_report(
-            path_affiliation=filters.path_affiliation,
-            path_lvl4=filters.path_lvl4,
-            completion_status=filters.completion_status,
-            search=filters.search,
-            years=filters.years,
-        )
-    except ValueError as exc:
-        # Invalid filter values or other issues in query parameters
-        raise HTTPException(status_code=400, detail=str(exc))
+    is_global, affiliations = gate_backoffice(current_user, "export")
+    scoped_path_affiliation = narrow_path_affiliation(
+        filters.path_affiliation, is_global, affiliations
+    )
+    if not is_global and not scoped_path_affiliation:
+        data = []
+    else:
+        try:
+            data = await CarbonReportModuleRepository(db).get_results_report(
+                path_affiliation=scoped_path_affiliation,
+                path_lvl4=filters.path_lvl4,
+                completion_status=filters.completion_status,
+                search=filters.search,
+                years=filters.years,
+            )
+        except ValueError as exc:
+            # Invalid filter values or other issues in query parameters
+            raise HTTPException(status_code=400, detail=str(exc))
 
     timestamp = datetime.now(timezone.utc).strftime(EXPORT_CSV_TIMESTAMP_FORMAT)
     if format == "json":

--- a/backend/app/api/v1/backoffice_reporting.py
+++ b/backend/app/api/v1/backoffice_reporting.py
@@ -1,20 +1,60 @@
 from typing import Annotated, List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, or_
 from sqlalchemy.orm import aliased
+from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_db
 from app.core.logging import get_logger
-from app.core.security import require_permission
+from app.core.security import get_current_active_user
 from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.unit import UnitRead
+from app.utils.permissions import derive_backoffice_affiliations, has_permission
 
 # Services
 logger = get_logger(__name__)
 router = APIRouter()
+
+
+def _affiliation_predicate(affiliations: set[str]) -> ColumnElement[bool]:
+    """Build the SQL predicate matching ``Unit.path_name`` against affiliations.
+
+    ACCRED ``sortpath`` is a single token (e.g. ``"SV"``, ``"STI"``,
+    ``"Engineering"``); ``Unit.path_name`` is a separator-joined ancestor list
+    (observed shapes: ``"EPFL > STI > LMSC"`` and ``"EPFL ENAC IT4R-TEST"``).
+    Padding the column with leading/trailing spaces lets a single
+    ``% <aff> %`` ILIKE catch tokens at any position regardless of separator
+    (` > ` or plain space) and avoids false positives like ``SV`` matching
+    ``SVOPS``.
+    """
+    # ``coalesce`` keeps the predicate well-defined when ``path_name`` is NULL
+    # (NULL rows simply never match).
+    padded = func.concat(" ", func.coalesce(col(Unit.path_name), ""), " ")
+    return or_(*[padded.ilike(f"% {aff} %") for aff in affiliations])
+
+
+def _gate_backoffice_users_view(user: User) -> tuple[bool, set[str]]:
+    """Authorize ``backoffice.users.view`` and return the caller's scope.
+
+    Raises 403 if the user holds neither the bare ``backoffice.users`` key nor
+    any ``backoffice.users/<aff>`` key. Returns ``(is_global, affiliations)``;
+    callers apply the affiliation predicate when ``is_global`` is False.
+
+    Uses ``has_permission(..., any_scope=True)`` because affiliation-scoped
+    users only hold ``backoffice.users/<aff>`` keys — ``require_permission``'s
+    literal-path lookup would 403 them.
+    """
+    perms = user.calculate_permissions()
+    if not has_permission(perms, "backoffice.users", "view", any_scope=True):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied",
+        )
+    return derive_backoffice_affiliations(perms)
 
 
 @router.get("/affiliations", response_model=List[UnitRead])
@@ -26,7 +66,7 @@ async def list_affiliations(
     page: int = 1,
     page_size: Annotated[int, Query(le=100)] = 100,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_permission("backoffice.users", "view")),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     List affiliation units (Level 2 and Level 3).
@@ -36,7 +76,16 @@ async def list_affiliations(
     - Level 3: Institut
 
     Each unit includes its unit_type_label for UI distinction.
+
+    Affiliation-scoped backoffice users (#459) only see units whose
+    ``path_name`` contains one of their affiliations.
     """
+    is_global, affiliations = _gate_backoffice_users_view(current_user)
+
+    # Defence-in-depth: a non-global caller with no affiliations sees nothing.
+    if not is_global and not affiliations:
+        return []
+
     # 1. Initialize query with SQLModel's select
     query = select(Unit).where(col(Unit.is_active))
 
@@ -50,11 +99,15 @@ async def list_affiliations(
     if name:
         query = query.where(col(Unit.name).ilike(f"%{name}%"))
 
-    # 4. Sorting and Pagination
+    # 4. Affiliation scoping (#459)
+    if not is_global:
+        query = query.where(_affiliation_predicate(affiliations))
+
+    # 5. Sorting and Pagination
     offset = (page - 1) * page_size
     query = query.order_by(Unit.name).offset(offset).limit(page_size)
 
-    # 5. Execution
+    # 6. Execution
     result = await db.exec(query)
     return result.all()
 
@@ -71,8 +124,14 @@ async def list_units(
     page: int = 1,
     page_size: Annotated[int, Query(le=100)] = 100,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_permission("backoffice.users", "view")),
+    current_user: User = Depends(get_current_active_user),
 ):
+    is_global, affiliations = _gate_backoffice_users_view(current_user)
+
+    # Defence-in-depth: a non-global caller with no affiliations sees nothing.
+    if not is_global and not affiliations:
+        return []
+
     # 1. Initialize query with SQLModel's select
     query = select(Unit).where(col(Unit.is_active))
 
@@ -99,10 +158,14 @@ async def list_units(
             col(Unit.parent_institutional_code) == parent_alias.institutional_code,
         ).where(parent_alias.unit_type_label == parent_unit_type_label)
 
-    # 4. Sorting and Pagination
+    # 4. Affiliation scoping (#459)
+    if not is_global:
+        query = query.where(_affiliation_predicate(affiliations))
+
+    # 5. Sorting and Pagination
     offset = (page - 1) * page_size
     query = query.order_by(Unit.name).offset(offset).limit(page_size)
 
-    # 5. Execution (The SQLModel way)
+    # 6. Execution (The SQLModel way)
     result = await db.exec(query)
     return result.all()

--- a/backend/app/api/v1/backoffice_reporting.py
+++ b/backend/app/api/v1/backoffice_reporting.py
@@ -1,9 +1,7 @@
 from typing import Annotated, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import func, or_
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import aliased
-from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -13,48 +11,11 @@ from app.core.security import get_current_active_user
 from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.unit import UnitRead
-from app.utils.permissions import derive_backoffice_affiliations, has_permission
+from app.utils.scoping import build_affiliation_predicate, gate_backoffice
 
 # Services
 logger = get_logger(__name__)
 router = APIRouter()
-
-
-def _affiliation_predicate(affiliations: set[str]) -> ColumnElement[bool]:
-    """Build the SQL predicate matching ``Unit.path_name`` against affiliations.
-
-    ACCRED ``sortpath`` is a single token (e.g. ``"SV"``, ``"STI"``,
-    ``"Engineering"``); ``Unit.path_name`` is a separator-joined ancestor list
-    (observed shapes: ``"EPFL > STI > LMSC"`` and ``"EPFL ENAC IT4R-TEST"``).
-    Padding the column with leading/trailing spaces lets a single
-    ``% <aff> %`` ILIKE catch tokens at any position regardless of separator
-    (` > ` or plain space) and avoids false positives like ``SV`` matching
-    ``SVOPS``.
-    """
-    # ``coalesce`` keeps the predicate well-defined when ``path_name`` is NULL
-    # (NULL rows simply never match).
-    padded = func.concat(" ", func.coalesce(col(Unit.path_name), ""), " ")
-    return or_(*[padded.ilike(f"% {aff} %") for aff in affiliations])
-
-
-def _gate_backoffice_users_view(user: User) -> tuple[bool, set[str]]:
-    """Authorize ``backoffice.users.view`` and return the caller's scope.
-
-    Raises 403 if the user holds neither the bare ``backoffice.users`` key nor
-    any ``backoffice.users/<aff>`` key. Returns ``(is_global, affiliations)``;
-    callers apply the affiliation predicate when ``is_global`` is False.
-
-    Uses ``has_permission(..., any_scope=True)`` because affiliation-scoped
-    users only hold ``backoffice.users/<aff>`` keys — ``require_permission``'s
-    literal-path lookup would 403 them.
-    """
-    perms = user.calculate_permissions()
-    if not has_permission(perms, "backoffice.users", "view", any_scope=True):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied",
-        )
-    return derive_backoffice_affiliations(perms)
 
 
 @router.get("/affiliations", response_model=List[UnitRead])
@@ -80,7 +41,7 @@ async def list_affiliations(
     Affiliation-scoped backoffice users (#459) only see units whose
     ``path_name`` contains one of their affiliations.
     """
-    is_global, affiliations = _gate_backoffice_users_view(current_user)
+    is_global, affiliations = gate_backoffice(current_user)
 
     # Defence-in-depth: a non-global caller with no affiliations sees nothing.
     if not is_global and not affiliations:
@@ -101,7 +62,7 @@ async def list_affiliations(
 
     # 4. Affiliation scoping (#459)
     if not is_global:
-        query = query.where(_affiliation_predicate(affiliations))
+        query = query.where(build_affiliation_predicate(affiliations))
 
     # 5. Sorting and Pagination
     offset = (page - 1) * page_size
@@ -126,7 +87,7 @@ async def list_units(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
-    is_global, affiliations = _gate_backoffice_users_view(current_user)
+    is_global, affiliations = gate_backoffice(current_user)
 
     # Defence-in-depth: a non-global caller with no affiliations sees nothing.
     if not is_global and not affiliations:
@@ -160,7 +121,7 @@ async def list_units(
 
     # 4. Affiliation scoping (#459)
     if not is_global:
-        query = query.where(_affiliation_predicate(affiliations))
+        query = query.where(build_affiliation_predicate(affiliations))
 
     # 5. Sorting and Pagination
     offset = (page - 1) * page_size

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -53,6 +53,7 @@ from app.tasks._background import fire_and_forget
 from app.tasks.runner import run_job
 from app.tasks.unit_sync_tasks import SyncUnitRequest
 from app.utils.request_context import extract_ip_address, extract_route_payload
+from app.utils.scoping import require_any_scope
 
 
 def _job_type_for(target_type: TargetType, ingestion_method: IngestionMethod) -> str:
@@ -992,7 +993,7 @@ async def get_jobs_by_status(
     filter_type: str = "completed",
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list:
     """
@@ -1015,7 +1016,7 @@ async def get_jobs_by_year(
     year: int,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list:
     """
@@ -1054,7 +1055,7 @@ async def get_latest_jobs_by_year(
     year: int,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list:
     """
@@ -1188,7 +1189,7 @@ class WorkerResponse(BaseModel):
 async def list_workers(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list[WorkerResponse]:
     """Return the set of live worker pods.
@@ -1382,7 +1383,7 @@ async def get_active_pipelines(
     modules: str,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> dict[int, str]:
     """Return the active pipeline_id (if any) for each requested module.
@@ -1440,12 +1441,20 @@ async def get_active_year_level_pipelines(
     year: int,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list[str]:
     """Return active **year-level** pipeline_ids (``entity_type=GLOBAL_PER_YEAR``).
 
-    **Required Permission**: ``backoffice.data_management.view``
+    **Required Permission**: ``backoffice.data_management:view`` under any scope.
+    Both the back-office Data Management page (Backoffice Administrators) and
+    the Logs page (Super Admin only) read from this endpoint, so the gate
+    accepts affiliation-scoped backoffice grants alongside the bare superadmin
+    key (#459 follow-up).
+
+    Year-level pipelines are not affiliation-bound, so the returned list is
+    not filtered by the caller's affiliation — the data is shared across the
+    back-office area.
 
     Issue #867 — back-office data-management page reload reattach.  The
     sibling ``GET /active-pipelines`` only sees module-scoped pipelines
@@ -1460,13 +1469,6 @@ async def get_active_year_level_pipelines(
     ``entity_type=GLOBAL_PER_YEAR`` and the given ``year``.  Order is
     most-recent-first by job id; the frontend treats the list as a
     set, but a stable order makes assertion-based tests trivial.
-
-    The endpoint applies only the global ``backoffice.data_management.view``
-    gate — there is no per-module decision loop here because year-level
-    pipelines are not module-scoped (the per-module security guard on
-    the sibling endpoint defends against pipeline_id enumeration across
-    *modules* a backoffice user can't read; year-level pipelines have
-    no equivalent sub-perimeter today).
 
     Empty result is the steady state — both "no active year-level
     pipelines" and "U1's pipeline-stamping for unit_sync hasn't shipped
@@ -1484,7 +1486,7 @@ async def get_recalculation_status(
     year: int,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list[ModuleRecalculationStatus]:
     """Return per-module recalculation status for the given year.
@@ -1542,7 +1544,7 @@ async def list_pipelines(
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> PipelineListResponse:
     """Paginated, filtered list of ingestion/recalc pipelines (#1234).
@@ -1666,7 +1668,7 @@ async def get_pipeline_jobs(
     pipeline_id: UUID,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> PipelineResponse:
     """Return every job in a multi-step pipeline run, ordered by id.
@@ -1723,7 +1725,7 @@ async def pipeline_stream_by_id(
     pipeline_id: UUID,
     request: Request,
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ):
     """Server-Sent Events stream for every job sharing a ``pipeline_id``.
@@ -2184,7 +2186,7 @@ async def get_stale_stats(
     ),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(
-        require_permission("backoffice.data_management", "view")
+        require_any_scope("view", "backoffice.data_management")
     ),
 ) -> list[StaleStatsEntry]:
     """Read-only backstop for the aggregation pipeline (Plan 310-D Follow-up 1

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -134,15 +134,17 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
         # GlobalScope → no suffix; RoleScope → "/{institutional_id}" or
         # "/{affiliation}". Affiliation-based scoping (#459) narrows
         # backoffice.* permissions to a sub-perimeter (ACCRED sortpath).
+        # Empty-string identifiers fall through to the sentinel — defensive
+        # against upstream bugs producing ``institutional_id=""``.
         if is_global_scope(s):
             return ""
         if isinstance(s, RoleScope):
-            if s.institutional_id is not None:
+            if s.institutional_id:
                 return f"/{s.institutional_id}"
             if s.affiliation:
                 return f"/{s.affiliation}"
         elif isinstance(s, dict):
-            if s.get("institutional_id") is not None:
+            if s.get("institutional_id"):
                 return f"/{s['institutional_id']}"
             if s.get("affiliation"):
                 return f"/{s['affiliation']}"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -48,11 +48,9 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
     This function maps role-based access control to permission-based access control.
     It processes all user roles and generates a comprehensive permissions structure.
 
-    IMPORTANT: Role domains are generally independent, with some exceptions:
+    IMPORTANT: Role domains are independent, with one exception:
     - Backoffice roles (CO2_BACKOFFICE_METIER) ONLY grant backoffice.* permissions
-    - User roles (CO2_USER_*) primarily grant modules.* permissions
-      Exception: CO2_USER_PRINCIPAL also grants backoffice.users.edit for unit-scoped
-      role assignment (to assign co2.user.std to unit members)
+    - User roles (CO2_USER_*) ONLY grant modules.* permissions
     - System roles (CO2_SUPERADMIN) grant system.* permissions
       Exception: CO2_SUPERADMIN also grants full backoffice.* access
     - A person can have multiple roles, and permissions combine
@@ -87,8 +85,7 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
       * backoffice.documentation: view, edit (view/edit documentation)
 
     User Roles (affect modules.* ONLY):
-    - CO2_USER_PRINCIPAL: Full module access (view + edit) + can assign co2.user.std
-      role to unit members (backoffice.users.edit for unit scope)
+    - CO2_USER_PRINCIPAL: Full module access (view + edit) for the unit
     - CO2_USER_STD: View and edit access to professional_travel module
       (own trips only - enforced via resource-level policy)
 
@@ -170,32 +167,32 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
         # BACKOFFICE ROLES - Only affect backoffice.* permissions
         # Compare using enum value for consistency
         if role_name == RoleName.CO2_BACKOFFICE_METIER.value:
-            # GlobalScope → un-scoped keys (full backoffice reach).
-            # RoleScope(affiliation=...) → scoped keys "backoffice.X/{affiliation}"
-            # so endpoints can narrow results to the user's sub-perimeter (#459).
-            # RoleScope(institutional_id=...) is not produced by ACCRED today; if
-            # it ever appears it falls through to the un-scoped branch.
-            bo_key = scope_key if is_affiliation_scope(scope) else ""
-            if is_global_scope(scope) or is_role_scope(scope):
-                permissions[f"backoffice.reporting{bo_key}"] = merge_actions(
-                    permissions.get(f"backoffice.reporting{bo_key}"),
+            # CO2_BACKOFFICE_METIER is always sub-perimeter-bound: ACCRED only
+            # ever produces ``RoleScope(affiliation=LVL3)`` for this role. Only
+            # CO2_SUPERADMIN gets cross-affiliation reach (the bare backoffice.*
+            # keys below). Any other scope shape (GlobalScope, institutional_id)
+            # is unconfigured and emits nothing — gate_backoffice will 403 the
+            # caller, surfacing the misconfiguration rather than masking it.
+            if is_affiliation_scope(scope):
+                permissions[f"backoffice.reporting{scope_key}"] = merge_actions(
+                    permissions.get(f"backoffice.reporting{scope_key}"),
                     ["view", "export"],
                 )
-                permissions[f"backoffice.users{bo_key}"] = merge_actions(
-                    permissions.get(f"backoffice.users{bo_key}"),
+                permissions[f"backoffice.users{scope_key}"] = merge_actions(
+                    permissions.get(f"backoffice.users{scope_key}"),
                     ["view", "edit", "export"],
                 )
-                permissions[f"backoffice.data_management{bo_key}"] = merge_actions(
-                    permissions.get(f"backoffice.data_management{bo_key}"),
-                    [
-                        "view",
-                        "edit",
-                        "export",
-                        "sync",
-                    ],
+                # Backoffice Administrator only gets view + export on
+                # data_management. edit + sync are Super Admin only
+                # (Configuration write + Pipeline Operations) — granting them
+                # here would let a scoped backoffice user trigger syncs or
+                # mutate factor data the moment a route is opened any-scope.
+                permissions[f"backoffice.data_management{scope_key}"] = merge_actions(
+                    permissions.get(f"backoffice.data_management{scope_key}"),
+                    ["view", "export"],
                 )
-                permissions[f"backoffice.documentation{bo_key}"] = merge_actions(
-                    permissions.get(f"backoffice.documentation{bo_key}"),
+                permissions[f"backoffice.documentation{scope_key}"] = merge_actions(
+                    permissions.get(f"backoffice.documentation{scope_key}"),
                     ["view", "edit"],
                 )
 
@@ -259,11 +256,6 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
                         "edit",
                         "sync",
                     ],
-                )
-                # Principals can assign co2.user.std role to unit members
-                # This grants backoffice.users.edit for unit-scoped role assignment
-                permissions["backoffice.users"] = merge_actions(
-                    permissions.get("backoffice.users"), ["edit"]
                 )
 
         elif role_name == RoleName.CO2_USER_STD.value:

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -124,23 +124,31 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
             return "institutional_id" in s or "affiliation" in s
         return False
 
+    # Helper to check if a scope carries an affiliation (and no institutional_id).
+    # Used to gate backoffice sub-perimeter scoping (#459).
+    def is_affiliation_scope(s):
+        if isinstance(s, RoleScope):
+            return bool(s.affiliation) and s.institutional_id is None
+        if isinstance(s, dict):
+            return bool(s.get("affiliation")) and s.get("institutional_id") is None
+        return False
+
     def as_scope_key(s):
-        # Note: affiliation-based permissions are not implemented yet,
-        # so we return empty string for now to avoid granting permissions
-        # based on unrecognized scope formats, but this can be updated in
-        # the future when affiliation-based permissions are implemented
+        # GlobalScope → no suffix; RoleScope → "/{institutional_id}" or
+        # "/{affiliation}". Affiliation-based scoping (#459) narrows
+        # backoffice.* permissions to a sub-perimeter (ACCRED sortpath).
         if is_global_scope(s):
             return ""
         if isinstance(s, RoleScope):
-            if s.institutional_id and s.institutional_id is not None:
+            if s.institutional_id is not None:
                 return f"/{s.institutional_id}"
             if s.affiliation:
-                return ""
+                return f"/{s.affiliation}"
         elif isinstance(s, dict):
-            if "institutional_id" in s and s["institutional_id"] is not None:
+            if s.get("institutional_id") is not None:
                 return f"/{s['institutional_id']}"
-            if "affiliation" in s:
-                return ""
+            if s.get("affiliation"):
+                return f"/{s['affiliation']}"
         # Default to no scope if unrecognized format (should not grant permissions)
         return "/?"
 
@@ -162,18 +170,23 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
         # BACKOFFICE ROLES - Only affect backoffice.* permissions
         # Compare using enum value for consistency
         if role_name == RoleName.CO2_BACKOFFICE_METIER.value:
-            # to stream sync/jobs
-            # Backoffice metier can have either global scope or affiliation scope
-            # Grants full backoffice access for reporting, docs, and data updates
+            # GlobalScope → un-scoped keys (full backoffice reach).
+            # RoleScope(affiliation=...) → scoped keys "backoffice.X/{affiliation}"
+            # so endpoints can narrow results to the user's sub-perimeter (#459).
+            # RoleScope(institutional_id=...) is not produced by ACCRED today; if
+            # it ever appears it falls through to the un-scoped branch.
+            bo_key = scope_key if is_affiliation_scope(scope) else ""
             if is_global_scope(scope) or is_role_scope(scope):
-                permissions["backoffice.reporting"] = merge_actions(
-                    permissions.get("backoffice.reporting"), ["view", "export"]
+                permissions[f"backoffice.reporting{bo_key}"] = merge_actions(
+                    permissions.get(f"backoffice.reporting{bo_key}"),
+                    ["view", "export"],
                 )
-                permissions["backoffice.users"] = merge_actions(
-                    permissions.get("backoffice.users"), ["view", "edit", "export"]
+                permissions[f"backoffice.users{bo_key}"] = merge_actions(
+                    permissions.get(f"backoffice.users{bo_key}"),
+                    ["view", "edit", "export"],
                 )
-                permissions["backoffice.data_management"] = merge_actions(
-                    permissions.get("backoffice.data_management"),
+                permissions[f"backoffice.data_management{bo_key}"] = merge_actions(
+                    permissions.get(f"backoffice.data_management{bo_key}"),
                     [
                         "view",
                         "edit",
@@ -181,8 +194,9 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
                         "sync",
                     ],
                 )
-                permissions["backoffice.documentation"] = merge_actions(
-                    permissions.get("backoffice.documentation"), ["view", "edit"]
+                permissions[f"backoffice.documentation{bo_key}"] = merge_actions(
+                    permissions.get(f"backoffice.documentation{bo_key}"),
+                    ["view", "edit"],
                 )
 
         # USER ROLES - Only affect modules.* permissions

--- a/backend/app/providers/role_provider.py
+++ b/backend/app/providers/role_provider.py
@@ -22,6 +22,10 @@ from app.providers.test_fixtures import (
 logger = get_logger(__name__)
 settings = get_settings()
 
+# ACCRED sortpath hierarchy level used as the backoffice affiliation token.
+# Example: "EPFL ENAC ENAC-SG ENAC-IT" → level 3 = "ENAC-SG".
+AFFILIATION_LEVEL = 3
+
 
 class RoleProvider(ABC):
     """Abstract base class for role providers.
@@ -542,14 +546,30 @@ class AccredRoleProvider(RoleProvider):
                     # Global super admin role
                     roles.append(Role(role=auth_name, on=GlobalScope()))
                 elif auth_name == RoleName.CO2_BACKOFFICE_METIER:
-                    affiliations_names = (
-                        auth.get("reason").get("resource").get("sortpath")
+                    sortpath = (
+                        auth.get("reason", {}).get("resource", {}).get("sortpath") or ""
                     )
-                    # Map to affiliation scope (placeholder logic)
+                    # ACCRED sortpath is a space-separated hierarchy
+                    # ("EPFL ENAC ENAC-SG ENAC-IT"). Affiliation scoping operates
+                    # at LVL3 (e.g. "ENAC-SG"). Skip authorizations that cannot
+                    # resolve LVL3 — they cannot be scoped meaningfully.
+                    levels = sortpath.split()
+                    if len(levels) < AFFILIATION_LEVEL:
+                        logger.warning(
+                            "Backoffice metier sortpath too short; "
+                            "cannot resolve affiliation; skipping",
+                            extra={
+                                "auth_name": auth_name,
+                                "user_id": user_id,
+                                "sortpath": sortpath,
+                            },
+                        )
+                        continue
+                    affiliation = levels[AFFILIATION_LEVEL - 1]
                     roles.append(
                         Role(
                             role=auth_name,
-                            on=RoleScope(affiliation=affiliations_names),
+                            on=RoleScope(affiliation=affiliation),
                         )
                     )
                 else:

--- a/backend/app/utils/permissions.py
+++ b/backend/app/utils/permissions.py
@@ -7,6 +7,32 @@ Permissions are calculated dynamically from roles and returned as a structured d
 from typing import Optional
 
 
+def derive_backoffice_affiliations(
+    permissions: Optional[dict],
+    anchor_path: str = "backoffice.users",
+) -> tuple[bool, set[str]]:
+    """Inspect permission keys for backoffice sub-perimeter scoping (#459).
+
+    Returns ``(is_global, affiliations)``:
+    - ``is_global`` is True iff the bare ``anchor_path`` key is present, meaning
+      the user holds a ``GlobalScope`` (or superadmin) backoffice grant and
+      should NOT be narrowed.
+    - ``affiliations`` is the set of sub-perimeter labels parsed from
+      ``{anchor_path}/<aff>`` keys (multi-affiliation users yield multiple
+      entries — natural union semantics).
+
+    ``backoffice.users`` is the canonical anchor because all four backoffice
+    permission groups are emitted in lockstep by ``calculate_user_permissions``
+    for ``CO2_BACKOFFICE_METIER``.
+    """
+    if not permissions:
+        return False, set()
+    is_global = anchor_path in permissions
+    prefix = f"{anchor_path}/"
+    affiliations = {k.removeprefix(prefix) for k in permissions if k.startswith(prefix)}
+    return is_global, affiliations
+
+
 def has_permission(
     permissions: Optional[dict],
     path: str,

--- a/backend/app/utils/permissions.py
+++ b/backend/app/utils/permissions.py
@@ -14,16 +14,17 @@ def derive_backoffice_affiliations(
     """Inspect permission keys for backoffice sub-perimeter scoping (#459).
 
     Returns ``(is_global, affiliations)``:
-    - ``is_global`` is True iff the bare ``anchor_path`` key is present, meaning
-      the user holds a ``GlobalScope`` (or superadmin) backoffice grant and
-      should NOT be narrowed.
+    - ``is_global`` is True iff the bare ``anchor_path`` key is present, which
+      in practice means the user holds CO2_SUPERADMIN (the only role that
+      emits bare backoffice.* keys; CO2_BACKOFFICE_METIER is always scoped).
     - ``affiliations`` is the set of sub-perimeter labels parsed from
       ``{anchor_path}/<aff>`` keys (multi-affiliation users yield multiple
       entries — natural union semantics).
 
     ``backoffice.users`` is the canonical anchor because all four backoffice
     permission groups are emitted in lockstep by ``calculate_user_permissions``
-    for ``CO2_BACKOFFICE_METIER``.
+    for both CO2_BACKOFFICE_METIER (scoped variant) and CO2_SUPERADMIN (bare).
+    Any one of the four keys would work; ``backoffice.users`` is historical.
     """
     if not permissions:
         return False, set()

--- a/backend/app/utils/scoping.py
+++ b/backend/app/utils/scoping.py
@@ -1,0 +1,113 @@
+"""Affiliation-scoping helpers shared by backoffice routers (#459).
+
+The pure permission utilities live in ``app.utils.permissions`` and stay
+free of SQLAlchemy / FastAPI. This module owns the SQL-level predicate
+that maps ACCRED affiliation tokens onto ``Unit.path_name``, plus the
+gate helper that raises 403 when the caller is not a backoffice user.
+"""
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy import func, or_
+from sqlalchemy.sql.elements import ColumnElement
+from sqlmodel import col
+
+from app.core.security import get_current_active_user
+from app.models.unit import Unit
+from app.models.user import User
+from app.utils.permissions import derive_backoffice_affiliations, has_permission
+
+
+def build_affiliation_predicate(affiliations: set[str]) -> ColumnElement[bool]:
+    """Build the SQL predicate matching ``Unit.path_name`` against affiliations.
+
+    ACCRED ``sortpath`` is a space-separated 4-level hierarchy
+    (e.g. ``"EPFL ENAC ENAC-SG ENAC-IT"``); ``role_provider.py`` extracts
+    LVL3 (``"ENAC-SG"``) as the affiliation token. ``Unit.path_name`` is a
+    separator-joined ancestor list (observed shapes: ``"EPFL > STI > LMSC"``
+    and ``"EPFL ENAC IT4R-TEST"``). Padding the column with leading/trailing
+    spaces lets a single ``% <aff> %`` ILIKE catch the LVL3 token at any
+    position regardless of separator (` > ` or plain space) and avoids false
+    positives like ``SV`` matching ``SVOPS``.
+
+    ``coalesce`` keeps the predicate well-defined when ``path_name`` is NULL
+    (NULL rows simply never match).
+    """
+    padded = func.concat(" ", func.coalesce(col(Unit.path_name), ""), " ")
+    return or_(*[padded.ilike(f"% {aff} %") for aff in affiliations])
+
+
+def gate_backoffice(
+    user: User,
+    action: str = "view",
+    anchor_path: str = "backoffice.users",
+) -> tuple[bool, set[str]]:
+    """Authorize ``<anchor_path>:<action>`` under any scope; return scope.
+
+    Raises 403 if the user holds neither the bare ``anchor_path`` key nor any
+    ``anchor_path/<aff>`` key granting ``action``. Returns
+    ``(is_global, affiliations)``; callers apply ``build_affiliation_predicate``
+    when ``is_global`` is False.
+
+    The default anchor is ``backoffice.users`` (canonical for backoffice
+    routes); pass ``backoffice.data_management`` for sync/pipeline routes
+    or ``system.users`` for superadmin-only routes.
+
+    Uses ``has_permission(..., any_scope=True)`` because affiliation-scoped
+    users only hold ``<anchor>/<aff>`` keys — ``require_permission``'s
+    literal-path lookup would 403 them.
+    """
+    perms = user.calculate_permissions()
+    if not has_permission(perms, anchor_path, action, any_scope=True):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied",
+        )
+    return derive_backoffice_affiliations(perms, anchor_path=anchor_path)
+
+
+def require_any_scope(action: str = "view", anchor_path: str = "backoffice.users"):
+    """FastAPI dependency factory: gate ``<anchor_path>:<action>`` any-scope.
+
+    Drop-in replacement for ``require_permission`` for routes that only need
+    the 403 gate, not the ``(is_global, affiliations)`` tuple. For routes
+    that filter data by affiliation, call ``gate_backoffice`` inside the
+    handler instead.
+
+    Example::
+
+        @router.get("/jobs")
+        async def list_jobs(
+            current_user: User = Depends(
+                require_any_scope("view", "backoffice.data_management")
+            ),
+            ...
+        ):
+    """
+
+    async def _dep(
+        current_user: User = Depends(get_current_active_user),
+    ) -> User:
+        gate_backoffice(current_user, action=action, anchor_path=anchor_path)
+        return current_user
+
+    return _dep
+
+
+def narrow_path_affiliation(
+    requested: list[str] | None,
+    is_global: bool,
+    affiliations: set[str],
+) -> list[str] | None:
+    """Intersect a caller-provided ``path_affiliation`` filter with their scope.
+
+    - ``is_global`` callers pass through unchanged.
+    - Scoped callers: intersect their request with their affiliation set
+      (or default to the full set when they pass nothing).
+    - Returns the narrowed list; an empty list signals "no allowed affiliations"
+      and the caller should short-circuit to an empty result.
+    """
+    if is_global:
+        return requested
+    if requested:
+        return [a for a in requested if a in affiliations]
+    return list(affiliations)

--- a/backend/tests/integration/v1/test_permission_scope_e2e.py
+++ b/backend/tests/integration/v1/test_permission_scope_e2e.py
@@ -217,7 +217,7 @@ class TestPermissionScopeEndToEnd:
 # ─────────────────────────────────────────────────────────────────────────────
 # Backoffice ACCRED affiliation scoping (#459)
 #
-# Affiliation-scoped backoffice managers (e.g. "Anna for SV") only hold
+# Affiliation-scoped backoffice managers (e.g. an SV-scoped admin) only hold
 # ``backoffice.X/<affiliation>`` permission keys. Endpoints that swap
 # ``require_permission`` for an inline ``any_scope=True`` gate must:
 #   1. let the request through (the user IS a backoffice manager),
@@ -297,8 +297,10 @@ class TestBackofficeAffiliationScopeEndToEnd:
     sub-perimeter; GlobalScope keeps full reach (#459)."""
 
     def test_global_backoffice_sees_all_units(self, client, monkeypatch):
-        """GlobalScope backoffice → bare ``backoffice.users`` key → no narrowing."""
-        user = _user("11111", [_backoffice()])
+        """Superadmin → bare ``backoffice.users`` key → no narrowing.
+        (CO2_BACKOFFICE_METIER is always sub-perimeter-bound; cross-affiliation
+        reach is exclusive to CO2_SUPERADMIN.)"""
+        user = _user("11111", [_superadmin()])
         _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
         r = client.get(BACKOFFICE_UNITS_URL)
         assert r.status_code == 200, r.text
@@ -363,3 +365,180 @@ class TestBackofficeAffiliationScopeEndToEnd:
         assert r.status_code == 200, r.text
         names = {u["name"] for u in r.json()}
         assert names == {"SV-FAC"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/v1/backoffice/* (six endpoints previously gated by strict
+# ``require_permission`` — Phase 2 / #459 opened them under ``any_scope=True``
+# with server-side affiliation narrowing).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+BACKOFFICE_YEARS_URL = "/api/v1/backoffice/years"
+
+
+def _wire_backoffice_years(
+    monkeypatch, user, years_by_unit_path: dict[str, list[int]]
+) -> None:
+    """Stub the ``/backoffice/years`` query path.
+
+    ``years_by_unit_path`` maps a unit ``path_name`` → years that unit has
+    reports for. The mock inspects the compiled SQL for the affiliation
+    ILIKE literals (same trick as ``_wire_backoffice``) and returns the
+    union of years whose unit's ``path_name`` matches any literal. With
+    no literals (global caller), all years are returned.
+    """
+    app.dependency_overrides[deps_module.get_current_user] = lambda: user
+
+    async def mock_get_db():
+        db = MagicMock()
+
+        async def mock_exec(query):
+            compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+            tokens = re.findall(r"like\s+lower\('% ([^ ]+?) %'\)", compiled, re.I)
+
+            def path_matches(path: str) -> bool:
+                if not tokens:
+                    return True
+                padded = f" {(path or '').lower()} "
+                return any(f" {t.lower()} " in padded for t in tokens)
+
+            collected = sorted(
+                {
+                    y
+                    for path, years in years_by_unit_path.items()
+                    if path_matches(path)
+                    for y in years
+                },
+                reverse=True,
+            )
+            result = MagicMock()
+            result.all = lambda: collected
+            return result
+
+        db.exec = mock_exec
+        yield db
+
+    app.dependency_overrides[deps_module.get_db] = mock_get_db
+
+
+class TestBackofficeYearsAffiliationScoping:
+    """``/backoffice/years`` exposes distinct CarbonReport.year values.
+
+    For non-global callers the query joins ``Unit`` and applies the
+    affiliation predicate, so scoped users only see years for which their
+    affiliation has reports.
+    """
+
+    YEARS_BY_PATH = {
+        "EPFL > SV > SV-LAB": [2024, 2025],
+        "EPFL > STI > STI-LAB": [2023],
+    }
+
+    def test_global_backoffice_sees_all_years(self, client, monkeypatch):
+        """Superadmin (the only role with cross-affiliation reach) sees every year."""
+        user = _user("11111", [_superadmin()])
+        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+        r = client.get(BACKOFFICE_YEARS_URL)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert set(body["years"]) == {"2023", "2024", "2025"}
+        assert body["latest"] == "2025"
+
+    def test_scoped_backoffice_sees_only_in_affiliation_years(
+        self, client, monkeypatch
+    ):
+        user = _user("11111", [_backoffice_scoped("SV")])
+        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+        r = client.get(BACKOFFICE_YEARS_URL)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        # SV has 2024 + 2025; STI's 2023 must be filtered out.
+        assert set(body["years"]) == {"2024", "2025"}
+        assert body["latest"] == "2025"
+
+    def test_scoped_backoffice_cross_affiliation_returns_empty(
+        self, client, monkeypatch
+    ):
+        user = _user("11111", [_backoffice_scoped("CDH")])
+        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+        r = client.get(BACKOFFICE_YEARS_URL)
+        assert r.status_code == 200, r.text
+        assert r.json() == {"years": [], "latest": ""}
+
+    def test_no_backoffice_role_denied(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+        r = client.get(BACKOFFICE_YEARS_URL)
+        assert r.status_code == 403, r.text
+
+    def test_principal_denied_after_backoffice_grant_removal(self, client, monkeypatch):
+        """Pin the Phase 2 removal: CO2_USER_PRINCIPAL no longer grants
+        backoffice.users.edit, so a principal-only user must NOT pass the
+        backoffice gate."""
+        user = _user("11111", [_principal(UNIT_IID)])
+        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+        r = client.get(BACKOFFICE_YEARS_URL)
+        assert r.status_code == 403, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/v1/sync/active-pipelines/year/{year} — shared by the configuration
+# (data-management) page and the logs page. Both Backoffice Administrators
+# (scoped) and Super Admin (global) must reach it (#459 follow-up).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+ACTIVE_PIPELINES_URL = "/api/v1/sync/active-pipelines/year/2026"
+
+
+def _wire_active_pipelines(monkeypatch, user) -> None:
+    """Stub the DataIngestionRepository so the route handler can run."""
+    app.dependency_overrides[deps_module.get_current_user] = lambda: user
+
+    async def mock_get_db():
+        yield MagicMock()
+
+    app.dependency_overrides[deps_module.get_db] = mock_get_db
+
+    mock_repo = MagicMock()
+    mock_repo.get_active_year_level_pipeline_ids = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "app.api.v1.data_sync.DataIngestionRepository", lambda db: mock_repo
+    )
+
+
+class TestActivePipelinesPerYearGate:
+    """The route gates on ``backoffice.data_management:view`` under ANY scope.
+
+    Configuration page (Backoffice Administrator, affiliation-scoped) and
+    Logs page (Super Admin, global) both consume this endpoint — both must
+    pass.
+    """
+
+    def test_superadmin_passes(self, client, monkeypatch):
+        user = _user("11111", [_superadmin()])
+        _wire_active_pipelines(monkeypatch, user)
+        r = client.get(ACTIVE_PIPELINES_URL)
+        assert r.status_code == 200, r.text
+
+    def test_scoped_backoffice_metier_passes(self, client, monkeypatch):
+        """Pin the bug fix: a backoffice metier with only
+        ``backoffice.data_management/<aff>`` was 403'd by the old
+        ``require_permission`` strict lookup."""
+        user = _user("11111", [_backoffice_scoped("ENAC-SG")])
+        _wire_active_pipelines(monkeypatch, user)
+        r = client.get(ACTIVE_PIPELINES_URL)
+        assert r.status_code == 200, r.text
+
+    def test_principal_denied(self, client, monkeypatch):
+        user = _user("11111", [_principal(UNIT_IID)])
+        _wire_active_pipelines(monkeypatch, user)
+        r = client.get(ACTIVE_PIPELINES_URL)
+        assert r.status_code == 403, r.text
+
+    def test_std_denied(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire_active_pipelines(monkeypatch, user)
+        r = client.get(ACTIVE_PIPELINES_URL)
+        assert r.status_code == 403, r.text

--- a/backend/tests/integration/v1/test_permission_scope_e2e.py
+++ b/backend/tests/integration/v1/test_permission_scope_e2e.py
@@ -20,6 +20,7 @@ A test of this shape would have caught the regression — these are the tests
 that pin the chain back together.
 """
 
+import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -27,7 +28,14 @@ from fastapi.testclient import TestClient
 
 import app.api.deps as deps_module
 from app.main import app
-from app.models.user import GlobalScope, Role, RoleName, RoleScope
+from app.models.unit import Unit
+from app.models.user import (
+    GlobalScope,
+    Role,
+    RoleName,
+    RoleScope,
+    calculate_user_permissions,
+)
 
 UNIT_IID = "0184"
 OTHER_IID = "9999"
@@ -57,6 +65,10 @@ def _user(institutional_id: str, roles: list) -> MagicMock:
     u.email = "test@example.com"
     u.institutional_id = institutional_id
     u.roles = roles
+    # Route handlers that call ``current_user.calculate_permissions()``
+    # directly (e.g. the backoffice endpoints scoped by affiliation in #459)
+    # need the mock to return real permission keys.
+    u.calculate_permissions = lambda: calculate_user_permissions(roles)
     return u
 
 
@@ -70,6 +82,13 @@ def _std(iid: str) -> Role:
 
 def _backoffice() -> Role:
     return Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())
+
+
+def _backoffice_scoped(affiliation: str) -> Role:
+    return Role(
+        role=RoleName.CO2_BACKOFFICE_METIER,
+        on=RoleScope(affiliation=affiliation),
+    )
 
 
 def _superadmin() -> Role:
@@ -193,3 +212,154 @@ class TestPermissionScopeEndToEnd:
         data = r.json()
         assert len(data) == 1
         assert data[0]["institutional_id"] == "11111"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backoffice ACCRED affiliation scoping (#459)
+#
+# Affiliation-scoped backoffice managers (e.g. "Anna for SV") only hold
+# ``backoffice.X/<affiliation>`` permission keys. Endpoints that swap
+# ``require_permission`` for an inline ``any_scope=True`` gate must:
+#   1. let the request through (the user IS a backoffice manager),
+#   2. narrow results to units whose ``path_name`` carries the affiliation.
+# GlobalScope backoffice / superadmin keep the bare keys and bypass narrowing.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+BACKOFFICE_UNITS_URL = "/api/v1/backoffice-reporting/units"
+BACKOFFICE_AFFILIATIONS_URL = "/api/v1/backoffice-reporting/affiliations"
+
+
+def _unit(uid: int, iid: str, name: str, path_name: str, level: int = 3) -> Unit:
+    """Construct a fixture Unit (active by default)."""
+    return Unit(
+        id=uid,
+        institutional_code=str(uid),
+        institutional_id=iid,
+        name=name,
+        level=level,
+        path_name=path_name,
+        is_active=True,
+    )
+
+
+# Two-school fixture: one unit under SV, one under STI.
+_SV_UNIT = _unit(1, "sv-cf", "SV-LAB", "EPFL > SV > SV-LAB")
+_STI_UNIT = _unit(2, "sti-cf", "STI-LAB", "EPFL > STI > STI-LAB")
+
+
+def _wire_backoffice(monkeypatch, user, units: list) -> None:
+    """Wire dependency overrides for the backoffice endpoints.
+
+    Captures every ``where`` clause the route attaches and applies them to the
+    in-memory ``units`` fixture, so SQL-level filters (level, affiliation
+    predicate) actually narrow results. The route uses ``db.exec(query).all()``;
+    we honour ``query.where(...)`` chaining without touching real SQL.
+    """
+    app.dependency_overrides[deps_module.get_current_user] = lambda: user
+
+    async def mock_get_db():
+        db = MagicMock()
+
+        async def mock_exec(query):
+            # Compile the query and emulate the affiliation predicate in
+            # memory. We extract every ``LIKE '% <token> %'`` literal from
+            # the compiled SQL and require a unit's padded ``path_name`` to
+            # contain at least one of them. If no such literal appears, the
+            # query is un-narrowed (global caller) and we return all units.
+            #
+            # Coupled to the exact predicate shape from
+            # ``_affiliation_predicate``: any refactor that drops the
+            # ``LIKE lower('% <aff> %')`` form flips this to "no tokens" →
+            # all rows return → the scoped tests fail with the unscoped
+            # row count. That IS the signal that the predicate moved.
+            compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+            tokens = re.findall(r"like\s+lower\('% ([^ ]+?) %'\)", compiled, re.I)
+
+            def keep(u: Unit) -> bool:
+                if not tokens:
+                    return True
+                padded = f" {(u.path_name or '').lower()} "
+                return any(f" {t.lower()} " in padded for t in tokens)
+
+            result = MagicMock()
+            result.all = lambda: [u for u in units if keep(u)]
+            return result
+
+        db.exec = mock_exec
+        yield db
+
+    app.dependency_overrides[deps_module.get_db] = mock_get_db
+
+
+class TestBackofficeAffiliationScopeEndToEnd:
+    """Affiliation-scoped backoffice users only see units inside their
+    sub-perimeter; GlobalScope keeps full reach (#459)."""
+
+    def test_global_backoffice_sees_all_units(self, client, monkeypatch):
+        """GlobalScope backoffice → bare ``backoffice.users`` key → no narrowing."""
+        user = _user("11111", [_backoffice()])
+        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+        r = client.get(BACKOFFICE_UNITS_URL)
+        assert r.status_code == 200, r.text
+        names = {u["name"] for u in r.json()}
+        assert names == {"SV-LAB", "STI-LAB"}
+
+    def test_scoped_backoffice_sees_only_in_affiliation_units(
+        self, client, monkeypatch
+    ):
+        """SV-scoped caller → only SV unit in the response."""
+        user = _user("11111", [_backoffice_scoped("SV")])
+        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+        r = client.get(BACKOFFICE_UNITS_URL)
+        assert r.status_code == 200, r.text
+        names = {u["name"] for u in r.json()}
+        assert names == {"SV-LAB"}
+
+    def test_scoped_backoffice_cross_affiliation_returns_empty(
+        self, client, monkeypatch
+    ):
+        """SV-scoped caller against STI-only data → 200 empty list.
+        The gate accepts (the user holds ``backoffice.users/SV``) but the
+        affiliation predicate filters everything out."""
+        user = _user("11111", [_backoffice_scoped("SV")])
+        _wire_backoffice(monkeypatch, user, [_STI_UNIT])
+        r = client.get(BACKOFFICE_UNITS_URL)
+        assert r.status_code == 200, r.text
+        assert r.json() == []
+
+    def test_scoped_backoffice_multi_affiliation_unions(self, client, monkeypatch):
+        """A user holding both SV and STI roles sees the union."""
+        user = _user("11111", [_backoffice_scoped("SV"), _backoffice_scoped("STI")])
+        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+        r = client.get(BACKOFFICE_UNITS_URL)
+        assert r.status_code == 200, r.text
+        names = {u["name"] for u in r.json()}
+        assert names == {"SV-LAB", "STI-LAB"}
+
+    def test_no_backoffice_role_denied(self, client, monkeypatch):
+        """Std user → 403 (still gated on ``backoffice.users.view``)."""
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+        r = client.get(BACKOFFICE_UNITS_URL)
+        assert r.status_code == 403, r.text
+
+    def test_superadmin_sees_all_units(self, client, monkeypatch):
+        """Regression guard: superadmin still bypasses narrowing."""
+        user = _user("11111", [_superadmin()])
+        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+        r = client.get(BACKOFFICE_UNITS_URL)
+        assert r.status_code == 200, r.text
+        assert len(r.json()) == 2
+
+    def test_scoped_backoffice_affiliations_endpoint(self, client, monkeypatch):
+        """``/backoffice/affiliations`` mirrors ``/units`` for narrowing.
+        Build the fixture at level 2/3 (the endpoint filters levels in [2, 3])."""
+        sv_aff = _unit(10, "sv-fac", "SV-FAC", "EPFL > SV", level=2)
+        sti_aff = _unit(11, "sti-fac", "STI-FAC", "EPFL > STI", level=2)
+        user = _user("11111", [_backoffice_scoped("SV")])
+        _wire_backoffice(monkeypatch, user, [sv_aff, sti_aff])
+        r = client.get(BACKOFFICE_AFFILIATIONS_URL)
+        assert r.status_code == 200, r.text
+        names = {u["name"] for u in r.json()}
+        assert names == {"SV-FAC"}

--- a/backend/tests/unit/models/test_user_base_calculate_permissions.py
+++ b/backend/tests/unit/models/test_user_base_calculate_permissions.py
@@ -51,13 +51,19 @@ class TestUserBaseCalculatePermissions:
         assert "export" in perms["backoffice.users"]
 
     def test_calculate_permissions_multiple_roles(self):
-        """Test calculate_permissions with multiple roles."""
+        """Test calculate_permissions with multiple roles.
+
+        CO2_BACKOFFICE_METIER is sub-perimeter-bound (affiliation-scoped);
+        combined with CO2_USER_STD it yields a scoped backoffice key plus
+        the std module key."""
         user_base = UserBase()
         user_base.roles = [
-            Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope()),
+            Role(
+                role=RoleName.CO2_BACKOFFICE_METIER,
+                on=RoleScope(affiliation="SV"),
+            ),
             Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="12345")),
         ]
         perms = user_base.calculate_permissions()
-        # Should have both backoffice and module permissions
-        assert "view" in perms["backoffice.users"]
+        assert "view" in perms["backoffice.users/SV"]
         assert "view" in perms["modules.professional_travel/12345"]

--- a/backend/tests/unit/providers/test_role_provider.py
+++ b/backend/tests/unit/providers/test_role_provider.py
@@ -302,14 +302,19 @@ class TestAccredRoleProvider:
     async def test_accred_fetch_roles_with_backoffice_metier(
         self, accred_provider, sample_user_id
     ):
-        """Test fetching backoffice.metier role with affiliation scope."""
+        """ACCRED sortpath is a 4-level hierarchy; affiliation is LVL3."""
         mock_response = {
             "authorizations": [
                 {
                     "name": f"{RoleName.CO2_BACKOFFICE_METIER.value}",
                     "state": "active",
                     "accredunitid": "12345",
-                    "reason": {"resource": {"cf": "12345", "sortpath": "Engineering"}},
+                    "reason": {
+                        "resource": {
+                            "cf": "12345",
+                            "sortpath": "EPFL ENAC ENAC-SG ENAC-IT",
+                        }
+                    },
                 }
             ]
         }
@@ -331,8 +336,40 @@ class TestAccredRoleProvider:
         assert len(roles) == 1
         assert roles[0] == Role(
             role=RoleName.CO2_BACKOFFICE_METIER,
-            on=RoleScope(affiliation="Engineering"),
+            on=RoleScope(affiliation="ENAC-SG"),
         )
+
+    @pytest.mark.asyncio
+    async def test_accred_backoffice_metier_short_sortpath_skipped(
+        self, accred_provider, sample_user_id
+    ):
+        """Sortpath shorter than 3 levels cannot resolve LVL3 — role is dropped."""
+        mock_response = {
+            "authorizations": [
+                {
+                    "name": f"{RoleName.CO2_BACKOFFICE_METIER.value}",
+                    "state": "active",
+                    "accredunitid": "12345",
+                    "reason": {"resource": {"cf": "12345", "sortpath": "EPFL ENAC"}},
+                }
+            ]
+        }
+
+        with patch(
+            "app.providers.role_provider.httpx.AsyncClient"
+        ) as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response_obj = AsyncMock()
+            mock_response_obj.json = Mock(return_value=mock_response)
+            mock_response_obj.raise_for_status = Mock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response_obj
+
+            mock_client_class.return_value = mock_client
+
+            roles = await accred_provider.get_roles_by_user_id(sample_user_id)
+
+        assert roles == []
 
     @pytest.mark.asyncio
     async def test_accred_no_authorizations_found(

--- a/backend/tests/unit/utils/test_permissions.py
+++ b/backend/tests/unit/utils/test_permissions.py
@@ -540,15 +540,36 @@ class TestPermissionInvariants:
                 )
 
     @pytest.mark.parametrize("roles", _INVARIANT_ROLE_LISTS)
-    def test_backoffice_and_system_keys_never_scoped(self, roles):
-        """``backoffice.*`` and ``system.*`` permissions are flat (un-scoped).
-        Adding a unit suffix to them would silently break un-scoped lookups."""
+    def test_system_keys_never_scoped(self, roles):
+        """``system.*`` permissions are flat — adding a unit suffix would
+        silently break un-scoped lookups. (``backoffice.*`` is scoped by
+        affiliation for sub-perimeter managers since #459; see the dedicated
+        backoffice tests below.)"""
         perms = calculate_user_permissions(roles)
         for key in perms:
-            if key.startswith(("backoffice.", "system.")):
+            if key.startswith("system."):
                 assert "/" not in key, (
-                    f"Scoped non-module key found: {key!r} (roles={roles})"
+                    f"Scoped system key found: {key!r} (roles={roles})"
                 )
+
+    @pytest.mark.parametrize("roles", _INVARIANT_ROLE_LISTS)
+    def test_backoffice_keys_only_scoped_by_affiliation(self, roles):
+        """Backoffice keys are either bare (GlobalScope / superadmin / principal
+        side-grant) or carry an affiliation suffix ``/<aff>`` (#459). A unit-id
+        suffix on a backoffice key would mean a wrongly-shaped scope leaked
+        through ``as_scope_key``."""
+        perms = calculate_user_permissions(roles)
+        for key in perms:
+            if not key.startswith("backoffice."):
+                continue
+            if "/" not in key:
+                continue
+            suffix = key.split("/", 1)[1]
+            # Affiliations are name-like tokens (e.g. "SV", "Engineering") —
+            # never the all-digit institutional_id shape ("0184", "10208").
+            assert not suffix.isdigit(), (
+                f"Backoffice key carries unit-id suffix: {key!r} (roles={roles})"
+            )
 
     def test_principal_subsumes_std_for_same_unit(self):
         """``[std, principal]`` for the same unit yields the same key-set as
@@ -574,23 +595,77 @@ class TestPermissionInvariants:
             )
 
 
-class TestBackofficeScopingCurrentBehavior:
-    """Pin current backoffice-permission scoping behaviour.
+class TestBackofficeAffiliationScoping:
+    """Backoffice sub-perimeter scoping by ACCRED affiliation (#459).
 
-    Backoffice metier permissions are ALWAYS stored un-scoped today, even when
-    the role itself carries a ``RoleScope`` (institutional_id or affiliation).
-    Issue #459 will introduce a sub-perimeter (per-affiliation) scoping for
-    backoffice managers (e.g. "Anna can only see SV"). When that lands, these
-    tests are expected to fail — that's the signal to update the contract.
-
-    NOTE: Affiliation-based roles are intentionally only meaningful for
-    backoffice; we do not test affiliation on ``user.*`` roles because the
-    role-assignment layer is responsible for never producing that shape.
+    Affiliation-scoped backoffice users hold ``backoffice.X/<affiliation>``
+    keys; GlobalScope users keep the bare ``backoffice.X`` keys. The two
+    shapes coexist via the ``any_scope=True`` lookup mode on endpoints.
     """
 
-    def test_backoffice_with_iid_role_scope_keys_stay_unscoped(self):
-        # TODO(#459): backoffice scoping by sub-perimeter — replace this with
-        # a scoped assertion once the new key shape is decided.
+    _BACKOFFICE_BARE = (
+        "backoffice.reporting",
+        "backoffice.users",
+        "backoffice.data_management",
+        "backoffice.documentation",
+    )
+
+    def test_affiliation_scope_emits_scoped_keys_only(self):
+        """Anna (affiliation=SV) should only hold ``backoffice.X/SV`` keys."""
+        roles = [
+            Role(
+                role=RoleName.CO2_BACKOFFICE_METIER,
+                on=RoleScope(affiliation="SV"),
+            )
+        ]
+        perms = calculate_user_permissions(roles)
+        expected = {f"{p}/SV" for p in self._BACKOFFICE_BARE}
+        assert set(perms) == expected
+        # Action sets must be preserved on the scoped keys.
+        assert set(perms["backoffice.users/SV"]) == {"view", "edit", "export"}
+        assert set(perms["backoffice.reporting/SV"]) == {"view", "export"}
+
+    def test_global_scope_keeps_bare_keys(self):
+        """Regression guard: GlobalScope backoffice stays un-scoped."""
+        roles = [Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())]
+        perms = calculate_user_permissions(roles)
+        for path in self._BACKOFFICE_BARE:
+            assert path in perms, f"missing bare key {path}"
+            assert f"{path}/" not in " ".join(perms), (
+                f"GlobalScope leaked a scoped variant of {path}"
+            )
+
+    def test_multi_affiliation_unions(self):
+        """Two backoffice roles on SV and STI → both scoped keys present."""
+        roles = [
+            Role(
+                role=RoleName.CO2_BACKOFFICE_METIER,
+                on=RoleScope(affiliation="SV"),
+            ),
+            Role(
+                role=RoleName.CO2_BACKOFFICE_METIER,
+                on=RoleScope(affiliation="STI"),
+            ),
+        ]
+        perms = calculate_user_permissions(roles)
+        assert "backoffice.users/SV" in perms
+        assert "backoffice.users/STI" in perms
+        assert "backoffice.users" not in perms
+
+    def test_affiliation_scope_via_dict_role(self):
+        """Roles deserialized from JSON come in as dicts — the dict branch of
+        ``as_scope_key`` must produce the same ``/<affiliation>`` suffix."""
+        role_dict = {
+            "role": RoleName.CO2_BACKOFFICE_METIER.value,
+            "on": {"affiliation": "SV"},
+        }
+        perms = calculate_user_permissions([Role(**role_dict)])
+        assert "backoffice.users/SV" in perms
+
+    def test_iid_role_scope_falls_back_to_unscoped(self):
+        """Defensive: ACCRED never produces this shape for backoffice today,
+        but if it ever leaks through we degrade gracefully to un-scoped keys
+        rather than emitting a meaningless ``backoffice.users/0184``."""
         roles = [
             Role(
                 role=RoleName.CO2_BACKOFFICE_METIER,
@@ -602,25 +677,25 @@ class TestBackofficeScopingCurrentBehavior:
             assert key.startswith("backoffice."), (
                 f"unexpected non-backoffice key: {key!r}"
             )
-            assert "/" not in key, f"backoffice key carries a scope suffix: {key!r}"
+            assert "/" not in key, f"unexpected scope suffix: {key!r}"
 
-    def test_backoffice_with_affiliation_role_scope_keys_stay_unscoped(self):
-        # TODO(#459): this is exactly the case the new sub-perimeter scoping
-        # is meant to address — Anna with affiliation "SV" should only see
-        # data for SV. Update this test then.
-        roles = [
-            Role(
-                role=RoleName.CO2_BACKOFFICE_METIER,
-                on=RoleScope(affiliation="SV"),
-            )
-        ]
-        perms = calculate_user_permissions(roles)
-        assert perms, "backoffice on affiliation should currently grant flat perms"
-        for key in perms:
-            assert key.startswith("backoffice."), (
-                f"unexpected non-backoffice key: {key!r}"
-            )
-            assert "/" not in key, f"backoffice key carries a scope suffix: {key!r}"
+
+class TestHasPermissionAnyScopeAffiliation:
+    """``has_permission(..., any_scope=True)`` must match affiliation keys.
+
+    This pins the rationale for swapping ``require_permission`` for an inline
+    ``any_scope=True`` check on the backoffice endpoints (#459).
+    """
+
+    def test_any_scope_matches_affiliation_key(self):
+        perms = {"backoffice.users/SV": ["view", "edit", "export"]}
+        assert has_permission(perms, "backoffice.users", "view", any_scope=True) is True
+
+    def test_default_lookup_misses_affiliation_key(self):
+        """A bare-path lookup against an affiliation-only user must return
+        False — this is exactly why the endpoints need ``any_scope=True``."""
+        perms = {"backoffice.users/SV": ["view"]}
+        assert has_permission(perms, "backoffice.users", "view") is False
 
 
 class TestHasPermissionAgainstRealPermissions:

--- a/backend/tests/unit/utils/test_permissions.py
+++ b/backend/tests/unit/utils/test_permissions.py
@@ -41,14 +41,13 @@ class TestCalculateUserPermissions:
         assert "modules.headcount" not in result
         assert "modules.equipment" not in result
 
-    def test_backoffice_metier_global_scope(self):
-        """Test backoffice metier with global scope grants full backoffice access."""
+    def test_backoffice_metier_global_scope_grants_nothing(self):
+        """CO2_BACKOFFICE_METIER is sub-perimeter-bound: a GlobalScope shape is
+        not produced by ACCRED and grants no permissions. Only CO2_SUPERADMIN
+        gets cross-affiliation backoffice reach."""
         roles = [Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())]
         result = calculate_user_permissions(roles)
-
-        assert "view" in result["backoffice.users"]
-        assert "edit" in result["backoffice.users"]
-        assert "export" in result["backoffice.users"]
+        assert result == {}
 
     def test_superadmin_wrong_scope(self):
         """Test superadmin with unit scope does not grant permissions."""
@@ -85,8 +84,12 @@ class TestCalculateUserPermissions:
         assert "edit" in result["modules.research_facilities/10208"]
         assert "view" in result["modules.external_cloud_and_ai/10208"]
         assert "edit" in result["modules.external_cloud_and_ai/10208"]
-        # Principal also gets backoffice.users.edit for unit-scoped role assignment
-        assert "edit" in result["backoffice.users"]
+        # Principal is a unit role only — no backoffice.* grants. Backoffice
+        # access requires CO2_BACKOFFICE_METIER (or CO2_SUPERADMIN).
+        assert not any(key.startswith("backoffice.") for key in result), (
+            f"Principal leaked backoffice keys: "
+            f"{[k for k in result if k.startswith('backoffice.')]}"
+        )
 
     def test_user_std_unit_scope(self):
         """Test user std with unit scope grants view and edit for professional_travel."""  # noqa: E501
@@ -115,17 +118,24 @@ class TestCalculateUserPermissions:
         assert "modules.headcount/10208" not in result
 
     def test_combined_backoffice_and_user_roles(self):
-        """Test that permissions from different domains combine."""
+        """Test that permissions from different domains combine.
+
+        Uses the affiliation-scoped backoffice shape because that is the only
+        valid CO2_BACKOFFICE_METIER configuration (GlobalScope is not produced
+        by ACCRED for this role)."""
         roles = [
-            Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope()),
+            Role(
+                role=RoleName.CO2_BACKOFFICE_METIER,
+                on=RoleScope(affiliation="SV"),
+            ),
             Role(role=RoleName.CO2_USER_STD, on=RoleScope(institutional_id="10208")),
         ]
         result = calculate_user_permissions(roles)
 
-        # Backoffice permissions
-        assert "backoffice.users" in result
-        assert "view" in result["backoffice.users"]
-        assert "edit" in result["backoffice.users"]
+        # Backoffice permissions (affiliation-scoped key shape)
+        assert "backoffice.users/SV" in result
+        assert "view" in result["backoffice.users/SV"]
+        assert "edit" in result["backoffice.users/SV"]
 
         # Module permissions - CO2_USER_STD grants professional_travel.view and edit
         assert "view" in result["modules.professional_travel/10208"]
@@ -354,7 +364,18 @@ _PRINCIPAL_MODULES = (
 )
 _STD_MODULES = ("professional_travel", "external_cloud_and_ai")
 
+_BACKOFFICE_AFF = "SV"
+# Scoped key shape emitted by CO2_BACKOFFICE_METIER (affiliation-bound).
 _BACKOFFICE_KEYS = frozenset(
+    {
+        f"backoffice.reporting/{_BACKOFFICE_AFF}",
+        f"backoffice.users/{_BACKOFFICE_AFF}",
+        f"backoffice.data_management/{_BACKOFFICE_AFF}",
+        f"backoffice.documentation/{_BACKOFFICE_AFF}",
+    }
+)
+# Bare key shape emitted by CO2_SUPERADMIN (cross-affiliation reach).
+_BACKOFFICE_KEYS_BARE = frozenset(
     {
         "backoffice.reporting",
         "backoffice.users",
@@ -382,7 +403,12 @@ def _r_std(iid: str) -> Role:
 
 
 def _r_backoffice() -> Role:
-    return Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())
+    """Backoffice metier — always sub-perimeter-bound (affiliation-scoped).
+    GlobalScope is not a valid configuration for this role."""
+    return Role(
+        role=RoleName.CO2_BACKOFFICE_METIER,
+        on=RoleScope(affiliation=_BACKOFFICE_AFF),
+    )
 
 
 def _r_superadmin() -> Role:
@@ -402,12 +428,9 @@ class TestRoleDomainIsolation:
             pytest.param(_r_std(_IID_A), ("modules.",), id="std"),
             pytest.param(
                 _r_principal(_IID_A),
-                # TODO(pm-confirm): principal currently grants
-                # ``backoffice.users.edit`` (for unit-scoped role assignment).
-                # Verify with PM whether this exception is still desired; if
-                # removed, drop "backoffice.users" below and the matching line
-                # in calculate_user_permissions.
-                ("modules.", "backoffice.users"),
+                # Principal is a unit-area role: only modules.* keys.
+                # (backoffice.users.edit was removed in #459 Phase 2.)
+                ("modules.",),
                 id="principal",
             ),
             pytest.param(_r_backoffice(), ("backoffice.",), id="backoffice"),
@@ -441,55 +464,60 @@ _STD_KEYS_B = _modules(_STD_MODULES, _IID_B)
 _COMPOSITION_CASES = [
     pytest.param(
         [_r_principal(_IID_A)],
-        # TODO(pm-confirm): principal grants backoffice.users.edit
-        _PRINCIPAL_KEYS_A | {"backoffice.users"},
-        _PRINCIPAL_KEYS_B | _SYSTEM_KEYS | (_BACKOFFICE_KEYS - {"backoffice.users"}),
+        _PRINCIPAL_KEYS_A,
+        _PRINCIPAL_KEYS_B | _SYSTEM_KEYS | _BACKOFFICE_KEYS | _BACKOFFICE_KEYS_BARE,
         id="principal-A",
     ),
     pytest.param(
         [_r_std(_IID_A)],
         _STD_KEYS_A,
-        (_PRINCIPAL_KEYS_A - _STD_KEYS_A) | _BACKOFFICE_KEYS | _SYSTEM_KEYS,
+        (_PRINCIPAL_KEYS_A - _STD_KEYS_A)
+        | _BACKOFFICE_KEYS
+        | _BACKOFFICE_KEYS_BARE
+        | _SYSTEM_KEYS,
         id="std-A",
     ),
     pytest.param(
+        # Backoffice metier is sub-perimeter-bound → scoped key shape only.
         [_r_backoffice()],
         set(_BACKOFFICE_KEYS),
-        _PRINCIPAL_KEYS_A | _SYSTEM_KEYS,
+        _PRINCIPAL_KEYS_A | _BACKOFFICE_KEYS_BARE | _SYSTEM_KEYS,
         id="backoffice",
     ),
     pytest.param(
+        # Superadmin is the only role with cross-affiliation reach → bare keys.
         [_r_superadmin()],
-        set(_BACKOFFICE_KEYS) | set(_SYSTEM_KEYS),
-        _PRINCIPAL_KEYS_A,
+        set(_BACKOFFICE_KEYS_BARE) | set(_SYSTEM_KEYS),
+        _PRINCIPAL_KEYS_A | _BACKOFFICE_KEYS,
         id="superadmin",
     ),
     pytest.param(
         # std + principal on the same unit: principal subsumes std (idempotent).
         [_r_std(_IID_A), _r_principal(_IID_A)],
-        _PRINCIPAL_KEYS_A | {"backoffice.users"},
-        _PRINCIPAL_KEYS_B | _SYSTEM_KEYS,
+        _PRINCIPAL_KEYS_A,
+        _PRINCIPAL_KEYS_B | _SYSTEM_KEYS | _BACKOFFICE_KEYS | _BACKOFFICE_KEYS_BARE,
         id="std+principal-same-unit",
     ),
     pytest.param(
         # Multi-unit: full perms on A, only travel+cloud on B. Critically,
         # principal-only modules MUST NOT appear under /B.
         [_r_principal(_IID_A), _r_std(_IID_B)],
-        _PRINCIPAL_KEYS_A | _STD_KEYS_B | {"backoffice.users"},
-        _PRINCIPAL_KEYS_B - _STD_KEYS_B,
+        _PRINCIPAL_KEYS_A | _STD_KEYS_B,
+        (_PRINCIPAL_KEYS_B - _STD_KEYS_B) | _BACKOFFICE_KEYS | _BACKOFFICE_KEYS_BARE,
         id="principal-A+std-B",
     ),
     pytest.param(
         # Two domains active: backoffice + principal — system.* must stay absent.
         [_r_backoffice(), _r_principal(_IID_A)],
         _PRINCIPAL_KEYS_A | _BACKOFFICE_KEYS,
-        set(_SYSTEM_KEYS),
+        set(_SYSTEM_KEYS) | _BACKOFFICE_KEYS_BARE,
         id="backoffice+principal",
     ),
     pytest.param(
         # All three domains — full union, nothing forbidden.
+        # Backoffice metier adds scoped keys; superadmin adds bare keys.
         [_r_superadmin(), _r_backoffice(), _r_principal(_IID_A)],
-        _PRINCIPAL_KEYS_A | _BACKOFFICE_KEYS | _SYSTEM_KEYS,
+        _PRINCIPAL_KEYS_A | _BACKOFFICE_KEYS | _BACKOFFICE_KEYS_BARE | _SYSTEM_KEYS,
         set(),
         id="superadmin+backoffice+principal",
     ),
@@ -611,7 +639,13 @@ class TestBackofficeAffiliationScoping:
     )
 
     def test_affiliation_scope_emits_scoped_keys_only(self):
-        """Anna (affiliation=SV) should only hold ``backoffice.X/SV`` keys."""
+        """An SV-scoped backoffice user should only hold ``backoffice.X/SV`` keys.
+
+        Action sets follow the EPFL role spec for Backoffice Administrator:
+        users (view/edit/export), reporting (view/export), data_management
+        (view/export ONLY — edit + sync are Super Admin exclusives),
+        documentation (view/edit).
+        """
         roles = [
             Role(
                 role=RoleName.CO2_BACKOFFICE_METIER,
@@ -621,19 +655,55 @@ class TestBackofficeAffiliationScoping:
         perms = calculate_user_permissions(roles)
         expected = {f"{p}/SV" for p in self._BACKOFFICE_BARE}
         assert set(perms) == expected
-        # Action sets must be preserved on the scoped keys.
+        # Action sets must match the role spec on the scoped keys.
         assert set(perms["backoffice.users/SV"]) == {"view", "edit", "export"}
         assert set(perms["backoffice.reporting/SV"]) == {"view", "export"}
+        assert set(perms["backoffice.data_management/SV"]) == {"view", "export"}
+        assert set(perms["backoffice.documentation/SV"]) == {"view", "edit"}
 
-    def test_global_scope_keeps_bare_keys(self):
-        """Regression guard: GlobalScope backoffice stays un-scoped."""
-        roles = [Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())]
+    def test_scoped_backoffice_lacks_data_management_sync(self):
+        """Regression pin: scoped backoffice metier MUST NOT have edit or sync
+        on data_management. Granting those would let a non-Super-Admin trigger
+        pipeline syncs or mutate factor data the moment a route is opened
+        any-scope."""
+        roles = [
+            Role(
+                role=RoleName.CO2_BACKOFFICE_METIER,
+                on=RoleScope(affiliation="SV"),
+            )
+        ]
+        perms = calculate_user_permissions(roles)
+        assert "edit" not in perms["backoffice.data_management/SV"]
+        assert "sync" not in perms["backoffice.data_management/SV"]
+
+    def test_superadmin_has_data_management_edit_and_sync(self):
+        """Counterpart: Super Admin keeps all four actions on data_management."""
+        roles = [Role(role=RoleName.CO2_SUPERADMIN, on=GlobalScope())]
+        perms = calculate_user_permissions(roles)
+        assert set(perms["backoffice.data_management"]) == {
+            "view",
+            "edit",
+            "export",
+            "sync",
+        }
+
+    def test_superadmin_keeps_bare_keys(self):
+        """CO2_SUPERADMIN is the only role with cross-affiliation reach; it
+        emits bare backoffice.* keys (no ``/<aff>`` suffix). CO2_BACKOFFICE_METIER
+        is always sub-perimeter-bound and cannot reach this shape."""
+        roles = [Role(role=RoleName.CO2_SUPERADMIN, on=GlobalScope())]
         perms = calculate_user_permissions(roles)
         for path in self._BACKOFFICE_BARE:
             assert path in perms, f"missing bare key {path}"
             assert f"{path}/" not in " ".join(perms), (
-                f"GlobalScope leaked a scoped variant of {path}"
+                f"Superadmin leaked a scoped variant of {path}"
             )
+
+    def test_backoffice_metier_global_scope_grants_nothing(self):
+        """Regression guard: CO2_BACKOFFICE_METIER + GlobalScope is an
+        unconfigured shape (never produced by ACCRED) and yields no permissions."""
+        roles = [Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())]
+        assert calculate_user_permissions(roles) == {}
 
     def test_multi_affiliation_unions(self):
         """Two backoffice roles on SV and STI → both scoped keys present."""

--- a/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
+++ b/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
@@ -1,9 +1,34 @@
 ---
-status: draft
+status: delivered
 issue: 459
 last_updated: 2026-05-22
 title: "Backoffice ACCRED affiliation scoping"
 summary: "Scope backoffice.* permissions by ACCRED-provided affiliation so each backoffice manager sees only their sub-perimeter."
+---
+
+## Delivered
+
+Shipped in PR #1271 on `feat/459-backoffice-accred-affiliation-scoping`. Divergences from the original plan:
+
+- **URL prefix**: the affected endpoints are mounted at `/api/v1/backoffice-reporting/{affiliations,units}` (not `/api/v1/backoffice/...`). The plan referenced the file path `backend/app/api/v1/backoffice_reporting.py` correctly; only the public URL was misstated.
+- **`as_scope_key` branching**: backoffice metier with `RoleScope(institutional_id=...)` falls back to un-scoped keys rather than emitting a meaningless `backoffice.users/<iid>`. ACCRED never produces this shape today (only `GlobalScope` or `RoleScope(affiliation=...)`), so the defensive un-scoped degrade is safer than introducing a key shape no consumer matches.
+- **Permission helper**: added `derive_backoffice_affiliations(permissions, anchor_path)` in `backend/app/utils/permissions.py` to parse `(is_global, affiliations)` from the permission dict — both endpoints share it via `_gate_backoffice_users_view` in `backend/app/api/v1/backoffice_reporting.py`.
+- **`path_name` predicate**: implemented as `concat(' ', coalesce(path_name, ''), ' ') ILIKE '% <aff> %'`, which covers both observed separators (`' > '` and plain space) in a single clause, handles NULL `path_name`, and avoids the `SV ↔ SVOPS` boundary bug.
+- **Empty-affiliation semantic** (open question #6): chose `200 []` — the gate accepts (the user is a backoffice manager) and the predicate filters everything out.
+- **Cross-endpoint blast radius** (open question #5): the broader `/api/v1/backoffice/*` surface (`backend/app/api/v1/backoffice.py`: list reporting units, exports; `backend/app/api/v1/data_sync.py`: sync endpoints; `backend/app/api/v1/factors.py`) still gates via `require_permission`, so affiliation-scoped users will now 403 on those routes. This is the security-correct posture (an SV manager has no business exporting global user lists or triggering global syncs) and is left explicit. Follow-up scoping for these endpoints, if needed, can reuse `_gate_backoffice_users_view` + `_affiliation_predicate`.
+
+The four pinning tests in `TestBackofficeScopingCurrentBehavior` were replaced by `TestBackofficeAffiliationScoping` + `TestHasPermissionAnyScopeAffiliation` in `backend/tests/unit/utils/test_permissions.py`. The `test_backoffice_and_system_keys_never_scoped` invariant was split into a strict `system.*` invariant and a relaxed `backoffice.*` rule that allows non-digit (affiliation) suffixes. End-to-end coverage lives in `TestBackofficeAffiliationScopeEndToEnd` in `backend/tests/integration/v1/test_permission_scope_e2e.py`.
+
+## Known follow-up (frontend)
+
+`frontend/src/utils/permission.ts:hasPermission()` does a strict `path in permissions` lookup. After this PR, an affiliation-scoped backoffice user holds only `backoffice.users/<aff>` keys (no bare `backoffice.users`), so the following call sites will hide menu items and block navigation for them:
+
+- `frontend/src/components/layout/Co2Header.vue:53` — backoffice header entry.
+- `frontend/src/components/layout/Co2Sidebar.vue:23` — backoffice sidebar entry.
+- `frontend/src/router/routes.ts` (8 occurrences) — backoffice route guards.
+
+This is out of scope for this PR (backend-only per the issue scope), but is a hard prerequisite for affiliation-scoped backoffice users to actually USE the affiliation-filtered endpoints. Recommended fix: extend `hasPermission()` (or add a sibling `hasAnyScopePermission()`) to fall back to `path/<*>` keys when the bare key is absent, mirroring the backend `any_scope=True` mode. Track as a follow-up issue.
+
 ---
 
 ## Problem

--- a/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
+++ b/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: in-progress
 issue: 459
 last_updated: 2026-05-26
 title: "Backoffice ACCRED affiliation scoping"

--- a/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
+++ b/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
@@ -1,0 +1,151 @@
+---
+status: draft
+issue: 459
+last_updated: 2026-05-22
+title: "Backoffice ACCRED affiliation scoping"
+summary: "Scope backoffice.* permissions by ACCRED-provided affiliation so each backoffice manager sees only their sub-perimeter."
+---
+
+## Problem
+
+`RoleScope.affiliation` exists on the user model (`backend/app/models/user.py:31`) and the ACCRED provider already populates it from the `reason.resource.sortpath` field of each `calco2.backoffice.metier` authorization (`backend/app/providers/role_provider.py:544-554`). However, the affiliation is currently ignored downstream:
+
+- `as_scope_key()` returns `""` for any `RoleScope` with only an affiliation set (`backend/app/models/user.py:137-138, 142-143`), with an inline comment acknowledging the gap.
+- `calculate_user_permissions()` emits a fixed, **unscoped** key set for `CO2_BACKOFFICE_METIER` — `backoffice.reporting`, `backoffice.users`, `backoffice.data_management`, `backoffice.documentation` — regardless of whether the role is `GlobalScope` or `RoleScope(affiliation=...)` (`backend/app/models/user.py:164-186`).
+- `/backoffice/affiliations` and `/backoffice/units` (`backend/app/api/v1/backoffice_reporting.py:20-108`) gate on `require_permission("backoffice.users", "view")` and return **all active units** with no per-caller filtering.
+
+Concrete impact: Anna, a Faculty SV backoffice manager whose ACCRED `sortpath` is `"SV"`, has the same blast radius as a global backoffice admin. She sees STI, IC, ENAC, CDH, CDM units in the affiliation/unit dropdowns and reporting tables. This violates the EPFL accreditation model and the explicit ACCRED contract that backoffice roles are sub-perimeter-bound.
+
+## Decision applied
+
+Backoffice "sub-perimeter" comes from **ACCRED-provided affiliation(s) on the user**. Populate `RoleScope.affiliation` from ACCRED (already done); emit `backoffice.*/{affiliation}` keys; filter `/backoffice/affiliations`, `/backoffice/units`, and any backoffice reporting endpoints by the user's affiliations.
+
+`GlobalScope` (superadmin, plus any backoffice role explicitly granted globally) continues to bypass affiliation filtering. Affiliation acts purely as a narrowing predicate on top of the existing permission gate.
+
+## Files to change
+
+- `backend/app/models/user.py`
+  - `as_scope_key()` (lines 127-145): return `f"/{s.affiliation}"` instead of `""` when only `affiliation` is set.
+  - `calculate_user_permissions()` (lines 164-186): for `CO2_BACKOFFICE_METIER` with `RoleScope(affiliation=...)`, emit `backoffice.reporting/{affiliation}`, `backoffice.users/{affiliation}`, `backoffice.data_management/{affiliation}`, `backoffice.documentation/{affiliation}`. `GlobalScope` keeps the bare keys.
+- `backend/app/api/v1/backoffice_reporting.py`
+  - `list_affiliations()` (lines 20-59): swap `require_permission("backoffice.users", "view")` for an inline gate that uses `has_permission(..., any_scope=True)`, then filter by the caller's affiliation set.
+  - `list_units()` (lines 62-108): same gate change + same affiliation filter.
+- `backend/tests/unit/models/test_user.py` (or the existing matching test file — locate during impl): add cases for `as_scope_key(RoleScope(affiliation="SV"))` → `"/SV"` and `calculate_user_permissions([backoffice_metier @ affiliation=SV])` emitting only the four `backoffice.*/SV` keys.
+- `backend/tests/integration/v1/test_permission_scope_e2e.py`: add `_backoffice_scoped(affiliation)` helper and three new test methods (see Tests section).
+
+Files explicitly **not** changed:
+
+- `backend/app/providers/role_provider.py` — ACCRED → `RoleScope.affiliation` mapping is already in place (verified at lines 544-554; covered by `test_role_provider.py:301-335`).
+- `backend/app/utils/permissions.py` — `has_permission(..., any_scope=True)` already supports the lookup pattern we need; no signature change.
+- `backend/app/core/security.py` — `require_permission`/`is_permitted` keep their current shape; the backoffice endpoints simply stop using `require_permission` and inline a scoped check, mirroring the taxonomy-route precedent already documented in `utils/permissions.py:32-38`.
+- `frontend/src/components/organisms/backoffice/reporting/` — backend-side narrowing is sufficient; the existing dropdowns already render whatever the API returns.
+
+## Approach
+
+1. **Fix `as_scope_key`** (`backend/app/models/user.py:127-145`). Replace the two `if s.affiliation: return ""` branches with `return f"/{s.affiliation}"`. Both the `RoleScope` and `dict` branches need updating. This is a single-line semantic change but it is load-bearing for everything downstream.
+
+2. **Branch `calculate_user_permissions` on scope type for backoffice** (`backend/app/models/user.py:164-186`). The current code emits the same four bare keys whether `is_global_scope(scope)` or `is_role_scope(scope)`. Split the branch:
+   - If `is_global_scope(scope)`: keep emitting the bare keys (`backoffice.reporting`, `backoffice.users`, `backoffice.data_management`, `backoffice.documentation`) — global backoffice keeps cross-affiliation reach.
+   - If `is_role_scope(scope)` and `scope_key` (from `as_scope_key`) is non-empty: emit `backoffice.reporting{scope_key}`, `backoffice.users{scope_key}`, `backoffice.data_management{scope_key}`, `backoffice.documentation{scope_key}`. A user with two `CO2_BACKOFFICE_METIER` roles on `SV` and `STI` ends up with both `backoffice.users/SV` and `backoffice.users/STI` (natural union via the merge_actions pattern).
+   - The `CO2_SUPERADMIN` branch (line 275-303) already requires `is_global_scope`, no change.
+
+3. **Swap the endpoint gate** in `backend/app/api/v1/backoffice_reporting.py`. Replace `current_user: User = Depends(require_permission("backoffice.users", "view"))` on both endpoints with `current_user: User = Depends(get_current_active_user)` and call `has_permission(current_user.calculate_permissions(), "backoffice.users", "view", any_scope=True)` at the top of each handler — raise `HTTPException(403)` on miss. Rationale: `require_permission` does a literal-path lookup via `is_permitted` → `fnmatch` (`backend/app/core/security.py:210-217`) which fails for users whose only key is `backoffice.users/SV`. The `any_scope=True` path on `has_permission` (`backend/app/utils/permissions.py:55-67`) is the exact mechanism we need and matches the taxonomy precedent.
+
+4. **Derive the caller's affiliation set** inside each handler. Pseudocode:
+
+   ```python
+   perms = current_user.calculate_permissions()
+   is_global = "backoffice.users" in perms  # bare key only emitted for GlobalScope
+   affiliations = {
+       k.removeprefix("backoffice.users/")
+       for k in perms
+       if k.startswith("backoffice.users/")
+   }
+   ```
+
+   If `is_global` is true, skip the affiliation predicate entirely. Otherwise apply it. (Use `backoffice.users` as the canonical anchor because both endpoints already gate on that key; the four backoffice keys are emitted in lockstep so any one would work.)
+
+5. **Apply the affiliation predicate to the SQL queries.** Both endpoints already build a `select(Unit)` (lines 41, 77). For affiliation-scoped callers, add an `OR`-joined `path_name ILIKE` clause per affiliation. The recommended shape (see Open Questions for the field choice):
+
+   ```python
+   from sqlalchemy import or_
+   if not is_global and affiliations:
+       query = query.where(
+           or_(*[col(Unit.path_name).ilike(f"% {aff} %") for aff in affiliations])
+       )
+   elif not is_global and not affiliations:
+       return []  # defence-in-depth: scoped user with no affiliations sees nothing
+   ```
+
+   Whitespace boundaries (`% {aff} %`) avoid `SV` matching `SVOPS` etc. The `path_name` column is space-separated (`"EHE ASSOCIATIONS SCIENC-CULT 180C"`, see `backend/app/models/unit.py:76-79`).
+
+6. **Multi-affiliation users (multiple `CO2_BACKOFFICE_METIER` roles)** are handled as a union: the permissions dict naturally accumulates one scoped key per affiliation, and the SQL predicate is an `OR` across the set. A user with affiliations `{SV, STI}` sees the union of SV's and STI's units.
+
+7. **`GlobalScope` backoffice / superadmin** keep the bare `backoffice.users` key, so the `is_global` short-circuit in step 4 skips filtering and they see everything as today.
+
+## Tests
+
+### Backend unit tests (`backend/tests/unit/models/test_user.py` and `backend/tests/unit/utils/test_permissions.py`)
+
+- `test_as_scope_key_affiliation_returns_prefixed_string`: `as_scope_key(RoleScope(affiliation="SV"))` → `"/SV"`, both via the `RoleScope` object branch and via the `dict` branch.
+- `test_as_scope_key_global_still_returns_empty`: regression guard for `GlobalScope()` → `""`.
+- `test_calculate_user_permissions_backoffice_metier_with_affiliation_emits_scoped_keys`: a single `CO2_BACKOFFICE_METIER @ affiliation=SV` role yields exactly `{backoffice.reporting/SV, backoffice.users/SV, backoffice.data_management/SV, backoffice.documentation/SV}` with correct action lists, and **no** bare `backoffice.*` keys.
+- `test_calculate_user_permissions_backoffice_metier_global_unchanged`: regression guard — `GlobalScope` still emits bare keys.
+- `test_calculate_user_permissions_backoffice_multi_affiliation_unions`: two `CO2_BACKOFFICE_METIER` roles on `SV` and `STI` yield both `backoffice.users/SV` and `backoffice.users/STI`.
+- `test_has_permission_any_scope_matches_affiliation_keys`: `has_permission({"backoffice.users/SV": ["view"]}, "backoffice.users", "view", any_scope=True)` → `True`; same call with `any_scope=False` → `False` (pins the rationale for the endpoint change in step 3).
+
+### Backend integration tests (`backend/tests/integration/v1/test_permission_scope_e2e.py`)
+
+Add a helper alongside the existing `_principal`/`_std`/`_backoffice`/`_superadmin`:
+
+```python
+def _backoffice_scoped(affiliation: str) -> Role:
+    return Role(role=RoleName.CO2_BACKOFFICE_METIER, on=RoleScope(affiliation=affiliation))
+```
+
+Add a new test class `TestBackofficeAffiliationScopeEndToEnd` covering `/api/v1/backoffice/units` (and the same shape for `/affiliations` if convenient):
+
+- `test_global_backoffice_sees_all_units`: caller with `_backoffice()` (GlobalScope) → 200, full unit list. Pins the global short-circuit.
+- `test_scoped_backoffice_sees_only_in_affiliation_units`: caller with `_backoffice_scoped("SV")` against a fixture that returns one SV unit and one STI unit → 200, response contains only the SV unit.
+- `test_scoped_backoffice_cross_affiliation_returns_empty`: same caller against an STI-only fixture → 200 with empty list (the request is permitted — the user has `backoffice.users/SV` — but the predicate filters everything out). This is the cross-affiliation isolation guarantee.
+- `test_scoped_backoffice_no_affiliations_denied_or_empty`: caller with role wired but affiliation set empty (defence-in-depth from step 5) → 200 empty. Document the chosen semantic in the assertion.
+- `test_unscoped_request_denied_for_non_backoffice`: caller with only `_std(UNIT_IID)` → 403. Confirms the gate still rejects non-backoffice callers.
+- `test_superadmin_sees_all_units`: regression guard, mirrors the pattern at line 174.
+
+Use the existing `_wire` pattern for dependency overrides; supplement with a unit-list fixture function rather than reusing `_ALL_MEMBERS` (which is headcount-specific).
+
+## Verification
+
+```bash
+cd backend
+uv run pytest tests/unit/utils/test_permissions.py tests/unit/models/test_user.py -xvs
+uv run pytest tests/integration/v1/test_permission_scope_e2e.py -xvs
+make backend-dev   # then curl /api/v1/backoffice/units with a scoped backoffice token, verify filtered result
+```
+
+Sanity-check the full backoffice suite as well — `uv run pytest tests/integration/v1/test_backoffice_reporting.py -xvs` if such a file exists; otherwise run the broader integration sweep `uv run pytest tests/integration/v1/ -xvs`.
+
+Manual e2e (post-deploy):
+
+1. Log in as a known SV-scoped backoffice user.
+2. Open the Reporting page, inspect the affiliation dropdown — should only list SV-tree units (Faculty SV + its institutes).
+3. Open the Units table — only SV units should appear.
+4. Repeat as a global backoffice / superadmin — every active unit should appear.
+
+## Open questions
+
+1. **Which `Unit` field matches ACCRED `sortpath`?** The test fixture uses `"Engineering"` (a school-name-shaped string); production values are unconfirmed. Candidates:
+   - `path_name` (e.g. `"EHE ASSOCIATIONS SCIENC-CULT 180C"`) — human-readable, space-separated, supports `ILIKE` boundary matching. **Recommended** unless evidence shows otherwise.
+   - `path_institutional_code` (numeric, space-separated) — would require an `affiliation→code` lookup table; not justified by current data.
+   - A new dedicated column populated during ACCRED unit sync — overkill for v0.x.
+     Confirm the production `sortpath` shape against a real ACCRED payload before locking step 5.
+
+2. **ACCRED `sortpath` shape: single string or list?** Read of `role_provider.py:544-554` and the existing test (`test_role_provider.py:312`) shows a single string per authorization. A user with multiple sub-perimeters has multiple `CO2_BACKOFFICE_METIER` authorizations, each with its own `sortpath`, which our union-via-key-accumulation handles cleanly. Confirm with a real ACCRED payload that `sortpath` never returns a list/comma-string.
+
+3. **Union vs intersection across affiliations.** The plan assumes union (a user with `{SV, STI}` sees both). This matches the natural multi-role semantics of every other role in the system and the implicit ACCRED contract (each authorization is an additive grant). Confirm with the product owner that no scenario calls for intersection.
+
+4. **`backoffice.documentation` scoping.** Should documentation editing also be sub-perimeter-bound, or is documentation a shared corpus across the whole calculator (in which case `backoffice.documentation` stays unscoped even for affiliation-scoped backoffice users)? Plan currently treats it the same as the other three — scope it. Easy to reverse before merge if product disagrees.
+
+5. **Endpoints beyond `/affiliations` and `/units`.** Issue title mentions "Reporting" generically. Audit `backend/app/api/v1/` for any other route gated on `backoffice.*` that returns unit-keyed data (e.g. backoffice carbon-report listings, export endpoints). If any exist, they need the same `any_scope=True` + predicate treatment; list them in the implementation PR description.
+
+6. **Empty-affiliation scoped user — 200 with `[]` or 403?** Plan picks `200 []` (defence-in-depth: gate passes, predicate filters everything). Alternative is 403. Pick one explicitly during implementation and pin with the test from the Tests section.

--- a/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
+++ b/docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md
@@ -1,12 +1,58 @@
 ---
-status: delivered
+status: in_progress
 issue: 459
-last_updated: 2026-05-22
+last_updated: 2026-05-26
 title: "Backoffice ACCRED affiliation scoping"
 summary: "Scope backoffice.* permissions by ACCRED-provided affiliation so each backoffice manager sees only their sub-perimeter."
 ---
 
-## Delivered
+## Phase 2 (2026-05-26): production sortpath shape + frontend gate
+
+Phase 1 (PR #1271) shipped against a single-token sortpath assumption ("Engineering"). The first real ACCRED payloads showed sortpath is a space-separated 4-level path (e.g. `"EPFL ENAC ENAC-SG ENAC-IT"`), so the affiliation-suffixed permission keys looked like `backoffice.users/EPFL ENAC ENAC-SG ENAC-IT` — readable but unusable as a sub-perimeter token. Phase 2 resolves Open Question #1 and closes the Phase 1 frontend follow-up.
+
+**Backend — LVL3 trim** (`backend/app/providers/role_provider.py`):
+
+- ACCRED sortpath is now split on whitespace and reduced to LVL3 (index 2, e.g. `"ENAC-SG"`) before being assigned to `RoleScope.affiliation`. The cut-off was confirmed against real EPFL payloads: LVL3 is the unit-of-interest for backoffice scoping; LVL4 is too granular and LVL1/2 are too broad.
+- Authorizations whose sortpath has fewer than 3 levels are logged at warning level and dropped (cannot resolve a meaningful affiliation). Picked "strict skip" over "use deepest token" to surface upstream data issues rather than silently miscategorise users.
+- Module-level constant `AFFILIATION_LEVEL = 3` documents the level choice; tests pin the trim (`test_accred_fetch_roles_with_backoffice_metier` uses a 4-token sortpath) and the skip path (`test_accred_backoffice_metier_short_sortpath_skipped`).
+
+**Backend — principal no longer grants backoffice.users.edit** (`backend/app/models/user.py`):
+
+- The Phase 1 plan inherited a grant where `CO2_USER_PRINCIPAL` emitted an un-scoped `backoffice.users: ["edit"]` "so principals could assign std roles." Per the current role spec (Standard/Principal are unit-area roles; Backoffice Admin/Super Admin are the only backoffice-area roles), this was a leak: a principal could pass `has_permission("backoffice.users", "edit", any_scope=True)` and reach backoffice surfaces. Removed.
+- Knock-on test updates: `test_user_principal_unit_scope` now asserts no `backoffice.*` keys leak from principal-only roles; the `TestRoleCompositionKeys` cases for `principal-A`, `std+principal-same-unit`, `principal-A+std-B` drop the `{backoffice.users}` allowance and move it to `forbidden`.
+
+**Frontend — generic back-office area gate** (`frontend/src/utils/permission.ts`, `frontend/src/stores/auth.ts`, `frontend/src/components/layout/Co2Header.vue`):
+
+- Added `hasBackOfficeAreaPermission(permissions, action)` which scans for any `backoffice.*` OR `system.*` key (bare or `/<aff>`-suffixed) granting `action`. Both prefixes are matched because the back-office area covers both `backoffice.*` features (reporting, users, data management, documentation) and `system.*` features (Super Admin tabs: configuration, pipeline operations, logs). Exposed via `authStore.hasUserBackOfficeAreaPermission(action)`.
+- `Co2Header.vue`'s `hasBackOfficeAccess` computed now calls the broader helper. Affiliation-scoped users (whose only key shape is `backoffice.X/ENAC-SG`) AND Super Admins with only `system.*` grants both see the entry button.
+- Comment fix at `backoffice_reporting.py:_affiliation_predicate` to reflect the real sortpath shape ("space-separated 4-level hierarchy; `role_provider.py` extracts LVL3").
+
+**Frontend — path-specific any-scope guard** (`frontend/src/utils/permission.ts`, `frontend/src/stores/auth.ts`, `frontend/src/router/guards/permissionGuard.ts`, `frontend/src/components/layout/Co2Sidebar.vue`):
+
+- Closes the Phase 1 frontend follow-up. Added `hasAnyScopePermission(permissions, path, action)` mirroring the backend's `has_permission(..., any_scope=True)`: matches the bare path OR any `path/<*>` variant. Exposed via `authStore.hasUserAnyScopePermission(path, action)`.
+- `requirePermission(path, action)` in `permissionGuard.ts` now uses the any-scope check, so an `ENAC-SG`-scoped backoffice admin can enter `back-office/*` routes despite holding only `backoffice.users/ENAC-SG`. The guard now also emits `console.warn` on denial — previously the unauthorized redirect was silent, making misconfigured permissions hard to diagnose.
+- `Co2Sidebar.vue`'s `hasBackOfficeEditPermission` switched to the any-scope check (same root cause).
+- Module routes are unaffected — they use `requireModuleEditPermission` (workspace-scoped), which keeps unit isolation. The any-scope mode is documented as "do not use for unit-data routes" in `permission.ts`.
+
+**Regression coverage**: `frontend/tests/unit/permission.spec.ts` — 11 cases total: 7 for `hasBackOfficeAreaPermission` (scoped/bare backoffice keys, reporting-only scoped user, `system.*` key, action mismatch, module-only user, null permissions) + 4 for `hasAnyScopePermission` (scoped edit, bare edit, path isolation against module keys, prefix isolation against `backoffice.users_other`).
+
+**Backend — open the broader `/backoffice/*` surface to scoped users** (`backend/app/api/v1/backoffice.py`, `backend/app/utils/scoping.py`):
+
+- Reverses the Phase 1 "left explicit" decision after evidence that the strict gate blocks normal navigation for ENAC-SG (and other LVL3) backoffice admins. All six endpoints — `/units`, `/export`, `/years`, `/report/usage`, `/report/detailed`, `/report/results` — drop `Depends(require_permission(...))` for `Depends(get_current_active_user)` + inline `gate_backoffice(user, action)` from the new `app.utils.scoping` module.
+- Server-side affiliation enforcement: `narrow_path_affiliation(filters.path_affiliation, is_global, affiliations)` intersects the caller-supplied `path_affiliation` query param with the caller's affiliation set; a scoped user cannot escape their scope by passing a foreign affiliation. Empty intersection → empty result (defence-in-depth, mirroring the existing `/backoffice-reporting/units` pattern).
+- `/years` had no `path_affiliation` filter at all, so the query was extended with `JOIN units ON CarbonReport.unit_id = units.id` + the affiliation predicate when the caller is scoped. Global callers keep the original distinct-year query (no join).
+- `_affiliation_predicate` and the gate helper moved out of `backoffice_reporting.py` into `app/utils/scoping.py` (`build_affiliation_predicate`, `gate_backoffice`, `narrow_path_affiliation`). `backoffice_reporting.py` now imports the shared versions; behaviour unchanged (Phase 1 e2e tests still green).
+- Regression coverage: `TestBackofficeYearsAffiliationScoping` in `backend/tests/integration/v1/test_permission_scope_e2e.py` — 5 cases pinning global/scoped/cross-affiliation/std-denied/principal-denied behavior. The principal-denied case is the explicit pin for the Phase 2 grant removal (`CO2_USER_PRINCIPAL` no longer leaks `backoffice.users.edit`).
+
+**Backend — sweep remaining `data_sync.py` strict gates + tighten data_management action set** (`backend/app/api/v1/data_sync.py`, `backend/app/utils/scoping.py`, `backend/app/models/user.py`):
+
+- Added FastAPI dependency factory `require_any_scope(action, anchor_path)` in `scoping.py` — drop-in replacement for `require_permission` for routes that only need the 403 gate (not the affiliation tuple). Converted 10 strict-gated `view`-action routes in `data_sync.py` (`/jobs/by-status`, `/jobs/year/{year}`, `/jobs/year/{year}/latest`, `/workers`, `/active-pipelines`, `/active-pipelines/year/{year}`, `/recalculation-status`, `/pipelines`, `/pipelines/{pipeline_id}`, plus a tenth view-gated endpoint). Sync-action routes (`/dispatch`, `/factor reupload`, etc., 6 total) stay on strict `require_permission` — they are Super-Admin-only per the role spec.
+- Tightened the `CO2_BACKOFFICE_METIER` permission emission: scoped backoffice metier now gets `backoffice.data_management/<aff>: ["view", "export"]` only (was `["view", "edit", "export", "sync"]`). Matches the EPFL role spec — Backoffice Administrator has read/export but not write/sync on data_management; Super Admin keeps the full set on the bare key. Closes the latent leak where opening a sync route any-scope would have inadvertently granted scoped users pipeline-trigger / factor-mutation rights.
+- Regression coverage: `TestBackofficeAffiliationScoping.test_affiliation_scope_emits_scoped_keys_only` now asserts the full action sets for all four scoped keys; new `test_scoped_backoffice_lacks_data_management_sync` and `test_superadmin_has_data_management_edit_and_sync` pin the asymmetry. The `TestActivePipelinesPerYearGate` e2e class already covers the any-scope gate pattern end-to-end.
+
+---
+
+## Delivered (Phase 1)
 
 Shipped in PR #1271 on `feat/459-backoffice-accred-affiliation-scoping`. Divergences from the original plan:
 
@@ -39,7 +85,7 @@ This is out of scope for this PR (backend-only per the issue scope), but is a ha
 - `calculate_user_permissions()` emits a fixed, **unscoped** key set for `CO2_BACKOFFICE_METIER` — `backoffice.reporting`, `backoffice.users`, `backoffice.data_management`, `backoffice.documentation` — regardless of whether the role is `GlobalScope` or `RoleScope(affiliation=...)` (`backend/app/models/user.py:164-186`).
 - `/backoffice/affiliations` and `/backoffice/units` (`backend/app/api/v1/backoffice_reporting.py:20-108`) gate on `require_permission("backoffice.users", "view")` and return **all active units** with no per-caller filtering.
 
-Concrete impact: Anna, a Faculty SV backoffice manager whose ACCRED `sortpath` is `"SV"`, has the same blast radius as a global backoffice admin. She sees STI, IC, ENAC, CDH, CDM units in the affiliation/unit dropdowns and reporting tables. This violates the EPFL accreditation model and the explicit ACCRED contract that backoffice roles are sub-perimeter-bound.
+Concrete impact: a Faculty SV backoffice manager whose ACCRED `sortpath` resolves to `"SV"` has the same blast radius as a global backoffice admin — they see STI, IC, ENAC, CDH, CDM units in the affiliation/unit dropdowns and reporting tables. This violates the EPFL accreditation model and the explicit ACCRED contract that backoffice roles are sub-perimeter-bound.
 
 ## Decision applied
 

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -50,7 +50,7 @@ const handleLogout = async () => {
 };
 
 const hasBackOfficeAccess = computed(() => {
-  return authStore.hasUserPermission('backoffice.users', PermissionAction.VIEW);
+  return authStore.hasUserBackOfficeAreaPermission(PermissionAction.VIEW);
 });
 
 const isInBackOfficeRoute = computed(() => isBackOfficeRoute(route));

--- a/frontend/src/components/layout/Co2Sidebar.vue
+++ b/frontend/src/components/layout/Co2Sidebar.vue
@@ -20,7 +20,10 @@ function navigateToRoute(routeName: string) {
 }
 
 const hasBackOfficeEditPermission = computed(() => {
-  return authStore.hasUserPermission('backoffice.users', PermissionAction.EDIT);
+  return authStore.hasUserAnyScopePermission(
+    'backoffice.users',
+    PermissionAction.EDIT,
+  );
 });
 
 const hasSuperAdminRole = computed(() => {

--- a/frontend/src/router/guards/permissionGuard.ts
+++ b/frontend/src/router/guards/permissionGuard.ts
@@ -7,11 +7,13 @@ import { PermissionAction } from 'src/constant/permissions';
 import type { Module } from 'src/constant/modules';
 
 /**
- * Create a route guard that requires a specific permission.
+ * Create a route guard that requires a specific permission under ANY scope.
  *
- * This function returns a Vue Router navigation guard that checks if the user
- * has the required permission. If the permission is granted, navigation proceeds.
- * If not, the user is redirected to the unauthorized page.
+ * Accepts the bare path (`backoffice.users`) OR any scoped variant
+ * (`backoffice.users/ENAC-SG`, `backoffice.users/0184`). This is the
+ * right shape for back-office and system routes — affiliation-scoped
+ * users and unit-scoped users both pass. Module routes use
+ * `requireModuleEditPermission` instead (workspace-scoped).
  *
  * @param path - The permission path (e.g., 'backoffice.users')
  * @param action - The action to check (defaults to 'view')
@@ -26,12 +28,13 @@ export function requirePermission(
     if (window.__LIGHTHOUSE_BYPASS__) return true;
 
     const authStore = useAuthStore();
-    const hasRequiredPermission = authStore.hasUserPermission(path, action);
-    if (hasRequiredPermission === true) {
+    if (authStore.hasUserAnyScopePermission(path, action)) {
       return true;
-    } else {
-      return { name: 'unauthorized' };
     }
+    console.warn(
+      `[permissionGuard] denied: '${path}' (${action}); redirecting to unauthorized`,
+    );
+    return { name: 'unauthorized' };
   };
 }
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -9,7 +9,12 @@ import {
 import { Router } from 'vue-router';
 import { computed } from 'vue';
 import { PermissionAction } from 'src/constant/permissions';
-import { hasPermission, getModulePermissionPath } from 'src/utils/permission';
+import {
+  hasPermission,
+  hasAnyScopePermission,
+  hasBackOfficeAreaPermission,
+  getModulePermissionPath,
+} from 'src/utils/permission';
 import { Module } from 'src/constant/modules';
 import { useWorkspaceStore } from './workspace';
 interface User {
@@ -150,6 +155,33 @@ export const useAuthStore = defineStore('auth', () => {
     return hasUserPermission(path, action);
   }
 
+  /**
+   * Check if the current user can access the back-office area (any
+   * `backoffice.*` or `system.*` permission granting `action`). Use for
+   * generic entry points (e.g. the header button) that should appear for
+   * any back-office user regardless of role, sub-domain, or affiliation.
+   */
+  function hasUserBackOfficeAreaPermission(
+    action: PermissionAction = PermissionAction.VIEW,
+  ): boolean {
+    if (!user.value || !user.value.permissions) return false;
+    return hasBackOfficeAreaPermission(user.value.permissions, action);
+  }
+
+  /**
+   * Check if the current user has `action` on `path` under ANY scope
+   * (bare path OR any `path/<*>` variant). Use for back-office route
+   * guards and menu gates that should accept GlobalScope, unit-scoped,
+   * and affiliation-scoped users alike.
+   */
+  function hasUserAnyScopePermission(
+    path: string,
+    action: PermissionAction = PermissionAction.VIEW,
+  ): boolean {
+    if (!user.value || !user.value.permissions) return false;
+    return hasAnyScopePermission(user.value.permissions, path, action);
+  }
+
   return {
     user,
     loading,
@@ -162,5 +194,7 @@ export const useAuthStore = defineStore('auth', () => {
     isAuthenticated,
     hasUserPermission,
     hasUserModulePermission,
+    hasUserBackOfficeAreaPermission,
+    hasUserAnyScopePermission,
   };
 });

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -74,6 +74,71 @@ export function hasPermission(
 }
 
 /**
+ * Check if the user has `action` on `path` under ANY scope.
+ *
+ * Matches the bare path (`backoffice.users`) AND any scoped variant
+ * (`backoffice.users/ENAC-SG`, `backoffice.users/0184`). Mirrors the
+ * backend's `has_permission(..., any_scope=True)` mode (see
+ * `backend/app/utils/permissions.py`). Use for back-office routes/menu
+ * items that should accept GlobalScope users, unit-scoped users, AND
+ * affiliation-scoped users alike (#459).
+ *
+ * Do NOT use for unit-data routes — those need workspace-scoped checks
+ * to enforce unit isolation. Use `hasPermission(...)` with a workspace
+ * context instead.
+ */
+export function hasAnyScopePermission(
+  permissions: FlatUserPermissions | null | undefined,
+  path: string,
+  action: PermissionAction = PermissionAction.VIEW,
+): boolean {
+  if (
+    !permissions ||
+    typeof permissions !== 'object' ||
+    Array.isArray(permissions)
+  ) {
+    return false;
+  }
+  if (!path || typeof path !== 'string' || path.trim().length === 0) {
+    return false;
+  }
+  const scopePrefix = `${path}/`;
+  for (const [key, actions] of Object.entries(permissions)) {
+    if (key !== path && !key.startsWith(scopePrefix)) continue;
+    if (Array.isArray(actions) && actions.includes(action)) return true;
+  }
+  return false;
+}
+
+/**
+ * Check if the user holds ANY back-office area permission granting `action`.
+ *
+ * The back-office area covers both `backoffice.*` features (reporting, users,
+ * data management, documentation) and `system.*` features (super-admin-only
+ * tabs like configuration, pipeline operations, logs). Matches bare keys
+ * (`backoffice.users`, emitted for GlobalScope) AND affiliation-scoped keys
+ * (`backoffice.users/ENAC-SG`, emitted for ACCRED sub-perimeter users).
+ * Used to gate UI entry points to the back-office area as a whole (#459).
+ */
+export function hasBackOfficeAreaPermission(
+  permissions: FlatUserPermissions | null | undefined,
+  action: PermissionAction = PermissionAction.VIEW,
+): boolean {
+  if (
+    !permissions ||
+    typeof permissions !== 'object' ||
+    Array.isArray(permissions)
+  ) {
+    return false;
+  }
+  for (const [key, actions] of Object.entries(permissions)) {
+    if (!key.startsWith('backoffice.') && !key.startsWith('system.')) continue;
+    if (Array.isArray(actions) && actions.includes(action)) return true;
+  }
+  return false;
+}
+
+/**
  * Maps frontend module names to backend permission paths.
  * Only modules with defined permissions are included.
  *

--- a/frontend/tests/unit/permission.spec.ts
+++ b/frontend/tests/unit/permission.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for ``hasBackOfficeAreaPermission`` — the helper that
+ * gates the back-office entry button in ``Co2Header.vue``.
+ *
+ * The bug it pins (#459 follow-up): after the backend started emitting
+ * affiliation-scoped keys (``backoffice.users/<aff>`` instead of bare
+ * ``backoffice.users``), gating on ``hasUserPermission('backoffice.users',
+ * 'view')`` hid the button for ACCRED sub-perimeter users — even though
+ * they hold full backoffice grants on their affiliation. This helper
+ * accepts bare keys, affiliation-scoped keys, and ``system.*`` keys
+ * (Super Admin's domain).
+ */
+
+import { test, expect } from '@playwright/test';
+
+import {
+  hasAnyScopePermission,
+  hasBackOfficeAreaPermission,
+} from '../../src/utils/permission';
+import { PermissionAction } from '../../src/constant/permissions';
+
+test('affiliation-scoped backoffice key grants access', () => {
+  const perms = {
+    'backoffice.users/ENAC-SG': ['view', 'edit', 'export'],
+    'backoffice.reporting/ENAC-SG': ['view', 'export'],
+  } as never;
+  expect(hasBackOfficeAreaPermission(perms, PermissionAction.VIEW)).toBe(true);
+});
+
+test('bare backoffice key grants access (GlobalScope users)', () => {
+  const perms = {
+    'backoffice.users': ['view', 'edit', 'export'],
+  } as never;
+  expect(hasBackOfficeAreaPermission(perms, PermissionAction.VIEW)).toBe(true);
+});
+
+test('reporting-only scoped user can still enter back-office', () => {
+  const perms = {
+    'backoffice.reporting/SV': ['view'],
+  } as never;
+  expect(hasBackOfficeAreaPermission(perms, PermissionAction.VIEW)).toBe(true);
+});
+
+test('system.* key grants access (Super Admin via system.users)', () => {
+  const perms = {
+    'system.users': ['edit'],
+  } as never;
+  expect(hasBackOfficeAreaPermission(perms, PermissionAction.EDIT)).toBe(true);
+});
+
+test('action mismatch returns false (edit-only key, asking view)', () => {
+  const perms = {
+    'backoffice.users': ['edit'],
+  } as never;
+  expect(hasBackOfficeAreaPermission(perms, PermissionAction.VIEW)).toBe(false);
+});
+
+test('module-only user (principal/std) has no back-office access', () => {
+  const perms = {
+    'modules.headcount/0184': ['view', 'edit'],
+    'modules.professional_travel/0184': ['view', 'edit'],
+  } as never;
+  expect(hasBackOfficeAreaPermission(perms, PermissionAction.VIEW)).toBe(false);
+});
+
+test('null/undefined permissions returns false', () => {
+  expect(hasBackOfficeAreaPermission(null, PermissionAction.VIEW)).toBe(false);
+  expect(hasBackOfficeAreaPermission(undefined, PermissionAction.VIEW)).toBe(
+    false,
+  );
+});
+
+// hasAnyScopePermission — path-specific scope fallback, used by router
+// guards and the sidebar's edit-permission check. Pin both that scoped
+// keys count AND that path isolation holds (don't match foreign paths).
+
+test('hasAnyScopePermission: affiliation-scoped edit grants edit', () => {
+  const perms = {
+    'backoffice.users/ENAC-SG': ['view', 'edit', 'export'],
+  } as never;
+  expect(
+    hasAnyScopePermission(perms, 'backoffice.users', PermissionAction.EDIT),
+  ).toBe(true);
+});
+
+test('hasAnyScopePermission: bare path edit grants edit (GlobalScope)', () => {
+  const perms = {
+    'backoffice.users': ['view', 'edit'],
+  } as never;
+  expect(
+    hasAnyScopePermission(perms, 'backoffice.users', PermissionAction.EDIT),
+  ).toBe(true);
+});
+
+test('hasAnyScopePermission: path isolation — module key does NOT match backoffice path', () => {
+  const perms = {
+    'modules.headcount/0184': ['view', 'edit'],
+  } as never;
+  expect(
+    hasAnyScopePermission(perms, 'backoffice.users', PermissionAction.EDIT),
+  ).toBe(false);
+});
+
+test('hasAnyScopePermission: prefix isolation — backoffice.users does NOT match backoffice.users_other', () => {
+  // Guards against an accidental `key.startsWith(path)` (without the `/`)
+  // that would let a sibling path slip past.
+  const perms = {
+    'backoffice.users_other/ENAC-SG': ['edit'],
+  } as never;
+  expect(
+    hasAnyScopePermission(perms, 'backoffice.users', PermissionAction.EDIT),
+  ).toBe(false);
+});


### PR DESCRIPTION
Draft plan for #459 — backoffice managers should see only units in their ACCRED sub-perimeter.

Strategy (already confirmed): populate `RoleScope.affiliation` from ACCRED, emit `backoffice.*/{affiliation}` keys, filter backoffice listing endpoints by the caller's affiliations.

See `docs/src/implementation-plans/459-backoffice-accred-affiliation-scoping.md` in this diff.

Closes #459 (after Phase B implementation).