### PR TITLE
feat 1155: use plural refrigerants label and simplify tooltip

### DIFF
--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -31,7 +31,7 @@ const LABEL_KEY_MAP: Record<string, string> = {
   co2: 'process-emissions.category.co2',
   ch4: 'process-emissions.category.ch4',
   n2o: 'process-emissions.category.n2o',
-  refrigerants: 'process-emissions.category.refrigerant',
+  refrigerants: 'process-emissions.category.refrigerants',
   // buildings
   combustion: 'charts-energy-combustion-subcategory',
   heating_thermal: 'charts-heating-thermal-subcategory',

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -48,7 +48,7 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   co2: 'process-emissions.category.co2',
   ch4: 'process-emissions.category.ch4',
   n2o: 'process-emissions.category.n2o',
-  refrigerants: 'process-emissions.category.refrigerant',
+  refrigerants: 'process-emissions.category.refrigerants',
   lighting: 'charts-lighting-subcategory',
   cooling: 'charts-cooling-subcategory',
   ventilation: 'charts-ventilation-subcategory',

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -826,7 +826,7 @@ const chartOption = computed((): EChartsOption => {
       label: { show: false },
     },
     {
-      name: t('process-emissions.category.refrigerant'),
+      name: t('process-emissions.category.refrigerants'),
       type: 'bar' as const,
       stack: 'total',
       animation: true,
@@ -1176,14 +1176,18 @@ const chartOption = computed((): EChartsOption => {
               }
             }
 
-            emitTooltip({
-              title: name,
-              rows,
-              separatorRow: {
-                label: t('total'),
-                value: formatTonnesForChart(total),
-              },
-            });
+            if (rows.length === 1) {
+              emitTooltip({ rows });
+            } else {
+              emitTooltip({
+                title: name,
+                rows,
+                separatorRow: {
+                  label: t('total'),
+                  value: formatTonnesForChart(total),
+                },
+              });
+            }
             return '';
           },
         },


### PR DESCRIPTION
## What does this change?
Two small fixes to the results charts:

- `GenericEmissionTreeMapChart.vue`, `EmissionTypeBreakdownChart.vue`, `ModuleCarbonFootprintChart.vue`: changes the i18n key for the refrigerants process-emission category from `process-emissions.category.refrigerant` (singular) to `process-emissions.category.refrigerants` (plural) to match the correct key
- `ModuleCarbonFootprintChart.vue`: simplifies the bar chart tooltip so that when a bar has only one segment (i.e. `rows.length === 1`), the tooltip renders just that row without a title or total separator — avoiding a redundant repeated label

## Why is this needed?
The refrigerant label was resolving to a missing i18n key, likely showing a raw key string in the UI. The single-segment tooltip was showing a title and a "Total" row that duplicated the only value shown, adding noise without any information.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1155