### PR TITLE
feat 1181: normalize equipment class/subclass and CSV lookup

### DIFF
--- a/backend/app/modules/equipment_electric_consumption/schemas.py
+++ b/backend/app/modules/equipment_electric_consumption/schemas.py
@@ -1,6 +1,7 @@
 from typing import Optional, Self
 
 from pydantic import ValidationInfo, field_validator, model_validator
+from sqlalchemy import func
 
 from app.core.config import get_settings
 from app.core.logging import get_logger
@@ -156,15 +157,33 @@ class EquipmentModuleHandler(BaseModuleHandler):
         "name": DataEntry.data["name"].as_string(),
         "active_power_w": Factor.values["active_power_w"].as_float(),
         "standby_power_w": Factor.values["standby_power_w"].as_float(),
-        "equipment_class": Factor.classification["equipment_class"].as_string(),
-        "sub_class": Factor.classification["sub_class"].as_string(),
+        "equipment_class": func.regexp_replace(
+            func.regexp_replace(
+                func.lower(DataEntry.data["equipment_class"].as_string()),
+                "^equipment_factor_",
+                "",
+            ),
+            "[^a-z0-9]",
+            "",
+            "g",
+        ),
+        "sub_class": func.regexp_replace(
+            func.regexp_replace(
+                func.lower(DataEntry.data["sub_class"].as_string()),
+                "^equipment_factor_(sub_)?",
+                "",
+            ),
+            "[^a-z0-9]",
+            "",
+            "g",
+        ),
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
     filter_map = {
         "name": DataEntry.data["name"].as_string(),
-        "equipment_class": Factor.classification["equipment_class"].as_string(),
-        "sub_class": Factor.classification["sub_class"].as_string(),
+        "equipment_class": DataEntry.data["equipment_class"].as_string(),
+        "sub_class": DataEntry.data["sub_class"].as_string(),
     }
 
     async def pre_compute(self, data_entry, session) -> dict:

--- a/backend/app/seed/seed_helper.py
+++ b/backend/app/seed/seed_helper.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, Optional
 
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -130,6 +131,28 @@ async def load_factors_map(
         if key_kind not in factors_map:
             factors_map[key_kind] = pf
 
+        # Strategy 3: Normalized label lookup — allows human-readable CSV labels
+        # (e.g. "Agitator / Incubator") to match internal factor keys
+        # (e.g. "equipment_factor_agitator_incubator").
+        if pf.classification and kind_field:
+            norm_kind = normalize_kind_for_lookup(
+                pf.classification.get(kind_field, "") or ""
+            )
+            norm_subkind = (
+                normalize_kind_for_lookup(
+                    pf.classification.get(subkind_field, "") or ""
+                )
+                if subkind_field
+                else ""
+            )
+            if norm_kind:
+                norm_key_full = (
+                    f"_n_:{pf.data_entry_type_id}:{pf_year}:{norm_kind}:{norm_subkind}"
+                )
+                factors_map.setdefault(norm_key_full, pf)
+                norm_key_kind = f"_n_:{pf.data_entry_type_id}:{pf_year}:{norm_kind}"
+                factors_map.setdefault(norm_key_kind, pf)
+
     # logger.info(f"Loaded {len(factors)} factors with {len(factors_map)} lookup keys")
     return factors_map
 
@@ -139,6 +162,20 @@ def normalize_kind(kind: str) -> str:
     # Class names are mostly unique in table_power.csv
     # Just normalize to lowercase for matching
     return kind.lower().strip()
+
+
+def normalize_kind_for_lookup(kind: str) -> str:
+    """Normalize a kind value for flexible label↔key matching.
+
+    Strips internal prefixes (e.g. ``equipment_factor_``, ``equipment_factor_sub_``)
+    and removes all non-alphanumeric characters so that a human-readable CSV label
+    like "Agitator / Incubator" matches the factor key
+    "equipment_factor_agitator_incubator".
+    """
+    v = kind.lower().strip()
+    v = re.sub(r"^equipment_factor_(?:sub_)?", "", v)
+    v = re.sub(r"[^a-z0-9]", "", v)
+    return v
 
 
 def is_in_factors_map(

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -27,6 +27,7 @@ from app.repositories.unit_repo import UnitRepository
 from app.schemas.carbon_report import CarbonReportCreate
 from app.schemas.data_entry import DATA_ENTRY_META_FIELDS, ModuleHandler
 from app.schemas.user import UserRead
+from app.seed.seed_helper import normalize_kind_for_lookup
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.carbon_report_service import CarbonReportService
 from app.services.data_entry_emission_service import (
@@ -935,8 +936,45 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                         f"{(kind_value or '').lower()}"
                     )
                     factor = setup_result["factors_map"].get(key_kind)
+                # Fallback: normalized label lookup (e.g. "Agitator / Incubator"
+                # matches factor key "equipment_factor_agitator_incubator")
+                if not factor:
+                    norm_kind = normalize_kind_for_lookup(kind_value or "")
+                    norm_subkind = normalize_kind_for_lookup(subkind_value or "")
+                    if norm_kind:
+                        norm_key_full = (
+                            f"_n_:{data_entry_type.value}:{year_value}"
+                            f":{norm_kind}:{norm_subkind}"
+                        )
+                        factor = setup_result["factors_map"].get(norm_key_full)
+                        if not factor and subkind_value:
+                            norm_key_kind = (
+                                f"_n_:{data_entry_type.value}:{year_value}:{norm_kind}"
+                            )
+                            factor = setup_result["factors_map"].get(norm_key_kind)
                 if factor:
                     primary_factor_id = factor.id
+                    # Normalize the stored kind/subkind to the canonical factor key
+                    # so that imported entries and manually-created entries use the
+                    # same value (avoiding split sort groups in the table).
+                    if handler.kind_field and handler.kind_field in filtered_row:
+                        canonical = (factor.classification or {}).get(
+                            handler.kind_field
+                        )
+                        if canonical:
+                            filtered_row = {
+                                **filtered_row,
+                                handler.kind_field: canonical,
+                            }
+                    if handler.subkind_field and handler.subkind_field in filtered_row:
+                        canonical_sub = (factor.classification or {}).get(
+                            handler.subkind_field
+                        )
+                        if canonical_sub is not None:
+                            filtered_row = {
+                                **filtered_row,
+                                handler.subkind_field: canonical_sub,
+                            }
 
             # Resolve carbon_report_module_id
             carbon_report_module_id = None


### PR DESCRIPTION
## What does this change?
Normalizes equipment class/subclass values during CSV import so that human-readable labels in uploaded files match internal factor keys, and eliminates split sort groups in the equipment table.

- `seed_helper.py`: adds `normalize_kind_for_lookup()` which strips internal prefixes (`equipment_factor_`, `equipment_factor_sub_`) and removes all non-alphanumeric characters; adds a third lookup strategy (Strategy 3) in `load_factors_map` that registers each factor under a normalized key (`_n_:<type>:<year>:<norm_kind>:<norm_subkind>`) in addition to the existing exact-match keys
- `base_csv_provider.py`: adds a fallback factor lookup using `normalize_kind_for_lookup` when the exact-match lookup fails (e.g. CSV row has `"Agitator / Incubator"` but the factor key is `"equipment_factor_agitator_incubator"`); once a factor is resolved, rewrites the `kind_field` and `subkind_field` values in the row to the canonical values from the factor's classification, so imported entries always use the same key as manually-created entries
- `schemas.py` (equipment module): updates the `select_map` to normalize `equipment_class` and `sub_class` from `DataEntry.data` at query time using `func.lower` + `func.regexp_replace` (stripping the `equipment_factor_` prefix and non-alphanumeric chars), so that entries created before this fix also sort and group consistently; updates `filter_map` to read from `DataEntry.data` instead of `Factor.classification`

## Why is this needed?
Equipment entries imported via CSV used human-readable labels (`"Agitator / Incubator"`) while manually-created entries used internal factor keys (`"equipment_factor_agitator_incubator"`). This caused them to appear as separate sort groups in the table, and CSV imports silently dropped the factor association when the label didn't match exactly.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1181