### PR TITLE
fix: updated research facilities factor computation

### DIFF
--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
+from app.models.data_entry_emission import EmissionType
 from app.models.factor import Factor
 from app.repositories.carbon_report_repo import CarbonReportRepository
 from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
@@ -94,7 +95,18 @@ class ResearchFacilitiesCommonFactorUpdateProvider(BaseFactorUpdateProvider):
         breakdown = await DataEntryEmissionRepository(session).get_emission_breakdown(
             carbon_report.id
         )
+        # Filter per emission type: process_emissions, buildings, equipment, purchases
+        included_emission_type_ids = [
+            EmissionType.process_emissions.value,
+            EmissionType.buildings.value,
+            EmissionType.equipment.value,
+            EmissionType.purchases.value,
+        ]
         # breakdown: list of (module_type_id, emission_type_id, kg_co2eq_sum)
-        total: float = sum(kg for _module_type_id, _emission_type_id, kg in breakdown)
+        total: float = sum(
+            kg
+            for _module_type_id, _emission_type_id, kg in breakdown
+            if _emission_type_id in included_emission_type_ids
+        )
 
         return {"kg_co2eq_sum": total}

--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
@@ -53,6 +53,13 @@ class ResearchFacilitiesCommonFactorUpdateProvider(BaseFactorUpdateProvider):
             ValueError: When the Unit or CarbonReport cannot be found — these
                         are surfaced as errors, not silent skips.
         """
+        # Skip if kg_co2eq_sum is not missing (already computed)
+        if factor.values.get("kg_co2eq_sum") is not None:
+            logger.info(
+                f"Factor {factor.id} already has kg_co2eq_sum; skipping computation"
+            )
+            return None
+
         researchfacility_id: Optional[str] = factor.classification.get(
             "researchfacility_id"
         )

--- a/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
+++ b/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
@@ -17,7 +17,9 @@ def _make_provider() -> ResearchFacilitiesCommonFactorUpdateProvider:
     )
 
 
-def _make_factor(researchfacility_id: str | None) -> MagicMock:
+def _make_factor(
+    researchfacility_id: str | None, kg_co2eq_sum: float | None = None
+) -> MagicMock:
     factor = MagicMock()
     factor.id = 42
     factor.classification = (
@@ -25,6 +27,7 @@ def _make_factor(researchfacility_id: str | None) -> MagicMock:
         if researchfacility_id is not None
         else {}
     )
+    factor.values = {"kg_co2eq_sum": kg_co2eq_sum} if kg_co2eq_sum is not None else {}
     return factor
 
 
@@ -41,7 +44,7 @@ async def test_happy_path_sums_all_valid_emissions():
     """Multiple emission rows from different modules
     → kg_co2eq_sum = sum of all emissions of interest."""
     provider = _make_provider()
-    factor = _make_factor("RF-001")
+    factor = _make_factor("RF-001", None)
     session = MagicMock()
 
     breakdown = [
@@ -97,7 +100,7 @@ async def test_unit_not_found_raises_value_error():
 async def test_carbon_report_not_found_raises_value_error():
     """CarbonReport not found → ValueError raised."""
     provider = _make_provider()
-    factor = _make_factor("RF-001")
+    factor = _make_factor("RF-001", None)
     session = MagicMock()
 
     with (
@@ -121,7 +124,7 @@ async def test_carbon_report_not_found_raises_value_error():
 async def test_zero_emissions_returns_zero_sum():
     """Empty emission breakdown → returns {"kg_co2eq_sum": 0.0}."""
     provider = _make_provider()
-    factor = _make_factor("RF-002")
+    factor = _make_factor("RF-002", None)
     session = MagicMock()
 
     with (
@@ -152,7 +155,19 @@ async def test_zero_emissions_returns_zero_sum():
 async def test_missing_researchfacility_id_returns_none():
     """Missing researchfacility_id in classification → returns None (factor skipped)."""
     provider = _make_provider()
-    factor = _make_factor(None)
+    factor = _make_factor(None, None)
+    session = MagicMock()
+
+    result = await provider.compute_factor_values(factor, 2025, session)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_existing_kg_co2eq_sum_skips_computation():
+    """Existing kg_co2eq_sum in factor.values → returns None (factor skipped)."""
+    provider = _make_provider()
+    factor = _make_factor("RF-003", kg_co2eq_sum=123.45)
     session = MagicMock()
 
     result = await provider.compute_factor_values(factor, 2025, session)

--- a/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
+++ b/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.data_entry_emission import EmissionType
 from app.services.data_ingestion.computed_providers.research_facilities_common import (
     ResearchFacilitiesCommonFactorUpdateProvider,
 )
@@ -36,16 +37,18 @@ def _make_carbon_report(report_id: int = 10) -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
-async def test_happy_path_sums_all_emissions():
-    """Multiple emission rows from different modules → kg_co2eq_sum = sum of all."""
+async def test_happy_path_sums_all_valid_emissions():
+    """Multiple emission rows from different modules
+    → kg_co2eq_sum = sum of all emissions of interest."""
     provider = _make_provider()
     factor = _make_factor("RF-001")
     session = MagicMock()
 
     breakdown = [
-        (1, 100, 500.0),
-        (2, 200, 300.0),
-        (3, 300, 200.0),
+        (1, EmissionType.process_emissions.value, 500.0),
+        (2, EmissionType.buildings.value, 300.0),
+        (3, EmissionType.equipment.value, 200.0),
+        (4, EmissionType.research_facilities.value, 600.0),  # Not included in sum
     ]
 
     with (

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -586,12 +586,12 @@ export default {
     fr: 'Calculer les facteurs',
   },
   data_management_compute_factors_confirm_title: {
-    en: 'Recompute Factors',
-    fr: 'Recalculer les facteurs',
+    en: 'Compute Missing Factors',
+    fr: 'Calculer les facteurs manquants',
   },
   data_management_compute_factors_confirm_message: {
-    en: 'This will recompute the emission factors from the existing data entries for this submodule. Any previously computed factors will be overwritten. Do you want to proceed?',
-    fr: "Ceci recalculera les facteurs d'émission à partir des données existantes pour ce sous-module. Les facteurs précédemment calculés seront écrasés. Souhaitez-vous continuer ?",
+    en: 'This will compute the emission factors from the existing data entries for this submodule. Only factors with missing values will be updated. Do you want to proceed?',
+    fr: "Ceci calculera les facteurs d'émission à partir des données existantes pour ce sous-module. Uniquement les facteurs avec des valeurs manquantes seront mis à jour. Souhaitez-vous continuer ?",
   },
   data_management_compute_factors_success: {
     en: 'Factors computed successfully',


### PR DESCRIPTION
## What does this change?

* fix: existing kg_co2eq_sum skips research facilities common factor computation
* fix: updated backoffice compute factors button and help
* fix: added filter per emission type of interest when computing research facilities common factors

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1414

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
