### PR TITLE
feat 1041: change carbon footprint title translations

### DIFF
--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -485,11 +485,11 @@ export default {
     fr: 'Empreinte carbone des voyages professionnels',
   },
   'carbon_footprint_title_process-emissions': {
-    en: 'Process emission carbon footprint',
-    fr: "Empreinte carbone de gaz d'emission",
+    en: 'Process emissions carbon footprint',
+    fr: 'Empreinte carbone des émissions de procédés',
   },
   'carbon_footprint_title_equipment-electric-consumption': {
-    en: 'Equipment use carbon footprint',
+    en: 'Equipment usage carbon footprint',
     fr: "Empreinte carbone liée à l'utilisation des équipements",
   },
   'carbon_footprint_tooltip_equipment-electric-consumption': {
@@ -505,11 +505,11 @@ export default {
     fr: 'Empreinte carbone des bâtiments',
   },
   'carbon_footprint_title_external-cloud-and-ai': {
-    en: 'Carbon footprint from the use of AI services and external cloud services',
-    fr: "Empreinte carbone liée à l'utilisation des services d'IA et des services cloud externes",
+    en: 'External clouds & AI usage carbon footprint',
+    fr: "Empreinte carbone liée à l'utilisation des clouds externes et de l'IA",
   },
   'carbon_footprint_title_research-facilities': {
-    en: 'Carbon footprint from the use of research infrastructures',
+    en: 'Research facilities usage carbon footprint',
     fr: "Empreinte carbone liée à l'utilisation des infrastructures de recherche",
   },
   'carbon_footprint_subtitle_research-facilities': {


### PR DESCRIPTION
## What does this change?
Updates four module carbon footprint title strings in `common.ts` for consistency with the phrasing used elsewhere in the results page:

- `process-emissions`: EN `"Process emission..."` → `"Process emissions..."` (plural); FR rewritten to match the results page string
- `equipment-electric-consumption`: EN `"Equipment use..."` → `"Equipment usage..."`
- `external-cloud-and-ai`: EN shortened from a long descriptive sentence to `"External clouds & AI usage carbon footprint"`; FR shortened to match
- `research-facilities`: EN shortened from `"Carbon footprint from the use of research infrastructures"` to `"Research facilities usage carbon footprint"`

## Why is this needed?
The per-module chart titles were phrased differently from the equivalent strings on the results summary page, creating inconsistency across the UI. This aligns them to the same pattern used throughout.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1041