### PR TITLE
fix: integration test for travel plane

### DIFF
--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -167,7 +167,7 @@ _AI_USE_MAP: dict[str, EmissionType] = {
 _PLANE_CABIN_MAP: dict[str, EmissionType] = {
     "first": EmissionType.professional_travel__plane__first,
     "business": EmissionType.professional_travel__plane__business,
-    "eco": EmissionType.professional_travel__plane__eco,
+    "economy": EmissionType.professional_travel__plane__eco,
 }
 
 _TRAIN_CLASS_MAP: dict[str, EmissionType] = {

--- a/backend/tests/integration/services/data_ingestion/test_factor_lifecycle_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_factor_lifecycle_pg.py
@@ -377,7 +377,7 @@ async def test_new_factor_matches_unmatched_entries_strategy_b(
                     "user_institutional_id": "U-001",
                     "origin_iata": "GVA",
                     "destination_iata": "CDG",
-                    "cabin_class": "eco",
+                    "cabin_class": "economy",
                     "number_of_trips": 1,
                 },
             )
@@ -409,8 +409,15 @@ async def test_new_factor_matches_unmatched_entries_strategy_b(
             new_factor = Factor(
                 emission_type_id=EmissionType.professional_travel__plane.value,
                 data_entry_type_id=DataEntryTypeEnum.plane.value,
-                classification={"category": "very_short_haul"},
-                values={"ef_kg_co2eq_per_km": 0.1},
+                classification={
+                    "category": "very_short_haul",
+                    "cabin_class": "economy",
+                },
+                values={
+                    "ef_kg_co2eq_per_km": 0.1,
+                    "min_distance": 0,
+                    "max_distance": 800,
+                },
                 year=2025,
             )
             repo = FactorRepository(s)

--- a/backend/tests/integration/services/data_ingestion/test_recalc_source_uniformity_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_recalc_source_uniformity_pg.py
@@ -75,7 +75,7 @@ from .conftest import seeded_year_with_units
 # already cached on the row.
 _YEAR = 2025
 _HAUL = "long_haul"
-_CABIN = "eco"
+_CABIN = "economy"
 _DISTANCE_KM = 5_000.0
 _RFI = 1.9
 _INITIAL_EF = 0.10  # kg_co2eq per km
@@ -136,10 +136,12 @@ async def test_recalc_uniform_across_source_types(pg_dsn) -> None:
         factor = Factor(
             emission_type_id=EmissionType.professional_travel__plane.value,
             data_entry_type_id=DataEntryTypeEnum.plane.value,
-            classification={"category": _HAUL},
+            classification={"category": _HAUL, "cabin_class": _CABIN},
             values={
                 "ef_kg_co2eq_per_km": _INITIAL_EF,
                 "rfi_adjustment": _RFI,
+                "min_distance": 3500,
+                "max_distance": 20000,
             },
             year=_YEAR,
         )

--- a/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
@@ -201,8 +201,15 @@ async def test_travel_plane_factor_values_change_propagates(pg_dsn):
         factor = Factor(
             emission_type_id=EmissionType.professional_travel__plane.value,
             data_entry_type_id=DataEntryTypeEnum.plane.value,
-            classification={"category": "very_short_haul"},
-            values={"ef_kg_co2eq_per_km": 0.1},
+            classification={
+                "category": "very_short_haul",
+                "cabin_class": "economy",
+            },
+            values={
+                "ef_kg_co2eq_per_km": 0.1,
+                "min_distance": 0,
+                "max_distance": 800,
+            },
             year=2025,
         )
         s.add(factor)
@@ -217,7 +224,7 @@ async def test_travel_plane_factor_values_change_propagates(pg_dsn):
                 "user_institutional_id": "U-001",
                 "origin_iata": "GVA",
                 "destination_iata": "CDG",
-                "cabin_class": "eco",
+                "cabin_class": "economy",
                 "number_of_trips": 1,
             },
         )
@@ -304,8 +311,15 @@ async def test_travel_plane_factor_drop_clears_emission(pg_dsn):
         factor = Factor(
             emission_type_id=EmissionType.professional_travel__plane.value,
             data_entry_type_id=DataEntryTypeEnum.plane.value,
-            classification={"category": "very_short_haul"},
-            values={"ef_kg_co2eq_per_km": 0.1},
+            classification={
+                "category": "very_short_haul",
+                "cabin_class": "economy",
+            },
+            values={
+                "ef_kg_co2eq_per_km": 0.1,
+                "min_distance": 0,
+                "max_distance": 800,
+            },
             year=2025,
         )
         s.add(factor)
@@ -320,7 +334,7 @@ async def test_travel_plane_factor_drop_clears_emission(pg_dsn):
                 "user_institutional_id": "U-001",
                 "origin_iata": "GVA",
                 "destination_iata": "CDG",
-                "cabin_class": "eco",
+                "cabin_class": "economy",
                 "number_of_trips": 1,
             },
         )

--- a/backend/tests/integration/services/data_ingestion/test_travel_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_travel_pg.py
@@ -244,8 +244,12 @@ async def _seed_plane_factor(session: AsyncSession) -> int:
         data_entry_type_id=DataEntryTypeEnum.plane.value,
         # The trimmed CSV's GVA→CDG distance lands in the very_short_haul
         # bucket (haul category derived in pre_compute).
-        classification={"category": "very_short_haul"},
-        values={"ef_kg_co2eq_per_km": 0.1},
+        classification={"category": "very_short_haul", "cabin_class": "economy"},
+        values={
+            "ef_kg_co2eq_per_km": 0.1,
+            "min_distance": 0,
+            "max_distance": 800,
+        },
         year=YEAR,
     )
     session.add(factor)
@@ -978,7 +982,7 @@ async def test_api_provider_load_data_persists_external_integration_with_zero_ov
             "kg_co2eq": 0,  # int zero
             "OUT_CO2_CORRECTED": 999.0,  # must NOT win
             "number_of_trips": 1,
-            "cabin_class": "eco",
+            "cabin_class": "economy",
         },
         {
             "carbon_report_module_id": module_id,
@@ -988,7 +992,7 @@ async def test_api_provider_load_data_persists_external_integration_with_zero_ov
             "kg_co2eq": 0.0,  # float zero
             "OUT_CO2_CORRECTED": 999.0,
             "number_of_trips": 1,
-            "cabin_class": "eco",
+            "cabin_class": "economy",
         },
         {
             "carbon_report_module_id": module_id,
@@ -998,7 +1002,7 @@ async def test_api_provider_load_data_persists_external_integration_with_zero_ov
             "kg_co2eq": None,  # missing → fallback applies
             "OUT_CO2_CORRECTED": 5.0,
             "number_of_trips": 1,
-            "cabin_class": "eco",
+            "cabin_class": "economy",
         },
     ]
 
@@ -1090,7 +1094,7 @@ async def test_kg_co2eq_zero_int_override_survives_async_recalc_path(
                 "user_institutional_id": "U-API-0",
                 "origin_iata": "GVA",
                 "destination_iata": "CDG",
-                "cabin_class": "eco",
+                "cabin_class": "economy",
                 "number_of_trips": 1,
                 # Override is the V2 boundary: int zero — a plane trip
                 # someone manually corrected to 0 (e.g. cancelled).  Must
@@ -1173,7 +1177,7 @@ async def test_kg_co2eq_zero_float_override_survives_async_recalc_path(
                 "user_institutional_id": "U-API-1",
                 "origin_iata": "GVA",
                 "destination_iata": "CDG",
-                "cabin_class": "eco",
+                "cabin_class": "economy",
                 "number_of_trips": 1,
                 KG_CO2EQ_OVERRIDE_KEY: 0.0,
             },


### PR DESCRIPTION
## What does this change?
Fixes plane emission factor lookup when cabin class is missing or unmatched, corrects the `"eco"` → `"economy"` key in the cabin class emission type map, and adds missing `min_distance`/`max_distance` fields to plane factor fixtures in integration tests.

**`data_entry_emission_service.py`:** adds a B1b fallback in the factor resolution path — when a kind+subkind query returns no results (e.g. the cabin class stored on an entry doesn't match any factor classification key), it retries with `subkind=None` (kind-only) so that haul-category-keyed plane factors are still found

**`data_entry_emission_type_map.py`:** changes `_PLANE_CABIN_MAP` key from `"eco"` to `"economy"` to match the normalised value now stored by the plane handler (aligns with the #863 change that maps `"eco"` → `"economy"` before factor lookup)

**Tests:** adds `min_distance` and `max_distance` to plane factor `values` in five integration test fixtures (`test_factor_lifecycle_pg`, `test_strategy_b_rematch_pg` ×2, `test_travel_pg`, `test_recalc_source_uniformity_pg`) — these fields are now required by the `TravelPlaneFactorCreate` DTO validator introduced in #863

## Why is this needed?
After #863 added `min_distance`/`max_distance` to the plane factor schema and normalised cabin class values, several integration tests were failing because their seeded factors omitted the new required fields, and the emission type map still used the old `"eco"` key. The B1b fallback ensures backward compatibility for entries that have a cabin class not present in the factor data.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Fixes integration test failures introduced by #863