### PR TITLE
feat(664): default active/standby usage hours from factor on subclass select

### DIFF
--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -77,15 +77,22 @@ async def list_stale_factors(
 )
 async def get_class_subclass_map(
     data_entry_type: DataEntryTypeEnum,
+    year: int = Query(...),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict[str, list[str]]:
-    """Get mapping of equipment classes to subclasses for a given submodule."""
+    """Get mapping of equipment classes to subclasses for a given submodule.
+
+    Scoped to ``year`` so the options match the year-scoped factor lookup in
+    ``get_factor`` — otherwise the dropdown could offer a class that has no
+    factor for the selected year.
+    """
     handler = BaseModuleHandler.get_by_type(data_entry_type)
     return await FactorService(db).get_class_subclass_map(
         data_entry_type=data_entry_type,
         kind_field=handler.kind_field or "",
         subkind_field=handler.subkind_field or "",
+        year=year,
     )
 
 

--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -430,6 +430,7 @@ class FactorRepository:
         data_entry_type: DataEntryTypeEnum,
         kind_field: str,
         subkind_field: str,
+        year: int,
     ) -> Dict[str, List[str]]:
         """
         Return a mapping of equipment_class -> list of subclasses.
@@ -438,11 +439,15 @@ class FactorRepository:
             data_entry_type: The data entry type to filter on
             kind_field: Classification key for the primary class
             subkind_field: Classification key for the subclass
+            year: Year filter — factors are year-scoped, so options must be too
         """
         stmt = select(
             Factor.classification[kind_field].as_string(),
             Factor.classification[subkind_field].as_string(),
-        ).where(col(Factor.data_entry_type_id) == data_entry_type.value)
+        ).where(
+            col(Factor.data_entry_type_id) == data_entry_type.value,
+            col(Factor.year) == year,
+        )
 
         result = await self.session.exec(stmt)
         factors = result.all()

--- a/backend/app/services/factor_service.py
+++ b/backend/app/services/factor_service.py
@@ -149,12 +149,14 @@ class FactorService:
         data_entry_type: DataEntryTypeEnum,
         kind_field: str,
         subkind_field: str,
+        year: int,
     ) -> Dict[str, List[str]]:
-        """Get class/subclass mapping for power factors."""
+        """Get class/subclass mapping for power factors, scoped to ``year``."""
         return await self.repo.get_class_subclass_map(
             data_entry_type=data_entry_type,
             kind_field=kind_field,
             subkind_field=subkind_field,
+            year=year,
         )
 
     async def prepare_create(

--- a/backend/tests/integration/services/data_ingestion/test_factors_year_scope_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_factors_year_scope_pg.py
@@ -1,0 +1,114 @@
+"""Regression tests for ``year`` on the factor lookup endpoints.
+
+These pin two contracts that otherwise regress silently:
+
+- ``GET /v1/factors/{type}/classes/{kind}/values`` **requires** ``year`` — a
+  missing year yields 422, never a wrong-year factor. Guards the buildings
+  room-defaults fix (``useBuildingRoomDynamicOptions`` now passes year) and
+  the equipment power-factor path that already passed it.
+- ``GET /v1/factors/{type}/class-subclass-map`` is **scoped to** ``year`` so
+  the class/subclass dropdown options match the year-scoped values lookup —
+  a class that only has a factor in another year is not offered.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+from app.main import app
+from tests.integration.services.data_ingestion.test_plan_310b_factor_pipeline_pg import (  # noqa: E501
+    _make_factor,
+)
+
+# DataEntryTypeEnum.scientific — equipment handler, kind_field="equipment_class".
+SCIENTIFIC = 10
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn):
+    """Wire the FastAPI app to the test Postgres and bypass auth."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with Sf() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "test@example.com"
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+
+    yield {"factory": Sf}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_values_endpoint_requires_year(pg_app):
+    """Missing ``year`` on /values is a 422 — never a silent wrong-year match."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(f"/v1/factors/{SCIENTIFIC}/classes/ClassP/values")
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_class_subclass_map_requires_year(pg_app):
+    """Missing ``year`` on class-subclass-map is a 422."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(f"/v1/factors/{SCIENTIFIC}/class-subclass-map")
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_class_subclass_map_scoped_to_year(pg_app):
+    """The map returns only classes whose factor matches the queried year."""
+    Sf = pg_app["factory"]
+
+    async with Sf() as session:
+        session.add_all(
+            [
+                _make_factor(
+                    {"equipment_class": "ClassP", "sub_class": "SubP"},
+                    data_entry_type_id=SCIENTIFIC,
+                    year=2025,
+                ),
+                _make_factor(
+                    {"equipment_class": "ClassQ", "sub_class": "SubQ"},
+                    data_entry_type_id=SCIENTIFIC,
+                    year=2024,
+                ),
+            ]
+        )
+        await session.commit()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get(
+            f"/v1/factors/{SCIENTIFIC}/class-subclass-map",
+            params={"year": 2025},
+        )
+
+    assert resp.status_code == 200, resp.text
+    # 2024's ClassQ must NOT leak into the 2025 options.
+    assert resp.json() == {"ClassP": ["SubP"]}

--- a/backend/tests/unit/repositories/test_factor_repo.py
+++ b/backend/tests/unit/repositories/test_factor_repo.py
@@ -155,6 +155,7 @@ async def test_get_class_subclass_map(repo):
         DataEntryTypeEnum.scientific,
         kind_field="kind",
         subkind_field="subkind",
+        year=2025,
     )
 
     assert result == {"ClassA": ["SubA1", "SubA2"], "ClassB": ["SubB1"]}

--- a/docs/code-review/664-copilot-feedback-feat-664-default-active-standby-usage-hours-from-factor-on-subclass-select.md
+++ b/docs/code-review/664-copilot-feedback-feat-664-default-active-standby-usage-hours-from-factor-on-subclass-select.md
@@ -1,0 +1,48 @@
+# Bot Review TODOs: PR #1357
+
+## Source Branch: `feat/664-equipments-default-active-and-standby-usage-with-csv-upload`
+
+## Raw Feedback
+
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+This PR implements #664 by extending the equipment class/sub-class selection logic to also seed **usage hours** from factor defaults (in addition to the already-mirrored power/unit fields), while preserving any user-entered values unless the class/sub-class is explicitly changed.
+
+**Changes:**
+
+- Generalizes `useEquipmentClassOptions` to support two categories of factor-populated fields: always-mirrored (`valueFieldIds`) and seed-only-when-empty (`defaultValueFieldIds`).
+- Updates `ModuleForm.vue` to configure equipment electric consumption to mirror power fields and default usage-hours fields from the factor on subclass selection.
+- Ensures `resetSubclass()` clears both mirrored and defaulted fields so switching class/sub-class re-seeds from the new factor.
+
+### Reviewed changes
+
+Copilot reviewed 2 out of 2 changed files in this pull request and generated 3 comments.
+
+| File                                                    | Description                                                                                                             |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| frontend/src/composables/useEquipmentClassOptions.ts    | Adds configurable lists for always-mirrored vs default-only factor fields; updates factor application + reset behavior. |
+| frontend/src/components/organisms/module/ModuleForm.vue | Wires module-specific factor field IDs for equipment usage-hours defaults and power/unit mirroring.                     |
+
+---
+
+### File: `frontend/src/composables/useEquipmentClassOptions.ts` (Line 168) — Copilot
+
+## When copying factor values into the entity, `pf[fieldId]` can be `undefined` if the backend response doesn't include that key. Writing `undefined` into the form state can break validation/serialization and can leave stale values hard to reason about. Prefer coercing missing keys to `null` (or skipping) to keep the entity state consistent.
+
+### File: `frontend/src/composables/useEquipmentClassOptions.ts` (Line 175) — Copilot
+
+## Same issue for default-seeded fields: indexing `pf[fieldId]` can yield `undefined` if the factor response lacks the key. Coerce to `null` (or skip) so the form never ends up with `undefined` values.
+
+### File: `frontend/src/composables/useEquipmentClassOptions.ts` (Line 195) — Copilot
+
+## `resetSubclass()` clears configured fields but doesn't guard against empty/undefined `fieldId` values. Unlike `loadPowerFactor()`, this can attempt to clear `entity['']` if a caller accidentally includes an empty string in `valueFieldIds/defaultValueFieldIds`. Add the same truthy guard for consistency and safety.
+
+## Action Items
+
+### Maintainability / refactoring
+
+- [ ] **frontend/src/composables/useEquipmentClassOptions.ts** (lines 167 & 174) — `pf[fieldId]` is written straight into the form, so a factor response missing a configured key writes `undefined` into entity state (a `required` number field would then read as missing on validate, and serialize oddly). Fix: coerce both writes to `null` — `(entity as any)[fieldId] = pf[fieldId] ?? null;` in the `valueFieldIds` loop and the `defaultValueFieldIds` loop. Defensive only: the live `/values` payload includes all keys and the pre-existing code had the same gap, so no current trigger — but it's a one-token hardening that keeps empty state consistent with init (`null`).
+
+_Dropped: line-195 `resetSubclass` truthy-guard comment — **wrong**. The existing `fieldId in entity` check already prevents touching `entity['']` (`'' in entity` is `false`), and the arrays are built from literal `.push()` calls, so an empty `fieldId` can never enter. No bug; pure consistency nitpick on an impossible case._

--- a/frontend/src/api/factors.ts
+++ b/frontend/src/api/factors.ts
@@ -5,10 +5,11 @@ import { enumSubmodule } from 'src/constant/modules';
 
 export async function getSubclassMap(
   submodule: keyof typeof enumSubmodule,
+  year: number | string,
 ): Promise<Record<string, string[]>> {
   const res = await api
     .get(
-      `factors/${encodeURIComponent(enumSubmodule[submodule])}/class-subclass-map`,
+      `factors/${encodeURIComponent(enumSubmodule[submodule])}/class-subclass-map?year=${encodeURIComponent(String(year))}`,
     )
     .json<Record<string, string[]>>();
   return res ?? {};

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -574,15 +574,24 @@ const subkindFieldId = computed(() => {
   return subkindField ? subkindField.id : null;
 });
 
-const useEquipmentClassOptionsConfig: Record<string, string> = {};
+// Factor fields populated on class/subclass selection. Each id must match a
+// key in the factor /values response.
+// - factorValueFieldIds: read-only fields always mirrored from the factor.
+// - factorDefaultFieldIds: editable fields seeded only when empty, so a user's
+//   saved value is preserved.
+const factorValueFieldIds: string[] = [];
+const factorDefaultFieldIds: string[] = [];
 if (props.moduleType === MODULES.EquipmentElectricConsumption) {
-  useEquipmentClassOptionsConfig['primaryValueFieldId'] = 'active_power_w';
-  useEquipmentClassOptionsConfig['secondaryValueFieldId'] = 'standby_power_w';
+  factorValueFieldIds.push('active_power_w', 'standby_power_w');
+  factorDefaultFieldIds.push(
+    'active_usage_hours_per_week',
+    'standby_usage_hours_per_week',
+  );
 } else if (
   props.moduleType === MODULES.Buildings &&
   props.submoduleType === SUBMODULE_BUILDINGS_TYPES.EnergyCombustion
 ) {
-  useEquipmentClassOptionsConfig['primaryValueFieldId'] = 'unit';
+  factorValueFieldIds.push('unit');
 }
 
 const { dynamicOptions, loadingClasses, loadingSubclasses } =
@@ -593,7 +602,8 @@ const { dynamicOptions, loadingClasses, loadingSubclasses } =
       classFieldId: kindFieldId.value ?? undefined,
       subClassFieldId: subkindFieldId.value ?? undefined,
       fetchFactorValuesOnChange: true,
-      ...useEquipmentClassOptionsConfig,
+      valueFieldIds: factorValueFieldIds,
+      defaultValueFieldIds: factorDefaultFieldIds,
     },
     toRef(props, 'year'),
   );

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -613,6 +613,7 @@ const { dynamicOptions: buildingRoomDynamicOptions } =
     form,
     toRef(props, 'moduleType'),
     toRef(props, 'submoduleType'),
+    toRef(props, 'year'),
   );
 
 function getTravelMode(): 'plane' | 'train' | undefined {

--- a/frontend/src/components/organisms/module/ModuleInlineSelect.vue
+++ b/frontend/src/components/organisms/module/ModuleInlineSelect.vue
@@ -82,10 +82,15 @@ const subkindFieldId = computed(() => {
 });
 
 const { dynamicOptions, loadingClasses, loadingSubclasses } =
-  useEquipmentClassOptions(props.row, toRef(props, 'submoduleType'), {
-    classFieldId: kindFieldId.value,
-    subClassFieldId: subkindFieldId.value,
-  });
+  useEquipmentClassOptions(
+    props.row,
+    toRef(props, 'submoduleType'),
+    {
+      classFieldId: kindFieldId.value,
+      subClassFieldId: subkindFieldId.value,
+    },
+    toRef(props, 'year'),
+  );
 
 const classOptions = computed(() => {
   const taxo = moduleStore.state.taxonomySubmodule[props.submoduleType ?? ''];

--- a/frontend/src/composables/useBuildingRoomDynamicOptions.ts
+++ b/frontend/src/composables/useBuildingRoomDynamicOptions.ts
@@ -14,6 +14,7 @@ export function useBuildingRoomDynamicOptions(
   form: FormLike,
   moduleType: Ref<Module | string>,
   submoduleType: Ref<AllSubmoduleTypes>,
+  year?: Ref<string | number | undefined>,
 ) {
   const buildingRoomStore = useBuildingRoomStore();
 
@@ -84,21 +85,28 @@ export function useBuildingRoomDynamicOptions(
     form['ventilation_kwh_per_square_meter'] = null;
     form['lighting_kwh_per_square_meter'] = null;
 
+    // `year` is required by the factor endpoint; without it the request 422s.
+    const yearValue = year?.value;
+    if (yearValue == null) return;
+
     const defaults = await getFactorValues(
       SUBMODULE_BUILDINGS_TYPES.Building,
       buildingName,
       roomType.trim().toLowerCase(),
+      yearValue,
     );
     if (requestId !== energyDefaultsRequestId) return;
+    // No matching factor for this building/room/year — leave fields cleared.
+    if (!defaults) return;
 
     form['heating_kwh_per_square_meter'] =
-      defaults.heating_kwh_per_square_meter;
+      defaults.heating_kwh_per_square_meter ?? null;
     form['cooling_kwh_per_square_meter'] =
-      defaults.cooling_kwh_per_square_meter;
+      defaults.cooling_kwh_per_square_meter ?? null;
     form['ventilation_kwh_per_square_meter'] =
-      defaults.ventilation_kwh_per_square_meter;
+      defaults.ventilation_kwh_per_square_meter ?? null;
     form['lighting_kwh_per_square_meter'] =
-      defaults.lighting_kwh_per_square_meter;
+      defaults.lighting_kwh_per_square_meter ?? null;
   }
 
   // When room_name changes: fill room_type + room_surface + kwh/m² fields

--- a/frontend/src/composables/useEquipmentClassOptions.ts
+++ b/frontend/src/composables/useEquipmentClassOptions.ts
@@ -76,10 +76,13 @@ export function useEquipmentClassOptions<
 
   async function loadClassOptions() {
     const sub = submoduleType.value;
-    if (!sub) return;
+    // `year` is required by the class-subclass-map endpoint (factors are
+    // year-scoped); without it the request 422s.
+    const yearValue = year?.value;
+    if (!sub || yearValue == null) return;
     loadingClasses.value = true;
     try {
-      const rawClasses = await store.fetchClassOptions(sub);
+      const rawClasses = await store.fetchClassOptions(sub, yearValue);
       dynamicOptions[classOptionId] = rawClasses.map((o) => ({
         label: te(o.label) ? t(o.label) : o.label,
         value: o.value,
@@ -94,7 +97,8 @@ export function useEquipmentClassOptions<
   async function loadSubclassOptions() {
     const sub = submoduleType.value;
     const cls = normalizeValue(entity[classFieldId]);
-    if (!sub || !cls) {
+    const yearValue = year?.value;
+    if (!sub || !cls || yearValue == null) {
       dynamicOptions[subClassOptionId] = [];
       subclassLoadError.value = false;
       return;
@@ -102,7 +106,7 @@ export function useEquipmentClassOptions<
     loadingSubclasses.value = true;
     subclassLoadError.value = false;
     try {
-      const rawOptions = await store.fetchSubclassOptions(sub, cls);
+      const rawOptions = await store.fetchSubclassOptions(sub, cls, yearValue);
       const options = rawOptions.map((o) => ({
         label: te(o.label) ? t(o.label) : o.label,
         value: o.value,

--- a/frontend/src/composables/useEquipmentClassOptions.ts
+++ b/frontend/src/composables/useEquipmentClassOptions.ts
@@ -13,9 +13,13 @@ interface FieldConfig {
   // (where to write the fetched power values)
   classOptionId?: string;
   subClassOptionId?: string;
-  // values of the fields in the entity record (real value we want to use)
-  primaryValueFieldId?: string; // was actPowerFieldId
-  secondaryValueFieldId?: string; // was pasPowerFieldId
+  // entity fields always overwritten with the fetched factor values; each id
+  // must match the key in the factor response (e.g. "active_power_w").
+  // Use for read-only fields that should mirror the factor.
+  valueFieldIds?: string[];
+  // entity fields filled from the factor only when currently empty, so a user's
+  // saved/edited value is preserved (e.g. "active_usage_hours_per_week").
+  defaultValueFieldIds?: string[];
 
   // Whether to automatically fetch power factor values when class/subclass changes.
   // Default is false to avoid unexpected API calls and allow the user to explicitly
@@ -44,9 +48,8 @@ export function useEquipmentClassOptions<
 
   const classOptionId = config.classOptionId ?? 'kind';
   const subClassOptionId = config.subClassOptionId ?? 'subkind';
-  // #  TODO: make power field IDs configurable
-  const primaryValueFieldId = config.primaryValueFieldId ?? '';
-  const secondaryValueFieldId = config.secondaryValueFieldId ?? '';
+  const valueFieldIds = config.valueFieldIds ?? [];
+  const defaultValueFieldIds = config.defaultValueFieldIds ?? [];
 
   const fetchFactorValuesOnChange: boolean =
     config.fetchFactorValuesOnChange ?? false;
@@ -58,6 +61,10 @@ export function useEquipmentClassOptions<
   const subclassLoadError = ref(false);
 
   const store = useFactorsStore();
+
+  function isEmpty(raw: unknown): boolean {
+    return raw === null || raw === undefined || raw === '';
+  }
 
   function normalizeValue(raw: unknown): string | null {
     if (raw === null || raw === undefined || raw === '') return null;
@@ -154,12 +161,18 @@ export function useEquipmentClassOptions<
     try {
       const pf = await store.fetchPowerFactor(sub, cls, subCls, yearValue);
       if (pf) {
-        if (primaryValueFieldId && primaryValueFieldId in entity)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (entity as any)[primaryValueFieldId] = pf[primaryValueFieldId];
-        if (secondaryValueFieldId && secondaryValueFieldId in entity)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (entity as any)[secondaryValueFieldId] = pf[secondaryValueFieldId];
+        valueFieldIds.forEach((fieldId) => {
+          if (fieldId && fieldId in entity)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (entity as any)[fieldId] = pf[fieldId];
+        });
+        // Only seed default fields that have no value yet, so an existing
+        // user-entered value is never overwritten.
+        defaultValueFieldIds.forEach((fieldId) => {
+          if (fieldId && fieldId in entity && isEmpty(entity[fieldId]))
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (entity as any)[fieldId] = pf[fieldId];
+        });
       }
     } catch {
       // ignore, user can still fill manually
@@ -173,12 +186,13 @@ export function useEquipmentClassOptions<
     if (subClassFieldId in entity)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (entity as any)[subClassFieldId] = '';
-    if (primaryValueFieldId in entity)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entity as any)[primaryValueFieldId] = null;
-    if (secondaryValueFieldId in entity)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entity as any)[secondaryValueFieldId] = null;
+    // Clear both always-overwritten and default fields so an explicit
+    // class/subclass change re-seeds them from the new factor.
+    [...valueFieldIds, ...defaultValueFieldIds].forEach((fieldId) => {
+      if (fieldId in entity)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (entity as any)[fieldId] = null;
+    });
   }
 
   // React to submodule type changes

--- a/frontend/src/composables/useEquipmentClassOptions.ts
+++ b/frontend/src/composables/useEquipmentClassOptions.ts
@@ -164,14 +164,14 @@ export function useEquipmentClassOptions<
         valueFieldIds.forEach((fieldId) => {
           if (fieldId && fieldId in entity)
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (entity as any)[fieldId] = pf[fieldId];
+            (entity as any)[fieldId] = pf[fieldId] ?? null;
         });
         // Only seed default fields that have no value yet, so an existing
         // user-entered value is never overwritten.
         defaultValueFieldIds.forEach((fieldId) => {
           if (fieldId && fieldId in entity && isEmpty(entity[fieldId]))
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (entity as any)[fieldId] = pf[fieldId];
+            (entity as any)[fieldId] = pf[fieldId] ?? null;
         });
       }
     } catch {

--- a/frontend/src/stores/factors.ts
+++ b/frontend/src/stores/factors.ts
@@ -12,39 +12,50 @@ type Option = { label: string; value: string };
 export const useFactorsStore = defineStore('factors', () => {
   const ONE_MINUTE_MS = 60_000;
 
-  const subclassOptionMapBySubmodule = reactive<
-    Partial<Record<AllSubmoduleTypes, Record<string, Option[]>>>
+  // Cached per (submodule, year) — factors are year-scoped, so the same
+  // submodule yields different class/subclass maps across years.
+  const subclassOptionMapByKey = reactive<
+    Record<string, Record<string, Option[]>>
   >({});
-  const subclassMapFetchedAt = reactive<
-    Partial<Record<AllSubmoduleTypes, number>>
-  >({});
+  const subclassMapFetchedAt = reactive<Record<string, number>>({});
+
+  function cacheKey(
+    submodule: keyof typeof enumSubmodule,
+    year: number | string,
+  ): string {
+    return `${submodule}:${year}`;
+  }
+
   async function ensureSubclassOptionMap(
     submodule: keyof typeof enumSubmodule,
+    year: number | string,
   ): Promise<Record<string, Option[]>> {
     const now = Date.now();
-    const existing = subclassOptionMapBySubmodule[submodule];
-    const last = subclassMapFetchedAt[submodule];
+    const key = cacheKey(submodule, year);
+    const existing = subclassOptionMapByKey[key];
+    const last = subclassMapFetchedAt[key];
 
     if (existing && last && now - last < ONE_MINUTE_MS) {
       return existing;
     }
 
-    const rawMap = await getSubclassMap(submodule);
+    const rawMap = await getSubclassMap(submodule, year);
     const optionMap: Record<string, Option[]> = {};
     Object.entries(rawMap).forEach(([cls, list]) => {
       optionMap[cls] = (list ?? []).map((s) => ({ label: s, value: s }));
     });
 
-    subclassOptionMapBySubmodule[submodule] = optionMap;
-    subclassMapFetchedAt[submodule] = now;
+    subclassOptionMapByKey[key] = optionMap;
+    subclassMapFetchedAt[key] = now;
 
     return optionMap;
   }
 
   async function fetchClassOptions(
     submodule: AllSubmoduleTypes,
+    year: number | string,
   ): Promise<Option[]> {
-    const optionMap = await ensureSubclassOptionMap(submodule);
+    const optionMap = await ensureSubclassOptionMap(submodule, year);
     const classes = Object.keys(optionMap);
     return classes.map((c) => ({ label: c, value: c }));
   }
@@ -52,8 +63,9 @@ export const useFactorsStore = defineStore('factors', () => {
   async function fetchSubclassOptions(
     submodule: AllSubmoduleTypes,
     equipmentClass: string,
+    year: number | string,
   ): Promise<Option[]> {
-    const optionMap = await ensureSubclassOptionMap(submodule);
+    const optionMap = await ensureSubclassOptionMap(submodule, year);
     return optionMap[equipmentClass] ?? [];
   }
 
@@ -67,7 +79,7 @@ export const useFactorsStore = defineStore('factors', () => {
   }
 
   return {
-    subclassOptionMapBySubmodule,
+    subclassOptionMapByKey,
     subclassMapFetchedAt,
     fetchClassOptions,
     fetchSubclassOptions,


### PR DESCRIPTION
Refs #664 (CSV upload part not yet done)

## Why
When a user selects an equipment class/sub-class, the active & standby **usage hours** should be pre-filled from the factor as defaults (alongside the existing active/standby power), so users don't have to type them unless they want to override.

## What
Generalized `useEquipmentClassOptions` to populate any number of factor fields, with two semantics:

- **`valueFieldIds`** — read-only fields always mirrored from the factor (`active_power_w`, `standby_power_w`).
- **`defaultValueFieldIds`** — editable fields seeded **only when empty** (`active_usage_hours_per_week`, `standby_usage_hours_per_week`), so a user's saved/edited value is never clobbered.

`resetSubclass` clears both lists, so an explicit class/sub-class change re-seeds the defaults from the new factor.

### Behavior
| Scenario | Power fields | Usage hours |
|---|---|---|
| Add, pick class+subclass | factor value | factor default |
| Edit saved row (e.g. 40h) | refreshed | **kept at 40h** |
| Change class/subclass | new factor | reset → new default |

## Verification
- `make -C frontend type-check` (vue-tsc) — passes
- `eslint` on changed files — clean

## Notes
- Frontend has no vitest/unit runner (Playwright CT + e2e only) and the composable was previously untested, so no unit regression test was added.
