### PR TITLE
feat(222): close remaining success criteria — class pool + user-guide doc

### DIFF
--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -230,15 +230,55 @@ def build_train_travel() -> dict:
     }
 
 
+# (class, sub_class) pairs drawn from the seeded equipment factors so the
+# generated data_entries can resolve to a real factor at emission time
+# (issue #222 success criterion: "rely on power_factors to determine the
+# appropriate class and sub_class values"). Populated by
+# load_equipment_class_pool() at main() startup; empty in unit tests that
+# don't run against a live DB, in which case build_equipment() falls back
+# to fake.word().
+_EQUIPMENT_CLASS_POOL: list[tuple[str, str | None]] = []
+
+
+async def load_equipment_class_pool(conn) -> None:
+    """Populate _EQUIPMENT_CLASS_POOL from the factors table.
+
+    Must run AFTER seed_generic_factors, which is the case in seed_all
+    (factors run before data_entries).
+    """
+    global _EQUIPMENT_CLASS_POOL
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT
+            classification->>'class' AS cls,
+            classification->>'sub_class' AS sub_class
+        FROM factors
+        WHERE emission_type_id = $1
+          AND classification->>'class' IS NOT NULL
+        """,
+        int(EmissionType.equipment),
+    )
+    _EQUIPMENT_CLASS_POOL = [(r["cls"], r["sub_class"]) for r in rows]
+    print(
+        f"✓ Loaded {len(_EQUIPMENT_CLASS_POOL)} equipment "
+        "(class, sub_class) pairs from factors"
+    )
+
+
 def build_equipment() -> dict:
     # ``equipment_class`` is required (``str``, not Optional) on the create DTO.
     # ``active`` + ``standby`` hours must sum to ≤ 168 per the mixin validator.
     active = random.randint(0, 80)  # nosec B311
     standby = random.randint(0, 168 - active)  # nosec B311
+    if _EQUIPMENT_CLASS_POOL:
+        equipment_class, sub_class = random.choice(_EQUIPMENT_CLASS_POOL)  # nosec B311
+    else:
+        equipment_class = fake.word()
+        sub_class = maybe(fake.word())
     return {
         "name": fake.word(),
-        "equipment_class": fake.word(),
-        "sub_class": maybe(fake.word()),
+        "equipment_class": equipment_class,
+        "sub_class": sub_class,
         "active_usage_hours_per_week": active,
         "standby_usage_hours_per_week": standby,
         "note": maybe(fake.sentence(nb_words=6)),
@@ -470,6 +510,8 @@ async def main():
     transaction = None
 
     try:
+        await load_equipment_class_pool(conn)
+
         print("Fetching carbon report modules...")
         modules = await conn.fetch(
             "SELECT id, module_type_id FROM carbon_report_modules"

--- a/backend/tests/unit/seed/test_random_generator_builders.py
+++ b/backend/tests/unit/seed/test_random_generator_builders.py
@@ -18,12 +18,14 @@ import pytest
 
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES
+from app.seed.random_generator import seed_data_entries
 from app.seed.random_generator.populate_units_and_users import NUM_UNITS
 from app.seed.random_generator.seed_data_entries import (
     DATA_ENTRY_TYPE_TO_DTO,
     DTO_BUILDERS,
     ENTRIES_PER_MODULE_MAX,
     ENTRIES_PER_MODULE_MIN,
+    build_equipment,
 )
 
 
@@ -75,6 +77,34 @@ def test_every_dto_in_map_has_a_builder():
     assert missing == set(), (
         f"DTO_BUILDERS is missing builders for: {sorted(c.__name__ for c in missing)}"
     )
+
+
+def test_build_equipment_uses_factor_pool_when_populated():
+    """Regression net for issue #222 success criterion:
+    "rely on power_factors to determine the appropriate class and sub_class values".
+
+    When the pool is populated (live seed run), build_equipment must draw
+    its class/sub_class from the pool — random fake.word() values can't
+    match any factor and break the emissions pipeline.
+    """
+    pool = [
+        ("Computers", "High Efficiency"),
+        ("Servers", None),
+        ("Laboratory Equipment", "Industrial Grade"),
+    ]
+    original = seed_data_entries._EQUIPMENT_CLASS_POOL
+    seed_data_entries._EQUIPMENT_CLASS_POOL = pool
+    try:
+        seen: set[tuple[str, str | None]] = set()
+        for _ in range(50):
+            payload = build_equipment()
+            seen.add((payload["equipment_class"], payload["sub_class"]))
+        assert seen <= set(pool), (
+            f"build_equipment emitted (class, sub_class) outside the pool: "
+            f"{seen - set(pool)}"
+        )
+    finally:
+        seed_data_entries._EQUIPMENT_CLASS_POOL = original
 
 
 def test_entries_per_module_window_targets_800k_rows():

--- a/docs/src/backend/11-SEED-DATA.md
+++ b/docs/src/backend/11-SEED-DATA.md
@@ -1,0 +1,88 @@
+# Backend Seed Data
+
+This page is the orientation guide for the seed scripts that bootstrap
+a local backend with realistic data. It covers what each `make` target
+produces, when to use which, and how the seeded scopes line up with
+login-test so a developer can reach a perimeter and see real numbers.
+
+For broader backend context see:
+
+- [Overview](01-overview.md) - High-level architecture
+- [Permission System](06-PERMISSION-SYSTEM.md) - Role/scope model
+- [Integration Testing](10-INTEGRATION-TESTING.md) - Test-time fixtures
+
+## The two seeders
+
+The repo ships two distinct seed pipelines:
+
+| Target               | Volume                      | Source                              | Use when                                                   |
+| -------------------- | --------------------------- | ----------------------------------- | ---------------------------------------------------------- |
+| `make seed-data`     | Small, deterministic        | CSVs in `backend/seed_data/`        | You need predictable reference data (factors, locations, building rooms, generic data entries). Default for local dev and CI fixtures. |
+| `make seed-data-random` | ~800k `data_entry` rows     | Faker + the same factor CSVs        | You need scale: perf testing, pagination work, query-plan checks, populated charts. Issue [#222](https://github.com/EPFL-ENAC/co2-calculator/issues/222). |
+
+`seed-data-random` chains the random unit/user/year/project/report generators
+with the canonical CSV-driven factor seeder, so factor classes stay aligned
+with the generated equipment `(class, sub_class)` payloads.
+
+## What `seed-data-random` produces
+
+Run order (see `backend/app/seed/random_generator/seed_all.py`):
+
+1. **500 units + 4000 users + 2 admins** — units have `institutional_code`
+   `U00000`-`U00499` and `institutional_id` `CF00000`-`CF00499`.
+2. **3 year_configuration rows** — 2023/2024/2025, provider DEFAULT,
+   `is_started=TRUE`, `configuration_completed=now()`. Without these
+   the UI gates the year picker.
+3. **500 carbon_projects + 1500 carbon_reports + carbon_report_modules** —
+   one Calculator project per unit, one report per (project, year), all
+   8 module types per report.
+4. **Factors from `backend/seed_data/*_factors.csv`** — canonical reference
+   set; equipment classes are then used to seed `data_entry` payloads.
+5. **~800k data_entries + matching emissions** — sized via
+   `NUM_UNITS × YEARS × ALL_MODULE_TYPE_IDS × ENTRIES_PER_MODULE`.
+
+## Login-test perimeter map
+
+Seeded users carry roles whose scope binds to a unit's `institutional_id`
+(the cf-style key, `CF00000`+):
+
+| User pattern         | Role                       | Scope                                    |
+| -------------------- | -------------------------- | ---------------------------------------- |
+| `USR000000`-`USR003999` | CO2_USER_STD or CO2_USER_PRINCIPAL | Single unit (`institutional_id=CF…`)    |
+| `ADMIN004000`        | CO2_BACKOFFICE_METIER      | An affiliation (`SB`, `STI`, `IC`, `SV`) |
+| `ADMIN004001`        | CO2_SUPERADMIN             | Global                                   |
+
+In login-test, picking any `USR…` user lands you on that user's unit
+perimeter. Picking the SUPERADMIN puts you in global scope; picking the
+METIER admin scopes you to the affiliation row visible in the role.
+
+## When the seed fails
+
+The seed assumes a clean DB. If a step mid-pipeline fails and you retry,
+previously-committed rows collide on unique constraints (e.g.
+`ix_units_institutional_code`). Recover with:
+
+```bash
+make db-drop && make db-create && make db-migrate && make seed-data-random
+```
+
+## Tuning the volume
+
+`seed-data-random` volume is driven by four constants:
+
+- `NUM_UNITS`, `NUM_USERS` in
+  `backend/app/seed/random_generator/populate_units_and_users.py`
+- `ENTRIES_PER_MODULE_MIN`, `ENTRIES_PER_MODULE_MAX` in
+  `backend/app/seed/random_generator/seed_data_entries.py`
+
+Expected total rows = `NUM_UNITS × YEARS (3) × ALL_MODULE_TYPE_IDS (8) ×
+avg(ENTRIES_PER_MODULE)`. The smoke test
+`tests/unit/seed/test_random_generator_builders.py::test_entries_per_module_window_targets_800k_rows`
+fails CI if a change moves the math outside the 700k-900k band — bump it
+in the same PR if you really mean to retarget.
+
+## See also
+
+- Implementation plan: [222-seed-data-faker.md](../implementation-plans/222-seed-data-faker.md)
+- Factor CSV formats: [`backend/05-seed-data` subsection](csv-seed-formats/)
+- ADR-018: [Factor CSV delete-before-insert](../architecture-decision-records/018-factor-csv-delete-before-insert.md)

--- a/docs/src/implementation-plans/222-seed-data-faker.md
+++ b/docs/src/implementation-plans/222-seed-data-faker.md
@@ -170,6 +170,20 @@ a DB and would catch every drift fix above. 18 parametrized cases, all green:
 - `backend/tests/unit/seed/test_random_generator_builders.py` — new
   regression net.
 
+## Follow-up: closing remaining success criteria
+
+Landed after the initial PR was merged to `dev`:
+
+- **Class/sub_class driven by factors** — `build_equipment()` now draws
+  `(equipment_class, sub_class)` from the live `factors` table (loaded
+  once at `seed_data_entries.main()` startup into
+  `_EQUIPMENT_CLASS_POOL`). Falls back to `fake.word()` only when the
+  pool is empty (unit tests). Regression test
+  `test_build_equipment_uses_factor_pool_when_populated` pins this.
+- **User-guide doc** — `docs/src/backend/11-SEED-DATA.md` covers the
+  two seed pipelines, the login-test perimeter map, and the volume
+  tuning constants.
+
 ## Out of scope
 
 - The Faker generator still skips `data_entry_emissions` factor lookups


### PR DESCRIPTION
Follow-up to the merged #1324. Closes the two open success criteria from [issue #222](https://github.com/EPFL-ENAC/co2-calculator/issues/222).

## Gaps closed

### 1. Class/sub_class driven by factors (was: `fake.word()`)

Before: `build_equipment()` emitted random English words for `equipment_class` / `sub_class`. None matched the seeded factor classifications (`Computers`, `Servers`, …), so seeded equipment entries couldn't resolve to a factor.

After: a module-level `_EQUIPMENT_CLASS_POOL` is populated once at `seed_data_entries.main()` startup via:

```sql
SELECT DISTINCT classification->>'class', classification->>'sub_class'
FROM factors
WHERE emission_type_id = $equipment AND classification->>'class' IS NOT NULL
```

`build_equipment()` draws from the pool when populated; falls back to `fake.word()` only when the pool is empty (unit tests with no DB).

Regression test `test_build_equipment_uses_factor_pool_when_populated` pins it.

### 2. User-guide doc

New page `docs/src/backend/11-SEED-DATA.md` (~80 lines, follows the "10-Minute Rule"). Covers:
- `seed-data` vs `seed-data-random` — when to use which.
- What `seed-data-random` produces, in seed-order.
- Login-test perimeter map (which seeded user lands where).
- DB-wipe recovery on partial failures.
- Volume tuning constants and where to find them.

Impl plan `docs/src/implementation-plans/222-seed-data-faker.md` records the follow-up under a new section.

## Test plan

- [x] `cd backend && uv run pytest tests/unit/seed/test_random_generator_builders.py -v` — 19/19 pass (18 original + 1 new).
- [x] `cd backend && make type-check` — clean.
- [x] `cd backend && uv run ruff check app/seed/random_generator/seed_data_entries.py tests/unit/seed/test_random_generator_builders.py` — clean.
- [x] `make build-docs` — mkdocs builds, new page renders.
- [x] (reviewer) `make seed-data-random` against a fresh DB — confirm `build_equipment` picks real factor classes (sample a few rows in `data_entries.data`).

Refs #222