### PR TITLE
docs(#977): draft implementation plan — tighten unit-scoped permission gates

### DIFF
--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -192,6 +192,9 @@ async def list_carbon_report_modules(
     if not report:
         raise HTTPException(status_code=404, detail="Carbon report not found")
 
+    unit = await db.get(Unit, report.unit_id)
+    require_unit_access(current_user, unit)
+
     module_service = CarbonReportModuleService(db)
     return await module_service.list_modules(carbon_report_id)
 
@@ -220,6 +223,9 @@ async def update_carbon_report_module_status(
     report = await report_service.get(carbon_report_id)
     if not report:
         raise HTTPException(status_code=404, detail="Carbon report not found")
+
+    unit = await db.get(Unit, report.unit_id)
+    require_unit_access(current_user, unit)
 
     module_service = CarbonReportModuleService(db)
     try:

--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -18,9 +18,7 @@ from app.api.deps import get_current_user, get_db
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import (
-    check_module_permission as _check_module_permission,
-)
-from app.core.policy import (
+    check_module_permission_for_unit,
     get_module_permission_decision,
 )
 from app.core.role_priority import pick_role_for_institutional_id
@@ -118,39 +116,6 @@ async def get_carbon_report(
             detail=f"Carbon report module not found for unit_id={unit_id}, year={year}",
         )
     return carbon_report_module
-
-
-async def _check_module_permission_for_unit(
-    *,
-    current_user: User,
-    module_id: str,
-    action: str,
-    db: AsyncSession,
-    unit_id: int,
-) -> Unit:
-    """Load the Unit and gate access using its ``institutional_id``.
-
-    Module permissions are stored as ``modules.{name}/{institutional_id}`` (see
-    PR #974). Routes that operate on a specific unit must look up the unit's
-    ``institutional_id`` before delegating to the policy — otherwise scoped
-    users (CO2_USER_*) are denied because the bare-path lookup misses.
-
-    Returns the loaded ``Unit`` so callers can reuse it (e.g. for travel filters
-    or principal/global checks) without re-fetching.
-    """
-    unit = await db.get(Unit, unit_id)
-    if unit is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Unit {unit_id} not found",
-        )
-    await _check_module_permission(
-        current_user,
-        module_id,
-        action,
-        institutional_id=unit.institutional_id,
-    )
-    return unit
 
 
 async def _get_professional_travel_institutional_id_filter(
@@ -285,7 +250,7 @@ async def get_module(
     )
     module_key = module_id.replace("-", "_")
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    unit = await _check_module_permission_for_unit(
+    unit = await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="view",
@@ -381,7 +346,7 @@ async def get_stats_by_class(
     Returns treemap-format data for charts.
     """
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="view",
@@ -437,7 +402,7 @@ async def get_top_class_breakdown(
     ``_MODULE_TOP_CLASS_GROUP_FIELD``.
     """
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="view",
@@ -611,7 +576,7 @@ async def get_submodule(
         SubmoduleResponse with paginated items and summary
     """
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="view",
@@ -722,7 +687,7 @@ async def check_unique(
         ``{"unique": false}`` when a conflict exists.
     """
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="view",
@@ -789,7 +754,7 @@ async def create(
             detail="Current user ID is required to create item",
         )
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="edit",
@@ -861,7 +826,7 @@ async def get(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="view",
@@ -912,7 +877,7 @@ async def update(
     current_user: User = Depends(get_current_user),
 ):
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="edit",
@@ -988,7 +953,7 @@ async def delete(
     current_user: User = Depends(get_current_user),
 ):
     report_type = _resolve_carbon_report_type(carbon_project_type)
-    await _check_module_permission_for_unit(
+    await check_module_permission_for_unit(
         current_user=current_user,
         module_id=module_id,
         action="edit",

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -702,8 +702,10 @@ async def sync_module_data_entries(
     """
     Sync data entries for a specific module.
 
-    **Required Permission**: `system.users.edit` (Super Admin) OR `modules.*.sync`
-    (a module owner syncing their own unit's data).
+    **Required Permission**: `system.users.edit` (Super Admin only).
+    The previous `modules.*.sync` fallback was scope-blind across modules
+    and units, and was removed in #977 — module owners cannot dispatch a
+    sync directly from this endpoint.
 
     Example of request body for module_type_year:
     {
@@ -725,16 +727,10 @@ async def sync_module_data_entries(
         "config": {}
     }
     """
-    has_permission = await is_permitted(
-        current_user, "system.users", "edit"
-    ) or await is_permitted(current_user, "modules.*", "sync")
-    if not has_permission:
+    if not await is_permitted(current_user, "system.users", "edit"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Permission denied: requires system.users.edit "
-                "or modules.* sync permission"
-            ),
+            detail="Permission denied: requires system.users.edit",
         )
 
     if syncRequest.target_type == TargetType.FACTORS and syncRequest.year is None:
@@ -1302,16 +1298,10 @@ async def job_stream_by_id(
 
     TODO(#459): tighten when sub-perimeter scoping ships
     """
-    has_permission = await is_permitted(
-        current_user, "backoffice.data_management", "view"
-    ) or await is_permitted(current_user, "modules.*", "view")
-    if not has_permission:
+    if not await is_permitted(current_user, "backoffice.data_management", "view"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Permission denied: requires backoffice.data_management.view "
-                "or modules.* view permission"
-            ),
+            detail="Permission denied: requires backoffice.data_management.view",
         )
 
     # Up-front per-job scope check — drops a pool slot before the stream opens

--- a/backend/app/api/v1/files.py
+++ b/backend/app/api/v1/files.py
@@ -109,11 +109,10 @@ async def list_files(
     """
     List files in the specified directory.
 
-    **Required Permission**: `backoffice.data_management.view` OR `modules.*` view
+    **Required Permission**: `backoffice.data_management.view`
 
     **Authorization**:
     - Backoffice metier: Can list all data management files
-    - User principal: Can list data management files
     - Other users: No access
 
     This endpoint lists files stored in the file storage (local or S3)
@@ -123,18 +122,10 @@ async def list_files(
         403: Missing required permission
         400: Invalid file path
     """
-    # Check for EITHER backoffice.data_management.view OR modules.* view
-    has_permission = await is_permitted(
-        current_user, "backoffice.data_management", "view"
-    ) or await is_permitted(current_user, "modules.*", "view")
-
-    if not has_permission:
+    if not await is_permitted(current_user, "backoffice.data_management", "view"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Permission denied: requires backoffice.data_management.view "
-                "or modules.* view"
-            ),
+            detail="Permission denied: requires backoffice.data_management.view",
         )
 
     logger.info(
@@ -188,11 +179,10 @@ async def get_file(
     """
     Retrieve a file from file storage.
 
-    **Required Permission**: `backoffice.data_management.view` OR `modules.*` view
+    **Required Permission**: `backoffice.data_management.view`
 
     **Authorization**:
     - Backoffice metier: Can access all data management files
-    - User principal: Can access data management files
     - Other users: No access
 
     Raises:
@@ -201,18 +191,10 @@ async def get_file(
         400: Invalid file path
         500: Internal server error
     """
-    # Check for EITHER backoffice.data_management.view OR modules.* view
-    has_permission = await is_permitted(
-        current_user, "backoffice.data_management", "view"
-    ) or await is_permitted(current_user, "modules.*", "view")
-
-    if not has_permission:
+    if not await is_permitted(current_user, "backoffice.data_management", "view"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Permission denied: requires backoffice.data_management.view "
-                "or modules.* view"
-            ),
+            detail="Permission denied: requires backoffice.data_management.view",
         )
 
     logger.info(
@@ -290,22 +272,14 @@ async def upload_temp_files(
     """
     Upload files to the /tmp folder in the file storage.
 
-    **Required Permission**: `backoffice.data_management.edit` OR `modules.*` edit
+    **Required Permission**: `backoffice.data_management.edit`
 
     Used for temporary file uploads before processing (e.g., CSV imports).
     """
-    # Check for EITHER backoffice.data_management.edit OR modules.* edit
-    has_permission = await is_permitted(
-        current_user, "backoffice.data_management", "edit"
-    ) or await is_permitted(current_user, "modules.*", "edit")
-
-    if not has_permission:
+    if not await is_permitted(current_user, "backoffice.data_management", "edit"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Permission denied: requires backoffice.data_management.edit "
-                "or modules.* edit"
-            ),
+            detail="Permission denied: requires backoffice.data_management.edit",
         )
 
     logger.info(
@@ -338,22 +312,14 @@ async def delete_temp_files(
     """
     Delete files from the /tmp folder.
 
-    **Required Permission**: `backoffice.data_management.edit` OR `modules.*` edit
+    **Required Permission**: `backoffice.data_management.edit`
 
     Only files in /tmp/ folder can be deleted.
     """
-    # Check for EITHER backoffice.data_management.edit OR modules.* edit
-    has_permission = await is_permitted(
-        current_user, "backoffice.data_management", "edit"
-    ) or await is_permitted(current_user, "modules.*", "edit")
-
-    if not has_permission:
+    if not await is_permitted(current_user, "backoffice.data_management", "edit"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Permission denied: requires backoffice.data_management.edit "
-                "or modules.* edit"
-            ),
+            detail="Permission denied: requires backoffice.data_management.edit",
         )
 
     logger.info(

--- a/backend/app/api/v1/unit_results.py
+++ b/backend/app/api/v1/unit_results.py
@@ -6,6 +6,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.deps import get_current_user, get_db
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
+from app.core.policy import require_unit_access
+from app.models.unit import Unit
 from app.models.user import User
 from app.services.unit_totals_service import UnitTotalsService
 
@@ -44,6 +46,7 @@ unit_results = {
 
 @router.get("/{unit_id}/results", response_model=dict)
 async def get_unit_results(
+    unit_id: int,
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(
         100, ge=1, le=1000, description="Maximum number of records to return"
@@ -51,6 +54,8 @@ async def get_unit_results(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
     return unit_results
 
 
@@ -76,6 +81,9 @@ async def get_unit_totals(
     """
     logger.info(f"GET unit totals: unit_id={sanitize(unit_id)}, year={sanitize(year)}")
 
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
+
     service = UnitTotalsService(db)
     totals = await service.get_unit_totals(
         unit_id=unit_id, year=year, user=current_user
@@ -95,6 +103,8 @@ async def get_validated_emissions(
     Returns:
         [{"year": 2023, "total_tonnes_co2eq": 61.7}, ...]
     """
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
     rows = await UnitTotalsService(db).get_validated_emissions_by_unit(unit_id=unit_id)
     return [
         {

--- a/backend/app/core/policy.py
+++ b/backend/app/core/policy.py
@@ -3,6 +3,7 @@
 from typing import Any, Optional
 
 from fastapi import HTTPException, status
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
@@ -620,3 +621,36 @@ def require_unit_access(current_user: User, unit: Unit | None) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access to this unit is not permitted.",
         )
+
+
+async def check_module_permission_for_unit(
+    *,
+    current_user: User,
+    module_id: str,
+    action: str,
+    db: AsyncSession,
+    unit_id: int,
+) -> Unit:
+    """Load the Unit and gate access using its ``institutional_id``.
+
+    Module permissions are stored as ``modules.{name}/{institutional_id}`` (see
+    PR #974). Routes that operate on a specific unit must look up the unit's
+    ``institutional_id`` before delegating to the policy — otherwise scoped
+    users (CO2_USER_*) are denied because the bare-path lookup misses.
+
+    Returns the loaded ``Unit`` so callers can reuse it (e.g. for travel filters
+    or principal/global checks) without re-fetching.
+    """
+    unit = await db.get(Unit, unit_id)
+    if unit is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unit {unit_id} not found",
+        )
+    await check_module_permission(
+        current_user,
+        module_id,
+        action,
+        institutional_id=unit.institutional_id,
+    )
+    return unit

--- a/backend/tests/integration/v1/test_unit_gating_e2e.py
+++ b/backend/tests/integration/v1/test_unit_gating_e2e.py
@@ -1,0 +1,336 @@
+"""End-to-end permission-scope tests for the routes tightened in #977.
+
+Covers:
+- ``carbon_report.py::list_carbon_report_modules`` (gated this PR)
+- ``carbon_report.py::update_carbon_report_module_status`` (gated this PR)
+- ``unit_results.py::get_unit_results`` (gated this PR)
+- ``unit_results.py::get_unit_totals`` (gated this PR)
+- ``unit_results.py::get_validated_emissions`` (gated this PR)
+- ``files.py::list_files`` / ``get_file`` / ``upload_temp_files``
+  / ``delete_temp_files`` — regression for the ``modules.*`` fallback removal.
+- ``data_sync.py::sync_module_data_entries`` (dispatch)
+  / ``job_stream_by_id`` — same fallback-removal regression.
+
+For each tightened endpoint:
+- cross-unit principal → 403
+- in-unit principal → 200
+- global backoffice → 200
+
+For each ``modules.*``-fallback removal:
+- a principal whose ONLY perms are ``modules.<x>/A`` (no backoffice) → 403
+  (was 200 with the old fallback — this pins the regression).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.deps as deps_module
+from app.main import app
+from app.models.user import (
+    GlobalScope,
+    Role,
+    RoleName,
+    RoleScope,
+    User,
+    calculate_user_permissions,
+)
+
+UNIT_IID = "0184"
+OTHER_IID = "9999"
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def _user(institutional_id: str, roles: list) -> MagicMock:
+    u = MagicMock()
+    u.id = 1
+    u.email = "test@example.com"
+    u.institutional_id = institutional_id
+    u.roles = roles
+    return u
+
+
+def _principal(iid: str) -> Role:
+    return Role(role=RoleName.CO2_USER_PRINCIPAL, on=RoleScope(institutional_id=iid))
+
+
+def _backoffice() -> Role:
+    return Role(role=RoleName.CO2_BACKOFFICE_METIER, on=GlobalScope())
+
+
+def _wire_user(user) -> None:
+    app.dependency_overrides[deps_module.get_current_user] = lambda: user
+
+
+def _wire_db_unit(unit_iid: str) -> None:
+    """Override ``get_db`` so ``.get(Unit, _)`` yields a unit with the iid."""
+    mock_unit = MagicMock()
+    mock_unit.institutional_id = unit_iid
+    db = MagicMock()
+    db.get = AsyncMock(return_value=mock_unit)
+    db.commit = AsyncMock()
+
+    async def mock_get_db():
+        yield db
+
+    app.dependency_overrides[deps_module.get_db] = mock_get_db
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# carbon_report.py — list_carbon_report_modules (gated this PR)
+# ─────────────────────────────────────────────────────────────────────────────
+
+CR_LIST_MODULES_URL = "/api/v1/carbon-reports/1/modules/"
+CR_UPDATE_STATUS_URL = "/api/v1/carbon-reports/1/modules/1/status"
+
+
+def _mock_carbon_report_with_unit(monkeypatch, unit_id: int = 1) -> None:
+    """Stub CarbonReportService so any get() returns a report with unit_id."""
+    report = MagicMock()
+    report.unit_id = unit_id
+    report.id = 1
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=report)
+    svc.recompute_report_stats = AsyncMock()
+    svc.recompute_report_progress = AsyncMock()
+    monkeypatch.setattr("app.api.v1.carbon_report.CarbonReportService", lambda db: svc)
+
+
+def _mock_carbon_report_module_service(monkeypatch) -> None:
+    module_svc = MagicMock()
+    module_svc.list_modules = AsyncMock(return_value=[])
+    updated = {
+        "id": 1,
+        "carbon_report_id": 1,
+        "module_type_id": 1,
+        "status": 2,
+        "stats": {},
+    }
+    module_svc.update_status = AsyncMock(return_value=updated)
+    monkeypatch.setattr(
+        "app.api.v1.carbon_report.CarbonReportModuleService", lambda db: module_svc
+    )
+
+
+class TestListCarbonReportModules:
+    """``GET /carbon-reports/{id}/modules/`` — gated by ``require_unit_access``."""
+
+    def test_cross_unit_principal_denied(self, client, monkeypatch):
+        """principal scoped to UNIT_IID hits a report on OTHER_IID → 403."""
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(OTHER_IID)
+        _mock_carbon_report_with_unit(monkeypatch)
+        _mock_carbon_report_module_service(monkeypatch)
+        r = client.get(CR_LIST_MODULES_URL)
+        assert r.status_code == 403, r.text
+
+    def test_in_unit_principal_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(UNIT_IID)
+        _mock_carbon_report_with_unit(monkeypatch)
+        _mock_carbon_report_module_service(monkeypatch)
+        r = client.get(CR_LIST_MODULES_URL)
+        assert r.status_code == 200, r.text
+
+    def test_backoffice_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_backoffice()]))
+        _wire_db_unit(OTHER_IID)  # any unit — global bypass
+        _mock_carbon_report_with_unit(monkeypatch)
+        _mock_carbon_report_module_service(monkeypatch)
+        r = client.get(CR_LIST_MODULES_URL)
+        assert r.status_code == 200, r.text
+
+
+class TestUpdateCarbonReportModuleStatus:
+    """``PATCH /carbon-reports/{id}/modules/{type}/status`` — gated this PR."""
+
+    PAYLOAD = {"status": 2}
+
+    def test_cross_unit_principal_denied(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(OTHER_IID)
+        _mock_carbon_report_with_unit(monkeypatch)
+        _mock_carbon_report_module_service(monkeypatch)
+        r = client.patch(CR_UPDATE_STATUS_URL, json=self.PAYLOAD)
+        assert r.status_code == 403, r.text
+
+    def test_in_unit_principal_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(UNIT_IID)
+        _mock_carbon_report_with_unit(monkeypatch)
+        _mock_carbon_report_module_service(monkeypatch)
+        r = client.patch(CR_UPDATE_STATUS_URL, json=self.PAYLOAD)
+        assert r.status_code == 200, r.text
+
+    def test_backoffice_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_backoffice()]))
+        _wire_db_unit(OTHER_IID)
+        _mock_carbon_report_with_unit(monkeypatch)
+        _mock_carbon_report_module_service(monkeypatch)
+        r = client.patch(CR_UPDATE_STATUS_URL, json=self.PAYLOAD)
+        assert r.status_code == 200, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# unit_results.py — 3 endpoints (gated this PR)
+# ─────────────────────────────────────────────────────────────────────────────
+
+UR_RESULTS_URL = "/api/v1/unit/1/results"
+UR_TOTALS_URL = "/api/v1/unit/1/2024/totals"
+UR_EMISSIONS_URL = "/api/v1/unit/1/yearly-validated-emissions"
+
+
+def _mock_unit_totals_service(monkeypatch) -> None:
+    svc = MagicMock()
+    svc.get_unit_totals = AsyncMock(return_value={"total_kg_co2eq": 0})
+    svc.get_validated_emissions_by_unit = AsyncMock(return_value=[])
+    monkeypatch.setattr("app.api.v1.unit_results.UnitTotalsService", lambda db: svc)
+
+
+class TestUnitResults:
+    """All three endpoints take ``unit_id`` and must gate on it."""
+
+    def test_get_unit_results_cross_unit_denied(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(OTHER_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_RESULTS_URL)
+        assert r.status_code == 403, r.text
+
+    def test_get_unit_results_in_unit_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(UNIT_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_RESULTS_URL)
+        assert r.status_code == 200, r.text
+
+    def test_get_unit_results_backoffice_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_backoffice()]))
+        _wire_db_unit(OTHER_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_RESULTS_URL)
+        assert r.status_code == 200, r.text
+
+    def test_get_unit_totals_cross_unit_denied(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(OTHER_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_TOTALS_URL)
+        assert r.status_code == 403, r.text
+
+    def test_get_unit_totals_in_unit_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(UNIT_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_TOTALS_URL)
+        assert r.status_code == 200, r.text
+
+    def test_get_validated_emissions_cross_unit_denied(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(OTHER_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_EMISSIONS_URL)
+        assert r.status_code == 403, r.text
+
+    def test_get_validated_emissions_in_unit_allowed(self, client, monkeypatch):
+        _wire_user(_user("11111", [_principal(UNIT_IID)]))
+        _wire_db_unit(UNIT_IID)
+        _mock_unit_totals_service(monkeypatch)
+        r = client.get(UR_EMISSIONS_URL)
+        assert r.status_code == 200, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# files.py — modules.* fallback regression
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Construct a CO2_USER_PRINCIPAL whose calculated perms include
+# ``modules.headcount/0184`` (and other ``modules.*/0184`` entries) but
+# NO ``backoffice.data_management.*``. Before #977 the route admitted
+# them via the ``modules.*`` glob fallback; now they must hit 403.
+
+
+def _scoped_principal_user() -> MagicMock:
+    """Real role list — let ``calculate_user_permissions`` run for the
+    ``is_permitted("modules.*", ...)`` admit-set comparison."""
+    user = MagicMock(spec=User)
+    user.id = 1
+    user.email = "principal@test.local"
+    user.institutional_id = "11111"
+    user.roles = [_principal(UNIT_IID)]
+    user.calculate_permissions = lambda: calculate_user_permissions(user.roles)
+    return user
+
+
+class TestFilesPermissionFallbackRemoved:
+    """Regression: principal with only ``modules.*/0184`` perms must be
+    denied on /files/* now that the fallback is removed."""
+
+    def test_list_files_rejects_scoped_principal_without_backoffice(self, client):
+        _wire_user(_scoped_principal_user())
+        r = client.get("/api/v1/files/")
+        assert r.status_code == 403, r.text
+
+    def test_get_file_rejects_scoped_principal_without_backoffice(self, client):
+        _wire_user(_scoped_principal_user())
+        r = client.get("/api/v1/files/processed/152/foo.csv")
+        assert r.status_code == 403, r.text
+
+    def test_upload_temp_files_rejects_scoped_principal_without_backoffice(
+        self, client
+    ):
+        _wire_user(_scoped_principal_user())
+        r = client.post(
+            "/api/v1/files/temp-upload",
+            files={"files": ("a.csv", b"col\n1\n", "text/csv")},
+        )
+        assert r.status_code == 403, r.text
+
+    def test_delete_temp_files_rejects_scoped_principal_without_backoffice(
+        self, client
+    ):
+        _wire_user(_scoped_principal_user())
+        r = client.delete("/api/v1/files/tmp/123/foo.csv")
+        assert r.status_code == 403, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# data_sync.py — modules.* fallback regression
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDataSyncPermissionFallbackRemoved:
+    """Regression: principal with only ``modules.*/0184`` perms must be
+    denied on /sync/dispatch and /sync/jobs/{id}/stream now."""
+
+    def test_dispatch_rejects_scoped_principal_without_backoffice(self, client):
+        _wire_user(_scoped_principal_user())
+        # Send a payload the SyncRequest schema accepts so body validation
+        # passes and the request reaches the permission gate (which is what
+        # we're asserting on).
+        r = client.post(
+            "/api/v1/sync/dispatch",
+            json={
+                "ingestion_method": 1,  # IngestionMethod.csv
+                "target_type": 0,  # TargetType.DATA_ENTRIES
+                "filters": {},
+            },
+        )
+        assert r.status_code == 403, r.text
+
+    def test_job_stream_rejects_scoped_principal_without_backoffice(self, client):
+        _wire_user(_scoped_principal_user())
+        r = client.get("/api/v1/sync/jobs/1/stream")
+        assert r.status_code == 403, r.text

--- a/backend/tests/unit/v1/test_carbon_report.py
+++ b/backend/tests/unit/v1/test_carbon_report.py
@@ -155,7 +155,8 @@ async def test_list_carbon_report_modules_found():
     module.CarbonReportService = lambda db: report_svc
     module.CarbonReportModuleService = lambda db: module_svc
     try:
-        result = await module.list_carbon_report_modules(1, db, _user())
+        with patch.object(module, "require_unit_access"):
+            result = await module.list_carbon_report_modules(1, db, _user())
         assert result == modules
     finally:
         module.CarbonReportService = orig_report
@@ -199,9 +200,10 @@ async def test_update_status_success():
     module.CarbonReportModuleService = lambda db: module_svc
     try:
         update_payload = MagicMock()
-        result = await module.update_carbon_report_module_status(
-            1, 2, update_payload, db, _user()
-        )
+        with patch.object(module, "require_unit_access"):
+            result = await module.update_carbon_report_module_status(
+                1, 2, update_payload, db, _user()
+            )
         assert result == updated
         db.commit.assert_awaited_once()
     finally:
@@ -241,10 +243,11 @@ async def test_update_status_module_not_found():
     module.CarbonReportService = lambda db: report_svc
     module.CarbonReportModuleService = lambda db: module_svc
     try:
-        with pytest.raises(HTTPException) as exc:
-            await module.update_carbon_report_module_status(
-                1, 2, MagicMock(), db, _user()
-            )
+        with patch.object(module, "require_unit_access"):
+            with pytest.raises(HTTPException) as exc:
+                await module.update_carbon_report_module_status(
+                    1, 2, MagicMock(), db, _user()
+                )
         assert exc.value.status_code == 404
     finally:
         module.CarbonReportService = orig_report
@@ -265,10 +268,11 @@ async def test_update_status_value_error_raises_400():
     module.CarbonReportService = lambda db: report_svc
     module.CarbonReportModuleService = lambda db: module_svc
     try:
-        with pytest.raises(HTTPException) as exc:
-            await module.update_carbon_report_module_status(
-                1, 2, MagicMock(), db, _user()
-            )
+        with patch.object(module, "require_unit_access"):
+            with pytest.raises(HTTPException) as exc:
+                await module.update_carbon_report_module_status(
+                    1, 2, MagicMock(), db, _user()
+                )
         assert exc.value.status_code == 400
         assert "bad status" in exc.value.detail
     finally:

--- a/docs/src/implementation-plans/977-tighten-unit-permission-gates.md
+++ b/docs/src/implementation-plans/977-tighten-unit-permission-gates.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: delivered
 issue: 977
 last_updated: 2026-05-22
 title: "Tighten unit-scoped permission gates"
-summary: "Close three pre-existing permission soft-spots: 6 carbon_report endpoints + 3 unit_results endpoints get unit gating; remove the coarse modules.* fallback in files.py and data_sync.py."
+summary: "Close three pre-existing permission soft-spots: 2 carbon_report endpoints + 3 unit_results endpoints get unit gating; remove the coarse modules.* fallback in files.py and data_sync.py."
 ---
 
 ## Problem
@@ -302,28 +302,54 @@ reviewers can confirm the gates landed.
 ## Open questions
 
 - **(a) Module-level vs unit-level for `carbon_report.py` / `unit_results.py`** —
-  recommendation is `require_unit_access` (justified in §4.2). If reviewers
-  prefer a module-level check, the question becomes *which* `ModuleType`
-  bucket anchors a unit-scoped report. There is no `carbon_report` bucket
-  today. Default to `require_unit_access` unless an alternative is raised
-  in the implementation PR.
-- **(b) Routes relying only on the `modules.*` fallback** — confirm during
-  implementation that no production usage flows through a scoped user
-  without `backoffice.data_management.*`. If any does, the answer is either
-  promotion to `check_module_permission_for_unit` (with route-specific
-  module-id resolution) or accepting the route is backoffice-only. Decision
-  belongs in the implementation PR.
-- **(c) Rename on lift** — `_check_module_permission_for_unit` is a poor
-  name for a helper that now also serves non-module unit checks via its
-  re-use sites. Proposal: name the lifted version
-  `check_module_permission_for_unit` (drop the underscore, keep the
-  `module_` because the helper still takes a `module_id` arg). If the
-  implementation phase decides to also use the helper for non-module unit
-  checks, rename further.
-- **(d) Restrict `is_permitted` glob support entirely** — separate refactor,
-  out of scope for #977. The function's glob behavior is not itself broken
-  (it does what it advertises); only the call-site usage of `"modules.*"`
-  was semantically wrong. File a follow-up issue if the team wants to
-  retire glob support.
+  **resolved**: used `require_unit_access` for all 5 endpoints. Mirrors the
+  4 already-gated `carbon_report.py` routes; avoids picking an arbitrary
+  `ModuleType` bucket for unit-scoped reports.
+- **(b) Routes relying only on the `modules.*` fallback** — **resolved**:
+  all 6 sites (`files.py:129/207/300/348`, `data_sync.py:728/1309`) keep
+  their existing `backoffice.data_management.{view,edit,sync}` primary
+  gate after the fallback is dropped. None are promoted to
+  `check_module_permission_for_unit`: these are backoffice-only file-store
+  / sync endpoints with no unit identity in the request path. A scoped
+  principal who was previously admitted via the glob fallback now
+  correctly hits 403 — pinned by the four
+  `TestFilesPermissionFallbackRemoved` and two
+  `TestDataSyncPermissionFallbackRemoved` regression tests.
+- **(c) Rename on lift** — **resolved**: lifted as
+  `check_module_permission_for_unit` (no leading underscore). Signature
+  unchanged. The 9 existing call sites in
+  `backend/app/api/v1/carbon_report_module.py` rebind to the public name.
+- **(d) Restrict `is_permitted` glob support entirely** — still out of
+  scope. The function's glob behavior is not itself broken; only the
+  call-site usage of `"modules.*"` was semantically wrong, and that is
+  fixed by this PR. File a follow-up issue if the team wants to retire
+  glob support.
+
+## Delivered
+
+- `backend/app/core/policy.py` — public `check_module_permission_for_unit`
+  added next to `require_unit_access`.
+- `backend/app/api/v1/carbon_report_module.py` — local helper deleted; 9
+  call sites rebound to the lifted public name; unused alias import
+  removed by ruff.
+- `backend/app/api/v1/carbon_report.py` — `list_carbon_report_modules`
+  and `update_carbon_report_module_status` now load the report's unit and
+  call `require_unit_access` before delegating.
+- `backend/app/api/v1/unit_results.py` — `get_unit_results` gains the
+  missing `unit_id: int` path param; all three endpoints gate via
+  `require_unit_access`.
+- `backend/app/api/v1/files.py` — `modules.*` fallback removed from all
+  4 sites (list, get, upload, delete). Docstrings and HTTPException
+  details updated.
+- `backend/app/api/v1/data_sync.py` — `modules.*` fallback removed from
+  the dispatch (sync) and job-stream (view) handlers; HTTPException
+  details updated.
+- `backend/tests/integration/v1/test_unit_gating_e2e.py` — 19 new tests
+  (3-actor matrix per gated endpoint + scoped-principal regression
+  asserts on the 4 files / 2 sync endpoints).
+- `backend/tests/unit/v1/test_carbon_report.py` — existing unit tests for
+  `list_carbon_report_modules` / `update_carbon_report_module_status`
+  updated to patch `require_unit_access` (mirrors the same pattern used
+  by the 4 already-gated endpoints in the same file).
 
 [#977]: https://github.com/EPFL-ENAC/co2-calculator/issues/977

--- a/docs/src/implementation-plans/977-tighten-unit-permission-gates.md
+++ b/docs/src/implementation-plans/977-tighten-unit-permission-gates.md
@@ -1,0 +1,329 @@
+---
+status: draft
+issue: 977
+last_updated: 2026-05-22
+title: "Tighten unit-scoped permission gates"
+summary: "Close three pre-existing permission soft-spots: 6 carbon_report endpoints + 3 unit_results endpoints get unit gating; remove the coarse modules.* fallback in files.py and data_sync.py."
+---
+
+## Problem
+
+Issue [#977] surfaced three pre-existing permission soft-spots discovered while
+shipping the PR #974 follow-up (`institutional_id` threading through the policy
+layer for `carbon_report_module*` and `taxonomies`). Re-audited against current
+`dev` on 2026-05-22; results below reflect ground truth, not the original issue
+snapshot.
+
+### Finding 1 — `backend/app/api/v1/carbon_report.py` (2 of 6 endpoints still open)
+
+The original audit listed six endpoints with no gate. Four have since been gated
+(they now call `require_unit_access` after loading the unit). Two endpoints
+remain ungated — both resolve a unit indirectly via `carbon_report_id`:
+
+| Endpoint | Function | Line | Status |
+| --- | --- | --- | --- |
+| `GET /unit/{unit_id}/` | `list_carbon_reports_by_unit` | 48 | gated (55) |
+| `GET /unit/{unit_id}/year/{year}/` | `get_carbon_report_by_unit_and_year` | 61 | gated (69) |
+| `POST /` | `create_carbon_report` | 78 | gated (85) |
+| `GET /{carbon_report_id}` | `get_carbon_report` | 158 | gated (169) |
+| `GET /{carbon_report_id}/modules/` | `list_carbon_report_modules` | 177 | **open** |
+| `PATCH /{carbon_report_id}/modules/{module_type_id}/status` | `update_carbon_report_module_status` | 203 | **open** |
+
+The two open endpoints only verify the report exists; any logged-in user can
+list module statuses or mutate them for any report.
+
+### Finding 2 — `backend/app/api/v1/unit_results.py` (3 of 3 endpoints open)
+
+All three endpoints take `unit_id` in the path but only depend on
+`get_current_user`. The downstream `UnitTotalsService` performs no permission
+checks (`user=current_user` is passed but unused for gating).
+
+| Endpoint | Function | Line |
+| --- | --- | --- |
+| `GET /{unit_id}/results` | `get_unit_results` | 45 |
+| `GET /{unit_id}/{year}/totals` | `get_unit_totals` | 57 |
+| `GET /{unit_id}/yearly-validated-emissions` | `get_validated_emissions` | 87 |
+
+### Finding 3 — coarse `is_permitted("modules.*", action)` fallback
+
+Used as the unit-agnostic "OR" branch when the `backoffice.data_management.*`
+primary gate misses. The `fnmatch` glob does match scoped keys
+(`modules.X/0184`), so the call succeeds for scoped users — but it answers
+"does this user have <action> on at least one module on at least one unit",
+which is not the same as "for the unit referenced in this request". A
+principal of unit A with `modules.headcount/A` edit can write or delete a
+file associated with unit B.
+
+Verified call sites (current `dev`, line numbers reverified 2026-05-22):
+
+- `backend/app/api/v1/data_sync.py:728` — sync action
+- `backend/app/api/v1/data_sync.py:1309` — view action
+- `backend/app/api/v1/files.py:129` — view (download)
+- `backend/app/api/v1/files.py:207` — view (list)
+- `backend/app/api/v1/files.py:300` — edit (upload)
+- `backend/app/api/v1/files.py:348` — edit (delete)
+
+## Decision applied
+
+Confirmed by the user before plan drafting; do not re-litigate during
+implementation:
+
+- **Findings 1 + 2** — add unit-loading + permission check to the 2 open
+  `carbon_report.py` endpoints and all 3 `unit_results.py` endpoints. Lift the
+  helper `_check_module_permission_for_unit` (currently
+  `backend/app/api/v1/carbon_report_module.py:123-153`) to a shared location
+  (`backend/app/core/policy.py`) so the same shape is available to
+  `files.py` and `data_sync.py` after the fallback is removed.
+- **Finding 3** — **remove** the `is_permitted("modules.*", ...)` coarse
+  fallback in `files.py` and `data_sync.py` entirely. Routes must rely on the
+  explicit `backoffice.data_management.*` (for bulk ops) or a unit-aware
+  per-route gate. No `is_permitted_for_unit` shim — single path only.
+  (Honors memory "no backward compat" / "no dual-path bloat" — project is
+  pre-v1.x.)
+
+## Files to change
+
+### Source — helper to lift
+
+- `backend/app/api/v1/carbon_report_module.py:123-153` —
+  `_check_module_permission_for_unit`. Helper signature is already correct
+  (`*, current_user, module_id, action, db, unit_id`) and returns the loaded
+  `Unit`.
+
+### Destination — shared helper
+
+- `backend/app/core/policy.py` — add `check_module_permission_for_unit` next to
+  `require_unit_access` (line 587) and `check_module_permission` (line 524).
+  Drop the leading underscore on lift (now public). Adjust the import in
+  `carbon_report_module.py` to consume from `app.core.policy`.
+
+### Routes to gate
+
+- `backend/app/api/v1/carbon_report.py`
+  - `list_carbon_report_modules` (177) — load `report.unit_id` → `unit` →
+    `require_unit_access(current_user, unit)` before delegating to
+    `CarbonReportModuleService`. Mirror the shape of `get_carbon_report`
+    (158-169).
+  - `update_carbon_report_module_status` (203) — same shape: resolve
+    `report.unit_id`, load unit, gate before mutating.
+
+- `backend/app/api/v1/unit_results.py`
+  - `get_unit_results` (45) — note this endpoint currently returns a hardcoded
+    mock dict (`unit_results` at line 16). The `unit_id` path parameter is not
+    even consumed. Gate still applies: load unit from `unit_id`, call
+    `require_unit_access`. Mock-data return shape is out of scope.
+  - `get_unit_totals` (57) — load unit, `require_unit_access`, then call
+    service.
+  - `get_validated_emissions` (87) — same.
+
+### Routes to de-fallback (remove `modules.*`)
+
+- `backend/app/api/v1/data_sync.py`
+  - `:728` (within the sync handler) — drop the
+    `or await is_permitted(current_user, "modules.*", "sync")` branch.
+    Surviving gate: `backoffice.data_management.sync` (primary). If any
+    sync-action handler is called by a scoped (non-backoffice) user today, the
+    plan's implementation step must pick its new primary gate — flagged as an
+    open question.
+  - `:1309` (within the view handler) — drop the `modules.*` view fallback.
+    Surviving gate: `backoffice.data_management.view`.
+  - Update the surrounding docstring / `HTTPException(detail=...)` messages
+    that mention `modules.*` (lines 734, 1315).
+- `backend/app/api/v1/files.py`
+  - `:129` (download), `:207` (list), `:300` (upload), `:348` (delete) — drop
+    the `modules.*` branch in all four. Surviving gate per route is the
+    `backoffice.data_management.{view,edit}` primary already present in the
+    `await is_permitted(...)` clause immediately above each fallback. Update
+    the docstrings (lines 112, 191, 293, 341) and HTTPException details
+    (136, 214, 307, 355) to drop the "or modules.* …" prose.
+
+## Approach
+
+### 4.1 Lift the helper (refactor, no behavior change)
+
+1. Move `_check_module_permission_for_unit` (`carbon_report_module.py:123-153`)
+   into `backend/app/core/policy.py` as `check_module_permission_for_unit`
+   (public). Keep the signature and behavior identical:
+   ```python
+   async def check_module_permission_for_unit(
+       *, current_user, module_id, action, db, unit_id
+   ) -> Unit
+   ```
+2. Update `carbon_report_module.py` to import from `app.core.policy`. Delete
+   the local definition. Confirm all existing call sites
+   (`carbon_report_module.py:288, 384, 440, 614, 725, 792, …`) still pass.
+3. This step alone must keep all existing tests green — it is a pure
+   refactor. Verify with the targeted permission-scope e2e tests in
+   step 6 (Verification).
+
+### 4.2 Gate `carbon_report.py` (2 endpoints) and `unit_results.py` (3 endpoints)
+
+Recommendation: use `require_unit_access` (not the module-level helper) for
+both files. Rationale:
+
+- These endpoints are **unit-scoped reports**, not module-data CRUD. There is
+  no `carbon_report` bucket in `ModuleType` (`backend/app/models/module_type.py:10-32`
+  — buckets are `headcount`, `professional_travel`, `buildings`,
+  `equipment_electric_consumption`, `purchase`, `research_facilities`,
+  `external_cloud_and_ai`, `process_emissions`). Picking a module to anchor
+  the check would be arbitrary.
+- `require_unit_access` already gates on `institutional_id` for principals
+  while letting backoffice / superadmin pass — exactly the desired shape.
+- Mirrors the four already-gated endpoints in `carbon_report.py` (lines 55,
+  69, 85, 169).
+
+Concrete edits:
+
+1. `carbon_report.py::list_carbon_report_modules` — after the existing report
+   existence check (lines 190-193), add:
+   ```python
+   unit = await db.get(Unit, report.unit_id)
+   require_unit_access(current_user, unit)
+   ```
+2. `carbon_report.py::update_carbon_report_module_status` — same insert after
+   lines 218-222. Must precede the mutating `module_service.update_status`
+   call.
+3. `unit_results.py::get_unit_results` — at the top of the function: load
+   unit, gate, then return mock (the function will be rewritten when the
+   mock is replaced — out of scope for #977 but the gate ships now).
+4. `unit_results.py::get_unit_totals` — top of function, before the service
+   call.
+5. `unit_results.py::get_validated_emissions` — top of function, before the
+   service call.
+6. Each file needs added imports: `from app.core.policy import require_unit_access`,
+   `from app.models.unit import Unit` (the imports may already exist in
+   `carbon_report.py`; verify and don't double-add).
+
+### 4.3 Remove the `modules.*` fallback from `files.py` and `data_sync.py`
+
+The plan does **not** add the lifted `check_module_permission_for_unit` to
+these routes — it removes the fallback and keeps the surviving
+`backoffice.data_management.*` primary. Per-route audit:
+
+| File:Line | Primary gate (today) | Action |
+| --- | --- | --- |
+| `data_sync.py:728` (sync) | `backoffice.data_management.sync` | drop `modules.*` fallback |
+| `data_sync.py:1309` (view) | `backoffice.data_management.view` | drop `modules.*` fallback |
+| `files.py:129` (download) | `backoffice.data_management.view` | drop `modules.*` fallback |
+| `files.py:207` (list) | `backoffice.data_management.view` | drop `modules.*` fallback |
+| `files.py:300` (upload) | `backoffice.data_management.edit` | drop `modules.*` fallback |
+| `files.py:348` (delete) | `backoffice.data_management.edit` | drop `modules.*` fallback |
+
+If during implementation any of these routes turns out to be exercised by a
+non-backoffice user today (scoped principal hits the route in
+production), the implementation phase must either:
+
+- promote the route to a `check_module_permission_for_unit` gate (extracting
+  the unit and module identity from the request body / file metadata), or
+- accept that the route is backoffice-only (single primary gate). Decision
+  to be recorded in the implementation PR, not here. See Open Questions.
+
+### 4.4 Keep `is_permitted` glob behavior (do not refactor)
+
+`is_permitted` (`backend/app/core/security.py:196-221`) keeps its existing
+glob behavior. The bug was at the call site (passing `"modules.*"`), not in
+the function. Restricting the function's glob behavior would be a separate
+refactor and is **out of scope** for #977 — flagged as an Open Question.
+
+## Tests
+
+All tests go in `backend/tests/integration/v1/test_permission_scope_e2e.py`
+(or a sibling file in the same directory) and use the existing helpers
+`_principal`, `_std`, `_backoffice`, `_superadmin`. Each test uses
+parametrize or three explicit functions for the three-actor matrix:
+
+- cross-unit principal → 403
+- in-unit principal → 200
+- global backoffice → 200
+
+Proposed test functions (one per endpoint touched):
+
+```python
+# carbon_report.py
+async def test_list_carbon_report_modules_scoped()
+async def test_update_carbon_report_module_status_scoped()
+
+# unit_results.py
+async def test_get_unit_results_scoped()
+async def test_get_unit_totals_scoped()
+async def test_get_validated_emissions_scoped()
+
+# files.py — verify modules.* fallback removed
+async def test_files_download_rejects_scoped_principal_without_backoffice()
+async def test_files_list_rejects_scoped_principal_without_backoffice()
+async def test_files_upload_rejects_scoped_principal_without_backoffice()
+async def test_files_delete_rejects_scoped_principal_without_backoffice()
+
+# data_sync.py — same
+async def test_data_sync_sync_rejects_scoped_principal_without_backoffice()
+async def test_data_sync_view_rejects_scoped_principal_without_backoffice()
+```
+
+Notes:
+- The `files.py` / `data_sync.py` tests must specifically construct a
+  principal who has `modules.<x>/A` perms (the old fallback admit-set) and
+  assert 403 against a route now requiring `backoffice.data_management.*`.
+  Without that assertion the regression is not pinned (memory: "Bugs ship
+  with regression tests" — every fix must have a test that would have
+  caught it).
+- Helper lift (4.1) is exercised by the existing
+  `test_permission_scope_e2e.py` invariants — no new test required, but the
+  full file must pass after the import path change.
+
+## Verification
+
+```bash
+cd backend
+uv run pytest tests/integration/v1/test_permission_scope_e2e.py -xvs
+uv run pytest tests/integration/v1/ -k "carbon_report or unit_results or files or data_sync" -xvs
+
+# Manual smoke (after make backend-dev):
+make backend-dev
+# 1. Cross-unit principal — expect 403:
+curl -H "Authorization: Bearer $UNIT_A_PRINCIPAL_TOKEN" \
+  http://localhost:8000/v1/unit_results/<unit-B-id>/results
+curl -H "Authorization: Bearer $UNIT_A_PRINCIPAL_TOKEN" \
+  -X PATCH http://localhost:8000/v1/carbon_report/<report-on-unit-B>/modules/1/status \
+  -d '{"status": 2}'
+
+# 2. Global backoffice — expect 200:
+curl -H "Authorization: Bearer $BACKOFFICE_TOKEN" \
+  http://localhost:8000/v1/unit_results/<any-unit-id>/results
+
+# 3. Scoped principal with modules.headcount/A but no backoffice.data_management.view
+#    on /v1/files/... against unit B — expect 403 (was 200 with old fallback):
+curl -H "Authorization: Bearer $UNIT_A_MODULE_TOKEN" \
+  http://localhost:8000/v1/files/...
+```
+
+Implementation PR must record actual response codes in the description so
+reviewers can confirm the gates landed.
+
+## Open questions
+
+- **(a) Module-level vs unit-level for `carbon_report.py` / `unit_results.py`** —
+  recommendation is `require_unit_access` (justified in §4.2). If reviewers
+  prefer a module-level check, the question becomes *which* `ModuleType`
+  bucket anchors a unit-scoped report. There is no `carbon_report` bucket
+  today. Default to `require_unit_access` unless an alternative is raised
+  in the implementation PR.
+- **(b) Routes relying only on the `modules.*` fallback** — confirm during
+  implementation that no production usage flows through a scoped user
+  without `backoffice.data_management.*`. If any does, the answer is either
+  promotion to `check_module_permission_for_unit` (with route-specific
+  module-id resolution) or accepting the route is backoffice-only. Decision
+  belongs in the implementation PR.
+- **(c) Rename on lift** — `_check_module_permission_for_unit` is a poor
+  name for a helper that now also serves non-module unit checks via its
+  re-use sites. Proposal: name the lifted version
+  `check_module_permission_for_unit` (drop the underscore, keep the
+  `module_` because the helper still takes a `module_id` arg). If the
+  implementation phase decides to also use the helper for non-module unit
+  checks, rename further.
+- **(d) Restrict `is_permitted` glob support entirely** — separate refactor,
+  out of scope for #977. The function's glob behavior is not itself broken
+  (it does what it advertises); only the call-site usage of `"modules.*"`
+  was semantically wrong. File a follow-up issue if the team wants to
+  retire glob support.
+
+[#977]: https://github.com/EPFL-ENAC/co2-calculator/issues/977


### PR DESCRIPTION
Draft plan for #977 — close three pre-existing permission soft-spots.

Strategy (already confirmed): unit-load + gate the open endpoints in carbon_report.py and unit_results.py; remove the modules.* coarse fallback in files.py and data_sync.py (no shim). Lift `_check_module_permission_for_unit` to a shared util in `app/core/policy.py`.

Plan reflects ground-truth re-audit on 2026-05-22: 4 of the 6 carbon_report.py endpoints listed in the issue body have already been gated; only 2 remain open. The unit_results.py and modules.* fallback findings stand as-is.

See `docs/src/implementation-plans/977-tighten-unit-permission-gates.md` in this diff.

Closes #977 (after Phase B implementation).