### PR TITLE
feat(charts): add ChartEmptyState component for improved no-data handling

### DIFF
--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -19,6 +19,7 @@ import {
   AriaComponent,
 } from 'echarts/components';
 import VChart from 'vue-echarts';
+import ChartEmptyState from 'src/components/molecules/ChartEmptyState.vue';
 import TooltipEcharts from './TooltipEcharts.vue';
 import { useEchartsTooltip } from './useEchartsTooltip';
 import { useColorblindStore } from 'src/stores/colorblind';
@@ -503,22 +504,18 @@ defineExpose({ downloadPNG });
 
 <template>
   <div class="q-mb-md">
-    <div class="flex justify-center items-center">
-      <v-chart
-        v-if="chartData.bars.length"
-        ref="chartRef"
-        :key="colorblindStore.enabled ? 'cb' : 'default'"
-        class="chart"
-        autoresize
-        :option="chartOption"
-        :update-options="{ replaceMerge: ['series'] }"
-        :style="{ height: chartHeight + 'px' }"
-        @vue:mounted="onChartReady"
-      />
-      <span v-else class="text-body2 text-secondary">
-        {{ $t('no-chart-data') }}
-      </span>
-    </div>
+    <v-chart
+      v-if="chartData.bars.length"
+      ref="chartRef"
+      :key="colorblindStore.enabled ? 'cb' : 'default'"
+      class="chart"
+      autoresize
+      :option="chartOption"
+      :update-options="{ replaceMerge: ['series'] }"
+      :style="{ height: chartHeight + 'px' }"
+      @vue:mounted="onChartReady"
+    />
+    <chart-empty-state v-else />
     <Teleport to="body">
       <tooltip-echarts
         v-if="tooltip.visible"

--- a/frontend/src/components/molecules/ChartEmptyState.vue
+++ b/frontend/src/components/molecules/ChartEmptyState.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="chart-empty-state">
+    <span class="text-body2 text-secondary">{{ $t('no-chart-data') }}</span>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.chart-empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 80px;
+  padding: 8px 0;
+}
+</style>

--- a/frontend/src/components/molecules/HeadCountBarChart.vue
+++ b/frontend/src/components/molecules/HeadCountBarChart.vue
@@ -18,6 +18,7 @@ import { useEchartsTooltip } from 'src/components/charts/results/useEchartsToolt
 
 import { colors } from 'src/constant/charts';
 import { MODULES } from 'src/constant/modules';
+import { getHeadcountChartKeys } from 'src/utils/headcountChart';
 
 use([
   CanvasRenderer,
@@ -63,8 +64,10 @@ const colorMap: Record<string, string> = {
   other: colors.value.mint.darker,
 };
 
+const chartKeys = computed(() => getHeadcountChartKeys(props.stats));
+
 const chartOptions = computed<EChartsOption>(() => {
-  const keys = Object.keys(props.stats ?? {});
+  const keys = chartKeys.value;
 
   return {
     tooltip: {

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -1,17 +1,15 @@
 <template>
   <q-card-section class="text-left module-charts q-px-none">
     <template v-if="type === 'headcount'">
-      <div class="q-px-lg q-mx-sm">
-        <h2 class="text-h5 text-weight-medium q-mb-md text-bold text-black">
+      <div class="q-mx-lg">
+        <div class="text-body1 text-weight-medium q-ml-sm q-mb-md text-black">
           {{ $t('headcount-charts-title') }}
-        </h2>
+        </div>
         <headCountBarChart
-          v-if="hasStats"
+          v-if="headcountChartKeys.length"
           :stats="moduleStore?.state?.data?.stats"
         />
-        <span v-else class="text-body2 text-secondary">
-          {{ $t(`${type}-charts-no-data-message`) }}
-        </span>
+        <chart-empty-state v-else />
       </div>
     </template>
     <template v-else>
@@ -82,9 +80,7 @@
             :data="moduleTreemapData"
             :print-mode="printMode"
           />
-          <span v-else class="text-body2 text-secondary">
-            {{ $t('no-chart-data') }}
-          </span>
+          <chart-empty-state v-else />
         </template>
         <template v-else>
           <emission-type-breakdown-chart
@@ -96,9 +92,7 @@
             :print-mode="printMode"
           />
 
-          <span v-else class="text-body2 text-secondary">
-            {{ $t('no-chart-data') }}
-          </span>
+          <chart-empty-state v-else />
         </template>
       </div>
       <template v-if="type === MODULES.ProfessionalTravel && !isPrintMode">
@@ -141,6 +135,7 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Module, MODULES } from 'src/constant/modules';
+import ChartEmptyState from 'src/components/molecules/ChartEmptyState.vue';
 import HeadCountBarChart from 'src/components/molecules/HeadCountBarChart.vue';
 import TripsMap from 'src/components/molecules/TripsMap.vue';
 import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTreeMapChart.vue';
@@ -158,6 +153,7 @@ import {
   MODULE_TO_CATEGORIES,
 } from 'src/constant/charts';
 import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakdownInfo';
+import { getHeadcountChartKeys } from 'src/utils/headcountChart';
 
 const props = withDefaults(
   defineProps<{
@@ -313,10 +309,9 @@ watch(
   () => fetchTopClassBreakdownIfNeeded(),
 );
 
-const hasStats = computed(() => {
-  const stats = moduleStore.state.data?.stats;
-  return !!stats && Object.keys(stats).length > 0;
-});
+const headcountChartKeys = computed(() =>
+  getHeadcountChartKeys(moduleStore.state.data?.stats),
+);
 
 const moduleTreemapData = computed(() => {
   const breakdown = moduleStore.state.emissionBreakdown?.module_breakdown;

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -393,7 +393,10 @@ const showModuleForm = computed(
 );
 
 const showViewOnlyBadge = computed(
-  () => Boolean(props.submodule.moduleFields) && !isFormDisabled.value,
+  () =>
+    Boolean(props.submodule.moduleFields) &&
+    !isFormDisabled.value &&
+    !canEdit.value,
 );
 
 // Map data is fetched once at the module-charts level (ModuleCharts.vue

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -28,6 +28,7 @@ const memberFields: ModuleField[] = [
     ratio: '1/4',
     icon: 'o_filter_drama',
     columnSize: 'sm',
+    readOnly: true,
     hideIn: { form: true },
   },
   {
@@ -39,6 +40,7 @@ const memberFields: ModuleField[] = [
     icon: 'o_assignment_ind',
     optionLabelsAreKeys: true,
     columnSize: 'sm',
+    readOnly: true,
     options: [
       { value: '51', label: '51' },
       { value: '52', label: '52' },
@@ -57,6 +59,7 @@ const memberFields: ModuleField[] = [
     type: 'text',
     sortable: false,
     ratio: '1/4',
+    readOnly: true,
     hideIn: { form: true },
   },
   {
@@ -69,6 +72,7 @@ const memberFields: ModuleField[] = [
     sortable: false,
     ratio: '1/4',
     icon: 'o_timer',
+    readOnly: true,
     hideIn: { form: true },
   },
 ];
@@ -88,7 +92,6 @@ const studentFields: ModuleField[] = [
     sortable: true,
     ratio: '12/12',
     icon: iconMap['o_timer'],
-    hideIn: { form: true },
   },
 ];
 

--- a/frontend/src/utils/headcountChart.ts
+++ b/frontend/src/utils/headcountChart.ts
@@ -1,0 +1,7 @@
+export function getHeadcountChartKeys(
+  stats?: Record<string, number> | null,
+): string[] {
+  return Object.keys(stats ?? {}).filter(
+    (key) => key !== 'student' || (stats?.[key] ?? 0) > 0,
+  );
+}


### PR DESCRIPTION
## What does this change?
Introduces a shared `ChartEmptyState` component, fixes the headcount chart to suppress the student bar when its value is zero, and marks all headcount member fields as read-only in the table.

**New files:**
- `components/molecules/ChartEmptyState.vue`: centered "no data" placeholder with a minimum height of 80px, replacing ad-hoc `<span v-else>` empty states throughout the app
- `utils/headcountChart.ts`: `getHeadcountChartKeys()` — returns the stats keys for the headcount bar chart, filtering out `"student"` when its value is zero

**Component changes:**
- `EmissionTypeBreakdownChart.vue`: replaces the wrapping `<div class="flex justify-center">` + inline empty-state span with `<chart-empty-state v-else />`; removes the now-redundant outer wrapper div
- `ModuleCharts.vue`: replaces all three inline `<span v-else>` no-data messages with `<chart-empty-state>`; switches the headcount chart visibility check from `hasStats` (any non-empty stats) to `headcountChartKeys.length > 0` (keys after student filtering); removes the `hasStats` computed; downgrades the chart section heading from `<h2>` to a `<div>` to match the rest of the module
- `HeadCountBarChart.vue`: uses `getHeadcountChartKeys` to derive the chart keys instead of `Object.keys(props.stats ?? {})`
- `SubModuleSection.vue`: fixes `showViewOnlyBadge` — now also requires `!canEdit.value`, so the "view only" badge no longer appears for users who do have edit permission
- `headcount.ts` (module config): adds `readOnly: true` to all four member fields (`name`, `sius_code`, `user_institutional_id`, `fte`); removes `hideIn: { form: true }` from the student `fte` field

## Why is this needed?
The student bar was appearing in the headcount chart with a value of zero when no student FTE had been entered, creating a misleading empty bar. The inline empty-state spans were also inconsistent in appearance and placement across charts. The "view only" badge logic was also incorrectly shown to users with edit access.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1365 (student bar removal)