### PR TITLE
fix 986: standardize capitalization for "IT equipment" across multiple i18n files

### DIFF
--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -510,7 +510,7 @@ export default {
     fr: 'Équipements scientifiques',
   },
   data_management_submodule_it_equipment: {
-    en: 'IT Equipment',
+    en: 'IT equipment',
     fr: 'Équipements IT',
   },
   data_management_submodule_consumables_accessories: {

--- a/frontend/src/i18n/equipment_electric_consumption.ts
+++ b/frontend/src/i18n/equipment_electric_consumption.ts
@@ -92,11 +92,11 @@ Si la puissance moyenne active ou standby de votre équipement est différente d
     fr: 'Équipements scientifiques',
   },
   [`${MODULES.EquipmentElectricConsumption}-it`]: {
-    en: 'IT Equipment',
+    en: 'IT equipment',
     fr: 'Équipements IT',
   },
   [`${MODULES.EquipmentElectricConsumption}-other`]: {
-    en: 'Other Equipment',
+    en: 'Other equipment',
     fr: 'Autres équipements',
   },
   [`${MODULES.EquipmentElectricConsumption}-scientific-equipment-table-title`]:

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -3,7 +3,7 @@ import { MODULES, SUBMODULE_EXTERNAL_CLOUD_TYPES } from 'src/constant/modules';
 export default {
   [MODULES.ExternalCloudAndAI]: {
     en: 'External clouds & AI',
-    fr: 'Clouds Externes & IA',
+    fr: 'Clouds externes & IA',
   },
   [`${MODULES.ExternalCloudAndAI}-description`]: {
     en: 'Enter external clouds usage data to estimate the carbon footprint.',

--- a/frontend/src/i18n/purchase.ts
+++ b/frontend/src/i18n/purchase.ts
@@ -82,12 +82,12 @@ export default {
     },
   [`${MODULES.Purchase}.${SUBMODULE_PURCHASE_TYPES.ITEquipmentPurchases}-table-title`]:
     {
-      en: 'IT Equipments ({count})',
+      en: 'IT equipments ({count})',
       fr: 'Équipements informatiques ({count})',
     },
   [`${MODULES.Purchase}-${SUBMODULE_PURCHASE_TYPES.ITEquipmentPurchases}-form-title`]:
     {
-      en: 'Add IT Equipment',
+      en: 'Add IT equipment',
       fr: 'Ajouter un équipement informatique',
     },
   [`${MODULES.Purchase}.${SUBMODULE_PURCHASE_TYPES.ConsumablePurchases}-table-title`]:
@@ -157,8 +157,8 @@ export default {
     },
   [`${MODULES.Purchase}-${SUBMODULE_PURCHASE_TYPES.ITEquipmentPurchases}-table-title-info-tooltip`]:
     {
-      en: 'Purchase It Equipment Tooltip',
-      fr: 'Purchase It Equipment Tooltip',
+      en: 'Purchase It equipment Tooltip',
+      fr: 'Purchase It equipment Tooltip',
     },
   [`${MODULES.Purchase}-${SUBMODULE_PURCHASE_TYPES.ConsumablePurchases}-table-title-info-tooltip`]:
     {

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -722,7 +722,7 @@ export default {
     fr: 'Reste',
   },
   'charts-equipment-it': {
-    en: 'IT Equipment',
+    en: 'IT equipment',
     fr: 'Équipements IT',
   },
   'charts-buildings-it': {


### PR DESCRIPTION
## What does this change?
Standardizes English label casing across the frontend i18n files:
- "IT Equipment" → "IT equipment" (sentence case)
- "Other Equipment" → "Other equipment"
- "Clouds Externes & IA" → "Clouds externes & IA" (French sentence case)

Affected files: `backoffice_data_management.ts`, `equipment_electric_consumption.ts`, `external_cloud.ts`, `purchase.ts`, `results.ts`

## Why is this needed?
Labels were inconsistently capitalized. This aligns all UI strings with sentence case, which is the established naming convention in the app.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] No console.log or debug statements

## Testing checklist
- [x] No logic changes — visual/text only, no tests required