### PR TITLE
fix/504 rename grey energy

### DIFF
--- a/backend/app/models/data_entry_emission.py
+++ b/backend/app/models/data_entry_emission.py
@@ -164,7 +164,7 @@ class EmissionType(int, Enum):
     buildings__combustion__pellets = 60204
     buildings__combustion__forest_chips = 60205
     buildings__combustion__wood_logs = 60206
-    buildings__embodied_energy = (
+    buildings__construction_and_renovation = (
         60300  # scope 3 — embodied emissions of construction materials
     )
 
@@ -443,7 +443,9 @@ _PARENT_MAP: dict[int, int] = {
     EmissionType.buildings__combustion__wood_logs.value: (
         EmissionType.buildings__combustion.value
     ),
-    EmissionType.buildings__embodied_energy.value: EmissionType.buildings.value,
+    EmissionType.buildings__construction_and_renovation.value: (
+        EmissionType.buildings.value
+    ),
     # process_emissions
     EmissionType.process_emissions__ch4.value: EmissionType.process_emissions.value,
     EmissionType.process_emissions__co2.value: EmissionType.process_emissions.value,
@@ -817,7 +819,7 @@ _SCOPE_CATEGORY_MAP: dict[int, EmissionMeta] = {
         "scope": Scope.scope1,
         "category": EmissionCategory.buildings_energy_combustion,
     },
-    EmissionType.buildings__embodied_energy.value: {
+    EmissionType.buildings__construction_and_renovation.value: {
         "scope": Scope.scope3,
         "category": EmissionCategory.embodied_energy,
     },

--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -93,7 +93,7 @@ MODULE_TYPE_TO_EMISSION_ROOTS: dict[ModuleTypeEnum, list[EmissionType]] = {
     ModuleTypeEnum.professional_travel: [EmissionType.professional_travel],
     ModuleTypeEnum.buildings: [
         EmissionType.buildings,
-        EmissionType.buildings__embodied_energy,
+        EmissionType.buildings__construction_and_renovation,
     ],
     ModuleTypeEnum.equipment: [EmissionType.equipment],
     ModuleTypeEnum.purchase: [EmissionType.purchases],

--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -648,7 +648,7 @@ class BuildingEmbodiedEnergyModuleHandler(BaseModuleHandler):
         return self.update_dto.model_validate(payload)
 
     def resolve_computations(self, data_entry, emission_type, ctx):
-        if emission_type != EmissionType.buildings__embodied_energy:
+        if emission_type != EmissionType.buildings__construction_and_renovation:
             return []
 
         def _building_embodied_energy_formula(
@@ -726,7 +726,7 @@ class BuildingEmbodiedEnergyFactorHandler(BaseFactorHandler):
     registration_keys = [
         DataEntryTypeEnum.building_embodied_energy,
     ]
-    emission_type: EmissionType = EmissionType.buildings__embodied_energy
+    emission_type: EmissionType = EmissionType.buildings__construction_and_renovation
 
     create_dto = BuildingEmbodiedEnergyFactorCreate
     update_dto = BuildingEmbodiedEnergyFactorUpdate

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -1071,15 +1071,64 @@ class CarbonReportModuleRepository:
         if hierarchy_unit_ids is not None and not hierarchy_unit_ids:
             return []
 
+        # Pre-aggregate CO2 by (unit_id, year, module_status) across all modules
+        # so each data-entry row can carry per-status totals for its unit-year.
+        status_co2_cols: List[Any] = [
+            col(CarbonReport.unit_id).label("s_unit_id"),
+            col(CarbonReport.year).label("s_year"),
+            col(CarbonReportModule.status).label("module_status"),
+            func.coalesce(func.sum(col(DataEntryEmission.kg_co2eq)), 0).label(
+                "total_co2"
+            ),
+        ]
+        status_stmt = (
+            select(*status_co2_cols)
+            .select_from(DataEntry)
+            .join(
+                CarbonReportModule,
+                CarbonReportModule.id == DataEntry.carbon_report_module_id,
+            )
+            .join(
+                CarbonReport,
+                CarbonReport.id == CarbonReportModule.carbon_report_id,
+            )
+            .outerjoin(
+                DataEntryEmission,
+                DataEntryEmission.data_entry_id == DataEntry.id,
+            )
+            .group_by(
+                col(CarbonReport.unit_id),
+                col(CarbonReport.year),
+                col(CarbonReportModule.status),
+            )
+        )
+        if years:
+            status_stmt = status_stmt.where(col(CarbonReport.year).in_(years))
+        if hierarchy_unit_ids is not None:
+            status_stmt = status_stmt.where(
+                col(CarbonReport.unit_id).in_(hierarchy_unit_ids)
+            )
+
+        status_rows = (await self.session.exec(status_stmt)).all()
+        status_co2_lookup: dict[tuple, dict[int, float]] = {}
+        for sr in status_rows:
+            key = (sr.s_unit_id, sr.s_year)
+            if key not in status_co2_lookup:
+                status_co2_lookup[key] = {}
+            status_co2_lookup[key][sr.module_status] = float(sr.total_co2)
+
         report: list[dict] = []
 
         columns: List[Any] = [
             col(DataEntry.data_entry_type_id),
             col(CarbonReport.year),
+            col(Unit.id).label("unit_id"),
             col(Unit.institutional_id).label("unit_institutional_id"),
             col(Unit.path_name).label("unit_path_name"),
             col(DataEntry.id).label("data_entry_id"),
             col(DataEntry.data),
+            col(CarbonReportModule.last_updated).label("module_last_updated"),
+            col(User.display_name).label("principal_user_name"),
             func.coalesce(
                 func.sum(col(DataEntryEmission.kg_co2eq)),
                 0,
@@ -1101,12 +1150,19 @@ class CarbonReportModuleRepository:
                 DataEntryEmission,
                 DataEntryEmission.data_entry_id == DataEntry.id,
             )
+            .outerjoin(
+                User,
+                User.institutional_id == Unit.principal_user_institutional_id,
+            )
             .where(DataEntry.data_entry_type_id == data_entry_type.value)
             .group_by(
                 col(CarbonReport.year),
+                col(Unit.id),
                 col(Unit.institutional_id),
                 col(Unit.path_name),
                 col(DataEntry.id),
+                col(CarbonReportModule.last_updated),
+                col(User.display_name),
             )
         )
 
@@ -1166,16 +1222,37 @@ class CarbonReportModuleRepository:
                 # Remove primary_factor_id from data
                 data = row.data.copy() if row.data else {}
                 data.pop("primary_factor_id", None)
+
+                last_update_iso = None
+                if row.module_last_updated is not None:
+                    last_update_iso = datetime.fromtimestamp(
+                        row.module_last_updated, tz=timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+                status_breakdown = status_co2_lookup.get((row.unit_id, row.year), {})
+
                 report.append(
                     {
+                        "unit_id": row.unit_id,
                         "data_entry_type": DataEntryTypeEnum(
                             row.data_entry_type_id
                         ).name,
                         "year": row.year,
                         "unit_institutional_id": row.unit_institutional_id,
                         "unit_path_name": row.unit_path_name,
+                        "principal_user": row.principal_user_name or "",
+                        "last_update": last_update_iso,
                         "data_entry_id": row.data_entry_id,
                         **data,
+                        "validated_categories_co2": round(
+                            status_breakdown.get(ModuleStatus.VALIDATED, 0), 1
+                        ),
+                        "in_progress_categories_co2": round(
+                            status_breakdown.get(ModuleStatus.IN_PROGRESS, 0), 1
+                        ),
+                        "not_started_categories_co2": round(
+                            status_breakdown.get(ModuleStatus.NOT_STARTED, 0), 1
+                        ),
                         "kg_co2eq": row.kg_co2eq,
                     }
                 )

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -637,7 +637,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.data_entry_type_id)
                 == DataEntryTypeEnum.building_embodied_energy.value,
                 col(DataEntryEmission.emission_type_id)
-                == EmissionType.buildings__embodied_energy.value,
+                == EmissionType.buildings__construction_and_renovation.value,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
                 building_name_expr.isnot(None),
                 building_name_expr != "",
@@ -686,7 +686,7 @@ class DataEntryEmissionRepository:
                 col(DataEntry.data_entry_type_id)
                 == DataEntryTypeEnum.building_embodied_energy.value,
                 col(DataEntryEmission.emission_type_id)
-                == EmissionType.buildings__embodied_energy.value,
+                == EmissionType.buildings__construction_and_renovation.value,
                 col(DataEntryEmission.kg_co2eq).isnot(None),
                 col(DataEntryEmission.kg_co2eq) > 0,
             )

--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -104,7 +104,7 @@ DATA_ENTRY_TO_EMISSION_TYPES: dict[DataEntryTypeEnum, list[EmissionType] | None]
     DataEntryTypeEnum.building: None,  # → _resolve_building_rooms()
     DataEntryTypeEnum.energy_combustion: None,  # → _resolve_combustion()
     DataEntryTypeEnum.building_embodied_energy: [
-        EmissionType.buildings__embodied_energy
+        EmissionType.buildings__construction_and_renovation
     ],  # embodied energy for buildings, scope 3
     # --- Process Emissions — resolved at runtime (emitted_gas key) ------------
     DataEntryTypeEnum.process_emissions: None,  # → _resolve_process_emissions()

--- a/backend/tests/integration/services/data_ingestion/test_buildings_csv_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_buildings_csv_pg.py
@@ -583,7 +583,7 @@ async def test_building_embodied_energy_factor_change_propagates_across_entries(
         # 'default'}`` branch in ``BuildingEmbodiedEnergyModuleHandler.
         # resolve_computations``.
         factor = Factor(
-            emission_type_id=EmissionType.buildings__embodied_energy.value,
+            emission_type_id=EmissionType.buildings__construction_and_renovation.value,
             data_entry_type_id=DataEntryTypeEnum.building_embodied_energy.value,
             classification={"building_name": "default", "category": "default"},
             values={"ef_kgco2eq_per_m2": 100.0},

--- a/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
@@ -772,7 +772,7 @@ async def test_building_embodied_energy_factor_values_change_propagates(pg_dsn):
         )
 
         factor = Factor(
-            emission_type_id=EmissionType.buildings__embodied_energy.value,
+            emission_type_id=EmissionType.buildings__construction_and_renovation.value,
             data_entry_type_id=DataEntryTypeEnum.building_embodied_energy.value,
             classification={"building_name": "BC", "category": "default"},
             values={"ef_kgco2eq_per_m2": 100.0},

--- a/backend/tests/unit/repositories/test_data_entry_emission_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_emission_repo.py
@@ -1161,9 +1161,9 @@ async def test_embodied_energy_by_building_groups_by_name(db_session: AsyncSessi
         db_session.add(
             DataEntryEmission(
                 data_entry_id=entry.id,
-                emission_type_id=EmissionType.buildings__embodied_energy,
+                emission_type_id=EmissionType.buildings__construction_and_renovation,
                 kg_co2eq=kg,
-                scope=EmissionType.buildings__embodied_energy.scope,
+                scope=EmissionType.buildings__construction_and_renovation.scope,
             )
         )
         entries.append(entry)


### PR DESCRIPTION
## What does this change?
Renames `buildings__embodied_energy` to `buildings__construction_and_renovation` throughout the backend, and enriches the backoffice reporting CSV export with additional per-unit fields.

**Backend — emission type rename:**
- `EmissionType.buildings__embodied_energy` (value 60300) → `EmissionType.buildings__construction_and_renovation` in `data_entry_emission.py`, including the `_PARENT_MAP` and `_SCOPE_CATEGORY_MAP` entries
- `MODULE_TYPE_TO_EMISSION_ROOTS`: updates the buildings entry to use the new name
- `buildings/schemas.py`: `BuildingEmbodiedEnergyModuleHandler.resolve_computations` and `BuildingEmbodiedEnergyFactorHandler.emission_type` updated
- `data_entry_emission_type_map.py`: `DATA_ENTRY_TO_EMISSION_TYPES` updated
- `data_entry_emission_repo.py`: two query filters updated
- All integration and unit test fixtures updated (4 files)

**Backend — reporting CSV enrichment (`carbon_report_module_repo.py`):**
- Adds a pre-aggregation query that groups CO₂ by `(unit_id, year, module_status)` — produces a lookup of validated/in-progress/not-started totals per unit-year
- Main query now also selects `Unit.id`, `CarbonReportModule.last_updated`, and `User.display_name` (via outer join on `Unit.principal_user_institutional_id`)
- Each report row now includes: `unit_id`, `principal_user`, `last_update` (ISO 8601), `validated_categories_co2`, `in_progress_categories_co2`, `not_started_categories_co2`

## Why is this needed?
"Embodied energy" was a misleading label — the data actually covers construction and renovation emissions. Renaming to `construction_and_renovation` makes the emission type self-documenting. The reporting CSV enrichment adds context fields that the back-office needs to assess completion status and accountability per unit.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature (reporting CSV enrichment)
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced