### PR TITLE
fix/1395 desactivate input form

### DIFF
--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -193,11 +193,17 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
           {{ $t('data_management_submodule_inputs_deactivation_description') }}
         </div>
         <q-checkbox
-          :model-value="isSubmoduleInputsDeactivated(submodule)"
+          :model-value="
+            submodule.forceInputsDeactivated ||
+            isSubmoduleInputsDeactivated(submodule)
+          "
           color="accent"
+          :disable="!!submodule.forceInputsDeactivated"
           :label="$t('data_management_submodule_inputs_deactivation_label')"
           @update:model-value="
-            (val: boolean) => updateSubmoduleInputsDeactivated(submodule, val)
+            (val: boolean) =>
+              !submodule.forceInputsDeactivated &&
+              updateSubmoduleInputsDeactivated(submodule, val)
           "
         />
       </q-card>

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="hasTopBar" class="q-mb-md flex justify-between items-center wrap">
-    <div v-if="hasModuleUpload" class="q-gutter-sm">
+    <div v-if="hasModuleUpload && !isInputDeactivated" class="q-gutter-sm">
       <q-btn
         outline
         icon="o_view_list"
@@ -368,6 +368,7 @@ import ModuleInlineSelect from './ModuleInlineSelect.vue';
 import NoteDialog from 'src/components/molecules/NoteDialog.vue';
 import { QInput, QSelect, useQuasar } from 'quasar';
 import { useModuleStore, useTimelineStore } from 'src/stores/modules';
+import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useAuthStore } from 'src/stores/auth';
 import {
   useBackofficeDataManagement,
@@ -703,6 +704,14 @@ const props = withDefaults(defineProps<ModuleTableProps>(), {
 });
 const moduleStore = useModuleStore();
 const timelineStore = useTimelineStore();
+const yearConfigStore = useYearConfigStore();
+
+const isInputDeactivated = computed(() => {
+  const unifiedConfig = yearConfigStore.getModule(props.moduleType as Module);
+  if (!unifiedConfig) return false;
+  const subConfig = unifiedConfig.submodules[props.submoduleType as string];
+  return subConfig?.inputs_deactivated ?? false;
+});
 
 const moduleColors = computed(() =>
   getModuleIconColors(String(props.moduleType), String(props.submoduleType)),

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -64,7 +64,6 @@
           :module-color-lighter="submoduleLighterColor"
         />
       </div>
-      <q-separator />
       <div
         v-if="isInputDeactivated"
         class="q-mx-lg q-my-md inputs-deactivated-notice"
@@ -94,11 +93,6 @@
             :module-color="submoduleColor"
             @submit="submitForm"
           />
-        </div>
-        <div v-else-if="showViewOnlyBadge" class="q-mx-lg q-my-md">
-          <q-badge color="warning" class="q-px-md q-py-sm">
-            {{ $t('common_view_only') }}
-          </q-badge>
         </div>
       </template>
     </q-card-section>
@@ -165,7 +159,7 @@
           :is-simulator="isSimulator"
         />
       </div>
-      <q-separator />
+
       <div v-if="hasModuleForm && !disable && canEdit" class="q-mx-lg">
         <module-form
           ref="formRef"
@@ -390,13 +384,6 @@ const hasModuleForm = computed(() => {
 
 const showModuleForm = computed(
   () => hasModuleForm.value && !isFormDisabled.value && canEdit.value,
-);
-
-const showViewOnlyBadge = computed(
-  () =>
-    Boolean(props.submodule.moduleFields) &&
-    !isFormDisabled.value &&
-    !canEdit.value,
 );
 
 // Map data is fetched once at the module-charts level (ModuleCharts.vue

--- a/frontend/src/constant/backoffice-module-config.ts
+++ b/frontend/src/constant/backoffice-module-config.ts
@@ -16,6 +16,7 @@ export type SubmoduleConfig = {
   mandatoryData?: boolean;
   mandatoryReference?: boolean;
   noThreshold?: true;
+  forceInputsDeactivated?: true;
 };
 
 export const MODULE_SUBMODULES: Partial<
@@ -188,12 +189,14 @@ export const MODULE_SUBMODULES: Partial<
       labelKey: 'data_management_submodule_research_facilities',
       moduleTypeId: 6,
       dataEntryTypeId: 70,
+      forceInputsDeactivated: true,
     },
     {
       key: 'mice_and_fish_animal_facilities',
       labelKey: 'data_management_submodule_animal_facilities',
       moduleTypeId: 6,
       dataEntryTypeId: 71,
+      forceInputsDeactivated: true,
     },
   ],
   [MODULES.ExternalCloudAndAI]: [

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -28,8 +28,6 @@ const memberFields: ModuleField[] = [
     ratio: '1/4',
     icon: 'o_filter_drama',
     columnSize: 'sm',
-    readOnly: true,
-    hideIn: { form: true },
   },
   {
     id: 'sius_code',
@@ -51,7 +49,6 @@ const memberFields: ModuleField[] = [
       { value: '58', label: '58' },
       { value: '59', label: '59' },
     ],
-    hideIn: { form: true },
   },
   {
     id: 'user_institutional_id',
@@ -59,8 +56,6 @@ const memberFields: ModuleField[] = [
     type: 'text',
     sortable: false,
     ratio: '1/4',
-    readOnly: true,
-    hideIn: { form: true },
   },
   {
     id: 'fte',
@@ -72,8 +67,6 @@ const memberFields: ModuleField[] = [
     sortable: false,
     ratio: '1/4',
     icon: 'o_timer',
-    readOnly: true,
-    hideIn: { form: true },
   },
 ];
 

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -38,7 +38,7 @@ const memberFields: ModuleField[] = [
     icon: 'o_assignment_ind',
     optionLabelsAreKeys: true,
     columnSize: 'sm',
-    readOnly: true,
+
     options: [
       { value: '51', label: '51' },
       { value: '52', label: '52' },


### PR DESCRIPTION
## What does this change?
Hides the CSV upload button when a submodule's inputs are deactivated, removes the "view only" badge, removes the two `q-separator` elements between the submodule header and body, and un-hides headcount fields from the add/edit form.

**`ModuleTable.vue`:** adds `isInputDeactivated` computed (reads `submodules[submoduleType].inputs_deactivated` from `yearConfigStore`); gates the CSV upload button group with `v-if="hasModuleUpload && !isInputDeactivated"` so it disappears when data entry is locked

**`SubModuleSection.vue`:** removes the `showViewOnlyBadge` computed and its associated `<q-badge>` block; removes both `<q-separator />` elements that appeared between the submodule title row and the content area

**`headcount.ts` (module config):** removes `hideIn: { form: true }` from all member fields (`name`, `sius_code`, `user_institutional_id`, `fte`) and the student `fte` field, making them visible in the add/edit form

## Why is this needed?
When `inputs_deactivated` is set on a submodule (e.g. research facilities, or a locked headcount), the CSV upload button was still visible even though uploads would be rejected. The "view only" badge was also confusing — the `isInputDeactivated` notice already communicates read-only status. Headcount fields also needed to be visible in the form so users can review or manually add entries when needed.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Closes #1395