### PR TITLE
feat: make backoffice data and pipeline SuperAdmin-only

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -79,11 +79,11 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
     }
 
     Backoffice Roles (affect backoffice.* ONLY):
-    - CO2_BACKOFFICE_METIER: Full backoffice access including:
+    - CO2_BACKOFFICE_METIER: Backoffice access excluding Configuration/Pipeline tabs:
       * backoffice.reporting: view, export (view reports, generate exports)
       * backoffice.users: view, edit (view user list, assign roles)
-      * backoffice.data_management: view, edit, export, sync
-        (upload/download CSV, trigger sync)
+      * backoffice.data_management: view, export (read-only; edit/sync
+      reserved for SuperAdmin)
       * backoffice.documentation: view, edit (view/edit documentation)
 
     User Roles (affect modules.* ONLY):
@@ -162,9 +162,9 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
         # BACKOFFICE ROLES - Only affect backoffice.* permissions
         # Compare using enum value for consistency
         if role_name == RoleName.CO2_BACKOFFICE_METIER.value:
-            # to stream sync/jobs
             # Backoffice metier can have either global scope or affiliation scope
-            # Grants full backoffice access for reporting, docs, and data updates
+            # Grants backoffice access for reporting, docs, and read-only data access.
+            # edit and sync on backoffice.data_management are reserved for SuperAdmin.
             if is_global_scope(scope) or is_role_scope(scope):
                 permissions["backoffice.reporting"] = merge_actions(
                     permissions.get("backoffice.reporting"), ["view", "export"]
@@ -176,9 +176,7 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
                     permissions.get("backoffice.data_management"),
                     [
                         "view",
-                        "edit",
                         "export",
-                        "sync",
                     ],
                 )
                 permissions["backoffice.documentation"] = merge_actions(

--- a/docs/src/implementation-plans/862-backoffice-update-permissions.md
+++ b/docs/src/implementation-plans/862-backoffice-update-permissions.md
@@ -1,0 +1,70 @@
+# Update Backoffice Permissions (Issue #862 / modified from #168)
+
+## Context
+
+The backoffice currently has two permission tiers: "limitedAccess" (Backoffice Administrator + Super Admin) and "superAdminOnly" (Super Admin alone). The new spec requires that the **Configuration** and **Pipeline Operations** tabs join **Logs** as Super Admin-only, while all other backoffice tabs remain accessible to both Backoffice Administrator and Super Admin.
+
+### Role → tab access table
+
+| Tab                     | BackofficeAdministrator (`calco2.backoffice.metier`) | SuperAdmin (`calco2.superadmin`) |
+| ----------------------- | ---------------------------------------------------- | -------------------------------- |
+| Reporting               | ✅                                                   | ✅                               |
+| User Management         | ✅                                                   | ✅                               |
+| Documentation Editing   | ✅                                                   | ✅                               |
+| UI Texts Editing        | ✅                                                   | ✅                               |
+| **Configuration**       | ❌                                                   | ✅                               |
+| **Pipeline Operations** | ❌                                                   | ✅                               |
+| **Logs**                | ❌                                                   | ✅                               |
+
+---
+
+## Changes
+
+### 1. `frontend/src/constant/navigation.ts`
+
+Change both items from `limitedAccess: true` → `superAdminOnly: true`. Remove the stale comment above `BACKOFFICE_PIPELINE_OPERATIONS` that described the old access rule.
+
+- `BACKOFFICE_DATA_MANAGEMENT`: `limitedAccess: true` → `superAdminOnly: true`
+- `BACKOFFICE_PIPELINE_OPERATIONS`: `limitedAccess: true` → `superAdminOnly: true`
+
+`Co2Sidebar.vue` already handles `superAdminOnly` correctly and the SA short-circuit already applies — no sidebar changes needed.
+
+### 2. `frontend/src/router/routes.ts`
+
+Change the `beforeEnter` guard for the two routes from `backoffice.users / EDIT` to `system.users / EDIT` (matching the pattern already used by the Logs route):
+
+- `back-office/data-management`: `requirePermission('backoffice.users', PermissionAction.EDIT)` → `requirePermission('system.users', PermissionAction.EDIT)`
+- `back-office/pipeline-operations`: same change
+
+### 3. `backend/app/api/v1/year_configuration.py`
+
+The Configuration tab's write operations are guarded with `backoffice.data_management.edit`. Change those guards to `system.users.edit` to enforce SuperAdmin-only at the API level (three locations):
+
+```python
+# before
+if not await is_permitted(current_user, "backoffice.data_management", "edit"):
+# after
+if not await is_permitted(current_user, "system.users", "edit"):
+```
+
+Update matching error-detail strings and docstrings from "backoffice data managers" → "super administrators".
+
+### 4. `backend/app/api/v1/data_sync.py`
+
+The Pipeline Operations tab's trigger/sync operations are guarded with `backoffice.data_management.sync`. Change those to `system.users.edit`:
+
+- `require_permission("backoffice.data_management", "sync")` → `require_permission("system.users", "edit")`
+- `is_permitted(current_user, "backoffice.data_management", "sync")` → `is_permitted(current_user, "system.users", "edit")`
+
+**Leave `backoffice.data_management.view` guards unchanged** — those view endpoints are also consumed by regular module pages and must remain accessible to BackofficeMetier.
+
+Update affected docstrings from `backoffice.data_management.sync` → `system.users.edit` and "backoffice data manager" → "super administrator".
+
+---
+
+## Verification
+
+1. Log in as `calco2.backoffice.metier` → Configuration and Pipeline Operations tabs appear disabled in the sidebar; direct navigation to `/back-office/data-management` and `/back-office/pipeline-operations` redirects to `/unauthorized`.
+2. Attempt a year-configuration mutation or a sync trigger via the API with a BackofficeMetier token → expect HTTP 403.
+3. Log in as `calco2.superadmin` → all three restricted tabs (Configuration, Pipeline Operations, Logs) are accessible.
+4. BackofficeMetier can still access Reporting, User Management, Documentation Editing, UI Texts Editing.

--- a/frontend/src/constant/navigation.ts
+++ b/frontend/src/constant/navigation.ts
@@ -32,7 +32,7 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     routeName: 'backoffice-data-management',
     description: 'backoffice-data-management-description',
     icon: 'data_object',
-    limitedAccess: true,
+    superAdminOnly: true,
   },
   BACKOFFICE_LOGS: {
     routeName: 'backoffice-logs',
@@ -40,15 +40,10 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     icon: 'o_list_alt',
     superAdminOnly: true,
   },
-  // Pipeline operations sits below Logs — both back-office metier and
-  // super-admin can access (same endpoints as the data-management
-  // configuration page, so the same access rules apply).  `limitedAccess`
-  // gates on the back-office permission; the super-admin short-circuit
-  // in Co2Sidebar.isItemDisabled ensures SA always sees it too.
   BACKOFFICE_PIPELINE_OPERATIONS: {
     routeName: 'backoffice-pipeline-operations',
     description: 'backoffice-pipeline-operations-description',
     icon: 'o_account_tree',
-    limitedAccess: true,
+    superAdminOnly: true,
   },
 };

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -221,7 +221,7 @@ const routes: RouteRecordRaw[] = [
             name: BACKOFFICE_NAV.BACKOFFICE_DATA_MANAGEMENT.routeName,
             component: () => import('pages/back-office/DataManagementPage.vue'),
             beforeEnter: requirePermission(
-              'backoffice.users',
+              'backoffice.data_management',
               PermissionAction.EDIT,
             ),
             meta: {
@@ -237,7 +237,7 @@ const routes: RouteRecordRaw[] = [
             component: () =>
               import('pages/back-office/PipelineOperationsConsolePage.vue'),
             beforeEnter: requirePermission(
-              'backoffice.users',
+              'backoffice.data_management',
               PermissionAction.EDIT,
             ),
             meta: {


### PR DESCRIPTION
## What does this change?
Tightens back-office route guards so that the Configuration and Pipeline Operations tabs are restricted to Super Admin only. Specifically:
- `navigation.ts`: flips `BACKOFFICE_DATA_MANAGEMENT` and `BACKOFFICE_PIPELINE_OPERATIONS` from `limitedAccess: true` to `superAdminOnly: true`, and removes the now-incorrect comment above the pipeline item
- `routes.ts`: changes the `beforeEnter` guard for both routes from `backoffice.users / EDIT` to `backoffice.data_management / EDIT`
- `backend/app/models/user.py`: removes `edit` and `sync` from the `backoffice.data_management` permission set granted to `CO2_BACKOFFICE_METIER`, leaving only `view` and `export`

## Why is this needed?
The Backoffice Administrator role was incorrectly granted edit/sync access to `backoffice.data_management`, giving it access to the Configuration and Pipeline Operations tabs. Per the updated spec, those tabs should be Super Admin-only (joining Logs), while Reporting, User Management, Documentation Editing, and UI Texts Editing remain accessible to both roles.

## Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Configuration change

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #862
- Related to #168