### PR TITLE
feat 1370: enhance table action visibility and note handling

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -177,18 +177,14 @@
               @blur="commitInline(slotProps.row, col)"
             ></component>
           </template>
-          <template
-            v-else-if="
-              col.name === 'action' &&
-              props.submoduleConfig?.hasTableAction !== false
-            "
-          >
+          <template v-else-if="col.name === 'action' && showTableActions">
             <q-btn
+              v-if="showTableNote"
               :icon="noteButtonIcon(slotProps.row.note)"
               :color="noteButtonColor(slotProps.row.note)"
               :style="noteButtonStyle(slotProps.row.note)"
               :text-color="noteButtonTextColor(slotProps.row.note)"
-              :disable="isDisabled"
+              :disable="isNoteDisabled"
               unelevated
               no-caps
               dense
@@ -202,7 +198,7 @@
               </q-tooltip>
             </q-btn>
             <q-btn
-              v-if="canEdit && hasModuleUpload"
+              v-if="showTableRowActions && canEdit && hasModuleUpload"
               icon="o_delete"
               color="grey-4"
               text-color="primary"
@@ -784,6 +780,25 @@ const isDisabled = computed(
       !canEdit.value),
 );
 
+const showTableRowActions = computed(
+  () => props.submoduleConfig?.hasTableAction !== false,
+);
+
+const showTableNote = computed(
+  () =>
+    showTableRowActions.value || props.submoduleConfig?.hasTableNote === true,
+);
+
+const showTableActions = computed(() => showTableNote.value);
+
+// Notes stay available on read-only tables; only permission and validation block them.
+const isNoteDisabled = computed(
+  () =>
+    !props.isSimulator &&
+    (timelineStore.itemStates[props.moduleType] === MODULE_STATES.Validated ||
+      !canEdit.value),
+);
+
 const filterTerm = ref('');
 const confirmDelete = ref(false);
 const ItemName = ref<string>('');
@@ -922,7 +937,7 @@ const qCols = computed<TableViewColumn[]>(() => {
       }
     });
 
-  if (props.submoduleConfig.hasTableAction !== false) {
+  if (showTableActions.value) {
     baseCols.push({
       name: 'action',
       label: $t('common_actions'),

--- a/frontend/src/constant/module-config/research-facilities.ts
+++ b/frontend/src/constant/module-config/research-facilities.ts
@@ -107,6 +107,7 @@ export const researchFacilities: ModuleConfig = {
       moduleFields: researchFacilitiesFields,
       hasFormTooltip: false,
       hasTableAction: false,
+      hasTableNote: true,
     },
     {
       id: SUBMODULE_RESEARCH_FACILITIES_TYPES.AnimalFacilities,
@@ -115,6 +116,7 @@ export const researchFacilities: ModuleConfig = {
       moduleFields: animalFields,
       hasFormTooltip: false,
       hasTableAction: false,
+      hasTableNote: true,
     },
   ],
 };

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -128,6 +128,8 @@ export interface Submodule {
   hasFormTooltip?: boolean | string;
   hasFormAddWithNote?: boolean;
   hasTableAction?: boolean;
+  /** Show note button in the table even when data rows are read-only. */
+  hasTableNote?: boolean;
   addButtonLabelKey?: string;
   tooltipKey?: string;
   notifyInfoOnAddKey?: string;


### PR DESCRIPTION
## What does this change?
Decouples the note button from table row actions so it can be shown on read-only tables, and enables notes on the research facilities submodules.

**`moduleConfig.ts`:** adds optional `hasTableNote?: boolean` to the `Submodule` interface — when `true`, the note button is shown even when `hasTableAction` is `false`

**`ModuleTable.vue`:** introduces three new computed properties:
- `showTableRowActions`: `true` when `hasTableAction !== false` (existing behaviour, now named)
- `showTableNote`: `true` when either `showTableRowActions` or `hasTableNote` is set
- `showTableActions`: `true` when `showTableNote` is true (drives the `action` column visibility)
- `isNoteDisabled`: mirrors the old `isDisabled` logic but is used exclusively for the note button, keeping notes unblocked by the upload-in-progress check

The note `q-btn` is now gated by `v-if="showTableNote"` and the delete/upload `q-btn` by `v-if="showTableRowActions && canEdit && hasModuleUpload"`. The `action` column is appended whenever `showTableActions` is true.

**`research-facilities.ts`:** adds `hasTableNote: true` to both the research facilities and animal facilities submodules (both already had `hasTableAction: false`)

## Why is this needed?
Research facilities and animal facilities rows are read-only (populated by the back-office), so `hasTableAction` was set to `false` and no action column appeared. Users had no way to add notes to individual rows. The new `hasTableNote` flag adds the note button independently of the row edit/delete actions.

## Type of change
- [x] ✨ New feature
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1370