### PR TITLE
feat 1449: add q-select component overrides for improved styling

### DIFF
--- a/frontend/src/css/05-components/quasar-overrides/_q-select.scss
+++ b/frontend/src/css/05-components/quasar-overrides/_q-select.scss
@@ -1,0 +1,3 @@
+.q-field__native .ellipsis {
+  overflow: visible;
+}

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -35,6 +35,7 @@
   @import './05-components/quasar-overrides/q-tooltip';
   @import './05-components/quasar-overrides/q-dialog';
   @import './05-components/quasar-overrides/q-table';
+  @import './05-components/quasar-overrides/q-select';
 }
 
 @layer components {


### PR DESCRIPTION
## What does this change?
Adds a new Quasar override stylesheet for `q-select` that sets `overflow: visible` on the `.q-field__native .ellipsis` selector, and imports it in `app.scss`.

## Why is this needed?
Long option labels in `q-select` fields (e.g. process emissions gas names) were being clipped by the default `overflow: hidden` / `text-overflow: ellipsis` behaviour applied by Quasar's `.ellipsis` utility class inside the native field slot. Setting `overflow: visible` allows the full label to display without being cut off.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1449