### PR TITLE
feat: Add columnSize support to module table

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -71,8 +71,9 @@
           :align="col.align"
           class="q-pa-xs"
           :class="{
-            'column-max-width': col.maxColumnWidth,
-            'column-min-width': col.minColumnWidth,
+            'column-max-width': col.maxColumnWidth !== undefined,
+            'column-min-width':
+              col.minColumnWidth !== undefined || col.columnSize !== undefined,
           }"
           :style="getColumnStyle(col)"
         >
@@ -348,8 +349,12 @@
 import FilesUploadDialog from 'src/components/organisms//data-management/FilesUploadDialog.vue';
 
 import { computed, ref, watch, nextTick, onMounted, onUnmounted } from 'vue';
-import type { ModuleField } from 'src/constant/moduleConfig';
-import type { ModuleConfig, Submodule } from 'src/constant/moduleConfig';
+import { COLUMN_SIZES } from 'src/constant/moduleConfig';
+import type {
+  ModuleField,
+  ModuleConfig,
+  Submodule,
+} from 'src/constant/moduleConfig';
 import { useI18n } from 'vue-i18n';
 import ModuleForm from './ModuleForm.vue';
 import ModuleInlineSelect from './ModuleInlineSelect.vue';
@@ -745,6 +750,7 @@ type TableViewColumn = {
   optionLabelKey?: string;
   tooltip?: string;
   type: ModuleField['type'];
+  columnSize?: ModuleField['columnSize'];
   minColumnWidth?: number;
   maxColumnWidth?: number;
   readOnlyWhen?: ModuleField['readOnlyWhen'];
@@ -799,6 +805,7 @@ const qCols = computed<TableViewColumn[]>(() => {
             options,
             tooltip: index === 0 ? tooltip : undefined, // Only first column gets tooltip
             type: f.type,
+            columnSize: f.columnSize,
             minColumnWidth: f.minColumnWidth,
             maxColumnWidth: f.maxColumnWidth,
             readOnlyWhen: f.readOnlyWhen,
@@ -835,6 +842,7 @@ const qCols = computed<TableViewColumn[]>(() => {
           optionLabelKey: f.optionLabelKey,
           tooltip,
           type: f.type,
+          columnSize: f.columnSize,
           minColumnWidth: f.minColumnWidth,
           maxColumnWidth: f.maxColumnWidth,
           readOnlyWhen: f.readOnlyWhen,
@@ -862,6 +870,7 @@ const qCols = computed<TableViewColumn[]>(() => {
       options: undefined,
       tooltip: undefined,
       type: 'text',
+      columnSize: 'sm',
       minColumnWidth: undefined,
       maxColumnWidth: undefined,
     });
@@ -1158,21 +1167,26 @@ function cellClasses(row: ModuleRow, col: { name: string; field: string }) {
 
 function getColumnStyle(col: TableViewColumn) {
   const style: Record<string, string> = {};
-  if (col.minColumnWidth) {
-    style['--min-column-width'] = `${col.minColumnWidth}px`;
+  const minWidth =
+    col.minColumnWidth ??
+    (col.columnSize !== undefined ? COLUMN_SIZES[col.columnSize] : undefined);
+  if (minWidth !== undefined) {
+    style['--min-column-width'] = `${minWidth}px`;
   }
-  if (col.maxColumnWidth) {
+  if (col.maxColumnWidth !== undefined) {
     style['--max-column-width'] = `${col.maxColumnWidth}px`;
   }
   return style;
 }
 
 function getColumnClasses(row: ModuleRow, col: TableViewColumn) {
+  const hasMinWidth =
+    col.minColumnWidth !== undefined || col.columnSize !== undefined;
   return [
     cellClasses(row, col),
     'table-cell',
-    { 'column-max-width': col.maxColumnWidth },
-    { 'column-min-width': col.minColumnWidth },
+    { 'column-max-width': col.maxColumnWidth !== undefined },
+    { 'column-min-width': hasMinWidth },
   ];
 }
 

--- a/frontend/src/constant/module-config/buildings.ts
+++ b/frontend/src/constant/module-config/buildings.ts
@@ -17,6 +17,7 @@ const roomFields: ModuleField[] = [
     align: 'left',
     ratio: '1/3',
     icon: 'o_apartment',
+    columnSize: 'sm',
   },
   {
     id: 'room_name',
@@ -30,6 +31,7 @@ const roomFields: ModuleField[] = [
     align: 'left',
     ratio: '1/3',
     icon: 'o_meeting_room',
+    columnSize: 'md',
   },
   {
     id: 'room_type',
@@ -41,8 +43,7 @@ const roomFields: ModuleField[] = [
     align: 'left',
     ratio: '1/3',
     icon: 'o_category',
-    minColumnWidth: 150,
-    maxColumnWidth: 150,
+    columnSize: 'md',
     disableUntilField: 'room_name',
     // IMPORTANT: these values are backend emission-factor lookup keys.
     // Do not translate or rename without matching backend seed/data updates.
@@ -81,7 +82,7 @@ const roomFields: ModuleField[] = [
     disableUntilField: 'room_name',
     icon: 'o_image_aspect_ratio',
     tooltip: `${MODULES.Buildings}.tooltips.ratio`,
-    minColumnWidth: 140,
+    columnSize: 'md',
   },
   {
     id: 'heating_kwh_per_square_meter',
@@ -159,6 +160,7 @@ const energyCombustionFields: ModuleField[] = [
     ratio: '1/3',
     icon: 'o_local_fire_department',
     hideIn: { form: false },
+    columnSize: 'lg',
     optionOrder: [
       'buildings_combustion_type_natural_gas',
       'buildings_combustion_type_heating_oil',

--- a/frontend/src/constant/module-config/equipment-electric-consumption.ts
+++ b/frontend/src/constant/module-config/equipment-electric-consumption.ts
@@ -43,6 +43,7 @@ const baseModuleFields: ModuleField[] = [
     editableInline: true,
     ratio: '1/2',
     icon: 'o_category',
+    columnSize: 'lg',
   },
   {
     id: 'sub_class',
@@ -60,6 +61,7 @@ const baseModuleFields: ModuleField[] = [
     readOnly: false,
     ratio: '1/2',
     icon: 'o_category',
+    columnSize: 'lg',
   },
   {
     id: 'active_usage_hours_per_week',

--- a/frontend/src/constant/module-config/external-cloud-and-ai.ts
+++ b/frontend/src/constant/module-config/external-cloud-and-ai.ts
@@ -24,6 +24,7 @@ const cloudFields: ModuleField[] = [
     editableInline: true,
     ratio: '1/2',
     icon: 'o_category',
+    columnSize: 'md',
   },
   {
     id: 'service_type',
@@ -41,6 +42,7 @@ const cloudFields: ModuleField[] = [
     editableInline: true,
     ratio: '1/2',
     icon: 'o_category',
+    columnSize: 'md',
   },
   // {
   //   id: 'region',
@@ -59,6 +61,7 @@ const cloudFields: ModuleField[] = [
     ratio: '3/4',
     hideIn: { form: false },
     sortable: true,
+    columnSize: 'sm',
   },
   {
     id: 'currency',
@@ -69,6 +72,7 @@ const cloudFields: ModuleField[] = [
     editableInline: true,
     hideIn: { form: false },
     sortable: true,
+    columnSize: 'sm',
     options: [
       { value: 'eur', label: 'EUR' },
       { value: 'chf', label: 'CHF' },
@@ -81,6 +85,7 @@ const cloudFields: ModuleField[] = [
     type: 'number',
     hideIn: { form: true },
     sortable: true,
+    columnSize: 'sm',
   },
 ];
 
@@ -97,6 +102,7 @@ const externalAIFields: ModuleField[] = [
     inputTypeName: 'QSelect',
     sortable: true,
     type: 'select',
+    columnSize: 'md',
   },
   {
     id: 'usage_type',
@@ -110,6 +116,7 @@ const externalAIFields: ModuleField[] = [
     inputTypeName: 'QSelect',
     sortable: true,
     type: 'select',
+    columnSize: 'md',
   },
   {
     id: 'fte_count',
@@ -123,6 +130,7 @@ const externalAIFields: ModuleField[] = [
     sortable: true,
     hideIn: { table: false },
     defaultFrom: 'total_fte',
+    columnSize: 'sm',
   },
   {
     id: 'requests_per_user_per_day',
@@ -135,6 +143,7 @@ const externalAIFields: ModuleField[] = [
     ratio: '4/12',
     sortable: true,
     hideIn: { table: false },
+    columnSize: 'sm',
     options: [
       {
         value: '1-5 times per day',
@@ -161,6 +170,7 @@ const externalAIFields: ModuleField[] = [
     hideIn: { form: true },
     sortable: true,
     ratio: '4/12',
+    columnSize: 'sm',
   },
 ];
 

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -28,6 +28,7 @@ const memberFields: ModuleField[] = [
     required: true,
     ratio: '1/4',
     icon: 'o_filter_drama',
+    columnSize: 'sm',
   },
   {
     id: 'position_category',
@@ -40,6 +41,7 @@ const memberFields: ModuleField[] = [
     ratio: '1/4',
     icon: 'o_assignment_ind',
     optionLabelsAreKeys: true,
+    columnSize: 'sm',
     options: [
       { value: 'professor', label: 'headcount_professor' },
       {

--- a/frontend/src/constant/module-config/process_emissions.ts
+++ b/frontend/src/constant/module-config/process_emissions.ts
@@ -17,6 +17,7 @@ const processEmissionsFields: ModuleField[] = [
     ratio: '1/3',
     hideIn: { form: false },
     icon: 'o_science',
+    columnSize: 'lg',
   },
   {
     id: 'subcategory',
@@ -30,6 +31,7 @@ const processEmissionsFields: ModuleField[] = [
     align: 'left',
     ratio: '1/3',
     hideIn: { form: false },
+    columnSize: 'lg',
     conditionalVisibility: {
       showWhen: {
         fieldId: 'category',

--- a/frontend/src/constant/module-config/purchase.ts
+++ b/frontend/src/constant/module-config/purchase.ts
@@ -43,7 +43,7 @@ const purchaseFields: ModuleField[] = [
     editableInline: true,
     ratio: '1/4',
     icon: 'o_category',
-    maxColumnWidth: 200,
+    columnSize: 'md',
   },
   {
     id: 'quantity',
@@ -55,6 +55,7 @@ const purchaseFields: ModuleField[] = [
     ratio: '1/4',
     hideIn: { form: false },
     sortable: true,
+    columnSize: 'xs',
   },
   {
     id: 'total_spent_amount',
@@ -66,6 +67,7 @@ const purchaseFields: ModuleField[] = [
     ratio: '1/4',
     hideIn: { form: false },
     sortable: true,
+    columnSize: 'xs',
   },
   {
     id: 'currency',
@@ -76,6 +78,7 @@ const purchaseFields: ModuleField[] = [
     hideIn: { form: false },
     sortable: true,
     ratio: '1/4',
+    columnSize: 'xs',
     options: [
       { value: 'chf', label: 'CHF' },
       { value: 'eur', label: 'EUR' },

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -1,6 +1,16 @@
 import { Threshold } from 'src/constant/modules';
 import type { AllSubmoduleTypes } from 'src/constant/modules';
 export type FormStructure = 'single' | 'perSubmodule' | 'grouped';
+
+export const COLUMN_SIZES = {
+  xs: 80,
+  sm: 120,
+  md: 160,
+  lg: 200,
+  xl: 260,
+} as const;
+
+export type ColumnSize = keyof typeof COLUMN_SIZES;
 export type FieldType =
   | 'text'
   | 'number'
@@ -75,6 +85,7 @@ export interface ModuleField {
   align?: 'left' | 'right' | 'center';
   ratio?: string;
   icon?: string;
+  columnSize?: ColumnSize;
   minColumnWidth?: number;
   maxColumnWidth?: number;
   hideIn?: {

--- a/frontend/src/css/05-components/quasar-overrides/_q-table.scss
+++ b/frontend/src/css/05-components/quasar-overrides/_q-table.scss
@@ -1,14 +1,14 @@
 .q-table th,
 .q-table td {
-  padding: 4px 2px;
+  padding: 4px;
 }
 
 .q-table th:first-child,
 .q-table td:first-child {
-  padding-left: 16px;
+  padding-left: 8px;
 }
 
 .q-table th:last-child,
 .q-table td:last-child {
-  padding-right: 16px;
+  padding-right: 8px;
 }


### PR DESCRIPTION
## What does this change?
Introduces a `columnSize` token system to replace ad-hoc `minColumnWidth`/`maxColumnWidth` magic numbers across module configs.

- `moduleConfig.ts`: adds a `COLUMN_SIZES` map (`xs: 80, sm: 120, md: 160, lg: 200, xl: 260`) and a `ColumnSize` type; adds `columnSize?: ColumnSize` to `ModuleField`
- `ModuleTable.vue`: updates `getColumnStyle` and `getColumnClasses` to resolve `columnSize` through `COLUMN_SIZES` as a fallback when `minColumnWidth` is not set; fixes truthy checks on width properties to use `!== undefined`
- Module configs (`buildings`, `equipment-electric-consumption`, `external-cloud-and-ai`, `headcount`, `process_emissions`, `purchase`): replaces hardcoded `minColumnWidth`/`maxColumnWidth` values with the appropriate `columnSize` token

## Why is this needed?
Column widths were scattered as raw pixel values across many module config files, making them hard to keep consistent and adjust globally. A shared token set makes sizing declarative and maintainable from one place.

## Type of change
- [x] 🔧 Configuration change
- [x] 🎨 Design/UI improvement
- [x] 🧹 Code cleanup

## Related issues
- Closes #1233