### PR TITLE
fix(chart-colors): update train color scheme to use lighter shade of baby blue

### DIFF
--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1049,7 +1049,7 @@ const chartOption = computed((): EChartsOption => {
         color: getSubcategoryColor(
           'professional_travel',
           'train',
-          colors.value.babyBlue.dark,
+          colors.value.babyBlue.light,
         ),
       },
       label: { show: false },

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -454,7 +454,7 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
     },
     professional_travel: {
       plane: colors.value.babyBlue.darker,
-      train: colors.value.babyBlue.default,
+      train: colors.value.babyBlue.light,
     },
     external_cloud_and_ai: {
       clouds: colors.value.lavender.darker,


### PR DESCRIPTION
## What does this change?
Updates the train subcategory color from `babyBlue.default` to `babyBlue.light` in both the `CHART_SUBCATEGORY_COLOR_SCHEMES` constant and the `ModuleCarbonFootprintChart` fallback color, so train and plane bars are more visually distinct from each other.

## Why is this needed?
The train bar was too close in shade to the plane bar (`babyBlue.darker` vs `babyBlue.default`), making them hard to tell apart in the stacked chart. Using `babyBlue.light` increases the contrast between the two travel subcategories.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- related #761