### PR TITLE
feat/864 reporting layout page reporting

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -322,6 +322,7 @@ async def list_backoffice_units(
         data=unit_reporting_data,
         pagination=PaginationMeta(**result),
         emission_breakdown=result.get("emission_breakdown"),
+        it_breakdown=result.get("it_breakdown"),
         validated_units_count=result.get("validated_units_count", 0),
         in_progress_units_count=result.get("in_progress_units_count", 0),
         not_started_units_count=result.get("not_started_units_count", 0),

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -19,6 +19,12 @@ from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.carbon_report import CarbonReportModuleCreate
 from app.utils.emission_category import build_chart_breakdown
+from app.utils.it_breakdown import (
+    IT_EMISSION_TYPES,
+    ITSqlTotals,
+    build_it_breakdown,
+    get_validated_source_module_type_ids,
+)
 
 logger = get_logger(__name__)
 
@@ -754,6 +760,35 @@ class CarbonReportModuleRepository:
             validated_module_type_ids=validated_module_type_ids,
         )
 
+        # Build IT breakdown from the same aggregated rows (no extra SQL needed)
+        rows_no_add = [(mt, et, kg) for mt, et, kg, _add in chart_rows]
+        it_type_ids = {et.value for et in IT_EMISSION_TYPES}
+        validated_source_ids = set(
+            get_validated_source_module_type_ids(validated_module_type_ids)
+        )
+        it_total_kg = sum(kg for _mt, et, kg in rows_no_add if et in it_type_ids)
+        overall_total_kg = sum(kg for _mt, _et, kg in rows_no_add)
+        validated_source_total_kg = sum(
+            kg for mt, _et, kg in rows_no_add if mt in validated_source_ids
+        )
+        validated_it_kg = sum(
+            kg
+            for mt, et, kg in rows_no_add
+            if mt in validated_source_ids and et in it_type_ids
+        )
+        it_sql_totals: ITSqlTotals = {
+            "it_total_kg": float(it_total_kg),
+            "overall_total_kg": float(overall_total_kg),
+            "validated_source_total_kg": float(validated_source_total_kg),
+            "validated_it_kg": float(validated_it_kg),
+        }
+        it_breakdown = build_it_breakdown(
+            rows=rows_no_add,
+            total_fte=global_fte,
+            validated_module_type_ids=validated_module_type_ids,
+            sql_totals=it_sql_totals,
+        )
+
         # --- STEP 3: Use cached stats from CarbonReport ---
         # Build reporting data using pre-computed stats
         reporting_data = []
@@ -823,6 +858,7 @@ class CarbonReportModuleRepository:
             "page_size": page_size,
             "total_pages": ceil(total / page_size) if page_size > 0 else 1,
             "emission_breakdown": emission_breakdown,
+            "it_breakdown": it_breakdown,
             "validated_units_count": validated_units_count,
             "in_progress_units_count": in_progress_units_count,
             "not_started_units_count": not_started_units_count,

--- a/backend/app/schemas/backoffice.py
+++ b/backend/app/schemas/backoffice.py
@@ -69,6 +69,7 @@ class PaginatedUnitReportingData(BaseModel):
     data: List[UnitReportingData]
     pagination: PaginationMeta
     emission_breakdown: Optional[Dict[str, Any]] = None
+    it_breakdown: Optional[Dict[str, Any]] = None
     validated_units_count: int = 0
     in_progress_units_count: int = 0
     not_started_units_count: int = 0

--- a/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
+++ b/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
@@ -45,9 +45,11 @@ const props = withDefaults(
   defineProps<{
     data: ItBreakdownResponse;
     printMode?: boolean;
+    compact?: boolean;
   }>(),
   {
     printMode: false,
+    compact: false,
   },
 );
 
@@ -151,7 +153,16 @@ const categoryColor = computed(() => ({
 const WAFFLE_TOTAL_UNITS = 1000;
 const WAFFLE_COLS = 50;
 const WAFFLE_ROWS = 20;
+const WAFFLE_COLS_COMPACT = 100;
+const WAFFLE_ROWS_COMPACT = 10;
 const NON_IT_COLOR = '#C8C6BE';
+
+const waffleCols = computed(() =>
+  props.compact ? WAFFLE_COLS_COMPACT : WAFFLE_COLS,
+);
+const waffleRows = computed(() =>
+  props.compact ? WAFFLE_ROWS_COMPACT : WAFFLE_ROWS,
+);
 
 interface WaffleCategory {
   key: string;
@@ -224,9 +235,10 @@ const waffleCategoryData = computed<WaffleCategory[]>(() => {
   return cats;
 });
 
-const cellSize = computed(() => Math.max(8, waffleWidth.value / WAFFLE_COLS));
-
-const waffleHeight = computed(() => cellSize.value * WAFFLE_ROWS);
+const cellSize = computed(() =>
+  Math.max(4, waffleWidth.value / waffleCols.value),
+);
+const waffleHeight = computed(() => cellSize.value * waffleRows.value);
 const hasWaffleSize = computed(() => waffleWidth.value > 0);
 
 const waffleChartOption = computed<EChartsOption>(() => {
@@ -263,7 +275,10 @@ const waffleChartOption = computed<EChartsOption>(() => {
       data: cells
         .map((c, idx) => ({ c, idx }))
         .filter(({ c }) => c.key === cat.key)
-        .map(({ idx }) => [idx % WAFFLE_COLS, Math.floor(idx / WAFFLE_COLS)]),
+        .map(({ idx }) => [
+          idx % waffleCols.value,
+          Math.floor(idx / waffleCols.value),
+        ]),
       itemStyle: cat.isIT
         ? {
             color: cat.color,
@@ -297,14 +312,14 @@ const waffleChartOption = computed<EChartsOption>(() => {
     xAxis: {
       type: 'value' as const,
       min: -0.5,
-      max: WAFFLE_COLS - 0.5,
+      max: waffleCols.value - 0.5,
       show: false,
       splitLine: { show: false },
     },
     yAxis: {
       type: 'value' as const,
       min: -0.5,
-      max: WAFFLE_ROWS - 0.5,
+      max: waffleRows.value - 0.5,
       show: false,
       splitLine: { show: false },
       inverse: true,

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -18,12 +18,14 @@ const props = withDefaults(
     /** Carbon report year (Results page selected year). */
     year?: number;
     printMode?: boolean;
+    compact?: boolean;
   }>(),
   {
     loading: false,
     co2PerKmKg: 0,
     year: undefined,
     printMode: false,
+    compact: false,
   },
 );
 
@@ -117,6 +119,7 @@ const downloadPNG = () => breakdownChartRef.value?.downloadPNG();
           ref="breakdownChartRef"
           :data="data"
           :print-mode="printMode"
+          :compact="compact"
         />
       </q-card>
 

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -270,7 +270,7 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
           :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
         />
       </div>
-      <q-card flat class="grid-2-col q-mt-xl">
+      <q-card flat class="q-mt-xl" style="display:grid;grid-template-columns:2fr 1fr;gap:16px">
         <ModuleCarbonFootprintChart
           :breakdown-data="reportingEmissionBreakdown"
           :title="$t('backoffice_reporting_aggregated_results_title')"

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -22,6 +22,7 @@ import UnitDialogue from 'src/components/organisms/backoffice/reporting/UnitDial
 import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
 import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
 import EmissionBreakdownChart from 'src/components/charts/EmissionBreakdownChart.vue';
+import ItFocusSection from 'src/components/organisms/ItFocusSection.vue';
 import { useRouter } from 'vue-router';
 const backofficeStore = useBackofficeStore();
 const router = useRouter();
@@ -80,6 +81,7 @@ const loading = computed(() => backofficeStore.unitsLoading);
 const reportingEmissionBreakdown = computed(
   () => units.value?.emission_breakdown ?? null,
 );
+const reportingItBreakdown = computed(() => units.value?.it_breakdown ?? null);
 
 const tableRows = computed(() => units.value?.data ?? []);
 const validatedCount = computed(() => units.value?.validated_units_count ?? 0);
@@ -270,7 +272,11 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
           :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
         />
       </div>
-      <q-card flat class="q-mt-xl" style="display:grid;grid-template-columns:2fr 1fr;gap:16px">
+      <q-card
+        flat
+        class="q-mt-xl"
+        style="display: grid; grid-template-columns: 2fr 1fr; gap: 16px"
+      >
         <ModuleCarbonFootprintChart
           :breakdown-data="reportingEmissionBreakdown"
           :title="$t('backoffice_reporting_aggregated_results_title')"
@@ -293,6 +299,13 @@ async function handleModuleStateUpdate(module: Module, states: ModuleState[]) {
         :breakdown-data="reportingEmissionBreakdown"
         class="q-mt-xl"
       />
+      <q-card v-if="reportingItBreakdown" flat bordered class="q-mt-xl">
+        <ItFocusSection
+          :data="reportingItBreakdown"
+          :loading="loading"
+          :compact="true"
+        />
+      </q-card>
       <div class="flex justify-between items-center q-pt-xl q-pb-md">
         <span class="text-body1 text-weight-medium">{{
           $t('backoffice_reporting_usage_statistic')

--- a/frontend/src/stores/backoffice.ts
+++ b/frontend/src/stores/backoffice.ts
@@ -3,7 +3,10 @@ import { reactive, ref } from 'vue';
 import { api } from 'src/api/http';
 import { applyUnitFiltersToParams } from 'src/api/backoffice';
 import type { ModuleState } from 'src/constant/moduleStates';
-import type { EmissionBreakdownResponse } from 'src/stores/modules';
+import type {
+  EmissionBreakdownResponse,
+  ItBreakdownResponse,
+} from 'src/stores/modules';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE_UNITS = 10;
@@ -32,6 +35,7 @@ interface BackofficeUnitDataPagination {
     total: number;
   };
   emission_breakdown?: EmissionBreakdownResponse | null;
+  it_breakdown?: ItBreakdownResponse | null;
   validated_units_count?: number;
   in_progress_units_count?: number;
   not_started_units_count?: number;


### PR DESCRIPTION
## What does this change?
Adds an IT breakdown waffle chart to the backoffice reporting page, powered by aggregated IT data computed server-side from the same rows already fetched for the emission breakdown.

- `carbon_report_module_repo.py`: after building `chart_rows`, computes IT totals (`it_total_kg`, `overall_total_kg`, `validated_source_total_kg`, `validated_it_kg`) from the same rows without an extra SQL query, then calls `build_it_breakdown` to produce the IT breakdown dict
- `backoffice.py`: passes `it_breakdown` from the repo result into the `PaginatedUnitReportingData` response
- `backoffice.py` (schema): adds `it_breakdown: Optional[Dict[str, Any]]` to `PaginatedUnitReportingData`
- `backoffice.ts` (store): adds `it_breakdown?: ItBreakdownResponse | null` to `BackofficeUnitDataPagination`; imports `ItBreakdownResponse`
- `ReportingPage.vue`: adds `reportingItBreakdown` computed from the store; renders `ItFocusSection` in compact mode when data is available; changes the summary grid from `grid-2-col` to a `2fr 1fr` inline grid
- `ItFocusSection.vue` / `ItFocusBreakdownChart.vue`: adds a `compact` prop that switches the waffle to a 100×10 grid (instead of 50×20) and lowers the minimum cell size to 4px, making it fit in a narrower column

## Why is this needed?
The backoffice reporting page showed aggregated emission data but had no visibility into the IT share of total emissions. Reusing the existing IT breakdown computation (no new SQL) and the existing waffle chart component (new compact layout mode) adds this view with minimal overhead.

## Type of change
- [x] ✨ New feature

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #864