### PR TITLE
feat 902: display form disclaimer for new module entries

### DIFF
--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -275,6 +275,14 @@
             />
           </template>
         </q-card-actions>
+        <div
+          v-if="
+            !rowData && $te(`${moduleType}-${submoduleType}-form-disclaimer`)
+          "
+          class="q-mx-lg q-mb-xl q-mt-sm text-caption text-grey-7"
+        >
+          {{ $t(`${moduleType}-${submoduleType}-form-disclaimer`) }}
+        </div>
       </q-form>
     </q-card-section>
     <NoteDialog

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -119,6 +119,16 @@ export default {
       fr: 'External AI Tooltip',
     },
 
+  [`${MODULES.ExternalCloudAndAI}-${SUBMODULE_EXTERNAL_CLOUD_TYPES.external_clouds}-form-disclaimer`]:
+    {
+      en: "The unit's external cloud management lead enters the data for the entire team",
+      fr: "Le responsable de la gestion des clouds externes de l'unité remplit les données pour toute l'équipe",
+    },
+  [`${MODULES.ExternalCloudAndAI}-${SUBMODULE_EXTERNAL_CLOUD_TYPES.external_ai}-form-disclaimer`]:
+    {
+      en: 'Each member of the unit is responsible for recording their personal usage associated with their FTE',
+      fr: "Chaque membre de l'unité est responsable de saisir son utilisation personnelle associé à son EPT",
+    },
   [`${MODULES.ExternalCloudAndAI}-title-tooltip-subtext`]: {
     en: 'You can add data one at a time using the Add button below, or upload several entries at once using a file that follows the template.',
     fr: 'Vous pouvez ajouter les données une par une en utilisant le bouton « Ajouter » ci-dessous, ou importer plusieurs entrées à la fois via un fichier respectant le modèle fourni.',


### PR DESCRIPTION
## What does this change?
Adds a per-submodule disclaimer below the form action buttons for new entries, and reverts two unrelated changes from other branches that were accidentally included.

- `ModuleForm.vue`: adds a disclaimer block below the form action buttons, shown only when creating a new entry (`!rowData`) and only when a `{moduleType}-{submoduleType}-form-disclaimer` i18n key exists (`$te` check)
- `external_cloud.ts`: adds disclaimer strings for both external cloud submodules — clouds ("the unit's cloud lead enters data for the whole team") and AI ("each member enters their own personal usage")

## Why is this needed?
The external cloud and AI submodules have different data-entry ownership rules that users need to be aware of before filling in the form. A contextual disclaimer directly in the form is clearer than a tooltip or separate documentation.

## Type of change
- [x] ✨ New feature
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #902