### PR TITLE
feat(#1215): move 'Incomplete' tag computation to backend

### DIFF
--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -23,6 +23,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.deps import get_current_user, get_db
 from app.core.logging import get_logger
 from app.core.security import is_permitted
+from app.core.submodule_mandatoriness import (
+    MODULES_REQUIRING_COMMON_FACTOR,
+    get_submodule_mandatoriness,
+)
 from app.models.audit import AuditChangeTypeEnum, AuditDocument
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import (
@@ -155,6 +159,84 @@ def _enrich_config_with_jobs(
             common_job = _pick_latest_job(job_lookup, m_id, None, target_val)
             module_val[field_name] = common_job.model_dump() if common_job else None
     return config
+
+
+def _enrich_config_with_incomplete_flags(config: dict) -> dict:
+    """Inject backend-computed ``incomplete`` + ``incomplete_reasons`` per #1215.
+
+    A submodule is incomplete iff a *mandatory* upload (factor or
+    reference) is missing. An errored job (``result == 2``) is NOT
+    missing — the upload-card surfaces error state independently.
+    Must run after ``_enrich_config_with_jobs`` (depends on the
+    ``latest_*_job`` keys it writes).
+    """
+    for module_key, module_val in config.get("modules", {}).items():
+        if not isinstance(module_val, dict):
+            continue
+        try:
+            module_type_id = int(module_key)
+        except (ValueError, TypeError):
+            continue
+        _annotate_module_incomplete(module_val, module_type_id)
+    return config
+
+
+def _annotate_module_incomplete(module_val: dict, module_type_id: int) -> None:
+    """Annotate each submodule, then roll up to the module's ``incomplete``.
+
+    Disabled modules carry ``incomplete=False`` regardless of state —
+    matches the legacy frontend gate.
+    """
+    common_factor_present = module_val.get("latest_common_factor_job") is not None
+    any_enabled_incomplete = False
+    submodules = module_val.get("submodules", {})
+    if isinstance(submodules, dict):
+        for sub_key, sub_val in submodules.items():
+            if not isinstance(sub_val, dict):
+                continue
+            try:
+                data_entry_type_id = int(sub_key)
+            except (ValueError, TypeError):
+                continue
+            reasons = _submodule_incomplete_reasons(
+                sub_val, module_type_id, data_entry_type_id, common_factor_present
+            )
+            sub_val["incomplete"] = bool(reasons)
+            sub_val["incomplete_reasons"] = reasons
+            if reasons and sub_val.get("enabled", True):
+                any_enabled_incomplete = True
+    if not module_val.get("enabled", True):
+        module_val["incomplete"] = False
+        return
+    needs_common = (
+        module_type_id in MODULES_REQUIRING_COMMON_FACTOR
+        and not common_factor_present
+    )
+    module_val["incomplete"] = any_enabled_incomplete or needs_common
+
+
+def _submodule_incomplete_reasons(
+    sub_val: dict,
+    module_type_id: int,
+    data_entry_type_id: int,
+    common_factor_present: bool,
+) -> list[str]:
+    """Return missing-mandatory reasons for one submodule.
+
+    A mandatory factor is satisfied by either the submodule's own
+    ``latest_factor_job`` or the module's ``latest_common_factor_job``
+    (matches the legacy frontend rule). Reference has no such fallback.
+    """
+    rules = get_submodule_mandatoriness(module_type_id, data_entry_type_id)
+    reasons: list[str] = []
+    has_factor = (
+        sub_val.get("latest_factor_job") is not None or common_factor_present
+    )
+    if rules.mandatory_factor and not has_factor:
+        reasons.append("missing_factor")
+    if rules.mandatory_reference and sub_val.get("latest_reference_job") is None:
+        reasons.append("missing_reference")
+    return reasons
 
 
 def _pick_latest_job(
@@ -469,6 +551,7 @@ async def get_year_configuration(
 
     enriched_config = copy.deepcopy(result.config)
     _enrich_config_with_jobs(enriched_config, job_lookup)
+    _enrich_config_with_incomplete_flags(enriched_config)
 
     recalc_rows = await repo.get_recalculation_status_by_year(year)
     recalculation_status = _build_recalculation_status(recalc_rows)
@@ -637,8 +720,22 @@ async def create_year_configuration(
         },
     )
 
-    response = YearConfigurationResponse.model_validate(new_config)
-    response.pipeline_id = str(pipeline_id)
+    # Issue #1215 — freshly-created years have no jobs yet; enrich so the
+    # response carries ``incomplete=True`` on every mandatory submodule.
+    # Otherwise the frontend reads ``undefined`` → false and the operator
+    # sees a deceptively-complete UI before uploading anything.
+    enriched_config = copy.deepcopy(new_config.config)
+    _enrich_config_with_jobs(enriched_config, {})
+    _enrich_config_with_incomplete_flags(enriched_config)
+    response = YearConfigurationResponse(
+        year=new_config.year,
+        is_started=new_config.is_started,
+        configuration_completed=new_config.configuration_completed,
+        config=enriched_config,
+        recalculation_status=[],
+        updated_at=new_config.updated_at,
+        pipeline_id=str(pipeline_id),
+    )
     return response
 
 
@@ -759,6 +856,7 @@ async def update_year_configuration(
 
     enriched_config = copy.deepcopy(result.config)
     _enrich_config_with_jobs(enriched_config, job_lookup)
+    _enrich_config_with_incomplete_flags(enriched_config)
 
     recalc_rows = await repo.get_recalculation_status_by_year(year)
     recalculation_status = _build_recalculation_status(recalc_rows)

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -209,8 +209,7 @@ def _annotate_module_incomplete(module_val: dict, module_type_id: int) -> None:
         module_val["incomplete"] = False
         return
     needs_common = (
-        module_type_id in MODULES_REQUIRING_COMMON_FACTOR
-        and not common_factor_present
+        module_type_id in MODULES_REQUIRING_COMMON_FACTOR and not common_factor_present
     )
     module_val["incomplete"] = any_enabled_incomplete or needs_common
 
@@ -229,9 +228,7 @@ def _submodule_incomplete_reasons(
     """
     rules = get_submodule_mandatoriness(module_type_id, data_entry_type_id)
     reasons: list[str] = []
-    has_factor = (
-        sub_val.get("latest_factor_job") is not None or common_factor_present
-    )
+    has_factor = sub_val.get("latest_factor_job") is not None or common_factor_present
     if rules.mandatory_factor and not has_factor:
         reasons.append("missing_factor")
     if rules.mandatory_reference and sub_val.get("latest_reference_job") is None:

--- a/backend/app/core/submodule_mandatoriness.py
+++ b/backend/app/core/submodule_mandatoriness.py
@@ -1,0 +1,82 @@
+"""Submodule mandatoriness rules for the "Incomplete" tag (#1215).
+
+Only ``factor`` and ``reference`` uploads are mandatory; ``data`` (CSV)
+and ``api_data`` are not. Mandatoriness moved here from the frontend
+constant so the backend can emit ``incomplete`` and the frontend just
+renders it ("Backend is source of truth").
+"""
+
+from typing import NamedTuple
+
+
+class SubmoduleMandatoriness(NamedTuple):
+    """Per-submodule mandatoriness flags."""
+
+    mandatory_factor: bool
+    mandatory_reference: bool
+
+
+# Keyed by (module_type_id, data_entry_type_id). Mirrors the frontend
+# ``MODULE_SUBMODULES`` constant; ``noFactors`` entries are marked
+# ``mandatory_factor=False`` — their factors come from a module-level
+# common-factor upload (see MODULES_REQUIRING_COMMON_FACTOR).
+SUBMODULE_MANDATORINESS: dict[tuple[int, int], SubmoduleMandatoriness] = {
+    # Headcount
+    (1, 1): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    (1, 2): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    # ProfessionalTravel — train + plane have mandatory reference
+    (2, 21): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=True),
+    (2, 20): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=True),
+    # Buildings — building has mandatory reference; embodied energy is
+    # factors-only (no separate flag needed beyond mandatory_factor=True).
+    (3, 30): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=True),
+    (3, 31): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    (3, 32): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    # EquipmentElectricConsumption — all submodules are noFactors; factors
+    # come from the module-level common-factor upload (see
+    # MODULES_REQUIRING_COMMON_FACTOR).
+    (4, 10): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (4, 11): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (4, 12): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    # Purchase — most submodules are noFactors; additional_purchases (67)
+    # carries its own factors.
+    (5, 60): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 61): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 62): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 63): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 64): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 65): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 66): SubmoduleMandatoriness(mandatory_factor=False, mandatory_reference=False),
+    (5, 67): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    # ResearchFacilities
+    (6, 70): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    (6, 71): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    # ExternalCloudAndAI
+    (7, 40): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    (7, 41): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+    # ProcessEmissions
+    (8, 50): SubmoduleMandatoriness(mandatory_factor=True, mandatory_reference=False),
+}
+
+
+# Modules whose factor uploads live at the module level (common-factor)
+# rather than per-submodule — Equipment Electric Consumption + Purchase.
+# Mirrors the frontend ``MODULE_COMMON_UPLOADS`` constant.
+MODULES_REQUIRING_COMMON_FACTOR: frozenset[int] = frozenset({4, 5})
+
+_DEFAULT_MANDATORINESS = SubmoduleMandatoriness(
+    mandatory_factor=False, mandatory_reference=False
+)
+
+
+def get_submodule_mandatoriness(
+    module_type_id: int, data_entry_type_id: int
+) -> SubmoduleMandatoriness:
+    """Return mandatoriness for a (module, submodule) pair.
+
+    Unknown pairs default to no mandatory uploads so an unseeded
+    submodule never raises "Incomplete" by accident.
+    """
+    return SUBMODULE_MANDATORINESS.get(
+        (module_type_id, data_entry_type_id), _DEFAULT_MANDATORINESS
+    )

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -376,13 +376,13 @@ class SubmoduleConfig(BaseModel):
     # is missing. Errored jobs do NOT count as missing.
     incomplete: bool = Field(
         default=False,
-        description="True when a mandatory upload is missing (read-only, injected by API)",
+        description="True when a mandatory upload is missing (read-only from API)",
     )
     incomplete_reasons: List[str] = Field(
         default_factory=list,
         description=(
             "Reasons the submodule is incomplete, e.g. "
-            '["missing_factor", "missing_reference"] (read-only, injected by API)'
+            '["missing_factor", "missing_reference"] (read-only fromAPI)'
         ),
     )
 

--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -372,6 +372,19 @@ class SubmoduleConfig(BaseModel):
         default=None,
         description="Latest reference data sync job (read-only, injected by API)",
     )
+    # Issue #1215 — true iff a mandatory upload (factor or reference)
+    # is missing. Errored jobs do NOT count as missing.
+    incomplete: bool = Field(
+        default=False,
+        description="True when a mandatory upload is missing (read-only, injected by API)",
+    )
+    incomplete_reasons: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Reasons the submodule is incomplete, e.g. "
+            '["missing_factor", "missing_reference"] (read-only, injected by API)'
+        ),
+    )
 
     @field_validator("threshold")
     @classmethod
@@ -392,6 +405,15 @@ class ModuleConfig(BaseModel):
     submodules: Dict[str, SubmoduleConfig] = Field(
         default_factory=dict,
         description="Configuration for each data entry type under this module",
+    )
+    # Issue #1215 — module-level rollup over enabled submodules + the
+    # common-factor mandatoriness signal (modules 4 and 5 today).
+    incomplete: bool = Field(
+        default=False,
+        description=(
+            "True when any enabled submodule is incomplete or a required "
+            "common upload is missing (read-only, injected by API)"
+        ),
     )
 
 

--- a/backend/tests/unit/v1/test_year_configuration_incomplete_flag.py
+++ b/backend/tests/unit/v1/test_year_configuration_incomplete_flag.py
@@ -1,0 +1,302 @@
+"""Tests for the backend-computed "Incomplete" flag (#1215).
+
+Mandatoriness rule: only ``factor`` and ``reference`` uploads are
+mandatory. ``data`` (CSV) and ``api_data`` do NOT drive the flag.
+
+Computation rule: ``incomplete`` iff a mandatory job is *missing* (no
+row). An errored job (``result == 2``) is NOT missing — the upload-card
+surfaces error state independently. The errored-job test below is the
+issue-#1215 regression invariant.
+"""
+
+from app.api.v1.year_configuration import _enrich_config_with_incomplete_flags
+
+
+def _sub(latest_factor_job=None, latest_reference_job=None, **extra) -> dict:
+    """Build a submodule dict matching the shape after
+    ``_enrich_config_with_jobs``.
+    """
+    sub: dict = {
+        "enabled": True,
+        "threshold": None,
+        "latest_data_job": None,
+        "latest_factor_job": latest_factor_job,
+        "latest_reference_job": latest_reference_job,
+        "latest_api_data_job": None,
+    }
+    sub.update(extra)
+    return sub
+
+
+def _job(result: int = 0) -> dict:
+    """Build a minimal job dict — only fields the helper inspects."""
+    return {"result": result}
+
+
+def _module(submodules: dict, latest_common_factor_job=None, **extra) -> dict:
+    mod: dict = {
+        "enabled": True,
+        "uncertainty_tag": "medium",
+        "submodules": submodules,
+        "latest_common_data_job": None,
+        "latest_common_factor_job": latest_common_factor_job,
+    }
+    mod.update(extra)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# 4-quadrant matrix on a mandatory-factor + mandatory-reference submodule
+# (train: module_type_id=2, data_entry_type_id=21).
+# ---------------------------------------------------------------------------
+
+
+class TestSubmoduleMatrix:
+    def test_factor_present_reference_present(self):
+        config = {
+            "modules": {
+                "2": _module({"21": _sub(_job(), _job())}),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        sub = config["modules"]["2"]["submodules"]["21"]
+        assert sub["incomplete"] is False
+        assert sub["incomplete_reasons"] == []
+
+    def test_factor_missing_reference_present(self):
+        config = {
+            "modules": {
+                "2": _module({"21": _sub(None, _job())}),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        sub = config["modules"]["2"]["submodules"]["21"]
+        assert sub["incomplete"] is True
+        assert sub["incomplete_reasons"] == ["missing_factor"]
+
+    def test_factor_present_reference_missing(self):
+        config = {
+            "modules": {
+                "2": _module({"21": _sub(_job(), None)}),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        sub = config["modules"]["2"]["submodules"]["21"]
+        assert sub["incomplete"] is True
+        assert sub["incomplete_reasons"] == ["missing_reference"]
+
+    def test_factor_missing_reference_missing(self):
+        config = {
+            "modules": {
+                "2": _module({"21": _sub(None, None)}),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        sub = config["modules"]["2"]["submodules"]["21"]
+        assert sub["incomplete"] is True
+        assert sub["incomplete_reasons"] == ["missing_factor", "missing_reference"]
+
+
+# ---------------------------------------------------------------------------
+# Regression pin for issue #1215: an errored job is NOT missing.
+# Before the fix, the frontend treated ``result != 0`` as incomplete —
+# which left the badge stuck on after a successful re-upload because
+# the previous job's error never cleared the flag.
+# ---------------------------------------------------------------------------
+
+
+class TestErroredJobNotMissing:
+    def test_errored_factor_with_success_reference_is_not_incomplete(self):
+        """Issue #1215 regression: errored job ≠ missing."""
+        config = {
+            "modules": {
+                "2": _module(
+                    {"21": _sub(_job(result=2), _job(result=0))},
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        sub = config["modules"]["2"]["submodules"]["21"]
+        assert sub["incomplete"] is False
+        assert sub["incomplete_reasons"] == []
+
+    def test_errored_data_job_does_not_make_submodule_incomplete(self):
+        """``data`` (CSV) is not mandatory — its error must not raise the flag."""
+        sub_dict = _sub(_job(), _job())
+        sub_dict["latest_data_job"] = _job(result=2)
+        config = {"modules": {"2": _module({"21": sub_dict})}}
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["2"]["submodules"]["21"]["incomplete"] is False
+
+
+# ---------------------------------------------------------------------------
+# Module-level rollup
+# ---------------------------------------------------------------------------
+
+
+class TestModuleAggregation:
+    def test_any_enabled_submodule_incomplete_makes_module_incomplete(self):
+        config = {
+            "modules": {
+                "2": _module(
+                    {
+                        "21": _sub(_job(), _job()),  # complete
+                        "20": _sub(None, _job()),  # missing factor
+                    }
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["2"]["incomplete"] is True
+
+    def test_disabled_incomplete_submodule_does_not_raise_module(self):
+        sub_disabled = _sub(None, None)
+        sub_disabled["enabled"] = False
+        config = {
+            "modules": {
+                "2": _module(
+                    {
+                        "21": _sub(_job(), _job()),  # complete, enabled
+                        "20": sub_disabled,  # incomplete but disabled
+                    }
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["2"]["incomplete"] is False
+
+    def test_all_submodules_complete_module_complete(self):
+        config = {
+            "modules": {
+                "2": _module(
+                    {
+                        "21": _sub(_job(), _job()),
+                        "20": _sub(_job(), _job()),
+                    }
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["2"]["incomplete"] is False
+
+    def test_disabled_module_never_incomplete(self):
+        """A disabled module's badge stays off even with missing mandatories."""
+        disabled = _module({"21": _sub(None, None)})
+        disabled["enabled"] = False
+        config = {"modules": {"2": disabled}}
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["2"]["incomplete"] is False
+
+    def test_disabled_common_factor_module_never_incomplete(self):
+        """Disabled common-factor module: missing common-factor is irrelevant."""
+        disabled = _module({"10": _sub()}, latest_common_factor_job=None)
+        disabled["enabled"] = False
+        config = {"modules": {"4": disabled}}
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["4"]["incomplete"] is False
+
+
+# ---------------------------------------------------------------------------
+# Common-factor modules (Equipment Electric Consumption = 4, Purchase = 5).
+# Submodules are ``noFactors``; factors come from the module-level upload.
+# ---------------------------------------------------------------------------
+
+
+class TestCommonFactorModules:
+    def test_module_with_common_factor_present_is_complete(self):
+        config = {
+            "modules": {
+                "4": _module(
+                    {
+                        "10": _sub(),  # no factor, no reference (mandatoriness=False)
+                        "11": _sub(),
+                        "12": _sub(),
+                    },
+                    latest_common_factor_job=_job(),
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["4"]["incomplete"] is False
+        for sub_key in ("10", "11", "12"):
+            assert config["modules"]["4"]["submodules"][sub_key]["incomplete"] is False
+
+    def test_module_with_missing_common_factor_is_incomplete(self):
+        config = {
+            "modules": {
+                "4": _module(
+                    {
+                        "10": _sub(),
+                        "11": _sub(),
+                        "12": _sub(),
+                    },
+                    latest_common_factor_job=None,
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["4"]["incomplete"] is True
+
+    def test_errored_common_factor_is_not_missing(self):
+        """An errored common-factor job exists — module is not incomplete."""
+        config = {
+            "modules": {
+                "4": _module(
+                    {"10": _sub()},
+                    latest_common_factor_job=_job(result=2),
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["4"]["incomplete"] is False
+
+    def test_common_factor_satisfies_mandatory_submodule_factor(self):
+        """When a module's common-factor exists, per-submodule mandatory
+        factor is satisfied even without a per-submodule factor job.
+        """
+        # purchase additional_purchases (5, 67) has mandatory_factor=True
+        config = {
+            "modules": {
+                "5": _module(
+                    {"67": _sub(latest_factor_job=None)},
+                    latest_common_factor_job=_job(),
+                ),
+            }
+        }
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["5"]["submodules"]["67"]["incomplete"] is False
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — defensive handling
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_unknown_submodule_pair_defaults_to_no_mandatoriness(self):
+        """A submodule not in the mandatoriness table defaults to no
+        mandatory uploads — safer than guessing.
+        """
+        config = {"modules": {"99": _module({"99": _sub(None, None)})}}
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]["99"]["submodules"]["99"]["incomplete"] is False
+        assert config["modules"]["99"]["incomplete"] is False
+
+    def test_non_numeric_module_key_skipped(self):
+        config = {"modules": {"abc": _module({"99": _sub(None, None)})}}
+        _enrich_config_with_incomplete_flags(config)
+        # Module key wasn't parseable as int — helper should not
+        # crash and should not write a flag.
+        assert "incomplete" not in config["modules"]["abc"]
+
+    def test_non_dict_submodule_value_skipped(self):
+        config = {"modules": {"2": {"submodules": {"21": "bad"}, "enabled": True}}}
+        _enrich_config_with_incomplete_flags(config)
+        # The submodule entry stayed a string; the module-level flag
+        # was still computed (against an empty enabled-sub set).
+        assert config["modules"]["2"]["incomplete"] is False
+
+    def test_empty_modules(self):
+        config: dict = {"modules": {}}
+        _enrich_config_with_incomplete_flags(config)
+        assert config == {"modules": {}}

--- a/docs/src/implementation-plans/1215-incomplete-tag-stale-on-upload-error.md
+++ b/docs/src/implementation-plans/1215-incomplete-tag-stale-on-upload-error.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: delivered
 issue: 1215
 last_updated: 2026-05-22
 title: "Move 'Incomplete' tag computation to backend"
@@ -362,3 +362,48 @@ with how this codebase has shaped it. Recommendation: keep
 co-located in the router file for this PR; refactor both helpers to
 the service in a follow-up if size becomes an issue (the router is
 already 1006 lines).
+
+## 8. Delivery notes (2026-05-22)
+
+- **(a)** Resolved: mandatoriness moved to `backend/app/core/submodule_mandatoriness.py`
+  (single-file module beside the existing `backend/app/core/constants.py`,
+  not a new `app/constants/` package). Exposes
+  `SUBMODULE_MANDATORINESS` (keyed by `(module_type_id, data_entry_type_id)`),
+  `MODULES_REQUIRING_COMMON_FACTOR = {4, 5}`, and a `get_submodule_mandatoriness`
+  lookup with a defensive default (unknown pair → no mandatory uploads).
+- **(b)** Verified against `MODULE_SUBMODULES` / `MODULE_COMMON_UPLOADS`
+  in `frontend/src/constant/backoffice-module-config.ts`:
+  `mandatoryReference` matches train (21), plane (20), and building (30);
+  `noFactors` matches the Equipment (4, *) and Purchase (5, *) submodules
+  except `additional_purchases` (5, 67). Common-factor modules are exactly 4 and 5.
+- **(c)** Applied as proposed — backend honours the legacy fallback:
+  a submodule's mandatory factor is satisfied by either its own
+  `latest_factor_job` **or** the module's `latest_common_factor_job`.
+- **(d)** Applied as proposed — module-level surfaces `incomplete: bool` only.
+  No `incomplete_reasons` at module level.
+- **(e)** Kept the helper co-located in
+  `backend/app/api/v1/year_configuration.py`. Single `_annotate_module_incomplete`
+  helper does one pass (annotate submodules + roll up the module flag) instead
+  of two separate functions.
+
+**Files changed:**
+
+Backend:
+- `backend/app/core/submodule_mandatoriness.py` (new)
+- `backend/app/api/v1/year_configuration.py` (+helper, +2 call sites)
+- `backend/app/schemas/year_configuration.py` (+`incomplete`/`incomplete_reasons` fields)
+- `backend/tests/unit/v1/test_year_configuration_incomplete_flag.py` (new, 19 tests)
+
+Frontend:
+- `frontend/src/stores/yearConfig.ts` (deleted `isSubmoduleIncomplete`/`isModuleIncomplete`;
+  `anyModuleIncomplete` reads backend flags; added `incomplete`/`incomplete_reasons` to
+  `SubmoduleConfig`/`ModuleConfig` types)
+- `frontend/src/composables/useModuleConfig.ts` (thin `isModuleIncomplete` reading backend flag)
+- `frontend/src/composables/useSubmoduleConfig.ts` (thin `isSubmoduleIncomplete` reading backend flag)
+- `frontend/src/components/organisms/data-management/ModuleConfig.vue` (comment refresh)
+- `frontend/tests/integration/data-management.spec.ts` (+2 regression tests: 1215a, 1215b)
+- `frontend/tests/integration/setup/data-management-mocks.ts` (stub includes `incomplete: false`)
+
+**Disabled-module gate moved to the backend** — `_annotate_module_incomplete`
+short-circuits `module.incomplete = False` when `module.enabled` is false,
+so the frontend no longer needs the `isModuleEnabled` guard.

--- a/docs/src/implementation-plans/1215-incomplete-tag-stale-on-upload-error.md
+++ b/docs/src/implementation-plans/1215-incomplete-tag-stale-on-upload-error.md
@@ -1,0 +1,364 @@
+---
+status: draft
+issue: 1215
+last_updated: 2026-05-22
+title: "Move 'Incomplete' tag computation to backend"
+summary: "Backend year-configuration response emits explicit incomplete + reasons per submodule/module. Frontend deletes its client-side derivation. Only factor + reference uploads are mandatory."
+---
+
+# 1215 — Move "Incomplete" tag computation to backend
+
+## 1. Problem
+
+**Symptom** (issue #1215): in the BackOffice → Configuration page, the
+"Incomplete" tag remains visible on a module/submodule even when the
+mandatory factor + reference uploads have completed successfully.
+
+**Root cause**: the tag is derived client-side in
+`frontend/src/stores/yearConfig.ts:460-503` by `isSubmoduleIncomplete()` /
+`isModuleIncomplete()`. The derivation has several brittle checks that
+conflate "missing job" with "errored job" and add non-mandatory data
+sources into the rule. Concretely:
+
+- Lines 465-468: `!sub.noFactors` branch returns `true` when
+  `latest_factor_job.result !== 0` — i.e. an errored factor job is
+  reported as Incomplete, even though "Incomplete" is supposed to mean
+  *absence*, not run state. Errored jobs are already surfaced by the
+  upload-card inline.
+- Lines 469-478: the `mandatoryData` branch treats CSV `data` as
+  mandatory whenever the flag is true. Per the strategic decision (see
+  §2) `data` is not mandatory at all.
+- Lines 480-482: same conflation for `latest_reference_job` — an
+  errored job makes the submodule Incomplete.
+- **Lines 484-487 (the likely smoking gun)**: a module-level
+  `latest_common_data_job` is required to be present with
+  `result === 0` for any submodule that is "common" (no
+  `dataEntryTypeId`). When a module's common-data CSV doesn't exist or
+  errored, this branch fires and the module-level
+  `isModuleIncomplete()` returns true even when every per-submodule
+  factor + reference upload is green — matching the screenshot in the
+  issue body. Common-data is not part of the new mandatoriness rule
+  either.
+
+The fix is not another patch to this function — it is to **delete the
+function** and let the backend, which owns the job state, emit the
+flag.
+
+## 2. Decision applied
+
+**Move the source of truth to the backend.** Stop computing
+`isSubmoduleIncomplete` / `isModuleIncomplete` in the frontend store.
+The `/year-configuration/{year}` endpoint emits an explicit
+`incomplete: bool` (plus rationale) per submodule and per module.
+Frontend just renders the flag.
+
+**Mandatoriness semantics** (confirmed): only `factor` and `reference`
+uploads are mandatory. CSV `data` upload and `api_data` are NOT
+mandatory and must NOT drive the "Incomplete" tag.
+
+**Computation rule** (confirmed): a submodule is `incomplete` iff a
+mandatory job is **missing** (no row in the database). A job that
+exists but errored (`result == 2`) does NOT make the submodule
+incomplete — the upload-card already surfaces the error inline.
+"Incomplete" is about *absence*, not run state.
+
+**Caveat**: a submodule that doesn't offer factors (`noFactors: true`
+today) cannot be incomplete for missing factors. Same for reference
+when the submodule has no reference target. See §7 open question (a)
+on where this mandatoriness signal lives once we move the rule to the
+backend.
+
+Frontend `isSubmoduleIncomplete` / `isModuleIncomplete` derivations
+get **deleted entirely** (no dual-path bloat — pre-v1.x; memory
+"Backend is source of truth — frontend renders backend transforms").
+
+## 3. Files to change
+
+### Backend
+
+- `backend/app/api/v1/year_configuration.py`
+  - Lines 104-157: `_enrich_config_with_jobs` already injects
+    `latest_*_job` fields. Either extend this function (or, preferred,
+    add a sibling `_enrich_config_with_incomplete_flags`) to run after
+    job enrichment and populate the new `incomplete` /
+    `incomplete_reasons` fields on each submodule dict and on each
+    module dict.
+  - Single call site: the `GET /year-configuration/{year}` handler
+    (further down in the same file — to be located precisely by the
+    implementer; the file is 1006 lines). The handler currently calls
+    `_enrich_config_with_jobs(config_dict, job_lookup)`; the new
+    enrichment step is invoked here too.
+
+- `backend/app/schemas/year_configuration.py`
+  - Lines 345-374: `SubmoduleConfig` — add two typed fields:
+    - `incomplete: bool = Field(default=False, ...)`
+    - `incomplete_reasons: list[str] = Field(default_factory=list, ...)`
+      (e.g. `["missing_factor", "missing_reference"]`).
+  - Lines 385-395: `ModuleConfig` — add the same two typed fields at
+    module level. While we're here, **also type the existing
+    `latest_common_data_job` / `latest_common_factor_job` fields** —
+    today the router writes them as untyped dict keys (see line 156),
+    which is the inconsistency that lets the schema lie to the
+    frontend about response shape. (Optional cleanup; flag in PR
+    description if the implementer keeps it scope-creep-free.)
+
+- Mandatoriness source — see §7 open question (a). Depending on the
+  resolution, this may add either:
+  - a new `backend/app/constants/submodule_mandatoriness.py` module
+    (preferred — move the frontend constant verbatim), or
+  - new typed fields on `SubmoduleConfig`
+    (`mandatory_factor: bool`, `mandatory_reference: bool`,
+    `has_factors: bool`, `has_data: bool`) populated from a table
+    lookup.
+
+### Frontend
+
+- `frontend/src/stores/yearConfig.ts:460-503` — **DELETE**
+  `isSubmoduleIncomplete()` and `isModuleIncomplete()`. Remove them
+  from the store's return object at lines 582-583. Update
+  `anyModuleIncomplete` (lines 522-527) to read backend `incomplete`
+  flags from `config.value.config.modules[*].incomplete` instead of
+  calling the deleted helpers.
+- `frontend/src/components/organisms/data-management/ModuleConfig.vue:318-324`
+  — change the `v-else-if="isModuleIncomplete(module)"` to read the
+  backend field. Also drop the import at line 31.
+- `frontend/src/components/molecules/data-management/SubmoduleItem.vue:140-149`
+  — change `isSubmoduleIncomplete(submodule)` to read the backend
+  field. Also drop the import at line 26.
+- `frontend/src/components/organisms/data-management/ModuleConfig.vue:144-147`
+  — the comment and guard reference `isModuleIncomplete`; update both
+  to use the backend field.
+- `frontend/src/composables/useModuleConfig.ts:39,176` — drop the
+  destructure and the re-export of `isModuleIncomplete`.
+- `frontend/src/composables/useSubmoduleConfig.ts:28,275` — same for
+  `isSubmoduleIncomplete`.
+- `frontend/src/types/` (and any OpenAPI-generated types if a codegen
+  step exists — verify in `frontend/package.json` scripts) — surface
+  the new `incomplete` / `incomplete_reasons` fields on submodule and
+  module types.
+- `frontend/src/constant/backoffice-module-config.ts` — depending on
+  §7 (a), this file either shrinks (mandatoriness fields removed
+  because backend now owns them) or stays put.
+
+## 4. Approach
+
+### 4.1 Backend: emit the flag
+
+In `_enrich_config_with_incomplete_flags` (new helper in
+`year_configuration.py`):
+
+- For each submodule dict (already enriched with `latest_*_job`):
+  - If the submodule's mandatoriness signal says factors are mandatory
+    AND `latest_factor_job is None` AND
+    `module.latest_common_factor_job is None` →
+    `reasons.append("missing_factor")`.
+  - If reference is mandatory AND `latest_reference_job is None` →
+    `reasons.append("missing_reference")`.
+  - `submodule["incomplete"] = bool(reasons)`.
+  - `submodule["incomplete_reasons"] = reasons`.
+- For each module dict, aggregate:
+  - `module["incomplete"] = any(sub["incomplete"] for sub in
+    enabled_submodules)` (only enabled — disabled submodules don't
+    count, matching today's `isSubmoduleEnabled(sub) &&
+    isSubmoduleIncomplete(sub)` in the deleted helper).
+  - Module-level `incomplete_reasons` — see §7 (d).
+
+Errored jobs (`result == 2`) do **not** count as incomplete (key
+behavior change from the current frontend rule). The upload-card
+surfaces error state independently.
+
+### 4.2 Backend: regression + matrix tests
+
+Add to `backend/tests/unit/services/test_year_config_service.py`
+(or to a new helper-targeted file
+`backend/tests/unit/v1/test_year_configuration_incomplete_flag.py`
+since the logic currently lives in the router file — the implementer
+picks based on where the helper ends up):
+
+- **4-quadrant matrix** for a mandatory-factor + mandatory-reference
+  submodule:
+  - factor present + reference present → `incomplete is False`,
+    `incomplete_reasons == []`.
+  - factor present + reference missing → `incomplete is True`,
+    reasons contains `"missing_reference"` only.
+  - factor missing + reference present → `incomplete is True`,
+    reasons contains `"missing_factor"` only.
+  - factor missing + reference missing → `incomplete is True`,
+    both reasons present.
+- **Errored-job pin**: factor job exists with `result == 2`,
+  reference job exists with `result == 0` → `incomplete is False`
+  (errored ≠ missing). This is the regression invariant.
+- **Disabled-submodule pin**: an enabled module with one disabled
+  submodule that's missing factors → module-level `incomplete is
+  False` (disabled subs don't count).
+- **Module-level aggregation**: any enabled submodule incomplete →
+  module incomplete.
+
+### 4.3 Frontend: delete derivation, render backend flag
+
+1. Delete `isSubmoduleIncomplete` and `isModuleIncomplete` from
+   `yearConfig.ts` (lines 460-503). Remove from the return object
+   (lines 582-583).
+2. Update `anyModuleIncomplete` (lines 522-527) to read
+   `config.value.config.modules[*].incomplete` instead of calling the
+   deleted helpers. Keep `isReductionObjectiveIncomplete` as-is — that
+   one is unrelated.
+3. Update `ModuleConfig.vue:318` and `SubmoduleItem.vue:142` to read
+   the backend flag (typed via the updated `ModuleConfig` /
+   `SubmoduleConfig` types) — pulling from the enriched config dict
+   the store already exposes.
+4. Update `useModuleConfig.ts` (lines 39, 176) and
+   `useSubmoduleConfig.ts` (lines 28, 275) — drop the destructured
+   names and re-exports.
+5. Regenerate TS types if `bun run codegen` (or equivalent) is the
+   pattern — verify by checking `frontend/package.json`. Otherwise
+   hand-edit `frontend/src/types/*` to add the new fields.
+
+### 4.4 Frontend: extend integration test
+
+In `frontend/tests/integration/data-management.spec.ts` (tests 9 and
+9b around lines 472-631 today):
+
+- Stub the year-config response with `incomplete: true` on a
+  submodule → assert the badge renders.
+- Stub with `incomplete: false` on a submodule whose `latest_factor_job`
+  has `result == 2` (error) → assert NO badge renders. This is the
+  **issue-#1215 regression case** translated to a unit-test contract:
+  upload succeeded mandatorily, backend says not-incomplete, badge
+  must hide.
+- Delete any unit tests that targeted the now-removed helpers (none
+  found in the search, but verify with `grep -r "isSubmoduleIncomplete"
+  frontend/tests/`).
+
+### 4.5 Manual smoke checklist
+
+Run `make backend-dev` + `bun run dev`, navigate to
+BackOffice → Configuration, and verify:
+
+1. Mandatory factor + reference both successful → no "Incomplete" tag
+   on submodule or module.
+2. Mandatory factor missing → "Incomplete" tag visible; backend
+   response includes `incomplete_reasons: ["missing_factor"]`.
+3. Mandatory factor present but errored (`result == 2`), reference
+   present and OK → **no** "Incomplete" tag (key behavior change vs
+   current).
+4. Data CSV errored or missing, all mandatories present → no
+   "Incomplete" tag (data is not mandatory under the new rule).
+
+## 5. Tests
+
+### Backend
+
+- 4-quadrant submodule matrix (see §4.2).
+- Errored-job pin (regression; covers issue #1215 invariant at the
+  unit level).
+- Disabled-submodule pin.
+- Module-level aggregation pin.
+- File path: `backend/tests/unit/v1/test_year_configuration_incomplete_flag.py`
+  (proposed — implementer co-locates with the helper's final home).
+
+### Frontend
+
+- Integration test asserting badge consumes the backend
+  `incomplete` field directly (no client-side derivation).
+- **Regression** for the issue body: stubbed response with all
+  mandatory jobs `result == 0` and `incomplete: false` → no badge.
+  Located in
+  `frontend/tests/integration/data-management.spec.ts` alongside the
+  existing tests 9 / 9b.
+
+### Regression statement
+
+The issue body scenario — mandatory factor + reference uploads
+successful, "Incomplete" tag still visible — is covered by:
+- the backend errored-job pin (proves the rule emits the right flag);
+- the frontend integration test (proves the renderer consumes the flag
+  and not a derived helper).
+
+Both are mandatory per repo memory ("Bugs ship with regression
+tests").
+
+## 6. Verification
+
+```bash
+cd backend
+uv run pytest tests/unit/v1/test_year_configuration_incomplete_flag.py -xvs
+uv run pytest tests/integration/v1/ -k year_configuration -xvs
+
+cd ../frontend
+bun run lint && bun run typecheck
+bun run test:integration
+make type-check   # vue-tsc — husky-equivalent gate (memory note)
+
+# Manual:
+make backend-dev   # one terminal
+bun run dev        # another terminal
+# Navigate to Backoffice → Configuration and walk the 4 cases in §4.5.
+```
+
+## 7. Open questions
+
+**(a) Where does the mandatoriness signal live once the rule moves to
+the backend?**
+Today `mandatoryReference` / `mandatoryData` / `noFactors` / `noData`
+are hardcoded in `frontend/src/constant/backoffice-module-config.ts`.
+The backend currently has no equivalent — so it cannot, today, know
+whether a submodule's missing `latest_factor_job` is "incomplete" or
+"this submodule doesn't have factors". Three options:
+
+1. **Move the constant to backend verbatim** (preferred —
+   single-source-of-truth, fits "Backend is source of truth"; lowest
+   moving parts). Create
+   `backend/app/constants/submodule_mandatoriness.py` keyed by
+   `(module_type_id, data_entry_type_id)`. Surface the resolved flags
+   on the `SubmoduleConfig` response so the frontend can keep showing
+   per-submodule UI affordances (which still need to know e.g.
+   `noFactors`).
+2. Add per-submodule mandatoriness flags as typed `SubmoduleConfig`
+   fields and populate from a DB-backed table (long-term clean; out
+   of scope for a bug fix).
+3. Compute mandatoriness from existing tables (e.g. "this
+   `data_entry_type_id` has a row in `factor_types`") — fragile and
+   requires the implementer to verify each module's data model.
+
+**Recommendation: option 1 for this PR.** Defer 2/3 to a separate
+issue.
+
+**(b) Does the frontend `mandatoryReference` constant agree with what
+the backend will read?**
+Spot-check the constant (lines 38-70 today) — references are
+mandatory for `train`, `plane`, `building`. Confirm during
+implementation that the backend's resolved mandatoriness matches
+every existing entry in `backoffice-module-config.ts` before deleting
+the frontend copy.
+
+**(c) Module-level aggregation when a module has
+`latest_common_factor_job`.**
+The existing frontend rule (line 466) treats
+`mod.latest_common_factor_job` as a fallback when a submodule has no
+`latest_factor_job`. Does the new backend rule honor this? Proposal:
+*yes* — at module level, if the module exposes
+`latest_common_factor_job` (i.e. it has a common-factor target), then
+that job's presence/absence drives a module-level `incomplete` flag
+in addition to per-submodule rollup. Verify by inspecting which
+modules today populate `latest_common_factor_job` (the router at
+`year_configuration.py:154-156`).
+
+**(d) Module-level `incomplete_reasons`.**
+Should the module-level response surface a reasons list (a flat union
+of submodule reasons, or just a sentinel like `["submodule_incomplete"]`)?
+The UI today only needs the badge — so the simpler `bool incomplete`
+is enough for v1. Recommendation: ship `incomplete: bool` at module
+level without `incomplete_reasons` for now; add per-module reasons
+only if a future UX wants them.
+
+**(e) Where does the new `_enrich_config_with_incomplete_flags` helper
+live?**
+Stay in `backend/app/api/v1/year_configuration.py` alongside
+`_enrich_config_with_jobs` (router-co-located), or move to
+`backend/app/services/year_config_service.py`? The existing
+enrichment lives in the router file, which is unusual but consistent
+with how this codebase has shaped it. Recommendation: keep
+co-located in the router file for this PR; refactor both helpers to
+the service in a follow-up if size becomes an issue (the router is
+already 1006 lines).

--- a/frontend/src/components/organisms/data-management/ModuleConfig.vue
+++ b/frontend/src/components/organisms/data-management/ModuleConfig.vue
@@ -137,13 +137,13 @@ const moduleNeedsRecalculation = computed<boolean>(
 const showRecalcButton = computed<boolean>(() => {
   // Hidden during active recalc — the badge says it all.
   if (isRecalculating.value) return false;
-  // Hidden in the "start" state where the module is missing
-  // required factors and/or data uploads.  Without those, the
-  // recalc has nothing to compute against — the operator first
-  // needs to upload the missing pieces; the recalc button there
-  // is a misleading affordance.  ``isModuleIncomplete`` already
-  // tracks "any required factor/data job is missing or errored"
-  // for the badge above; reuse it to keep the two consistent.
+  // Hidden in the "start" state where the module is missing required
+  // factor (and/or reference) uploads. Without those, the recalc has
+  // nothing to compute against — the operator first needs to upload
+  // the missing pieces; the recalc button there is a misleading
+  // affordance. Issue #1215 — ``isModuleIncomplete`` now reads the
+  // backend-computed flag (missing-mandatory only; errored jobs no
+  // longer raise it).
   if (isModuleIncomplete(props.module)) return false;
   return hasRecalcFailure.value || moduleNeedsRecalculation.value;
 });

--- a/frontend/src/composables/useModuleConfig.ts
+++ b/frontend/src/composables/useModuleConfig.ts
@@ -36,7 +36,12 @@ export function useModuleConfig(options: UseModuleConfigOptions) {
   const { t: $t } = useI18n();
   const yearConfigStore = useYearConfigStore();
 
-  const { isModuleEnabled, isModuleIncomplete, getModule } = yearConfigStore;
+  const { isModuleEnabled, getModule } = yearConfigStore;
+
+  /** Issue #1215 — backend-computed "Incomplete" flag. */
+  function isModuleIncomplete(module: string): boolean {
+    return !!getModule(module as Module)?.incomplete;
+  }
 
   type UncertaintyTag = ModuleConfigType['uncertainty_tag'];
 

--- a/frontend/src/composables/useSubmoduleConfig.ts
+++ b/frontend/src/composables/useSubmoduleConfig.ts
@@ -25,11 +25,24 @@ export function useSubmoduleConfig(options: UseSubmoduleConfigOptions) {
   const backofficeDataManagement = useBackofficeDataManagement();
   const {
     isSubmoduleEnabled,
-    isSubmoduleIncomplete,
     isSubmoduleInputsDeactivated,
     getModule,
     getModuleNameFromSubmodule,
   } = yearConfigStore;
+
+  /**
+   * Issue #1215 — read the backend-computed flag from the enriched
+   * submodule dict. Common-uploads (no ``dataEntryTypeId``) inherit
+   * their module-level rollup since they have no per-submodule entry.
+   */
+  function isSubmoduleIncomplete(sub: SubmoduleConfig): boolean {
+    const mod =
+      yearConfigStore.config?.config?.modules?.[String(sub.moduleTypeId)];
+    if (sub.dataEntryTypeId === undefined) {
+      return !!mod?.incomplete;
+    }
+    return !!mod?.submodules?.[String(sub.dataEntryTypeId)]?.incomplete;
+  }
 
   function toSyncJobResponse(
     job?: SyncJobSummary | null,

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -3,11 +3,10 @@ import { computed, ref } from 'vue';
 import { api } from 'src/api/http';
 import {
   MODULE_SUBMODULES,
-  MODULE_COMMON_UPLOADS,
   type SubmoduleConfig as ModuleUploadConfig,
   type SubmoduleConfig as StaticSubmoduleConfig,
 } from 'src/constant/backoffice-module-config';
-import { MODULES_LIST, type Module } from 'src/constant/modules';
+import { type Module } from 'src/constant/modules';
 
 export interface FileMetadata {
   path: string;
@@ -42,6 +41,13 @@ export interface SubmoduleConfig {
   latest_api_data_job?: SyncJobSummary | null;
   latest_factor_job?: SyncJobSummary | null;
   latest_reference_job?: SyncJobSummary | null;
+  /**
+   * Issue #1215 — backend-computed "Incomplete" flag. True iff a
+   * mandatory upload (factor or reference) is missing. Frontend
+   * renders this directly instead of re-deriving from latest_* jobs.
+   */
+  incomplete?: boolean;
+  incomplete_reasons?: string[];
 }
 
 export interface SyncJobSummary {
@@ -63,6 +69,8 @@ export interface ModuleConfig {
   submodules: Record<string, SubmoduleConfig>;
   latest_common_data_job?: SyncJobSummary | null;
   latest_common_factor_job?: SyncJobSummary | null;
+  /** Issue #1215 — module-level "Incomplete" rollup (backend-computed). */
+  incomplete?: boolean;
 }
 
 export interface UnifiedModuleConfig {
@@ -71,6 +79,8 @@ export interface UnifiedModuleConfig {
   submodules: Record<string, UnifiedSubmoduleConfig>;
   latest_common_data_job?: SyncJobSummary | null;
   latest_common_factor_job?: SyncJobSummary | null;
+  /** Issue #1215 — module-level "Incomplete" rollup (backend-computed). */
+  incomplete?: boolean;
 }
 
 export interface UnifiedSubmoduleConfig extends SubmoduleConfig {
@@ -457,51 +467,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     return mod?.submodules?.[subKey]?.inputs_deactivated ?? false;
   }
 
-  function isSubmoduleIncomplete(sub: ModuleUploadConfig): boolean {
-    const mod = config.value?.config?.modules?.[String(sub.moduleTypeId)];
-    const subConfig = sub.dataEntryTypeId
-      ? mod?.submodules?.[String(sub.dataEntryTypeId)]
-      : undefined;
-    if (!sub.noFactors) {
-      const job = subConfig?.latest_factor_job ?? mod?.latest_common_factor_job;
-      if (!job || job.result !== 0) return true;
-    }
-    if (sub.mandatoryData) {
-      const dataJob = subConfig?.latest_data_job ?? mod?.latest_common_data_job;
-      const dataOk = !!dataJob && dataJob.result === 0;
-      if (sub.hasApi) {
-        const apiJob = subConfig?.latest_api_data_job;
-        const apiOk = !!apiJob && apiJob.result === 0;
-        if (!dataOk && !apiOk) return true;
-      } else if (!dataOk) {
-        return true;
-      }
-    }
-    if (sub.mandatoryReference) {
-      const refJob = subConfig?.latest_reference_job;
-      if (!refJob || refJob.result !== 0) return true;
-    }
-    if (!sub.noData && !sub.dataEntryTypeId) {
-      const job = mod?.latest_common_data_job;
-      if (!job || job.result !== 0) return true;
-    }
-    return false;
-  }
-
-  function isModuleIncomplete(module: string): boolean {
-    if (!isModuleEnabled(module)) return false;
-    const submodules =
-      MODULE_SUBMODULES[module as keyof typeof MODULE_SUBMODULES] ?? [];
-    const commonUploads =
-      MODULE_COMMON_UPLOADS[module as keyof typeof MODULE_COMMON_UPLOADS] ?? [];
-    if (submodules.length === 0 && commonUploads.length === 0) return false;
-    return (
-      submodules.some(
-        (sub) => isSubmoduleEnabled(sub) && isSubmoduleIncomplete(sub),
-      ) || commonUploads.some((common) => isSubmoduleIncomplete(common))
-    );
-  }
-
   /** True when reduction objectives goals or CSV files are not fully configured. */
   const isReductionObjectiveIncomplete = computed(() => {
     if (!config.value) return false;
@@ -518,13 +483,17 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     return !hasGoal || !allFilesUploaded;
   });
 
-  /** True when any enabled module has mandatory uploads missing or failed. */
-  const anyModuleIncomplete = computed(
-    () =>
-      !!config.value &&
-      (MODULES_LIST.some((m) => isModuleIncomplete(m)) ||
-        isReductionObjectiveIncomplete.value),
-  );
+  /**
+   * Issue #1215 — module-level "Incomplete" comes from the backend
+   * (disabled modules carry ``incomplete=false``); OR with the
+   * still-frontend reduction-objectives flag.
+   */
+  const anyModuleIncomplete = computed(() => {
+    if (!config.value) return false;
+    const modules = config.value.config?.modules ?? {};
+    const anyModule = Object.values(modules).some((m) => !!m?.incomplete);
+    return anyModule || isReductionObjectiveIncomplete.value;
+  });
 
   function getModuleConfig(module: Module): ModuleConfig | null {
     const moduleTypeIdMap = buildModuleTypeIdMapping();
@@ -579,8 +548,6 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     isModuleEnabled,
     isSubmoduleEnabled,
     isSubmoduleInputsDeactivated,
-    isModuleIncomplete,
-    isSubmoduleIncomplete,
     getModuleUncertaintyTag,
     // Methods
     fetchConfig,

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -630,6 +630,152 @@ test.describe('back-office data-management — happy paths', () => {
     );
   });
 
+  test('1215a — Incomplete badge renders when backend sets module.incomplete=true', async ({
+    page,
+  }) => {
+    // Issue #1215: the badge is now driven by the backend-emitted
+    // ``incomplete`` flag, not by a frontend derivation. This test
+    // pins the new contract: backend says incomplete → badge visible.
+    const yearConfigIncomplete = (year: number) => ({
+      ...buildYearConfig({ year }),
+      config: {
+        modules: {
+          '1': {
+            enabled: true,
+            uncertainty_tag: 'medium',
+            incomplete: true,
+            submodules: {
+              '1': {
+                enabled: true,
+                threshold: null,
+                latest_factor_job: null,
+                latest_data_job: null,
+                incomplete: true,
+                incomplete_reasons: ['missing_factor'],
+              },
+            },
+          },
+        },
+        reduction_objectives: {
+          files: {
+            institutional_footprint: null,
+            population_projections: null,
+            unit_scenarios: null,
+          },
+          goals: [],
+          institutional_footprint: [],
+          population_projections: [],
+          unit_scenarios: [],
+        },
+      },
+    });
+
+    await mockBackend(page, {
+      onGetYearConfig: async (route, year) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(yearConfigIncomplete(year)),
+        });
+      },
+    });
+
+    await page.goto(DATA_MANAGEMENT_URL);
+
+    // Module-level Incomplete badge is part of the collapsed module
+    // header — visible without expanding.
+    const badge = page
+      .getByText(/incomplete|incomplet/i)
+      .first();
+    await expect(badge).toBeVisible({ timeout: 10000 });
+  });
+
+  test('1215b — no Incomplete badge when backend says complete despite errored jobs (regression)', async ({
+    page,
+  }) => {
+    // Issue #1215 regression: previously the frontend treated
+    // ``result === 2`` (errored job) as "Incomplete", leaving the
+    // badge stuck on after a user re-uploaded successfully. With the
+    // backend now owning the flag, an errored job that still exists
+    // means "present" — the badge stays hidden. The upload-card
+    // surfaces the error inline; the module-level badge is for
+    // *missing* uploads only.
+    const erroredFactor = {
+      job_id: 999,
+      module_type_id: 1,
+      data_entry_type_id: 1,
+      year: 2024,
+      ingestion_method: 1,
+      target_type: 1,
+      state: 3,
+      result: 2,
+      status_message: 'Factor ingestion failed',
+      meta: {},
+    };
+    // Reduction-objectives reuses the same "Incomplete" label — fully
+    // populate it so the only signal left is module.incomplete (= false here).
+    const fileMeta = {
+      path: '/uploads/x.csv',
+      filename: 'x.csv',
+      uploaded_at: '2024-01-01T00:00:00Z',
+    };
+    const yearConfigStaleErroredJob = (year: number) => ({
+      ...buildYearConfig({ year }),
+      config: {
+        modules: {
+          '1': {
+            enabled: true,
+            uncertainty_tag: 'medium',
+            incomplete: false, // backend says complete (job exists)
+            submodules: {
+              '1': {
+                enabled: true,
+                threshold: null,
+                latest_factor_job: erroredFactor, // errored but PRESENT
+                latest_data_job: null,
+                incomplete: false,
+                incomplete_reasons: [],
+              },
+            },
+          },
+        },
+        reduction_objectives: {
+          files: {
+            institutional_footprint: fileMeta,
+            population_projections: fileMeta,
+            unit_scenarios: fileMeta,
+          },
+          goals: [
+            { target_year: 2030, reduction_percentage: 50, reference_year: 2024 },
+          ],
+          institutional_footprint: [],
+          population_projections: [],
+          unit_scenarios: [],
+        },
+      },
+    });
+
+    await mockBackend(page, {
+      onGetYearConfig: async (route, year) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(yearConfigStaleErroredJob(year)),
+        });
+      },
+    });
+
+    await page.goto(DATA_MANAGEMENT_URL);
+
+    // Wait for the page to settle before asserting absence.
+    await expect(page.getByText(/year configuration/i).first()).toBeVisible();
+
+    // No "Incomplete" badge anywhere — even though latest_factor_job
+    // has result=2 (errored). Match the i18n keys ``common_filter_incomplete``
+    // would render as ("Incomplete" / "Incomplet").
+    await expect(page.getByText(/^incomplete$|^incomplet$/i)).toHaveCount(0);
+  });
+
   test('8 — year-level reload-rehydrate (Issue #867): GET /sync/active-pipelines/year/{year} fires on mount and on year change', async ({
     page,
   }) => {
@@ -782,7 +928,7 @@ async function expandHeadcountAndMember(page: Page): Promise<void> {
  * The button is disabled when `anyModuleIncomplete || is_started` —
  * `anyModuleIncomplete` iterates `MODULES_LIST` (8 modules) and checks
  * `isReductionObjectiveIncomplete`.  To reach the "enabled" branch we
- * mark every module disabled (so `isModuleIncomplete` short-circuits)
+ * mark every module disabled (so the backend-emitted `incomplete` flag stays false)
  * and supply a complete `reduction_objectives` (one goal + all 3 files).
  */
 

--- a/frontend/tests/integration/data-management.spec.ts
+++ b/frontend/tests/integration/data-management.spec.ts
@@ -684,9 +684,7 @@ test.describe('back-office data-management — happy paths', () => {
 
     // Module-level Incomplete badge is part of the collapsed module
     // header — visible without expanding.
-    const badge = page
-      .getByText(/incomplete|incomplet/i)
-      .first();
+    const badge = page.getByText(/incomplete|incomplet/i).first();
     await expect(badge).toBeVisible({ timeout: 10000 });
   });
 
@@ -746,7 +744,11 @@ test.describe('back-office data-management — happy paths', () => {
             unit_scenarios: fileMeta,
           },
           goals: [
-            { target_year: 2030, reduction_percentage: 50, reference_year: 2024 },
+            {
+              target_year: 2030,
+              reduction_percentage: 50,
+              reference_year: 2024,
+            },
           ],
           institutional_footprint: [],
           population_projections: [],

--- a/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
+++ b/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
@@ -82,12 +82,18 @@ async function dispatchPipelineUpdate(
  * the badge appearing and the pipe being available for ``dispatch``.
  */
 async function waitForSsePipe(page: Page, pipelineId: string): Promise<void> {
-  await page.waitForFunction((pipelineId) => {
-    const map = (window as Window & { __ssePipes?: Map<string, unknown> })
-      .__ssePipes;
-    if (!map) return false;
-    return map.has(`/api/v1/sync/pipelines/${pipelineId}/stream`);
-  }, pipelineId);
+  await page.waitForFunction(
+    (pipelineId) => {
+      const map = (window as Window & { __ssePipes?: Map<string, unknown> })
+        .__ssePipes;
+      if (!map) return false;
+      return map.has(`/api/v1/sync/pipelines/${pipelineId}/stream`);
+    },
+    pipelineId,
+    // Match the default expect timeout so failures surface in ~5s
+    // instead of burning the full 30s test budget.
+    { timeout: 5000 },
+  );
 }
 
 /**

--- a/frontend/tests/integration/setup/data-management-mocks.ts
+++ b/frontend/tests/integration/setup/data-management-mocks.ts
@@ -89,19 +89,26 @@ export function buildYearConfig(options: YearConfigBuilderOptions) {
   const baseHeadcount = {
     enabled: true,
     uncertainty_tag: 'medium',
+    // Issue #1215 — backend-computed module-level "Incomplete" flag.
+    // Default: complete (factor + data both SUCCESS below).
+    incomplete: false,
     submodules: {
-      // member — required factor + data both SUCCESS so isModuleIncomplete=false
+      // member — required factor + data both SUCCESS, backend incomplete=false
       '1': {
         enabled: true,
         threshold: null,
         latest_factor_job: SUCCESS_FACTOR_JOB,
         latest_data_job: SUCCESS_DATA_JOB,
+        incomplete: false,
+        incomplete_reasons: [],
       },
       // student — noData=true, only factor required
       '2': {
         enabled: true,
         threshold: null,
         latest_factor_job: SUCCESS_FACTOR_JOB,
+        incomplete: false,
+        incomplete_reasons: [],
       },
     },
   };

--- a/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
+++ b/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
@@ -228,9 +228,26 @@ export function buildYearConfigResponse(year: number): unknown {
           submodules: {},
           latest_common_data_job: null,
           latest_common_factor_job: null,
+          // Issue #1215 — backend now emits a module-level rollup. False
+          // here keeps these pipeline-observability tests off the
+          // "Incomplete" code path.
+          incomplete: false,
         },
       },
-      reduction_objectives: {},
+      // Mirror the real backend shape — ``isReductionObjectiveIncomplete``
+      // calls ``ro.goals.some(...)`` and ``files?.<key>``; ``goals`` must
+      // be an array or the computed throws and the page never mounts.
+      reduction_objectives: {
+        institutional_footprint: [],
+        population_projections: [],
+        unit_scenarios: [],
+        files: {
+          institutional_footprint: null,
+          population_projections: null,
+          unit_scenarios: null,
+        },
+        goals: [],
+      },
     },
     recalculation_status: [
       {


### PR DESCRIPTION
Closes #1215.

## Summary

- Move the "Incomplete" tag from a brittle frontend derivation in `yearConfig.ts:460-503` to a backend-emitted `incomplete: bool` + `incomplete_reasons: list[str]` per submodule (and `incomplete: bool` per module) on `/v1/year-configuration/{year}`.
- Mandatoriness rule: only `factor` and `reference` uploads are mandatory. CSV `data` and `api_data` are NOT.
- Computation rule: a submodule is `incomplete` iff a mandatory upload is *missing*. An errored job (`result == 2`) does NOT count as missing — that was the root cause of the stale badge in #1215.

## Files changed

- Backend: `app/core/submodule_mandatoriness.py` (new), `app/api/v1/year_configuration.py` (helper + 3 call sites: GET/POST/PATCH), `app/schemas/year_configuration.py` (+2 typed fields).
- Frontend: deleted `isSubmoduleIncomplete` / `isModuleIncomplete` from `stores/yearConfig.ts`; composables now expose thin readers of the backend flag. `ModuleConfig.vue` / `SubmoduleItem.vue` consume the flag via the composable API (unchanged at the call site).
- Plan doc marked `status: delivered`.

## Test plan

- [x] Backend: `uv run pytest backend/tests/unit/v1/test_year_configuration_incomplete_flag.py` — 19 tests (4-quadrant matrix, errored-job regression pin, common-factor modules, disabled-module gate, edge cases).
- [x] Backend: `uv run pytest backend/tests/unit/v1/test_year_configuration.py backend/tests/integration/v1 -k year_configuration` — 33 pre-existing tests still pass.
- [x] Frontend: `npm run test:e2e -- tests/integration/data-management.spec.ts` — 17 tests (15 pre-existing + 2 new: `1215a` badge renders when backend says incomplete; `1215b` badge stays hidden when backend says complete despite an errored job — issue-#1215 regression invariant).
- [x] `make type-check` (vue-tsc + mypy) — green.
- [x] `npm run lint` — green.
- [ ] Manual smoke: walk the 4 cases in plan §4.5 once on a real dev stack.