### PR TITLE
feat 1375: reorder UploadCardReferences before UploadCardData

### DIFF
--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -270,6 +270,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         @compute-factors="openComputedFactorConfirm"
         @abort="handleAbortPipeline"
       />
+
       <UploadCardReferences
         v-if="getImportRow(submodule).hasOtherUpload"
         :row="getImportRow(submodule)"


### PR DESCRIPTION
## What does this change?
Reorders the upload cards in `SubmoduleItem.vue` so `UploadCardReferences` appears before `UploadCardData` instead of after.

## Why is this needed?
Reference files must be uploaded before data files for imports to resolve correctly. Having the reference card below the data card implied the wrong upload order to users.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1375