### PR TITLE
fix: use ilike to search (speed up by trigram index) and sort by similarity

### DIFF
--- a/backend/app/repositories/location_repo.py
+++ b/backend/app/repositories/location_repo.py
@@ -64,16 +64,19 @@ class LocationRepository:
 
         # Use PostgreSQL trigram similarity for efficient searching
         # This works with our GIN indexes using gin_trgm_ops
+        wildcard_query = f"%{query}%"
         search_condition = or_(
-            text("LOWER(name) % LOWER(:query)").bindparams(bindparam("query", query)),
-            text("LOWER(iata_code) % LOWER(:query)").bindparams(
-                bindparam("query", query)
+            text("name ilike :wildcard_query").bindparams(
+                bindparam("wildcard_query", wildcard_query)
             ),
-            text("LOWER(municipality) % LOWER(:query)").bindparams(
-                bindparam("query", query)
+            text("iata_code ilike :wildcard_query").bindparams(
+                bindparam("wildcard_query", wildcard_query)
             ),
-            text("LOWER(keywords) % LOWER(:query)").bindparams(
-                bindparam("query", query)
+            text("municipality ilike :wildcard_query").bindparams(
+                bindparam("wildcard_query", wildcard_query)
+            ),
+            text("keywords ilike :wildcard_query").bindparams(
+                bindparam("wildcard_query", wildcard_query)
             ),
         )
 


### PR DESCRIPTION
## What does this change?

* match per string included instead of pure trigram, to keep results with lower similarity 

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1439 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
