### PR TITLE
feat 948: initialize submodule pagination to newest first

### DIFF
--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -383,10 +383,10 @@ export const useModuleStore = defineStore('modules', () => {
     if (!(submoduleId in state.taxonomySubmodule)) {
       state.taxonomySubmodule[submoduleId] = null;
     }
-    // always initialize pagination with defaults
+    // always initialize pagination with defaults (newest first)
     state.paginationSubmodule[submoduleId] = {
-      sortBy: undefined,
-      descending: false,
+      sortBy: 'id',
+      descending: true,
       page: 1,
       rowsPerPage: 20,
       rowsNumber: 0,


### PR DESCRIPTION
## What does this change?
Changes the default sort order for submodule tables to newest-first by initialising pagination with `sortBy: 'id'` and `descending: true` instead of no sort.

## Why is this needed?
Newly added entries were appearing at the bottom of the table, requiring users to scroll or paginate to find what they just added. Sorting by `id` descending puts the most recently created entry at the top.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #948