### PR TITLE
feat 1113: disallow thresholds for headcount module

### DIFF
--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -22,6 +22,7 @@ from pydantic import (
 )
 
 from app.models.data_ingestion import IngestionResult
+from app.models.module_type import ModuleTypeEnum
 
 # Type definitions
 UncertaintyTag = Literal["low", "medium", "high", "none"]
@@ -448,6 +449,7 @@ class YearConfigurationUpdate(BaseModel):
         if not self.config or "modules" not in self.config:
             return self
         modules = self.config["modules"]
+        MODULES_WITHOUT_THRESHOLD = {str(ModuleTypeEnum.headcount)}
         for module_key, module_val in modules.items():
             if not isinstance(module_val, dict):
                 continue
@@ -458,6 +460,11 @@ class YearConfigurationUpdate(BaseModel):
                 if not isinstance(sub_val, dict):
                     continue
                 threshold = sub_val.get("threshold")
+                if threshold is not None and module_key in MODULES_WITHOUT_THRESHOLD:
+                    raise ValueError(
+                        f"threshold cannot be set for module {module_key} "
+                        f"(data is not in tCO2eq)"
+                    )
                 if threshold is not None and (
                     not isinstance(threshold, (int, float)) or threshold < 0
                 ):

--- a/backend/tests/unit/schemas/test_year_configuration.py
+++ b/backend/tests/unit/schemas/test_year_configuration.py
@@ -186,13 +186,14 @@ class TestReductionObjectiveGoal:
 
 class TestYearConfigurationUpdateValidation:
     def test_valid_thresholds(self):
+        # Use module "2" (professional travel) — headcount ("1") has no thresholds
         update = YearConfigurationUpdate(
             config={
                 "modules": {
-                    "1": {
+                    "2": {
                         "submodules": {
-                            "10": {"threshold": 100.0},
-                            "11": {"threshold": None},
+                            "20": {"threshold": 100.0},
+                            "21": {"threshold": None},
                         }
                     }
                 }
@@ -200,14 +201,30 @@ class TestYearConfigurationUpdateValidation:
         )
         assert update.config is not None
 
-    def test_negative_threshold_rejected(self):
-        with pytest.raises(ValidationError, match="threshold.*must be a number >= 0"):
+    def test_headcount_threshold_rejected(self):
+        with pytest.raises(
+            ValidationError, match="threshold cannot be set for module 1"
+        ):
             YearConfigurationUpdate(
                 config={
                     "modules": {
                         "1": {
                             "submodules": {
-                                "10": {"threshold": -5.0},
+                                "1": {"threshold": 100.0},
+                            }
+                        }
+                    }
+                }
+            )
+
+    def test_negative_threshold_rejected(self):
+        with pytest.raises(ValidationError, match="threshold.*must be a number >= 0"):
+            YearConfigurationUpdate(
+                config={
+                    "modules": {
+                        "2": {
+                            "submodules": {
+                                "20": {"threshold": -5.0},
                             }
                         }
                     }
@@ -219,9 +236,9 @@ class TestYearConfigurationUpdateValidation:
             YearConfigurationUpdate(
                 config={
                     "modules": {
-                        "1": {
+                        "2": {
                             "submodules": {
-                                "10": {"threshold": "abc"},
+                                "20": {"threshold": "abc"},
                             }
                         }
                     }

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -201,45 +201,49 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
           "
         />
       </q-card>
-      <q-separator class="q-my-xs" />
-      <q-card
-        flat
-        class="col q-px-lg q-pt-lg q-pb-md"
-        :class="{ 'submodule-item--disabled': isSubmoduleDisabled(submodule) }"
-      >
-        <div class="row items-center q-mb-xs">
-          <q-icon
-            name="legend_toggle"
-            color="accent"
-            size="xs"
-            class="q-mr-sm"
-          />
-          <div class="text-body2 text-weight-medium">
-            {{ $t('data_management_threshold_title') }}
+      <template v-if="!submodule.noThreshold">
+        <q-separator class="q-my-xs" />
+        <q-card
+          flat
+          class="col q-px-lg q-pt-lg q-pb-md"
+          :class="{
+            'submodule-item--disabled': isSubmoduleDisabled(submodule),
+          }"
+        >
+          <div class="row items-center q-mb-xs">
+            <q-icon
+              name="legend_toggle"
+              color="accent"
+              size="xs"
+              class="q-mr-sm"
+            />
+            <div class="text-body2 text-weight-medium">
+              {{ $t('data_management_threshold_title') }}
+            </div>
           </div>
-        </div>
-        <div class="text-caption text-secondary q-mb-sm">
-          {{ $t('data_management_threshold_description') }}
-        </div>
-        <q-input
-          :model-value="getSubmoduleThreshold(submodule)"
-          type="number"
-          dense
-          outlined
-          size="md"
-          :debounce="600"
-          :suffix="$t('tco2eq')"
-          :placeholder="$t('no_threshold')"
-          style="max-width: 500px"
-          @update:model-value="
-            (val: string | number | null) =>
-              updateSubmoduleThreshold(
-                submodule,
-                val === '' || val === null ? null : Number(val),
-              )
-          "
-        />
-      </q-card>
+          <div class="text-caption text-secondary q-mb-sm">
+            {{ $t('data_management_threshold_description') }}
+          </div>
+          <q-input
+            :model-value="getSubmoduleThreshold(submodule)"
+            type="number"
+            dense
+            outlined
+            size="md"
+            :debounce="600"
+            :suffix="$t('tco2eq')"
+            :placeholder="$t('no_threshold')"
+            style="max-width: 500px"
+            @update:model-value="
+              (val: string | number | null) =>
+                updateSubmoduleThreshold(
+                  submodule,
+                  val === '' || val === null ? null : Number(val),
+                )
+            "
+          />
+        </q-card>
+      </template>
       <q-separator v-if="submoduleShowsImportRow(submodule)" class="q-my-xs" />
     </template>
 

--- a/frontend/src/constant/backoffice-module-config.ts
+++ b/frontend/src/constant/backoffice-module-config.ts
@@ -15,6 +15,7 @@ export type SubmoduleConfig = {
   factorsOnly?: true;
   mandatoryData?: boolean;
   mandatoryReference?: boolean;
+  noThreshold?: true;
 };
 
 export const MODULE_SUBMODULES: Partial<
@@ -26,6 +27,7 @@ export const MODULE_SUBMODULES: Partial<
       labelKey: `${MODULES.Headcount}-member`,
       moduleTypeId: 1,
       dataEntryTypeId: 1,
+      noThreshold: true,
     },
     {
       key: 'student',
@@ -33,6 +35,7 @@ export const MODULE_SUBMODULES: Partial<
       moduleTypeId: 1,
       dataEntryTypeId: 2,
       noData: true,
+      noThreshold: true,
     },
   ],
   [MODULES.ProfessionalTravel]: [


### PR DESCRIPTION
## What does this change?
Prevents thresholds from being set on the Headcount module, both in the backend schema validation and in the configuration UI.

- `year_configuration.py`: adds `MODULES_WITHOUT_THRESHOLD = {"1"}` and raises a `ValueError` during validation if a threshold is submitted for any module in that set; headcount stores FTE not tCO2eq so a threshold has no meaning
- `test_year_configuration.py`: adds `test_headcount_threshold_rejected` to pin the new validation; updates existing threshold tests to use module `"2"` (professional travel) so they no longer accidentally test against headcount
- `backoffice-module-config.ts`: adds `noThreshold: true` to both headcount submodule entries (`member` and `student`)
- `SubmoduleItem.vue`: wraps the threshold card and its separator in `v-if="!submodule.noThreshold"` so the field is hidden entirely for submodules that don't support it

## Why is this needed?
The threshold input was visible for headcount submodules, but headcount totals are in FTE, not tCO2eq. Entering a threshold there was meaningless and the backend would now reject it — hiding the field prevents user confusion and makes the UI consistent with the data model.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1113