### PR TITLE
feat: support module-level sync permissions

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -261,6 +261,24 @@ async def _resolve_source_job_to_file_path(
     return f"{folder}/{filename}"
 
 
+async def _institutional_id_for_crm(
+    db: AsyncSession,
+    carbon_report_module_id: int,
+) -> Optional[str]:
+    """Resolve carbon_report_module_id → unit.institutional_id."""
+    stmt = (
+        select(Unit.institutional_id)
+        .join(CarbonReport, CarbonReport.unit_id == Unit.id)  # type: ignore[arg-type]
+        .join(
+            CarbonReportModule,
+            CarbonReportModule.carbon_report_id == CarbonReport.id,  # type: ignore[arg-type]
+        )
+        .where(CarbonReportModule.id == carbon_report_module_id)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
 async def _institutional_id_for_job(
     job: DataIngestionJob, db: AsyncSession
 ) -> Optional[str]:
@@ -702,10 +720,10 @@ async def sync_module_data_entries(
     """
     Sync data entries for a specific module.
 
-    **Required Permission**: `system.users.edit` (Super Admin only).
-    The previous `modules.*.sync` fallback was scope-blind across modules
-    and units, and was removed in #977 — module owners cannot dispatch a
-    sync directly from this endpoint.
+    **Required Permission**: `system.users.edit` (Super Admin) OR
+    `modules.{name}.sync` for the unit (principal users uploading from the
+    module page). The module-owner path requires `target_type=DATA_ENTRIES`
+    with both `carbon_report_module_id` and `module_type_id` in config.
 
     Example of request body for module_type_year:
     {
@@ -727,11 +745,34 @@ async def sync_module_data_entries(
         "config": {}
     }
     """
-    if not await is_permitted(current_user, "system.users", "edit"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: requires system.users.edit",
+    is_superadmin = await is_permitted(current_user, "system.users", "edit")
+    if not is_superadmin:
+        crm_id = (
+            syncRequest.config.carbon_report_module_id if syncRequest.config else None
         )
+        mod_type_id = syncRequest.config.module_type_id if syncRequest.config else None
+        if (
+            syncRequest.target_type == TargetType.DATA_ENTRIES
+            and crm_id is not None
+            and mod_type_id is not None
+        ):
+            institutional_id = await _institutional_id_for_crm(db, crm_id)
+            if institutional_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Unit for carbon_report_module_id {crm_id} not found",
+                )
+            await check_module_permission(
+                current_user,
+                mod_type_id,
+                "sync",
+                institutional_id=institutional_id,
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied: requires system.users.edit",
+            )
 
     if syncRequest.target_type == TargetType.FACTORS and syncRequest.year is None:
         raise HTTPException(

--- a/backend/app/api/v1/files.py
+++ b/backend/app/api/v1/files.py
@@ -30,6 +30,7 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.security import is_permitted
 from app.models.user import User
+from app.utils.permissions import has_permission
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -276,10 +277,19 @@ async def upload_temp_files(
 
     Used for temporary file uploads before processing (e.g., CSV imports).
     """
-    if not await is_permitted(current_user, "backoffice.data_management", "edit"):
+    perms = current_user.calculate_permissions()
+    can_upload = has_permission(perms, "backoffice.data_management", "edit") or any(
+        isinstance(actions, list) and "sync" in actions
+        for key, actions in perms.items()
+        if key.startswith("modules.")
+    )
+    if not can_upload:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied: requires backoffice.data_management.edit",
+            detail=(
+                "Permission denied: requires backoffice.data_management.edit"
+                " or module sync access"
+            ),
         )
 
     logger.info(


### PR DESCRIPTION
## What does this change?
Two related fixes: allows principal users to trigger module-level CSV syncs, and removes the year-scoping requirement from the class/subclass map endpoint.

**Sync permissions:**
- `data_sync.py`: widens `sync_module_data_entries` to accept `modules.{name}.sync` on the unit's scope (principal users) in addition to `system.users.edit` (super admin), when `target_type=DATA_ENTRIES` and both `carbon_report_module_id` and `module_type_id` are present; adds `_institutional_id_for_crm` to resolve the unit from a `carbon_report_module_id`
- `files.py`: widens the temp file upload permission check to also allow users who hold any `modules.*.sync` permission, so principal users can upload CSV files before triggering the sync

**Year-scoping removal from class/subclass map:**
- `factors.py` (API): removes the `year` query parameter from `get_class_subclass_map`
- `factor_repo.py` / `factor_service.py`: removes the `year` filter from the SQL query and service layer
- `factors.ts` (API): removes `year` from `getSubclassMap` call
- `factors.ts` (store): removes year from cache key, switching from a `submodule:year` compound key to submodule-only; renames `subclassOptionMapByKey` to `subclassOptionMapBySubmodule`
- `useEquipmentClassOptions.ts`: removes `year` dependency from class/subclass loading; reverts `valueFieldIds`/`defaultValueFieldIds` arrays back to `primaryValueFieldId`/`secondaryValueFieldId` scalar config (reverting the #664 generalisation)
- `useBuildingRoomDynamicOptions.ts`: removes the `year` guard on building room defaults
- `ModuleForm.vue` / `ModuleInlineSelect.vue`: updates config objects to match the simplified composable API
- `test_factors_year_scope_pg.py`: deleted (tests for the year-scoped behaviour that no longer exists)
- `test_factor_repo.py`: removes `year=2025` from the unit test call
- `docs/code-review/664-copilot-feedback-...md`: deleted (stale bot review doc)

## Why is this needed?
Principal users (unit managers) were blocked from uploading and syncing their own module data because the upload and sync endpoints required super admin permissions. The year parameter on the class/subclass map was also causing 422 errors in contexts where the year wasn't available, and the year-scoping was unnecessary since factors across years share the same class/subclass taxonomy.

## Type of change
- [x] 🐛 Bug fix
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #977 (follow-up: restoring module-owner sync path)