### PR TITLE
feat: move UploadCardReferences before UploadCardData

### DIFF
--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -270,7 +270,13 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         @compute-factors="openComputedFactorConfirm"
         @abort="handleAbortPipeline"
       />
-
+      <UploadCardReferences
+        v-if="getImportRow(submodule).hasOtherUpload"
+        :row="getImportRow(submodule)"
+        :year="selectedYear"
+        @completed="handleReferenceCompleted"
+        @progressing="handleReferenceProgressing"
+      />
       <UploadCardData
         v-if="getImportRow(submodule).hasData"
         :row="getImportRow(submodule)"
@@ -285,13 +291,6 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         @upload="(row) => openDataEntryDialog(row, TargetType.DATA_ENTRIES)"
         @recalculate="() => triggerTypeRecalculation(submodule)"
         @abort="handleAbortPipeline"
-      />
-      <UploadCardReferences
-        v-if="getImportRow(submodule).hasOtherUpload"
-        :row="getImportRow(submodule)"
-        :year="selectedYear"
-        @completed="handleReferenceCompleted"
-        @progressing="handleReferenceProgressing"
       />
     </div>
 


### PR DESCRIPTION
## What does this change?
Reorders the upload cards in `SubmoduleItem.vue` so `UploadCardReferences` appears before `UploadCardData` instead of after.

## Why is this needed?
Reference files (e.g. building rooms reference, locations) must be uploaded before the corresponding data files for the import to resolve correctly. Having the reference card visually below the data card was confusing and implied the wrong upload order to users.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1385