### PR TITLE
feat: make button styles and structure in various dialog components consistent

### DIFF
--- a/frontend/src/components/molecules/NoteDialog.vue
+++ b/frontend/src/components/molecules/NoteDialog.vue
@@ -10,13 +10,7 @@
           {{ title }}
         </div>
         <q-space />
-        <q-btn
-          icon="close"
-          flat
-          round
-          dense
-          @click="$emit('update:modelValue', false)"
-        />
+        <q-btn v-close-popup flat size="md" icon="o_close" color="grey-6" />
       </q-card-section>
 
       <q-separator class="q-mt-sm" />

--- a/frontend/src/components/molecules/data-management/ComputedFactorDialog.vue
+++ b/frontend/src/components/molecules/data-management/ComputedFactorDialog.vue
@@ -37,11 +37,20 @@ function handleConfirm() {
         <div class="text-h6">
           {{ $t('data_management_compute_factors_confirm_title') }}
         </div>
+        <q-space />
+        <q-btn
+          flat
+          size="md"
+          icon="o_close"
+          color="grey-6"
+          @click="handleClose"
+        />
       </q-card-section>
+      <q-separator />
       <q-card-section class="text-body2">
         {{ $t('data_management_compute_factors_confirm_message') }}
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="q-px-md q-pb-md">
         <q-btn flat :label="$t('common_cancel')" @click="handleClose" />
         <q-btn
           color="accent"

--- a/frontend/src/components/molecules/data-management/DataEntryDialogContent.vue
+++ b/frontend/src/components/molecules/data-management/DataEntryDialogContent.vue
@@ -262,7 +262,7 @@ watch(showDialog, (newVal) => {
 
       <q-separator />
 
-      <q-card-section class="q-pt-sm">
+      <q-card-actions class="q-px-md q-pb-md">
         <q-btn
           aria-label="data-entry-save"
           :label="
@@ -285,7 +285,7 @@ watch(showDialog, (newVal) => {
                 : (showDialog = false)
           "
         />
-      </q-card-section>
+      </q-card-actions>
     </q-card>
   </q-dialog>
 </template>

--- a/frontend/src/components/molecules/data-management/ModuleRecalculationDialog.vue
+++ b/frontend/src/components/molecules/data-management/ModuleRecalculationDialog.vue
@@ -42,7 +42,16 @@ function handleConfirm() {
         <div class="text-h6">
           {{ $t('data_management_recalculate_emissions_title') }}
         </div>
+        <q-space />
+        <q-btn
+          flat
+          size="md"
+          icon="o_close"
+          color="grey-6"
+          @click="handleClose"
+        />
       </q-card-section>
+      <q-separator />
       <q-card-section class="text-body2">
         {{ $t('data_management_recalculate_emissions_description') }}
       </q-card-section>
@@ -70,7 +79,7 @@ function handleConfirm() {
           @update:model-value="(val) => emit('update:onlyStale', val)"
         />
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="q-px-md q-pb-md">
         <q-btn flat :label="$t('common_cancel')" @click="handleClose" />
         <q-btn
           color="accent"

--- a/frontend/src/components/organisms/data-management/FilesUploadDialog.vue
+++ b/frontend/src/components/organisms/data-management/FilesUploadDialog.vue
@@ -64,8 +64,11 @@ const uploadFiles = async () => {
           {{ $t('data_management_upload_csv_files') }}
         </div>
 
-        <!-- Wrap in q-form with @submit.prevent -->
-        <q-form class="q-gutter-md" @submit.prevent="uploadFiles">
+        <q-form
+          id="files-upload-form"
+          class="q-gutter-md"
+          @submit.prevent="uploadFiles"
+        >
           <q-file
             v-model="selectedFiles"
             dense
@@ -76,20 +79,27 @@ const uploadFiles = async () => {
             accept=".csv, text/csv"
             @keyup.enter="uploadFiles"
           />
-
-          <q-btn
-            :label="$t('data_management_upload')"
-            size="sm"
-            color="accent"
-            type="submit"
-            :disabled="
-              !selectedFiles || selectedFiles.length === 0 || isUploading
-            "
-          />
-
-          <q-linear-progress v-if="isUploading" indeterminate color="accent" />
         </q-form>
+
+        <q-linear-progress
+          v-if="isUploading"
+          indeterminate
+          color="accent"
+          class="q-mt-sm"
+        />
       </q-card-section>
+      <q-card-actions class="q-px-md q-pb-md">
+        <q-btn
+          :label="$t('data_management_upload')"
+          size="sm"
+          color="accent"
+          form="files-upload-form"
+          type="submit"
+          :disabled="
+            !selectedFiles || selectedFiles.length === 0 || isUploading
+          "
+        />
+      </q-card-actions>
     </q-card>
   </q-dialog>
 </template>

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -878,9 +878,21 @@ onUnmounted(() => {
          many rows and a misclick is easy. -->
     <q-dialog v-model="abortDialog" persistent>
       <q-card style="min-width: 360px">
-        <q-card-section>
+        <q-card-section class="row items-center q-pb-none">
           <div class="text-h6">{{ $t('pipeops_abort_title') }}</div>
-          <div class="text-body2 text-grey-8 q-mt-sm">
+          <q-space />
+          <q-btn
+            flat
+            size="md"
+            icon="o_close"
+            color="grey-6"
+            :disable="aborting"
+            @click="abortDialog = false"
+          />
+        </q-card-section>
+        <q-separator />
+        <q-card-section>
+          <div class="text-body2 text-grey-8">
             {{ $t('pipeops_abort_body') }}
           </div>
           <div v-if="abortTarget" class="q-mt-sm text-caption text-grey-7">
@@ -890,7 +902,7 @@ onUnmounted(() => {
             / {{ abortTarget.year ?? '—' }}
           </div>
         </q-card-section>
-        <q-card-actions align="right">
+        <q-card-actions class="q-px-md q-pb-md">
           <q-btn
             flat
             :label="$t('pipeops_abort_cancel')"
@@ -914,15 +926,9 @@ onUnmounted(() => {
         <q-card-section class="row items-center q-pb-none">
           <div class="text-subtitle1">{{ $t('pipeops_msg_title') }}</div>
           <q-space />
-          <q-btn
-            flat
-            dense
-            icon="content_copy"
-            :label="$t('pipeops_msg_copy')"
-            @click="copyMsg"
-          />
-          <q-btn v-close-popup flat dense round icon="close" />
+          <q-btn v-close-popup flat size="md" icon="o_close" color="grey-6" />
         </q-card-section>
+        <q-separator />
         <q-card-section>
           <pre
             class="q-pa-md bg-grey-2 rounded-borders"
@@ -936,6 +942,14 @@ onUnmounted(() => {
             >{{ msgText }}</pre
           >
         </q-card-section>
+        <q-card-actions class="q-px-md q-pb-md">
+          <q-btn
+            flat
+            icon="content_copy"
+            :label="$t('pipeops_msg_copy')"
+            @click="copyMsg"
+          />
+        </q-card-actions>
       </q-card>
     </q-dialog>
   </q-page>


### PR DESCRIPTION
## What does this change?
Standardises dialog structure across the app so all dialogs follow the same pattern: title row with a close `X` button, a `q-separator`, body content, and a `q-card-actions` footer for action buttons.

- `NoteDialog.vue`: replaces the manual `@click="$emit(...)"` close button with `v-close-popup`; switches to outlined `o_close` icon with consistent sizing
- `ComputedFactorDialog.vue`: adds close button + separator to header; moves action buttons to `q-card-actions` with consistent padding
- `ModuleRecalculationDialog.vue`: same header/footer treatment as above
- `DataEntryDialogContent.vue`: converts the footer `q-card-section` to `q-card-actions` with consistent padding
- `FilesUploadDialog.vue`: moves the upload button out of the `q-form` into a `q-card-actions` footer (linked via `form="files-upload-form"`); moves the progress bar to after the form
- `PipelineOperationsConsolePage.vue`: restructures both the abort dialog and the message dialog — splits title and body into separate `q-card-section` blocks with a separator; moves action buttons to `q-card-actions` with consistent padding; moves the copy button to the footer; replaces the inline close button style with the standard `o_close` pattern

## Why is this needed?
Dialog structure was inconsistent across the app — some had close buttons, some didn't; action buttons were sometimes in `q-card-section`, sometimes in `q-card-actions` with varying alignment and padding. This makes all dialogs visually and structurally uniform.

## Type of change
- [x] 🎨 Design/UI improvement
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1232