### PR TITLE
fix/link color

### DIFF
--- a/frontend/src/components/charts/results/ReductionObjectiveChart.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveChart.vue
@@ -104,7 +104,7 @@ const chartTitle = computed(() =>
         {{ $t('results_objectives_2040_subtitle') }}
         (
         <a
-          class="objective-subtitle__link"
+          class="link"
           href="https://e4s.center/fr/resources/reports/carbon-removal-net-zero-and-implications-for-switzerland/"
           target="_blank"
           rel="noopener noreferrer"

--- a/frontend/src/css/02-tokens/_decisions.scss
+++ b/frontend/src/css/02-tokens/_decisions.scss
@@ -136,9 +136,9 @@ $sidebar-tooltip-arrow-size: 5px !default;
 $sidebar-tooltip-arrow-offset-x: -5px !default;
 
 // Link
-$link-color: opt.$tokens-colors-red-red-100 !default;
+$link-color: opt.$tokens-colors-canard !default;
 $link-underline-color: opt.$tokens-colors-base-black !default;
 $link-hover-color: opt.$tokens-colors-base-black !default;
-$link-hover-underline-color: opt.$tokens-colors-red-red-100 !default;
-$link-visited-color: opt.$tokens-colors-red-red-100 !default;
-$link-active-color: opt.$tokens-colors-red-red-100 !default;
+$link-hover-underline-color: opt.$tokens-colors-canard !default;
+$link-visited-color: opt.$tokens-colors-canard !default;
+$link-active-color: opt.$tokens-colors-canard !default;


### PR DESCRIPTION
## What does this change?
Two unrelated fixes bundled together:

- `_decisions.scss`: changes link color tokens from `red-red-100` to `canard` (the app's primary teal) across all link states (`color`, `hover-underline-color`, `visited-color`, `active-color`)
- `ReductionObjectiveChart.vue`: updates the external link in the reduction objective subtitle to use the global `link` class.

## Why is this needed?
Links were rendering in red (`red-red-100`), which was inconsistent with the rest of the UI that uses canard as the primary interactive color. 

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement
