### PR TITLE
feat 1193: prevent comma input in numeric fields

### DIFF
--- a/frontend/src/components/organisms/data-management/ModuleThresholdInput.vue
+++ b/frontend/src/components/organisms/data-management/ModuleThresholdInput.vue
@@ -90,6 +90,7 @@ function onValueChange() {
         dense
         outlined
         class="bg-white"
+        @keydown="(e) => e.key === ',' && e.preventDefault()"
         @update:model-value="onValueChange"
       />
       <div v-else class="text-body2">

--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -199,6 +199,10 @@
                 :size="inp.type === 'checkbox' ? 'xs' : undefined"
                 :emit-value="inp.type === 'select'"
                 :map-options="inp.type === 'select'"
+                @keydown="
+                  (e) =>
+                    inp.type === 'number' && e.key === ',' && e.preventDefault()
+                "
               >
                 <template v-if="inp.icon && inp.type !== 'checkbox'" #prepend>
                   <q-icon :name="inp.icon" color="grey-6" size="xs" />


### PR DESCRIPTION
## What does this change?
Prevents comma characters from being entered in numeric input fields.

- `ModuleForm.vue`: adds a `@keydown` handler on all form inputs that calls `e.preventDefault()` when `e.key === ','` and the field type is `'number'`
- `ModuleThresholdInput.vue`: same handler on the threshold input field

## Why is this needed?
On keyboards where the decimal separator is a comma (e.g. French/Swiss-French layouts), users could accidentally type a comma into a numeric field. This produces an invalid value that passes silently through the UI but fails backend validation. Blocking the comma key at input time prevents the issue before it reaches the form submission.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced