### PR TITLE
feat: add unit tests for plane emission calculations and cabin class resolution

### DIFF
--- a/backend/tests/unit/utils/test_plane_cabin_class.py
+++ b/backend/tests/unit/utils/test_plane_cabin_class.py
@@ -1,0 +1,47 @@
+"""Unit tests for plane cabin-class → EmissionType resolution.
+
+Verifies that ``_resolve_plane`` (used by ``resolve_emission_types`` at
+runtime) correctly maps each cabin class to its EmissionType leaf, and
+that unknown or missing values return ``None`` (no emission produced).
+"""
+
+import pytest
+
+from app.models.data_entry_emission import EmissionType
+from app.utils.data_entry_emission_type_map import _resolve_plane
+
+
+@pytest.mark.parametrize(
+    "cabin_class, expected",
+    [
+        ("economy", EmissionType.professional_travel__plane__eco),
+        ("ECONOMY", EmissionType.professional_travel__plane__eco),
+        ("business", EmissionType.professional_travel__plane__business),
+        ("Business", EmissionType.professional_travel__plane__business),
+        ("first", EmissionType.professional_travel__plane__first),
+        ("First", EmissionType.professional_travel__plane__first),
+    ],
+)
+def test_resolve_plane_maps_class_to_emission_type(
+    cabin_class: str, expected: EmissionType
+) -> None:
+    result = _resolve_plane({"cabin_class": cabin_class})
+    assert result == [expected], (
+        f"cabin_class={cabin_class!r}: expected [{expected}], got {result}"
+    )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"cabin_class": "eco"},  # old wrong frontend value — must NOT match
+        {"cabin_class": "premium"},
+        {"cabin_class": ""},
+        {},  # missing key
+    ],
+)
+def test_resolve_plane_returns_none_for_unknown_class(data: dict) -> None:
+    result = _resolve_plane(data)
+    assert result is None, (
+        f"data={data!r}: expected None for unknown cabin class, got {result}"
+    )

--- a/backend/tests/unit/utils/test_plane_calculation.py
+++ b/backend/tests/unit/utils/test_plane_calculation.py
@@ -1,0 +1,223 @@
+"""Unit tests that the plane emission formula produces correct kg CO₂eq values.
+
+Formula (from issue #863):
+    kg_co2eq = distance_km × EF(category, cabin_class) × RFI_adjustment
+
+EF / RFI values are taken directly from backend/seed_data/travel_planes_factors.csv.
+No DB or async fixture is needed — ``_apply_formula`` is pure arithmetic.
+"""
+
+import pytest
+
+from app.models.data_entry_emission import EmissionComputation, EmissionType
+from app.modules.professional_travel.schemas import ProfessionalTravelPlaneModuleHandler
+from app.services.data_entry_emission_service import DataEntryEmissionService
+
+# ---------------------------------------------------------------------------
+# Factor values from travel_planes_factors.csv (all RFI = 1.35)
+# ---------------------------------------------------------------------------
+_EF = {
+    ("short_to_medium_haul", "economy"): 0.2906,
+    ("short_to_medium_haul", "business"): 0.4471,
+    ("short_to_medium_haul", "first"): 0.2906,
+    ("medium_to_long_haul", "economy"): 0.1902,
+    ("medium_to_long_haul", "business"): 0.3930,
+    ("medium_to_long_haul", "first"): 0.6056,
+}
+_RFI = 1.35
+
+
+def _svc() -> DataEntryEmissionService:
+    """Service instance with no DB session — _apply_formula is pure."""
+    return DataEntryEmissionService(None)  # type: ignore[arg-type]
+
+
+def _comp() -> EmissionComputation:
+    """Minimal EmissionComputation for plane handler resolve_computations."""
+    return EmissionComputation(
+        emission_type=EmissionType.professional_travel__plane__eco,
+        formula_key="ef_kg_co2eq_per_km",
+        quantity_key="distance_km",
+        multiplier_key="rfi_adjustment",
+        multiplier_default=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Formula correctness for all 6 factor combinations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "category, cabin_class, distance_km",
+    [
+        ("short_to_medium_haul", "economy", 506.0),  # GVA → CDG (haversine+95)
+        ("short_to_medium_haul", "business", 506.0),
+        ("short_to_medium_haul", "first", 506.0),
+        ("medium_to_long_haul", "economy", 5926.0),  # CDG → JFK
+        ("medium_to_long_haul", "business", 5926.0),
+        ("medium_to_long_haul", "first", 5926.0),
+    ],
+)
+def test_apply_formula_matches_spec(
+    category: str, cabin_class: str, distance_km: float
+) -> None:
+    ef = _EF[(category, cabin_class)]
+    expected = distance_km * ef * _RFI
+
+    result = _svc()._apply_formula(
+        ctx={"distance_km": distance_km},
+        factor_values={"ef_kg_co2eq_per_km": ef, "rfi_adjustment": _RFI},
+        comp=_comp(),
+    )
+
+    assert result == pytest.approx(expected, rel=1e-6), (
+        f"{category}/{cabin_class}: expected {expected:.4f} kg CO₂eq, got {result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Short-haul first == short-haul economy (same EF per spec)
+# ---------------------------------------------------------------------------
+
+
+def test_short_haul_first_equals_short_haul_economy() -> None:
+    distance_km = 500.0
+    eco = _svc()._apply_formula(
+        ctx={"distance_km": distance_km},
+        factor_values={
+            "ef_kg_co2eq_per_km": _EF[("short_to_medium_haul", "economy")],
+            "rfi_adjustment": _RFI,
+        },
+        comp=_comp(),
+    )
+    first = _svc()._apply_formula(
+        ctx={"distance_km": distance_km},
+        factor_values={
+            "ef_kg_co2eq_per_km": _EF[("short_to_medium_haul", "first")],
+            "rfi_adjustment": _RFI,
+        },
+        comp=_comp(),
+    )
+    assert eco == pytest.approx(first, rel=1e-9), (
+        "Short-haul first class must use the same EF as economy per issue #863 spec"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Business > economy on both hauls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category", ["short_to_medium_haul", "medium_to_long_haul"])
+def test_business_emits_more_than_economy(category: str) -> None:
+    distance_km = 1000.0
+    eco = _svc()._apply_formula(
+        ctx={"distance_km": distance_km},
+        factor_values={
+            "ef_kg_co2eq_per_km": _EF[(category, "economy")],
+            "rfi_adjustment": _RFI,
+        },
+        comp=_comp(),
+    )
+    biz = _svc()._apply_formula(
+        ctx={"distance_km": distance_km},
+        factor_values={
+            "ef_kg_co2eq_per_km": _EF[(category, "business")],
+            "rfi_adjustment": _RFI,
+        },
+        comp=_comp(),
+    )
+    assert biz > eco, (
+        f"{category}: business ({biz:.2f}) should exceed economy ({eco:.2f})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Long-haul first is the highest emitter per km
+# ---------------------------------------------------------------------------
+
+
+def test_long_haul_first_highest_emitter() -> None:
+    distance_km = 6000.0
+    results = {
+        cls: _svc()._apply_formula(
+            ctx={"distance_km": distance_km},
+            factor_values={
+                "ef_kg_co2eq_per_km": _EF[("medium_to_long_haul", cls)],
+                "rfi_adjustment": _RFI,
+            },
+            comp=_comp(),
+        )
+        for cls in ("economy", "business", "first")
+    }
+    assert results["first"] > results["business"] > results["economy"], (
+        f"Long-haul ranking wrong: {results}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. number_of_trips multiplier (distance_km already = one_trip × n_trips)
+# ---------------------------------------------------------------------------
+
+
+def test_two_trips_doubles_emission() -> None:
+    distance_one_trip = 506.0
+    ef = _EF[("short_to_medium_haul", "economy")]
+
+    one = _svc()._apply_formula(
+        ctx={"distance_km": distance_one_trip},
+        factor_values={"ef_kg_co2eq_per_km": ef, "rfi_adjustment": _RFI},
+        comp=_comp(),
+    )
+    two = _svc()._apply_formula(
+        ctx={"distance_km": distance_one_trip * 2},
+        factor_values={"ef_kg_co2eq_per_km": ef, "rfi_adjustment": _RFI},
+        comp=_comp(),
+    )
+    assert two == pytest.approx(one * 2, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 6. resolve_computations wires the correct FactorQuery keys
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_computations_passes_cabin_class_as_subkind() -> None:
+    """The handler must forward cabin_class as subkind so the factor repo
+    can match the right EF row (category × cabin_class)."""
+    handler = ProfessionalTravelPlaneModuleHandler()
+
+    class _FakeEntry:
+        id = 1
+        data = {"cabin_class": "business"}
+
+    ctx = {"haul_category": "short_to_medium_haul", "distance_km": 506.0}
+    computations = handler.resolve_computations(
+        _FakeEntry(), EmissionType.professional_travel__plane__business, ctx
+    )
+
+    assert len(computations) == 1
+    fq = computations[0].factor_query
+    assert fq is not None
+    assert fq.kind == "short_to_medium_haul", (
+        f"expected haul_category as kind, got {fq.kind}"
+    )
+    assert fq.subkind == "business", (
+        f"expected cabin_class as subkind, got {fq.subkind}"
+    )
+
+
+@pytest.mark.parametrize("cabin_class", ["economy", "business", "first"])
+def test_resolve_computations_all_classes(cabin_class: str) -> None:
+    handler = ProfessionalTravelPlaneModuleHandler()
+
+    class _FakeEntry:
+        id = 1
+        data = {"cabin_class": cabin_class}
+
+    ctx = {"haul_category": "medium_to_long_haul", "distance_km": 5926.0}
+    computations = handler.resolve_computations(
+        _FakeEntry(), EmissionType.professional_travel__plane__first, ctx
+    )
+    assert computations[0].factor_query.subkind == cabin_class


### PR DESCRIPTION
## What does this change?
Adds two new unit test modules covering the plane emission calculation and the cabin class → EmissionType resolution.

**`test_plane_calculation.py` (new):** tests the plane emission formula (`distance_km × EF × RFI`) across all 6 factor combinations (2 haul categories × 3 cabin classes) using values from `travel_planes_factors.csv`:
- Parametrised formula correctness for each category/class/distance combination
- Short-haul first class equals short-haul economy (same EF per spec)
- Business > economy on both hauls
- Long-haul ranking: first > business > economy
- Two trips doubles the emission (distance_km already incorporates number_of_trips)
- `resolve_computations` passes `haul_category` as `kind` and `cabin_class` as `subkind` in the `FactorQuery`
- Parametrised check that all three cabin classes are forwarded correctly as subkind

**`test_plane_cabin_class.py` (new):** tests `_resolve_plane` (cabin class → EmissionType leaf):
- Case-insensitive mapping of `economy`/`business`/`first` to their respective `EmissionType` values
- Returns `None` for unknown values: `"eco"` (old frontend value), `"premium"`, empty string, missing key

## Why is this needed?
The plane cabin class feature (#863) has no dedicated unit tests. These tests lock down the formula arithmetic and the cabin class resolution logic independently of the database, preventing regressions as the factor CSV values or handler logic evolves.
