### PR TITLE
feat: refresh top-class breakdown for certain modules

### DIFF
--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -676,6 +676,7 @@ export const useModuleStore = defineStore('modules', () => {
       invalidateValidatedTotals();
       invalidateEmissionBreakdown();
       await refreshEmissionBreakdownIfNeeded();
+      await refreshTopClassBreakdownIfNeeded(moduleType, unitId, year);
     } catch (err: unknown) {
       if (err instanceof Error) state.error = err.message ?? 'Unknown error';
       else state.error = 'Unknown error';
@@ -732,6 +733,7 @@ export const useModuleStore = defineStore('modules', () => {
       invalidateValidatedTotals();
       invalidateEmissionBreakdown();
       await refreshEmissionBreakdownIfNeeded();
+      await refreshTopClassBreakdownIfNeeded(moduleType, unit, year);
     } catch (err: unknown) {
       if (err instanceof Error) state.error = err.message ?? 'Unknown error';
       else state.error = 'Unknown error';
@@ -769,6 +771,7 @@ export const useModuleStore = defineStore('modules', () => {
       invalidateValidatedTotals();
       invalidateEmissionBreakdown();
       await refreshEmissionBreakdownIfNeeded();
+      await refreshTopClassBreakdownIfNeeded(moduleType, unit, year);
     } catch (err: unknown) {
       if (err instanceof Error) state.error = err.message ?? 'Unknown error';
       else state.error = 'Unknown error';
@@ -867,6 +870,26 @@ export const useModuleStore = defineStore('modules', () => {
       }
     } finally {
       state.loadingTopClassBreakdown = false;
+    }
+  }
+
+  async function refreshTopClassBreakdownIfNeeded(
+    moduleType: Module,
+    unit: number,
+    year: string,
+  ) {
+    const TOP_CLASS_MODULES = [
+      MODULES.EquipmentElectricConsumption,
+      MODULES.Purchase,
+      MODULES.ResearchFacilities,
+    ];
+    if (!(TOP_CLASS_MODULES as Module[]).includes(moduleType)) return;
+    try {
+      const path = `modules/${encodeURIComponent(unit)}/${encodeURIComponent(year)}/${encodeURIComponent(moduleType)}/top-class-breakdown`;
+      const data = await api.get(path).json<Array<Record<string, unknown>>>();
+      state.topClassBreakdown = data;
+    } catch {
+      // keep existing data on error — don't blank the chart
     }
   }
 


### PR DESCRIPTION
## What does this change?
Refreshes the top-class breakdown chart immediately after a data mutation for modules that use it, so the chart updates without requiring a page reload or manual refresh.

- `modules.ts`: adds `refreshTopClassBreakdownIfNeeded(moduleType, unit, year)` which re-fetches `top-class-breakdown` from the API for the three modules that have a top-class breakdown (`EquipmentElectricConsumption`, `Purchase`, `ResearchFacilities`); calls it after `refreshEmissionBreakdownIfNeeded` in the three mutation paths (create, update, delete)

## Why is this needed?
After adding, editing, or deleting a data entry in Equipment, Purchase, or Research Facilities, the top-class breakdown chart was showing stale data until the user navigated away and back. The emission breakdown was already refreshed on mutation; this extends the same pattern to the top-class breakdown.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #918