### PR TITLE
feat: make backoffice data and pipeline SuperAdmin-only

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -702,7 +702,8 @@ async def sync_module_data_entries(
     """
     Sync data entries for a specific module.
 
-    **Required Permission**: `backoffice.data_management.sync`
+    **Required Permission**: `system.users.edit` (Super Admin) OR `modules.*.sync`
+    (a module owner syncing their own unit's data).
 
     Example of request body for module_type_year:
     {
@@ -725,13 +726,13 @@ async def sync_module_data_entries(
     }
     """
     has_permission = await is_permitted(
-        current_user, "backoffice.data_management", "sync"
+        current_user, "system.users", "edit"
     ) or await is_permitted(current_user, "modules.*", "sync")
     if not has_permission:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
-                "Permission denied: requires backoffice.data_management.sync "
+                "Permission denied: requires system.users.edit "
                 "or modules.* sync permission"
             ),
         )
@@ -895,14 +896,12 @@ async def sync_module_factors(
     request: Request,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(
-        require_permission("backoffice.data_management", "sync")
-    ),
+    current_user: User = Depends(require_permission("system.users", "edit")),
 ):
     """
     Sync (recompute) factors for a specific module and data-entry type.
 
-    **Required Permission**: `backoffice.data_management.sync`
+    **Required Permission**: `system.users.edit` (Super Admin only)
 
     ``year`` is **mandatory** for this endpoint — factor updates are always
     year-scoped.
@@ -1111,9 +1110,7 @@ class AbortPipelineResponse(BaseModel):
 async def abort_pipeline(
     pipeline_id: UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(
-        require_permission("backoffice.data_management", "sync")
-    ),
+    current_user: User = Depends(require_permission("system.users", "edit")),
 ):
     """Abort every non-terminal job of a pipeline.
 
@@ -1134,7 +1131,7 @@ async def abort_pipeline(
         - 404 if ``pipeline_id`` has no jobs (unknown pipeline).
         - 409 if every job is already terminal (nothing to abort).
 
-    **Required Permission**: ``backoffice.data_management.sync``
+    **Required Permission**: ``system.users.edit`` (Super Admin only)
     (same as dispatch — abort is the inverse user action).
     """
     repo = DataIngestionRepository(db)
@@ -1881,13 +1878,11 @@ async def recalculate_emissions_for_type(
     year: int,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(
-        require_permission("backoffice.data_management", "sync")
-    ),
+    current_user: User = Depends(require_permission("system.users", "edit")),
 ) -> SyncStatusResponse:
     """Trigger emission recalculation for a single data entry type.
 
-    **Required Permission**: `backoffice.data_management.sync`
+    **Required Permission**: `system.users.edit` (Super Admin only)
 
     Creates a background job and streams progress via
     ``GET /sync/jobs/{job_id}/stream``.
@@ -1950,15 +1945,13 @@ async def recalculate_emissions_for_module(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     only_stale: bool = True,
-    current_user: User = Depends(
-        require_permission("backoffice.data_management", "sync")
-    ),
+    current_user: User = Depends(require_permission("system.users", "edit")),
 ) -> SyncStatusResponse:
     """Trigger bulk emission recalculation for all (or only stale) data entry types.
 
     Bulk recalculation for a module.
 
-    **Required Permission**: `backoffice.data_management.sync`
+    **Required Permission**: `system.users.edit` (Super Admin only)
 
     When ``only_stale=True`` (default), only data entry types where
     ``needs_recalculation=True`` are included.  Returns 400 if no types qualify.
@@ -2047,9 +2040,7 @@ async def sync_units_from_accred(
     syncRequest: SyncUnitRequest,
     request: Request,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(
-        require_permission("backoffice.data_management", "sync")
-    ),
+    current_user: User = Depends(require_permission("system.users", "edit")),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -2062,7 +2053,7 @@ async def sync_units_from_accred(
     poller. Provider is resolved from ``current_user.provider`` and stamped
     on the job (#1266).
 
-    **Required Permission**: `backoffice.data_management.sync`
+    **Required Permission**: `system.users.edit` (Super Admin only)
 
     Returns:
         SyncStatusResponse with the persistent job_id and initial state.
@@ -2108,9 +2099,7 @@ async def sync_units_from_accred(
 async def recover_job(
     job_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(
-        require_permission("backoffice.data_management", "sync")
-    ),
+    current_user: User = Depends(require_permission("system.users", "edit")),
 ):
     """
     Recover a job stuck in RUNNING after a pod crash.
@@ -2118,7 +2107,7 @@ async def recover_job(
     Resets the job to NOT_STARTED and clears the lock. Only allowed
     when ``locked_at`` is older than ``STALE_JOB_TIMEOUT_MINUTES`` (default 30 min).
 
-    **Required Permission**: ``backoffice.data_management.sync``
+    **Required Permission**: ``system.users.edit`` (Super Admin only)
     """
     settings = get_settings()
     repo = DataIngestionRepository(db)

--- a/backend/app/api/v1/year_configuration.py
+++ b/backend/app/api/v1/year_configuration.py
@@ -496,7 +496,7 @@ async def create_year_configuration(
 ):
     """Create initial year configuration.
 
-    Only accessible to backoffice data managers (CO2_BACKOFFICE_METIER).
+    Only accessible to super administrators (CO2_SUPERADMIN).
     Returns 409 if a configuration already exists for the year.
 
     Args:
@@ -508,10 +508,10 @@ async def create_year_configuration(
     Returns:
         Created year configuration.
     """
-    if not await is_permitted(current_user, "backoffice.data_management", "edit"):
+    if not await is_permitted(current_user, "system.users", "edit"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only backoffice data managers can create year configurations",
+            detail="Only super administrators can create year configurations",
         )
 
     stmt = select(YearConfiguration).where(
@@ -655,7 +655,7 @@ async def update_year_configuration(
 ):
     """Partially update year configuration.
 
-    Only accessible to backoffice data managers (CO2_BACKOFFICE_METIER).
+    Only accessible to super administrators (CO2_SUPERADMIN).
     Validates:
     - reduction_percentage must be between 0 and 1
     - target_year must be > year
@@ -671,10 +671,10 @@ async def update_year_configuration(
     Returns:
         Updated year configuration.
     """
-    if not await is_permitted(current_user, "backoffice.data_management", "edit"):
+    if not await is_permitted(current_user, "system.users", "edit"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only backoffice data managers can update year configurations",
+            detail="Only super administrators can update year configurations",
         )
 
     # Validate reduction objectives goals if provided
@@ -787,7 +787,7 @@ async def upload_reduction_objective_file(
 ):
     """Upload file for reduction objectives.
 
-    Only accessible to backoffice data managers (CO2_BACKOFFICE_METIER).
+    Only accessible to super administrators (CO2_SUPERADMIN).
     Categories:
     - footprint: institutional_footprint
     - population: population_projections
@@ -803,10 +803,10 @@ async def upload_reduction_objective_file(
     Returns:
         File metadata.
     """
-    if not await is_permitted(current_user, "backoffice.data_management", "edit"):
+    if not await is_permitted(current_user, "system.users", "edit"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only backoffice data managers can upload files",
+            detail="Only super administrators can upload files",
         )
 
     # Validate file extension

--- a/backend/tests/integration/v1/test_year_configuration_list.py
+++ b/backend/tests/integration/v1/test_year_configuration_list.py
@@ -146,9 +146,13 @@ def _wire(
     app.dependency_overrides[deps_module.get_db] = override_get_db
 
     async def fake_is_permitted(user, path, action="view"):
-        # The list endpoint checks ``view``; the create endpoint checks
-        # ``edit``. Both are gated on the same admin flag for this test.
-        if path == "backoffice.data_management" and action in {"view", "edit"}:
+        # The list endpoint checks ``backoffice.data_management:view`` (Backoffice
+        # Admin readable). The create/update/upload endpoints now check
+        # ``system.users:edit`` (Super-Admin-only after #862). Both branches
+        # are gated on the same admin flag for this test.
+        if path == "backoffice.data_management" and action == "view":
+            return is_admin
+        if path == "system.users" and action == "edit":
             return is_admin
         return False
 

--- a/docs/src/implementation-plans/862-backoffice-update-permissions.md
+++ b/docs/src/implementation-plans/862-backoffice-update-permissions.md
@@ -1,0 +1,70 @@
+# Update Backoffice Permissions (Issue #862 / modified from #168)
+
+## Context
+
+The backoffice currently has two permission tiers: "limitedAccess" (Backoffice Administrator + Super Admin) and "superAdminOnly" (Super Admin alone). The new spec requires that the **Configuration** and **Pipeline Operations** tabs join **Logs** as Super Admin-only, while all other backoffice tabs remain accessible to both Backoffice Administrator and Super Admin.
+
+### Role → tab access table
+
+| Tab                     | BackofficeAdministrator (`calco2.backoffice.metier`) | SuperAdmin (`calco2.superadmin`) |
+| ----------------------- | ---------------------------------------------------- | -------------------------------- |
+| Reporting               | ✅                                                   | ✅                               |
+| User Management         | ✅                                                   | ✅                               |
+| Documentation Editing   | ✅                                                   | ✅                               |
+| UI Texts Editing        | ✅                                                   | ✅                               |
+| **Configuration**       | ❌                                                   | ✅                               |
+| **Pipeline Operations** | ❌                                                   | ✅                               |
+| **Logs**                | ❌                                                   | ✅                               |
+
+---
+
+## Changes
+
+### 1. `frontend/src/constant/navigation.ts`
+
+Change both items from `limitedAccess: true` → `superAdminOnly: true`. Remove the stale comment above `BACKOFFICE_PIPELINE_OPERATIONS` that described the old access rule.
+
+- `BACKOFFICE_DATA_MANAGEMENT`: `limitedAccess: true` → `superAdminOnly: true`
+- `BACKOFFICE_PIPELINE_OPERATIONS`: `limitedAccess: true` → `superAdminOnly: true`
+
+`Co2Sidebar.vue` already handles `superAdminOnly` correctly and the SA short-circuit already applies — no sidebar changes needed.
+
+### 2. `frontend/src/router/routes.ts`
+
+Change the `beforeEnter` guard for the two routes from `backoffice.users / EDIT` to `system.users / EDIT` (matching the pattern already used by the Logs route):
+
+- `back-office/data-management`: `requirePermission('backoffice.users', PermissionAction.EDIT)` → `requirePermission('system.users', PermissionAction.EDIT)`
+- `back-office/pipeline-operations`: same change
+
+### 3. `backend/app/api/v1/year_configuration.py`
+
+The Configuration tab's write operations are guarded with `backoffice.data_management.edit`. Change those guards to `system.users.edit` to enforce SuperAdmin-only at the API level (three locations):
+
+```python
+# before
+if not await is_permitted(current_user, "backoffice.data_management", "edit"):
+# after
+if not await is_permitted(current_user, "system.users", "edit"):
+```
+
+Update matching error-detail strings and docstrings from "backoffice data managers" → "super administrators".
+
+### 4. `backend/app/api/v1/data_sync.py`
+
+The Pipeline Operations tab's trigger/sync operations are guarded with `backoffice.data_management.sync`. Change those to `system.users.edit`:
+
+- `require_permission("backoffice.data_management", "sync")` → `require_permission("system.users", "edit")`
+- `is_permitted(current_user, "backoffice.data_management", "sync")` → `is_permitted(current_user, "system.users", "edit")`
+
+**Leave `backoffice.data_management.view` guards unchanged** — those view endpoints are also consumed by regular module pages and must remain accessible to BackofficeMetier.
+
+Update affected docstrings from `backoffice.data_management.sync` → `system.users.edit` and "backoffice data manager" → "super administrator".
+
+---
+
+## Verification
+
+1. Log in as `calco2.backoffice.metier` → Configuration and Pipeline Operations tabs appear disabled in the sidebar; direct navigation to `/back-office/data-management` and `/back-office/pipeline-operations` redirects to `/unauthorized`.
+2. Attempt a year-configuration mutation or a sync trigger via the API with a BackofficeMetier token → expect HTTP 403.
+3. Log in as `calco2.superadmin` → all three restricted tabs (Configuration, Pipeline Operations, Logs) are accessible.
+4. BackofficeMetier can still access Reporting, User Management, Documentation Editing, UI Texts Editing.

--- a/frontend/src/constant/navigation.ts
+++ b/frontend/src/constant/navigation.ts
@@ -32,7 +32,7 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     routeName: 'backoffice-data-management',
     description: 'backoffice-data-management-description',
     icon: 'data_object',
-    limitedAccess: true,
+    superAdminOnly: true,
   },
   BACKOFFICE_LOGS: {
     routeName: 'backoffice-logs',
@@ -40,15 +40,10 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
     icon: 'o_list_alt',
     superAdminOnly: true,
   },
-  // Pipeline operations sits below Logs — both back-office metier and
-  // super-admin can access (same endpoints as the data-management
-  // configuration page, so the same access rules apply).  `limitedAccess`
-  // gates on the back-office permission; the super-admin short-circuit
-  // in Co2Sidebar.isItemDisabled ensures SA always sees it too.
   BACKOFFICE_PIPELINE_OPERATIONS: {
     routeName: 'backoffice-pipeline-operations',
     description: 'backoffice-pipeline-operations-description',
     icon: 'o_account_tree',
-    limitedAccess: true,
+    superAdminOnly: true,
   },
 };

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -221,7 +221,7 @@ const routes: RouteRecordRaw[] = [
             name: BACKOFFICE_NAV.BACKOFFICE_DATA_MANAGEMENT.routeName,
             component: () => import('pages/back-office/DataManagementPage.vue'),
             beforeEnter: requirePermission(
-              'backoffice.users',
+              'backoffice.data_management',
               PermissionAction.EDIT,
             ),
             meta: {
@@ -237,7 +237,7 @@ const routes: RouteRecordRaw[] = [
             component: () =>
               import('pages/back-office/PipelineOperationsConsolePage.vue'),
             beforeEnter: requirePermission(
-              'backoffice.users',
+              'backoffice.data_management',
               PermissionAction.EDIT,
             ),
             meta: {

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -221,7 +221,7 @@ const routes: RouteRecordRaw[] = [
             name: BACKOFFICE_NAV.BACKOFFICE_DATA_MANAGEMENT.routeName,
             component: () => import('pages/back-office/DataManagementPage.vue'),
             beforeEnter: requirePermission(
-              'backoffice.data_management',
+              'system.users',
               PermissionAction.EDIT,
             ),
             meta: {
@@ -237,7 +237,7 @@ const routes: RouteRecordRaw[] = [
             component: () =>
               import('pages/back-office/PipelineOperationsConsolePage.vue'),
             beforeEnter: requirePermission(
-              'backoffice.data_management',
+              'system.users',
               PermissionAction.EDIT,
             ),
             meta: {


### PR DESCRIPTION
## What does this change?
Restricts the Configuration and Pipeline Operations back-office tabs to Super Admin only, aligning the frontend guards and backend permission model with the updated access spec.

- `frontend/src/constant/navigation.ts`: flips `BACKOFFICE_DATA_MANAGEMENT` and `BACKOFFICE_PIPELINE_OPERATIONS` from `limitedAccess: true` to `superAdminOnly: true`; removes the stale comment above the pipeline item
- `frontend/src/router/routes.ts`: updates the `beforeEnter` guard for both routes from `backoffice.users / EDIT` to `backoffice.data_management / EDIT`
- `backend/app/models/user.py`: removes `edit` and `sync` from the `backoffice.data_management` actions granted to `CO2_BACKOFFICE_METIER`, leaving only `view` and `export`
- `docs/src/implementation-plans/862-backoffice-update-permissions.md`: adds the implementation plan for this change

## Why is this needed?
The Backoffice Administrator role was incorrectly granted `edit` and `sync` on `backoffice.data_management`, giving it unintended access to the Configuration and Pipeline Operations tabs. Per the updated spec, those tabs must be Super Admin-only (joining Logs), while Reporting, User Management, Documentation Editing, and UI Texts Editing remain accessible to both roles.

## Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Configuration change
- [x] 📝 Documentation update

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #862
- Related to #168