### PR TITLE
feat 952: change purchase field translation

### DIFF
--- a/frontend/src/i18n/purchase.ts
+++ b/frontend/src/i18n/purchase.ts
@@ -26,8 +26,8 @@ export default {
     fr: 'Description de l’article',
   },
   [`${MODULES.Purchase}.inputs.purchase_institutional_code`]: {
-    en: 'UNSPSC Code',
-    fr: 'Code UNSPSC',
+    en: 'UNSPSC description',
+    fr: 'Description UNSPSC',
   },
   [`${MODULES.Purchase}.inputs.purchase_institutional_code-hint`]: {
     en: 'To identify the corresponding UNSPSC Code, please consult the reference table.',


### PR DESCRIPTION
## What does this change?
Renames the `purchase_institutional_code` field label in both English and French:
- EN: `UNSPSC Code` → `UNSPSC description`
- FR: `Code UNSPSC` → `Description UNSPSC`

## Why is this needed?
The field displays the UNSPSC description text, not the raw code, so the label was misleading. This aligns the UI label with what the field actually contains.

## Related issues
- Closes #952