### PR TITLE
feat/946 feat travel display traveller

### DIFF
--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -42,8 +42,8 @@ export default {
     fr: 'Distance (km)',
   },
   [`${MODULES.ProfessionalTravel}-field-traveler`]: {
-    en: 'Traveler',
-    fr: 'Voyageur',
+    en: 'Name',
+    fr: 'Nom',
   },
   [`${MODULES.ProfessionalTravel}-field-emissions`]: {
     en: 'kg CO₂-eq',


### PR DESCRIPTION
## What does this change?
Renames the `traveler` field label in the professional travel module from "Traveler / Voyageur" to "Name / Nom".

## Why is this needed?
The column header "Traveler" was inconsistent with the field label used in other modules (e.g. headcount uses "Name"). Using "Name" makes the UI more consistent and less ambiguous.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #946