### PR TITLE
feat 1382: respect auth when computing visible modules

### DIFF
--- a/frontend/src/components/organisms/module/ModuleNavigation.vue
+++ b/frontend/src/components/organisms/module/ModuleNavigation.vue
@@ -6,6 +6,7 @@ import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import { useTimelineStore } from 'src/stores/modules';
 import { MODULE_STATES } from 'src/constant/moduleStates';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import { useAuthStore } from 'src/stores/auth';
 
 const props = defineProps<{
   currentModule: Module;
@@ -14,9 +15,13 @@ const props = defineProps<{
 const $route = useRoute();
 const timelineStore = useTimelineStore();
 const yearConfigStore = useYearConfigStore();
+const authStore = useAuthStore();
 
 const visibleModulesList = computed(() =>
-  MODULES_LIST.filter((m) => yearConfigStore.isModuleVisible(m)),
+  MODULES_LIST.filter(
+    (m) =>
+      yearConfigStore.isModuleVisible(m) && authStore.canUserAccessModule(m),
+  ),
 );
 
 const currentIndex = computed(() => {
@@ -79,8 +84,12 @@ const resultsRoute = computed(() => {
   };
 });
 
-// Validate current module when navigating away
+const canValidateCurrentModule = computed(() =>
+  authStore.hasUserCanValidateModuleStatus(),
+);
+
 function validateCurrentModule() {
+  if (!canValidateCurrentModule.value) return;
   timelineStore.setState(props.currentModule, MODULE_STATES.Validated);
 }
 </script>

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { MODULES } from 'src/constant/modules';
+import { MODULES_LIST } from 'src/constant/modules';
 import { MODULES_CONFIG } from 'src/constant/module-config';
 import { MODULE_CARDS } from 'src/constant/moduleCards';
 import { getModuleTypeId, MODULE_STATES } from 'src/constant/moduleStates';
@@ -21,6 +21,8 @@ const authStore = useAuthStore();
 const moduleStore = useModuleStore();
 const yearConfigStore = useYearConfigStore();
 
+const hasModulePermission = authStore.hasUserModulePermission;
+
 const currentYear = computed(
   () => workspaceStore.selectedYear ?? new Date().getFullYear(),
 );
@@ -36,11 +38,13 @@ const validatedTotals = computed(() => {
   return moduleStore.state.validatedTotals;
 });
 
-const firstEditableModule = computed(() => {
-  return Object.values(MODULES).find((module) =>
-    hasModulePermission(module, PermissionAction.EDIT),
-  );
-});
+const firstEditableModule = computed(() =>
+  MODULES_LIST.find(
+    (module) =>
+      yearConfigStore.isModuleVisible(module) &&
+      authStore.canUserAccessModule(module),
+  ),
+);
 
 const moduleCardTotals = computed(() => {
   const modules = validatedTotals.value?.modules;
@@ -52,12 +56,6 @@ const moduleCardTotals = computed(() => {
   );
 });
 
-function hasModulePermission(
-  module: Module,
-  action: PermissionAction,
-): boolean {
-  return authStore.hasUserModulePermission(module, action);
-}
 const timelineStore = useTimelineStore();
 
 const moduleCardsWithStatus = computed(() =>


### PR DESCRIPTION
## What does this change?
Applies auth and year-config visibility checks consistently to module navigation and the home page "first editable module" link.

- `ModuleNavigation.vue`: adds `authStore.canUserAccessModule(m)` to the `visibleModulesList` filter alongside `isModuleVisible`, so prev/next navigation skips modules the user can't access; adds `canValidateCurrentModule` computed that checks `EDIT` permission on the unit scope before calling `setState` in `validateCurrentModule`
- `HomePage.vue`: rewrites `firstEditableModule` to use `MODULES_LIST` (ordered) filtered by `isModuleVisible` + `canUserAccessModule` instead of iterating `Object.values(MODULES)` with a raw `hasUserModulePermission` check; removes the local `hasModulePermission` wrapper function; cleans up the import order

## Why is this needed?
The prev/next module arrows and the home page "start" button were not filtering by auth permissions, so they could land users on modules they have no access to. The validate-on-navigate logic also didn't check whether the user actually has edit permission before marking the module as validated.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1382