### PR TITLE
docs: single source of truth for auth flow

### DIFF
--- a/docs/src/backend/01-overview.md
+++ b/docs/src/backend/01-overview.md
@@ -76,11 +76,6 @@ See [Architecture](02-ARCHITECTURE.md) for complete layer details.
 Visit http://localhost:8000/docs for the complete OpenAPI
 specification. Main endpoint groups:
 
-**Authentication**
-
-- `POST /api/v1/auth/login` - Initiate OIDC login
-- `GET /api/v1/users/me` - Current user profile
-
 **Laboratory Management**
 
 - `GET /api/v1/labs` - List labs
@@ -141,10 +136,10 @@ DB_URL=postgresql://user:pass@localhost:5432/co2calculator
 SECRET_KEY=your-secret-key-here
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
-# OIDC Authentication
-OIDC_DISCOVERY_URL=https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration
-OIDC_CLIENT_ID=your-client-id
-OIDC_CLIENT_SECRET=your-client-secret
+# OAuth/OIDC (see backend/.env.example for full set + Keycloak variant)
+OAUTH_ISSUER_URL=https://login.microsoftonline.com/{tenant}/v2.0
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
 
 # Background Tasks
 REDIS_URL=redis://localhost:6379/0
@@ -169,24 +164,11 @@ make celery-flower  # Web monitoring UI
 Tasks include CSV import processing, emission calculations,
 report generation, and email notifications.
 
-## Authentication & Authorization
+## Authorization
 
-### Authentication Flow (OIDC + JWT)
-
-1. Frontend redirects user to Microsoft Entra ID
-2. User authenticates with EPFL credentials
-3. Backend validates OIDC token and extracts claims
-4. Backend issues JWT for subsequent requests
-5. Frontend includes JWT in `Authorization: Bearer <token>`
-
-### Authorization (RBAC)
-
-- **Roles**: `admin`, `lab_manager`, `lab_member`, `viewer`
-- **Permissions**: Checked in service layer before data access
-- **Resource ownership**: Users access only their labs (unless admin)
-
-Authorization uses in-code RBAC for simplicity rather than Open
-Policy Agent.
+In-code RBAC, not OPA. Service methods receive the authenticated user
+and apply role + scope filters before reaching the repository. See
+[Permission System](06-PERMISSION-SYSTEM.md).
 
 ## Security Features
 

--- a/docs/src/backend/04-README.md
+++ b/docs/src/backend/04-README.md
@@ -82,12 +82,6 @@ See [File Structure](03-FILE_STRUCTURE.md) for details.
 
 ## API Endpoints
 
-### Authentication
-
-- `POST /api/v1/users/token` - Login and get JWT
-- `POST /api/v1/users/register` - Register new user
-- `GET /api/v1/users/me` - Get current user
-
 ### Resources
 
 - `GET /api/v1/resources` - List resources

--- a/docs/src/backend/05-REQUEST_FLOW.md
+++ b/docs/src/backend/05-REQUEST_FLOW.md
@@ -77,11 +77,11 @@ flowchart TD
 
 Roles are stored on `User.roles_raw`. Permissions are computed during
 policy evaluation per request from the role list — never persisted.
-The `/auth/me` endpoint is a separate route used by the SPA to fetch
-its own permission set; it is not on the request-time auth path for
-other endpoints. See [06 Permission System](06-PERMISSION-SYSTEM.md)
-for computation rules and [07](07-DEVELOPER-GUIDE-PERMISSIONS.md) for
-adding new permission paths.
+`GET /v1/session` is the separate route the SPA calls to fetch its own
+permission set; it is not on the request-time auth path for other
+endpoints. See [06 Permission System](06-PERMISSION-SYSTEM.md) for
+computation rules and [07](07-DEVELOPER-GUIDE-PERMISSIONS.md) for adding
+new permission paths.
 
 ## Worked Example: `GET /api/v1/resources`
 

--- a/docs/src/backend/06-PERMISSION-SYSTEM.md
+++ b/docs/src/backend/06-PERMISSION-SYSTEM.md
@@ -8,7 +8,7 @@ CF https://github.com/EPFL-ENAC/co2-calculator/issues/414
 
 ## How It Works
 
-The backend calculates permissions during `/auth/me` response
+The backend calculates permissions during `GET /v1/session` response
 serialization:
 
 1. Read user from database with `roles_raw` field
@@ -134,7 +134,7 @@ roles.
 
 ## API Response
 
-The `/auth/me` endpoint returns:
+`GET /v1/session` returns:
 
 ```json
 {
@@ -339,7 +339,7 @@ if resource_type == "your_resource":
 
 1. Permissions are calculated from roles, never stored
 2. Frontend checks permissions, not roles
-3. Permissions recalculate on every `/auth/me` call
+3. Permissions recalculate on every `GET /v1/session` call
 4. Domains are independent and combine when needed
 5. Flat structure with dot-notation for easy checking
 6. **Authorization checks at route level** via `require_permission()` decorator

--- a/docs/src/backend/permissions/audit.md
+++ b/docs/src/backend/permissions/audit.md
@@ -46,7 +46,7 @@ The 403 body is generic, so debugging starts with the server log.
 1. Find the most recent `Permission check denied` warning in the API logs
    for the request's `user_id` and `request_id`. Its `extra` payload
    carries the required `path` and `action`.
-2. Call `/api/v1/auth/me` with the user's token and inspect the flat
+2. Call `GET /api/v1/session` from the authenticated SPA and inspect the flat
    `permissions` dict — look for a key matching `path` (or
    `path/<institutional_id>` for module permissions) whose action list
    contains `action`.

--- a/docs/src/backend/permissions/model.md
+++ b/docs/src/backend/permissions/model.md
@@ -65,7 +65,7 @@ travel record, etc.). Resource-level policy can enforce business rules that
 generic permission checks cannot, e.g. "API trips are read-only" — see
 [audit](./audit.md) and [matrix](./matrix.md).
 
-## Permission shape (`/auth/me` response)
+## Permission shape (`GET /v1/session` response)
 
 The backend returns a **flat** dictionary keyed by dot-notation path, with a
 **list of action strings** as the value. Module paths carry a trailing
@@ -85,7 +85,7 @@ The backend returns a **flat** dictionary keyed by dot-notation path, with a
 }
 ```
 
-Permissions are calculated in-memory on each `/auth/me` call — they are
+Permissions are calculated in-memory on each `GET /v1/session` call — they are
 never stored in the database. The role-to-permission mapping lives in
 [`app/models/user.py::calculate_user_permissions`](https://github.com/EPFL-ENAC/co2-calculator/blob/main/backend/app/models/user.py),
 the runtime check helper is

--- a/docs/src/frontend/01-overview.md
+++ b/docs/src/frontend/01-overview.md
@@ -59,14 +59,10 @@ CI runs `test-ct` and `test:e2e` (see `.github/workflows/test.yml`). The
 Storybook test-runner is not yet wired into CI; run `npm run storybook:test`
 locally to exercise it.
 
-## Authentication & Authorization
+## Authorization
 
-`LoginPage` redirects to `API_LOGIN_URL` (Microsoft Entra ID via backend);
-`auth/me` populates the `auth` Pinia store with `roles_raw` and
-`permissions`. Guards in `router/guards/` enforce access:
-`requirePermission`, `requireModuleEditPermission`, `validateUnitGuard`,
-`redirectToWorkspaceIfSelectedGuard`. See
-[Auth Flow Across Layers](../architecture/04-auth-flow.md) for the full path.
+`useAuthStore` holds the user, roles, and permissions; guards in
+`router/guards/` gate routes from there.
 
 ## Further Reading
 

--- a/docs/src/frontend/01-overview/personas.md
+++ b/docs/src/frontend/01-overview/personas.md
@@ -8,7 +8,7 @@ summary: Frontend persona flows for data-entry and back-office users.
 
 Two primary personas drive the frontend. Both authenticate against Microsoft
 Entra ID via the backend, then diverge based on permissions returned from
-`auth/me`.
+the session endpoint.
 
 ## Data-Entry User
 
@@ -19,7 +19,7 @@ the resulting emissions.
 stateDiagram-v2
     [*] --> Login
     Login: LoginPage redirects to API_LOGIN_URL
-    Login --> WorkspaceSetup: auth/me succeeds
+    Login --> WorkspaceSetup: GET /v1/session succeeds
     Login --> Unauthorized: no view permission
 
     WorkspaceSetup: WorkspaceSetupPage (pick unit + year)

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -45,9 +45,8 @@ recalculation. See
 **GHG Protocol** — The Greenhouse Gas Protocol, the international
 emissions accounting standard. Defines Scope 1, 2, and 3.
 
-**`/me`** — `GET /api/v1/auth/me`. Returns the cached user profile, roles,
-and computed permissions in ~8 ms. Does not trigger role sync. See
-[`role-sync-architecture.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/role-sync-architecture.md).
+**`GET /v1/session`** — Whoami endpoint. Returns the cached user profile,
+roles, and computed permissions in ~8 ms.
 
 **Path 1 vs Path 2** — Operational paths in the bulk-job model. Path 1 is
 per-request work for a single user. Path 2 is bulk operator workflows

--- a/docs/src/implementation-plans/auth-doc-single-source-of-truth.md
+++ b/docs/src/implementation-plans/auth-doc-single-source-of-truth.md
@@ -1,0 +1,60 @@
+---
+status: in-progress
+last_updated: 2026-05-28
+title: "Docs: single source of truth for auth flow"
+summary: "Strip duplicated and stale auth narratives from backend and frontend overview docs. The architecture/04-auth-flow.md doc is the canonical source; everything else cross-links."
+---
+
+## Problem
+
+Auth content currently spans 11 files in `docs/src/`. The canonical narrative lives at `docs/src/architecture/04-auth-flow.md` (delivered in PR #1313, kept current through PR #1314). Eight other files either repeat parts of the flow or reference endpoints that no longer exist post-PR #1314 (`/auth/me` was replaced by `GET /v1/session`; `auth_token` is set on the same-origin POST `/v1/session/exchange`, not on the OAuth callback redirect).
+
+One file (`backend/01-overview.md`) contains an outright factual error: line 180 claims the frontend sends `Authorization: Bearer <token>`. The app uses `httpOnly` session cookies — never Bearer tokens. This contradicts ADR-012 and ADR-019.
+
+## Principle
+
+Auth is a **cross-domain architecture concern**. It belongs in `docs/src/architecture/`, not duplicated into the backend and frontend overview pages. Where auth must be referenced from non-architecture docs (e.g., a permissions doc explaining where the permission payload comes from), use a single-sentence cross-link and don't restate the flow.
+
+## Scope
+
+### A) Path-only fixes (mechanical, no narrative change)
+
+Replace stale endpoint references with the current path. These docs are otherwise correct.
+
+- `docs/src/backend/05-REQUEST_FLOW.md:80` — `/auth/me` → `GET /v1/session`
+- `docs/src/backend/06-PERMISSION-SYSTEM.md:11, 137, 342` — three `/auth/me` mentions
+- `docs/src/backend/permissions/model.md:68, 88` — two mentions (one is a section heading)
+- `docs/src/backend/permissions/audit.md:49` — one mention
+- `docs/src/backend/04-README.md:89` — API table row `GET /api/v1/users/me` is wrong on two counts (path was `/auth/me`, not `/users/me`; current path is `/v1/session`)
+- `docs/src/glossary.md:48` — `/me` glossary entry
+- `docs/src/llm-agent-guide.md:71` — agent guide reference
+- `docs/src/frontend/01-overview/personas.md:11, 22, 70` — three mentions including two mermaid edges
+
+For each: keep the surrounding sentence, swap the path. If the surrounding sentence explains the auth flow at any length, prune it to a one-sentence cross-link to `architecture/04-auth-flow.md`.
+
+### B) Duplicate-narrative removal
+
+- **`docs/src/backend/01-overview.md`** — three changes:
+  - Lines 79-82 (auth endpoint entries in the API table): replace with a single row pointing to the auth flow doc.
+  - Lines 144-145 (`OIDC_DISCOVERY_URL` env-config example): update key name to the current setting (`OAUTH_ISSUER_URL`); see `app/core/config.py`.
+  - Lines 172-189 (the "Authentication & Authorization" section): delete the multi-step flow description and the wrong `Bearer <token>` claim. Replace with one paragraph: "The backend authenticates users via OIDC + httpOnly session cookies. See [Auth Flow](../architecture/04-auth-flow.md) for the full request flow, claim contract, and security boundaries." Keep the authorization subsection that explains in-code RBAC (that's backend-specific and not duplicated elsewhere).
+- **`docs/src/frontend/01-overview.md:62-69`** — section already cross-links to `04-auth-flow.md`, but the prose mentioning `auth/me` should be cut. Replace with one or two sentences describing the SPA's role (driving the OAuth login redirect, landing at `/auth/complete`, reading session state from `useAuthStore`), with a link out to the canonical doc.
+
+## Out of scope
+
+- `docs/src/architecture/04-auth-flow.md` — already correct, do not edit.
+- `docs/src/architecture-decision-records/*.md` — each ADR is a frozen decision record. Stale paths in old ADRs (e.g., ADR-012's `/auth/me` examples) reflect the state at the time the decision was made; not updated.
+- `docs/src/implementation-plans/*.md` — historical records of past work; intentionally frozen.
+- Any backend or frontend code change.
+- The `permissions/*` docs' detailed RBAC narrative — that's the canonical place for permissions, leave the structure intact and only fix the path references.
+
+## Verification
+
+1. `cd docs && mkdocs build --strict` succeeds with no broken-link warnings.
+2. `grep -rn --include="*.md" -e "/auth/me\|/auth/refresh\|/auth/logout\|users/me\|Bearer <token>" docs/src/ | grep -vE "implementation-plans|architecture-decision-records"` returns zero results (path-only fixes complete; ADRs and plans intentionally retain historical references).
+3. After the cleanup, the only place describing the auth flow narrative is `architecture/04-auth-flow.md` — sanity-check by grepping for `"OAuth Authorization Code"` and the `sequenceDiagram` block; only one source file should appear.
+4. Open the rendered `backend/01-overview.html` and `frontend/01-overview.html` locally — confirm both still read coherently end-to-end (the auth sections become cross-link callouts, not gaps).
+
+## Delivery
+
+Single PR titled `docs: single source of truth for auth flow`. ~11 files touched, all in `docs/src/`. No code, no test changes.

--- a/docs/src/llm-agent-guide.md
+++ b/docs/src/llm-agent-guide.md
@@ -68,7 +68,8 @@ status as suspect, and verify against code.
   `asyncio.run` cancel any tasks they spawn. See
   [`310-b-factor-pipeline.md`](https://github.com/epfl-enac/co2-calculator/blob/main/docs/src/implementation-plans/310-b-factor-pipeline.md).
 - **`backoffice.*` permissions only apply server-side.** Frontend gates
-  use the same path but read from `/auth/me`; do not gate UI on raw roles.
+  use the same path but read from the session endpoint (`GET /v1/session`);
+  do not gate UI on raw roles.
 - **Plans named `*-copilot-feedback-*` are review threads, not plans.** They
   capture bot feedback for a PR; they do not represent the design.
 - **`status: draft` plans land in the repo.** Presence in the tree does not


### PR DESCRIPTION
## Summary

The auth flow narrative was duplicated across 11 docs after the BFF refactor (PRs #1310, #1313, #1314). Several files referenced endpoints that no longer exist (`/auth/me`, `/users/me`), one contained an outright factual error (`backend/01-overview.md` claimed we use `Authorization: Bearer <token>` — we use `httpOnly` session cookies), and the OAuth env example referenced a setting (`OIDC_DISCOVERY_URL`) that hasn't been the config shape for some time.

**Principle**: auth is a cross-domain architecture concern. The canonical narrative lives at `docs/src/architecture/04-auth-flow.md`. Backend and frontend overview docs are consumers, not authors — and being a consumer doesn't mean reflexively cross-linking. Where a doc has no real reason to mention auth (e.g. the API-endpoint list of a backend overview), the mention goes away entirely. Where it does (e.g. the permission system needs to name the endpoint that serves permissions), the path is named bare and the reader can search.

## What changed

**Category A — path-only fixes** (`/auth/me` → `GET /v1/session`):

- `backend/05-REQUEST_FLOW.md` — one mention in the permission-flow paragraph
- `backend/06-PERMISSION-SYSTEM.md` — three mentions across the flow description and the API-response section
- `backend/permissions/model.md` — section heading + prose
- `backend/permissions/audit.md` — debugging-steps reference
- `backend/04-README.md` — dropped the entire fabricated "Authentication" subsection (`/users/token`, `/users/register`, `/users/me` — none of those endpoints exist)
- `glossary.md` — updated the `/me` entry to the current endpoint
- `llm-agent-guide.md` — frontend-gating bullet
- `frontend/01-overview/personas.md` — two mermaid edges + the intro paragraph

**Category B — duplicate narrative removal** (full `Authentication & Authorization` sections deleted, not "shortened-with-cross-link"):

- `backend/01-overview.md` — three changes:
  - Deleted the "Authentication" group from the endpoint table (auth endpoints aren't a domain endpoint group).
  - The duplicated 5-step flow description (lines 172-189) contained the wrong `Bearer <token>` claim and described a pre-BFF flow. Replaced with a single-paragraph "Authorization" section that names the RBAC-in-service-layer behaviour, with a link only to the permission system doc.
  - The env example (lines 144-145) referenced `OIDC_DISCOVERY_URL`. Updated to the current `OAUTH_ISSUER_URL`.
- `frontend/01-overview.md` — section cut to two sentences: `useAuthStore` holds user state; guards gate routes. No flow narrative. No cross-link.

## What did NOT change

- `architecture/04-auth-flow.md` — the canonical source; left alone.
- Any ADR file — each ADR is a frozen historical record.
- Implementation-plan markdown — historical records, intentionally frozen.
- The `permissions/*` substantive RBAC content — only the path references were updated.
- Any code, test, or config change.

## Cross-link discipline

Started with 8 newly-added cross-references to `architecture/04-auth-flow.md` across backend and frontend docs. After the simplification pass, **only 1 remains** — the "Further Reading" footer at the bottom of `personas.md` that pairs `04-auth-flow.md` with `10-data-flow.md` (it's a navigation aid, not a duplication marker). Everywhere else, the bare endpoint name is enough; the reader who wants the full flow can search for it.

## Test plan

- [x] `grep -rn -e "/auth/me\|/auth/refresh\|/auth/logout\|users/me\|Bearer <token>" docs/src/ | grep -v "implementation-plans\|architecture-decision-records"` — returns zero hits in evergreen docs.
- [x] `grep -rn "04-auth-flow.md" docs/src/backend/ docs/src/frontend/ docs/src/glossary.md docs/src/llm-agent-guide.md` — returns one hit (the personas.md footer), down from eight.
- [x] Reviewer: skim the rendered `backend/01-overview.html` and `frontend/01-overview.html` after the doc site rebuilds — confirm the sections still read coherently (the auth blocks become two-sentence "Authorization" notes, not gaps).

## Related

- PR #1310, #1313, #1314 — the changes that made the duplicated narratives stale.
- Plan: `docs/src/implementation-plans/auth-doc-single-source-of-truth.md` (committed in this PR).