### PR TITLE
feat: enhance module visibility and access control in sidebar and home page

### DIFF
--- a/frontend/src/components/organisms/layout/Co2ModuleSidebar.vue
+++ b/frontend/src/components/organisms/layout/Co2ModuleSidebar.vue
@@ -40,8 +40,10 @@ const currentTotalResult = computed(() => {
 });
 
 const visibleItems = computed(() =>
-  timelineItems.filter((item) =>
-    yearConfigStore.isModuleVisible(item.link as Module),
+  timelineItems.filter(
+    (item) =>
+      yearConfigStore.isModuleVisible(item.link as Module) &&
+      authStore.canUserAccessModule(item.link as Module),
   ),
 );
 

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -4,7 +4,6 @@ import { useI18n } from 'vue-i18n';
 import { MODULES } from 'src/constant/modules';
 import { MODULES_CONFIG } from 'src/constant/module-config';
 import { MODULE_CARDS } from 'src/constant/moduleCards';
-import type { ModuleCard } from 'src/constant/moduleCards';
 import { getModuleTypeId, MODULE_STATES } from 'src/constant/moduleStates';
 import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import { useWorkspaceStore } from 'src/stores/workspace';
@@ -61,14 +60,13 @@ function hasModulePermission(
 }
 const timelineStore = useTimelineStore();
 
-const moduleCardsWithStatus = computed(() => {
-  return MODULE_CARDS.map(
-    (card): ModuleCard => ({
-      ...card,
-      isDisabled: !yearConfigStore.isModuleVisible(card.module),
-    }),
-  );
-});
+const moduleCardsWithStatus = computed(() =>
+  MODULE_CARDS.filter(
+    (card) =>
+      yearConfigStore.isModuleVisible(card.module) &&
+      authStore.canUserAccessModule(card.module),
+  ),
+);
 
 const modulesCounterText = computed(() => t('home_modules_counter'));
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -183,6 +183,15 @@ export const useAuthStore = defineStore('auth', () => {
     return hasUserPermission(path, action);
   }
 
+  function canUserAccessModule(module: Module): boolean {
+    const path = getModulePermissionPath(module);
+    if (!path) return true; // Unprotected module, accessible to all users
+    return (
+      hasUserAnyScopePermission(path, PermissionAction.VIEW) ||
+      hasUserAnyScopePermission(path, PermissionAction.EDIT)
+    );
+  }
+
   /**
    * Check if the current user can access the back-office area (any
    * `backoffice.*` or `system.*` permission granting `action`). Use for
@@ -223,6 +232,7 @@ export const useAuthStore = defineStore('auth', () => {
     isAuthenticated,
     hasUserPermission,
     hasUserModulePermission,
+    canUserAccessModule,
     hasUserBackOfficeAreaPermission,
     hasUserAnyScopePermission,
   };


### PR DESCRIPTION
## What does this change?
Hides modules from the sidebar and home page when the current user has no view or edit permission for them, in addition to the existing year-config visibility check.

- `auth.ts`: adds `canUserAccessModule(module)` — returns `true` if the module has no permission path (unprotected), or if the user holds at least `VIEW` or `EDIT` on any scope for that module's permission path
- `Co2ModuleSidebar.vue`: adds `authStore.canUserAccessModule` to the `visibleItems` filter alongside `isModuleVisible`
- `HomePage.vue`: replaces the `map` (which was setting `isDisabled`) with a `filter` that removes cards the user can't access; removes the now-unused `ModuleCard` type import

## Why is this needed?
Modules that a user has no permission to access were still appearing in the sidebar and on the home page (just disabled). They should be hidden entirely to reduce confusion and avoid showing irrelevant entries to users with limited roles.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #361