### PR TITLE
fix: reverted departure date requiredness

### DIFF
--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -59,7 +59,7 @@ const commonTravelFields: ModuleField[] = [
     id: 'departure_date',
     labelKey: `${MODULES.ProfessionalTravel}-field-start-date`,
     type: 'date',
-    required: true,
+    required: false,
     sortable: true,
     ratio: '1/1',
     editableInline: false,


### PR DESCRIPTION
## What does this change?

Departure date not required, affects only the frontend (was still optional in the backend).

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
