### PR TITLE
fix(963): surface backend error detail + align required fields with backend

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -236,13 +236,28 @@ export const api = ky.create({
 
           const skipCodes = (options as ApiOptions).skipErrorCodes ?? [];
           if (!skipCodes.includes(res.status)) {
-            // For other errors, show a generic error toast
+            // Surface the backend's error detail when present — the bare status
+            // line ("400 Bad Request") doesn't tell the user what to fix.
+            let detail: string | undefined;
+            try {
+              const cloned = res.clone();
+              if (!cloned.bodyUsed) {
+                const body = (await cloned.json()) as { detail?: unknown };
+                if (typeof body?.detail === 'string') {
+                  detail = body.detail;
+                }
+              }
+            } catch {
+              // Non-JSON body; fall back to the generic status message.
+            }
             Notify.create({
               color: 'negative',
-              message: i18n.global.t('http_error_occurred', {
-                status: res.status,
-                text: res.statusText,
-              }),
+              message:
+                detail ??
+                i18n.global.t('http_error_occurred', {
+                  status: res.status,
+                  text: res.statusText,
+                }),
               position: 'top',
               timeout: 3000,
               actions: [{ icon: 'close', color: 'white' }],

--- a/frontend/src/constant/module-config/external-cloud-and-ai.ts
+++ b/frontend/src/constant/module-config/external-cloud-and-ai.ts
@@ -55,6 +55,7 @@ const cloudFields: ModuleField[] = [
     id: 'spent_amount',
     labelKey: `${MODULES.ExternalCloudAndAI}.inputs.spent_amount`,
     type: 'number',
+    required: true,
     editableInline: true,
     min: 0,
     step: 0.01,

--- a/frontend/src/constant/module-config/purchase.ts
+++ b/frontend/src/constant/module-config/purchase.ts
@@ -61,6 +61,7 @@ const purchaseFields: ModuleField[] = [
     id: 'total_spent_amount',
     labelKey: `${MODULES.Purchase}.inputs.total_spent_amount`,
     type: 'number',
+    required: true,
     editableInline: true,
     min: 0,
     step: 0.01,


### PR DESCRIPTION
## Why

Creating a purchase/cloud entry with an empty amount returned a silent **400 Bad Request** — the form let `total_spent_amount` / `spent_amount` submit as `null`, which the backend rejects (both are required, no default). The user only saw `"An error occurred: 400 Bad Request"`, hiding the actual validation `detail` the backend already returns.

Two root causes:
1. The global error toast showed only `status`/`statusText`, discarding the response body's `detail`.
2. Frontend form configs didn't mark fields `required` that the backend `*HandlerCreate` models require.

## Changes

**Error display — `api/http.ts`**
- The `afterResponse` handler now reads `detail` from the response body (cloning the response, as the 403 branch does) and shows it in the toast. Falls back to the existing `status {text}` message for non-JSON bodies. Guarded to `typeof detail === 'string'` so a raw FastAPI 422 array doesn't render as `[object Object]`.

**Required-field alignment (backend → frontend)**
Cross-referenced all module-configs against their backend Create models. Two fields were backend-required but not frontend-required, causing the silent 400:
- `purchase.ts` → `total_spent_amount`: added `required: true`
- `external-cloud-and-ai.ts` → `spent_amount`: added `required: true`

Verified `ModuleForm.vue` enforces per-field `required` on submit for `number` fields (these configs use per-field `required`, not submodule-level `requiredFieldIds`), so the change is effective.

**Pagination defaults — `stores/modules.ts`**
- Submodule pagination now initializes with `sortBy: undefined` / `descending: false` instead of forcing `id` descending.

## Not changed (intentional)
- Fields where the **frontend is stricter** than the backend (e.g. `headcount.fte`, equipment usage hours, `purchase_institutional_code`) were left as-is — they protect data quality and don't cause 400s.
- `PurchaseAdditionalHandlerCreate` has a backend-required/frontend-missing mismatch (`coef_to_kg`), but its fields aren't form-rendered (`hideIn.form: true`), so no UI create path is affected.

## Test plan
- [x] `make type-check` (vue-tsc) clean
- [x] Submit purchase/cloud entry with empty amount → form blocks submit with required-field message
- [x] Trigger a backend 400 → toast shows the backend `detail`, not just the status line

Closes #963