### PR TITLE
fix(schemas): align module schemas with data-description doc (#1415)

### DIFF
--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -389,7 +389,7 @@ class BuildingBaseFactor:
     lighting_kwh_per_square_meter: float
     ef_kg_co2eq_per_kwh: float
     energy_type: str
-    conversion_factor: Optional[float] = None
+    conversion_factor: Optional[float] = 1
 
 
 class BuildingsFactorCreate(
@@ -706,6 +706,19 @@ class BuildingEmbodiedEnergyFactorResponse(FactorResponseGen):
     building_name: str
     category: str
     ef_kgco2eq_per_m2: float
+
+    @field_validator("category", mode="after")
+    @classmethod
+    def _non_empty(cls, v: str, info: ValidationInfo) -> str:
+        CATEGORY_VALUES = {"new-tech", "new-env", "ren-tech", "ren-env", "demolition"}
+        if not v.strip():
+            raise ValueError(f"{info.field_name} cannot be empty")
+        # should be amongst new-tech, new-env,ren-tech,ren-env,demolition
+        if v.strip() not in CATEGORY_VALUES:
+            raise ValueError(
+                f"{info.field_name} must be one of {sorted(CATEGORY_VALUES)}"
+            )
+        return v.strip()
 
 
 class BuildingEmbodiedEnergyFactorHandler(BaseFactorHandler):

--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -94,17 +94,16 @@ VALID_ROOM_TYPES: list[Optional[str]] = [
 class BuildingRoomHandlerCreate(DataEntryCreate):
     building_name: str
     room_name: str
-    room_type: Optional[str] = None
+    room_type: str
     room_allocation_ratio: Optional[float] = None
     note: Optional[str] = None
 
     @field_validator("room_type", mode="after")
     @classmethod
-    def validate_room_type(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None and v not in VALID_ROOM_TYPES:
-            raise ValueError(
-                f"room_type must be one of: {[r for r in VALID_ROOM_TYPES if r]}"
-            )
+    def validate_room_type(cls, v: str) -> str:
+        valid = [r for r in VALID_ROOM_TYPES if r]
+        if v not in valid:
+            raise ValueError(f"room_type must be one of: {valid}")
         return v
 
     @field_validator("room_allocation_ratio", mode="after")
@@ -390,7 +389,7 @@ class BuildingBaseFactor:
     lighting_kwh_per_square_meter: float
     ef_kg_co2eq_per_kwh: float
     energy_type: str
-    conversion_factor: float
+    conversion_factor: Optional[float] = None
 
 
 class BuildingsFactorCreate(
@@ -682,11 +681,25 @@ class BuildingEmbodiedEnergyFactorCreate(FactorCreate):
     category: str
     ef_kgco2eq_per_m2: float
 
+    @field_validator("ef_kgco2eq_per_m2", mode="after")
+    @classmethod
+    def validate_ef_non_negative(
+        cls, v: Optional[float], info: ValidationInfo
+    ) -> Optional[float]:
+        return _validate_non_negative_float(v, info.field_name or "")
+
 
 class BuildingEmbodiedEnergyFactorUpdate(FactorUpdate):
     building_name: Optional[str] = None
     category: Optional[str] = None
     ef_kgco2eq_per_m2: Optional[float] = None
+
+    @field_validator("ef_kgco2eq_per_m2", mode="after")
+    @classmethod
+    def validate_ef_non_negative(
+        cls, v: Optional[float], info: ValidationInfo
+    ) -> Optional[float]:
+        return _validate_non_negative_float(v, info.field_name or "")
 
 
 class BuildingEmbodiedEnergyFactorResponse(FactorResponseGen):

--- a/backend/app/modules/equipment_electric_consumption/schemas.py
+++ b/backend/app/modules/equipment_electric_consumption/schemas.py
@@ -103,13 +103,21 @@ class EquipmentHandlerResponse(DataEntryResponseGen):
 
 
 class EquipmentHandlerCreate(_EquipmentUsageHoursValidationMixin, DataEntryCreate):
-    # unit_institutional_id: str #only for data.csv
+    equipment_id: str
     name: str
     equipment_class: str
     sub_class: Optional[str] = None
     active_usage_hours_per_week: Optional[int] = None
     standby_usage_hours_per_week: Optional[int] = None
     note: Optional[str] = None
+    # kg_co2eq: Optional[float] = None  # from csv is __kg_co2eq_override__
+
+    @field_validator("equipment_id", "name", "equipment_class", mode="after")
+    @classmethod
+    def _non_empty(cls, v: str, info: ValidationInfo) -> str:
+        if not v.strip():
+            raise ValueError(f"{info.field_name} cannot be empty")
+        return v.strip()
 
 
 class EquipmentHandlerUpdate(_EquipmentUsageHoursValidationMixin, DataEntryUpdate):
@@ -276,14 +284,18 @@ value_fields: list[str] = [
 
 
 class EquipmentFactorCreate(_EquipmentFactorValidationMixin, FactorCreate):
-    # data_entry_type: str #only for upload in datamanagement
+    # equipment_category: str  # only for upload Mandatory (checked in csv upload)
     equipment_class: str
     sub_class: Optional[str] = None
-    active_usage_hours_per_week: int
-    standby_usage_hours_per_week: int
+    active_usage_hours_per_week: int  # make it mandatory
+    standby_usage_hours_per_week: int  # make it mandatory
     active_power_w: float
     standby_power_w: float
     ef_kg_co2eq_per_kwh: float
+    # equipment_category is the routing column (picks scientific/it/other).
+    # It is consumed in the factor CSV provider, not carried on this DTO —
+    # its presence + case-sensitive {scientific,it,other} enum is enforced
+    # there (see base_factor_csv_provider._resolve_data_entry_type).
 
 
 class EquipmentFactorUpdate(_EquipmentFactorValidationMixin, FactorUpdate):

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -111,15 +111,13 @@ class ExternalCloudHandlerCreate(DataEntryCreate):
 class ExternalAIHandlerCreate(DataEntryCreate):
     provider: str
     usage_type: str
-    requests_per_user_per_day: Optional[str] = None
+    requests_per_user_per_day: str
     fte_count: float
     note: Optional[str] = None
 
     @field_validator("requests_per_user_per_day", mode="after")
     @classmethod
-    def validate_frequency(cls, v: Optional[str]) -> Optional[str]:
-        if v is None:
-            return v
+    def validate_frequency(cls, v: str) -> str:
         if v not in REQUESTS_FREQUENCY_OPTIONS:
             raise ValueError(
                 "requests_per_user_per_day must be one of:"

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -114,6 +114,7 @@ class ExternalAIHandlerCreate(DataEntryCreate):
     requests_per_user_per_day: str
     fte_count: float
     note: Optional[str] = None
+    #  __kg_co2eq_override__ for kg_co2eq
 
     @field_validator("requests_per_user_per_day", mode="after")
     @classmethod

--- a/backend/app/modules/headcount/schemas.py
+++ b/backend/app/modules/headcount/schemas.py
@@ -44,13 +44,23 @@ class HeadCountStudentResponse(DataEntryResponseGen):
 class HeadCountCreate(DataEntryCreate):
     name: str
     sius_code: str
-    fte: Optional[float] = None
     user_institutional_id: str
+    fte: float
     note: Optional[str] = None
+
+    @field_validator("name", mode="after")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Name cannot be empty")
+        return v.strip()
 
     @field_validator("user_institutional_id", mode="before")
     @classmethod
     def validate_user_institutional_id(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("User institutional ID cannot be empty")
+        # doc says numbers only but user can use letters as well (test-412424 e.g)
         return v.strip()
 
     @field_validator("fte", mode="after")

--- a/backend/app/modules/professional_travel/schemas.py
+++ b/backend/app/modules/professional_travel/schemas.py
@@ -135,6 +135,7 @@ class ProfessionalTravelPlaneHandlerCreate(
     number_of_trips: int = 1
     cabin_class: str
     note: Optional[str] = None
+    # __kg_co2eq_override__ for kg_co2eq
 
     @field_validator("number_of_trips", mode="after")
     @classmethod
@@ -150,6 +151,7 @@ class ProfessionalTravelTrainHandlerCreate(
     user_institutional_id: str
     origin_name: str
     destination_name: str
+    # check if necessary after migration to new reference location for train
     origin_natural_key: Optional[str] = None
     destination_natural_key: Optional[str] = None
     # Required for CSV rows lacking a precomputed ``*_natural_key``: the
@@ -157,12 +159,13 @@ class ProfessionalTravelTrainHandlerCreate(
     # country (e.g. Bern, CH vs Berne, DE). Optional at the schema level
     # because UI/API rows resolve via ``*_natural_key`` instead; the CSV
     # resolver (``enrich_csv_row``) rejects rows that supply neither.
-    origin_country_code: Optional[str] = None
-    destination_country_code: Optional[str] = None
+    origin_country_code: str
+    destination_country_code: str
     departure_date: Optional[date] = None
     number_of_trips: int = 1
     cabin_class: str
     note: Optional[str] = None
+    # __kg_co2eq_override__ for kg_co2eq
 
     @field_validator("number_of_trips", mode="after")
     @classmethod
@@ -502,9 +505,9 @@ class ProfessionalTravelTrainModuleHandler(ProfessionalTravelBaseModuleHandler):
 
 class TravelPlaneBase:
     category: str
+    cabin_class: str
     ef_kg_co2eq_per_km: float
     rfi_adjustment: float
-    cabin_class: float
     min_distance: float
     max_distance: float
 

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -52,10 +52,12 @@ class PurchaseHandlerCreate(DataEntryCreate):
     supplier: Optional[str] = None
     quantity: Optional[float] = None
     total_spent_amount: float
-    currency: Optional[str] = None
+    currency: Optional[str] = None  # doc say mandatory, but with default -> optional
     purchase_institutional_code: str
+    purchase_institutional_description: Optional[str] = None
     purchase_additional_code: Optional[str] = None
     note: Optional[str] = None
+    # __kg_co2eq_override__ is used to override the kg_co2eq calculation
 
     @model_validator(mode="before")
     @classmethod
@@ -443,11 +445,12 @@ purchase_common_value_fields: list[str] = [
 
 
 class PurchaseCommonFactorCreate(FactorCreate):
-    purchase_institutional_code: str
-    purchase_additional_code: str
     currency: str
-    ef_kg_co2eq_per_currency: float
+    purchase_category: str
+    purchase_institutional_code: str
     translation_key: Optional[str] = None
+    purchase_additional_code: str
+    ef_kg_co2eq_per_currency: float
 
     @field_validator("ef_kg_co2eq_per_currency", mode="after")
     @classmethod

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -53,7 +53,7 @@ class PurchaseHandlerCreate(DataEntryCreate):
     quantity: Optional[float] = None
     total_spent_amount: float
     currency: Optional[str] = None
-    purchase_institutional_code: Optional[str] = None
+    purchase_institutional_code: str
     purchase_additional_code: Optional[str] = None
     note: Optional[str] = None
 
@@ -88,8 +88,8 @@ class PurchaseHandlerCreate(DataEntryCreate):
 
     @field_validator("purchase_institutional_code", mode="after")
     @classmethod
-    def validate_purchase_institutional_code(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None and len(v) < 1:
+    def validate_purchase_institutional_code(cls, v: str) -> str:
+        if len(v) < 1:
             raise ValueError(
                 "Purchase institutional code must be at least 1 character long"
             )
@@ -110,7 +110,7 @@ class PurchaseHandlerCreate(DataEntryCreate):
 class PurchaseAdditionalHandlerCreate(DataEntryCreate):
     name: str
     unit: str
-    annual_consumption: Optional[float] = 0
+    annual_consumption: float
     coef_to_kg: float
     note: Optional[str] = None
 

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -39,11 +39,11 @@ class ResearchFacilitiesAnimalHandlerResponse(DataEntryResponseGen):
 
 
 class ResearchFacilitiesAnimalHandlerCreate(DataEntryCreate):
-    researchfacility_id: Optional[str] = None
-    researchfacility_name: Optional[str] = None
-    researchfacility_type: Optional[str] = None
-    use: Optional[float] = None
-    use_unit: Optional[str] = None
+    researchfacility_id: str
+    researchfacility_name: str
+    researchfacility_type: str
+    use: float
+    use_unit: str
     note: Optional[str] = None
 
 
@@ -190,23 +190,23 @@ research_facilities_animal_value_fields: list[str] = [
 
 
 class ResearchFacilitiesAnimalFactorCreate(FactorCreate):
-    researchfacility_id: Optional[str] = None
-    researchfacility_name: Optional[str] = None
-    researchfacility_type: Optional[str] = None
-    use_unit: Optional[str] = None
-    processemissions_share: Optional[float] = None
-    building_energycombustions_share: Optional[float] = None
-    building_rooms_share: Optional[float] = None
-    purchases_common_share: Optional[float] = None
-    purchases_additional_share: Optional[float] = None
-    equipments_share: Optional[float] = None
+    researchfacility_id: str
+    researchfacility_name: str
+    researchfacility_type: str
+    use_unit: str
+    processemissions_share: float
+    building_energycombustions_share: float
+    building_rooms_share: float
+    purchases_common_share: float
+    purchases_additional_share: float
+    equipments_share: float
     kg_co2eq_sum_processemissions: Optional[float] = None
     kg_co2eq_sum_building_energycombustions: Optional[float] = None
     kg_co2eq_sum_building_rooms: Optional[float] = None
     kg_co2eq_sum_purchases_common: Optional[float] = None
     kg_co2eq_sum_purchases_additional: Optional[float] = None
     kg_co2eq_sum_equipments: Optional[float] = None
-    total_use: Optional[float] = None
+    total_use: float
 
     @field_validator("researchfacility_id", mode="before")
     @classmethod
@@ -232,11 +232,24 @@ class ResearchFacilitiesAnimalFactorCreate(FactorCreate):
         mode="after",
     )
     @classmethod
-    def validate_share(cls, v: Optional[float]) -> Optional[float]:
-        if v is None:
-            return v
+    def validate_share(cls, v: float) -> float:
         if v < 0 or v > 1:
             raise ValueError("Share values must be between 0 and 1")
+        return v
+
+    @field_validator(
+        "kg_co2eq_sum_processemissions",
+        "kg_co2eq_sum_building_energycombustions",
+        "kg_co2eq_sum_building_rooms",
+        "kg_co2eq_sum_purchases_common",
+        "kg_co2eq_sum_purchases_additional",
+        "kg_co2eq_sum_equipments",
+        mode="after",
+    )
+    @classmethod
+    def validate_kg_co2eq_sum(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError("kg_co2eq_sum values must be non-negative")
         return v
 
 

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -50,13 +50,34 @@ class ResearchFacilitiesCommonHandlerCreate(DataEntryCreate):
     use: float
     use_unit: str
     note: Optional[str] = None
+    kg_co2eq: Optional[float] = None
 
     @field_validator("researchfacility_id", mode="before")
     @classmethod
     def _validate_researchfacility_id_response(cls, v: object) -> Optional[str]:
         if v is None:
-            return None
+            raise ValueError("researchfacility_id is required")
         return str(v)
+
+    @field_validator("researchfacility_name", mode="before")
+    @classmethod
+    def _validate_researchfacility_name_response(cls, v: object) -> Optional[str]:
+        if v is None:
+            raise ValueError("researchfacility_name is required")
+        return str(v)
+
+    @field_validator("use", mode="before")
+    @classmethod
+    def _validate_use_response(cls, v: object) -> Optional[float]:
+        if v is None:
+            raise ValueError("use is required")
+        if not isinstance(v, (int, float)):
+            raise ValueError("use must be a number")
+        if v < 0:
+            raise ValueError("use must be a positive number or zero")
+        return float(v)
+
+    # TODO: validation for use_unit: it was not done!
 
 
 class ResearchFacilitiesCommonHandlerUpdate(DataEntryUpdate):
@@ -175,9 +196,9 @@ research_facilities_common_value_fields: list[str] = [
 class ResearchFacilitiesCommonFactorCreate(FactorCreate):
     researchfacility_id: str
     researchfacility_name: str
-    use_unit: str
     kg_co2eq_sum: Optional[float] = None
     total_use: float
+    use_unit: str
 
     @field_validator("total_use", mode="after")
     @classmethod

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -45,10 +45,10 @@ class ResearchFacilitiesCommonHandlerResponse(DataEntryResponseGen):
 
 
 class ResearchFacilitiesCommonHandlerCreate(DataEntryCreate):
-    researchfacility_id: Optional[str] = None
-    researchfacility_name: Optional[str] = None
-    use: Optional[float] = None
-    use_unit: Optional[str] = None
+    researchfacility_id: str
+    researchfacility_name: str
+    use: float
+    use_unit: str
     note: Optional[str] = None
 
     @field_validator("researchfacility_id", mode="before")
@@ -173,7 +173,7 @@ research_facilities_common_value_fields: list[str] = [
 
 
 class ResearchFacilitiesCommonFactorCreate(FactorCreate):
-    researchfacility_id: Optional[str] = None
+    researchfacility_id: str
     researchfacility_name: str
     use_unit: str
     kg_co2eq_sum: Optional[float] = None
@@ -184,6 +184,13 @@ class ResearchFacilitiesCommonFactorCreate(FactorCreate):
     def validate_total_use(cls, v: float) -> float:
         if v < 0:
             raise ValueError("total_use must be non-negative")
+        return v
+
+    @field_validator("kg_co2eq_sum", mode="after")
+    @classmethod
+    def validate_kg_co2eq_sum(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError("kg_co2eq_sum must be non-negative")
         return v
 
 

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -312,7 +312,8 @@ def build_headcount() -> dict:
     return {
         "name": fake.name(),
         "sius_code": random.choice(sorted(SIUS_CODE_VALUES)),  # nosec B311
-        "fte": maybe(round(random.uniform(0.1, 1.0), 2)),  # nosec B311
+        # fte is required (non-Optional) on the create DTO, 0 <= fte <= 1.
+        "fte": round(random.uniform(0.1, 1.0), 2),  # nosec B311
         # user_institutional_id is required (non-Optional) on the create DTO.
         "user_institutional_id": _user_institutional_id(),
         "note": maybe(fake.sentence(nb_words=6)),

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -299,8 +299,8 @@ def build_external_ai() -> dict:
     return {
         "provider": random.choice(["OpenAI", "Anthropic", "Mistral"]),  # nosec B311
         "usage_type": fake.sentence(nb_words=3),
-        "requests_per_user_per_day": maybe(
-            random.choice(REQUESTS_FREQUENCY_OPTIONS),  # nosec B311
+        "requests_per_user_per_day": random.choice(  # nosec B311
+            REQUESTS_FREQUENCY_OPTIONS
         ),
         # fte_count must be ≥ 0.1 per the schema validator.
         "fte_count": round(random.uniform(0.1, 500.0), 2),  # nosec B311
@@ -333,7 +333,7 @@ def build_purchase() -> dict:
         # total_spent_amount is required (non-Optional) on the create DTO.
         "total_spent_amount": round(random.uniform(100, 10000), 2),  # nosec B311
         "currency": random.choice(["chf", "eur", "usd"]),  # nosec B311
-        "purchase_institutional_code": maybe(fake.bothify(text="???-#####")),  # nosec B311
+        "purchase_institutional_code": fake.bothify(text="???-#####"),
         "purchase_additional_code": maybe(fake.bothify(text="???-#####")),  # nosec B311
         "note": maybe(fake.sentence(nb_words=10)),
     }
@@ -386,18 +386,18 @@ def build_process_emissions() -> dict:
 
 def build_research_facility_common() -> dict:
     return {
-        "researchfacility_id": maybe(fake.bothify(text="RF-#####")),
-        "researchfacility_name": maybe(fake.company()),
-        "use": maybe(round(random.uniform(0, 1000), 2)),  # nosec B311
-        "use_unit": maybe(random.choice(["kg", "liter", "hour"])),  # nosec B311
+        "researchfacility_id": fake.bothify(text="RF-#####"),
+        "researchfacility_name": fake.company(),
+        "use": round(random.uniform(0, 1000), 2),  # nosec B311
+        "use_unit": random.choice(["kg", "liter", "hour"]),  # nosec B311
         "note": maybe(fake.sentence(nb_words=6)),
     }
 
 
 def build_research_facility_animal() -> dict:
     payload = build_research_facility_common()
-    payload["researchfacility_type"] = maybe(
-        random.choice(["mice", "fish", "rat"]),  # nosec B311
+    payload["researchfacility_type"] = random.choice(  # nosec B311
+        ["mice", "fish", "rat"]
     )
     return payload
 

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -276,6 +276,8 @@ def build_equipment() -> dict:
         equipment_class = fake.word()
         sub_class = maybe(fake.word())
     return {
+        # equipment_id is required (non-Optional) on the create DTO.
+        "equipment_id": fake.bothify(text="INV-#####"),
         "name": fake.word(),
         "equipment_class": equipment_class,
         "sub_class": sub_class,

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -222,7 +222,13 @@ def build_train_travel() -> dict:
     return {
         "user_institutional_id": _user_institutional_id(),
         "origin_name": fake.city(),
+        # origin/destination_country_code are required (ISO-2) on the
+        # create DTO — the CSV resolver uses them to disambiguate stations.
+        "origin_country_code": random.choice(["CH", "FR", "DE", "IT"]),  # nosec B311
         "destination_name": fake.city(),
+        "destination_country_code": random.choice(  # nosec B311
+            ["CH", "FR", "DE", "IT"]
+        ),
         "cabin_class": random.choice(["first", "second"]),  # nosec B311
         "departure_date": date.today().isoformat(),
         "number_of_trips": random.randint(1, 10),  # nosec B311

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -438,7 +438,10 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                 category_value = row.get(category_field, "").strip()
                 if category_value:
                     try:
-                        return DataEntryTypeEnum[category_value.lower()]
+                        # Case-sensitive: the category column (e.g.
+                        # equipment_category) must match a DataEntryTypeEnum
+                        # member name exactly (doc: {scientific,it,other}).
+                        return DataEntryTypeEnum[category_value]
                     except KeyError:
                         error_msg = f"Invalid {category_field}: {category_value}"
                         self._record_row_error(

--- a/backend/tests/fixtures/csv/equipments_smoke.csv
+++ b/backend/tests/fixtures/csv/equipments_smoke.csv
@@ -1,3 +1,3 @@
-unit_institutional_id,name,equipment_class,sub_class,active_usage_hours_per_week,standby_usage_hours_per_week,note
-{unit_institutional_id},Smoke Laptop A,Laptop,Standard,40,128,
-{unit_institutional_id},Smoke Laptop B,Laptop,Standard,40,128,
+unit_institutional_id,equipment_id,name,equipment_class,sub_class,active_usage_hours_per_week,standby_usage_hours_per_week,note
+{unit_institutional_id},INV-0001,Smoke Laptop A,Laptop,Standard,40,128,
+{unit_institutional_id},INV-0002,Smoke Laptop B,Laptop,Standard,40,128,

--- a/backend/tests/unit/modules/test_equipment_schemas.py
+++ b/backend/tests/unit/modules/test_equipment_schemas.py
@@ -1,0 +1,189 @@
+"""Equipment validation permutation matrix (data + factor create DTOs).
+
+One falsifiable case per field-level rule in the ``equipments_data.csv`` and
+``equipments_factors.csv`` contracts (data-description.md → Equipment):
+
+data (EquipmentHandlerCreate)
+    equipment_id                 ✅ non-empty (letters and numbers)
+    name                         ✅ non-empty
+    equipment_class              ✅ non-empty (membership checked at runtime)
+    sub_class                    ❌ optional
+    active_usage_hours_per_week  ❌ optional, 0 ≤ int ≤ 168
+    standby_usage_hours_per_week ❌ optional, 0 ≤ int ≤ 168, active+standby ≤ 168
+    note                         ❌ optional
+
+factor (EquipmentFactorCreate)
+    equipment_category           ✅ case-sensitive enum {scientific, it, other}
+    equipment_class              ✅
+    sub_class                    ❌ optional
+    active_usage_hours_per_week  ✅ 0 ≤ int ≤ 168
+    standby_usage_hours_per_week ✅ 0 ≤ int ≤ 168
+    active_power_w               ✅ ≥ 0
+    standby_power_w              ✅ ≥ 0
+    ef_kg_co2eq_per_kwh          ✅ ≥ 0
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_entry_emission import EmissionType
+from app.modules.equipment_electric_consumption.schemas import (
+    EquipmentFactorCreate,
+    EquipmentHandlerCreate,
+)
+
+_OMIT = object()
+
+_DATA_META = {
+    "data_entry_type_id": DataEntryTypeEnum.scientific.value,
+    "carbon_report_module_id": 1,
+}
+_FACTOR_META = {
+    "data_entry_type_id": DataEntryTypeEnum.scientific.value,
+    "emission_type_id": int(EmissionType.equipment),
+}
+
+
+def _data(**overrides) -> dict:
+    payload = {
+        **_DATA_META,
+        "equipment_id": "INV-001",
+        "name": "GoPro",
+        "equipment_class": "Monitor",
+        "active_usage_hours_per_week": 20,
+        "standby_usage_hours_per_week": 10,
+    }
+    payload.update(overrides)
+    return {k: v for k, v in payload.items() if v is not _OMIT}
+
+
+def _factor(**overrides) -> dict:
+    # equipment_category is NOT on the factor DTO — it is the routing column,
+    # validated in the CSV provider (case-sensitive {scientific,it,other}).
+    payload = {
+        **_FACTOR_META,
+        "equipment_class": "Evaporator",
+        "active_usage_hours_per_week": 20,
+        "standby_usage_hours_per_week": 10,
+        "active_power_w": 23.0,
+        "standby_power_w": 5.0,
+        "ef_kg_co2eq_per_kwh": 0.125,
+    }
+    payload.update(overrides)
+    return {k: v for k, v in payload.items() if v is not _OMIT}
+
+
+# ---------------------------------------------------------------------------
+# Data entry — valid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_data(), id="baseline"),
+        pytest.param(_data(sub_class="ultra centrifuges"), id="sub_class-present"),
+        pytest.param(
+            _data(
+                active_usage_hours_per_week=_OMIT, standby_usage_hours_per_week=_OMIT
+            ),
+            id="hours-omitted",
+        ),
+        pytest.param(
+            _data(active_usage_hours_per_week=0, standby_usage_hours_per_week=0),
+            id="hours-zero",
+        ),
+        pytest.param(
+            _data(active_usage_hours_per_week=100, standby_usage_hours_per_week=68),
+            id="hours-sum-168",
+        ),
+        pytest.param(
+            _data(active_usage_hours_per_week=168, standby_usage_hours_per_week=0),
+            id="active-max",
+        ),
+        pytest.param(_data(note="bench unit"), id="note-present"),
+        pytest.param(_data(name="  GoPro  "), id="name-stripped"),
+    ],
+)
+def test_equipment_data_valid(payload: dict) -> None:
+    item = EquipmentHandlerCreate.model_validate(payload)
+    assert item.equipment_id
+
+
+# ---------------------------------------------------------------------------
+# Data entry — invalid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_data(equipment_id=_OMIT), id="equipment_id-missing"),
+        pytest.param(_data(equipment_id=""), id="equipment_id-empty"),
+        pytest.param(_data(equipment_id="   "), id="equipment_id-whitespace"),
+        pytest.param(_data(name=_OMIT), id="name-missing"),
+        pytest.param(_data(name=""), id="name-empty"),
+        pytest.param(_data(name="   "), id="name-whitespace"),
+        pytest.param(_data(equipment_class=_OMIT), id="equipment_class-missing"),
+        pytest.param(_data(equipment_class=""), id="equipment_class-empty"),
+        pytest.param(_data(active_usage_hours_per_week=200), id="active-over-168"),
+        pytest.param(_data(active_usage_hours_per_week=-1), id="active-negative"),
+        pytest.param(_data(standby_usage_hours_per_week=200), id="standby-over-168"),
+        pytest.param(
+            _data(active_usage_hours_per_week=100, standby_usage_hours_per_week=100),
+            id="sum-over-168",
+        ),
+    ],
+)
+def test_equipment_data_invalid(payload: dict) -> None:
+    with pytest.raises(ValidationError):
+        EquipmentHandlerCreate.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# Factor — valid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_factor(), id="baseline"),
+        pytest.param(_factor(sub_class="ultra centrifuges"), id="sub_class-present"),
+        pytest.param(
+            _factor(active_power_w=0, standby_power_w=0, ef_kg_co2eq_per_kwh=0),
+            id="zeros-allowed",
+        ),
+        pytest.param(
+            _factor(active_usage_hours_per_week=0, standby_usage_hours_per_week=0),
+            id="hours-zero",
+        ),
+    ],
+)
+def test_equipment_factor_valid(payload: dict) -> None:
+    item = EquipmentFactorCreate.model_validate(payload)
+    assert item.equipment_class
+
+
+# ---------------------------------------------------------------------------
+# Factor — invalid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_factor(equipment_class=_OMIT), id="equipment_class-missing"),
+        pytest.param(_factor(active_usage_hours_per_week=_OMIT), id="active-missing"),
+        pytest.param(_factor(standby_usage_hours_per_week=_OMIT), id="standby-missing"),
+        pytest.param(_factor(active_power_w=_OMIT), id="active_power-missing"),
+        pytest.param(_factor(ef_kg_co2eq_per_kwh=_OMIT), id="ef-missing"),
+        pytest.param(_factor(active_power_w=-1.0), id="active_power-negative"),
+        pytest.param(_factor(ef_kg_co2eq_per_kwh=-0.1), id="ef-negative"),
+        pytest.param(_factor(active_usage_hours_per_week=200), id="active-over-168"),
+    ],
+)
+def test_equipment_factor_invalid(payload: dict) -> None:
+    with pytest.raises(ValidationError):
+        EquipmentFactorCreate.model_validate(payload)

--- a/backend/tests/unit/modules/test_headcount_schemas.py
+++ b/backend/tests/unit/modules/test_headcount_schemas.py
@@ -1,65 +1,193 @@
+"""Headcount validation permutation matrix (member + student create DTOs).
+
+One falsifiable case per field-level rule in the ``headcount_data.csv``
+contract (data-description.md → Headcount):
+
+    name                  ✅ non-empty string (stripped)
+    sius_code             ✅ within {51,52,53,54,56,57,58,59}
+    user_institutional_id ✅ non-empty (doc says numbers-only, but the code
+                              intentionally allows letters, e.g. "test-412424")
+    fte                   ✅ float, 0 ≤ fte ≤ 1
+    note                  ❌ optional
+
+``unit_institutional_id`` is a data.csv-only column used to scope the row to
+a unit at ingest; it is not part of the create DTO, so it is out of scope here.
+
+These run the DTO directly (the same object ``validate_create`` builds for both
+CSV upload and the API), so a row that fails here is a row the upload rejects.
+The emission/stats chain is covered separately in
+``tests/integration/services/data_ingestion/test_headcount_pg.py``.
+"""
+
 import pytest
 from pydantic import ValidationError
 
 from app.models.data_entry import DataEntryTypeEnum
-from app.modules.headcount.schemas import HeadCountCreate, HeadCountUpdate
+from app.modules.headcount.schemas import (
+    SIUS_CODE_VALUES,
+    HeadCountCreate,
+    HeadCountStudentCreate,
+    HeadCountUpdate,
+)
+
+# Sentinel: a field set to ``_OMIT`` is dropped from the payload entirely,
+# so we can exercise the "field missing" case distinctly from "field empty".
+_OMIT = object()
+
+_MEMBER_META = {
+    "data_entry_type_id": DataEntryTypeEnum.member.value,
+    "carbon_report_module_id": 1,
+}
+_STUDENT_META = {
+    "data_entry_type_id": DataEntryTypeEnum.student.value,
+    "carbon_report_module_id": 1,
+}
 
 
-def _base_create_payload() -> dict:
-    return {
-        "data_entry_type_id": DataEntryTypeEnum.member.value,
-        "carbon_report_module_id": 1,
+def _member(**overrides) -> dict:
+    payload = {
+        **_MEMBER_META,
+        "name": "Alice Smith",
+        "sius_code": "51",
+        "user_institutional_id": "123456",
+        "fte": 0.8,
     }
+    payload.update(overrides)
+    return {k: v for k, v in payload.items() if v is not _OMIT}
 
 
-def test_headcount_create_accepts_valid_sius_code() -> None:
-    item = HeadCountCreate(
-        **_base_create_payload(),
-        name="Alice",
-        sius_code="51",
-        user_institutional_id="12345",
+def _student(**overrides) -> dict:
+    payload = {**_STUDENT_META, "fte": 0.5}
+    payload.update(overrides)
+    return {k: v for k, v in payload.items() if v is not _OMIT}
+
+
+# ---------------------------------------------------------------------------
+# Member — valid (passing) permutations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_member(), id="baseline"),
+        pytest.param(_member(fte=0.0), id="fte-lower-bound"),
+        pytest.param(_member(fte=1.0), id="fte-upper-bound"),
+        pytest.param(_member(fte=0.05), id="fte-doc-example"),
+        pytest.param(_member(fte="0.75"), id="fte-numeric-string-coerced"),
+        pytest.param(_member(note="seconded 50%"), id="note-present"),
+        pytest.param(_member(note=_OMIT), id="note-omitted"),
+        pytest.param(_member(name="  Bob Jones  "), id="name-stripped"),
+        # Doc says "numbers only" but the schema deliberately allows letters.
+        pytest.param(_member(user_institutional_id="test-412424"), id="uid-letters"),
+        *[
+            pytest.param(_member(sius_code=code), id=f"sius-{code}")
+            for code in sorted(SIUS_CODE_VALUES)
+        ],
+    ],
+)
+def test_headcount_member_valid(payload: dict) -> None:
+    item = HeadCountCreate.model_validate(payload)
+    assert item.sius_code in SIUS_CODE_VALUES
+    assert 0 <= item.fte <= 1
+
+
+def test_headcount_member_strips_name_and_uid() -> None:
+    item = HeadCountCreate.model_validate(
+        _member(name="  Bob Jones  ", user_institutional_id=" 123456 ")
     )
-    assert item.sius_code == "51"
+    assert item.name == "Bob Jones"
+    assert item.user_institutional_id == "123456"
 
 
-def test_headcount_create_rejects_invalid_sius_code() -> None:
+# ---------------------------------------------------------------------------
+# Member — invalid (failing) permutations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_member(name=_OMIT), id="name-missing"),
+        pytest.param(_member(name=""), id="name-empty"),
+        pytest.param(_member(name="   "), id="name-whitespace"),
+        pytest.param(_member(sius_code=_OMIT), id="sius-missing"),
+        pytest.param(_member(sius_code="55"), id="sius-not-in-set"),
+        pytest.param(_member(sius_code="60"), id="sius-out-of-range"),
+        pytest.param(_member(sius_code="professor"), id="sius-non-numeric"),
+        pytest.param(_member(user_institutional_id=_OMIT), id="uid-missing"),
+        pytest.param(_member(user_institutional_id=""), id="uid-empty"),
+        pytest.param(_member(user_institutional_id="   "), id="uid-whitespace"),
+        pytest.param(_member(fte=_OMIT), id="fte-missing"),
+        pytest.param(_member(fte=1.5), id="fte-above-one"),
+        pytest.param(_member(fte=-0.1), id="fte-negative"),
+        pytest.param(_member(fte="not-a-number"), id="fte-uncoercible"),
+    ],
+)
+def test_headcount_member_invalid(payload: dict) -> None:
     with pytest.raises(ValidationError):
-        HeadCountCreate(
-            **_base_create_payload(),
-            name="Alice",
-            sius_code="invalid_category",
-            user_institutional_id="12345",
-        )
+        HeadCountCreate.model_validate(payload)
 
 
-def test_headcount_update_accepts_valid_sius_code() -> None:
-    item = HeadCountUpdate(**_base_create_payload(), sius_code="54")
-    assert item.sius_code == "54"
+# ---------------------------------------------------------------------------
+# Student — fte is the only field; non-negative, no documented upper bound
+# ---------------------------------------------------------------------------
 
 
-def test_headcount_update_rejects_invalid_sius_code() -> None:
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_student(fte=0.5), id="baseline"),
+        pytest.param(_student(fte=0.0), id="fte-zero"),
+        pytest.param(_student(fte="0.5"), id="fte-numeric-string-coerced"),
+        # NOTE: student fte has no upper-bound check (unlike member's ≤1).
+        # If that asymmetry is unintended, this case flags it.
+        pytest.param(_student(fte=2.0), id="fte-above-one-allowed"),
+    ],
+)
+def test_headcount_student_valid(payload: dict) -> None:
+    item = HeadCountStudentCreate.model_validate(payload)
+    assert item.fte >= 0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_student(fte=_OMIT), id="fte-missing"),
+        pytest.param(_student(fte=-0.1), id="fte-negative"),
+        pytest.param(_student(fte="not-a-number"), id="fte-uncoercible"),
+    ],
+)
+def test_headcount_student_invalid(payload: dict) -> None:
     with pytest.raises(ValidationError):
-        HeadCountUpdate(
-            **_base_create_payload(),
-            sius_code="invalid_category",
-        )
+        HeadCountStudentCreate.model_validate(payload)
 
 
-def test_headcount_create_accepts_numeric_user_institutional_id() -> None:
-    item = HeadCountCreate(
-        **_base_create_payload(),
-        name="Alice",
-        sius_code="51",
-        user_institutional_id="12345",
-    )
-    assert item.user_institutional_id == "12345"
+# ---------------------------------------------------------------------------
+# Update DTO — fields optional, but constraints still enforced when present
+# ---------------------------------------------------------------------------
 
 
-def test_headcount_create_strips_whitespace_in_user_institutional_id() -> None:
-    item = HeadCountCreate(
-        **_base_create_payload(),
-        name="Alice",
-        sius_code="51",
-        user_institutional_id=" 12345 ",
-    )
-    assert item.user_institutional_id == "12345"
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({**_MEMBER_META, "sius_code": "54"}, id="sius-only"),
+        pytest.param({**_MEMBER_META, "fte": 0.9}, id="fte-only"),
+        pytest.param({**_MEMBER_META}, id="nothing-to-update"),
+    ],
+)
+def test_headcount_update_valid(payload: dict) -> None:
+    HeadCountUpdate.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({**_MEMBER_META, "sius_code": "invalid"}, id="sius-invalid"),
+        pytest.param({**_MEMBER_META, "fte": 1.5}, id="fte-above-one"),
+        pytest.param({**_MEMBER_META, "fte": -1}, id="fte-negative"),
+    ],
+)
+def test_headcount_update_invalid(payload: dict) -> None:
+    with pytest.raises(ValidationError):
+        HeadCountUpdate.model_validate(payload)

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -93,6 +93,55 @@ def test_resolve_data_entry_type_from_name_valid():
     assert data_entry_type == DataEntryTypeEnum.member
 
 
+def test_resolve_data_entry_type_category_exact_case_accepted():
+    """equipment_category routing accepts the exact lowercase enum name."""
+    handler = MagicMock()
+    handler.category_field = "equipment_category"
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv", "handlers": [handler]}, data_session=MagicMock()
+    )
+    stats = _build_stats()
+    setup_result = {
+        "handlers": [handler],
+        "valid_entry_types": [DataEntryTypeEnum.scientific],
+    }
+
+    data_entry_type = provider._resolve_data_entry_type(
+        row={"equipment_category": "scientific"},
+        setup_result=setup_result,
+        row_idx=1,
+        stats=stats,
+        max_row_errors=5,
+    )
+
+    assert data_entry_type == DataEntryTypeEnum.scientific
+
+
+def test_resolve_data_entry_type_category_wrong_case_rejected():
+    """Doc: equipment_category is case-sensitive — 'Scientific' is rejected."""
+    handler = MagicMock()
+    handler.category_field = "equipment_category"
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv", "handlers": [handler]}, data_session=MagicMock()
+    )
+    stats = _build_stats()
+    setup_result = {
+        "handlers": [handler],
+        "valid_entry_types": [DataEntryTypeEnum.scientific],
+    }
+
+    data_entry_type = provider._resolve_data_entry_type(
+        row={"equipment_category": "Scientific"},
+        setup_result=setup_result,
+        row_idx=1,
+        stats=stats,
+        max_row_errors=5,
+    )
+
+    assert data_entry_type is None
+    assert stats["row_errors_count"] == 1
+
+
 def test_resolve_data_entry_type_from_name_invalid():
     provider = ConcreteFactorProvider(
         {"file_path": "tmp/test.csv"}, data_session=MagicMock()


### PR DESCRIPTION
## Summary

Reconciles backend create-DTO validation with the [`data-description.md`](https://github.com/EPFL-ENAC/co2-calculator-back-office-doc/blob/main/docs/data-description.md) contract, per doc-repo issue **back-office-doc#4** ("Discrepancies between code and data") and its confirmations from @martina-gallato.

Both **factor** and **data** rows are validated through these DTOs during CSV ingest (`validate_create` at `base_factor_csv_provider.py:382` and `base_csv_provider.py:996`), so making a field mandatory here enforces it at upload time. All seed/factor/data CSVs were checked: every tightened column is already fully populated, and no seed value violates the new `>=0` checks.

Scope: **Groups 1, 2, 4** from the discrepancy plan. Group 3 (plane `cabin_class`/issue 863) is intentionally deferred — see below.

## Changes

**Factor schemas (Group 1)**
- `research_facilities` common: `researchfacility_id` mandatory; `kg_co2eq_sum` `>=0`
- `research_facilities` animals: `researchfacility_id` / `researchfacility_name` / `researchfacility_type` / `use_unit`, the six `*_share`, and `total_use` mandatory; `kg_co2eq_sum_*` `>=0`
- `buildings`: `conversion_factor` optional + nullable (formula already defaults to 1); embodied-energy `ef_kgco2eq_per_m2` `>=0`
- `external_ai`: `requests_per_user_per_day` mandatory
- `purchase`: `purchase_institutional_code` mandatory

**Data schemas (Group 2)**
- `research_facilities` common/animals data: `id` / `name` (/`type`) / `use` / `use_unit` mandatory
- `buildings`: `room_type` mandatory
- `purchase` additional: `annual_consumption` mandatory (doc commit `21ad909`)

**Seed generator** — random-data builders updated to always emit the now-mandatory fields.

## Doc-side follow-ups (no code — for @martina-gallato)
- `equipment_category`: drop "case-sensitive" — ingest already lowercases (`DataEntryTypeEnum[v.lower()]`) and validates `{scientific,it,other}`.
- clouds `currency`: widen doc to `{chf,eur,usd}` — EUR conversion via `ExchangeRatesService` is implemented.
- clouds `fte_count`: doc `>=1` -> `>=0.1` (code is intentionally `>=0.1`, consistent with headcount).
- embodied-energy `category`: keep as free string (categories will change).

## Out of scope (deferred)
- **Plane `cabin_class` / issue 863**: doc now wants a string `{business,economy,first}` that selects the factor, but it's currently `float` in `value_fields` and unused by the resolver. Making it a classification key changes the factor identity (breaks existing matches) and needs an `eco`->`economy` map + resolver wiring + a seed migration — that's the 863 work, tracked separately.
- **Train `origin/destination_country_code` Optional**: intentional. The CSV path enforces it (`enrich_csv_row` rejects rows lacking it); the UI/API path resolves via `*_natural_key`. The shared DTO stays Optional to serve both.

## Verification
- `tests/unit` — 1555 passed
- `tests/integration/services/data_ingestion` (Dockerized Postgres, exercises CSV -> `validate_create`) — 194 passed
- `ruff check` — clean