### PR TITLE
Feat/282 travels map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ storybook-static
 AGENTS.md
 .worktrees
 .claude/scheduled_tasks.lock
+
+# Local DB dumps + secrets (never commit)
+*.pgdump
+app_dump*

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -752,10 +752,22 @@ class DataEntryRepository:
         ``number_of_trips``. Rows whose origin or destination location did not
         resolve are dropped and counted into the returned ``dropped`` total.
         """
-        emission_agg_q = select(
-            DataEntryEmission.data_entry_id,
-            func.sum(DataEntryEmission.kg_co2eq).label("total_kg_co2eq"),
-        ).group_by(col(DataEntryEmission.data_entry_id))
+        # Scope the per-entry emission rollup to THIS module's entries. Without
+        # it, the subquery seq-scans and aggregates the whole emissions table
+        # (~700k rows) on every call — and the mode loop below runs it twice —
+        # which dominates the query (seconds on a cold cache). Restricting by
+        # data_entry_id turns that into an indexed lookup of the module's rows.
+        module_entry_ids = select(col(DataEntry.id)).where(
+            col(DataEntry.carbon_report_module_id) == carbon_report_module_id
+        )
+        emission_agg_q = (
+            select(
+                DataEntryEmission.data_entry_id,
+                func.sum(DataEntryEmission.kg_co2eq).label("total_kg_co2eq"),
+            )
+            .where(col(DataEntryEmission.data_entry_id).in_(module_entry_ids))
+            .group_by(col(DataEntryEmission.data_entry_id))
+        )
         if ROLLUP_EMISSION_TYPE_IDS:
             emission_agg_q = emission_agg_q.where(
                 col(DataEntryEmission.emission_type_id).notin_(ROLLUP_EMISSION_TYPE_IDS)
@@ -785,6 +797,10 @@ class DataEntryRepository:
         ):
             OriginLocation = aliased(Location)
             DestLocation = aliased(Location)
+            # Traveler identity (SCIPER) stored on the entry. The display name is
+            # resolved later from the unit's headcount roster (the canonical
+            # source), not the User table — see ``get_professional_travel_trips_map``.
+            traveler_id_key = DataEntry.data["user_institutional_id"].as_string()
 
             select_entities: list[Any] = [
                 OriginLocation.latitude,
@@ -795,6 +811,7 @@ class DataEntryRepository:
                 DestLocation.name,
                 emission_agg.c.total_kg_co2eq,
                 DataEntry.data["number_of_trips"].as_float(),
+                traveler_id_key,
             ]
             statement: Select[Any] = (
                 sa_select(*select_entities)
@@ -834,10 +851,21 @@ class DataEntryRepository:
             statement = statement.limit(remaining)
             result = await self.session.execute(statement)
             for row in result.all():
-                (o_lat, o_lng, o_name, d_lat, d_lng, d_name, kg, n_trips) = row
+                (
+                    o_lat,
+                    o_lng,
+                    o_name,
+                    d_lat,
+                    d_lng,
+                    d_name,
+                    kg,
+                    n_trips,
+                    traveler_id,
+                ) = row
                 if o_lat is None or o_lng is None or d_lat is None or d_lng is None:
                     dropped += 1
                     continue
+                tid = traveler_id or ""
                 legs.append(
                     {
                         "mode": mode,
@@ -849,6 +877,10 @@ class DataEntryRepository:
                         "destination_name": d_name or "",
                         "kg_co2eq": float(kg or 0.0),
                         "number_of_trips": int(n_trips) if n_trips is not None else 1,
+                        "traveler_id": tid,
+                        # traveler_name is filled from the headcount roster in the
+                        # service; default to the SCIPER until then.
+                        "traveler_name": tid,
                     }
                 )
 

--- a/backend/app/schemas/carbon_report_response.py
+++ b/backend/app/schemas/carbon_report_response.py
@@ -90,6 +90,8 @@ class TripLeg(BaseModel):
     destination_name: str
     kg_co2eq: float
     number_of_trips: int = 1
+    traveler_id: str = ""
+    traveler_name: str = ""
 
 
 class TripsMapResponse(BaseModel):

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -685,11 +685,16 @@ class DataEntryService:
 
         Frontend aggregates per-map (undirected by default), so this is one
         leg per source ``DataEntry``, not a per-route rollup.
+
+        Each leg carries the traveler's SCIPER (``traveler_id``); the frontend
+        resolves it to a display name via the headcount-members endpoint it
+        already calls (``traveler_name`` defaults to the SCIPER until then).
         """
         legs, dropped = await self.repo.get_professional_travel_trip_legs(
             carbon_report_module_id=carbon_report_module_id,
             institutional_id_filter=institutional_id_filter,
         )
+
         return TripsMapResponse(
             legs=[TripLeg(**leg) for leg in legs],
             dropped_count=dropped,

--- a/backend/tests/integration/v1/test_professional_travel_trips_map.py
+++ b/backend/tests/integration/v1/test_professional_travel_trips_map.py
@@ -41,6 +41,8 @@ ALL_LEGS = [
         "origin_name": "Geneva Airport",
         "destination_name": "JFK",
         "kg_co2eq": 1234.5,
+        "traveler_id": "alice",
+        "traveler_name": "Alice Dupont",
     },
     {
         "mode": "train",
@@ -51,6 +53,8 @@ ALL_LEGS = [
         "origin_name": "Lausanne",
         "destination_name": "Paris",
         "kg_co2eq": 10.0,
+        "traveler_id": "bob",
+        "traveler_name": "Bob Martin",
     },
 ]
 
@@ -101,7 +105,10 @@ def _wire(monkeypatch, user, decision_fn):
     captured: dict = {}
     mock_service = MagicMock()
 
-    async def mock_trips_map(carbon_report_module_id, institutional_id_filter=None):
+    async def mock_trips_map(
+        carbon_report_module_id,
+        institutional_id_filter=None,
+    ):
         captured["filter"] = institutional_id_filter
         legs = ALL_LEGS
         if institutional_id_filter is not None:
@@ -164,6 +171,12 @@ def test_principal_sees_full_unit_data(client, monkeypatch):
         assert captured["filter"] is None
         legs = r.json()["legs"]
         assert len(legs) == 2
+        # Each leg carries its traveler so the manager can filter by person.
+        assert {leg["traveler_id"] for leg in legs} == {"alice", "bob"}
+        assert {leg["traveler_name"] for leg in legs} == {
+            "Alice Dupont",
+            "Bob Martin",
+        }
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/unit/repositories/test_data_entry_repo_trips_map.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo_trips_map.py
@@ -324,6 +324,51 @@ async def test_leg_carries_number_of_trips(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_legs_carry_traveler_id_with_sciper_name_fallback(
+    db_session: AsyncSession,
+):
+    """Each leg exposes its traveler (SCIPER) so a unit manager can filter by
+    person. The repo does not resolve display names — that is the service's job
+    via the headcount roster — so ``traveler_name`` defaults to the SCIPER here.
+    """
+    repo = DataEntryRepository(db_session)
+    module_id = await _seed_module(db_session)
+    await _seed_location(
+        db_session,
+        mode=TransportModeEnum.plane,
+        name="Geneva Airport",
+        lat=46.2381,
+        lng=6.1090,
+        iata="GVA",
+    )
+
+    await _seed_plane(
+        db_session,
+        module_id=module_id,
+        origin_iata="GVA",
+        destination_iata="GVA",
+        kg_co2eq=1.0,
+        user_iid="alice",
+    )
+    await _seed_plane(
+        db_session,
+        module_id=module_id,
+        origin_iata="GVA",
+        destination_iata="GVA",
+        kg_co2eq=2.0,
+        user_iid="bob",
+    )
+
+    legs, _dropped = await repo.get_professional_travel_trip_legs(
+        carbon_report_module_id=module_id,
+    )
+
+    by_id = {leg["traveler_id"]: leg["traveler_name"] for leg in legs}
+    assert by_id["alice"] == "alice"  # SCIPER fallback (no roster at repo layer)
+    assert by_id["bob"] == "bob"
+
+
+@pytest.mark.asyncio
 async def test_train_join_disambiguates_same_name_stations(
     db_session: AsyncSession,
 ):

--- a/backend/tests/unit/services/test_data_entry_service.py
+++ b/backend/tests/unit/services/test_data_entry_service.py
@@ -5,6 +5,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.carbon_report import CarbonReportModule
 from app.models.data_entry import DataEntry, DataEntryStatusEnum, DataEntryTypeEnum
+from app.models.location import Location, TransportModeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User, UserProvider
 from app.schemas.data_entry import DataEntryCreate, DataEntryUpdate
@@ -586,3 +587,64 @@ async def test_get_total_per_field(db_session: AsyncSession):
     )
 
     assert result == pytest.approx(5.0, rel=0.01)
+
+
+@pytest.mark.asyncio
+async def test_trips_map_carries_traveler_sciper_without_resolving_name(
+    db_session: AsyncSession,
+):
+    """The service ships each leg's traveler SCIPER as both ``traveler_id`` and
+    (un-resolved) ``traveler_name``. Display-name resolution is the frontend's
+    job — it joins the SCIPER against the headcount-members endpoint — so the
+    service no longer touches the roster.
+    """
+    service = DataEntryService(db_session)
+
+    # Resolve the plane endpoint so the leg isn't dropped for missing coords.
+    gva_key = Location.compute_natural_key(
+        transport_mode=TransportModeEnum.plane,
+        name="Geneva Airport",
+        latitude=46.2381,
+        longitude=6.1090,
+        iata_code="GVA",
+    )
+    db_session.add(
+        Location(
+            transport_mode=TransportModeEnum.plane,
+            name="Geneva Airport",
+            latitude=46.2381,
+            longitude=6.1090,
+            iata_code="GVA",
+            natural_key=gva_key,
+        )
+    )
+
+    travel_module = CarbonReportModule(
+        carbon_report_id=1,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status="in_progress",
+    )
+    db_session.add(travel_module)
+    await db_session.flush()
+
+    db_session.add(
+        DataEntry(
+            carbon_report_module_id=travel_module.id,
+            data_entry_type_id=DataEntryTypeEnum.plane,
+            status=DataEntryStatusEnum.PENDING,
+            data={
+                "origin_iata": "GVA",
+                "destination_iata": "GVA",
+                "user_institutional_id": "alice",
+                "number_of_trips": 1,
+            },
+        )
+    )
+    await db_session.flush()
+
+    resolved = await service.get_professional_travel_trips_map(
+        carbon_report_module_id=travel_module.id,
+    )
+    assert len(resolved.legs) == 1
+    assert resolved.legs[0].traveler_id == "alice"
+    assert resolved.legs[0].traveler_name == "alice"

--- a/frontend/src/components/molecules/TripsMap.vue
+++ b/frontend/src/components/molecules/TripsMap.vue
@@ -1,95 +1,244 @@
 <template>
-  <div
-    class="trips-map"
-    :style="{ height }"
-    role="region"
-    :aria-label="ariaLabel"
-    :data-testid="testid"
-  >
-    <q-skeleton v-if="loading && !visibleLegs.length" :height="height" />
+  <div class="trips-map-block">
     <div
-      v-else-if="!visibleLegs.length"
-      class="column flex-center full-height text-center q-pa-md text-body2 text-secondary"
+      class="trips-map"
+      :style="{ height }"
+      role="region"
+      :aria-label="ariaLabel"
+      :data-testid="testid"
     >
-      <q-icon name="map" size="lg" class="text-grey-6 q-mb-sm" />
-      {{ t(`${MODULES.ProfessionalTravel}-trips-map-empty`) }}
-    </div>
-    <template v-else>
-      <div ref="mapEl" class="trips-map__canvas" />
-      <div class="trips-map__legend" aria-hidden="true">
-        <div class="trips-map__legend-block">
-          <div class="trips-map__legend-caption">
-            {{ t(`${MODULES.ProfessionalTravel}-trips-map-legend-emissions`) }}
+      <q-skeleton v-if="loading && !visibleLegs.length" :height="height" />
+      <div
+        v-else-if="!visibleLegs.length"
+        class="column flex-center full-height text-center q-pa-md text-body2 text-secondary"
+      >
+        <q-icon name="map" size="lg" class="text-grey-6 q-mb-sm" />
+        {{ t(`${MODULES.ProfessionalTravel}-trips-map-empty`) }}
+      </div>
+      <template v-else>
+        <div ref="mapEl" class="trips-map__canvas" />
+        <div class="trips-map__legend">
+          <div class="trips-map__legend-block" aria-hidden="true">
+            <div class="trips-map__legend-caption">
+              {{
+                t(`${MODULES.ProfessionalTravel}-trips-map-legend-emissions`)
+              }}
+            </div>
+            <div
+              class="trips-map__legend-gradient"
+              :style="{ background: CO2_RAMP_CSS }"
+            />
+            <div class="trips-map__legend-scale">
+              <span>0</span>
+              <span>{{ formatKgCo2eq(niceMaxKg) }}</span>
+            </div>
           </div>
+          <div class="trips-map__legend-block" aria-hidden="true">
+            <div class="trips-map__legend-caption">
+              {{ t(`${MODULES.ProfessionalTravel}-trips-map-legend-trips`) }}
+            </div>
+            <svg
+              class="trips-map__legend-width"
+              viewBox="0 0 120 12"
+              preserveAspectRatio="none"
+              aria-hidden="true"
+            >
+              <polygon points="2,6.75 118,1 118,11" />
+            </svg>
+            <div class="trips-map__legend-scale">
+              <span>1</span>
+              <span>{{ niceMaxTrips }}</span>
+            </div>
+          </div>
+          <!-- Selectable mode legend: the dashed-arc (plane) and straight-line
+               (train) glyphs double as toggles. Deselected → dimmed. Shown only
+               when both modes exist and no mode is pinned by the parent. -->
           <div
-            class="trips-map__legend-gradient"
-            :style="{ background: CO2_RAMP_CSS }"
-          />
-          <div class="trips-map__legend-scale">
-            <span>0</span>
-            <span>{{ formatKgCo2eq(niceMaxKg) }}</span>
+            v-if="showModeFilter"
+            class="trips-map__legend-modes trips-map__legend-modes--toggle"
+            role="group"
+            :aria-label="
+              t(`${MODULES.ProfessionalTravel}-trips-map-filter-mode-aria`)
+            "
+          >
+            <button
+              type="button"
+              class="trips-map__legend-mode"
+              :class="{
+                'trips-map__legend-mode--off': !isModeSelected('plane'),
+              }"
+              :aria-pressed="isModeSelected('plane')"
+              data-testid="trips-map-mode-plane"
+              @click="toggleMode('plane')"
+            >
+              <q-icon
+                :name="
+                  isModeSelected('plane')
+                    ? 'check_box'
+                    : 'check_box_outline_blank'
+                "
+                :color="isModeSelected('plane') ? 'primary' : 'grey-7'"
+                size="15px"
+              />
+              <svg
+                class="trips-map__legend-glyph"
+                viewBox="0 0 20 10"
+                aria-hidden="true"
+              >
+                <path d="M1 8 Q10 -2 19 8" />
+              </svg>
+              {{ t('plane') }}
+            </button>
+            <button
+              type="button"
+              class="trips-map__legend-mode"
+              :class="{
+                'trips-map__legend-mode--off': !isModeSelected('train'),
+              }"
+              :aria-pressed="isModeSelected('train')"
+              data-testid="trips-map-mode-train"
+              @click="toggleMode('train')"
+            >
+              <q-icon
+                :name="
+                  isModeSelected('train')
+                    ? 'check_box'
+                    : 'check_box_outline_blank'
+                "
+                :color="isModeSelected('train') ? 'primary' : 'grey-7'"
+                size="15px"
+              />
+              <svg
+                class="trips-map__legend-glyph"
+                viewBox="0 0 20 10"
+                aria-hidden="true"
+              >
+                <line x1="1" y1="5" x2="19" y2="5" />
+              </svg>
+              {{ t('train') }}
+            </button>
           </div>
-        </div>
-        <div class="trips-map__legend-block">
-          <div class="trips-map__legend-caption">
-            {{ t(`${MODULES.ProfessionalTravel}-trips-map-legend-trips`) }}
-          </div>
-          <svg
-            class="trips-map__legend-width"
-            viewBox="0 0 120 12"
-            preserveAspectRatio="none"
+          <!-- Static legend when there's nothing to toggle (single-mode data). -->
+          <div
+            v-else-if="!modeFilter"
+            class="trips-map__legend-modes"
             aria-hidden="true"
           >
-            <polygon points="2,6.75 118,1 118,11" />
-          </svg>
-          <div class="trips-map__legend-scale">
-            <span>1</span>
-            <span>{{ niceMaxTrips }}</span>
+            <span class="trips-map__legend-mode">
+              <svg
+                class="trips-map__legend-glyph"
+                viewBox="0 0 20 10"
+                aria-hidden="true"
+              >
+                <path d="M1 8 Q10 -2 19 8" />
+              </svg>
+              {{ t('plane') }}
+            </span>
+            <span class="trips-map__legend-mode">
+              <svg
+                class="trips-map__legend-glyph"
+                viewBox="0 0 20 10"
+                aria-hidden="true"
+              >
+                <line x1="1" y1="5" x2="19" y2="5" />
+              </svg>
+              {{ t('train') }}
+            </span>
           </div>
         </div>
-        <div v-if="!modeFilter" class="trips-map__legend-modes">
-          <span class="trips-map__legend-mode">
-            <svg
-              class="trips-map__legend-glyph"
-              viewBox="0 0 20 10"
-              aria-hidden="true"
-            >
-              <path d="M1 8 Q10 -2 19 8" />
-            </svg>
-            {{ t('plane') }}
-          </span>
-          <span class="trips-map__legend-mode">
-            <svg
-              class="trips-map__legend-glyph"
-              viewBox="0 0 20 10"
-              aria-hidden="true"
-            >
-              <line x1="1" y1="5" x2="19" y2="5" />
-            </svg>
-            {{ t('train') }}
-          </span>
-        </div>
-      </div>
-      <ul class="trips-map__sr-only">
-        <li v-for="(leg, idx) in visibleLegs" :key="idx">
+        <ul class="trips-map__sr-only">
+          <li v-for="(leg, idx) in visibleLegs" :key="idx">
+            {{
+              t(`${MODULES.ProfessionalTravel}-trips-map-leg-aria`, {
+                from: leg.fromName,
+                to: leg.toName,
+                count: leg.tripCount,
+                emissions: formatKgCo2eq(leg.totalKgCo2eq),
+              })
+            }}
+          </li>
+        </ul>
+      </template>
+    </div>
+
+    <!-- Member filter under the map: manager-only (the API only returns >1
+         traveler for a principal/global). -->
+    <div
+      v-if="travelers.length >= 2"
+      class="trips-map__members q-mt-md"
+      role="group"
+      :aria-label="
+        t(`${MODULES.ProfessionalTravel}-trips-map-filter-members-aria`)
+      "
+      data-testid="trips-map-member-filter"
+    >
+      <div class="row items-center q-mb-xs">
+        <span class="text-grey-8 text-weight-medium">
           {{
-            t(`${MODULES.ProfessionalTravel}-trips-map-leg-aria`, {
-              from: leg.fromName,
-              to: leg.toName,
-              count: leg.tripCount,
-              emissions: formatKgCo2eq(leg.totalKgCo2eq),
+            t(`${MODULES.ProfessionalTravel}-trips-map-filter-members-title`)
+          }}
+        </span>
+        <span class="trips-map__members-count q-ml-xs">
+          {{
+            t(`${MODULES.ProfessionalTravel}-trips-map-filter-members-label`, {
+              shown: shownTravelerCount,
+              total: travelers.length,
             })
           }}
-        </li>
-      </ul>
-    </template>
+        </span>
+        <q-space />
+        <button
+          type="button"
+          class="trips-map__members-action"
+          @click="selectAllTravelers"
+        >
+          {{ t(`${MODULES.ProfessionalTravel}-trips-map-filter-all`) }}
+        </button>
+        <span class="trips-map__members-sep">·</span>
+        <button
+          type="button"
+          class="trips-map__members-action"
+          @click="selectNoTravelers"
+        >
+          {{ t(`${MODULES.ProfessionalTravel}-trips-map-filter-none`) }}
+        </button>
+      </div>
+      <div class="trips-map__member-list">
+        <button
+          v-for="tr in travelers"
+          :key="tr.id"
+          type="button"
+          class="trips-map__member"
+          :class="{ 'trips-map__member--off': !isTravelerSelected(tr.id) }"
+          :aria-pressed="isTravelerSelected(tr.id)"
+          @click="toggleTraveler(tr.id)"
+          @mouseenter="hoveredTravelerId = tr.id"
+          @mouseleave="hoveredTravelerId = null"
+          @focus="hoveredTravelerId = tr.id"
+          @blur="hoveredTravelerId = null"
+        >
+          <q-icon
+            :name="
+              isTravelerSelected(tr.id)
+                ? 'check_circle'
+                : 'radio_button_unchecked'
+            "
+            :color="isTravelerSelected(tr.id) ? 'primary' : 'grey-5'"
+            size="13px"
+          />
+          <span class="trips-map__member-name">{{ tr.name }}</span>
+          <span class="trips-map__member-value">{{
+            formatKgCo2eq(tr.totalKgCo2eq)
+          }}</span>
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { runtimeConfig } from 'src/config/runtime';
 import { MODULES } from 'src/constant/modules';
 import type { TripLeg } from 'src/stores/modules';
 import { formatKgCo2eq, niceCeil } from 'src/utils/number';
@@ -98,7 +247,12 @@ import {
   LINE_COLOR_EXPR,
   aggregateLegs,
   buildEndpointFeatures,
+  buildLegPopupHtml,
   buildTripsGeoJson,
+  travelerTotals,
+  travelerRouteKeys,
+  legsToRender,
+  toggleTravelerSelection,
 } from 'src/utils/trips-map';
 
 const props = withDefaults(
@@ -121,9 +275,110 @@ const props = withDefaults(
 
 const { t } = useI18n();
 
-const LINE_LAYERS = ['trip-legs-lines'];
+const LINE_LAYERS = ['trip-legs-lines-train', 'trip-legs-lines-plane'];
 
-const visibleLegs = computed(() => aggregateLegs(props.legs, props.modeFilter));
+// Vector basemap (OpenFreeMap Positron): city labels, minimal land, no green.
+// Its seas are recoloured to the Professional Travel chart blue
+// (babyBlue.darker, #A2CBED) so the map reads as part of that section.
+const BASEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/positron';
+const SEA_COLOR = '#A2CBED';
+// Grey for routes dimmed during a member hover.
+const DIM_COLOR = '#b8b8b8';
+
+// Mode filter: a multi-select of plane / train. Both selected (the default) =
+// both shown; deselect one to focus the other. We never allow zero — the toggle
+// lives in the map legend, which is hidden when nothing is shown, so keeping at
+// least one mode avoids a dead-end. A parent-pinned `modeFilter` overrides this
+// and hides the toggle.
+const selectedModes = ref<Set<'plane' | 'train'>>(new Set(['plane', 'train']));
+
+// Only offer the toggle on the overall map and only when both modes are present
+// — filtering to a mode that has no trips would just blank the map.
+const showModeFilter = computed(
+  () =>
+    props.modeFilter === undefined &&
+    props.legs.some((l) => l.mode === 'plane') &&
+    props.legs.some((l) => l.mode === 'train'),
+);
+
+function isModeSelected(mode: 'plane' | 'train'): boolean {
+  return selectedModes.value.has(mode);
+}
+
+function toggleMode(mode: 'plane' | 'train') {
+  const next = new Set(selectedModes.value);
+  if (next.has(mode)) {
+    if (next.size === 1) return; // keep at least one mode visible
+    next.delete(mode);
+  } else {
+    next.add(mode);
+  }
+  selectedModes.value = next;
+}
+
+// Modes actually rendered. Pinned prop wins; otherwise the legend multi-select
+// when it's offered, else both (single-mode data has nothing to filter).
+const visibleModes = computed<Set<'plane' | 'train'>>(() => {
+  if (props.modeFilter) return new Set([props.modeFilter]);
+  if (!showModeFilter.value) return new Set(['plane', 'train']);
+  return selectedModes.value;
+});
+
+// Distinct travelers with per-person emission totals (only >1 for managers).
+const travelers = computed(() => travelerTotals(props.legs));
+
+// null = all travelers shown (default). A Set narrows to a chosen subset.
+const selectedTravelerIds = ref<Set<string> | null>(null);
+
+function isTravelerSelected(id: string): boolean {
+  return (
+    selectedTravelerIds.value === null || selectedTravelerIds.value.has(id)
+  );
+}
+
+const shownTravelerCount = computed(() =>
+  selectedTravelerIds.value === null
+    ? travelers.value.length
+    : selectedTravelerIds.value.size,
+);
+
+function toggleTraveler(id: string) {
+  selectedTravelerIds.value = toggleTravelerSelection(
+    selectedTravelerIds.value,
+    id,
+    travelers.value.map((tr) => tr.id),
+  );
+}
+
+function selectAllTravelers() {
+  selectedTravelerIds.value = null;
+}
+
+function selectNoTravelers() {
+  selectedTravelerIds.value = new Set();
+}
+
+// Hovering a member spotlights their routes: theirs stay in colour, every
+// other rendered route is dimmed. `null` = no hover.
+const hoveredTravelerId = ref<string | null>(null);
+const highlightKeys = computed(() =>
+  hoveredTravelerId.value === null
+    ? null
+    : travelerRouteKeys(props.legs, hoveredTravelerId.value),
+);
+
+// What the map renders: the selected set, plus the hovered member's legs (so a
+// deselected member's trips are revealed on hover). Their routes are then
+// spotlighted via highlightKeys, the rest dimmed.
+const visibleLegs = computed(() => {
+  const rendered = legsToRender(
+    props.legs,
+    selectedTravelerIds.value,
+    hoveredTravelerId.value,
+  );
+  const modes = visibleModes.value;
+  return aggregateLegs(rendered.filter((l) => modes.has(l.mode)));
+});
 
 // Legend bounds rounded up to a tidy ceiling so the scale reads 0→500 rather
 // than 0→459.
@@ -150,33 +405,15 @@ async function ensureMap() {
   if (map) return;
   map = new ml.Map({
     container: mapEl.value,
-    style: {
-      version: 8,
-      sources: {
-        osm: {
-          type: 'raster',
-          tiles: [runtimeConfig.mapTileStyleUrl],
-          tileSize: 256,
-          attribution: '© OpenStreetMap contributors',
-        },
-      },
-      layers: [
-        {
-          id: 'osm',
-          type: 'raster',
-          source: 'osm',
-          paint: {
-            'raster-saturation': -1,
-            'raster-brightness-min': 0.4,
-            'raster-opacity': 0.9,
-            'raster-contrast': -0.05,
-          },
-        },
-      ],
-    },
+    style: BASEMAP_STYLE_URL,
     center: [6.6323, 46.5197],
     zoom: 3,
-    attributionControl: false,
+    // Compact (ⓘ) attribution; the style's sources already credit
+    // OpenMapTiles + OpenStreetMap, we add the OpenFreeMap host credit.
+    attributionControl: {
+      compact: true,
+      customAttribution: '© OpenFreeMap',
+    },
   });
   (map as InstanceType<typeof ml.Map>).addControl(
     new ml.NavigationControl(),
@@ -190,7 +427,33 @@ async function ensureMap() {
     (map as InstanceType<typeof ml.Map> | null)?.resize();
   });
   resizeObserver.observe(mapEl.value);
+  // MapLibre renders the compact attribution expanded on first load; collapse
+  // it to just the ⓘ so it doesn't overlay the map until the user opens it.
+  const attrib = mapEl.value.querySelector('.maplibregl-ctrl-attrib');
+  attrib?.removeAttribute('open');
+  attrib?.classList.remove('maplibregl-compact-show');
   installLayers();
+}
+
+// Recolour the basemap's water fill layers to the Professional Travel chart
+// blue. Matches both ocean fills and inland-water fills by source-layer/id.
+function recolorSeas() {
+  if (!map || !MapLibreNS) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const m = map as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const layer of (m.getStyle()?.layers ?? []) as any[]) {
+    const name = `${layer['source-layer'] ?? ''} ${layer.id}`.toLowerCase();
+    // Seas are plain `fill` layers in this basemap (never fill-extrusion), so
+    // only the fill-* paint properties apply here.
+    if (
+      layer.type === 'fill' &&
+      /water|ocean|sea|bathymetr|marine/.test(name)
+    ) {
+      m.setPaintProperty(layer.id, 'fill-color', SEA_COLOR);
+      m.setPaintProperty(layer.id, 'fill-opacity', 1);
+    }
+  }
 }
 
 function installLayers() {
@@ -198,30 +461,57 @@ function installLayers() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ml = MapLibreNS as any;
   const m = map as InstanceType<typeof ml.Map>;
+  recolorSeas();
   m.addSource('trip-legs', {
     type: 'geojson',
-    data: buildTripsGeoJson(visibleLegs.value),
+    data: buildTripsGeoJson(visibleLegs.value, highlightKeys.value),
   });
   m.addSource('trip-endpoints', {
     type: 'geojson',
     data: buildEndpointFeatures(visibleLegs.value),
   });
-  // One layer for both modes (shape distinguishes them); line-sort-key keeps
-  // the heaviest emitters on top so they're never hidden.
+  // One layer per mode: trains solid, planes dashed — so the two modes read
+  // clearly even where curvature alone is ambiguous. line-sort-key keeps the
+  // heaviest emitters on top; dimmed (non-hovered) routes sort below so the
+  // spotlighted ones stay readable.
+  const lineLayout = {
+    'line-cap': 'round' as const,
+    'line-join': 'round' as const,
+    'line-sort-key': [
+      'case',
+      ['==', ['get', 'dim'], 1],
+      -1,
+      ['get', 'totalKgCo2eq'],
+    ],
+  };
+  // dim=1 (member hover, not this route) → flat grey, low opacity; otherwise
+  // the emissions ramp at full strength.
+  const linePaint = {
+    'line-color': [
+      'case',
+      ['==', ['get', 'dim'], 1],
+      DIM_COLOR,
+      LINE_COLOR_EXPR,
+    ],
+    'line-width': ['get', 'lineWidth'],
+    'line-opacity': ['case', ['==', ['get', 'dim'], 1], 0.18, 0.9],
+  };
   m.addLayer({
-    id: 'trip-legs-lines',
+    id: 'trip-legs-lines-train',
     type: 'line',
     source: 'trip-legs',
-    layout: {
-      'line-cap': 'round',
-      'line-join': 'round',
-      'line-sort-key': ['get', 'totalKgCo2eq'],
-    },
-    paint: {
-      'line-color': LINE_COLOR_EXPR,
-      'line-width': ['get', 'lineWidth'],
-      'line-opacity': 0.9,
-    },
+    filter: ['==', ['get', 'mode'], 'train'],
+    layout: lineLayout,
+    paint: linePaint,
+  });
+  // Planes reuse the train stroke, plus a dash.
+  m.addLayer({
+    id: 'trip-legs-lines-plane',
+    type: 'line',
+    source: 'trip-legs',
+    filter: ['==', ['get', 'mode'], 'plane'],
+    layout: lineLayout,
+    paint: { ...linePaint, 'line-dasharray': [2, 1.5] },
   });
   m.addLayer({
     id: 'trip-endpoints',
@@ -235,21 +525,19 @@ function installLayers() {
     },
   });
 
-  const popup = new ml.Popup({ closeButton: false, closeOnClick: false });
+  const popup = new ml.Popup({
+    closeButton: false,
+    closeOnClick: false,
+    offset: 12,
+  });
   m.on('mousemove', LINE_LAYERS, (e) => {
     m.getCanvas().style.cursor = 'pointer';
     const f = e.features?.[0];
     if (!f) return;
-    const p = f.properties as {
-      fromName: string;
-      toName: string;
-      tripCount: number;
-      totalKgCo2eq: number;
-    };
-    const html =
-      `<div style="font-size:12px"><strong>${escape(p.fromName)} ↔ ${escape(p.toName)}</strong><br/>` +
-      `${t(`${MODULES.ProfessionalTravel}-trips-map-popup-trips`, { count: p.tripCount })} · ${escape(formatKgCo2eq(Number(p.totalKgCo2eq)))}</div>`;
-    popup.setLngLat(e.lngLat).setHTML(html).addTo(m);
+    popup
+      .setLngLat(e.lngLat)
+      .setHTML(buildLegPopupHtml(f.properties, t))
+      .addTo(m);
   });
   m.on('mouseleave', LINE_LAYERS, () => {
     m.getCanvas().style.cursor = '';
@@ -273,12 +561,16 @@ function fitToLegs() {
   m.fitBounds(bounds, { padding: 32, maxZoom: 6, animate: false });
 }
 
-function escape(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+// Push the current legs GeoJSON (with hover dimming baked in) to the source.
+function refreshLegsSource() {
+  if (!map || !MapLibreNS) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const legsSrc = (map as any).getSource('trip-legs');
+  if (legsSrc && 'setData' in legsSrc) {
+    (legsSrc as { setData: (d: unknown) => void }).setData(
+      buildTripsGeoJson(visibleLegs.value, highlightKeys.value),
+    );
+  }
 }
 
 watch(
@@ -286,22 +578,32 @@ watch(
   () => {
     if (!map || !MapLibreNS) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const m = map as any;
-    const legsSrc = m.getSource('trip-legs');
-    const endsSrc = m.getSource('trip-endpoints');
-    if (legsSrc && 'setData' in legsSrc) {
-      (legsSrc as { setData: (d: unknown) => void }).setData(
-        buildTripsGeoJson(visibleLegs.value),
-      );
-    }
+    const endsSrc = (map as any).getSource('trip-endpoints');
+    refreshLegsSource();
     if (endsSrc && 'setData' in endsSrc) {
       (endsSrc as { setData: (d: unknown) => void }).setData(
         buildEndpointFeatures(visibleLegs.value),
       );
     }
-    fitToLegs();
   },
   { deep: true },
+);
+
+// Hover only restyles the existing lines — no refit, no endpoint rebuild.
+watch(highlightKeys, refreshLegsSource);
+
+// Refit only when the *selection* (or data/mode) changes — never on hover, so
+// revealing a hovered member's trips doesn't yank the viewport around. None of
+// these deps change on hover (props.legs is the same array; the selection ref
+// is untouched).
+watch(
+  [
+    selectedTravelerIds,
+    selectedModes,
+    () => props.modeFilter,
+    () => props.legs,
+  ],
+  () => fitToLegs(),
 );
 
 // Not gated on loading so a refetch swaps data in place instead of unmounting
@@ -351,11 +653,80 @@ onBeforeUnmount(() => {
   inset: 0;
 }
 
+// Member filter sits in normal flow below the map (not an overlay), so a
+// long roster wraps and pushes the card height rather than covering the map.
+.trips-map__members {
+  font-size: 12px;
+}
+
+.trips-map__members-count {
+  color: #9e9e9e;
+}
+
+// "All / None" as quiet text links rather than buttons.
+.trips-map__members-action {
+  padding: 0;
+  font: inherit;
+  color: #707070;
+  cursor: pointer;
+  background: none;
+  border: 0;
+
+  &:hover {
+    color: #212121;
+    text-decoration: underline;
+  }
+}
+
+.trips-map__members-sep {
+  margin: 0 4px;
+  color: #cfcfcf;
+}
+
+.trips-map__member-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px 2px;
+}
+
+// Each member is a borderless, background-free toggle: a small leading icon
+// carries the selected/unselected state. Hovering tints the row and spotlights
+// that person's trips on the map.
+.trips-map__member {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  font: inherit;
+  line-height: 1.4;
+  color: #212121;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  border-radius: 4px;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
+}
+
+.trips-map__member--off {
+  color: #9e9e9e;
+}
+
+.trips-map__member-value {
+  font-size: 0.85em;
+  opacity: 0.65;
+}
+
 .trips-map__legend {
   position: absolute;
   bottom: 8px;
   left: 8px;
   z-index: 1;
+  // Floor the width so the scales stay a sensible size; the mode toggles can
+  // push it wider, and the scale bars stretch to fill (width: 100% below).
+  min-width: 140px;
   padding: 6px 8px;
   font-size: 11px;
   line-height: 1.3;
@@ -376,14 +747,14 @@ onBeforeUnmount(() => {
 }
 
 .trips-map__legend-gradient {
-  width: 120px;
+  width: 100%;
   height: 8px;
   border-radius: 2px;
 }
 
 .trips-map__legend-width {
   display: block;
-  width: 120px;
+  width: 100%;
   height: 9px;
 }
 
@@ -405,10 +776,42 @@ onBeforeUnmount(() => {
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+// The legend is pointer-events:none so it never intercepts map drags; the mode
+// toggles re-enable them just on themselves.
+.trips-map__legend-modes--toggle {
+  pointer-events: auto;
+}
+
 .trips-map__legend-mode {
   display: flex;
   gap: 4px;
   align-items: center;
+}
+
+// Glyph rows double as toggle buttons: a leading checkbox + a hover background
+// make them read as clickable. Deselected stays legible (muted, not disabled)
+// so it clearly invites a click.
+button.trips-map__legend-mode {
+  padding: 1px 5px 1px 3px;
+  font: inherit;
+  color: #212121;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  border-radius: 4px;
+}
+
+button.trips-map__legend-mode:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.trips-map__legend-mode--off {
+  color: #8e8e8e;
+}
+
+.trips-map__legend-mode--off .trips-map__legend-glyph path,
+.trips-map__legend-mode--off .trips-map__legend-glyph line {
+  stroke: #bbb;
 }
 
 .trips-map__legend-glyph {
@@ -420,9 +823,18 @@ onBeforeUnmount(() => {
 .trips-map__legend-glyph path,
 .trips-map__legend-glyph line {
   fill: none;
-  stroke: #8c2981;
+  stroke: #555;
   stroke-width: 2;
   stroke-linecap: round;
+}
+
+// The plane glyph (curved <path>) is dashed to match the dashed plane arcs on
+// the map; the train glyph (straight <line>) stays solid. Butt caps + wider
+// gaps so the dashes read clearly at this small size (legend only — the map
+// keeps its own line-dasharray).
+.trips-map__legend-glyph path {
+  stroke-dasharray: 3 3;
+  stroke-linecap: butt;
 }
 
 .trips-map__sr-only {

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -95,9 +95,26 @@
           <chart-empty-state v-else />
         </template>
       </div>
+      <!-- ProfessionalTravel: the PNG download sits directly under the chart
+           (no divider above it); a divider then separates the trips map below,
+           all within the same card. -->
       <template v-if="type === MODULES.ProfessionalTravel && !isPrintMode">
-        <q-separator class="q-my-lg" />
-        <div class="q-mx-lg">
+        <q-card-section class="flex justify-start q-gutter-sm q-px-lg">
+          <q-btn
+            unelevated
+            no-caps
+            outline
+            icon="o_download"
+            :label="$t('common_download_as_png')"
+            size="xs"
+            dense
+            color="black"
+            class="text-weight-bold q-px-sm"
+            @click="downloadPNG"
+          />
+        </q-card-section>
+        <q-separator />
+        <div class="q-mx-lg q-my-lg">
           <div class="text-body1 text-weight-medium q-mb-sm text-black">
             {{ $t(`${MODULES.ProfessionalTravel}-trips-map-title-overall`) }}
           </div>
@@ -113,7 +130,15 @@
       </template>
     </template>
   </q-card-section>
-  <template v-if="type !== 'headcount' && !isPrintMode">
+  <!-- ProfessionalTravel renders its own download button under the chart
+       (above), so it is excluded here to avoid a duplicate. -->
+  <template
+    v-if="
+      type !== 'headcount' &&
+      type !== MODULES.ProfessionalTravel &&
+      !isPrintMode
+    "
+  >
     <q-separator />
     <q-card-section class="flex justify-start q-gutter-sm">
       <q-btn
@@ -154,6 +179,8 @@ import {
 } from 'src/constant/charts';
 import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakdownInfo';
 import { getHeadcountChartKeys } from 'src/utils/headcountChart';
+import { getHeadcountMembers } from 'src/api/modules';
+import { resolveTravelerNames } from 'src/utils/trips-map-data';
 
 const props = withDefaults(
   defineProps<{
@@ -275,11 +302,29 @@ function fetchTopClassBreakdownIfNeeded() {
   }
 }
 
+// SCIPER → display name for the unit's headcount roster. The trips-map API
+// ships only the traveler SCIPER; we resolve names here (the same headcount
+// endpoint the member table already uses) instead of on the backend.
+const travelerNames = ref<Map<string, string>>(new Map());
+
+async function loadTravelerNames(unitId: number, year: number | string) {
+  try {
+    const members = await getHeadcountMembers(unitId, year);
+    travelerNames.value = new Map(
+      members.map((m) => [m.institutional_id, m.name]),
+    );
+  } catch (err) {
+    // Non-fatal: legs simply fall back to showing the raw SCIPER.
+    console.error('Failed to load headcount members for trips map', err);
+  }
+}
+
 function fetchTripsMapIfNeeded() {
   const unitId = workspaceStore.selectedUnit?.id;
   const year = workspaceStore.selectedYear;
   if (unitId && year && props.type === MODULES.ProfessionalTravel) {
     void moduleStore.getProfessionalTravelTripsMap(unitId, String(year));
+    void loadTravelerNames(unitId, year);
   }
 }
 
@@ -300,7 +345,12 @@ watch(
   () => fetchTripsMapIfNeeded(),
 );
 
-const tripsMapLegs = computed(() => moduleStore.state.tripsMap?.legs ?? []);
+const tripsMapLegs = computed(() =>
+  resolveTravelerNames(
+    moduleStore.state.tripsMap?.legs ?? [],
+    travelerNames.value,
+  ),
+);
 
 // Re-fetch top-class breakdown when the module type changes (e.g. navigating
 // from purchases to equipment) so stale data from the previous module is replaced.

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -33,20 +33,6 @@
     </template>
     <q-separator />
     <q-card-section class="q-pa-none">
-      <div
-        v-if="submodule.topVisualization === 'trips-map' && tripsMapMode"
-        class="q-mx-lg q-mt-lg"
-      >
-        <trips-map
-          :legs="tripsMapLegs"
-          :mode-filter="tripsMapMode"
-          :loading="moduleStore.state.loadingTripsMap"
-          :aria-label="
-            $t(`${MODULES.ProfessionalTravel}-trips-map-title-${tripsMapMode}`)
-          "
-          :testid="`trips-map-${tripsMapMode}`"
-        />
-      </div>
       <div v-if="submodule.moduleFields" class="q-mx-lg q-my-xl">
         <module-table
           :module-fields="submodule.moduleFields"
@@ -64,6 +50,7 @@
           :module-color-lighter="submoduleLighterColor"
         />
       </div>
+      <q-separator />
       <div
         v-if="isInputDeactivated"
         class="q-mx-lg q-my-md inputs-deactivated-notice"
@@ -130,20 +117,6 @@
     </q-card-section>
     <q-separator />
     <q-card-section class="q-pa-none">
-      <div
-        v-if="submodule.topVisualization === 'trips-map' && tripsMapMode"
-        class="q-mx-lg q-mt-lg"
-      >
-        <trips-map
-          :legs="tripsMapLegs"
-          :mode-filter="tripsMapMode"
-          :loading="moduleStore.state.loadingTripsMap"
-          :aria-label="
-            $t(`${MODULES.ProfessionalTravel}-trips-map-title-${tripsMapMode}`)
-          "
-          :testid="`trips-map-${tripsMapMode}`"
-        />
-      </div>
       <div v-if="submodule.moduleFields" class="q-mx-lg q-my-xl">
         <module-table
           :module-fields="submodule.moduleFields"
@@ -159,7 +132,7 @@
           :is-simulator="isSimulator"
         />
       </div>
-
+      <q-separator />
       <div v-if="hasModuleForm && !disable && canEdit" class="q-mx-lg">
         <module-form
           ref="formRef"
@@ -196,7 +169,6 @@ import {
 } from 'src/constant/moduleConfig';
 import ModuleTable from 'src/components/organisms/module/ModuleTable.vue';
 import ModuleForm from 'src/components/organisms/module/ModuleForm.vue';
-import TripsMap from 'src/components/molecules/TripsMap.vue';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
@@ -209,11 +181,7 @@ import type {
   EnumSubmoduleType,
   Module,
 } from 'src/constant/modules';
-import {
-  enumSubmodule,
-  MODULES,
-  MODULES_THRESHOLD_TYPES,
-} from 'src/constant/modules';
+import { enumSubmodule, MODULES_THRESHOLD_TYPES } from 'src/constant/modules';
 import { useModuleStore, useTimelineStore } from 'src/stores/modules';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
@@ -385,18 +353,6 @@ const hasModuleForm = computed(() => {
 const showModuleForm = computed(
   () => hasModuleForm.value && !isFormDisabled.value && canEdit.value,
 );
-
-// Map data is fetched once at the module-charts level (ModuleCharts.vue
-// triggers `getProfessionalTravelTripsMap`); the plane/train cards just
-// filter and render. tripsMapMode is non-null only when the submodule
-// opts in via `topVisualization: 'trips-map'` and identifies as plane/train.
-const tripsMapMode = computed<'plane' | 'train' | null>(() => {
-  if (props.submodule.topVisualization !== 'trips-map') return null;
-  if (props.submodule.id === 'plane') return 'plane';
-  if (props.submodule.id === 'train') return 'train';
-  return null;
-});
-const tripsMapLegs = computed(() => moduleStore.state.tripsMap?.legs ?? []);
 
 const hasTableTooltip = computed(() => {
   if (!props.submodule.type) return false;

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -267,6 +267,18 @@ export default {
     en: '{count} trip | {count} trips',
     fr: '{count} voyage | {count} voyages',
   },
+  [`${MODULES.ProfessionalTravel}-trips-map-popup-mode`]: {
+    en: 'Mode',
+    fr: 'Mode',
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-popup-avg`]: {
+    en: 'Avg / trip',
+    fr: 'Moy. / trajet',
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-popup-travelers`]: {
+    en: 'Traveler | Travelers',
+    fr: 'Voyageur | Voyageurs',
+  },
   [`${MODULES.ProfessionalTravel}-trips-map-legend-emissions`]: {
     en: 'Emissions',
     fr: 'Émissions',
@@ -274,5 +286,29 @@ export default {
   [`${MODULES.ProfessionalTravel}-trips-map-legend-trips`]: {
     en: 'Trips',
     fr: 'Voyages',
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-filter-members-title`]: {
+    en: 'Unit members',
+    fr: "Membres de l'unité",
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-filter-members-label`]: {
+    en: '({shown}/{total} shown)',
+    fr: '({shown}/{total} affichés)',
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-filter-members-aria`]: {
+    en: 'Filter trips by unit member',
+    fr: "Filtrer les voyages par membre de l'unité",
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-filter-all`]: {
+    en: 'All',
+    fr: 'Tout',
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-filter-mode-aria`]: {
+    en: 'Filter trips by mode',
+    fr: 'Filtrer les voyages par mode',
+  },
+  [`${MODULES.ProfessionalTravel}-trips-map-filter-none`]: {
+    en: 'None',
+    fr: 'Aucun',
   },
 } as const;

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -51,6 +51,8 @@ export interface TripLeg {
   destination_name: string;
   kg_co2eq: number;
   number_of_trips: number;
+  traveler_id: string;
+  traveler_name: string;
 }
 
 export interface TripsMapResponse {

--- a/frontend/src/utils/trips-map-data.ts
+++ b/frontend/src/utils/trips-map-data.ts
@@ -1,0 +1,225 @@
+// Pure data helpers for the trips map: leg aggregation and the unit-manager
+// member filter. Kept free of i18n / maplibre / DOM imports so they can be
+// unit-tested in a plain Node runner (the display helpers live in
+// ./trips-map, which pulls in formatKgCo2eq → i18n).
+import type { TripLeg } from 'src/stores/modules';
+
+export interface AggregatedLeg {
+  mode: 'plane' | 'train';
+  from: [number, number];
+  to: [number, number];
+  fromName: string;
+  toName: string;
+  tripCount: number;
+  totalKgCo2eq: number;
+  // Direction-normalised identity of the route (mode + endpoint pair). Lets the
+  // hover highlight match a traveler's raw legs to aggregated routes.
+  key: string;
+  // Distinct traveler names on this route, heaviest emitter first. Drives the
+  // hover popup; empty when the legs carry no traveler (e.g. older data).
+  travelers: string[];
+}
+
+// Canonical orientation of a route so A→B and B→A collapse together: the
+// endpoint with the smaller (lng, lat) becomes "from". Numeric comparison (not
+// string-lexical) gives a clean total order. Returns the oriented endpoints,
+// their names, and the identity key — the single source of truth shared by
+// aggregateLegs and travelerRouteKeys so they always agree.
+export interface OrientedRoute {
+  from: [number, number];
+  to: [number, number];
+  fromName: string;
+  toName: string;
+  key: string;
+}
+
+export function orientRoute(
+  mode: 'plane' | 'train',
+  a: [number, number],
+  b: [number, number],
+  aName = '',
+  bName = '',
+): OrientedRoute {
+  const swap = b[0] < a[0] || (b[0] === a[0] && b[1] < a[1]);
+  const from = swap ? b : a;
+  const to = swap ? a : b;
+  return {
+    from,
+    to,
+    fromName: swap ? bName : aName,
+    toName: swap ? aName : bName,
+    key: `${mode}|${from[0]},${from[1]}|${to[0]},${to[1]}`,
+  };
+}
+
+// Direction-normalised route identity so A→B and B→A collapse to one key.
+export function routeKeyFor(
+  mode: 'plane' | 'train',
+  origin: [number, number],
+  dest: [number, number],
+): string {
+  return orientRoute(mode, origin, dest).key;
+}
+
+export interface TravelerTotal {
+  id: string;
+  name: string;
+  totalKgCo2eq: number;
+}
+
+// Merge raw legs into one route per (mode, endpoint-pair), summing trips and
+// emissions. Direction is normalised so A→B and B→A collapse together. Sorted
+// heaviest-emitting first.
+export function aggregateLegs(
+  legs: TripLeg[],
+  modeFilter?: 'plane' | 'train',
+): AggregatedLeg[] {
+  const filtered = modeFilter
+    ? legs.filter((l) => l.mode === modeFilter)
+    : legs;
+
+  type Bucket = Omit<AggregatedLeg, 'travelers'> & {
+    travelers: Map<string, { name: string; kg: number }>;
+  };
+  const buckets = new Map<string, Bucket>();
+  for (const l of filtered) {
+    const { from, to, fromName, toName, key } = orientRoute(
+      l.mode,
+      [l.origin_lng, l.origin_lat],
+      [l.destination_lng, l.destination_lat],
+      l.origin_name,
+      l.destination_name,
+    );
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        mode: l.mode,
+        from,
+        to,
+        fromName,
+        toName,
+        tripCount: 0,
+        totalKgCo2eq: 0,
+        key,
+        travelers: new Map(),
+      };
+      buckets.set(key, bucket);
+    }
+    bucket.tripCount += l.number_of_trips;
+    bucket.totalKgCo2eq += l.kg_co2eq;
+    const tid = l.traveler_id || l.traveler_name;
+    if (tid) {
+      const entry = bucket.travelers.get(tid);
+      if (entry) entry.kg += l.kg_co2eq;
+      else
+        bucket.travelers.set(tid, {
+          name: l.traveler_name || l.traveler_id,
+          kg: l.kg_co2eq,
+        });
+    }
+  }
+  return [...buckets.values()]
+    .map((bucket) => ({
+      mode: bucket.mode,
+      from: bucket.from,
+      to: bucket.to,
+      fromName: bucket.fromName,
+      toName: bucket.toName,
+      tripCount: bucket.tripCount,
+      totalKgCo2eq: bucket.totalKgCo2eq,
+      key: bucket.key,
+      travelers: [...bucket.travelers.values()]
+        .sort((x, y) => y.kg - x.kg)
+        .map((tr) => tr.name),
+    }))
+    .sort((x, y) => y.totalKgCo2eq - x.totalKgCo2eq);
+}
+
+// Join headcount-roster display names onto raw legs by SCIPER. The trips-map
+// API ships only the traveler SCIPER (in both traveler_id and traveler_name);
+// the frontend resolves names from the headcount-members endpoint. Travelers
+// absent from the roster keep their existing traveler_name (the SCIPER).
+export function resolveTravelerNames(
+  legs: TripLeg[],
+  namesById: Map<string, string>,
+): TripLeg[] {
+  if (!namesById.size) return legs;
+  return legs.map((l) => ({
+    ...l,
+    traveler_name: namesById.get(l.traveler_id) ?? l.traveler_name,
+  }));
+}
+
+// Per-traveler emission totals across the raw legs, heaviest first. Drives the
+// unit-manager member filter (only meaningful when the API returns >1 traveler,
+// i.e. for principal/global scope). Legs without a traveler_id are ignored.
+export function travelerTotals(legs: TripLeg[]): TravelerTotal[] {
+  const buckets = new Map<string, TravelerTotal>();
+  for (const l of legs) {
+    if (!l.traveler_id) continue;
+    const existing = buckets.get(l.traveler_id);
+    if (existing) {
+      existing.totalKgCo2eq += l.kg_co2eq;
+    } else {
+      buckets.set(l.traveler_id, {
+        id: l.traveler_id,
+        name: l.traveler_name || l.traveler_id,
+        totalKgCo2eq: l.kg_co2eq,
+      });
+    }
+  }
+  return [...buckets.values()].sort((a, b) => b.totalKgCo2eq - a.totalKgCo2eq);
+}
+
+// Route keys travelled by one person — used to highlight their trips on hover
+// (every other route is dimmed). Matches aggregateLegs' keys via routeKeyFor.
+export function travelerRouteKeys(
+  legs: TripLeg[],
+  travelerId: string,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const l of legs) {
+    if (l.traveler_id !== travelerId) continue;
+    keys.add(
+      routeKeyFor(
+        l.mode,
+        [l.origin_lng, l.origin_lat],
+        [l.destination_lng, l.destination_lat],
+      ),
+    );
+  }
+  return keys;
+}
+
+// Which legs the map renders, given the current selection and hover. Base =
+// the selected travelers' legs (all when `selected` is null). Hovering a member
+// always reveals THEIR legs on top — even a deselected one — so their trips can
+// be spotlighted; members who are neither selected nor hovered stay hidden.
+export function legsToRender(
+  legs: TripLeg[],
+  selected: Set<string> | null,
+  hovered: string | null,
+): TripLeg[] {
+  const base =
+    selected === null ? legs : legs.filter((l) => selected.has(l.traveler_id));
+  if (hovered === null || selected === null || selected.has(hovered)) {
+    return base;
+  }
+  return base.concat(legs.filter((l) => l.traveler_id === hovered));
+}
+
+// Toggle one traveler in the member filter. The selection is either `null`
+// (all travelers shown — the default) or an explicit Set. Flipping a member
+// out of the "all" state materialises the full set first; re-selecting every
+// member collapses back to `null` so "all" and "explicitly-all" stay
+// indistinguishable downstream. `allIds` is the full roster.
+export function toggleTravelerSelection(
+  current: Set<string> | null,
+  id: string,
+  allIds: string[],
+): Set<string> | null {
+  const next = new Set(current ?? allIds);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next.size === allIds.length ? null : next;
+}

--- a/frontend/src/utils/trips-map.ts
+++ b/frontend/src/utils/trips-map.ts
@@ -1,79 +1,45 @@
-import type { TripLeg } from 'src/stores/modules';
+import { MODULES } from 'src/constant/modules';
+import { formatKgCo2eq } from 'src/utils/number';
+import type { AggregatedLeg } from 'src/utils/trips-map-data';
 
-export interface AggregatedLeg {
-  mode: 'plane' | 'train';
-  from: [number, number];
-  to: [number, number];
-  fromName: string;
-  toName: string;
-  tripCount: number;
-  totalKgCo2eq: number;
-}
+// Pure aggregation + member-filter helpers live in ./trips-map-data (i18n-free
+// so they're unit-testable in Node); re-exported here so callers have a single
+// trips-map entry point.
+export type { AggregatedLeg, TravelerTotal } from 'src/utils/trips-map-data';
+export {
+  aggregateLegs,
+  travelerTotals,
+  travelerRouteKeys,
+  legsToRender,
+  toggleTravelerSelection,
+} from 'src/utils/trips-map-data';
 
-// Reversed-magma emissions ramp (low = pale gold, high = deep indigo). The CSS
-// gradient drives the legend; the maplibre expression drives the lines — same
-// stops, two forms.
+// Turbo emissions ramp, right half only (green → red). The CSS gradient drives
+// the legend; the maplibre expression drives the lines — same stops, two forms.
 export const CO2_RAMP_CSS =
-  'linear-gradient(to right, #fec287, #de4968 40%, #8c2981 70%, #3b0f70)';
+  'linear-gradient(to right, #1ae4b6 0%, #4bf57f 20%, #8fff49 40%, #c5ee36 55%, #f3c63a 70%, #fd902a 82%, #ef5911 92%, #c42503 100%)';
 
 export const LINE_COLOR_EXPR = [
   'interpolate',
   ['linear'],
   ['get', 'intensity'],
   0,
-  '#fec287',
+  '#1ae4b6',
+  0.2,
+  '#4bf57f',
   0.4,
-  '#de4968',
+  '#8fff49',
+  0.55,
+  '#c5ee36',
   0.7,
-  '#8c2981',
+  '#f3c63a',
+  0.82,
+  '#fd902a',
+  0.92,
+  '#ef5911',
   1,
-  '#3b0f70',
+  '#c42503',
 ];
-
-// Merge raw legs into one route per (mode, endpoint-pair), summing trips and
-// emissions. Direction is normalised so A→B and B→A collapse together. Sorted
-// heaviest-emitting first.
-export function aggregateLegs(
-  legs: TripLeg[],
-  modeFilter?: 'plane' | 'train',
-): AggregatedLeg[] {
-  const filtered = modeFilter
-    ? legs.filter((l) => l.mode === modeFilter)
-    : legs;
-
-  const buckets = new Map<string, AggregatedLeg>();
-  for (const l of filtered) {
-    const a: [number, number] = [l.origin_lng, l.origin_lat];
-    const b: [number, number] = [l.destination_lng, l.destination_lat];
-    let from = a;
-    let to = b;
-    let fromName = l.origin_name;
-    let toName = l.destination_name;
-    if (`${b[0]},${b[1]}` < `${a[0]},${a[1]}`) {
-      from = b;
-      to = a;
-      fromName = l.destination_name;
-      toName = l.origin_name;
-    }
-    const key = `${l.mode}|${from[0]},${from[1]}|${to[0]},${to[1]}`;
-    const existing = buckets.get(key);
-    if (existing) {
-      existing.tripCount += l.number_of_trips;
-      existing.totalKgCo2eq += l.kg_co2eq;
-    } else {
-      buckets.set(key, {
-        mode: l.mode,
-        from,
-        to,
-        fromName,
-        toName,
-        tripCount: l.number_of_trips,
-        totalKgCo2eq: l.kg_co2eq,
-      });
-    }
-  }
-  return [...buckets.values()].sort((a, b) => b.totalKgCo2eq - a.totalKgCo2eq);
-}
 
 // Quadratic-bezier arc between the endpoints, bowed `bulge` degrees off the
 // midpoint (perpendicular to travel direction). Bulge 0 → a straight line.
@@ -130,8 +96,13 @@ export function logNorm(value: number, min: number, max: number): number {
 }
 
 // One LineString per route. Colour encodes emissions, width encodes trip
-// volume — each log-normalised across the visible routes.
-export function buildTripsGeoJson(legs: AggregatedLeg[]) {
+// volume — each log-normalised across the visible routes. When `highlightKeys`
+// is set (member hover), routes not in it get `dim: 1` so the paint layer greys
+// them out; `null` means nothing is dimmed.
+export function buildTripsGeoJson(
+  legs: AggregatedLeg[],
+  highlightKeys: Set<string> | null = null,
+) {
   type GeoFeature = {
     type: 'Feature';
     properties: Record<string, unknown>;
@@ -161,6 +132,7 @@ export function buildTripsGeoJson(legs: AggregatedLeg[]) {
       leg.to,
       baseBulge(leg.from, leg.to, leg.mode),
     );
+    const dim = highlightKeys !== null && !highlightKeys.has(leg.key) ? 1 : 0;
     features.push({
       type: 'Feature',
       properties: {
@@ -171,6 +143,10 @@ export function buildTripsGeoJson(legs: AggregatedLeg[]) {
         totalKgCo2eq: leg.totalKgCo2eq,
         intensity,
         lineWidth,
+        dim,
+        // JSON-encoded: MapLibre stringifies array/object props on the way back
+        // out of interaction events, so encode explicitly and parse in the popup.
+        travelers: JSON.stringify(leg.travelers),
       },
       geometry: { type: 'LineString', coordinates: coords },
     });
@@ -193,4 +169,83 @@ export function buildEndpointFeatures(legs: AggregatedLeg[]) {
       geometry: { type: 'Point' as const, coordinates: p },
     })),
   };
+}
+
+// ── Hover popup ──────────────────────────────────────────────────────────────
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function popupRow(label: string, value: string): string {
+  return (
+    `<div class="row justify-between no-wrap">` +
+    `<span class="text-grey-7 q-mr-md">${label}</span>` +
+    `<span class="text-weight-medium">${value}</span></div>`
+  );
+}
+
+// Travelers come through MapLibre as a JSON string (see buildTripsGeoJson); be
+// lenient and also accept a raw array (direct calls / tests).
+function parseTravelers(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === 'string' && value.length) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.map(String);
+    } catch {
+      /* not JSON — ignore */
+    }
+  }
+  return [];
+}
+
+// HTML for the leg hover popup, built from a MapLibre feature's properties.
+// Compact, styled only with Quasar utility classes (no custom CSS) on top of
+// MapLibre's default popup card. `t` is passed in since i18n lives in the
+// component (it accepts an optional plural count). text-black: the popup renders
+// inside .module-charts, which sets a teal text colour — pin a neutral base so
+// the title/values aren't tinted.
+export function buildLegPopupHtml(
+  props: Record<string, unknown> | null,
+  t: (key: string, plural?: number) => string,
+): string {
+  const mode = String(props?.mode ?? '');
+  const fromName = String(props?.fromName ?? '');
+  const toName = String(props?.toName ?? '');
+  const tripCount = Number(props?.tripCount ?? 0);
+  const total = Number(props?.totalKgCo2eq ?? 0);
+  const avg = tripCount > 0 ? total / tripCount : 0;
+  const travelers = parseTravelers(props?.travelers);
+  const k = `${MODULES.ProfessionalTravel}-trips-map`;
+
+  // Travelers go last on a single line. The value sits flush right when it fits
+  // (margin-left:auto), and when it's too long it fills the remaining width and
+  // truncates with a trailing "…" (single-line text-overflow, which works with
+  // any alignment — unlike the multi-line clamp). min-width:0 lets the flex item
+  // shrink below its content so the ellipsis can kick in.
+  let travelersBlock = '';
+  if (travelers.length) {
+    const label = t(`${k}-popup-travelers`, travelers.length);
+    const names = travelers.join(', ');
+    travelersBlock =
+      `<div class="row no-wrap items-baseline q-mt-xs">` +
+      `<span class="text-grey-7 q-mr-md">${label}</span>` +
+      `<span class="ellipsis text-weight-medium" style="min-width:0;margin-left:auto">${escapeHtml(names)}</span>` +
+      `</div>`;
+  }
+
+  return (
+    `<div class="text-caption text-black" style="line-height:1.5; max-width:240px">` +
+    `<div class="text-weight-bold q-mb-xs">${escapeHtml(fromName)} ↔ ${escapeHtml(toName)}</div>` +
+    popupRow(t(`${k}-popup-mode`), escapeHtml(t(mode))) +
+    popupRow(t(`${k}-legend-trips`), String(tripCount)) +
+    popupRow(t(`${k}-legend-emissions`), escapeHtml(formatKgCo2eq(total))) +
+    popupRow(t(`${k}-popup-avg`), escapeHtml(formatKgCo2eq(avg))) +
+    travelersBlock +
+    `</div>`
+  );
 }

--- a/frontend/tests/unit/trips-map.spec.ts
+++ b/frontend/tests/unit/trips-map.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the trips-map member filter helpers (issue #282 follow-up).
+ *
+ * A unit manager (principal) sees every member's trips merged on the map.
+ * These helpers drive the "filter by member" panel: `travelerTotals` lists the
+ * distinct travelers with their CO₂ totals, `toggleTravelerSelection` is the
+ * checkbox state machine, and the two compose with `aggregateLegs` so that
+ * de-selecting a member drops their legs before aggregation.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { TripLeg } from '../../src/stores/modules';
+import {
+  aggregateLegs,
+  orientRoute,
+  resolveTravelerNames,
+  travelerTotals,
+  travelerRouteKeys,
+  legsToRender,
+  toggleTravelerSelection,
+} from '../../src/utils/trips-map-data';
+
+const ids = (ls: { traveler_id: string }[]) =>
+  [...new Set(ls.map((l) => l.traveler_id))].sort();
+
+function leg(partial: Partial<TripLeg>): TripLeg {
+  return {
+    mode: 'plane',
+    origin_lat: 46.2381,
+    origin_lng: 6.109,
+    destination_lat: 40.6413,
+    destination_lng: -73.7781,
+    origin_name: 'Geneva Airport',
+    destination_name: 'JFK',
+    kg_co2eq: 100,
+    number_of_trips: 1,
+    traveler_id: 'alice',
+    traveler_name: 'Alice Dupont',
+    ...partial,
+  };
+}
+
+const LEGS: TripLeg[] = [
+  leg({ traveler_id: 'alice', traveler_name: 'Alice Dupont', kg_co2eq: 100 }),
+  leg({ traveler_id: 'alice', traveler_name: 'Alice Dupont', kg_co2eq: 50 }),
+  leg({ traveler_id: 'bob', traveler_name: 'Bob Martin', kg_co2eq: 300 }),
+  leg({ traveler_id: 'carol', traveler_name: 'Carol Rossi', kg_co2eq: 20 }),
+];
+
+test('resolveTravelerNames joins roster names by SCIPER, keeps fallback', () => {
+  const raw = [
+    leg({ traveler_id: '111', traveler_name: '111' }),
+    leg({ traveler_id: '222', traveler_name: '222' }),
+  ];
+  const names = new Map([['111', 'Alice Dupont']]);
+  const out = resolveTravelerNames(raw, names);
+  expect(out.map((l) => l.traveler_name)).toEqual(['Alice Dupont', '222']);
+  // Pure: original legs are not mutated.
+  expect(raw[0]?.traveler_name).toBe('111');
+});
+
+test('resolveTravelerNames returns legs unchanged when roster is empty', () => {
+  const raw = [leg({ traveler_id: '111', traveler_name: '111' })];
+  expect(resolveTravelerNames(raw, new Map())).toBe(raw);
+});
+
+test('travelerTotals sums per traveler and sorts heaviest first', () => {
+  const totals = travelerTotals(LEGS);
+  expect(totals.map((t) => t.id)).toEqual(['bob', 'alice', 'carol']);
+  expect(totals.map((t) => t.totalKgCo2eq)).toEqual([300, 150, 20]);
+  expect(totals.find((t) => t.id === 'bob')?.name).toBe('Bob Martin');
+});
+
+test('travelerTotals falls back to id when name is empty', () => {
+  const totals = travelerTotals([
+    leg({ traveler_id: 'dave', traveler_name: '', kg_co2eq: 10 }),
+  ]);
+  expect(totals[0]?.name).toBe('dave');
+});
+
+test('travelerTotals ignores legs without a traveler id', () => {
+  const totals = travelerTotals([
+    leg({ traveler_id: '', traveler_name: '', kg_co2eq: 10 }),
+  ]);
+  expect(totals).toHaveLength(0);
+});
+
+test('toggleTravelerSelection materialises from "all" then drops one', () => {
+  const all = ['alice', 'bob', 'carol'];
+  const next = toggleTravelerSelection(null, 'carol', all);
+  expect(next).not.toBeNull();
+  expect([...(next as Set<string>)].sort()).toEqual(['alice', 'bob']);
+});
+
+test('toggleTravelerSelection collapses back to null when all re-selected', () => {
+  const all = ['alice', 'bob'];
+  const partial = new Set(['alice']);
+  expect(toggleTravelerSelection(partial, 'bob', all)).toBeNull();
+});
+
+test('toggleTravelerSelection re-adds a previously removed member', () => {
+  const all = ['alice', 'bob', 'carol'];
+  const partial = new Set(['alice']);
+  const next = toggleTravelerSelection(partial, 'bob', all);
+  expect([...(next as Set<string>)].sort()).toEqual(['alice', 'bob']);
+});
+
+test('travelerRouteKeys returns a person’s routes, matching aggregateLegs keys', () => {
+  const aliceKeys = travelerRouteKeys(LEGS, 'alice');
+  expect(aliceKeys.size).toBe(1); // alice's two legs share one route
+  const aliceAgg = aggregateLegs(LEGS.filter((l) => l.traveler_id === 'alice'));
+  expect([...aliceKeys]).toEqual([aliceAgg[0]?.key]);
+});
+
+test('travelerRouteKeys is empty for an unknown traveler', () => {
+  expect(travelerRouteKeys(LEGS, 'nobody').size).toBe(0);
+});
+
+test('orientRoute orders endpoints numerically, not lexically', () => {
+  // lng 10 vs 2: a string compare puts "10,0" < "2,0" (wrong); numeric puts
+  // 2 first. Either way A→B and B→A must collapse to the same key.
+  const ab = orientRoute('plane', [10, 0], [2, 0], 'Ten', 'Two');
+  const ba = orientRoute('plane', [2, 0], [10, 0], 'Two', 'Ten');
+  expect(ab.from).toEqual([2, 0]);
+  expect(ab.fromName).toBe('Two');
+  expect(ab.key).toBe(ba.key);
+});
+
+test('travelerRouteKeys normalises direction (A→B equals B→A)', () => {
+  const there = leg({
+    traveler_id: 'x',
+    origin_lng: 1,
+    origin_lat: 1,
+    destination_lng: 2,
+    destination_lat: 2,
+  });
+  const back = leg({
+    traveler_id: 'y',
+    origin_lng: 2,
+    origin_lat: 2,
+    destination_lng: 1,
+    destination_lat: 1,
+  });
+  const kx = [...travelerRouteKeys([there], 'x')][0];
+  const ky = [...travelerRouteKeys([back], 'y')][0];
+  expect(kx).toBe(ky);
+});
+
+test('legsToRender: null selection shows everyone (no hover)', () => {
+  expect(ids(legsToRender(LEGS, null, null))).toEqual([
+    'alice',
+    'bob',
+    'carol',
+  ]);
+});
+
+test('legsToRender: selection hides the rest', () => {
+  const sel = new Set(['alice']);
+  expect(ids(legsToRender(LEGS, sel, null))).toEqual(['alice']);
+});
+
+test('legsToRender: hovering a deselected member reveals only them on top', () => {
+  // bob selected; hover carol (deselected) → carol's legs are added, alice stays hidden.
+  const sel = new Set(['bob']);
+  expect(ids(legsToRender(LEGS, sel, 'carol'))).toEqual(['bob', 'carol']);
+});
+
+test('legsToRender: hovering an already-selected member adds nothing', () => {
+  const sel = new Set(['bob']);
+  expect(ids(legsToRender(LEGS, sel, 'bob'))).toEqual(['bob']);
+});
+
+test('aggregateLegs collects distinct travelers per route, heaviest first', () => {
+  // All LEGS share the GVA↔JFK route → one aggregated leg. Sorted by each
+  // person's emissions: bob 300, alice 100+50=150, carol 20.
+  const [route] = aggregateLegs(LEGS);
+  expect(route?.travelers).toEqual([
+    'Bob Martin',
+    'Alice Dupont',
+    'Carol Rossi',
+  ]);
+});
+
+test('filtering then aggregating drops a de-selected member’s emissions', () => {
+  // Show only bob → only his 300 kg leg survives aggregation.
+  const selected = new Set(['bob']);
+  const filtered = LEGS.filter((l) => selected.has(l.traveler_id));
+  const aggregated = aggregateLegs(filtered);
+  const total = aggregated.reduce((s, a) => s + a.totalKgCo2eq, 0);
+  expect(total).toBe(300);
+});


### PR DESCRIPTION
## What does this change?

Update the interactive **trips map** to the Professional Travel module:

- Plane (dashed) + train (solid) routes on a vector basemap, coloured by emissions, width by trip volume.
- **Hover tooltip**: route, mode, trips, emissions, avg/trip, and the **traveler(s)** on that route.
- **Member filter** (managers only): show/hide each unit member's trips, with per-person CO₂ totals; hovering a member spotlights their routes and dims the rest.
- **Mode filter** in the legend: plane/train glyphs are selectable (multi-select).

Backend: trip legs now carry the traveler, with names resolved from the headcount roster (→ `User.display_name` → SCIPER). Scope unchanged (principals see the unit, standard users only their own).

## Type of change

- [x] ✨ New feature
- [x] 🎨 Design/UI improvement

## Testing

- [x] Tests added (backend: traveler attribution + name resolution; frontend: filter/aggregation helpers)
- [ ] Tested locally
- [ ] `make ci` passes

## Related issues

- Closes #282