### PR TITLE
feat/1043 wrong order of subcategory

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -377,10 +377,10 @@ _MODULE_TOP_CLASS_GROUP_FIELD: dict[ModuleTypeEnum, str] = {
     ModuleTypeEnum.research_facilities: "researchfacility_name",
 }
 
-# Maps module type → JSON data field to use as the human-readable label
-# in the top-class breakdown response (falls back to the group field when absent).
+# Maps module type → Factor.values JSON field to use as the segment label
+# in the top-class breakdown response (looked up from the Factor table).
 _MODULE_TOP_CLASS_LABEL_FIELD: dict[ModuleTypeEnum, str] = {
-    ModuleTypeEnum.purchase: "name",
+    ModuleTypeEnum.purchase: "translation_key",
 }
 
 
@@ -430,12 +430,23 @@ async def get_top_class_breakdown(
 
     data_entry_types = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(module_type, [])
 
-    stats = await DataEntryEmissionService(db).get_top_class_breakdown(
+    svc = DataEntryEmissionService(db)
+    stats = await svc.get_top_class_breakdown(
         carbon_report_module_id=carbon_report_module_id,
         data_entry_types=data_entry_types,
         group_by_field=group_field,
         report_year=int(year),
     )
+
+    factor_tk_field = _MODULE_TOP_CLASS_LABEL_FIELD.get(module_type)
+    if factor_tk_field:
+        stats = await svc.enrich_breakdown_with_factor_labels(
+            breakdown=stats,
+            data_entry_types=data_entry_types,
+            group_by_field=group_field,
+            factor_label_field=factor_tk_field,
+        )
+
     return stats
 
 

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -797,6 +797,54 @@ class DataEntryEmissionService:
             emission_type_ids=emission_type_ids,
         )
 
+    async def enrich_breakdown_with_factor_labels(
+        self,
+        breakdown: list[dict],
+        data_entry_types: list[DataEntryTypeEnum],
+        group_by_field: str,
+        factor_label_field: str,
+    ) -> list[dict]:
+        """Add a ``translation_key`` field to each non-rest child in breakdown.
+
+        Looks up ``Factor.values[factor_label_field]`` for each unique
+        ``group_by_field`` code and attaches it to the child dict so the
+        frontend can resolve the human-readable label via i18n.
+        """
+        codes = {
+            child["name"]
+            for group in breakdown
+            for child in group.get("children", [])
+            if child.get("name") != "rest"
+        }
+        if not codes:
+            return breakdown
+
+        stmt = (
+            select(
+                Factor.classification[group_by_field].as_string().label("code"),
+                Factor.values[factor_label_field].as_string().label("label"),
+            )
+            .where(
+                col(Factor.data_entry_type_id).in_(
+                    [det.value for det in data_entry_types]
+                ),
+                Factor.classification[group_by_field].as_string().in_(list(codes)),
+            )
+            .distinct()
+        )
+        rows = (await self.session.execute(stmt)).all()
+        code_to_label: dict[str, str] = {
+            row.code: row.label for row in rows if row.code and row.label
+        }
+
+        for group in breakdown:
+            for child in group.get("children", []):
+                label = code_to_label.get(child.get("name", ""))
+                if label:
+                    child["translation_key"] = label
+
+        return breakdown
+
     # # Dict of dataEntryTypeEnum , func to calculation formulas
     # FORMULAS: dict[EmissionType, Callable] = {}
 

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -106,7 +106,7 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
 export interface TopClassBreakdownItem {
   name: string;
   value: number;
-  children: Array<{ name: string; value: number }>;
+  children: Array<{ name: string; value: number; translation_key?: string }>;
 }
 
 const props = defineProps<{
@@ -220,7 +220,8 @@ const chartData = computed(() => {
         // Use a numeric suffix to guarantee unique, parseable segment keys
         const segKey = `_tcb_${segCounter++}`;
         segmentKeysSet.add(segKey);
-        segmentLabelOverrides.set(segKey, child.name);
+        // Prefer translation_key (i18n key from Factor table) over raw name
+        segmentLabelOverrides.set(segKey, child.translation_key ?? child.name);
         barData[segKey] = child.value / 1000.0; // kg → tonnes
       }
       bars.push(barData);

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -211,7 +211,12 @@ const chartData = computed(() => {
       barCategoryMap.set(compoundKey, categoryKey);
       barLabelMap.set(compoundKey, normalizedName);
 
-      for (const child of subcategory.children) {
+      const sortedChildren = [...subcategory.children].sort((a, b) => {
+        if (a.name === 'rest') return 1;
+        if (b.name === 'rest') return -1;
+        return b.value - a.value;
+      });
+      for (const child of sortedChildren) {
         // Use a numeric suffix to guarantee unique, parseable segment keys
         const segKey = `_tcb_${segCounter++}`;
         segmentKeysSet.add(segKey);

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -606,6 +606,69 @@ const datasetSource = computed(() => {
   return [...main, ...additional];
 });
 
+const EQUIPMENT_SUBKEYS = ['scientific', 'it', 'other'] as const;
+const PURCHASES_SUBKEYS = [
+  'scientific_equipment',
+  'it_equipment',
+  'consumable_accessories',
+  'biological_chemical_gaseous',
+  'services',
+  'vehicles',
+  'other_purchases',
+  'additional',
+] as const;
+
+const equipPurchRankings = computed(() => {
+  const findRow = (key: string) =>
+    datasetSource.value.find((r) => String(r.category_key ?? '') === key);
+
+  const rankSubkeys = (
+    row: Record<string, unknown> | undefined,
+    keys: readonly string[],
+  ) =>
+    [...keys]
+      .map((k) => ({ key: k, value: Number(row?.[k] ?? 0) }))
+      .sort((a, b) => b.value - a.value);
+
+  const equipRanked = rankSubkeys(findRow('equipment'), EQUIPMENT_SUBKEYS);
+  const purchAllRanked = rankSubkeys(findRow('purchases'), PURCHASES_SUBKEYS);
+  const purchTop3 = purchAllRanked.slice(0, 3);
+  const purchRestValue = purchAllRanked
+    .slice(3)
+    .reduce((s, e) => s + e.value, 0);
+
+  return { equipRanked, purchTop3, purchRestValue };
+});
+
+const enrichedDatasetSource = computed(() => {
+  const { equipRanked, purchTop3, purchRestValue } = equipPurchRankings.value;
+  return datasetSource.value.map((row) => {
+    const catKey = String(row.category_key ?? '');
+    if (catKey === 'equipment') {
+      const next = { ...row };
+      EQUIPMENT_SUBKEYS.forEach((k) => {
+        next[k] = 0;
+      });
+      equipRanked.forEach((item, i) => {
+        next[`equip_rank${i + 1}`] = item.value;
+      });
+      return next;
+    }
+    if (catKey === 'purchases') {
+      const next = { ...row };
+      PURCHASES_SUBKEYS.forEach((k) => {
+        next[k] = 0;
+      });
+      purchTop3.forEach((item, i) => {
+        next[`purch_rank${i + 1}`] = item.value;
+      });
+      next['purch_rest'] = purchRestValue;
+      return next;
+    }
+    return row;
+  });
+});
+
 const additionalSeriesData = computed(() => {
   if (!effectiveToggle.value) return [];
 
@@ -866,169 +929,67 @@ const chartOption = computed((): EChartsOption => {
       },
       label: { show: false },
     },
-    // Equipment — subcategories: scientific, it, other
-    {
-      name: t('charts-scientific-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'scientific' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'equipment',
-          'scientific',
-          colors.value.plum.darker,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-equipment-it'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'it' },
-      itemStyle: {
-        color: getSubcategoryColor('equipment', 'it', colors.value.plum.dark),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-other-equipment-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'other' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'equipment',
-          'other',
-          colors.value.plum.default,
-        ),
-      },
-      label: { show: false },
-    },
-    // Purchases — YY subcategories
-    {
-      name: t('charts-scientific-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'scientific_equipment' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'scientific_equipment',
-          colors.value.lavender.darker,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-equipment-it'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'it_equipment' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'it_equipment',
-          colors.value.lavender.dark,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-consumables-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'consumable_accessories' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'consumable_accessories',
-          colors.value.lavender.default,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-bio-chemicals-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'biological_chemical_gaseous' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'biological_chemical_gaseous',
-          colors.value.lavender.light,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-services-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'services' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'services',
-          colors.value.lavender.lighter,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-vehicles-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'vehicles' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'vehicles',
-          colors.value.lavender.default,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-other-purchases-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'other_purchases' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'other_purchases',
-          colors.value.lavender.dark,
-        ),
-      },
-      label: { show: false },
-    },
-    {
-      name: t('charts-additional-purchases-subcategory'),
-      type: 'bar' as const,
-      stack: 'total',
-      animation: true,
-      encode: { x: 'category', y: 'additional' },
-      itemStyle: {
-        color: getSubcategoryColor(
-          'purchases',
-          'additional',
-          colors.value.lavender.light,
-        ),
-      },
-      label: { show: false },
-    },
+    // Equipment — top-3 subcategories sorted by emission value (descending)
+    ...(() => {
+      const equipSubcatLabels: Record<string, string> = {
+        scientific: t('charts-scientific-subcategory'),
+        it: t('charts-equipment-it'),
+        other: t('charts-other-equipment-subcategory'),
+      };
+      return equipPurchRankings.value.equipRanked.map((item, i) => ({
+        name: equipSubcatLabels[item.key] ?? item.key,
+        type: 'bar' as const,
+        stack: 'total',
+        animation: true,
+        encode: { x: 'category', y: `equip_rank${i + 1}` },
+        itemStyle: {
+          color: getSubcategoryColor(
+            'equipment',
+            item.key,
+            colors.value.plum.default,
+          ),
+        },
+        label: { show: false },
+      }));
+    })(),
+    // Purchases — top-3 subcategories sorted by emission value + rest
+    ...(() => {
+      const purchSubcatLabels: Record<string, string> = {
+        scientific_equipment: t('charts-scientific-subcategory'),
+        it_equipment: t('charts-equipment-it'),
+        consumable_accessories: t('charts-consumables-subcategory'),
+        biological_chemical_gaseous: t('charts-bio-chemicals-subcategory'),
+        services: t('charts-services-subcategory'),
+        vehicles: t('charts-vehicles-subcategory'),
+        other_purchases: t('charts-other-purchases-subcategory'),
+        additional: t('charts-additional-purchases-subcategory'),
+      };
+      const top3Series = equipPurchRankings.value.purchTop3.map((item, i) => ({
+        name: purchSubcatLabels[item.key] ?? item.key,
+        type: 'bar' as const,
+        stack: 'total',
+        animation: true,
+        encode: { x: 'category', y: `purch_rank${i + 1}` },
+        itemStyle: {
+          color: getSubcategoryColor(
+            'purchases',
+            item.key,
+            colors.value.lightGreen.default,
+          ),
+        },
+        label: { show: false },
+      }));
+      const restSeries = {
+        name: t('charts-rest-subcategory'),
+        type: 'bar' as const,
+        stack: 'total',
+        animation: true,
+        encode: { x: 'category', y: 'purch_rest' },
+        itemStyle: { color: colors.value.lightGreen.lighter },
+        label: { show: false },
+      };
+      return [...top3Series, restSeries];
+    })(),
     // External cloud & AI — YY subcategories
     {
       name: t('charts-clouds-subcategory'),
@@ -1301,6 +1262,13 @@ const chartOption = computed((): EChartsOption => {
         'vehicles',
         'other_purchases',
         'additional',
+        'equip_rank1',
+        'equip_rank2',
+        'equip_rank3',
+        'purch_rank1',
+        'purch_rank2',
+        'purch_rank3',
+        'purch_rest',
         'plane',
         'train',
         'clouds',
@@ -1317,7 +1285,7 @@ const chartOption = computed((): EChartsOption => {
         'waste',
         'embodied_energy',
       ],
-      source: datasetSource.value as Array<Record<string, unknown>>,
+      source: enrichedDatasetSource.value as Array<Record<string, unknown>>,
     },
     series: seriesArray as echarts.SeriesOption[],
   };


### PR DESCRIPTION
## What does this change?
Fixes subcategory ordering in the carbon footprint charts for the Equipment and Purchases modules, and corrects the purchase segment label source.

- `EmissionTypeBreakdownChart.vue`: sorts subcategory children by emission value descending before rendering, with `rest` always last; uses `translation_key` (i18n key from the Factor table) over raw code as the segment label
- `ModuleCarbonFootprintChart.vue`: replaces the static per-subcategory series with dynamically ranked series — Equipment shows all 3 subcategories sorted by value, Purchases shows the top 3 by value plus a collapsed `rest` segment; switches the dataset source to `enrichedDatasetSource`
- `carbon_report_module.py`: adds a post-processing step to enrich the top-class breakdown with `translation_key` labels looked up from the Factor table for the Purchase module
- `data_entry_emission_service.py`: adds `enrich_breakdown_with_factor_labels()` which queries `Factor.values[field]` for each breakdown code and attaches the resolved label to each child entry

## Why is this needed?
Subcategories in the Equipment and Purchases charts were displayed in a fixed, arbitrary order rather than ranked by emission value, making it hard to read at a glance which categories contribute most. Additionally, purchase segment labels were showing raw UNSPSC codes instead of human-readable i18n keys.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1043