### PR TITLE
perf(ingestion): row-loop profiler + 20× CSV import speedup

### DIFF
--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -4,6 +4,7 @@ import io
 import time
 import urllib.parse
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, TypedDict
 
 from sqlmodel import col, select
@@ -196,6 +197,9 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         self._phase = ""
         self._phase_started_at = 0.0
         self._last_report_at = 0.0
+        # Per-segment wall-time accumulator for the row-loop profile (diagnostic;
+        # answers "where do the N seconds go" — DB-heavy segments stand out).
+        self._seg: Dict[str, float] = {}
         logger.info(
             f"Initializing {self.__class__.__name__} for job_id={self.job_id}, "
             f"file_path={self.source_file_path}"
@@ -780,6 +784,46 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         self._phase = phase
         self._phase_started_at = time.monotonic()
 
+    @contextmanager
+    def _timed(self, key: str):
+        """Accumulate wall time spent in a row-loop segment under ``key``.
+
+        Cheap (one perf_counter read each side); records on exit even when the
+        wrapped block returns/raises, so per-row early-exits still count.
+        """
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._seg[key] = self._seg.get(key, 0.0) + (time.perf_counter() - start)
+
+    def _log_row_loop_profile(self, parse_elapsed: float, rows: int) -> None:
+        """One-line breakdown of where the row-loop wall time went.
+
+        ``row`` is the total in ``_process_row``; ``loop_overhead`` is the rest
+        of the loop (CSV parse, blank-row skips, progress reports). ``row_other``
+        is per-row work outside the four timed sub-calls (filter/key/build).
+        """
+        seg = self._seg
+        row_t = seg.get("row", 0.0)
+        inner = ("resolve", "validate", "enrich", "populate")
+        per_row_ms = (parse_elapsed / rows * 1000) if rows else 0.0
+        logger.info(
+            "Row-loop profile: %d rows in %.1fs (%.2f ms/row) | row=%.1fs "
+            "[resolve=%.1f validate=%.1f enrich=%.1f populate=%.1f row_other=%.1f] "
+            "loop_overhead=%.1fs",
+            rows,
+            parse_elapsed,
+            per_row_ms,
+            row_t,
+            seg.get("resolve", 0.0),
+            seg.get("validate", 0.0),
+            seg.get("enrich", 0.0),
+            seg.get("populate", 0.0),
+            row_t - sum(seg.get(k, 0.0) for k in inner),
+            parse_elapsed - row_t,
+        )
+
     @staticmethod
     def _format_progress(
         phase: str, processed: int | None, total: int | None, elapsed: float
@@ -877,6 +921,10 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             await self._report(
                 "Parsing rows", processed=0, total=total_rows, stats=stats, force=True
             )
+            # Row-loop profile baseline (diagnostic).
+            self._seg = {}
+            parse_start = time.perf_counter()
+            row_idx = 0
             batch: List[DataEntry] = []
             # Parallel list of kg_co2eq overrides aligned with `batch` by index.
             # Carried out-of-band so kg_co2eq never lands in DataEntry.data.
@@ -916,6 +964,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
 
                 # Process single row, returns
                 # (data_entry, error_msg, factor, kg_co2eq_override)
+                _row_t0 = time.perf_counter()
                 (
                     data_entry,
                     error_msg,
@@ -928,6 +977,9 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                     stats,
                     max_row_errors,
                     unit_to_module_map,
+                )
+                self._seg["row"] = self._seg.get("row", 0.0) + (
+                    time.perf_counter() - _row_t0
                 )
 
                 if error_msg:
@@ -999,6 +1051,10 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                             result=None,
                             extra_metadata=dict(stats),
                         )
+
+            # Diagnostic: where did the row-loop time go (DB-heavy segments
+            # stand out vs CPU)? One line, real data/DB/handlers.
+            self._log_row_loop_profile(time.perf_counter() - parse_start, row_idx)
 
             # Finalize: process remaining batch, move file, update job
             self._enter_phase("Inserting")
@@ -1166,13 +1222,14 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             )
 
             # Resolve handler and data_entry_type first (needed for factor lookup)
-            (
-                data_entry_type,
-                handler,
-                error_msg,
-            ) = await self._resolve_handler_and_validate(
-                filtered_row, None, stats, row_idx, max_row_errors, setup_result
-            )
+            with self._timed("resolve"):
+                (
+                    data_entry_type,
+                    handler,
+                    error_msg,
+                ) = await self._resolve_handler_and_validate(
+                    filtered_row, None, stats, row_idx, max_row_errors, setup_result
+                )
 
             if error_msg:
                 return None, error_msg, None, None
@@ -1277,7 +1334,8 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             payload["primary_factor_id"] = primary_factor_id
 
             try:
-                validated = handler.validate_create(payload)
+                with self._timed("validate"):
+                    validated = handler.validate_create(payload)
             except Exception as validation_error:
                 error_msg = f"Validation error: {validation_error}"
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)
@@ -1290,18 +1348,22 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             # it to resolve origin_name/destination_name → *_natural_key via
             # a Location lookup so the recalc-time pre_compute can compute
             # distance. Returning a non-None error_msg skips the row.
-            data, enrich_error = await handler.enrich_csv_row(data, self.data_session)
+            with self._timed("enrich"):
+                data, enrich_error = await handler.enrich_csv_row(
+                    data, self.data_session
+                )
             if enrich_error is not None:
                 self._record_row_error(stats, row_idx, enrich_error, max_row_errors)
                 return None, enrich_error, None, None
 
-            handler_service = ModuleHandlerService(self.data_session)
-            if primary_factor_id and "factor_id_to_factor" in setup_result:
-                factor = setup_result["factor_id_to_factor"].get(primary_factor_id)
-                if factor is not None:
-                    data = await handler_service.populate_defaults(
-                        handler, data, factor
-                    )
+            with self._timed("populate"):
+                handler_service = ModuleHandlerService(self.data_session)
+                if primary_factor_id and "factor_id_to_factor" in setup_result:
+                    factor = setup_result["factor_id_to_factor"].get(primary_factor_id)
+                    if factor is not None:
+                        data = await handler_service.populate_defaults(
+                            handler, data, factor
+                        )
 
             # Persist the override on the data
             # entry under the reserved ``KG_CO2EQ_OVERRIDE_KEY`` carrier so

--- a/backend/app/services/data_ingestion/csv_providers/module_per_year.py
+++ b/backend/app/services/data_ingestion/csv_providers/module_per_year.py
@@ -190,11 +190,24 @@ class ModulePerYearCSVProvider(BaseCSVProvider):
                 filtered_row, handlers
             )
 
-            data_entry_type = lookup_data_entry_type_by_kind(
-                kind=kind_value,
-                subkind=subkind_value,
-                factors_maps_by_type=factors_maps_by_type,
+            # Type inference scans every factor key (tens of thousands) per
+            # call — the dominant per-row cost (a 9.5k-row purchase upload spent
+            # ~33s here). The result is a pure function of (kind, subkind), and
+            # those repeat heavily across rows, so memoise per file:
+            # O(rows × factors) → O(distinct kinds × factors).
+            type_cache: Dict[tuple[str, str | None], DataEntryTypeEnum | None] = (
+                setup_result.setdefault("type_by_kind_cache", {})
             )
+            cache_key = (kind_value, subkind_value)
+            if cache_key in type_cache:
+                data_entry_type = type_cache[cache_key]
+            else:
+                data_entry_type = lookup_data_entry_type_by_kind(
+                    kind=kind_value,
+                    subkind=subkind_value,
+                    factors_maps_by_type=factors_maps_by_type,
+                )
+                type_cache[cache_key] = data_entry_type
 
             if data_entry_type is None:
                 error_msg = (

--- a/backend/tests/unit/services/data_ingestion/test_module_per_year_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_per_year_csv_provider.py
@@ -426,3 +426,63 @@ async def test_resolve_configured_type_accepts_string_id():
     assert data_entry_type == DataEntryTypeEnum.member
     assert resolved_handler == handler
     assert error_msg is None
+
+
+@pytest.mark.asyncio
+async def test_type_inference_is_memoised_per_kind(monkeypatch):
+    """The per-row kind→type inference scans the full factors_map; the measured
+    cost of a 9.5k-row purchase upload was ~33s spent entirely here. Its result
+    is a pure function of (kind, subkind), which repeat across rows, so it must
+    be memoised on setup_result: the same kind is inferred once, not per row."""
+    provider = ModulePerYearCSVProvider(
+        {"file_path": "tmp/test.csv"}, data_session=MagicMock()
+    )
+    provider.job = SimpleNamespace(module_type_id=ModuleTypeEnum.purchase.value)
+
+    # Force the inference branch (no configured type, no category column) and
+    # stub the registry handler lookup so the test isolates memoisation.
+    monkeypatch.setattr(
+        provider,
+        "_resolve_type_from_config_or_category",
+        MagicMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year.BaseModuleHandler,
+        "get_by_type",
+        MagicMock(return_value=SimpleNamespace()),
+    )
+    spy = MagicMock(return_value=DataEntryTypeEnum.scientific)
+    monkeypatch.setattr(
+        csv_providers_module.module_per_year,
+        "lookup_data_entry_type_by_kind",
+        spy,
+    )
+
+    handler = SimpleNamespace(
+        kind_field="kind", subkind_field=None, category_field=None
+    )
+    setup_result = {"handlers": [handler], "factors_map": {}}
+    stats = _build_stats()
+
+    async def _resolve(kind):
+        return await provider._resolve_handler_and_validate(
+            filtered_row={"kind": kind},
+            factor=None,
+            stats=stats,
+            row_idx=1,
+            max_row_errors=5,
+            setup_result=setup_result,
+        )
+
+    type_a, _, _ = await _resolve("hood")
+    type_a2, _, _ = await _resolve("hood")  # same kind → cache hit
+    await _resolve("bench")  # new kind → one more scan
+
+    # One scan per distinct kind, not per row.
+    assert spy.call_count == 2
+    assert setup_result["type_by_kind_cache"] == {
+        ("hood", None): DataEntryTypeEnum.scientific,
+        ("bench", None): DataEntryTypeEnum.scientific,
+    }
+    # Caching does not change the inferred type.
+    assert type_a == type_a2 == DataEntryTypeEnum.scientific

--- a/docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md
+++ b/docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md
@@ -1,9 +1,9 @@
 ---
-status: in_progress
+status: delivered
 issue: 310-f
 last_updated: 2026-06-16
 title: "310-f Ingestion per-row efficiency"
-summary: "The CSV ingest parse/validate loop dominated wall-clock (~34s for 9555 purchase rows on dev). The first cut guessed line-level suspects and they were wrong. A row-loop profiler was added, and the trace pinned 33.4s of 34.5s on `resolve` — a per-row linear scan of ~23k factor keys in `lookup_data_entry_type_by_kind` (O(rows × factors)). Fixed by memoising the kind→type inference per (kind, subkind). Re-measure pending."
+summary: "The CSV ingest parse/validate loop dominated wall-clock (~34s for 9555 purchase rows on dev). The first cut guessed line-level suspects and they were wrong. A row-loop profiler was added, and the trace pinned 33.4s of 34.5s on `resolve` — a per-row linear scan of ~23k factor keys in `lookup_data_entry_type_by_kind` (O(rows × factors)). Fixed by memoising the kind→type inference per (kind, subkind); re-measured 34.5s → 1.7s (20×). A one-time index is a documented follow-up, not needed at current data shape."
 ---
 
 # 310-f Ingestion per-row efficiency
@@ -78,10 +78,20 @@ repeat heavily across rows, so memoise it per file on `setup_result` —
 per distinct kind. Mirrors the existing #1415 memoisation of the per-type split.
 Regression test: `test_type_inference_is_memoised_per_kind`.
 
-**Re-measure pending** — capture a fresh `Row-loop profile` line after deploy to
-confirm `resolve` collapses. If a file ever has near-unique kinds per row (memo
-ineffective), the follow-up is a one-time `kind → types` index in
-`lookup_data_entry_type_by_kind` instead of the per-row scan.
+**Re-measured (2026-06-16): 34.5s → 1.7s** — a 20× drop on the same 9555-row
+file (`resolve` 33.4s → 1.0s):
+
+```
+Row-loop profile: 9555 rows in 1.7s (0.17 ms/row) | row=1.6s
+  [resolve=1.0 validate=0.2 enrich=0.0 populate=0.0 row_other=0.5] loop_overhead=0.0s
+```
+
+The memo is sufficient at the current data shape — distinct kinds are few, so
+the per-distinct-kind scan that remains (the 1.0s) is cheap. **Possible
+follow-up, not currently needed:** if a file ever has near-unique kinds per row
+(memo ineffective), build a one-time `kind → types` index where the factor pools
+are computed and make each lookup O(1). `lookup_data_entry_type_by_kind` has
+exactly one caller, so that refactor is self-contained. Deferred — 1.7s is fine.
 
 The method below stays on record for future buckets.
 

--- a/docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md
+++ b/docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md
@@ -1,9 +1,9 @@
 ---
-status: proposed
+status: in_progress
 issue: 310-f
-last_updated: 2026-06-15
+last_updated: 2026-06-16
 title: "310-f Ingestion per-row efficiency"
-summary: "The CSV ingest parse/validate loop dominates wall-clock (~34s for 9555 purchase rows on dev). The first cut of this plan guessed line-level suspects and they were wrong (purchase rows aren't `member`, so the batched-uniqueness fix never ran). Rewritten measure-first: a row-loop profiler now logs where the time goes; optimize only the bucket the trace blames, and control for the dev CPU throttle."
+summary: "The CSV ingest parse/validate loop dominated wall-clock (~34s for 9555 purchase rows on dev). The first cut guessed line-level suspects and they were wrong. A row-loop profiler was added, and the trace pinned 33.4s of 34.5s on `resolve` — a per-row linear scan of ~23k factor keys in `lookup_data_entry_type_by_kind` (O(rows × factors)). Fixed by memoising the kind→type inference per (kind, subkind). Re-measure pending."
 ---
 
 # 310-f Ingestion per-row efficiency
@@ -32,12 +32,13 @@ Lesson: **profile before optimizing.** This rewrite makes that the first step.
 ## Step 0 (shipped): a row-loop profiler
 
 `base_csv_provider` now logs one diagnostic line at the end of the parse phase,
-on real data / real DB / real handlers:
+on real data / real DB / real handlers. The actual line for the 9555-row
+purchase upload (dev, 2026-06-16):
 
 ```
-Row-loop profile: 9555 rows in 33.8s (3.54 ms/row) | row=31.2s
-  [resolve=4.1 validate=18.7 enrich=0.2 populate=6.9 row_other=1.3]
-  loop_overhead=2.6s
+Row-loop profile: 9555 rows in 34.5s (3.61 ms/row) | row=34.2s
+  [resolve=33.4 validate=0.2 enrich=0.0 populate=0.0 row_other=0.6]
+  loop_overhead=0.3s
 ```
 
 Buckets (wall time, accumulated per row via `time.perf_counter`):
@@ -54,6 +55,35 @@ Buckets (wall time, accumulated per row via `time.perf_counter`):
 A **DB-bound** segment (hidden lazy-load N+1) shows as a large bucket dominated
 by await time; a **CPU-bound** segment shows as large under no concurrency. The
 breakdown tells which, without guessing.
+
+## Result: `resolve` was 33.4s of 34.5s — and the fix
+
+The trace ended the guessing. Not Pydantic (`validate=0.2`), not DB
+(`populate`/`enrich`≈0): **97% of the time was `resolve`**, in
+`lookup_data_entry_type_by_kind` (`seed_helper.py`). For every row it linearly
+scans **all ~23k factor keys** to infer the row's `data_entry_type` from its
+kind:
+
+```python
+keys = [k for k in factors_map.keys() if k.__contains__(f":{kind}:")]  # per type, per row
+```
+
+That's `O(rows × factors)` ≈ 9555 × 23k ≈ 220M substring checks ≈ 33s — so a CPU
+bump barely helps; it's an algorithm problem. (The original "23k factors"
+hunch was right, just via a per-row rescan, not memory.)
+
+**Fix (shipped):** the inference is a pure function of `(kind, subkind)`, which
+repeat heavily across rows, so memoise it per file on `setup_result` —
+`O(rows × factors)` → `O(distinct kinds × factors)`. Same result, computed once
+per distinct kind. Mirrors the existing #1415 memoisation of the per-type split.
+Regression test: `test_type_inference_is_memoised_per_kind`.
+
+**Re-measure pending** — capture a fresh `Row-loop profile` line after deploy to
+confirm `resolve` collapses. If a file ever has near-unique kinds per row (memo
+ineffective), the follow-up is a one-time `kind → types` index in
+`lookup_data_entry_type_by_kind` instead of the per-row scan.
+
+The method below stays on record for future buckets.
 
 ## Step 1: read the trace, then pick the target
 

--- a/docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md
+++ b/docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md
@@ -3,95 +3,98 @@ status: proposed
 issue: 310-f
 last_updated: 2026-06-15
 title: "310-f Ingestion per-row efficiency"
-summary: "The CSV ingest parse/validate loop is the dominant cost — ~34s for 9555 rows in the 2026-06-15 dev run, all CPU between the 0.2s delete and the 0.5s COPY. Plan to cut per-row Python work: profile first, then kill redundant calls, batch the per-row DB check, and avoid double validation. Pairs with the progress instrumentation shipped alongside it."
+summary: "The CSV ingest parse/validate loop dominates wall-clock (~34s for 9555 purchase rows on dev). The first cut of this plan guessed line-level suspects and they were wrong (purchase rows aren't `member`, so the batched-uniqueness fix never ran). Rewritten measure-first: a row-loop profiler now logs where the time goes; optimize only the bucket the trace blames, and control for the dev CPU throttle."
 ---
 
 # 310-f Ingestion per-row efficiency
 
-> **Status: proposed.** Companion to [[310-e-async-loop-and-pipeline-worker]]
-> (which covers loop hygiene + the worker). 310-e makes the loop _yield_
-> and _report progress_; 310-f makes it _faster_.
+> **Status: proposed.** Companion to [[310-e-async-loop-and-pipeline-worker]].
+> 310-e makes the loop _yield_ (so liveness survives) and _report progress_;
+> 310-f makes it _faster_ — **but only after measuring**.
 
-## Why
+## What the first cut got wrong
 
-Measured time map of a 9555-row `MODULE_PER_YEAR` upload (dev, 2026-06-15):
+The original 310-f listed line-level "suspects" and an attempt was made to fix
+them. It moved the needle by ~0s. Two mistakes, both from assuming instead of
+measuring:
 
-| Phase                                         | Time     |
-| --------------------------------------------- | -------- |
-| delete prior entries                          | 0.2s     |
-| **parse/validate rows (`_process_row` loop)** | **~34s** |
-| COPY insert                                   | 0.5s     |
-| emission recalc + aggregation                 | ~3s      |
+1. **Purchase rows aren't `member` rows.** The batched-uniqueness win (#2) only
+   replaces `check_institutional_id_unique`, which fires **only** for
+   `data_entry_type_id == member`. Purchase common data is
+   `other_purchases`/`consumable_accessories`/`scientific_equipment`/… — that
+   path never executed. Dead optimization for this file.
+2. **The yield fix was never a speed fix.** Yielding every 100 rows (310-e)
+   stops the liveness restart; it does **not** make the job faster. "Still 34s"
+   is the _correct_ outcome of that change, not a failure.
 
-~90% of wall-clock is the per-row Python loop. At ~280 rows/s it's also
-what risked event-loop starvation (now mitigated by yielding, not by being
-fast). This plan attacks the constant factor.
+Lesson: **profile before optimizing.** This rewrite makes that the first step.
 
-## Rule 0: profile before optimizing
+## Step 0 (shipped): a row-loop profiler
 
-Add a one-off `cProfile`/`pyinstrument` pass over `_process_row` on a
-representative file and rank by cumulative time. Optimize what the profile
-says, not what this doc guesses. The items below are the _suspects_ from
-reading the code — confirm each before touching it.
+`base_csv_provider` now logs one diagnostic line at the end of the parse phase,
+on real data / real DB / real handlers:
 
-## Suspects (from reading `_process_row`)
+```
+Row-loop profile: 9555 rows in 33.8s (3.54 ms/row) | row=31.2s
+  [resolve=4.1 validate=18.7 enrich=0.2 populate=6.9 row_other=1.3]
+  loop_overhead=2.6s
+```
 
-| #   | Suspect                                                                          | Fix                                                                    | Confidence |
-| --- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------- |
-| 1   | `_extract_kind_subkind_values` called **twice** per row (lines ~1164 and ~1189)  | Compute once, reuse                                                    | High       |
-| 2   | Per-member-row `check_institutional_id_unique` DB round-trip                     | Pre-load existing IDs per module, check in-memory                      | High       |
-| 3   | `DataEntry.model_validate` runs **twice** (row build, then `bulk_copy` line 109) | Build once; skip re-validation on the COPY path                        | Med        |
-| 4   | `_resolve_handler_and_validate` per row (handler lookup + DTO validate)          | Cache handler by resolved type; memoize validation by column-signature | Med        |
-| 5   | `filtered_row` dict-comp + factor-key f-strings rebuilt every row                | Hoist invariants; precompute per-handler column sets                   | Low        |
+Buckets (wall time, accumulated per row via `time.perf_counter`):
 
-### 1. Double `_extract_kind_subkind_values`
+| Bucket          | Covers                                                          |
+| --------------- | --------------------------------------------------------------- |
+| `resolve`       | `_resolve_handler_and_validate` (handler + type resolution)     |
+| `validate`      | `handler.validate_create` (Pydantic DTO)                        |
+| `enrich`        | `handler.enrich_csv_row` (per-handler hook; DB for some)        |
+| `populate`      | `ModuleHandlerService(...)` + `populate_defaults`               |
+| `row_other`     | rest of `_process_row`: filter, factor-key build, `DataEntry()` |
+| `loop_overhead` | outside `_process_row`: CSV parse, blank skips, progress        |
 
-`_process_row` calls it at line ~1164, then again at ~1189 inside the
-factor branch with the same `filtered_row`/`handlers`. Compute once before
-the branch and reuse. Pure win, no behaviour change.
+A **DB-bound** segment (hidden lazy-load N+1) shows as a large bucket dominated
+by await time; a **CPU-bound** segment shows as large under no concurrency. The
+breakdown tells which, without guessing.
 
-### 2. Per-row uniqueness query → batch pre-load
+## Step 1: read the trace, then pick the target
 
-For member entries, `check_institutional_id_unique` issues one query **per
-row** (`base_csv_provider.py` ~957). For a multi-thousand-row member CSV
-that's the long tail of the 34s. Pre-load existing `user_institutional_id`s
-for the in-scope modules once (one indexed query), hold them in a set, and
-check membership in memory — the intra-CSV duplicate set
-(`seen_institutional_ids`) already works this way; extend it with the
-DB-existing set. Keep a final DB unique constraint as the real guard.
+Run one real import (the purchase file that took 34s) and read the line. Then,
+and only then, optimize the dominant bucket. Candidate fixes per bucket — none
+are committed; the trace decides which (if any) apply:
 
-### 3. Validate `DataEntry` once
+| If dominant     | Likely cause                                                                                        | Candidate fix                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `validate`      | Pydantic re-validates every row                                                                     | Lighter validation (`model_construct` for trusted fields), or validate-by-column-signature memo |
+| `populate`      | `ModuleHandlerService` built **per row** (`base_csv_provider.py:1298`); `FactorService` in its ctor | Hoist the service out of the loop (build once, reuse)                                           |
+| `resolve`       | per-row handler/type lookup                                                                         | Cache resolved handler by type for the file                                                     |
+| `enrich`        | a handler doing a per-row DB lookup                                                                 | Batch the lookup (pre-load once) — note: purchase handlers are likely no-op here                |
+| `row_other`     | `filtered_row` dict-comp + factor-key f-strings + `DataEntry()` per row                             | Hoist invariants; build keys with tuples/`join`                                                 |
+| `loop_overhead` | CSV re-parse / progress writes                                                                      | Parse once; confirm progress is throttled                                                       |
 
-Rows are built into `DataEntry` objects, then `bulk_copy` re-runs
-`DataEntry.model_validate` on every one (now chunked, but still O(n) CPU).
-If the build path already yields validated instances, the COPY path can
-trust them (or use `model_construct` for the trusted internal hop). Verify
-nothing downstream depends on the second validation before removing it.
+Static reading (2026-06-15) found **no explicit per-row DB query** in the
+purchase path — factor lookup is in-memory by design, module id from an
+in-memory map, year from `_year_cache`, and `populate_defaults` reads an
+in-memory `factor.values`. So the prior is **CPU-bound** (Pydantic + object
+construction). The trace must confirm before any change — static reading cannot
+see a SQLAlchemy lazy-load N+1.
 
-### 4. Handler resolution caching
+## The dev CPU confound — measure on real headroom
 
-`_resolve_handler_and_validate` resolves a handler and validates a DTO per
-row. Within one file the handler set is fixed; cache the resolved handler
-by `data_entry_type` and, where rows share a column signature, memoize the
-validation outcome. Measure first — Pydantic validation may dominate or may
-be cheap depending on the model.
-
-### 5. Hoist per-row allocations
-
-`filtered_row` comprehension and the factor-lookup key f-strings allocate
-per row. Precompute per-handler `expected_columns` as a set (likely already
-one) and build keys with `str.join`/tuple keys instead of nested f-strings.
-Micro-optimisation — only if the profile flags it.
+The 34s was measured on a dev pod requesting **250m CPU**. A 0.9 ms/row job at
+one core reads as ~3.6 ms/row at a throttled quarter-core. Before concluding
+"the code is slow," reproduce the trace where CPU isn't throttled (local, or a
+right-sized pod). Part of the win may be CPU allocation / the dedicated worker
+([[310-e-async-loop-and-pipeline-worker]]), not constant-factor code work.
 
 ## Success criteria
 
-- Profile-ranked before/after on the same 9555-row file.
-- Target: parse/validate phase **≥2× faster** (≤~15s) without changing
-  ingest results (row counts, errors, emissions identical on a fixture).
-- No new event-loop starvation — yields from 310-e stay.
+- A `Row-loop profile` line captured **before** and **after** any change, same
+  file, comparable CPU.
+- Target: dominant bucket **≥2× faster**, ingest results byte-identical on a
+  fixture (row counts, errors, emissions).
+- No regression to the 310-e yields (loop stays responsive).
 
 ## Out of scope
 
-The structural move (worker deployment, threadpool offload) lives in
-[[310-e-async-loop-and-pipeline-worker]]. This plan is constant-factor work
-on the existing in-loop path; both can land independently.
+The structural move (worker deployment, threadpool offload) is in
+[[310-e-async-loop-and-pipeline-worker]]. This plan is constant-factor work on
+the in-loop path, gated on the trace.


### PR DESCRIPTION
## Why

A purchase-data CSV import (9555 rows) took **~34s** on dev and, before the 310-e liveness fix, kept restarting the pod mid-job. After confirming the liveness restart was the symptom, this branch finds and fixes the actual cost.

## What

**1. Row-loop profiler** (`base_csv_provider`) — a per-segment wall-time breakdown logged once at the end of the parse phase, on real data/DB/handlers:

```
Row-loop profile: 9555 rows in 34.5s (3.61 ms/row) | row=34.2s
  [resolve=33.4 validate=0.2 enrich=0.0 populate=0.0 row_other=0.6] loop_overhead=0.3s
```

It pinned **97% of the time on `resolve`** — ending the guessing (it was neither Pydantic nor DB).

**2. The fix** — `lookup_data_entry_type_by_kind` linearly scans **all ~23k factor keys per row** to infer `data_entry_type` from the row's kind: `O(rows × factors)` ≈ 220M substring checks. The inference is a pure function of `(kind, subkind)`, which repeat heavily across rows, so it's now **memoised per file** on `setup_result` — `O(rows × factors)` → `O(distinct kinds × factors)`. Mirrors the existing #1415 memoisation of the per-type split.

## Result

Re-measured on the same file: **34.5s → 1.7s (20×)**, `resolve` 33.4s → 1.0s.

```
Row-loop profile: 9555 rows in 1.7s (0.17 ms/row) | row=1.6s
  [resolve=1.0 validate=0.2 enrich=0.0 populate=0.0 row_other=0.5] loop_overhead=0.0s
```

A one-time `kind → types` index would shave the remaining ~1s but isn't needed at the current data shape — documented as a follow-up in 310-f.

## Tests
- `test_type_inference_is_memoised_per_kind` (new regression).
- Full ingestion suite green (536 passing), mypy clean.

See `docs/src/implementation-plans/310-f-ingestion-per-row-efficiency.md` for the full measure-first write-up.