### PR TITLE
feat 1374: preserve chart series on update and fix FR label

### DIFF
--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -510,6 +510,7 @@ defineExpose({ downloadPNG });
         class="chart"
         autoresize
         :option="chartOption"
+        :update-options="{ replaceMerge: ['series'] }"
         :style="{ height: chartHeight + 'px' }"
         @vue:mounted="onChartReady"
       />

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -435,7 +435,7 @@ export default {
   },
   'charts-cooling-subcategory': {
     en: 'Cooling',
-    fr: 'Climatisation',
+    fr: 'Refroidissement',
   },
   'charts-ventilation-subcategory': {
     en: 'Ventilation',


### PR DESCRIPTION
## What does this change?
- `EmissionTypeBreakdownChart.vue`: adds `:update-options="{ replaceMerge: ['series'] }"` to the VChart component so series are fully replaced on data updates instead of being merged with stale series from the previous render
- `results.ts`: corrects the French label for `charts-cooling-subcategory` from `"Climatisation"` (air conditioning) to `"Refroidissement"` (cooling), which is the accurate translation for the buildings cooling energy category

## Why is this needed?
Without `replaceMerge: ['series']`, switching between modules or updating chart data would leave ghost series from the previous state visible in the chart. The French "Climatisation" label was also a mistranslation — "Refroidissement" correctly describes building cooling energy rather than air conditioning specifically.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1374