### PR TITLE
feat 973: download as png in all charts

### DIFF
--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -15,6 +15,7 @@ import VChart from 'vue-echarts';
 import TooltipEcharts from './results/TooltipEcharts.vue';
 import { useEchartsTooltip } from './results/useEchartsTooltip';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 import { useColorblindStore } from 'src/stores/colorblind';
 
 import { buildChartDecal } from 'src/constant/charts';
@@ -238,6 +239,11 @@ const onChartReady = async () => {
   if (!chart) return;
   attach(chart);
 };
+
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'emission-breakdown');
+
+defineExpose({ downloadPNG });
 </script>
 
 <template>

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -34,6 +34,7 @@ use([
 
 import { formatTonnesForChart } from 'src/utils/number';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 
 const props = defineProps<{
   perPersonBreakdown?: Record<string, number> | null;
@@ -441,30 +442,8 @@ const chartOption = computed((): EChartsOption => {
   };
 });
 
-const downloadPNG = async () => {
-  const chart = chartRef.value?.chart;
-  if (!chart) return;
-
-  try {
-    // Wait a bit to ensure no animation in the image
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    const url = chart.getDataURL({
-      type: 'png',
-      pixelRatio: 2,
-      backgroundColor: '#fff',
-    });
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `carbon-footprint-per-person-${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  } catch (error) {
-    console.error('Error downloading chart:', error);
-  }
-};
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'carbon-footprint-per-person');
 
 const downloadCSV = () => {
   const escape = (v: unknown) => {

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -40,6 +40,7 @@ import {
 } from 'src/composables/useEmissionTreemap';
 import { formatTonnesForChart } from 'src/utils/number';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 
 const CATEGORY_LABEL_MAP: Record<string, string> = RESULTS_CATEGORY_LABEL_KEYS;
 
@@ -492,6 +493,11 @@ const onChartReady = async () => {
   if (!chart) return;
   attach(chart);
 };
+
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'emission-breakdown');
+
+defineExpose({ downloadPNG });
 </script>
 
 <template>

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -39,6 +39,7 @@ import type { EmissionBreakdownResponse } from 'src/stores/modules';
 import type { TooltipRow } from 'src/types/chartTooltip';
 import { formatTonnesForChart } from 'src/utils/number';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 
 const props = defineProps({
   breakdownData: {
@@ -1302,30 +1303,8 @@ const onChartReady = async () => {
   attach(chart);
 };
 
-const downloadPNG = async () => {
-  const chart = chartRef.value?.chart;
-  if (!chart) return;
-
-  try {
-    // Wait a bit to ensure no animation in the image
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    const url = chart.getDataURL({
-      type: 'png',
-      pixelRatio: 2,
-      backgroundColor: '#fff',
-    });
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `module-carbon-footprint-${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  } catch (error) {
-    console.error('Error downloading chart:', error);
-  }
-};
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'module-carbon-footprint');
 
 const downloadCSV = () => {
   const escape = (v: unknown) => {

--- a/frontend/src/components/charts/results/ReductionObjectiveChart.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveChart.vue
@@ -4,6 +4,14 @@ import { useI18n } from 'vue-i18n';
 import ReductionObjectiveEpflView from 'src/components/charts/results/ReductionObjectiveEpflView.vue';
 import ReductionObjectiveUnitView from 'src/components/charts/results/ReductionObjectiveUnitView.vue';
 
+const epflViewRef = ref<{ downloadPNG: () => Promise<void> } | null>(null);
+const unitViewRef = ref<{ downloadPNG: () => Promise<void> } | null>(null);
+
+const downloadPNG = () =>
+  moduleChartView.value === 'epfl'
+    ? epflViewRef.value?.downloadPNG()
+    : unitViewRef.value?.downloadPNG();
+
 type ModuleChartView = 'epfl' | 'unit';
 
 interface Props {
@@ -116,13 +124,29 @@ const chartTitle = computed(() =>
     <div class="q-pl-xl">
       <ReductionObjectiveEpflView
         v-if="moduleChartView === 'epfl'"
+        ref="epflViewRef"
         :hide-research-facilities="props.hideResearchFacilities"
       />
       <ReductionObjectiveUnitView
         v-else
+        ref="unitViewRef"
         :hide-research-facilities="props.hideResearchFacilities"
         :hide-additional-data="props.hideAdditionalData"
       />
     </div>
+  </q-card-section>
+  <q-separator />
+  <q-card-section class="flex justify-start q-gutter-sm">
+    <q-btn
+      unelevated
+      no-caps
+      outline
+      icon="o_download"
+      :label="$t('common_download_as_png')"
+      size="xs"
+      dense
+      class="text-weight-bold q-px-sm"
+      @click="downloadPNG"
+    />
   </q-card-section>
 </template>

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -21,6 +21,7 @@ import { useEchartsTooltip } from './useEchartsTooltip';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useColorblindStore } from 'src/stores/colorblind';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 import {
   buildChartDecal,
   CHART_CATEGORY_COLOR_SCHEMES,
@@ -246,6 +247,11 @@ const onChartReady = async () => {
   if (!chart) return;
   attach(chart);
 };
+
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'reduction-objective-epfl');
+
+defineExpose({ downloadPNG });
 
 function tooltipAxisValueToYearLabel(rawAxisValue: unknown): string {
   // When tooltip is driven by the hidden numeric axis, axisValue can be an index

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -36,6 +36,7 @@ import {
   RESULTS_CATEGORY_ORDER,
 } from 'src/constant/charts';
 import { MODULE_STATES } from 'src/constant/moduleStates';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 
 interface Props {
   hideResearchFacilities?: boolean;
@@ -147,6 +148,11 @@ const onChartReady = async () => {
   if (!chart) return;
   attach(chart);
 };
+
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'reduction-objective-unit');
+
+defineExpose({ downloadPNG });
 
 function tooltipSortIndex(seriesName: string): number {
   const idx = TOOLTIP_CATEGORY_ORDER.indexOf(

--- a/frontend/src/components/organisms/AdditionalCategoriesSection.vue
+++ b/frontend/src/components/organisms/AdditionalCategoriesSection.vue
@@ -19,6 +19,7 @@ import {
   AriaComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import { downloadCompositeChartAsPng } from 'src/utils/chartDownload';
 import TooltipEcharts from 'src/components/charts/results/TooltipEcharts.vue';
 import { useEchartsTooltip } from 'src/components/charts/results/useEchartsTooltip';
 import { useColorblindStore } from 'src/stores/colorblind';
@@ -408,6 +409,34 @@ const embodiedEnergyLegend = computed(() =>
       '#B8CCEC',
   })),
 );
+
+const downloadPNG = () => {
+  if (!chartsInView.value) return;
+  return downloadCompositeChartAsPng(
+    [
+      {
+        title: t('charts-commuting-category'),
+        charts: [
+          commutingCO2Ref.value?.chart,
+          commutingPhysicalRef.value?.chart,
+        ],
+      },
+      {
+        title: t('charts-food-category'),
+        charts: [foodCO2Ref.value?.chart, foodPhysicalRef.value?.chart],
+      },
+      {
+        title: t('charts-waste-category'),
+        charts: [wasteCO2Ref.value?.chart, wastePhysicalRef.value?.chart],
+      },
+      {
+        title: t('charts-embodied-energy-category'),
+        charts: [embodiedEnergyCO2Ref.value?.chart],
+      },
+    ].filter((col) => col.charts.some(Boolean)),
+    'additional-categories',
+  );
+};
 </script>
 
 <template>
@@ -814,6 +843,22 @@ const embodiedEnergyLegend = computed(() =>
           </div>
         </div>
       </q-card>
+      <template v-if="!printMode">
+        <q-separator />
+        <q-card-section class="flex justify-start q-gutter-sm">
+          <q-btn
+            unelevated
+            no-caps
+            outline
+            icon="o_download"
+            :label="$t('common_download_as_png')"
+            size="xs"
+            dense
+            class="text-weight-bold q-px-sm"
+            @click="downloadPNG"
+          />
+        </q-card-section>
+      </template>
     </div>
     <Teleport v-if="!printMode" to="body">
       <tooltip-echarts

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -15,6 +15,7 @@ import { CHART_CATEGORY_COLOR_SCHEMES, colors } from 'src/constant/charts';
 import { IT_FOCUS_CATEGORY_TO_MODULE } from 'src/constant/itFocus';
 import { MODULE_STATES } from 'src/constant/moduleStates';
 import { useTimelineStore } from 'src/stores/modules';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
 import { formatTonnesCO2, formatTonnesForChart } from 'src/utils/number';
 import type { ItBreakdownResponse } from 'src/stores/modules';
 
@@ -50,6 +51,9 @@ const onChartReady = async () => {
   if (!chart) return;
   attach(chart);
 };
+
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'it-focus');
 
 function isItCategoryModuleValidated(categoryKey: string): boolean {
   const mod = IT_FOCUS_CATEGORY_TO_MODULE[categoryKey];
@@ -461,6 +465,22 @@ const barChartOption = computed<EChartsOption>(() => {
           @vue:mounted="onChartReady"
         />
       </q-card>
+      <template v-if="!printMode">
+        <q-separator />
+        <q-card-section class="flex justify-start q-gutter-sm">
+          <q-btn
+            unelevated
+            no-caps
+            outline
+            icon="o_download"
+            :label="$t('common_download_as_png')"
+            size="xs"
+            dense
+            class="text-weight-bold q-px-sm"
+            @click="downloadPNG"
+          />
+        </q-card-section>
+      </template>
     </template>
 
     <!-- Loading state -->

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -82,6 +82,7 @@
         <template v-if="moduleChartView === 'breakdown'">
           <generic-emission-tree-map-chart
             v-if="moduleTreemapData.length"
+            ref="treemapChartRef"
             :key="type"
             :data="moduleTreemapData"
             :print-mode="printMode"
@@ -93,6 +94,7 @@
         <template v-else>
           <emission-type-breakdown-chart
             v-if="moduleCategoryRows.length"
+            ref="emissionTypeChartRef"
             :key="type"
             :category-rows="moduleCategoryRows"
             :top-class-breakdown="topClassBreakdownData"
@@ -106,6 +108,22 @@
       </div>
     </template>
   </q-card-section>
+  <template v-if="type !== 'headcount' && !isPrintMode">
+    <q-separator />
+    <q-card-section class="flex justify-start q-gutter-sm">
+      <q-btn
+        unelevated
+        no-caps
+        outline
+        icon="o_download"
+        :label="$t('common_download_as_png')"
+        size="xs"
+        dense
+        class="text-weight-bold q-px-sm"
+        @click="downloadPNG"
+      />
+    </q-card-section>
+  </template>
 </template>
 
 <script setup lang="ts">
@@ -146,6 +164,19 @@ const props = withDefaults(
 const { t, te } = useI18n();
 
 const moduleChartView = ref<'breakdown' | 'type'>(props.forcedView ?? 'type');
+
+const treemapChartRef = ref<{ downloadPNG: () => Promise<void> } | null>(null);
+const emissionTypeChartRef = ref<{ downloadPNG: () => Promise<void> } | null>(
+  null,
+);
+
+const downloadPNG = async () => {
+  if (moduleChartView.value === 'breakdown') {
+    await treemapChartRef.value?.downloadPNG();
+  } else {
+    await emissionTypeChartRef.value?.downloadPNG();
+  }
+};
 
 const isPrintMode = usePrintMode();
 const showControls = computed(() => {

--- a/frontend/src/utils/chartDownload.ts
+++ b/frontend/src/utils/chartDownload.ts
@@ -1,0 +1,125 @@
+interface EChartInstance {
+  getDataURL(opts?: {
+    type?: 'png' | 'svg' | 'jpeg';
+    pixelRatio?: number;
+    backgroundColor?: string;
+  }): string;
+}
+
+function triggerPngDownload(url: string, filename: string): void {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename.endsWith('.png') ? filename : `${filename}.png`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function pngFilename(base: string): string {
+  return `${base}-${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
+}
+
+export async function downloadEchartAsPng(
+  chart: EChartInstance | null | undefined,
+  filenameBase: string,
+): Promise<void> {
+  if (!chart) return;
+  try {
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+    const url = chart.getDataURL({
+      type: 'png',
+      pixelRatio: 2,
+      backgroundColor: '#fff',
+    });
+    triggerPngDownload(url, pngFilename(filenameBase));
+  } catch (error) {
+    console.error('Error downloading chart:', error);
+  }
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = url;
+  });
+}
+
+export interface CompositeColumn {
+  title: string;
+  charts: Array<EChartInstance | null | undefined>;
+}
+
+/** Stitches multiple ECharts instances side-by-side into one PNG download. */
+export async function downloadCompositeChartAsPng(
+  columns: CompositeColumn[],
+  filenameBase: string,
+  colWidth = 400,
+  chartHeight = 300,
+  titleHeight = 40,
+): Promise<void> {
+  const visibleCols = columns.filter((c) => c.charts.some(Boolean));
+  if (visibleCols.length === 0) return;
+
+  try {
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+    const maxRows = Math.max(
+      ...visibleCols.map((c) => c.charts.filter(Boolean).length),
+    );
+    const canvas = document.createElement('canvas');
+    canvas.width = colWidth * visibleCols.length;
+    canvas.height = titleHeight + chartHeight * maxRows;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    for (let i = 0; i < visibleCols.length; i++) {
+      const col = visibleCols[i];
+      const x = i * colWidth;
+
+      ctx.font = 'bold 14px Arial, sans-serif';
+      ctx.fillStyle = '#333333';
+      ctx.textAlign = 'center';
+      ctx.fillText(col.title, x + colWidth / 2, 24);
+
+      let rowIndex = 0;
+      for (const chart of col.charts) {
+        if (!chart) continue;
+        const url = chart.getDataURL({
+          type: 'png',
+          pixelRatio: 2,
+          backgroundColor: '#fff',
+        });
+        const img = await loadImage(url);
+        ctx.drawImage(
+          img,
+          x,
+          titleHeight + rowIndex * chartHeight,
+          colWidth,
+          chartHeight,
+        );
+        rowIndex++;
+      }
+
+      if (i < visibleCols.length - 1) {
+        ctx.strokeStyle = 'rgba(0,0,0,0.12)';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(x + colWidth, 0);
+        ctx.lineTo(x + colWidth, canvas.height);
+        ctx.stroke();
+      }
+    }
+
+    triggerPngDownload(
+      canvas.toDataURL('image/png'),
+      pngFilename(filenameBase),
+    );
+  } catch (error) {
+    console.error('Error downloading composite chart:', error);
+  }
+}


### PR DESCRIPTION
## What does this change?
Adds PNG download buttons to all results charts, backed by a shared utility module.

- `utils/chartDownload.ts` (new): extracts the repeated inline download logic into two reusable functions — `downloadEchartAsPng` for single charts, and `downloadCompositeChartAsPng` for stitching multiple ECharts instances side-by-side onto a single canvas
- `CarbonFootPrintPerPersonChart`, `ModuleCarbonFootprintChart`: replaces duplicated inline download implementations with a one-liner call to `downloadEchartAsPng`
- `GenericEmissionTreeMapChart`, `EmissionTypeBreakdownChart`, `ReductionObjectiveEpflView`, `ReductionObjectiveUnitView`: adds `downloadPNG` + `defineExpose` so parent components can trigger downloads
- `ModuleCharts`: adds refs to the treemap and breakdown chart children, delegates to the active view's `downloadPNG`, and renders a download button (hidden in print mode, hidden for headcount)
- `ReductionObjectiveChart`: proxies `downloadPNG` to whichever sub-view (EPFL or unit) is currently active, adds a download button
- `AdditionalCategoriesSection`, `ItFocusSection`: adds `downloadPNG` wired to `downloadCompositeChartAsPng` / `downloadEchartAsPng` respectively, with a download button hidden in print mode

## Why is this needed?
Users had no way to export results charts as images. The download logic was also duplicated across two chart components with no shared abstraction.

## Type of change
- [x] ✨ New feature
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #973