### PR TITLE
fix: chart ticks translation corrections

### DIFF
--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -502,7 +502,7 @@ export default {
     fr: 'LN2',
   },
   'charts-research-facilities-category': {
-    en: 'Research Facilities',
+    en: 'Research facilities',
     fr: 'Infrastructures de recherche',
   },
   'charts-equipment-category': {
@@ -543,7 +543,7 @@ export default {
   },
   'charts-equipment-electric-consumption-category': {
     en: 'Equipment',
-    fr: 'Équipement',
+    fr: 'Équipements',
   },
   'charts-external-cloud-category': {
     en: 'External clouds & AI',


### PR DESCRIPTION
## What does this change?
Two label corrections in `results.ts`:
- "Research Facilities" → "Research facilities" (sentence case)
- French "Équipement" → "Équipements" (plural, consistent with other equipment labels)

## Why is this needed?
Fixes inconsistent casing and a grammatical mismatch in chart axis/tick labels.

## Type of change
- [x] 🐛 Bug fix