### PR TITLE
chore(deps): consolidate dependency updates

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "itsdangerous==2.2.0",
     "aiosqlite>=0.21.0",                # fall back for when no external db is provided
     "fastapi[standard]==0.136.3",
-    "starlette==1.0.1",
+    "starlette==1.2.1",
     "uvicorn[standard]==0.49.0",
     "python-multipart==0.0.32",
     "sqlalchemy[asyncio,mypy]==2.0.50",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 
 [[package]]
@@ -427,7 +427,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "sqlalchemy", extras = ["asyncio", "mypy"], specifier = "==2.0.50" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
-    { name = "starlette", specifier = "==1.0.1" },
+    { name = "starlette", specifier = "==1.2.1" },
     { name = "types-passlib", specifier = ">=1.7.7.20250602" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.49.0" },
 ]
@@ -1991,15 +1991,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,8 +29,8 @@
         "@playwright/experimental-ct-vue": "=1.60.0",
         "@playwright/test": "=1.60.0",
         "@quasar/app-vite": "=2.6.2",
-        "@types/node": "=24.12.3",
-        "@vue/eslint-config-typescript": "=14.7.0",
+        "@types/node": "=24.13.0",
+        "@vue/eslint-config-typescript": "=14.8.0",
         "autoprefixer": "=10.5.0",
         "chokidar": "=4.0.3",
         "eslint": "=10.4.1",
@@ -49,7 +49,7 @@
         "typescript": "=5.9.3",
         "typescript-eslint": "^8.60.1",
         "vue-eslint-parser": "=10.4.1",
-        "vue-tsc": "=3.3.3"
+        "vue-tsc": "=3.3.4"
       },
       "engines": {
         "node": ">=v24.15.0 <25",
@@ -4333,13 +4333,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
-      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4746,15 +4746,15 @@
       }
     },
     "node_modules/@vue/eslint-config-typescript": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-14.7.0.tgz",
-      "integrity": "sha512-iegbMINVc+seZ/QxtzWiOBozctrHiF2WvGedruu2EbLujg9VuU0FQiNcN2z1ycuaoKKpF4m2qzB5HDEMKbxtIg==",
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-14.8.0.tgz",
+      "integrity": "sha512-yIquzhXH7ZsrwSSm+rYvoGCRY6wcuF4qBi76e0l7hHLq7YU0f9aC+RcR5fL+XJNfmBZxgX5cVl4sppt4x7ZCBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.56.0",
+        "@typescript-eslint/utils": "^8.60.0",
         "fast-glob": "^3.3.3",
-        "typescript-eslint": "^8.56.0",
+        "typescript-eslint": "^8.60.0",
         "vue-eslint-parser": "^10.4.0"
       },
       "engines": {
@@ -4772,9 +4772,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.3.tgz",
-      "integrity": "sha512-X6p+7nfY7vVT6dQwUJ+v0Jfq/lwIfhL2jMi91dQ3ln4hnlGXlxsDu/FNkeyHYgvYtyQy18ZX76IZy7X4diDbiQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.4.tgz",
+      "integrity": "sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11663,9 +11663,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12040,14 +12040,14 @@
       "license": "MIT"
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.3.tgz",
-      "integrity": "sha512-SWUEG7YRUeDJHT7Xsuhf02elYX2gxPzzAII7OxDAh4KNOr4QHQ0Lls0YfnaO5GNd560CwVa2HTfdqmA5MqvRqQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.4.tgz",
+      "integrity": "sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.3"
+        "@vue/language-core": "3.3.4"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,8 +42,8 @@
     "@playwright/experimental-ct-vue": "=1.60.0",
     "@playwright/test": "=1.60.0",
     "@quasar/app-vite": "=2.6.2",
-    "@types/node": "=24.12.3",
-    "@vue/eslint-config-typescript": "=14.7.0",
+    "@types/node": "=24.13.0",
+    "@vue/eslint-config-typescript": "=14.8.0",
     "autoprefixer": "=10.5.0",
     "chokidar": "=4.0.3",
     "eslint": "=10.4.1",
@@ -62,7 +62,7 @@
     "typescript": "=5.9.3",
     "typescript-eslint": "^8.60.1",
     "vue-eslint-parser": "=10.4.1",
-    "vue-tsc": "=3.3.3"
+    "vue-tsc": "=3.3.4"
   },
   "overrides": {
     "minimatch": "=10.2.4",


### PR DESCRIPTION
Superseded 4 dependabot PR(s):

- #1497 chore(deps-dev): bump @types/node from 24.12.3 to 24.13.0 in /frontend
- #1496 chore(deps-dev): bump @vue/eslint-config-typescript from 14.7.0 to 14.8.0 in /frontend
- #1495 chore(deps): bump starlette from 1.0.1 to 1.2.1 in /backend
- #1494 chore(deps-dev): bump vue-tsc from 3.3.3 to 3.3.4 in /frontend
ran dependabot script