### PR TITLE
fix(modules): prevent modules/undefined/null 422 on navigation

### DIFF
--- a/frontend/src/components/organisms/module/ModuleForm.vue
+++ b/frontend/src/components/organisms/module/ModuleForm.vue
@@ -190,7 +190,6 @@
                 :error-message="errors[inp.id]"
                 :min="inp.min"
                 :max="inp.max"
-                @blur="validateField(inp)"
                 :step="inp.step"
                 :dense="inp.type !== 'boolean' && inp.type !== 'checkbox'"
                 :outlined="inp.type !== 'boolean' && inp.type !== 'checkbox'"
@@ -200,6 +199,7 @@
                 :size="inp.type === 'checkbox' ? 'xs' : undefined"
                 :emit-value="inp.type === 'select'"
                 :map-options="inp.type === 'select'"
+                @blur="validateField(inp)"
               >
                 <template v-if="inp.icon && inp.type !== 'checkbox'" #prepend>
                   <q-icon :name="inp.icon" color="grey-6" size="xs" />

--- a/frontend/src/pages/app/ModulePage.vue
+++ b/frontend/src/pages/app/ModulePage.vue
@@ -67,6 +67,13 @@ const error = computed(() => moduleStore.state.error);
 // get data on mount and when route params change
 const getData = () => {
   if (!currentModuleType.value) return;
+  // Wait for the workspace to resolve unit/year; the watch re-fires once
+  // they land, so this only defers the fetch (it never drops it).
+  if (
+    workspaceStore.selectedUnit?.id == null ||
+    workspaceStore.selectedYear == null
+  )
+    return;
   if (
     currentModuleType.value &&
     forbiddenModules.includes(currentModuleType.value)

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -18,6 +18,7 @@ import type {
 } from 'src/constant/modules';
 import { useRoute } from 'vue-router';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { buildModulePath, hasValidModuleParams } from 'src/utils/modulePath';
 
 // Maps route names to their carbon_project_type integer (0 = Calculator, 1 = Simulator Explore)
 const SIMULATION_ROUTE_CARBON_PROJECT_TYPE: Record<string, number> = {
@@ -360,14 +361,9 @@ export const useModuleStore = defineStore('modules', () => {
     // submodule title counts are available without fetching full submodule data.
     moduleTotalsMap: reactive({} as Record<string, Record<number, number>>),
   });
-  function modulePath(moduleType: Module, unit: number, year: string) {
-    const moduleTypeEncoded = encodeURIComponent(moduleType);
-    const unitEncoded = encodeURIComponent(unit);
-    const yearEncoded = encodeURIComponent(year);
-    // Backend expects /{unit_id}/{year}/{module_id}
-    const path = `modules/${unitEncoded}/${yearEncoded}/${moduleTypeEncoded}`;
-    return path;
-  }
+  // Backend expects /{unit_id}/{year}/{module_id}; buildModulePath throws on
+  // unresolved unit/year so we never fire a `modules/undefined/null/...` 422.
+  const modulePath = buildModulePath;
 
   function initializeSubmoduleState(submoduleId: string) {
     if (!(submoduleId in state.expandedSubmodules)) {
@@ -399,6 +395,8 @@ export const useModuleStore = defineStore('modules', () => {
   }
 
   async function getModuleData(moduleType: Module, unit: number, year: string) {
+    // Skip until the workspace has resolved unit/year (avoids the 422).
+    if (!hasValidModuleParams(unit, year)) return;
     state.loading = true;
     state.error = null;
     state.data = null;
@@ -426,6 +424,8 @@ export const useModuleStore = defineStore('modules', () => {
     unit: number,
     year: string,
   ) {
+    // Skip until the workspace has resolved unit/year (avoids the 422).
+    if (!hasValidModuleParams(unit, year)) return;
     state.loading = true;
     state.error = null;
     try {
@@ -478,6 +478,8 @@ export const useModuleStore = defineStore('modules', () => {
     unit: number;
     year: string;
   }) {
+    // Skip until the workspace has resolved unit/year (avoids the 422).
+    if (!hasValidModuleParams(unit, year)) return;
     state.loadingSubmodule[submoduleType] = true;
     state.errorSubmodule[submoduleType] = null;
     state.dataSubmodule[submoduleType] = null;

--- a/frontend/src/utils/modulePath.ts
+++ b/frontend/src/utils/modulePath.ts
@@ -1,0 +1,38 @@
+import { Module } from 'src/constant/modules';
+
+/**
+ * Values produced when a Vue ref is stringified before it has resolved
+ * (`String(undefined)` / `String(null)`). The backend treats `{unit_id}`
+ * and `{year}` as ints, so these literals reach it as path segments and
+ * trigger a 422 — see the `modules/undefined/null/...` bug.
+ */
+const UNRESOLVED = new Set(['', 'undefined', 'null', 'NaN']);
+
+/** True when both unit and year are present and not unresolved placeholders. */
+export function hasValidModuleParams(
+  unit: number | string | null | undefined,
+  year: string | number | null | undefined,
+): boolean {
+  if (unit == null || year == null) return false;
+  return !UNRESOLVED.has(String(unit)) && !UNRESOLVED.has(String(year));
+}
+
+/**
+ * Single source of truth for `/modules/{unit}/{year}/{module}` paths.
+ * Throws on missing/unresolved params so a doomed request is never fired
+ * with `undefined`/`null` segments.
+ */
+export function buildModulePath(
+  moduleType: Module,
+  unit: number | string | null | undefined,
+  year: string | number | null | undefined,
+): string {
+  if (!hasValidModuleParams(unit, year)) {
+    throw new Error(
+      `buildModulePath: unresolved unit/year (unit=${unit}, year=${year})`,
+    );
+  }
+  return `modules/${encodeURIComponent(String(unit))}/${encodeURIComponent(
+    String(year),
+  )}/${encodeURIComponent(moduleType)}`;
+}

--- a/frontend/tests/unit/module-path.spec.ts
+++ b/frontend/tests/unit/module-path.spec.ts
@@ -31,5 +31,7 @@ test('rejects unresolved unit/year (the reported bug)', () => {
 
 test('throws rather than emit undefined/null segments', () => {
   expect(() => buildModulePath(MODULES.Equipment, undefined, null)).toThrow();
-  expect(() => buildModulePath(MODULES.Equipment, 'undefined', '2026')).toThrow();
+  expect(() =>
+    buildModulePath(MODULES.Equipment, 'undefined', '2026'),
+  ).toThrow();
 });

--- a/frontend/tests/unit/module-path.spec.ts
+++ b/frontend/tests/unit/module-path.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for the `modules/undefined/null/equipment` 422 bug.
+ *
+ * On navigation the module fetch could fire before the workspace store had
+ * resolved `selectedUnit`/`selectedYear`. The refs stringified to the literals
+ * `"undefined"`/`"null"`, which reached the backend as `{unit_id}`/`{year}`
+ * path segments and were rejected with 422. `buildModulePath` /
+ * `hasValidModuleParams` are the source-of-truth guard that prevents it.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { MODULES } from '../../src/constant/modules';
+import {
+  buildModulePath,
+  hasValidModuleParams,
+} from '../../src/utils/modulePath';
+
+test('builds a valid path when unit/year are resolved', () => {
+  expect(buildModulePath(MODULES.Equipment, 42, '2026')).toBe(
+    'modules/42/2026/equipment',
+  );
+});
+
+test('rejects unresolved unit/year (the reported bug)', () => {
+  expect(hasValidModuleParams(undefined, '2026')).toBe(false);
+  expect(hasValidModuleParams(42, null)).toBe(false);
+  // String(undefined) / String(null) — the exact values that hit the URL.
+  expect(hasValidModuleParams('undefined', 'null')).toBe(false);
+});
+
+test('throws rather than emit undefined/null segments', () => {
+  expect(() => buildModulePath(MODULES.Equipment, undefined, null)).toThrow();
+  expect(() => buildModulePath(MODULES.Equipment, 'undefined', '2026')).toThrow();
+});


### PR DESCRIPTION
## Problem
Navigating to home / workspace / module pages sometimes fired:

```
GET /api/v1/modules/undefined/null/equipment?carbon_project_type=0 → 422
```

The module fetch ran before the workspace store had resolved
`selectedUnit`/`selectedYear`. The refs stringified to the literals
`"undefined"`/`"null"`, which reached the backend as `{unit_id}`/`{year}`
path segments and were rejected with 422.

## Fix
Two layers:

1. **Guard the trigger** — `ModulePage.vue` `getData()` early-returns until
   `selectedUnit?.id` and `selectedYear` are both present. The existing
   `watch` re-fires once they resolve, so the fetch is only deferred.
2. **Defend at the source** — new `src/utils/modulePath.ts` exports
   `buildModulePath()` (throws on nullish / `"undefined"` / `"null"` / `"NaN"` / `""`)
   and `hasValidModuleParams()`. The store now builds every module URL through
   it, and `getModuleData` / `getModuleTotals` / `getSubmoduleData` early-return
   on invalid params — closing the bug for every call site, not just the
   reported page.

## Test
`tests/unit/module-path.spec.ts` pins the exact `undefined`/`null` failure.
Passes (9/9); `make type-check` (vue-tsc) green.