### PR TITLE
fix(#862): scope backoffice.reporting to a unit-cf subtree with intersection clamp

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -59,9 +59,8 @@ from app.schemas.backoffice import (
     UnitReportingData,
 )
 from app.utils.scoping import (
-    build_affiliation_predicate,
+    build_scope_subtree_predicate,
     gate_backoffice,
-    narrow_path_affiliation,
 )
 
 logger = get_logger(__name__)
@@ -251,11 +250,8 @@ async def list_backoffice_units(
     List units with their reporting completion status and outlier values.
     """
     is_global, affiliations = gate_backoffice(current_user, "view")
-    scoped_path_affiliation = narrow_path_affiliation(
-        filters.path_affiliation, is_global, affiliations
-    )
-    # Scoped caller whose request resolves to no allowed affiliations → empty.
-    if not is_global and not scoped_path_affiliation:
+    # Scoped caller with no granted affiliations → nothing to see.
+    if not is_global and not affiliations:
         return PaginatedUnitReportingData(
             data=[],
             pagination=PaginationMeta(
@@ -273,8 +269,10 @@ async def list_backoffice_units(
         raise HTTPException(status_code=400, detail=ERROR_AT_LEAST_ONE_YEAR)
 
     result = await carbon_report_module_repo.get_reporting_overview(
-        path_affiliation=scoped_path_affiliation,
+        path_affiliation=filters.path_affiliation,
         path_lvl4=filters.path_lvl4,
+        is_global=is_global,
+        scope_cfs=affiliations,
         completion_status=filters.completion_status,
         search=filters.search,
         modules=filters.modules,
@@ -419,7 +417,7 @@ async def get_available_years(
     sorted in descending order (latest first).
 
     Affiliation-scoped backoffice users see only the years where reports
-    exist for units inside their affiliation (#459).
+    exist for units inside their scope subtree (#862).
     """
     is_global, affiliations = gate_backoffice(current_user, "view")
     stmt = select(CarbonReport.year).distinct()
@@ -427,7 +425,7 @@ async def get_available_years(
         if not affiliations:
             return {"years": [], "latest": ""}
         stmt = stmt.join(Unit, col(CarbonReport.unit_id) == col(Unit.id)).where(
-            build_affiliation_predicate(affiliations)
+            build_scope_subtree_predicate(affiliations)
         )
     stmt = stmt.order_by(desc(CarbonReport.year))
     result = await db.exec(stmt)
@@ -448,16 +446,15 @@ async def report_usage(
         raise HTTPException(status_code=400, detail=ERROR_INVALID_FORMAT)
 
     is_global, affiliations = gate_backoffice(current_user, "export")
-    scoped_path_affiliation = narrow_path_affiliation(
-        filters.path_affiliation, is_global, affiliations
-    )
-    if not is_global and not scoped_path_affiliation:
+    if not is_global and not affiliations:
         data = []
     else:
         try:
             data = await CarbonReportModuleRepository(db).get_usage_report(
-                path_affiliation=scoped_path_affiliation,
+                path_affiliation=filters.path_affiliation,
                 path_lvl4=filters.path_lvl4,
+                is_global=is_global,
+                scope_cfs=affiliations,
                 completion_status=filters.completion_status,
                 search=filters.search,
                 modules=filters.modules,
@@ -517,10 +514,7 @@ async def report_detailed(
         raise HTTPException(status_code=400, detail=ERROR_INVALID_FORMAT)
 
     is_global, affiliations = gate_backoffice(current_user, "export")
-    scoped_path_affiliation = narrow_path_affiliation(
-        filters.path_affiliation, is_global, affiliations
-    )
-    scoped_caller_no_affiliations = not is_global and not scoped_path_affiliation
+    scoped_caller_no_affiliations = not is_global and not affiliations
 
     timestamp = datetime.now(timezone.utc).strftime(EXPORT_CSV_TIMESTAMP_FORMAT)
 
@@ -534,8 +528,10 @@ async def report_detailed(
                 try:
                     data = await CarbonReportModuleRepository(db).get_detailed_report(
                         data_entry_type=data_entry_type,
-                        path_affiliation=scoped_path_affiliation,
+                        path_affiliation=filters.path_affiliation,
                         path_lvl4=filters.path_lvl4,
+                        is_global=is_global,
+                        scope_cfs=affiliations,
                         completion_status=filters.completion_status,
                         search=filters.search,
                         modules=filters.modules,
@@ -608,16 +604,15 @@ async def report_results(
         raise HTTPException(status_code=400, detail=ERROR_INVALID_FORMAT)
 
     is_global, affiliations = gate_backoffice(current_user, "export")
-    scoped_path_affiliation = narrow_path_affiliation(
-        filters.path_affiliation, is_global, affiliations
-    )
-    if not is_global and not scoped_path_affiliation:
+    if not is_global and not affiliations:
         data = []
     else:
         try:
             data = await CarbonReportModuleRepository(db).get_results_report(
-                path_affiliation=scoped_path_affiliation,
+                path_affiliation=filters.path_affiliation,
                 path_lvl4=filters.path_lvl4,
+                is_global=is_global,
+                scope_cfs=affiliations,
                 completion_status=filters.completion_status,
                 search=filters.search,
                 years=filters.years,

--- a/backend/app/api/v1/backoffice_reporting.py
+++ b/backend/app/api/v1/backoffice_reporting.py
@@ -11,7 +11,7 @@ from app.core.security import get_current_active_user
 from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.unit import UnitRead
-from app.utils.scoping import build_affiliation_predicate, gate_backoffice
+from app.utils.scoping import build_scope_subtree_predicate, gate_backoffice
 
 # Services
 logger = get_logger(__name__)
@@ -38,8 +38,8 @@ async def list_affiliations(
 
     Each unit includes its unit_type_label for UI distinction.
 
-    Affiliation-scoped backoffice users (#459) only see units whose
-    ``path_name`` contains one of their affiliations.
+    Affiliation-scoped backoffice users (#862) only see units within the
+    subtree of their scope unit(s).
     """
     is_global, affiliations = gate_backoffice(current_user)
 
@@ -62,7 +62,7 @@ async def list_affiliations(
 
     # 4. Affiliation scoping (#459)
     if not is_global:
-        query = query.where(build_affiliation_predicate(affiliations))
+        query = query.where(build_scope_subtree_predicate(affiliations))
 
     # 5. Sorting and Pagination
     offset = (page - 1) * page_size
@@ -121,7 +121,7 @@ async def list_units(
 
     # 4. Affiliation scoping (#459)
     if not is_global:
-        query = query.where(build_affiliation_predicate(affiliations))
+        query = query.where(build_scope_subtree_predicate(affiliations))
 
     # 5. Sorting and Pagination
     offset = (page - 1) * page_size

--- a/backend/app/providers/role_provider.py
+++ b/backend/app/providers/role_provider.py
@@ -44,11 +44,6 @@ def _unit_or_own_scope(role_name, institutional_id: str):
     return UnitScope(institutional_id=institutional_id)
 
 
-# ACCRED sortpath hierarchy level used as the backoffice affiliation token.
-# Example: "EPFL ENAC ENAC-SG ENAC-IT" → level 3 = "ENAC-SG".
-AFFILIATION_LEVEL = 3
-
-
 class RoleProvider(ABC):
     """Abstract base class for role providers.
 
@@ -519,6 +514,7 @@ class AccredRoleProvider(RoleProvider):
                 "persid": user_id,
                 "state": "active",
                 "expand": "0",
+                # "type": "right", # decomment on new role calco2.backoffice.admin added
                 "searchauthorization": "calco2.",
             }
 
@@ -587,30 +583,15 @@ class AccredRoleProvider(RoleProvider):
                     # Global super admin role
                     roles.append(Role(role=auth_name, on=GlobalScope()))
                 elif auth_name == RoleName.CO2_BACKOFFICE_METIER:
-                    sortpath = (
-                        auth.get("reason", {}).get("resource", {}).get("sortpath") or ""
-                    )
-                    # ACCRED sortpath is a space-separated hierarchy
-                    # ("EPFL ENAC ENAC-SG ENAC-IT"). Affiliation scoping operates
-                    # at LVL3 (e.g. "ENAC-SG"). Skip authorizations that cannot
-                    # resolve LVL3 — they cannot be scoped meaningfully.
-                    levels = sortpath.split()
-                    if len(levels) < AFFILIATION_LEVEL:
-                        logger.warning(
-                            "Backoffice metier sortpath too short; "
-                            "cannot resolve affiliation; skipping",
-                            extra={
-                                "auth_name": auth_name,
-                                "user_id": user_id,
-                                "sortpath": sortpath,
-                            },
-                        )
-                        continue
-                    affiliation = levels[AFFILIATION_LEVEL - 1]
+                    # Affiliation scope is the authorized unit's cf, which
+                    # identifies a unit at any hierarchy level. Scoping later
+                    # resolves it to that unit's descendant subtree.
                     roles.append(
                         Role(
                             role=auth_name,
-                            on=AffiliationScope(affiliation=affiliation),
+                            on=AffiliationScope(
+                                affiliation=accred_unit_institutional_id
+                            ),
                         )
                     )
                 else:

--- a/backend/app/providers/test_fixtures.py
+++ b/backend/app/providers/test_fixtures.py
@@ -18,7 +18,10 @@ from app.models.user import (
     UserProvider,
 )
 
-TEST_AFFILIATION = "testaffiliation"
+# Backoffice_metier scope token: the cf (institutional_id) of the ENAC anchor
+# unit below. ACCRED grants the metier role on a unit at any level; scoping
+# resolves that cf to the unit's descendant subtree.
+TEST_AFFILIATION = "13030"
 
 
 def make_test_user_id(user_id: str) -> str:
@@ -79,35 +82,51 @@ def get_test_role_by_user_id(user_id: str) -> RoleName | None:
 
 _PRINCIPAL_ID = TEST_USERS[RoleName.CO2_USER_PRINCIPAL]["institutional_id"]
 
+# A coherent ENAC subtree: lvl2 anchor -> lvl3 -> lvl4. Each unit's own
+# institutional_code is the last token of its (self-inclusive) root->leaf
+# path_institutional_code, mirroring real ACCRED data
+# (" ".join(ancestors + [self])). EPFL root (code 10582 / cf 13029) is an
+# ancestor token only; it is not a stored unit.
 TEST_UNITS: List[Unit] = [
     Unit(
         provider=UserProvider.TEST,
-        institutional_code="TEST-12345",
-        institutional_id="TEST-1119",
-        name="ENAC-IT4R-TEST",
-        level=4,
+        institutional_code="12635",
+        institutional_id="13030",
+        name="ENAC-TEST",
+        level=2,
         principal_user_institutional_id=_PRINCIPAL_ID,
-        path_institutional_code="10582 10583 11435",
-        path_institutional_id="cf-10582 cf-10583 cf-11435",
-        path_name="EPFL ENAC IT4R-TEST",
+        path_institutional_code="10582 12635",
+        path_institutional_id="13029 13030",
+        path_name="EPFL ENAC-TEST",
     ),
     Unit(
         provider=UserProvider.TEST,
-        institutional_code="TEST-10208",
-        institutional_id="TEST-0184",
-        name="IC-TEST",
+        institutional_code="11435",
+        institutional_id="13031",
+        name="ENAC-SG-TEST",
         level=3,
         principal_user_institutional_id=_PRINCIPAL_ID,
-        path_institutional_code="10582 10583 11436",
-        path_institutional_id="cf-10582 cf-10583 cf-11436",
-        path_name="EPFL IC-TEST",
+        path_institutional_code="10582 12635 11435",
+        path_institutional_id="13029 13030 13031",
+        path_name="EPFL ENAC-TEST ENAC-SG-TEST",
+    ),
+    Unit(
+        provider=UserProvider.TEST,
+        institutional_code="14270",
+        institutional_id="13032",
+        name="ENAC-IT4R-TEST",
+        level=4,
+        principal_user_institutional_id=_PRINCIPAL_ID,
+        path_institutional_code="10582 12635 11435 14270",
+        path_institutional_id="13029 13030 13031 13032",
+        path_name="EPFL ENAC-TEST ENAC-SG-TEST ENAC-IT4R-TEST",
     ),
 ]
 
 # Quick lookup helpers
 TEST_UNIT_IDS = [u.institutional_id for u in TEST_UNITS if u.institutional_id]
-# Primary test unit id as a non-optional str for scope construction.
-_TEST_UNIT_IID: str = TEST_UNITS[0].institutional_id or ""
+# Primary (leaf) test unit id as a non-optional str for unit/own scope construction.
+_TEST_UNIT_IID: str = TEST_UNITS[-1].institutional_id or ""
 
 
 # -- Test Roles ---------------------------------------------------------------

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -280,22 +280,16 @@ class CarbonReportModuleRepository:
         # Unit.id is expected to be present, but SQL typing can expose Optional.
         return [(unit_id, code) for unit_id, code in rows if unit_id is not None]
 
-    async def _get_descendant_unit_ids(self, values: Optional[List[str]]) -> set[int]:
-        """Resolve hierarchy nodes to descendant unit IDs, including self."""
-        selected_units = await self._get_selected_units(values)
-        if not selected_units:
+    async def _descendants_of_codes(self, codes: set[str]) -> set[int]:
+        """Unit IDs whose path_institutional_code token-matches any ancestor code.
+
+        path_institutional_code is the indexed, self-inclusive root->leaf code
+        path, so a match includes the ancestor unit itself.
+        """
+        if not codes:
             return set()
-
-        selected_ids = {unit_id for unit_id, _ in selected_units}
-        selected_codes = {code for _, code in selected_units if code}
-
-        # No institutional codes — descendants can only be looked up by path,
-        # so return the directly resolved IDs to avoid a full-table scan.
-        if not selected_codes:
-            return selected_ids
-
         path_conditions = []
-        for code in selected_codes:
+        for code in codes:
             # Token-boundary matching for ancestor code in path string.
             path_conditions.extend(
                 [
@@ -305,16 +299,43 @@ class CarbonReportModuleRepository:
                     col(Unit.path_institutional_code).like(f"% {code} %"),
                 ]
             )
-
-        descendants_stmt = select(Unit.id).where(or_(*path_conditions))
-        descendant_ids = {
+        stmt = select(Unit.id).where(or_(*path_conditions))
+        return {
             unit_id
-            for unit_id in (await self.session.exec(descendants_stmt)).all()
+            for unit_id in (await self.session.exec(stmt)).all()
             if unit_id is not None
         }
 
+    async def _get_descendant_unit_ids(self, values: Optional[List[str]]) -> set[int]:
+        """Resolve hierarchy nodes (name/id values) to descendant IDs, incl. self."""
+        selected_units = await self._get_selected_units(values)
+        if not selected_units:
+            return set()
+
+        selected_ids = {unit_id for unit_id, _ in selected_units}
+        selected_codes = {code for _, code in selected_units if code}
+
+        # No institutional codes — descendants can only be looked up by path,
+        # so return the directly resolved IDs to avoid a full-table scan.
         # Ensure selected units are included even if path is null or non-standard.
-        return selected_ids.union(descendant_ids)
+        return selected_ids | await self._descendants_of_codes(selected_codes)
+
+    async def _get_scope_unit_ids(self, scope_cfs: Optional[set[str]]) -> set[int]:
+        """Resolve backoffice scope cfs to their descendant subtree, incl. self.
+
+        Scope tokens are unit cfs (institutional_id) at any level. Resolve each
+        to its institutional_code, then expand via path_institutional_code. An
+        unknown cf contributes nothing — a scoped caller must never widen to all.
+        """
+        if not scope_cfs:
+            return set()
+        stmt = select(Unit.id, Unit.institutional_code).where(
+            col(Unit.institutional_id).in_(scope_cfs)
+        )
+        rows = (await self.session.exec(stmt)).all()
+        anchor_ids = {unit_id for unit_id, _ in rows if unit_id is not None}
+        anchor_codes = {code for _, code in rows if code}
+        return anchor_ids | await self._descendants_of_codes(anchor_codes)
 
     async def _get_direct_unit_ids(self, values: Optional[List[str]]) -> set[int]:
         """Resolve direct unit filter values (ID/name) to unit IDs."""
@@ -325,33 +346,35 @@ class CarbonReportModuleRepository:
         self,
         path_affiliation: Optional[List[str]] = None,
         path_lvl4: Optional[List[str]] = None,
+        is_global: bool = True,
+        scope_cfs: Optional[set[str]] = None,
     ) -> Optional[set[int]]:
-        """
-        Build the effective unit ID filter with OR semantics.
+        """Effective unit ID filter: ``scope ∩ (affiliation ∪ lvl4)``.
 
-        - Affiliation filter: Gets all descendants (Lvl2+3)
-        - Units filter: Gets direct units (Lvl4)
-        - Result: Union of both sets (OR logic)
+        Endpoint filters keep OR semantics among themselves; the caller's
+        backoffice scope is an AND clamp on top.
 
         Returns:
-            - None when no hierarchy filters provided
-            - set of unit IDs (possibly empty) when at least one
-              filter was provided
+            - None when there is no constraint at all (global caller, no
+              filters) → query returns all units
+            - a concrete set (possibly empty) otherwise
+
+        A scoped (non-global) caller NEVER returns None: it always resolves to
+        its scope subtree, intersected with any filters. ``set()`` → zero rows.
         """
-        all_ids: set[int] = set()
-        any_filter = False
-
+        filter_set: Optional[set[int]] = None
         if path_affiliation is not None:
-            any_filter = True
-            all_ids.update(await self._get_descendant_unit_ids(path_affiliation))
+            filter_set = await self._get_descendant_unit_ids(path_affiliation)
         if path_lvl4 is not None:
-            any_filter = True
-            all_ids.update(await self._get_direct_unit_ids(path_lvl4))
+            filter_set = (filter_set or set()) | await self._get_direct_unit_ids(
+                path_lvl4
+            )
 
-        if not any_filter:
-            return None
+        if is_global:
+            return filter_set
 
-        return all_ids
+        scope_set = await self._get_scope_unit_ids(scope_cfs)
+        return scope_set if filter_set is None else scope_set & filter_set
 
     @staticmethod
     def _apply_report_filters(
@@ -392,6 +415,8 @@ class CarbonReportModuleRepository:
         self,
         path_affiliation: Optional[List[str]] = None,
         path_lvl4: Optional[List[str]] = None,
+        is_global: bool = True,
+        scope_cfs: Optional[set[str]] = None,
         completion_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
@@ -413,6 +438,8 @@ class CarbonReportModuleRepository:
         hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
             path_affiliation=path_affiliation,
             path_lvl4=path_lvl4,
+            is_global=is_global,
+            scope_cfs=scope_cfs,
         )
 
         # If filters were provided but resolve to no units, short-circuit early.
@@ -870,6 +897,8 @@ class CarbonReportModuleRepository:
         self,
         path_affiliation: Optional[List[str]] = None,
         path_lvl4: Optional[List[str]] = None,
+        is_global: bool = True,
+        scope_cfs: Optional[set[str]] = None,
         completion_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
@@ -895,6 +924,8 @@ class CarbonReportModuleRepository:
         hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
             path_affiliation=path_affiliation,
             path_lvl4=path_lvl4,
+            is_global=is_global,
+            scope_cfs=scope_cfs,
         )
         # If hierarchy filters were provided but matched no units, return no results.
         if hierarchy_unit_ids is not None and not hierarchy_unit_ids:
@@ -997,6 +1028,8 @@ class CarbonReportModuleRepository:
         data_entry_type: DataEntryTypeEnum,
         path_affiliation: Optional[List[str]] = None,
         path_lvl4: Optional[List[str]] = None,
+        is_global: bool = True,
+        scope_cfs: Optional[set[str]] = None,
         completion_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
@@ -1031,6 +1064,8 @@ class CarbonReportModuleRepository:
         hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
             path_affiliation=path_affiliation,
             path_lvl4=path_lvl4,
+            is_global=is_global,
+            scope_cfs=scope_cfs,
         )
         # If hierarchy filters were provided but matched no units, return no results.
         if hierarchy_unit_ids is not None and not hierarchy_unit_ids:
@@ -1151,6 +1186,8 @@ class CarbonReportModuleRepository:
         self,
         path_affiliation: Optional[List[str]] = None,
         path_lvl4: Optional[List[str]] = None,
+        is_global: bool = True,
+        scope_cfs: Optional[set[str]] = None,
         completion_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         years: Optional[List[int]] = None,
@@ -1172,6 +1209,8 @@ class CarbonReportModuleRepository:
         hierarchy_unit_ids = await self._resolve_hierarchy_unit_ids(
             path_affiliation=path_affiliation,
             path_lvl4=path_lvl4,
+            is_global=is_global,
+            scope_cfs=scope_cfs,
         )
         # If hierarchy filters were provided but matched no units, return no results.
         if hierarchy_unit_ids is not None and not hierarchy_unit_ids:

--- a/backend/app/utils/scoping.py
+++ b/backend/app/utils/scoping.py
@@ -1,13 +1,14 @@
-"""Affiliation-scoping helpers shared by backoffice routers (#459).
+"""Affiliation-scoping helpers shared by backoffice routers (#459, #862).
 
 The pure permission utilities live in ``app.utils.permissions`` and stay
-free of SQLAlchemy / FastAPI. This module owns the SQL-level predicate
-that maps ACCRED affiliation tokens onto ``Unit.path_name``, plus the
+free of SQLAlchemy / FastAPI. This module owns the SQL-level predicate that
+maps a backoffice scope (a set of unit cfs) onto the unit subtree, plus the
 gate helper that raises 403 when the caller is not a backoffice user.
 """
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import func, or_
+from sqlalchemy import and_, exists, func, or_
+from sqlalchemy.orm import aliased
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import col
 
@@ -17,23 +18,28 @@ from app.models.user import User
 from app.utils.permissions import derive_backoffice_affiliations, has_permission
 
 
-def build_affiliation_predicate(affiliations: set[str]) -> ColumnElement[bool]:
-    """Build the SQL predicate matching ``Unit.path_name`` against affiliations.
+def build_scope_subtree_predicate(scope_cfs: set[str]) -> ColumnElement[bool]:
+    """SQL predicate selecting units within the subtree of any scope cf (#862).
 
-    ACCRED ``sortpath`` is a space-separated 4-level hierarchy
-    (e.g. ``"EPFL ENAC ENAC-SG ENAC-IT"``); ``role_provider.py`` extracts
-    LVL3 (``"ENAC-SG"``) as the affiliation token. ``Unit.path_name`` is a
-    separator-joined ancestor list (observed shapes: ``"EPFL > STI > LMSC"``
-    and ``"EPFL ENAC IT4R-TEST"``). Padding the column with leading/trailing
-    spaces lets a single ``% <aff> %`` ILIKE catch the LVL3 token at any
-    position regardless of separator (` > ` or plain space) and avoids false
-    positives like ``SV`` matching ``SVOPS``.
-
-    ``coalesce`` keeps the predicate well-defined when ``path_name`` is NULL
-    (NULL rows simply never match).
+    A backoffice scope token is a unit cf (``institutional_id``) at any level.
+    A row is in scope iff some anchor unit ``A`` with ``A.institutional_id`` in
+    ``scope_cfs`` has its ``institutional_code`` as a token of the row's
+    ``path_institutional_code`` (the indexed, self-inclusive code path), so the
+    anchor itself and all its descendants match. Token-boundary matching avoids
+    false positives like code ``142`` matching ``1420``.
     """
-    padded = func.concat(" ", func.coalesce(col(Unit.path_name), ""), " ")
-    return or_(*[padded.ilike(f"% {aff} %") for aff in affiliations])
+    anchor = aliased(Unit)
+    code = anchor.institutional_code
+    path = col(Unit.path_institutional_code)
+    token_match = or_(
+        path == code,
+        path.like(func.concat(code, " %")),
+        path.like(func.concat("% ", code)),
+        path.like(func.concat("% ", code, " %")),
+    )
+    return exists().where(
+        and_(col(anchor.institutional_id).in_(scope_cfs), token_match)
+    )
 
 
 def gate_backoffice(
@@ -45,8 +51,9 @@ def gate_backoffice(
 
     Raises 403 if the user holds neither the bare ``anchor_path`` key nor any
     ``anchor_path/<aff>`` key granting ``action``. Returns
-    ``(is_global, affiliations)``; callers apply ``build_affiliation_predicate``
-    when ``is_global`` is False.
+    ``(is_global, affiliations)``; callers pass ``affiliations`` as ``scope_cfs``
+    to the report repo, or apply ``build_scope_subtree_predicate`` on a unit
+    query, when ``is_global`` is False.
 
     The default anchor is ``backoffice.reporting`` — the only affiliation-scoped
     backoffice area (#862), and therefore the only one whose affiliations can be
@@ -135,23 +142,3 @@ def require_module_or_config_view():
         return current_user
 
     return _dep
-
-
-def narrow_path_affiliation(
-    requested: list[str] | None,
-    is_global: bool,
-    affiliations: set[str],
-) -> list[str] | None:
-    """Intersect a caller-provided ``path_affiliation`` filter with their scope.
-
-    - ``is_global`` callers pass through unchanged.
-    - Scoped callers: intersect their request with their affiliation set
-      (or default to the full set when they pass nothing).
-    - Returns the narrowed list; an empty list signals "no allowed affiliations"
-      and the caller should short-circuit to an empty result.
-    """
-    if is_global:
-        return requested
-    if requested:
-        return [a for a in requested if a in affiliations]
-    return list(affiliations)

--- a/backend/tests/integration/v1/test_permission_scope_e2e.py
+++ b/backend/tests/integration/v1/test_permission_scope_e2e.py
@@ -20,14 +20,21 @@ A test of this shape would have caught the regression — these are the tests
 that pin the chain back together.
 """
 
-import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 import app.api.deps as deps_module
+from app.core.constants import ModuleStatus
 from app.main import app
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReport, CarbonReportType
 from app.models.unit import Unit
 from app.models.user import (
     AffiliationScope,
@@ -217,269 +224,253 @@ class TestPermissionScopeEndToEnd:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Backoffice ACCRED affiliation scoping (#459)
+# Backoffice affiliation scoping (#862) — over a real in-memory DB.
 #
-# Affiliation-scoped backoffice managers (e.g. an SV-scoped admin) only hold
-# ``backoffice.X/<affiliation>`` permission keys. Endpoints that swap
-# ``require_permission`` for an inline ``any_scope=True`` gate must:
-#   1. let the request through (the user IS a backoffice manager),
-#   2. narrow results to units whose ``path_name`` carries the affiliation.
-# GlobalScope backoffice / superadmin keep the bare keys and bypass narrowing.
+# A backoffice_metier scope token is a unit cf (institutional_id) at any level;
+# scoping resolves it to that unit's descendant subtree via the indexed
+# path_institutional_code. These E2E tests pin the route WIRING (gate → extract
+# affiliations → pass as scope). The scope MATCHING itself is covered with real
+# DB at the unit level by tests/unit/repositories/test_carbon_report_module_repo
+# (TestResolveHierarchyUnitIdsScope, TestGetReportingOverview) and
+# tests/unit/utils/test_scoping (TestBuildScopeSubtreePredicate).
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 BACKOFFICE_UNITS_URL = "/api/v1/backoffice-reporting/units"
 BACKOFFICE_AFFILIATIONS_URL = "/api/v1/backoffice-reporting/affiliations"
+BACKOFFICE_YEARS_URL = "/api/v1/backoffice/years"
+# The reporting overview page — the endpoint whose empty result started #862.
+BACKOFFICE_REPORTING_UNITS_URL = "/api/v1/backoffice/units?years=2024&years=2025"
+
+# Scope cfs (institutional_id) used in tests.
+ENAC_CF = "13030"
+STI_CF = "14000"
+ABSENT_CF = "99999"
 
 
-def _unit(uid: int, iid: str, name: str, path_name: str, level: int = 3) -> Unit:
-    """Construct a fixture Unit (active by default)."""
-    return Unit(
-        id=uid,
-        institutional_code=str(uid),
-        institutional_id=iid,
-        name=name,
-        level=level,
-        path_name=path_name,
-        is_active=True,
-    )
+async def _seed_backoffice_db(session: AsyncSession) -> None:
+    """Seed an ENAC subtree (lvl2→4) and a separate STI subtree.
 
-
-# Two-school fixture: one unit under SV, one under STI.
-_SV_UNIT = _unit(1, "sv-cf", "SV-LAB", "EPFL > SV > SV-LAB")
-_STI_UNIT = _unit(2, "sti-cf", "STI-LAB", "EPFL > STI > STI-LAB")
-
-
-def _wire_backoffice(monkeypatch, user, units: list) -> None:
-    """Wire dependency overrides for the backoffice endpoints.
-
-    Captures every ``where`` clause the route attaches and applies them to the
-    in-memory ``units`` fixture, so SQL-level filters (level, affiliation
-    predicate) actually narrow results. The route uses ``db.exec(query).all()``;
-    we honour ``query.where(...)`` chaining without touching real SQL.
+    path_institutional_code is the self-inclusive root→leaf code path, so a
+    unit is in ENAC's subtree iff ENAC's code (12635) is one of its tokens.
+    ENAC-IT4R has reports for 2024/2025; STI-LAB for 2023.
     """
+    units = [
+        Unit(
+            institutional_code="12635",
+            institutional_id=ENAC_CF,
+            name="ENAC",
+            level=2,
+            path_institutional_code="10582 12635",
+            is_active=True,
+        ),
+        Unit(
+            institutional_code="11435",
+            institutional_id="13031",
+            name="ENAC-SG",
+            level=3,
+            path_institutional_code="10582 12635 11435",
+            is_active=True,
+        ),
+        Unit(
+            institutional_code="14270",
+            institutional_id="13032",
+            name="ENAC-IT4R",
+            level=4,
+            path_institutional_code="10582 12635 11435 14270",
+            is_active=True,
+        ),
+        Unit(
+            institutional_code="13000",
+            institutional_id=STI_CF,
+            name="STI",
+            level=2,
+            path_institutional_code="10582 13000",
+            is_active=True,
+        ),
+        Unit(
+            institutional_code="13500",
+            institutional_id="14500",
+            name="STI-LAB",
+            level=4,
+            path_institutional_code="10582 13000 13500",
+            is_active=True,
+        ),
+    ]
+    session.add_all(units)
+    await session.flush()
+    by_name = {u.name: u for u in units}
+    reports = {"ENAC-IT4R": [2024, 2025], "STI-LAB": [2023]}
+    for name, years in reports.items():
+        unit = by_name[name]
+        project = CarbonProject(
+            unit_id=unit.id, carbon_report_type=CarbonReportType.CALCULATOR
+        )
+        session.add(project)
+        await session.flush()
+        for year in years:
+            session.add(
+                CarbonReport(
+                    year=year,
+                    unit_id=unit.id,
+                    carbon_project_id=project.id,
+                    overall_status=ModuleStatus.NOT_STARTED,
+                )
+            )
+    await session.commit()
+
+
+@pytest_asyncio.fixture
+async def backoffice_db():
+    """In-memory SQLite seeded with the ENAC/STI fixtures; yields a factory."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        await _seed_backoffice_db(session)
+    yield factory
+    await engine.dispose()
+
+
+def _wire_db(user, factory) -> None:
+    """Override the current user and bind the route's db to the seeded engine."""
     app.dependency_overrides[deps_module.get_current_user] = lambda: user
 
-    async def mock_get_db():
-        db = MagicMock()
+    async def override_get_db():
+        async with factory() as session:
+            yield session
 
-        async def mock_exec(query):
-            # Compile the query and emulate the affiliation predicate in
-            # memory. We extract every ``LIKE '% <token> %'`` literal from
-            # the compiled SQL and require a unit's padded ``path_name`` to
-            # contain at least one of them. If no such literal appears, the
-            # query is un-narrowed (global caller) and we return all units.
-            #
-            # Coupled to the exact predicate shape from
-            # ``_affiliation_predicate``: any refactor that drops the
-            # ``LIKE lower('% <aff> %')`` form flips this to "no tokens" →
-            # all rows return → the scoped tests fail with the unscoped
-            # row count. That IS the signal that the predicate moved.
-            compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
-            tokens = re.findall(r"like\s+lower\('% ([^ ]+?) %'\)", compiled, re.I)
-
-            def keep(u: Unit) -> bool:
-                if not tokens:
-                    return True
-                padded = f" {(u.path_name or '').lower()} "
-                return any(f" {t.lower()} " in padded for t in tokens)
-
-            result = MagicMock()
-            result.all = lambda: [u for u in units if keep(u)]
-            return result
-
-        db.exec = mock_exec
-        yield db
-
-    app.dependency_overrides[deps_module.get_db] = mock_get_db
+    app.dependency_overrides[deps_module.get_db] = override_get_db
 
 
 class TestBackofficeAffiliationScopeEndToEnd:
-    """Affiliation-scoped backoffice users only see units inside their
-    sub-perimeter; GlobalScope keeps full reach (#459)."""
+    """Affiliation-scoped backoffice users only see units inside their scope
+    subtree; GlobalScope keeps full reach (#862)."""
 
-    def test_global_backoffice_sees_all_units(self, client, monkeypatch):
-        """Superadmin → bare ``backoffice.users`` key → no narrowing.
-        (CO2_BACKOFFICE_METIER is always sub-perimeter-bound; cross-affiliation
-        reach is exclusive to CO2_SUPERADMIN.)"""
-        user = _user("11111", [_superadmin()])
-        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+    def test_global_backoffice_sees_all_units(self, client, backoffice_db):
+        _wire_db(_user("11111", [_superadmin()]), backoffice_db)
         r = client.get(BACKOFFICE_UNITS_URL)
         assert r.status_code == 200, r.text
         names = {u["name"] for u in r.json()}
-        assert names == {"SV-LAB", "STI-LAB"}
+        assert names == {"ENAC", "ENAC-SG", "ENAC-IT4R", "STI", "STI-LAB"}
 
-    def test_scoped_backoffice_sees_only_in_affiliation_units(
-        self, client, monkeypatch
-    ):
-        """SV-scoped caller → only SV unit in the response."""
-        user = _user("11111", [_backoffice_scoped("SV")])
-        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+    def test_scoped_backoffice_sees_only_in_subtree_units(self, client, backoffice_db):
+        """ENAC-scoped caller → only ENAC's subtree, never STI."""
+        _wire_db(_user("11111", [_backoffice_scoped(ENAC_CF)]), backoffice_db)
         r = client.get(BACKOFFICE_UNITS_URL)
         assert r.status_code == 200, r.text
         names = {u["name"] for u in r.json()}
-        assert names == {"SV-LAB"}
+        assert names == {"ENAC", "ENAC-SG", "ENAC-IT4R"}
 
     def test_scoped_backoffice_cross_affiliation_returns_empty(
-        self, client, monkeypatch
+        self, client, backoffice_db
     ):
-        """SV-scoped caller against STI-only data → 200 empty list.
-        The gate accepts (the user holds ``backoffice.users/SV``) but the
-        affiliation predicate filters everything out."""
-        user = _user("11111", [_backoffice_scoped("SV")])
-        _wire_backoffice(monkeypatch, user, [_STI_UNIT])
+        """Scope cf with no unit in this DB → gate passes, subtree is empty."""
+        _wire_db(_user("11111", [_backoffice_scoped(ABSENT_CF)]), backoffice_db)
         r = client.get(BACKOFFICE_UNITS_URL)
         assert r.status_code == 200, r.text
         assert r.json() == []
 
-    def test_scoped_backoffice_multi_affiliation_unions(self, client, monkeypatch):
-        """A user holding both SV and STI roles sees the union."""
-        user = _user("11111", [_backoffice_scoped("SV"), _backoffice_scoped("STI")])
-        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+    def test_scoped_backoffice_multi_affiliation_unions(self, client, backoffice_db):
+        """Holding both ENAC and STI scopes → the union of both subtrees."""
+        user = _user("11111", [_backoffice_scoped(ENAC_CF), _backoffice_scoped(STI_CF)])
+        _wire_db(user, backoffice_db)
         r = client.get(BACKOFFICE_UNITS_URL)
         assert r.status_code == 200, r.text
         names = {u["name"] for u in r.json()}
-        assert names == {"SV-LAB", "STI-LAB"}
+        assert names == {"ENAC", "ENAC-SG", "ENAC-IT4R", "STI", "STI-LAB"}
 
-    def test_no_backoffice_role_denied(self, client, monkeypatch):
-        """Std user → 403 (still gated on ``backoffice.users.view``)."""
-        user = _user("11111", [_std(UNIT_IID)])
-        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
+    def test_no_backoffice_role_denied(self, client, backoffice_db):
+        """Std user → 403 (gated on ``backoffice.reporting`` any-scope)."""
+        _wire_db(_user("11111", [_std(UNIT_IID)]), backoffice_db)
         r = client.get(BACKOFFICE_UNITS_URL)
         assert r.status_code == 403, r.text
 
-    def test_superadmin_sees_all_units(self, client, monkeypatch):
-        """Regression guard: superadmin still bypasses narrowing."""
-        user = _user("11111", [_superadmin()])
-        _wire_backoffice(monkeypatch, user, [_SV_UNIT, _STI_UNIT])
-        r = client.get(BACKOFFICE_UNITS_URL)
-        assert r.status_code == 200, r.text
-        assert len(r.json()) == 2
-
-    def test_scoped_backoffice_affiliations_endpoint(self, client, monkeypatch):
-        """``/backoffice/affiliations`` mirrors ``/units`` for narrowing.
-        Build the fixture at level 2/3 (the endpoint filters levels in [2, 3])."""
-        sv_aff = _unit(10, "sv-fac", "SV-FAC", "EPFL > SV", level=2)
-        sti_aff = _unit(11, "sti-fac", "STI-FAC", "EPFL > STI", level=2)
-        user = _user("11111", [_backoffice_scoped("SV")])
-        _wire_backoffice(monkeypatch, user, [sv_aff, sti_aff])
+    def test_scoped_backoffice_affiliations_endpoint(self, client, backoffice_db):
+        """``/affiliations`` shows only lvl2/3 within the ENAC subtree."""
+        _wire_db(_user("11111", [_backoffice_scoped(ENAC_CF)]), backoffice_db)
         r = client.get(BACKOFFICE_AFFILIATIONS_URL)
         assert r.status_code == 200, r.text
         names = {u["name"] for u in r.json()}
-        assert names == {"SV-FAC"}
+        assert names == {"ENAC", "ENAC-SG"}
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# /api/v1/backoffice/* (six endpoints previously gated by strict
-# ``require_permission`` — Phase 2 / #459 opened them under ``any_scope=True``
-# with server-side affiliation narrowing).
-# ─────────────────────────────────────────────────────────────────────────────
+class TestBackofficeReportingOverviewScoping:
+    """``/backoffice/units`` reporting overview — the page that #862 fixed.
 
-
-BACKOFFICE_YEARS_URL = "/api/v1/backoffice/years"
-
-
-def _wire_backoffice_years(
-    monkeypatch, user, years_by_unit_path: dict[str, list[int]]
-) -> None:
-    """Stub the ``/backoffice/years`` query path.
-
-    ``years_by_unit_path`` maps a unit ``path_name`` → years that unit has
-    reports for. The mock inspects the compiled SQL for the affiliation
-    ILIKE literals (same trick as ``_wire_backoffice``) and returns the
-    union of years whose unit's ``path_name`` matches any literal. With
-    no literals (global caller), all years are returned.
+    Overview rows exist only for units with CarbonReports; the fixture seeds
+    ENAC-IT4R (in ENAC's subtree, years 2024/25) and STI-LAB (outside, 2023).
     """
-    app.dependency_overrides[deps_module.get_current_user] = lambda: user
 
-    async def mock_get_db():
-        db = MagicMock()
+    def _names(self, payload) -> set[str]:
+        return {row["unit_name"] for row in payload["data"]}
 
-        async def mock_exec(query):
-            compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
-            tokens = re.findall(r"like\s+lower\('% ([^ ]+?) %'\)", compiled, re.I)
+    def test_global_sees_in_year_units(self, client, backoffice_db):
+        _wire_db(_user("11111", [_superadmin()]), backoffice_db)
+        r = client.get(BACKOFFICE_REPORTING_UNITS_URL)
+        assert r.status_code == 200, r.text
+        assert self._names(r.json()) == {"ENAC-IT4R"}
 
-            def path_matches(path: str) -> bool:
-                if not tokens:
-                    return True
-                padded = f" {(path or '').lower()} "
-                return any(f" {t.lower()} " in padded for t in tokens)
+    def test_scoped_sees_only_in_subtree(self, client, backoffice_db):
+        _wire_db(_user("11111", [_backoffice_scoped(ENAC_CF)]), backoffice_db)
+        r = client.get(BACKOFFICE_REPORTING_UNITS_URL)
+        assert r.status_code == 200, r.text
+        assert self._names(r.json()) == {"ENAC-IT4R"}
 
-            collected = sorted(
-                {
-                    y
-                    for path, years in years_by_unit_path.items()
-                    if path_matches(path)
-                    for y in years
-                },
-                reverse=True,
-            )
-            result = MagicMock()
-            result.all = lambda: collected
-            return result
+    def test_scoped_cross_affiliation_returns_empty(self, client, backoffice_db):
+        _wire_db(_user("11111", [_backoffice_scoped(STI_CF)]), backoffice_db)
+        r = client.get(BACKOFFICE_REPORTING_UNITS_URL)
+        assert r.status_code == 200, r.text
+        # STI's only report is 2023, outside the requested 2024/25 window.
+        assert r.json()["data"] == []
 
-        db.exec = mock_exec
-        yield db
-
-    app.dependency_overrides[deps_module.get_db] = mock_get_db
+    def test_scoped_out_of_scope_lvl4_filter_empty(self, client, backoffice_db):
+        """ENAC-scoped caller requesting the STI lab → clamped to empty."""
+        _wire_db(_user("11111", [_backoffice_scoped(ENAC_CF)]), backoffice_db)
+        r = client.get(BACKOFFICE_REPORTING_UNITS_URL + "&path_lvl4=STI-LAB")
+        assert r.status_code == 200, r.text
+        assert r.json()["data"] == []
 
 
 class TestBackofficeYearsAffiliationScoping:
-    """``/backoffice/years`` exposes distinct CarbonReport.year values.
+    """``/backoffice/years`` distinct CarbonReport.year values, scope-clamped."""
 
-    For non-global callers the query joins ``Unit`` and applies the
-    affiliation predicate, so scoped users only see years for which their
-    affiliation has reports.
-    """
-
-    YEARS_BY_PATH = {
-        "EPFL > SV > SV-LAB": [2024, 2025],
-        "EPFL > STI > STI-LAB": [2023],
-    }
-
-    def test_global_backoffice_sees_all_years(self, client, monkeypatch):
-        """Superadmin (the only role with cross-affiliation reach) sees every year."""
-        user = _user("11111", [_superadmin()])
-        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+    def test_global_backoffice_sees_all_years(self, client, backoffice_db):
+        _wire_db(_user("11111", [_superadmin()]), backoffice_db)
         r = client.get(BACKOFFICE_YEARS_URL)
         assert r.status_code == 200, r.text
         body = r.json()
         assert set(body["years"]) == {"2023", "2024", "2025"}
         assert body["latest"] == "2025"
 
-    def test_scoped_backoffice_sees_only_in_affiliation_years(
-        self, client, monkeypatch
-    ):
-        user = _user("11111", [_backoffice_scoped("SV")])
-        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+    def test_scoped_backoffice_sees_only_in_subtree_years(self, client, backoffice_db):
+        _wire_db(_user("11111", [_backoffice_scoped(ENAC_CF)]), backoffice_db)
         r = client.get(BACKOFFICE_YEARS_URL)
         assert r.status_code == 200, r.text
         body = r.json()
-        # SV has 2024 + 2025; STI's 2023 must be filtered out.
+        # ENAC subtree has 2024 + 2025; STI's 2023 is clamped out.
         assert set(body["years"]) == {"2024", "2025"}
         assert body["latest"] == "2025"
 
     def test_scoped_backoffice_cross_affiliation_returns_empty(
-        self, client, monkeypatch
+        self, client, backoffice_db
     ):
-        user = _user("11111", [_backoffice_scoped("CDH")])
-        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+        _wire_db(_user("11111", [_backoffice_scoped(ABSENT_CF)]), backoffice_db)
         r = client.get(BACKOFFICE_YEARS_URL)
         assert r.status_code == 200, r.text
         assert r.json() == {"years": [], "latest": ""}
 
-    def test_no_backoffice_role_denied(self, client, monkeypatch):
-        user = _user("11111", [_std(UNIT_IID)])
-        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+    def test_no_backoffice_role_denied(self, client, backoffice_db):
+        _wire_db(_user("11111", [_std(UNIT_IID)]), backoffice_db)
         r = client.get(BACKOFFICE_YEARS_URL)
         assert r.status_code == 403, r.text
 
-    def test_principal_denied_after_backoffice_grant_removal(self, client, monkeypatch):
-        """Pin the Phase 2 removal: CO2_USER_PRINCIPAL no longer grants
-        backoffice.users.edit, so a principal-only user must NOT pass the
-        backoffice gate."""
-        user = _user("11111", [_principal(UNIT_IID)])
-        _wire_backoffice_years(monkeypatch, user, self.YEARS_BY_PATH)
+    def test_principal_denied(self, client, backoffice_db):
+        """CO2_USER_PRINCIPAL does not grant backoffice.reporting → 403."""
+        _wire_db(_user("11111", [_principal(UNIT_IID)]), backoffice_db)
         r = client.get(BACKOFFICE_YEARS_URL)
         assert r.status_code == 403, r.text
 

--- a/backend/tests/unit/providers/test_role_provider.py
+++ b/backend/tests/unit/providers/test_role_provider.py
@@ -310,19 +310,18 @@ class TestAccredRoleProvider:
     async def test_accred_fetch_roles_with_backoffice_metier(
         self, accred_provider, sample_user_id
     ):
-        """ACCRED sortpath is a 4-level hierarchy; affiliation is LVL3."""
+        """Backoffice_metier affiliation scope is the authorized unit's cf.
+
+        The cf identifies a unit at any hierarchy level; it is used verbatim as
+        the affiliation token (not the accredunitid, not a sortpath level).
+        """
         mock_response = {
             "authorizations": [
                 {
                     "name": f"{RoleName.CO2_BACKOFFICE_METIER.value}",
                     "state": "active",
                     "accredunitid": "12345",
-                    "reason": {
-                        "resource": {
-                            "cf": "12345",
-                            "sortpath": "EPFL ENAC ENAC-SG ENAC-IT",
-                        }
-                    },
+                    "reason": {"resource": {"cf": "13030"}},
                 }
             ]
         }
@@ -344,40 +343,8 @@ class TestAccredRoleProvider:
         assert len(roles) == 1
         assert roles[0] == Role(
             role=RoleName.CO2_BACKOFFICE_METIER,
-            on=AffiliationScope(affiliation="ENAC-SG"),
+            on=AffiliationScope(affiliation="13030"),
         )
-
-    @pytest.mark.asyncio
-    async def test_accred_backoffice_metier_short_sortpath_skipped(
-        self, accred_provider, sample_user_id
-    ):
-        """Sortpath shorter than 3 levels cannot resolve LVL3 — role is dropped."""
-        mock_response = {
-            "authorizations": [
-                {
-                    "name": f"{RoleName.CO2_BACKOFFICE_METIER.value}",
-                    "state": "active",
-                    "accredunitid": "12345",
-                    "reason": {"resource": {"cf": "12345", "sortpath": "EPFL ENAC"}},
-                }
-            ]
-        }
-
-        with patch(
-            "app.providers.role_provider.httpx.AsyncClient"
-        ) as mock_client_class:
-            mock_client = AsyncMock()
-            mock_response_obj = AsyncMock()
-            mock_response_obj.json = Mock(return_value=mock_response)
-            mock_response_obj.raise_for_status = Mock()
-            mock_client.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_response_obj
-
-            mock_client_class.return_value = mock_client
-
-            roles = await accred_provider.get_roles_by_user_id(sample_user_id)
-
-        assert roles == []
 
     @pytest.mark.asyncio
     async def test_accred_no_authorizations_found(

--- a/backend/tests/unit/providers/test_test_fixtures.py
+++ b/backend/tests/unit/providers/test_test_fixtures.py
@@ -1,0 +1,53 @@
+"""Coherence tests for the TEST provider fixtures.
+
+The backoffice_metier scope token is a unit cf (``institutional_id``). The
+reporting query resolves it to descendant units via the indexed
+``path_institutional_code`` (cf -> institutional_code -> path token match).
+These tests assert TEST fixtures are hierarchically coherent under that rule,
+so end-to-end backoffice tests exercise a real subtree rather than an empty one.
+"""
+
+from app.models.user import AffiliationScope, RoleName
+from app.providers.test_fixtures import (
+    TEST_AFFILIATION,
+    TEST_ROLES,
+    TEST_UNITS,
+)
+
+
+def test_backoffice_metier_scope_is_a_unit_cf():
+    """TEST_AFFILIATION must equal the cf of a TEST unit (the scope anchor)."""
+    anchor = next(
+        (u for u in TEST_UNITS if u.institutional_id == TEST_AFFILIATION), None
+    )
+    assert anchor is not None, (
+        "TEST_AFFILIATION must be the institutional_id (cf) of a TEST unit; "
+        f"got {TEST_AFFILIATION!r}"
+    )
+
+
+def test_scope_anchor_resolves_to_descendant_units():
+    """cf -> institutional_code -> path_institutional_code must match >=1 unit.
+
+    Mirrors the reporting scope resolver: the anchor's institutional_code must
+    appear as a path token in its own and its descendants' path, since
+    path_institutional_code is self-inclusive (" ".join(ancestors + [self])).
+    """
+    anchor = next(u for u in TEST_UNITS if u.institutional_id == TEST_AFFILIATION)
+    code = anchor.institutional_code
+
+    in_subtree = [
+        u for u in TEST_UNITS if code in (u.path_institutional_code or "").split()
+    ]
+    assert in_subtree, (
+        "anchor institutional_code must appear in descendant "
+        "path_institutional_code tokens"
+    )
+    assert anchor in in_subtree, "path_institutional_code must be self-inclusive"
+
+
+def test_backoffice_metier_role_scope_matches_affiliation_constant():
+    """The metier role's AffiliationScope must carry TEST_AFFILIATION."""
+    roles = TEST_ROLES[RoleName.CO2_BACKOFFICE_METIER]
+    scopes = [r.on for r in roles if isinstance(r.on, AffiliationScope)]
+    assert any(s.affiliation == TEST_AFFILIATION for s in scopes)

--- a/backend/tests/unit/repositories/test_carbon_report_module_repo.py
+++ b/backend/tests/unit/repositories/test_carbon_report_module_repo.py
@@ -93,6 +93,132 @@ class TestMapModuleIdToName:
 # ---------------------------------------------------------------------------
 
 
+class TestScopeUnitIds:
+    """cf -> institutional_code -> descendant subtree via path_institutional_code."""
+
+    async def _build_enac_subtree(self, db_session, make_unit):
+        # Anchor (lvl2) + descendants share the anchor code 12635 as a path token.
+        anchor = await make_unit(
+            db_session,
+            institutional_code="12635",
+            institutional_id="13030",
+            level=2,
+            path_institutional_code="10582 12635",
+        )
+        child = await make_unit(
+            db_session,
+            institutional_code="11435",
+            institutional_id="13031",
+            level=3,
+            path_institutional_code="10582 12635 11435",
+        )
+        leaf = await make_unit(
+            db_session,
+            institutional_code="14270",
+            institutional_id="13032",
+            level=4,
+            path_institutional_code="10582 12635 11435 14270",
+        )
+        other = await make_unit(
+            db_session,
+            institutional_code="99999",
+            institutional_id="88888",
+            level=2,
+            path_institutional_code="10582 99999",
+        )
+        return anchor, child, leaf, other
+
+    async def test_resolves_cf_to_self_and_descendants(self, db_session, make_unit):
+        anchor, child, leaf, other = await self._build_enac_subtree(
+            db_session, make_unit
+        )
+        repo = CarbonReportModuleRepository(db_session)
+        ids = await repo._get_scope_unit_ids({"13030"})
+        assert ids == {anchor.id, child.id, leaf.id}
+        assert other.id not in ids
+
+    async def test_unknown_cf_resolves_to_empty_not_all(self, db_session, make_unit):
+        await self._build_enac_subtree(db_session, make_unit)
+        repo = CarbonReportModuleRepository(db_session)
+        # A scope cf with no matching unit must yield {} — never "all units".
+        assert await repo._get_scope_unit_ids({"does-not-exist"}) == set()
+
+
+class TestResolveHierarchyUnitIdsScope:
+    """scope ∩ (affiliation ∪ lvl4) — the security clamp invariant.
+
+    A scoped caller must always resolve to a concrete set, never None
+    (None means "no constraint" → all units, a privilege escalation).
+    """
+
+    async def _subtree(self, db_session, make_unit):
+        anchor = await make_unit(
+            db_session,
+            institutional_code="12635",
+            institutional_id="13030",
+            name="ENAC",
+            level=2,
+            path_institutional_code="10582 12635",
+        )
+        leaf = await make_unit(
+            db_session,
+            institutional_code="14270",
+            institutional_id="13032",
+            name="ENAC-IT4R",
+            level=4,
+            path_institutional_code="10582 12635 11435 14270",
+        )
+        outside = await make_unit(
+            db_session,
+            institutional_code="99999",
+            institutional_id="88888",
+            name="OUTSIDE",
+            level=4,
+            path_institutional_code="10582 99999",
+        )
+        return anchor, leaf, outside
+
+    async def test_global_no_filters_returns_none(self, db_session, make_unit):
+        await self._subtree(db_session, make_unit)
+        repo = CarbonReportModuleRepository(db_session)
+        result = await repo._resolve_hierarchy_unit_ids(is_global=True)
+        assert result is None
+
+    async def test_scoped_no_filters_returns_scope_set_not_none(
+        self, db_session, make_unit
+    ):
+        anchor, leaf, _ = await self._subtree(db_session, make_unit)
+        repo = CarbonReportModuleRepository(db_session)
+        result = await repo._resolve_hierarchy_unit_ids(
+            is_global=False, scope_cfs={"13030"}
+        )
+        assert result == {anchor.id, leaf.id}
+
+    async def test_scoped_intersects_in_scope_filter(self, db_session, make_unit):
+        anchor, leaf, _ = await self._subtree(db_session, make_unit)
+        repo = CarbonReportModuleRepository(db_session)
+        result = await repo._resolve_hierarchy_unit_ids(
+            path_lvl4=["ENAC-IT4R"], is_global=False, scope_cfs={"13030"}
+        )
+        assert result == {leaf.id}
+
+    async def test_scoped_out_of_scope_filter_yields_empty(self, db_session, make_unit):
+        await self._subtree(db_session, make_unit)
+        repo = CarbonReportModuleRepository(db_session)
+        result = await repo._resolve_hierarchy_unit_ids(
+            path_lvl4=["OUTSIDE"], is_global=False, scope_cfs={"13030"}
+        )
+        assert result == set()
+
+    async def test_global_with_filters_ignores_scope(self, db_session, make_unit):
+        _, _, outside = await self._subtree(db_session, make_unit)
+        repo = CarbonReportModuleRepository(db_session)
+        result = await repo._resolve_hierarchy_unit_ids(
+            path_lvl4=["OUTSIDE"], is_global=True
+        )
+        assert result == {outside.id}
+
+
 class TestCRUD:
     async def test_create(self, db_session, make_unit, make_carbon_report):
         unit = await make_unit(db_session)
@@ -359,6 +485,53 @@ class TestGetReportingOverview:
         result = await repo.get_reporting_overview(years=[2024])
         assert result["total"] == 0
         assert result["data"] == []
+
+    async def test_scoped_overview_clamps_to_subtree(
+        self, db_session, make_unit, make_carbon_report
+    ):
+        anchor = await make_unit(
+            db_session,
+            institutional_code="12635",
+            institutional_id="13030",
+            name="ENAC",
+            level=2,
+            path_institutional_code="10582 12635",
+        )
+        leaf = await make_unit(
+            db_session,
+            institutional_code="14270",
+            institutional_id="13032",
+            name="ENAC-IT4R",
+            level=4,
+            path_institutional_code="10582 12635 11435 14270",
+        )
+        outside = await make_unit(
+            db_session,
+            institutional_code="99999",
+            institutional_id="88888",
+            name="OUTSIDE",
+            level=4,
+            path_institutional_code="10582 99999",
+        )
+        for u in (anchor, leaf, outside):
+            await make_carbon_report(db_session, unit_id=u.id, year=2024)
+        repo = CarbonReportModuleRepository(db_session)
+
+        result = await repo.get_reporting_overview(
+            years=[2024], is_global=False, scope_cfs={"13030"}
+        )
+        names = {row["unit_name"] for row in result["data"]}
+        assert names == {"ENAC", "ENAC-IT4R"}
+        assert "OUTSIDE" not in names
+
+        # An out-of-scope lvl4 filter intersects to empty.
+        empty = await repo.get_reporting_overview(
+            years=[2024],
+            path_lvl4=["OUTSIDE"],
+            is_global=False,
+            scope_cfs={"13030"},
+        )
+        assert empty["total"] == 0
 
     async def test_basic_overview(
         self, db_session, make_unit, make_user, make_carbon_report

--- a/backend/tests/unit/utils/test_scoping.py
+++ b/backend/tests/unit/utils/test_scoping.py
@@ -1,0 +1,63 @@
+"""Tests for SQL-level backoffice scoping predicates."""
+
+from sqlmodel import select
+
+from app.models.unit import Unit
+from app.utils.scoping import build_scope_subtree_predicate
+
+
+async def _enac_subtree(db_session, make_unit):
+    anchor = await make_unit(
+        db_session,
+        institutional_code="12635",
+        institutional_id="13030",
+        name="ENAC",
+        level=2,
+        path_institutional_code="10582 12635",
+    )
+    child = await make_unit(
+        db_session,
+        institutional_code="11435",
+        institutional_id="13031",
+        name="ENAC-SG",
+        level=3,
+        path_institutional_code="10582 12635 11435",
+    )
+    leaf = await make_unit(
+        db_session,
+        institutional_code="14270",
+        institutional_id="13032",
+        name="ENAC-IT4R",
+        level=4,
+        path_institutional_code="10582 12635 11435 14270",
+    )
+    outside = await make_unit(
+        db_session,
+        institutional_code="99999",
+        institutional_id="88888",
+        name="OUTSIDE",
+        level=2,
+        path_institutional_code="10582 99999",
+    )
+    return anchor, child, leaf, outside
+
+
+class TestBuildScopeSubtreePredicate:
+    async def test_matches_anchor_and_descendants_only(self, db_session, make_unit):
+        anchor, child, leaf, outside = await _enac_subtree(db_session, make_unit)
+        stmt = select(Unit).where(build_scope_subtree_predicate({"13030"}))
+        rows = (await db_session.exec(stmt)).all()
+        names = {u.name for u in rows}
+        assert names == {"ENAC", "ENAC-SG", "ENAC-IT4R"}
+        assert "OUTSIDE" not in names
+
+    async def test_composes_with_level_filter_for_dropdown(self, db_session, make_unit):
+        await _enac_subtree(db_session, make_unit)
+        # The /affiliations dropdown shows lvl2/3 within the scope subtree.
+        stmt = (
+            select(Unit)
+            .where(build_scope_subtree_predicate({"13030"}))
+            .where(Unit.level.in_([2, 3]))  # type: ignore[attr-defined]
+        )
+        names = {u.name for u in (await db_session.exec(stmt)).all()}
+        assert names == {"ENAC", "ENAC-SG"}

--- a/docs/code-review/862-copilot-feedback-fix-862-scope-backoffice-reporting-to-a-unit-cf-subtree-with-intersection-clamp.md
+++ b/docs/code-review/862-copilot-feedback-fix-862-scope-backoffice-reporting-to-a-unit-cf-subtree-with-intersection-clamp.md
@@ -1,0 +1,91 @@
+# Bot Review TODOs: PR #1387
+
+## Source Branch: `fix/862/correct-permissions-scope`
+
+## Raw Feedback
+
+### Summary Feedback (github-advanced-security)
+
+---
+
+### Summary Feedback (copilot-pull-request-reviewer)
+
+## Pull request overview
+
+This pull request fixes backoffice reporting scoping by treating the metier “affiliation” scope token as an ACCRED unit **cf** (`institutional_id`) and resolving it to a **unit subtree** via `path_institutional_code`, then enforcing an **intersection clamp** so scoped callers can never query outside their subtree.
+
+**Changes:**
+
+- Replace prior `path_name`/LVL3 affiliation logic with cf→institutional_code→descendant-subtree resolution and apply `scope_set ∩ filter_set` across backoffice reporting queries.
+- Thread `(is_global, scope_cfs)` through reporting repository methods and route handlers; remove the old list-narrowing approach.
+- Add/refresh unit + integration tests to cover fixture coherence, resolver behavior, and end-to-end scoping over real DB queries.
+
+**Review notes (blocking):**
+
+- `backend/app/utils/scoping.py` builds LIKE patterns with `func.concat(...)`. On SQLite (used by the new E2E tests in this PR), `concat()` is typically not available and can fail at runtime (“no such function: concat”). This should be rewritten using SQLAlchemy string concatenation (`+`) or SQLAlchemy’s `concat` expression helper to remain cross-dialect.
+
+### Reviewed changes
+
+Copilot reviewed 13 out of 13 changed files in this pull request and generated no comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File                                                                              | Description                                                                                                       |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| docs/src/implementation-plans/862-backoffice-affiliation-scope-by-unit-subtree.md | Adds delivered implementation plan documenting cf→subtree resolution and intersection invariant.                  |
+| docs/src/backend/06-PERMISSION-SYSTEM.md                                          | Updates permission-system docs to describe the new subtree-scoped backoffice.reporting model.                     |
+| backend/app/utils/scoping.py                                                      | Replaces `path_name` affiliation predicate with `build_scope_subtree_predicate` (EXISTS over code-subtree match). |
+| backend/app/repositories/carbon_report_module_repo.py                             | Adds scope cf→subtree resolver and applies scope/filter intersection clamp across report queries.                 |
+| backend/app/providers/role_provider.py                                            | Makes backoffice_metier affiliation token equal to ACCRED unit cf; removes sortpath/LVL3 extraction logic.        |
+| backend/app/api/v1/backoffice.py                                                  | Threads scope into reporting overview/exports; switches year query narrowing to subtree predicate.                |
+| backend/app/api/v1/backoffice_reporting.py                                        | Applies subtree predicate to `/backoffice-reporting/{units,affiliations}` listing queries.                        |
+| backend/app/providers/test_fixtures.py                                            | Rebuilds TEST units into a coherent ENAC subtree and sets `TEST_AFFILIATION` to the anchor cf.                    |
+| backend/tests/unit/utils/test_scoping.py                                          | Adds unit tests for the SQL-level subtree predicate composition.                                                  |
+| backend/tests/unit/repositories/test_carbon_report_module_repo.py                 | Adds unit tests for scope resolver + intersection invariant + scoped overview clamp.                              |
+| backend/tests/unit/providers/test_test_fixtures.py                                | Adds coherence tests ensuring TEST fixtures exercise a real scope subtree.                                        |
+| backend/tests/unit/providers/test_role_provider.py                                | Updates role-provider tests to assert metier scope is cf-based (no sortpath parsing).                             |
+| backend/tests/integration/v1/test_permission_scope_e2e.py                         | Replaces SQL-string-emulation mocks with real in-memory DB E2E coverage for backoffice scoping.                   |
+
+</details>
+
+---
+
+### File: `backend/tests/unit/utils/test_scoping.py` (Line 47) — github-advanced-security[bot]
+
+## CodeQL / Unused local variable
+
+Variable anchor is not used.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/677)
+
+### File: `backend/tests/unit/utils/test_scoping.py` (Line 47) — github-advanced-security[bot]
+
+## CodeQL / Unused local variable
+
+Variable child is not used.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/678)
+
+### File: `backend/tests/unit/utils/test_scoping.py` (Line 47) — github-advanced-security[bot]
+
+## CodeQL / Unused local variable
+
+Variable leaf is not used.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/679)
+
+### File: `backend/tests/unit/utils/test_scoping.py` (Line 47) — github-advanced-security[bot]
+
+## CodeQL / Unused local variable
+
+Variable outside is not used.
+
+## [Show more details](https://github.com/EPFL-ENAC/co2-calculator/security/code-scanning/680)
+
+## Action Items
+
+### Maintainability / refactoring
+
+- [ ] **backend/app/utils/scoping.py** — `build_scope_subtree_predicate` builds LIKE patterns with `func.concat(...)`, which renders a literal `concat()` call rather than the SQL-standard `||`. Fix: replace each `func.concat(a, b)` with string concatenation via the `+` operator (e.g. `col(anchor.institutional_code) + " %"`), which SQLAlchemy renders as `||` on both SQLite and Postgres. Bot got it wrong that this _currently_ fails — verified the test SQLite is 3.50.4 (has `concat()` since 3.44) and all E2E tests pass; this is a portability hardening, not a live bug.
+- [ ] **backend/tests/unit/utils/test_scoping.py** (line 47) — `test_matches_anchor_and_descendants_only` unpacks `anchor, child, leaf, outside` from `_enac_subtree(...)` but never references them (it asserts on query results), tripping four CodeQL unused-variable alerts. Fix: drop the unpacking — call `await _enac_subtree(db_session, make_unit)` without assignment (matching the sibling test at line 55).

--- a/docs/src/backend/06-PERMISSION-SYSTEM.md
+++ b/docs/src/backend/06-PERMISSION-SYSTEM.md
@@ -34,8 +34,11 @@ produces an auditable trail.
 
 The enforcement anchor is [#414 — Enforce permissions across all
 routes](https://github.com/EPFL-ENAC/co2-calculator/issues/414). Backoffice
-scoping by sub-perimeter is being refined under
-[#459](https://github.com/EPFL-ENAC/co2-calculator/issues/459).
+reporting is scoped to a unit subtree: the metier scope token is an ACCRED unit
+cf (`institutional_id`) at any level, resolved to that unit's descendants via
+`path_institutional_code` ([#862](https://github.com/EPFL-ENAC/co2-calculator/issues/862),
+superseding the earlier path_name/sub-perimeter approach of
+[#459](https://github.com/EPFL-ENAC/co2-calculator/issues/459)).
 
 ## Implementation plans and related issues
 
@@ -46,7 +49,8 @@ scoping by sub-perimeter is being refined under
 | [Professional travel permission conflict](../implementation-plans/archive/698-permission-conflict.md)                  | [#698](https://github.com/EPFL-ENAC/co2-calculator/issues/698) | Abandoned   | Standard user with `professional_travel.edit` wrongly redirected.                        |
 | [Tighten unit-scoped permission gates](../implementation-plans/977-tighten-unit-permission-gates.md)                   | [#977](https://github.com/EPFL-ENAC/co2-calculator/issues/977) | Delivered   | Unit gating for `carbon_report` + `unit_results`; drops the coarse `modules.*` fallback. |
 | [Update backoffice permissions](../implementation-plans/862-backoffice-update-permissions.md)                          | [#862](https://github.com/EPFL-ENAC/co2-calculator/issues/862) | In progress | Page-driven model: one permission per backoffice page; removes `system.users`.           |
-| [Backoffice ACCRED affiliation scoping](../implementation-plans/459-backoffice-accred-affiliation-scoping.md)          | [#459](https://github.com/EPFL-ENAC/co2-calculator/issues/459) | In progress | Scope `backoffice.*` by ACCRED sub-perimeter (LVL3).                                     |
+| [Backoffice ACCRED affiliation scoping](../implementation-plans/459-backoffice-accred-affiliation-scoping.md)          | [#459](https://github.com/EPFL-ENAC/co2-calculator/issues/459) | Superseded  | Scope `backoffice.*` by ACCRED sub-perimeter; path_name approach replaced by #862.       |
+| [Affiliation scope by unit subtree](../implementation-plans/862-backoffice-affiliation-scope-by-unit-subtree.md)       | [#862](https://github.com/EPFL-ENAC/co2-calculator/issues/862) | Delivered   | Scope `backoffice.reporting` to a unit-cf subtree; `scope ∩ (affiliation ∪ lvl4)` clamp. |
 
 ## Files handling permissions
 
@@ -57,7 +61,8 @@ Core authorization infrastructure:
 - `app/models/user.py` — `RoleName` enum, User model, and `calculate_user_permissions()`.
 - `app/schemas/user.py` — `UserRead` with the `@computed_field` `permissions`.
 - `app/utils/permissions.py` — runtime check `has_permission()` and `derive_backoffice_affiliations()`.
-- `app/utils/scoping.py` — affiliation gate `gate_backoffice()` and SQL predicate helpers.
+- `app/utils/scoping.py` — affiliation gate `gate_backoffice()` and the
+  `build_scope_subtree_predicate()` unit-subtree SQL predicate.
 - `app/core/security.py` — `require_permission()` route decorator and `is_permitted()`.
 - `app/core/policy.py` — in-code policy evaluation (`query_policy`, resource access).
 - `app/services/authorization_service.py` — `get_data_filters()`, `check_resource_access()`.
@@ -185,7 +190,9 @@ key:
 
 - Principal grants are unit-scoped — `modules.X/<unit>`.
 - Standard-user grants are own-scoped — `modules.X/<unit>/own`.
-- `backoffice.reporting` is affiliation-scoped for metier — `/<aff>` (#459).
+- `backoffice.reporting` is affiliation-scoped for metier — `/<cf>`, where
+  `<cf>` is the granted unit's `institutional_id` at any level; the query
+  resolves it to that unit's subtree (#862).
 - All other `backoffice.*` keys are bare (global).
 
 > **Unit-level module operations** (e.g. PATCH a module's validation status)
@@ -196,12 +203,12 @@ key:
 
 ### Scope summary
 
-| Role                       | Scope       | Notes                                                                               |
-| -------------------------- | ----------- | ----------------------------------------------------------------------------------- |
-| `calco2.superadmin`        | Global      | Every `backoffice.*` page (bare keys); **no `modules.*` grants**                    |
-| `calco2.backoffice.metier` | Affiliation | `backoffice.reporting/<aff>` (scoped) + scope-less users / documentation / ui_texts |
-| `calco2.user.principal`    | Unit        | `view, edit, sync` on every `modules.X/<unit>` for assigned units                   |
-| `calco2.user.standard`     | Own         | `view, edit` on `modules.{professional_travel,external_cloud_and_ai}/<unit>/own`    |
+| Role                       | Scope       | Notes                                                                                           |
+| -------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| `calco2.superadmin`        | Global      | Every `backoffice.*` page (bare keys); **no `modules.*` grants**                                |
+| `calco2.backoffice.metier` | Affiliation | `backoffice.reporting/<cf>` (unit-subtree scoped) + scope-less users / documentation / ui_texts |
+| `calco2.user.principal`    | Unit        | `view, edit, sync` on every `modules.X/<unit>` for assigned units                               |
+| `calco2.user.standard`     | Own         | `view, edit` on `modules.{professional_travel,external_cloud_and_ai}/<unit>/own`                |
 
 ## How permissions are computed
 
@@ -222,7 +229,8 @@ Permissions are computed in-memory. No database writes occur.
 with a **list of action strings** as the value. Module paths carry an explicit
 scope suffix — `/<institutional_id>` (unit, principal) or
 `/<institutional_id>/own` (own, standard user); `backoffice.*` keys are bare
-except `backoffice.reporting/<aff>` for an affiliation-scoped metier.
+except `backoffice.reporting/<cf>` for an affiliation-scoped metier (the cf is
+resolved to a unit subtree at query time).
 
 ```json
 {
@@ -409,8 +417,9 @@ Use it for conditional rendering or to disable buttons. Backend
 - Integration: verify scope filtering with `standard / principal / superadmin`
   fixtures.
 - Update the [matrix](#role-permission-matrix) row, the route docstring, and
-  any changelog/ADR. Mention scope intent (global / unit / own) so reviewers
-  can match the grant against issue #459's sub-perimeter work.
+  any changelog/ADR. Mention scope intent (global / unit / own / affiliation)
+  so reviewers can match the grant against the backoffice subtree-scoping
+  work (#862).
 
 ## Audit trail
 

--- a/docs/src/implementation-plans/862-backoffice-affiliation-scope-by-unit-subtree.md
+++ b/docs/src/implementation-plans/862-backoffice-affiliation-scope-by-unit-subtree.md
@@ -1,0 +1,116 @@
+---
+status: delivered
+issue: 862
+last_updated: 2026-06-03
+title: "Backoffice affiliation scope by unit subtree (cf-anchored, intersection clamp)"
+summary: "Resolve backoffice.reporting affiliation scope from a single ACCRED unit cf (any level) into a descendant unit-id set via path_institutional_code, and clamp every backoffice query by intersecting the scope set with the endpoint filter set. Replaces path_name substring matching and list-narrowing."
+---
+
+## Context
+
+`backoffice.reporting` is affiliation-scoped for the metier role and global for
+superadmin. The scope token now comes straight from ACCRED as the authorized
+unit's **cf** (`institutional_id`) at **any** hierarchy level — see
+[role-scope-explicit-own-unit](role-scope-explicit-own-unit.md) and
+[862-backoffice-update-permissions](862-backoffice-update-permissions.md). For
+example cf `12000` is ENAC, sitting in path `EPFL ENAC ENAC-SG ENAC-IT4R`.
+
+Two defects motivated this plan:
+
+1. **Scope never resolves to units.** The reporting query resolves the
+   affiliation filter through `_get_selected_units` (matches `Unit.name`/`Unit.id`),
+   but the scope token is a cf. The TEST fixtures made this invisible:
+   `TEST_AFFILIATION = "testaffiliation"` matches no unit name _or_ path, so a
+   backoffice_metier user sees an empty reporting page. No test exercised the
+   scope-token → units path positively, so nothing caught it.
+2. **Wrong composition.** Filters were OR'd and scope was applied by narrowing
+   the affiliation _list_ (`narrow_path_affiliation`), not by intersecting unit
+   sets. A scoped caller could request a lvl4 unit outside their subtree and
+   still get rows.
+
+## Target model
+
+### Scope resolution (cf → subtree)
+
+The scope token is a `Unit.institutional_id` (cf). Resolve it to a concrete
+unit-id set:
+
+1. `institutional_code(s) ← SELECT institutional_code WHERE institutional_id IN tokens`
+2. `scope_set ← unit ids whose path_institutional_code token-matches any code (incl. self)`
+
+`path_institutional_code` is the indexed, self-inclusive query path
+(`" ".join(ancestors + [self])`); `path_institutional_id` (cf path) is nullable
+and "not queried" — do **not** match on it. This reuses the existing
+token-boundary matching in `_get_descendant_unit_ids`; only the resolver
+(cf → code, vs name/id → code) is new.
+
+Scope is "a unit at any level," full stop. There is no fixed affiliation level.
+`AFFILIATION_LEVEL` and the sortpath-splitting block in `role_provider.py` are
+**dead** and removed.
+
+### Composition (the security invariant)
+
+```
+filter_set = descendants(path_affiliation) ∪ direct(path_lvl4)   # None if no endpoint filters
+scope_set  = descendants(scope cf tokens)                        # for scoped callers
+```
+
+| Caller              | Endpoint filters | Effective unit-id set    |
+| ------------------- | ---------------- | ------------------------ |
+| global (superadmin) | none             | `None` → all units       |
+| global              | present          | `filter_set`             |
+| scoped (metier)     | none             | `scope_set`              |
+| scoped              | present          | `scope_set ∩ filter_set` |
+
+**Invariant:** a scoped caller never resolves to `None`. `None` means "no
+constraint" and would leak all units; a scoped caller must always produce a
+concrete set (possibly empty). `set()` flows to `WHERE id IN ()` → zero rows.
+Filters keep OR semantics among themselves; the scope is an AND clamp on top —
+matching `scope ∩ ((aff_A ∪ aff_B) ∪ (lvl4_X ∪ lvl4_Y))`.
+
+### Dropdowns (UX, not security)
+
+`/affiliations` and `/units` lists show, for a scoped caller, only units within
+the scope subtree (descendants-or-self of the scope unit), filtered to lvl2/3
+for `/affiliations`. If the scope is lvl4, `/affiliations` is empty — acceptable,
+since the reporting clamp still exposes the unit's own data. Superadmin sees all.
+This replaces the `path_name` ILIKE predicate with a `path_institutional_code`
+subtree predicate derived from the scope cf(s).
+
+## Touchpoints (each staged with a test)
+
+| File                                                                    | Change                                                                                                                                                                                                          |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app/providers/role_provider.py`                                        | Remove dead `AFFILIATION_LEVEL` + commented sortpath block; keep `AffiliationScope(affiliation=cf)`                                                                                                             |
+| `app/repositories/carbon_report_module_repo.py`                         | New cf→subtree scope resolver; `_resolve_hierarchy_unit_ids` takes scope and applies `scope_set ∩ filter_set` with the invariant above                                                                          |
+| `app/utils/scoping.py`                                                  | Add code-subtree predicate from scope cf(s); remove `build_affiliation_predicate` (path_name) and `narrow_path_affiliation` once call sites migrate                                                             |
+| `app/api/v1/backoffice.py` (×3: `/units`, usage export, results export) | Pass `is_global` + scope cf(s) to the repo clamp; drop `narrow_path_affiliation`                                                                                                                                |
+| `app/api/v1/backoffice_reporting.py` (×2: `/affiliations`, `/units`)    | Replace `build_affiliation_predicate` with the code-subtree predicate                                                                                                                                           |
+| `app/providers/test_fixtures.py`                                        | Rebuild TEST_UNITS as a coherent hierarchy: an anchor unit with a cf, whose `institutional_code` appears as a token in its own and every descendant's `path_institutional_code`; `TEST_AFFILIATION` = anchor cf |
+
+`gate_backoffice` / `derive_backoffice_affiliations` are unchanged — the cf is an
+opaque sub-perimeter token in the `backoffice.reporting/<cf>` key.
+
+## Tests
+
+- **Fixture coherence:** `TEST_AFFILIATION` resolves to ≥1 TEST unit _by the rule
+  the query uses_ (cf → code → `path_institutional_code` match). Fails today;
+  would have caught the original bug.
+- **Scope resolver:** cf token → expected descendant ids (incl. self) via
+  `path_institutional_code`; cf with no matching unit → empty set (logged, not "all").
+- **Invariant matrix (the regression guard):** the four rows above, asserting a
+  scoped caller is never `None`; scoped + out-of-scope lvl4 filter → `{}`;
+  superadmin + filters → `filter_set`; two affiliations in one facet → union.
+- **Dropdown:** scoped caller sees only lvl2/3 within the scope subtree;
+  superadmin sees all.
+- **Endpoint integration:** real-DB E2E in `test_permission_scope_e2e.py` (seeded
+  ENAC/STI subtrees) pin the route wiring — scoped caller sees only its subtree on
+  `/backoffice-reporting/units`, `/affiliations`, and `/backoffice/years`;
+  cross-affiliation scope → empty; superadmin → all. (Replaced the prior
+  SQL-string-emulation mocks, which tested the mock, not the query.)
+
+## Out of scope
+
+Role rename (`calco2.superadmin` → `calco2.backoffice.admin`) and the broader
+page-driven permission shape, both covered by
+[862-backoffice-update-permissions](862-backoffice-update-permissions.md).


### PR DESCRIPTION
## Why

A backoffice_metier user saw an **empty reporting page**. The scope token is an ACCRED unit **cf** (`institutional_id`), but the reporting query resolved the affiliation filter by `Unit.name`/`Unit.id` — so the cf matched nothing. The TEST fixtures hid it (`TEST_AFFILIATION = "testaffiliation"` matched no unit name or path), and **no test exercised the scope-token → units path**, so nothing caught it.

Two defects:
1. **Scope never resolved to units** — cf token vs name/id resolution mismatch.
2. **Wrong composition** — filters were OR'd and scope applied by narrowing the affiliation *list*, not by intersecting unit sets, so a scoped caller could reach a lvl4 unit outside their subtree.

## What

The scope token is an ACCRED unit cf at **any** level. Resolve it `cf → institutional_code → descendant subtree` via the indexed, self-inclusive `path_institutional_code`, and clamp every backoffice query with the invariant:

```
scope ∩ ( (aff_A ∪ aff_B) ∪ (lvl4_X ∪ lvl4_Y) )
```

A scoped caller **never** resolves to `None` (which would leak all units) — always a concrete, possibly-empty set.

| Caller | Filters | Effective set |
| --- | --- | --- |
| superadmin (global) | none | all units |
| superadmin | present | filter_set |
| metier (scoped) | none | scope_set |
| metier | present | scope_set ∩ filter_set |

### Changes
- **role_provider**: removed dead `AFFILIATION_LEVEL` + sortpath block; affiliation = cf.
- **repo**: `_get_scope_unit_ids` (cf→code→subtree); intersection clamp in `_resolve_hierarchy_unit_ids`; threaded `is_global`/`scope_cfs` through all four report methods.
- **scoping**: new `build_scope_subtree_predicate` (pure-SQL EXISTS); removed `build_affiliation_predicate` (path_name) and `narrow_path_affiliation`.
- **fixtures**: coherent ENAC subtree; `TEST_AFFILIATION` = anchor cf.
- **docs**: delivered plan + `06-PERMISSION-SYSTEM.md` update.

## Tests (TDD)
- Fixture coherence (the originally-missing test), cf→subtree resolver, the 4-case invariant matrix, and `get_reporting_overview` scoped clamp — all real-DB.
- Replaced the SQL-string-emulation mocks in `test_permission_scope_e2e.py` with real-DB E2E over `/backoffice/units` (the origin endpoint), `/backoffice-reporting/{units,affiliations}`, and `/backoffice/years`.
- 1581 unit + 27 e2e pass; `mypy app/` clean; ruff/prettier clean. The 4 `data_ingestion` `_pg` failures are pre-existing (verified on the clean tree, unrelated domain).