### PR TITLE
feat/1365 headcount update

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -294,7 +294,7 @@ async def get_module(
         )
         member_stats: dict = await DataEntryService(db).get_stats(
             carbon_report_module_id=carbon_report_module_id,
-            aggregate_by="position_category",
+            aggregate_by="sius_code",
             aggregate_field="fte",
             data_entry_type_id=DataEntryTypeEnum.member.value,
         )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -179,15 +179,6 @@ def calculate_user_permissions(roles: List[Role]) -> dict:
                     permissions.get("backoffice.ui_texts"),
                     ["view", "edit"],
                 )
-                # to be removed later on when new right is available
-                permissions["backoffice.configuration"] = merge_actions(
-                    permissions.get("backoffice.configuration"), ["view", "edit"]
-                )
-                permissions["backoffice.pipeline_operations"] = merge_actions(
-                    permissions.get("backoffice.pipeline_operations"),
-                    ["view", "edit"],
-                )
-
         # USER ROLES - Only affect modules.* permissions
         elif role_name == RoleName.CO2_USER_PRINCIPAL.value:
             # Principal is unit-scoped: full module access across the unit.

--- a/backend/app/modules/headcount/schemas.py
+++ b/backend/app/modules/headcount/schemas.py
@@ -26,22 +26,12 @@ from app.schemas.factor import (
 
 logger = get_logger(__name__)
 
-POSITION_CATEGORY_VALUES = {
-    "professor",
-    "scientific_collaborator",
-    "postdoctoral_assistant",
-    "doctoral_assistant",
-    "trainee",
-    "technical_administrative_staff",
-    "student",
-    "other",
-}
+SIUS_CODE_VALUES = {"51", "52", "53", "54", "56", "57", "58", "59"}
 
 
 class HeadcountItemResponse(DataEntryResponseGen):
     name: str
-    position_title: Optional[str] = None
-    position_category: Optional[str] = None
+    sius_code: Optional[str] = None
     fte: Optional[float] = None
     user_institutional_id: Optional[str] = None
     note: Optional[str] = None
@@ -53,8 +43,7 @@ class HeadCountStudentResponse(DataEntryResponseGen):
 
 class HeadCountCreate(DataEntryCreate):
     name: str
-    position_title: Optional[str] = None
-    position_category: Optional[str] = None
+    sius_code: str
     fte: Optional[float] = None
     user_institutional_id: str
     note: Optional[str] = None
@@ -75,14 +64,12 @@ class HeadCountCreate(DataEntryCreate):
             raise ValueError("FTE must be at least 0")
         return v
 
-    @field_validator("position_category", mode="after")
+    @field_validator("sius_code", mode="after")
     @classmethod
-    def validate_position_category(cls, v: Optional[str]) -> Optional[str]:
-        if v is None:
-            return v
-        if v not in POSITION_CATEGORY_VALUES:
-            allowed_values = ", ".join(sorted(POSITION_CATEGORY_VALUES))
-            raise ValueError(f"position_category must be one of: {allowed_values}")
+    def validate_sius_code(cls, v: str) -> str:
+        if v not in SIUS_CODE_VALUES:
+            allowed_values = ", ".join(sorted(SIUS_CODE_VALUES))
+            raise ValueError(f"sius_code must be one of: {allowed_values}")
         return v
 
 
@@ -112,8 +99,7 @@ class HeadCountStudentUpdate(DataEntryUpdate):
 
 class HeadCountUpdate(DataEntryUpdate):
     name: Optional[str] = None
-    position_title: Optional[str] = None
-    position_category: Optional[str] = None
+    sius_code: Optional[str] = None
     fte: Optional[float] = None
     note: Optional[str] = None
 
@@ -128,14 +114,14 @@ class HeadCountUpdate(DataEntryUpdate):
             raise ValueError("FTE must be at least 0")
         return v
 
-    @field_validator("position_category", mode="after")
+    @field_validator("sius_code", mode="after")
     @classmethod
-    def validate_position_category(cls, v: Optional[str]) -> Optional[str]:
+    def validate_sius_code(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v
-        if v not in POSITION_CATEGORY_VALUES:
-            allowed_values = ", ".join(sorted(POSITION_CATEGORY_VALUES))
-            raise ValueError(f"position_category must be one of: {allowed_values}")
+        if v not in SIUS_CODE_VALUES:
+            allowed_values = ", ".join(sorted(SIUS_CODE_VALUES))
+            raise ValueError(f"sius_code must be one of: {allowed_values}")
         return v
 
 
@@ -157,21 +143,15 @@ class HeadcountMemberModuleHandler(BaseModuleHandler):
     subkind_field = None
     require_subkind_for_factor = False
     require_factor_to_match = False
-    default_where: list = [
-        DataEntry.data["position_category"].as_string().is_(None)
-        | (DataEntry.data["position_category"].as_string() != "student")
-    ]
+    default_where: list = []
     filter_map: dict[str, Any] = {
         "name": DataEntry.data["name"].as_string(),
-        "position_title": DataEntry.data["position_title"].as_string(),
-        "position_category": DataEntry.data["position_category"].as_string(),
+        "sius_code": DataEntry.data["sius_code"].as_string(),
     }
     sort_map = {
         "id": DataEntry.id,
         "name": DataEntry.data["name"].as_string(),
-        "position_title": DataEntry.data["position_title"].as_string(),
-        "position_category": DataEntry.data["position_category"].as_string(),
-        "fte": DataEntry.data["fte"].as_float(),
+        "sius_code": DataEntry.data["sius_code"].as_string(),
     }
 
     def resolve_computations(

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -42,7 +42,7 @@ from app.modules.buildings.schemas import (
     BuildingEmbodiedEnergyHandlerCreate,
 )
 from app.modules.external_cloud_and_ai.schemas import REQUESTS_FREQUENCY_OPTIONS
-from app.modules.headcount.schemas import POSITION_CATEGORY_VALUES
+from app.modules.headcount.schemas import SIUS_CODE_VALUES
 from app.seed.seed_helper import versionapi
 
 fake = Faker()
@@ -311,10 +311,7 @@ def build_external_ai() -> dict:
 def build_headcount() -> dict:
     return {
         "name": fake.name(),
-        "position_title": maybe(fake.job()),
-        "position_category": maybe(
-            random.choice(sorted(POSITION_CATEGORY_VALUES)),  # nosec B311
-        ),
+        "sius_code": random.choice(sorted(SIUS_CODE_VALUES)),  # nosec B311
         "fte": maybe(round(random.uniform(0.1, 1.0), 2)),  # nosec B311
         # user_institutional_id is required (non-Optional) on the create DTO.
         "user_institutional_id": _user_institutional_id(),

--- a/backend/tests/integration/data_ingestion/test_csv_validation.py
+++ b/backend/tests/integration/data_ingestion/test_csv_validation.py
@@ -26,14 +26,14 @@ class TestCSVValidationErrors:
         provider = ModulePerYearCSVProvider(config, data_session=mock_session)
 
         # Empty CSV (headers only)
-        csv_text = "unit_institutional_id,name,position_category\n"
+        csv_text = "unit_institutional_id,name,function\n"
 
         # Should fail with specific error message
         with pytest.raises(ValueError, match="CSV file is empty"):
             await provider._validate_csv_headers(
                 csv_text,
-                expected_columns={"unit_institutional_id", "name", "position_category"},
-                required_columns={"unit_institutional_id", "name", "position_category"},
+                expected_columns={"unit_institutional_id", "name", "sius_code"},
+                required_columns={"unit_institutional_id", "name", "sius_code"},
             )
 
     @pytest.mark.asyncio
@@ -48,15 +48,15 @@ class TestCSVValidationErrors:
         mock_session = AsyncMock()
         provider = ModulePerYearCSVProvider(config, data_session=mock_session)
 
-        # CSV missing required column (position_category)
+        # CSV missing required column (function)
         csv_text = "unit_institutional_id,name\nUNIT001,John Doe\n"
 
         # Should fail with specific error message
         with pytest.raises(ValueError, match="missing required columns"):
             await provider._validate_csv_headers(
                 csv_text,
-                expected_columns={"unit_institutional_id", "name", "position_category"},
-                required_columns={"unit_institutional_id", "name", "position_category"},
+                expected_columns={"unit_institutional_id", "name", "sius_code"},
+                required_columns={"unit_institutional_id", "name", "sius_code"},
             )
 
 

--- a/backend/tests/integration/services/data_ingestion/test_headcount_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_headcount_pg.py
@@ -227,7 +227,7 @@ async def test_headcount_member_csv_no_factors_persists_entries_without_emission
             "name": f"Member {i}",
             "user_institutional_id": f"M-{i:03d}",
             "fte": fte,
-            "position_category": "professor",
+            "sius_code": "51",
         }
         for i, fte in enumerate([1.0, 0.8, 0.5], start=1)
     ]
@@ -342,7 +342,7 @@ async def test_headcount_member_csv_with_factors_produces_fte_weighted_stats(
             "name": f"Member {i}",
             "user_institutional_id": f"M-{i:03d}",
             "fte": fte,
-            "position_category": "professor",
+            "sius_code": "51",
         }
         for i, fte in enumerate(ftes, start=1)
     ]
@@ -570,7 +570,7 @@ async def test_headcount_member_reupload_with_new_ftes_refreshes_stats(
             "name": f"Member {i}",
             "user_institutional_id": f"M-{i:03d}",
             "fte": fte,
-            "position_category": "professor",
+            "sius_code": "51",
         }
         for i, fte in enumerate(initial_ftes, start=1)
     ]

--- a/backend/tests/integration/services/data_ingestion/test_reupload_semantics_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_reupload_semantics_pg.py
@@ -81,8 +81,8 @@ from .conftest import (
 # --------------------------------------------------------------------------- #
 # CSV builders — minimal headcount.member rows shaped so the real provider   #
 # accepts them: ``unit_institutional_id`` ties to a seeded Unit, the columns #
-# match ``HeadCountCreate``'s field set, and ``position_category`` is in     #
-# ``POSITION_CATEGORY_VALUES``.                                              #
+# match ``HeadCountCreate``'s field set, and ``sius_code`` is in             #
+# ``SIUS_CODE_VALUES``.                                                       #
 # --------------------------------------------------------------------------- #
 
 
@@ -98,7 +98,7 @@ def _csv_with_unit_column(
     Layout (one column-list, one branch on the optional ``kg_co2eq``
     override column):
 
-        unit_institutional_id,name,position_title,position_category,
+        unit_institutional_id,name,function,
         user_institutional_id,fte,note[,kg_co2eq]
 
     Every row is the same unit + a different (name, uid) pair so the
@@ -108,8 +108,7 @@ def _csv_with_unit_column(
     header_cols = [
         "unit_institutional_id",
         "name",
-        "position_title",
-        "position_category",
+        "sius_code",
         "user_institutional_id",
         "fte",
         "note",
@@ -121,8 +120,7 @@ def _csv_with_unit_column(
         cols = [
             unit_institutional_id,
             name,
-            "Adjoint",
-            "professor",
+            "51",
             user_uid,
             "0.50",
             "",

--- a/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
@@ -556,7 +556,7 @@ async def test_headcount_member_factor_values_change_propagates(pg_dsn):
                 "name": "Alice",
                 "user_institutional_id": "M-001",
                 "fte": 1.0,
-                "position_category": "professor",
+                "sius_code": "51",
             },
         )
         s.add(entry)

--- a/backend/tests/unit/modules/test_headcount_schemas.py
+++ b/backend/tests/unit/modules/test_headcount_schemas.py
@@ -12,35 +12,36 @@ def _base_create_payload() -> dict:
     }
 
 
-def test_headcount_create_accepts_valid_position_category() -> None:
+def test_headcount_create_accepts_valid_sius_code() -> None:
     item = HeadCountCreate(
         **_base_create_payload(),
         name="Alice",
-        position_category="professor",
+        sius_code="51",
         user_institutional_id="12345",
     )
-    assert item.position_category == "professor"
+    assert item.sius_code == "51"
 
 
-def test_headcount_create_rejects_invalid_position_category() -> None:
+def test_headcount_create_rejects_invalid_sius_code() -> None:
     with pytest.raises(ValidationError):
         HeadCountCreate(
             **_base_create_payload(),
             name="Alice",
-            position_category="invalid_category",
+            sius_code="invalid_category",
+            user_institutional_id="12345",
         )
 
 
-def test_headcount_update_accepts_valid_position_category() -> None:
-    item = HeadCountUpdate(**_base_create_payload(), position_category="student")
-    assert item.position_category == "student"
+def test_headcount_update_accepts_valid_sius_code() -> None:
+    item = HeadCountUpdate(**_base_create_payload(), sius_code="54")
+    assert item.sius_code == "54"
 
 
-def test_headcount_update_rejects_invalid_position_category() -> None:
+def test_headcount_update_rejects_invalid_sius_code() -> None:
     with pytest.raises(ValidationError):
         HeadCountUpdate(
             **_base_create_payload(),
-            position_category="invalid_category",
+            sius_code="invalid_category",
         )
 
 
@@ -48,6 +49,7 @@ def test_headcount_create_accepts_numeric_user_institutional_id() -> None:
     item = HeadCountCreate(
         **_base_create_payload(),
         name="Alice",
+        sius_code="51",
         user_institutional_id="12345",
     )
     assert item.user_institutional_id == "12345"
@@ -57,6 +59,7 @@ def test_headcount_create_strips_whitespace_in_user_institutional_id() -> None:
     item = HeadCountCreate(
         **_base_create_payload(),
         name="Alice",
+        sius_code="51",
         user_institutional_id=" 12345 ",
     )
     assert item.user_institutional_id == "12345"

--- a/frontend/src/components/molecules/HeadCountBarChart.vue
+++ b/frontend/src/components/molecules/HeadCountBarChart.vue
@@ -109,7 +109,7 @@ const chartOptions = computed<EChartsOption>(() => {
     dataset: {
       dimensions: ['category', 'value'],
       source: keys.map((key) => ({
-        category: te(`headcount_${key}`) ? t(`headcount_${key}`) : key,
+        category: te(key) ? t(key) : key,
         value: Math.round((props.stats?.[key] ?? 0) * 10) / 10,
       })),
     },

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -17,8 +17,8 @@ export const iconMap: Record<string, string> = {
   // Add more mappings as needed
 };
 
-// EN : Name | Position | Full-Time Equivalent (FTE)
-// FR : Nom | Position | Équivalent plein-temps (EPT)
+// EN : Name | Function | Full-Time Equivalent (FTE)
+// FR : Nom | Fonction | Équivalent plein-temps (EPT)
 const memberFields: ModuleField[] = [
   {
     id: 'name',
@@ -31,40 +31,27 @@ const memberFields: ModuleField[] = [
     columnSize: 'sm',
   },
   {
-    id: 'position_category',
-    labelKey: 'headcount-member-form-field-position-category-label',
+    id: 'sius_code',
+    labelKey: 'headcount-member-form-field-function-label',
     type: 'select',
     sortable: true,
     required: true,
-    requiredMessageKey: 'headcount-member-position-category-required',
+    requiredMessageKey: 'headcount-member-function-required',
     editableInline: true,
     ratio: '1/4',
     icon: 'o_assignment_ind',
     optionLabelsAreKeys: true,
     columnSize: 'sm',
     options: [
-      { value: 'professor', label: 'headcount_professor' },
-      {
-        value: 'scientific_collaborator',
-        label: 'headcount_scientific_collaborator',
-      },
-      {
-        value: 'postdoctoral_assistant',
-        label: 'headcount_postdoctoral_assistant',
-      },
-      {
-        value: 'doctoral_assistant',
-        label: 'headcount_doctoral_assistant',
-      },
-      { value: 'trainee', label: 'headcount_trainee' },
-      {
-        value: 'technical_administrative_staff',
-        label: 'headcount_technical_administrative_staff',
-      },
-      { value: 'other', label: 'headcount_other' },
+      { value: '51', label: '51' },
+      { value: '52', label: '52' },
+      { value: '53', label: '53' },
+      { value: '54', label: '54' },
+      { value: '56', label: '56' },
+      { value: '57', label: '57' },
+      { value: '58', label: '58' },
+      { value: '59', label: '59' },
     ],
-    readOnlyWhen: { fieldId: 'position_title', hasValue: true },
-    readOnlyDisplayField: 'position_title',
   },
   {
     id: 'user_institutional_id',
@@ -82,7 +69,7 @@ const memberFields: ModuleField[] = [
     min: 0,
     max: 1,
     step: 0.1,
-    sortable: true,
+    sortable: false,
     editableInline: true,
     ratio: '1/4',
     icon: 'o_timer',
@@ -139,8 +126,7 @@ export const headcount: ModuleConfig = {
       hasFormTooltip: false,
       csvTemplateHeaders: [
         'name',
-        'position_title',
-        'position_category',
+        'sius_code',
         'user_institutional_id',
         'fte',
         'note',

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -48,8 +48,8 @@ export default {
     fr: 'En raison des règles de protection des données, les noms des étudiant·es et les EPT individuels ne sont pas affichés automatiquement.',
   },
   [`${MODULES.Headcount}-charts-title`]: {
-    en: 'FTE per position',
-    fr: 'EPT par poste',
+    en: 'FTE per function',
+    fr: 'EPT par fonction',
   },
   [`${MODULES.Headcount}-charts-no-data-message`]: {
     en: 'No data available for FTE per position.',
@@ -78,13 +78,9 @@ export default {
     en: 'Full-Time Equivalent (FTE)',
     fr: 'Équivalent plein-temps (EPT)',
   },
-  [`${MODULES.Headcount}-member-form-field-position-label`]: {
-    en: 'Position',
-    fr: 'Position',
-  },
-  [`${MODULES.Headcount}-member-form-field-position-category-label`]: {
-    en: 'Position',
-    fr: 'Position',
+  [`${MODULES.Headcount}-member-form-field-function-label`]: {
+    en: 'Function',
+    fr: 'Fonction',
   },
   [`${MODULES.Headcount}-member-form-field-name-label`]: {
     en: 'Name',
@@ -129,9 +125,9 @@ export default {
     en: 'lorem ipsum',
     fr: 'Texte d’exemple',
   },
-  'headcount-member-position-category-required': {
-    en: 'Position is required',
-    fr: 'La position est obligatoire',
+  'headcount-member-function-required': {
+    en: 'Function is required',
+    fr: 'La fonction est obligatoire',
   },
   'headcount-member-error-duplicate-uid': {
     en: "This user's {label} already exists.",

--- a/frontend/src/i18n/headcount_factor.ts
+++ b/frontend/src/i18n/headcount_factor.ts
@@ -1,0 +1,34 @@
+export default {
+  '51': {
+    fr: 'Enseignant·e·s habilité·e·s à diriger une unité organisationnelle',
+    en: 'Professors',
+  },
+  '52': {
+    fr: 'Autres enseignant·e·s',
+    en: 'Other teaching staff',
+  },
+  '53': {
+    fr: 'Collaborateur·trices scientifiques',
+    en: 'Scientific collaborators',
+  },
+  '54': {
+    fr: 'Assistant·e·s et/ou doctorant·e·s',
+    en: 'Scientific and doctoral assistants',
+  },
+  '56': {
+    fr: 'Personnel de direction de la haute école',
+    en: 'Managerial staff',
+  },
+  '57': {
+    fr: 'Personnel administratif',
+    en: 'Administrative staff',
+  },
+  '58': {
+    fr: 'Personnel de soutien',
+    en: 'Support staff',
+  },
+  '59': {
+    fr: "Personnel d'exploitation",
+    en: 'Operational staff',
+  },
+} as const;


### PR DESCRIPTION
## What does this change?
Replaces the headcount `position_category` / `position_title` fields with `sius_code` (EPFL SIUS function codes 51–59) across the full stack.

**Backend:**
- `schemas.py` (headcount): replaces `POSITION_CATEGORY_VALUES` with `SIUS_CODE_VALUES = {"51"…"59"}`; removes `position_title` and `position_category` from create/update/response DTOs; adds `sius_code` (mandatory on create, optional on update) with a validator; removes the `default_where` student filter and the stale `position_title`/`position_category` entries from `filter_map` and `sort_map`
- `carbon_report_module.py`: changes `aggregate_by` from `"position_category"` to `"sius_code"` for the headcount stats endpoint
- `seed_data_entries.py`: switches from `POSITION_CATEGORY_VALUES` / `position_title` / `position_category` to `SIUS_CODE_VALUES` / `sius_code`
- Tests: updates all headcount fixtures from `position_category: "professor"` to `sius_code: "51"`; renames schema unit tests accordingly; fixes CSV builder in reupload semantics tests

**Frontend:**
- `headcount.ts` (module config): replaces the `position_category` select field with `sius_code`; options are now the eight numeric codes with `optionLabelsAreKeys: true` (resolved via `headcount_factor.ts`); removes the `readOnlyWhen` / `readOnlyDisplayField` logic tied to `position_title`; updates CSV template headers
- `headcount_factor.ts` (new i18n file): maps each SIUS code to its FR/EN label
- `headcount.ts` (i18n): renames label keys from `position-category` to `function`; updates chart title to "FTE per function"; adds `headcount-member-function-required`
- `HeadCountBarChart.vue`: changes i18n key lookup from `headcount_${key}` to `key` directly so SIUS codes resolve through `headcount_factor.ts`

## Why is this needed?
The headcount module was using a free-form `position_category` enum that doesn't map to EPFL's official SIUS function classification. Migrating to SIUS codes enables accurate FTE-per-function charts and aligns the data model with the institutional source.

## Type of change
- [x] ✨ New feature
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1365