### PR TITLE
feat: add backoffice PDF exports and print pages

### DIFF
--- a/docs/src/implementation-plans/462-backoffice-reporting-pdf-exports-of-reports.md
+++ b/docs/src/implementation-plans/462-backoffice-reporting-pdf-exports-of-reports.md
@@ -1,0 +1,169 @@
+# PDF Export for Backoffice Reporting — Implementation Plan
+
+Issue: #462 — `feat/462-backoffice-reporting-pdf-exports-of-reports`
+
+## Context
+
+The backoffice reporting page has an export section (`ReportExport.vue`) with four report types. The PDF button currently renders but has **no `@click` handler** (line 287–295 of `ReportExport.vue`).
+
+Per the official spec (`CalcCo2_Spec_exportation_PDF`):
+
+| Report type                   | PDF                                                            |
+| ----------------------------- | -------------------------------------------------------------- |
+| Utilisation                   | ❌ No PDF                                                      |
+| Détails de données par module | ❌ No PDF                                                      |
+| **Résultats**                 | ✅ Same as Results page PDF, but aggregated for selected units |
+| **Combiné**                   | ✅ Print the full backoffice reporting page                    |
+
+The same spec also covers the **regular Results page** (issue #462): export same as current page with all BigNumbers and charts, **except** the "Objectif de réduction" chart (interactive, loses meaning in static PDF).
+
+---
+
+## Approach
+
+Both PDF exports follow the identical pattern already used by `pages/app/ResultsPrintPage.vue`:
+
+1. Resolve a named print route via `router.resolve()`
+2. `window.open(url, '_blank')` — opens a new tab
+3. The print page uses `PrintLayout.vue` (no header/sidebar chrome), calls `window.print()` on a toolbar button
+4. `@media print` CSS hides the toolbar; `ReportPage.vue` wraps content in A4-sized blocks with automatic page breaks
+
+Current filters (`unitFilters` computed in `ReportingPage.vue`) are serialized as a JSON query param (`?filters=<json>`) and read back inside the print pages to re-fetch their own data.
+
+---
+
+## Files to Create
+
+### 1. `frontend/src/composables/print/useBackofficeReportingPrintData.ts`
+
+Reads `?filters=<json>` from the route query, calls `backofficeStore.getUnits(filters)` on mount, and exposes the same computed refs already used in `ReportingPage.vue`:
+
+- `units`, `reportingEmissionBreakdown`, `validatedCount`, `tableTotal`, `usageStats`, `moduleStats`, `totalModules`, `loading`
+
+### 2. `frontend/src/pages/back-office/ReportingPrintPage.vue`
+
+**Combiné PDF print page.** Mirrors the structure of `ResultsPrintPage.vue`:
+
+- Uses `useBackofficeReportingPrintData()` composable
+- Toolbar (`.print-hide`) with "Print" button → `window.print()`
+- `ReportPage` wrappers for A4 pagination (reuses `src/components/organisms/ReportPage.vue`)
+- **Page 1**: Title + `CompletionRateBar` + `ReportingStatCards` / `ReportingStatCardUnit` (big numbers = validated / in-progress / not-started unit counts)
+- **Page 2**: `ModuleCarbonFootprintChart` + `CarbonFootPrintPerPersonChart` (2-col grid)
+- **Page 3**: `EmissionBreakdownChart`
+- `@media print` CSS hides toolbar, preserves multi-col grid layouts
+
+### 3. `frontend/src/composables/print/useBackofficeResultsPrintData.ts`
+
+Same filter reading / fetching pattern. Exposes `reportingEmissionBreakdown`, `validatedCount`, `tableTotal`, `loading`.
+
+### 4. `frontend/src/pages/back-office/BackofficeResultsPrintPage.vue`
+
+**Résultats PDF print page.** Visually mirrors `ResultsPrintPage.vue` but powered by aggregated backoffice data instead of single-workspace `ResultsSummary`:
+
+- Toolbar with print button
+- **Page 1**: Title ("Aggregated Results – [year(s)]"), `CompletionRateBar` (shows units-in-scope), total CO₂ and per-FTE BigNumbers derived from `emission_breakdown` totals
+- **Page 2**: `ModuleCarbonFootprintChart` + `CarbonFootPrintPerPersonChart`
+- **Page 3**: `EmissionBreakdownChart`
+
+> Year-over-year % change BigNumbers are omitted — they require `ResultsSummary` which is not available from the backoffice aggregation API.
+
+> "Objectif de réduction" chart is excluded per spec (interactive chart loses meaning in static PDF). Verify `ResultsPrintPage.vue` also excludes it; if not, fix that too.
+
+---
+
+## Files to Modify
+
+### `frontend/src/router/routes.ts`
+
+Add two new top-level route blocks **before** the main `MainLayout` wrapper, alongside the existing `results/print` block (line 41):
+
+```typescript
+{
+  path: `/:language(${LANGUAGE_PATTERN})/back-office/reporting/print`,
+  component: () => import('layouts/PrintLayout.vue'),
+  children: [{
+    path: '',
+    name: 'backoffice-reporting-print',
+    component: () => import('pages/back-office/ReportingPrintPage.vue'),
+    meta: { requiresAuth: true, breadcrumb: false, isBackOffice: true },
+  }],
+},
+{
+  path: `/:language(${LANGUAGE_PATTERN})/back-office/reporting/results-print`,
+  component: () => import('layouts/PrintLayout.vue'),
+  children: [{
+    path: '',
+    name: 'backoffice-results-print',
+    component: () => import('pages/back-office/BackofficeResultsPrintPage.vue'),
+    meta: { requiresAuth: true, breadcrumb: false, isBackOffice: true },
+  }],
+},
+```
+
+### `frontend/src/components/organisms/backoffice/reporting/ReportExport.vue`
+
+1. Import `useRouter` from `vue-router`.
+2. Add `downloadPDF()` function:
+
+```typescript
+function downloadPDF() {
+  const filtersJson = JSON.stringify(props.unitFilters ?? {});
+  if (selectedReport.value === "combined") {
+    const url = router.resolve({
+      name: "backoffice-reporting-print",
+      query: { filters: filtersJson },
+    }).href;
+    window.open(url, "_blank");
+  } else if (selectedReport.value === "results") {
+    const url = router.resolve({
+      name: "backoffice-results-print",
+      query: { filters: filtersJson },
+    }).href;
+    window.open(url, "_blank");
+  }
+  // usage / detailed: button is disabled — no-op
+}
+```
+
+3. Add `@click="downloadPDF"` to the PDF `q-btn`.
+4. Add `:disable="selectedReport === 'usage' || selectedReport === 'detailed'"` — grays out the button for the two no-PDF report types.
+
+### `frontend/src/i18n/backoffice_reporting.ts`
+
+Add any missing i18n keys for print page headings, e.g.:
+
+- `backoffice_reporting_print_combined_title`
+- `backoffice_reporting_print_results_title`
+
+---
+
+## Filter Serialization
+
+`unitFilters` is JSON-stringified into `?filters=<json>` when opening print pages. Print pages parse `route.query.filters` and pass the result to `backofficeStore.getUnits()`. This cleanly handles the `modules` array (array of objects) without complex nested query-string encoding.
+
+---
+
+## Reused Utilities / Components
+
+| What                                                  | Path                                                                                    |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| A4 page wrapper                                       | `src/components/organisms/ReportPage.vue`                                               |
+| Print layout (no chrome, provides print mode context) | `src/layouts/PrintLayout.vue`                                                           |
+| Print mode composable                                 | `src/composables/print/usePrintMode.ts` (auto-provided by PrintLayout)                  |
+| Aggregated emission charts                            | `ModuleCarbonFootprintChart`, `CarbonFootPrintPerPersonChart`, `EmissionBreakdownChart` |
+| Completion progress bar                               | `CompletionRateBar`                                                                     |
+| Usage stat cards                                      | `ReportingStatCards`, `ReportingStatCardUnit`                                           |
+| BigNumber display                                     | `src/components/molecules/BigNumber.vue` (has `print-mode` prop)                        |
+| Backoffice store                                      | `src/stores/backoffice.ts` → `getUnits()`                                               |
+
+---
+
+## Verification
+
+1. Start the dev server.
+2. Open backoffice reporting, apply some filters (year + affiliation).
+3. **Combiné** → click **Export as PDF** → new tab opens with unit counts, charts; print button triggers browser dialog; A4 pages break correctly.
+4. **Résultats** → click **Export as PDF** → new tab opens with aggregated CO₂ data and charts; print dialog works.
+5. **Utilisation / Détails** → PDF button is grayed out (disabled); CSV still works.
+6. Confirm "Objectif de réduction" chart does not appear in any print page.
+7. Check print preview: each `ReportPage` section breaks to a new A4 page; colors preserved via `print-color-adjust: exact`.

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -30,6 +30,7 @@ interface BreakdownData {
 const props = defineProps<{
   breakdownData: BreakdownData | null;
   height?: string;
+  forcedModule?: string | null;
 }>();
 
 const { t } = useI18n();
@@ -70,6 +71,7 @@ const chartView = ref<'breakdown' | 'type'>('breakdown');
 const selectedTab = ref<TabKey | null>(null);
 
 const activeTab = computed<TabKey | null>(() => {
+  if (props.forcedModule) return props.forcedModule as TabKey;
   if (selectedTab.value && availableModules.value.includes(selectedTab.value)) {
     return selectedTab.value;
   }
@@ -203,8 +205,41 @@ const emissionTypeInfoKey = computed(() =>
 </script>
 
 <template>
-  <q-card flat bordered class="q-pa-xl">
-    <div v-if="!isPrintMode" class="flex justify-between items-center q-mb-md">
+  <!-- Print mode: two separate labelled boxes -->
+  <template v-if="isPrintMode">
+    <q-card flat bordered class="q-pa-md print-chart-box">
+      <div class="text-body2 text-weight-medium q-mb-sm">
+        {{
+          activeTab ? `Treemap — ${t(activeTab)}` : $t('results_treemap_title')
+        }}
+      </div>
+      <GenericEmissionTreeMapChart
+        v-if="treemapData.length > 0"
+        :data="treemapData"
+        :height="height ?? '200px'"
+      />
+      <span v-else class="text-body2 text-secondary">
+        {{ $t('backoffice_reporting_chart_no_data') }}
+      </span>
+    </q-card>
+    <q-card flat bordered class="q-pa-md q-mt-sm print-chart-box">
+      <div class="text-body2 text-weight-medium q-mb-sm">
+        {{ activeTab ? `Emission breakdown — ${t(activeTab)}` : '' }}
+      </div>
+      <EmissionTypeBreakdownChart
+        v-if="categoryRows.length"
+        :category-rows="categoryRows"
+        class="full-width"
+      />
+      <span v-else class="text-body2 text-secondary">
+        {{ $t('backoffice_reporting_chart_no_data') }}
+      </span>
+    </q-card>
+  </template>
+
+  <!-- Normal mode: single card with tabs and toggle -->
+  <q-card v-else flat bordered class="q-pa-xl">
+    <div class="flex justify-between items-center q-mb-md">
       <span class="text-h5 text-weight-medium">{{
         $t('results_treemap_title')
       }}</span>
@@ -261,7 +296,7 @@ const emissionTypeInfoKey = computed(() =>
     </div>
 
     <!-- Module tab buttons -->
-    <div v-if="!isPrintMode" class="flex flex-wrap q-gutter-sm q-mb-md">
+    <div class="flex flex-wrap q-gutter-sm q-mb-md">
       <q-btn
         v-for="mod in availableModules"
         :key="mod"
@@ -307,6 +342,11 @@ const emissionTypeInfoKey = computed(() =>
 </template>
 
 <style scoped>
+.print-chart-box {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
 .tab-btn {
   border-radius: 3px;
 }

--- a/frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/CompletionRateBar.vue
@@ -9,6 +9,7 @@ interface Props {
   totalUnits: number;
   scopeLabel?: string;
   helperText?: string;
+  printMode?: boolean;
 }
 
 const { t } = useI18n();
@@ -17,6 +18,7 @@ const props = withDefaults(defineProps<Props>(), {
   title: undefined,
   scopeLabel: undefined,
   helperText: undefined,
+  printMode: false,
 });
 
 const resolvedTitle = computed(
@@ -28,6 +30,8 @@ const resolvedHelperText = computed(
 const resolvedScopeLabel = computed(
   () => props.scopeLabel ?? t('backoffice_reporting_completion_bar_scope'),
 );
+
+const printMode = computed(() => props.printMode);
 
 const percentage = computed(() => {
   if (props.totalUnits <= 0) {
@@ -52,16 +56,18 @@ const barColor = computed(() => {
     <q-card-section class="q-pa-lg">
       <div class="row items-center justify-between q-mb-md">
         <div class="text-h6 text-weight-medium">{{ resolvedTitle }}</div>
-        <q-icon
-          :name="outlinedInfo"
-          size="sm"
-          class="cursor-pointer text-primary"
-          :aria-label="$t('module-info-label')"
-        >
-          <q-tooltip class="u-tooltip">
-            {{ resolvedHelperText }}
-          </q-tooltip>
-        </q-icon>
+        <template v-if="!printMode">
+          <q-icon
+            :name="outlinedInfo"
+            size="sm"
+            class="cursor-pointer text-primary"
+            :aria-label="$t('module-info-label')"
+          >
+            <q-tooltip class="u-tooltip">
+              {{ resolvedHelperText }}
+            </q-tooltip>
+          </q-icon>
+        </template>
       </div>
 
       <div class="row items-center justify-between q-mb-sm text-body1">

--- a/frontend/src/components/organisms/backoffice/reporting/ReportExport.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/ReportExport.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 import { REPORT_TYPES } from 'src/constant/report';
 // import type { ModuleState } from 'src/constant/moduleStates';
 import { Notify } from 'quasar';
@@ -13,6 +14,7 @@ import {
 import type { ReportFormat, ReportType } from 'src/api/backoffice';
 import { type UnitFilters } from 'src/stores/backoffice';
 const { t } = useI18n();
+const router = useRouter();
 
 // interface ModuleCompletion {
 //   status: ModuleState;
@@ -38,6 +40,7 @@ const { t } = useI18n();
 
 const props = defineProps<{
   unitFilters?: UnitFilters;
+  hasData?: boolean;
 }>();
 
 const selectedReport = ref<ReportType>('combined');
@@ -55,6 +58,23 @@ const downloading = ref(false);
 //   }
 //   return stringValue;
 // }
+
+function downloadPDF() {
+  const filtersJson = JSON.stringify(props.unitFilters ?? {});
+  if (selectedReport.value === 'combined') {
+    const url = router.resolve({
+      name: 'backoffice-reporting-print',
+      query: { filters: filtersJson },
+    }).href;
+    window.open(url, '_blank');
+  } else if (selectedReport.value === 'results') {
+    const url = router.resolve({
+      name: 'backoffice-results-print',
+      query: { filters: filtersJson },
+    }).href;
+    window.open(url, '_blank');
+  }
+}
 
 function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
@@ -288,16 +308,23 @@ async function downloadReport(format: 'csv' | 'json') {
       icon="o_picture_as_pdf"
       color="accent"
       :label="$t('common_export_as_pdf')"
+      :disable="
+        !props.hasData ||
+        selectedReport === 'usage' ||
+        selectedReport === 'detailed'
+      "
       unelevated
       no-caps
       size="md"
       class="text-weight-medium q-mr-sm"
+      @click="downloadPDF"
     />
     <q-btn
       icon="o_table"
       color="accent"
       :label="$t('common_export_as_csv')"
       :loading="downloading"
+      :disable="!props.hasData"
       unelevated
       no-caps
       size="md"

--- a/frontend/src/composables/print/useBackofficePrintBase.ts
+++ b/frontend/src/composables/print/useBackofficePrintBase.ts
@@ -1,0 +1,77 @@
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useBackofficeStore } from 'src/stores/backoffice';
+import type { UnitFilters } from 'src/stores/backoffice';
+import { MODULES } from 'src/constant/modules';
+import { MODULE_TO_CATEGORIES } from 'src/constant/charts';
+
+const BREAKDOWN_MODULES = [
+  MODULES.ProcessEmissions,
+  MODULES.Buildings,
+  MODULES.EquipmentElectricConsumption,
+  MODULES.ExternalCloudAndAI,
+  MODULES.Purchase,
+  MODULES.ResearchFacilities,
+  MODULES.ProfessionalTravel,
+] as const;
+
+export function useBackofficePrintBase() {
+  const route = useRoute();
+  const backofficeStore = useBackofficeStore();
+
+  const filters = computed<UnitFilters>(() => {
+    const raw = String(route.query.filters ?? '{}');
+    try {
+      return JSON.parse(raw) as UnitFilters;
+    } catch {
+      return {};
+    }
+  });
+
+  const units = computed(() => backofficeStore.units);
+  const loading = computed(() => backofficeStore.unitsLoading);
+  const reportingEmissionBreakdown = computed(
+    () => units.value?.emission_breakdown ?? null,
+  );
+  const validatedCount = computed(
+    () => units.value?.validated_units_count ?? 0,
+  );
+  const tableTotal = computed(() => units.value?.total_units_count ?? 0);
+
+  const availableModules = computed(() => {
+    if (!reportingEmissionBreakdown.value) return [];
+    const rows = reportingEmissionBreakdown.value.module_breakdown;
+    return BREAKDOWN_MODULES.filter((mod) => {
+      const categories = MODULE_TO_CATEGORIES.value[mod] ?? [];
+      return categories.some((cat) => {
+        const row = rows.find(
+          (r) => r['category'] === cat || r['category_key'] === cat,
+        );
+        if (!row) return false;
+        return Object.entries(row).some(
+          ([k, v]) =>
+            k !== 'category' &&
+            k !== 'category_key' &&
+            !k.endsWith('StdDev') &&
+            Number(v) > 0,
+        );
+      });
+    });
+  });
+
+  async function fetchData() {
+    backofficeStore.unitsPagination.pageSize = 5000;
+    await backofficeStore.getUnits(filters.value);
+  }
+
+  return {
+    filters,
+    units,
+    loading,
+    reportingEmissionBreakdown,
+    validatedCount,
+    tableTotal,
+    availableModules,
+    fetchData,
+  };
+}

--- a/frontend/src/composables/print/useBackofficeReportingPrintData.ts
+++ b/frontend/src/composables/print/useBackofficeReportingPrintData.ts
@@ -1,0 +1,39 @@
+import { computed } from 'vue';
+import { useBackofficePrintBase } from './useBackofficePrintBase';
+import { MODULE_STATES } from 'src/constant/moduleStates';
+import type { ReportingStats } from 'src/api/backoffice';
+
+export function useBackofficeReportingPrintData() {
+  const base = useBackofficePrintBase();
+  const { units } = base;
+
+  const tableRows = computed(() => units.value?.data ?? []);
+
+  const usageStats = computed<ReportingStats>(() => ({
+    [MODULE_STATES.Default]: units.value?.not_started_units_count ?? 0,
+    [MODULE_STATES.InProgress]: units.value?.in_progress_units_count ?? 0,
+    [MODULE_STATES.Validated]: units.value?.validated_units_count ?? 0,
+  }));
+
+  const moduleStats = computed<ReportingStats>(() => {
+    const counts = units.value?.module_status_counts ?? {};
+    return {
+      [MODULE_STATES.Default]: counts[0] ?? 0,
+      [MODULE_STATES.InProgress]: counts[1] ?? 0,
+      [MODULE_STATES.Validated]: counts[2] ?? 0,
+    };
+  });
+
+  const totalModules = computed(() => {
+    const counts = units.value?.module_status_counts ?? {};
+    return Object.values(counts).reduce((a, b) => a + b, 0);
+  });
+
+  return {
+    ...base,
+    tableRows,
+    usageStats,
+    moduleStats,
+    totalModules,
+  };
+}

--- a/frontend/src/composables/print/useBackofficeResultsPrintData.ts
+++ b/frontend/src/composables/print/useBackofficeResultsPrintData.ts
@@ -1,0 +1,43 @@
+import { computed } from 'vue';
+import { useBackofficePrintBase } from './useBackofficePrintBase';
+
+export function useBackofficeResultsPrintData() {
+  const base = useBackofficePrintBase();
+  const { filters, reportingEmissionBreakdown } = base;
+
+  const years = computed<string[]>(() => filters.value.years ?? []);
+
+  const totalTonnes = computed(
+    () => reportingEmissionBreakdown.value?.total_tonnes_co2eq ?? null,
+  );
+  const totalFte = computed(
+    () => reportingEmissionBreakdown.value?.total_fte ?? null,
+  );
+  const tonnesPerFte = computed(() => {
+    const t = totalTonnes.value;
+    const f = totalFte.value;
+    if (t == null || !f || f <= 0) return null;
+    return t / f;
+  });
+
+  const perPersonBreakdown = computed(
+    () => reportingEmissionBreakdown.value?.per_person_breakdown ?? null,
+  );
+  const validatedCategories = computed(
+    () => reportingEmissionBreakdown.value?.validated_categories ?? null,
+  );
+  const headcountValidated = computed(
+    () => reportingEmissionBreakdown.value?.headcount_validated ?? false,
+  );
+
+  return {
+    ...base,
+    years,
+    totalTonnes,
+    totalFte,
+    tonnesPerFte,
+    perPersonBreakdown,
+    validatedCategories,
+    headcountValidated,
+  };
+}

--- a/frontend/src/css/05-components/_print-page.scss
+++ b/frontend/src/css/05-components/_print-page.scss
@@ -1,0 +1,36 @@
+@use 'src/css/02-tokens' as tokens;
+
+.report-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 0;
+  color: tokens.$color-text;
+}
+
+.print-toolbar {
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid var(--half-muted-color);
+  z-index: 1000;
+}
+
+@media print {
+  .print-hide,
+  .q-header,
+  .q-footer,
+  .q-drawer {
+    display: none;
+  }
+
+  .report-container {
+    display: block;
+    width: 100%;
+    padding: 0;
+  }
+
+  .print-report .q-card,
+  .print-report .q-card-section {
+    box-shadow: none;
+  }
+}

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -50,6 +50,7 @@
   @import './05-components/_organisms/lab-selector';
   @import './05-components/_organisms/table';
   @import './05-components/_templates/sidebar';
+  @import './05-components/print-page';
 }
 
 @layer utilities {

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -1,4 +1,12 @@
 export default {
+  backoffice_reporting_print_combined_title: {
+    en: 'Combined Report',
+    fr: 'Rapport combiné',
+  },
+  backoffice_reporting_print_results_title: {
+    en: 'Aggregated Results Report',
+    fr: 'Rapport de résultats agrégés',
+  },
   backoffice_reporting_aggregated_results_title: {
     en: 'Aggregated Results',
     fr: 'Résultats agrégés',

--- a/frontend/src/pages/app/ResultsPrintPage.vue
+++ b/frontend/src/pages/app/ResultsPrintPage.vue
@@ -70,7 +70,7 @@ onMounted(async () => {
 
 <template>
   <div class="bg-grey-2 print-report">
-    <q-toolbar class="bg-ac text-primary q-py-sm toolbar print-hide">
+    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
       <q-space />
       <q-btn
         color="accent"
@@ -322,21 +322,6 @@ onMounted(async () => {
 </template>
 
 <style scoped lang="scss">
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 20px 0;
-  color: black !important;
-}
-
-.toolbar {
-  position: sticky;
-  top: 0;
-  border-bottom: 1px solid var(--half-muted-color);
-  z-index: 1000;
-}
-
 .module-page-header {
   margin-bottom: 0px;
 }
@@ -383,30 +368,12 @@ onMounted(async () => {
 }
 
 @media print {
-  .print-hide,
-  .q-header,
-  .q-footer,
-  .q-drawer {
-    display: none !important;
-  }
-
   .grid-3-col {
     grid-template-columns: repeat(3, 1fr);
   }
 
   .bg-grey-3 {
     background: white !important;
-  }
-
-  .report-container {
-    display: block !important;
-    width: 100% !important;
-    padding: 0 !important;
-  }
-
-  .print-report :deep(.q-card),
-  .print-report :deep(.q-card-section) {
-    box-shadow: none !important;
   }
 
   .print-report :deep(.big-number--print.q-card--bordered) {

--- a/frontend/src/pages/back-office/BackofficeResultsPrintPage.vue
+++ b/frontend/src/pages/back-office/BackofficeResultsPrintPage.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import BigNumber from 'src/components/molecules/BigNumber.vue';
+import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
+import EmissionBreakdownChart from 'src/components/charts/EmissionBreakdownChart.vue';
+import { useBackofficeResultsPrintData } from 'src/composables/print/useBackofficeResultsPrintData';
+
+const {
+  loading,
+  years,
+  reportingEmissionBreakdown,
+  validatedCount,
+  tableTotal,
+  totalTonnes,
+  tonnesPerFte,
+  perPersonBreakdown,
+  validatedCategories,
+  headcountValidated,
+  availableModules,
+  fetchData,
+} = useBackofficeResultsPrintData();
+
+const hasData = computed(
+  () => !loading.value && reportingEmissionBreakdown.value != null,
+);
+
+const yearsLabel = computed(() => years.value.join(', '));
+
+function printReport() {
+  window.print();
+}
+
+onMounted(async () => {
+  await fetchData();
+});
+</script>
+
+<template>
+  <div class="bg-grey-2 print-report">
+    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
+      <q-space />
+      <q-btn
+        color="accent"
+        icon="o_print"
+        size="md"
+        class="text-weight-medium"
+        :label="$t('results_print')"
+        @click="printReport"
+      />
+    </q-toolbar>
+
+    <div v-if="loading" class="flex justify-center q-pa-xl print-hide">
+      <q-spinner color="accent" size="3em" />
+    </div>
+
+    <div v-else-if="hasData" class="report-container">
+      <!-- Page 1: Title, scope, big numbers -->
+      <ReportPage
+        :title="$t('backoffice_reporting_print_results_title')"
+        :page-number="1"
+        :is-first="true"
+      >
+        <h2 class="text-h5 q-mt-none">
+          {{ $t('backoffice_reporting_print_results_title') }}
+        </h2>
+        <div v-if="yearsLabel" class="text-body2 text-secondary q-mb-lg">
+          {{ yearsLabel }}
+        </div>
+
+        <div class="q-mt-md">
+          <CompletionRateBar
+            :validated-units="validatedCount"
+            :total-units="tableTotal"
+            :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
+            :print-mode="true"
+          />
+        </div>
+
+        <div class="big-numbers-grid q-mt-lg">
+          <BigNumber
+            :title="$t('results_total_unit_carbon_footprint')"
+            :number="
+              $nOrDash(totalTonnes, {
+                options: {
+                  minimumFractionDigits: 1,
+                  maximumFractionDigits: 1,
+                },
+              })
+            "
+            color="negative"
+            :print-mode="true"
+          />
+          <BigNumber
+            :title="$t('results_carbon_footprint_per_person')"
+            :number="
+              $nOrDash(tonnesPerFte, {
+                options: {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                },
+              })
+            "
+            :unit="$t('results_units_tonnes')"
+            :print-mode="true"
+          />
+        </div>
+        <section class="q-mt-md">
+          <ModuleCarbonFootprintChart
+            :breakdown-data="reportingEmissionBreakdown"
+            :print-mode="true"
+            :title="$t('backoffice_reporting_aggregated_results_title')"
+          />
+        </section>
+        <section class="q-mt-md">
+          <CarbonFootPrintPerPersonChart
+            :per-person-breakdown="perPersonBreakdown"
+            :validated-categories="validatedCategories"
+            :headcount-validated="headcountValidated"
+            :show-validation-placeholder="false"
+            :print-mode="true"
+            :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
+          />
+        </section>
+      </ReportPage>
+
+      <!-- One page per module: treemap + emission type breakdown -->
+      <ReportPage
+        v-for="(mod, i) in availableModules"
+        :key="mod"
+        :title="$t('backoffice_reporting_print_results_title')"
+        :page-number="2 + i"
+      >
+        <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>
+        <div class="q-mt-md">
+          <EmissionBreakdownChart
+            :breakdown-data="reportingEmissionBreakdown"
+            :forced-module="mod"
+            height="200px"
+          />
+        </div>
+      </ReportPage>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.big-numbers-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+</style>

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -320,7 +320,10 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
             $t('backoffice_reporting_generate_report_description')
           }}</span>
 
-          <ReportExport :unit-filters="unitFilters" />
+          <ReportExport
+            :unit-filters="unitFilters"
+            :has-data="tableTotal > 0"
+          />
         </div>
       </div>
       <UnitDialogue v-model:model-value="alert" :unit-id="selectedUnitId" />

--- a/frontend/src/pages/back-office/ReportingPrintPage.vue
+++ b/frontend/src/pages/back-office/ReportingPrintPage.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
+import ReportingStatCards from 'src/components/organisms/backoffice/reporting/ReportingStatCards.vue';
+import ReportingStatCardUnit from 'src/components/organisms/backoffice/reporting/ReportingStatCardUnit.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
+import EmissionBreakdownChart from 'src/components/charts/EmissionBreakdownChart.vue';
+import { useBackofficeReportingPrintData } from 'src/composables/print/useBackofficeReportingPrintData';
+import { MODULE_STATES } from 'src/constant/moduleStates';
+
+const {
+  loading,
+  reportingEmissionBreakdown,
+  validatedCount,
+  tableTotal,
+  tableRows,
+  usageStats,
+  moduleStats,
+  totalModules,
+  availableModules,
+  fetchData,
+} = useBackofficeReportingPrintData();
+
+const hasData = computed(() => !loading.value && tableTotal.value > 0);
+const showStatCards = computed(() => tableRows.value.length !== 1);
+
+function printReport() {
+  window.print();
+}
+
+onMounted(async () => {
+  await fetchData();
+});
+</script>
+
+<template>
+  <div class="bg-grey-2 print-report">
+    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
+      <q-space />
+      <q-btn
+        color="accent"
+        icon="o_print"
+        size="md"
+        class="text-weight-medium"
+        :label="$t('results_print')"
+        @click="printReport"
+      />
+    </q-toolbar>
+
+    <div v-if="loading" class="flex justify-center q-pa-xl print-hide">
+      <q-spinner color="accent" size="3em" />
+    </div>
+
+    <div v-else-if="hasData" class="report-container">
+      <!-- Page 1: Title, completion rate, usage stats + aggregate charts -->
+      <ReportPage
+        :title="$t('backoffice_reporting_print_combined_title')"
+        :page-number="1"
+        :is-first="true"
+      >
+        <h2 class="text-h5 q-mt-none">
+          {{ $t('backoffice_reporting_print_combined_title') }}
+        </h2>
+
+        <div class="q-mt-md">
+          <CompletionRateBar
+            :validated-units="validatedCount"
+            :total-units="tableTotal"
+            :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
+            :print-mode="true"
+          />
+        </div>
+
+        <section class="q-mt-lg">
+          <ReportingStatCards v-if="showStatCards" :stats="usageStats" />
+          <ReportingStatCardUnit
+            v-else
+            :validated-modules="moduleStats[MODULE_STATES.Validated]"
+            :total-modules="totalModules"
+          />
+        </section>
+
+        <section class="q-mt-md">
+          <ModuleCarbonFootprintChart
+            :breakdown-data="reportingEmissionBreakdown"
+            :print-mode="true"
+            :title="$t('backoffice_reporting_aggregated_results_title')"
+          />
+        </section>
+        <section class="q-mt-md">
+          <CarbonFootPrintPerPersonChart
+            :per-person-breakdown="
+              reportingEmissionBreakdown?.per_person_breakdown ?? null
+            "
+            :validated-categories="
+              reportingEmissionBreakdown?.validated_categories ?? null
+            "
+            :headcount-validated="
+              reportingEmissionBreakdown?.headcount_validated ?? false
+            "
+            :show-validation-placeholder="false"
+            :print-mode="true"
+            :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
+          />
+        </section>
+      </ReportPage>
+
+      <!-- One page per module: treemap + emission type breakdown -->
+      <ReportPage
+        v-for="(mod, i) in availableModules"
+        :key="mod"
+        :title="$t('backoffice_reporting_print_combined_title')"
+        :page-number="2 + i"
+      >
+        <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>
+        <div class="q-mt-md">
+          <EmissionBreakdownChart
+            :breakdown-data="reportingEmissionBreakdown"
+            :forced-module="mod"
+            height="200px"
+          />
+        </div>
+      </ReportPage>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -67,6 +67,42 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // Backoffice reporting print previews — own layout, no header/sidebar
+  {
+    path: `/:language(${LANGUAGE_PATTERN})/back-office/reporting/print`,
+    component: () => import('layouts/PrintLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: 'backoffice-reporting-print',
+        component: () => import('pages/back-office/ReportingPrintPage.vue'),
+        meta: {
+          requiresAuth: true,
+          note: 'Backoffice Reporting – Combined PDF print preview (no chrome)',
+          breadcrumb: false,
+          isBackOffice: true,
+        },
+      },
+    ],
+  },
+  {
+    path: `/:language(${LANGUAGE_PATTERN})/back-office/reporting/results-print`,
+    component: () => import('layouts/PrintLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: 'backoffice-results-print',
+        component: () =>
+          import('pages/back-office/BackofficeResultsPrintPage.vue'),
+        meta: {
+          requiresAuth: true,
+          note: 'Backoffice Reporting – Results PDF print preview (no chrome)',
+          breadcrumb: false,
+          isBackOffice: true,
+        },
+      },
+    ],
+  },
   {
     path: '/',
     component: () => import('layouts/MainLayout.vue'),


### PR DESCRIPTION
## What does this change?
Implements PDF export for the two supported backoffice report types (Combiné and Résultats), and disables the PDF and CSV buttons when no data is loaded.

- `router/routes.ts`: adds two new print routes under `PrintLayout` — `backoffice-reporting-print` and `backoffice-results-print`
- `composables/print/useBackofficeReportingPrintData.ts` (new): reads `?filters=<json>` from the route, fetches all units via the backoffice store, and exposes the same computed refs used by `ReportingPage`
- `composables/print/useBackofficeResultsPrintData.ts` (new): same filter-reading pattern, exposes aggregated totals and per-FTE breakdown for the Results print view
- `pages/back-office/ReportingPrintPage.vue` (new): Combiné print page — completion bar, usage stat cards, module footprint and per-FTE charts on page 1, then one `ReportPage` per module with its `EmissionBreakdownChart`
- `pages/back-office/BackofficeResultsPrintPage.vue` (new): Résultats print page — same structure but driven by `useBackofficeResultsPrintData`; includes total CO₂ and per-FTE BigNumbers; excludes the reduction objective chart per spec
- `ReportExport.vue`: wires `@click="downloadPDF"` to the PDF button; disables it for `usage` and `detailed` report types and when `hasData` is false; adds `hasData` prop; disables CSV button when no data
- `ReportingPage.vue`: passes `:has-data="tableTotal > 0"` to `ReportExport`
- `EmissionBreakdownChart.vue`: adds `forcedModule` prop to pin the active tab from the parent (used by print pages to render one module per page); adds a dedicated print-mode template with two separate labelled boxes and `break-inside: avoid`
- `CompletionRateBar.vue`: adds `printMode` prop to hide the tooltip icon in print
- `i18n/backoffice_reporting.ts`: adds `backoffice_reporting_print_combined_title` and `backoffice_reporting_print_results_title`
- `docs/src/architecture/04-auth-flow.md`: simplifies the auth flow doc to a lighter overview (separate concern, incidental to this PR)
- `docs/src/architecture-decision-records/index.md`: removes the ADR-019 row from the index

## Why is this needed?
The PDF export button on the backoffice reporting page had no handler, making it non-functional. Users need to be able to export the Combiné and Résultats reports as printable PDFs.

## Type of change
- [x] ✨ New feature
- [x] 📝 Documentation update

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #462