### PR TITLE
fix/856 bugs tests explore simulator

### DIFF
--- a/frontend/src/api/modules.ts
+++ b/frontend/src/api/modules.ts
@@ -72,16 +72,21 @@ export interface HeadcountMemberDropdownItem {
  *
  * @param unitId - Unit ID
  * @param year - Reporting year
+ * @param carbonProjectType - 0 = Calculator, 1 = Simulator Explore. Scopes the
+ *   lookup to the matching carbon report so the simulator reads its own members.
  * @returns Ordered list of members with institutional_id and name
  */
 export async function getHeadcountMembers(
   unitId: number,
   year: number | string,
+  carbonProjectType = 0,
 ): Promise<HeadcountMemberDropdownItem[]> {
   const unitEncoded = encodeURIComponent(unitId);
   const yearEncoded = encodeURIComponent(String(year));
   return api
-    .get(`modules/${unitEncoded}/${yearEncoded}/headcount/members`, {})
+    .get(`modules/${unitEncoded}/${yearEncoded}/headcount/members`, {
+      searchParams: { carbon_project_type: carbonProjectType },
+    })
     .json<HeadcountMemberDropdownItem[]>();
 }
 

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1438,6 +1438,7 @@ const downloadCSV = () => {
         :class="['chart', { 'chart--print': isPrintMode }]"
         autoresize
         :option="chartOption"
+        :update-options="{ replaceMerge: ['dataset'] }"
         @rendered="recalculateScopeRects"
         @vue:mounted="onChartReady"
       />

--- a/frontend/src/components/organisms/module/HeadcountMemberSelect.vue
+++ b/frontend/src/components/organisms/module/HeadcountMemberSelect.vue
@@ -43,6 +43,7 @@ import { ref, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { MODULES } from 'src/constant/modules';
 import { useAuthStore } from 'src/stores/auth';
+import { useModuleStore } from 'src/stores/modules';
 import {
   getHeadcountMembers,
   type HeadcountMemberDropdownItem,
@@ -72,6 +73,7 @@ interface SelectOption {
 const loading = ref(false);
 const members = ref<HeadcountMemberDropdownItem[]>([]);
 const authStore = useAuthStore();
+const moduleStore = useModuleStore();
 const canEditHeadcount = computed(() =>
   authStore.hasUserModulePermission(MODULES.Headcount, PermissionAction.EDIT),
 );
@@ -91,7 +93,11 @@ async function fetchMembers() {
   if (!props.unitId || !props.year) return;
   loading.value = true;
   try {
-    members.value = await getHeadcountMembers(props.unitId, props.year);
+    members.value = await getHeadcountMembers(
+      props.unitId,
+      props.year,
+      moduleStore.carbonProjectType,
+    );
     options.value = buildOptions(members.value);
     if (!canEditHeadcount.value && options.value.length > 0) {
       emit('update:modelValue', options.value[0].value);

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -328,7 +328,11 @@ const travelerNames = ref<Map<string, string>>(new Map());
 
 async function loadTravelerNames(unitId: number, year: number | string) {
   try {
-    const members = await getHeadcountMembers(unitId, year);
+    const members = await getHeadcountMembers(
+      unitId,
+      year,
+      moduleStore.carbonProjectType,
+    );
     travelerNames.value = new Map(
       members.map((m) => [m.institutional_id, m.name]),
     );

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -1683,6 +1683,7 @@ onMounted(async () => {
       const members: HeadcountMemberDropdownItem[] = await getHeadcountMembers(
         props.unitId,
         props.year,
+        moduleStore.carbonProjectType,
       );
       headcountMembersMap.value = new Map(
         members.map((m) => [m.institutional_id, m.name]),

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -94,9 +94,7 @@
           />
           <template v-if="mountPrimaryCharts">
             <div class="chart-wrapper">
-              <ModuleCarbonFootprintChart
-                :breakdown-data="filteredBreakdown"
-              />
+              <ModuleCarbonFootprintChart :breakdown-data="filteredBreakdown" />
             </div>
           </template>
           <q-skeleton v-else type="rect" height="360px" class="full-width" />

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -95,7 +95,7 @@
           <template v-if="mountPrimaryCharts">
             <div class="chart-wrapper">
               <ModuleCarbonFootprintChart
-                :breakdown-data="moduleStore.state.emissionBreakdown"
+                :breakdown-data="filteredBreakdown"
               />
             </div>
           </template>
@@ -231,6 +231,17 @@ const totalTonnesCo2eq = computed(() => {
   }, 0);
 
   return moduleTotal || breakdown.total_tonnes_co2eq || 0;
+});
+
+const filteredBreakdown = computed(() => {
+  const bd = moduleStore.state.emissionBreakdown;
+  if (!bd) return bd;
+  return {
+    ...bd,
+    module_breakdown: bd.module_breakdown.filter(
+      (entry) => entry.category !== 'research_facilities',
+    ),
+  };
 });
 
 async function fetchEmissionBreakdown() {

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -435,6 +435,10 @@ export const useModuleStore = defineStore('modules', () => {
           searchParams: { carbon_project_type: carbonProjectType.value },
         })
         .json()) as ModuleResponse;
+      if (state.data?.data_entry_types_total_items) {
+        state.moduleTotalsMap[moduleType] =
+          state.data.data_entry_types_total_items;
+      }
     } catch (err: unknown) {
       if (err instanceof Error) {
         state.error = err.message ?? 'Unknown error';

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -1115,6 +1115,7 @@ export const useModuleStore = defineStore('modules', () => {
     getItBreakdown,
     prefetchAllModuleCounts,
     validatedTotalsCarbonReportId,
+    carbonProjectType,
     state,
   };
 });

--- a/frontend/tests/integration/setup/simulator-mocks.ts
+++ b/frontend/tests/integration/setup/simulator-mocks.ts
@@ -27,9 +27,11 @@ const MOCK_USER = {
   display_name: 'Test User',
   institutional_id: 'test-user',
   roles_raw: [],
-  // Global edit permission for headcount so the member form is shown.
+  // Global edit permission for headcount + professional-travel so both the
+  // member form and the plane/train traveler dropdown are shown.
   permissions: {
     'modules.headcount': ['view', 'edit'],
+    'modules.professional_travel': ['view', 'edit'],
   },
 };
 
@@ -87,6 +89,14 @@ function buildSubmoduleResponse(items: object[]) {
       total_kg_co2eq: 0,
     },
   };
+}
+
+// Traveler-dropdown payload (GET /modules/{unit}/{year}/headcount/members).
+// Shape differs from the submodule list: a flat array of {institutional_id, name}.
+function buildMembersDropdown(memberPosted: boolean) {
+  return memberPosted
+    ? [{ institutional_id: 'sciper-1', name: 'Test Member' }]
+    : [];
 }
 
 function buildEmissionBreakdown(totalTonnesCo2eq: number) {
@@ -178,17 +188,14 @@ export async function mockSimulatorBackend(page: Page): Promise<{
 
   // Headcount module totals (preview_limit=0) — stateful.
   // \? ensures this only matches the module endpoint, NOT /headcount/member.
-  await page.route(
-    /.*\/api\/v1\/modules\/10\/2024\/headcount\?/,
-    (route) => {
-      const totals = memberPosted ? { 1: 1, 2: 0 } : { 1: 0, 2: 0 };
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(buildModuleTotalsResponse('headcount', totals)),
-      });
-    },
-  );
+  await page.route(/.*\/api\/v1\/modules\/10\/2024\/headcount\?/, (route) => {
+    const totals = memberPosted ? { 1: 1, 2: 0 } : { 1: 0, 2: 0 };
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildModuleTotalsResponse('headcount', totals)),
+    });
+  });
 
   // headcount/member submodule — POST (create entry) + GET (list items).
   await page.route(
@@ -210,6 +217,22 @@ export async function mockSimulatorBackend(page: Page): Promise<{
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(buildSubmoduleResponse(items)),
+      });
+    },
+  );
+
+  // Traveler dropdown (headcount/members) — stateful. Registered AFTER the
+  // headcount/member route so its higher LIFO priority wins for the trailing
+  // "s". Returns [] before a member is posted, [Test Member] after. The
+  // assertion side also checks this is called with carbon_project_type=1 so
+  // the simulator reads its own report, not the calculator's.
+  await page.route(
+    /.*\/api\/v1\/modules\/10\/2024\/headcount\/members/,
+    (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildMembersDropdown(memberPosted)),
       });
     },
   );

--- a/frontend/tests/integration/setup/simulator-mocks.ts
+++ b/frontend/tests/integration/setup/simulator-mocks.ts
@@ -1,0 +1,285 @@
+/**
+ * HTTP-boundary mocks for the simulator-explore Playwright suite.
+ *
+ * Unlike the data-management suite, we do NOT set ``__LIGHTHOUSE_BYPASS__``
+ * because ``validateUnitGuard`` returns early when it sees the flag and
+ * never sets ``selectedUnit`` / ``selectedYear``.  ``SimulationExplorePage``
+ * accesses ``workspaceStore.selectedUnit!.id`` in onMounted, which throws a
+ * TypeError when selectedUnit is null — making the page untestable with the
+ * bypass flag.
+ *
+ * Instead we mock the minimal API surface (session, units, carbon-reports,
+ * year-configuration) so the real guards run, set up workspace state, and
+ * the page renders normally.
+ *
+ * IMPORTANT — Playwright 1.60 uses LIFO route evaluation: the LAST registered
+ * handler is evaluated FIRST.  Catch-alls must be registered FIRST so they
+ * have the LOWEST priority.  Specific routes registered AFTER override them.
+ */
+
+import type { Page } from '@playwright/test';
+
+export const SIMULATOR_URL = '/en/10/2024/simulation/explore/sim-1';
+
+const MOCK_USER = {
+  id: 1,
+  email: 'test@example.com',
+  display_name: 'Test User',
+  institutional_id: 'test-user',
+  roles_raw: [],
+  // Global edit permission for headcount so the member form is shown.
+  permissions: {
+    'modules.headcount': ['view', 'edit'],
+  },
+};
+
+const MOCK_UNIT = {
+  id: 10,
+  name: '10',
+  institutional_id: 'unit-10',
+  principal_user_id: 'user-1',
+  principal_user_function: 'Test',
+  principal_user_name: 'Test User',
+  affiliations: [],
+  current_user_role: 'principal',
+};
+
+// Regular (non-simulator) carbon report — used by validateUnitGuard.
+const MOCK_CARBON_REPORT = {
+  id: 42,
+  unit_id: 10,
+  year: 2024,
+  carbon_project_id: 1,
+};
+
+// Simulator explore carbon report — created/fetched by onMounted.
+const MOCK_SIMULATOR_REPORT = {
+  id: 99,
+  unit_id: 10,
+  year: 2024,
+  carbon_project_id: 1,
+};
+
+function buildModuleTotalsResponse(
+  moduleType: string,
+  data_entry_types_total_items: Record<number, number>,
+) {
+  return {
+    module_type: moduleType,
+    unit: 10,
+    year: '2024',
+    data_entry_types_total_items,
+    carbon_report_module_id: 100,
+    retrieved_at: '2024-01-01T00:00:00Z',
+    submodules: {},
+    totals: { total_submodules: 0, total_items: 0 },
+  };
+}
+
+function buildSubmoduleResponse(items: object[]) {
+  return {
+    id: 'member',
+    name: 'member',
+    items,
+    summary: {
+      total_items: items.length,
+      annual_consumption_kwh: 0,
+      total_kg_co2eq: 0,
+    },
+  };
+}
+
+function buildEmissionBreakdown(totalTonnesCo2eq: number) {
+  return {
+    module_breakdown: [],
+    total_tonnes_co2eq: totalTonnesCo2eq,
+    additional_breakdown: [],
+    per_person_breakdown: {},
+    validated_categories: [],
+    headcount_validated: false,
+    buildings_validated: false,
+    total_fte: 0,
+  };
+}
+
+/**
+ * Register all HTTP mocks for the simulator-explore page.
+ *
+ * Returns a request log for post-test assertions.  A single ``memberPosted``
+ * flag drives the stateful mocks: the headcount count response and the
+ * emission-breakdown response both change on the second call (after the
+ * POST to headcount/member).
+ *
+ * Route registration order follows Playwright 1.60 LIFO semantics:
+ * catch-alls are registered FIRST (lowest priority) and specific routes
+ * are registered LAST (highest priority / evaluated first).
+ */
+export async function mockSimulatorBackend(page: Page): Promise<{
+  requests: Array<{ method: string; url: string; body?: string }>;
+}> {
+  const requests: Array<{ method: string; url: string; body?: string }> = [];
+
+  // Track whether a member entry has been POSTed so stateful mocks can
+  // return the updated counts / breakdown on subsequent GET calls.
+  let memberPosted = false;
+
+  page.on('request', (req) => {
+    if (req.url().includes('/api/v1/')) {
+      requests.push({
+        method: req.method(),
+        url: req.url(),
+        body: req.postData() ?? undefined,
+      });
+    }
+  });
+
+  // ─── STEP 1: Register catch-alls first (lowest priority in LIFO) ──────────
+
+  // Absorb any remaining /api/v1/ calls (e.g. year-configuration list,
+  // validated-totals probes) without crashing the app.
+  await page.route('**/api/v1/**', (route) => {
+    return route.fulfill({ status: 404, body: '' });
+  });
+
+  // ─── STEP 2: Register specific routes last (highest priority in LIFO) ─────
+
+  // Taxonomy — ModuleTable calls getSubmoduleTaxonomy when expanded.
+  await page.route('**/api/v1/taxonomies/**', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ name: '', label: '', children: [] }),
+    });
+  });
+
+  // All other module preview_limit=0 calls (non-headcount modules).
+  await page.route(
+    /.*\/api\/v1\/modules\/10\/2024\/[^/?]+\?.*preview_limit/,
+    (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildModuleTotalsResponse('unknown', {})),
+      });
+    },
+  );
+
+  // Emission breakdown for the simulator report (id=99) — stateful.
+  await page.route(
+    /.*\/api\/v1\/modules-stats\/99\/emission-breakdown/,
+    (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildEmissionBreakdown(memberPosted ? 5 : 0)),
+      });
+    },
+  );
+
+  // Headcount module totals (preview_limit=0) — stateful.
+  // \? ensures this only matches the module endpoint, NOT /headcount/member.
+  await page.route(
+    /.*\/api\/v1\/modules\/10\/2024\/headcount\?/,
+    (route) => {
+      const totals = memberPosted ? { 1: 1, 2: 0 } : { 1: 0, 2: 0 };
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildModuleTotalsResponse('headcount', totals)),
+      });
+    },
+  );
+
+  // headcount/member submodule — POST (create entry) + GET (list items).
+  await page.route(
+    /.*\/api\/v1\/modules\/10\/2024\/headcount\/member/,
+    (route) => {
+      if (route.request().method() === 'POST') {
+        memberPosted = true;
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 1, name: 'Test Member', fte: 0.5 }),
+        });
+      }
+      // GET — return 0 items initially, 1 item after POST.
+      const items = memberPosted
+        ? [{ id: 1, name: 'Test Member', fte: 0.5 }]
+        : [];
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildSubmoduleResponse(items)),
+      });
+    },
+  );
+
+  // Simulator explore carbon report — GET 404, POST creates it.
+  await page.route(
+    /.*\/api\/v1\/carbon-reports\/simulator\/explore\/unit\/10\/reference-year\/2024\//,
+    (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ status: 404, body: '' });
+      }
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_SIMULATOR_REPORT),
+        });
+      }
+      return route.continue();
+    },
+  );
+
+  // Year configuration GET for a specific year — return 404 so all
+  // submodules are visible (yearConfig.config stays null).
+  await page.route(/.*\/api\/v1\/year-configuration\/\d+$/, (route) => {
+    return route.fulfill({ status: 404, body: '' });
+  });
+
+  // Module states — validateUnitGuard → fetchModuleStates(42).
+  await page.route(/.*\/api\/v1\/carbon-reports\/42\/modules\/$/, (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    });
+  });
+
+  // Regular carbon report — validateUnitGuard → selectCarbonReportForYear.
+  await page.route(
+    /.*\/api\/v1\/carbon-reports\/unit\/10\/year\/2024\/$/,
+    (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CARBON_REPORT),
+      });
+    },
+  );
+
+  // Users/units — validateUnitGuard calls getUnits().
+  await page.route(/.*\/api\/v1\/users\/units$/, (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([MOCK_UNIT]),
+    });
+  });
+
+  // Session — authGuard calls getUser() on /session.
+  // Registered LAST = highest priority (first evaluated in LIFO).
+  await page.route(/.*\/api\/v1\/session$/, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_USER),
+      });
+    }
+    return route.continue();
+  });
+
+  return { requests };
+}

--- a/frontend/tests/integration/simulator-explore.spec.ts
+++ b/frontend/tests/integration/simulator-explore.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Integration tests for SimulationExplorePage — verifies that the two
+ * reactive-update bugs are fixed WITHOUT a page reload:
+ *
+ *   Bug 1: submodule count "(x)" next to the submodule name stays stale after
+ *          adding an entry.  Fixed in modules.ts getModuleTotals() by keeping
+ *          state.moduleTotalsMap in sync after each fetch.
+ *
+ *   Bug 2: emission breakdown chart / total CO₂eq doesn't update after adding
+ *          an entry.  Fixed in ModuleCarbonFootprintChart.vue by adding
+ *          :update-options="{ replaceMerge: ['dataset'] }" so ECharts replaces
+ *          the stale dataset instead of merging it.
+ *
+ * The suite mocks the HTTP boundary (page.route) so the guards run normally
+ * (unit, year, and selectedCarbonReport are all populated before onMounted
+ * fires) without needing a real backend.  __LIGHTHOUSE_BYPASS__ is NOT used
+ * because it skips validateUnitGuard entirely, leaving selectedUnit null and
+ * causing a TypeError in SimulationExplorePage onMounted.
+ *
+ * i18n strings (EN):
+ *   headcount-member-table-title  → "Member ({count})| Members ({count})"
+ *   count=0 → "Members (0)"   (plural)
+ *   count=1 → "Member (1)"    (singular)
+ *
+ *   formatTonnesCO2(0) → "0.0"   (|value| < 1 → 1 decimal)
+ *   formatTonnesCO2(5) → "5"     (|value| ≥ 1 → 0 decimals)
+ */
+import { test, expect } from '@playwright/test';
+import { mockSimulatorBackend, SIMULATOR_URL } from './setup/simulator-mocks';
+
+test.describe('simulation explore — reactive updates after adding entry', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear any persisted Pinia state (e.g. selectedParams) that could bleed
+    // between tests and cause validateUnitGuard to navigate elsewhere.
+    await page.addInitScript(() => {
+      try {
+        localStorage.clear();
+      } catch {
+        // Ignore — some contexts restrict localStorage before first load.
+      }
+    });
+  });
+
+  test('submodule count updates reactively after posting entry', async ({
+    page,
+  }) => {
+    await mockSimulatorBackend(page);
+    await page.goto(SIMULATOR_URL);
+
+    // Wait for simulatorReady (set after selectSimulatorExploreCarbonReport).
+    await expect(page.locator('.q-list')).toBeVisible();
+
+    // Expand the Headcount module section.
+    await page.getByText('Headcount', { exact: true }).first().click();
+
+    // Member submodule header shows "(0)" on initial load.
+    await expect(page.getByText('Members (0)')).toBeVisible();
+
+    // Expand the member submodule to reveal the form.
+    await page.getByText('Members (0)').click();
+
+    // Wait for the Add button to confirm the form rendered.
+    await expect(
+      page.getByRole('button', { name: 'Add', exact: true }),
+    ).toBeVisible();
+
+    // Fill the Name field so we're submitting realistic data.
+    await page.locator('input[type="text"]').first().fill('Test Member');
+
+    // Submit the entry.
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    // Bug 1 regression guard: the count must update to 1 WITHOUT a page
+    // reload.  Playwright's toBeVisible times out if the element never
+    // appears, which would indicate the bug is still present.
+    await expect(page.getByText('Member (1)')).toBeVisible();
+  });
+
+  test('total CO₂eq updates reactively after posting entry', async ({
+    page,
+  }) => {
+    await mockSimulatorBackend(page);
+    await page.goto(SIMULATOR_URL);
+
+    // Wait for the module list and for the BigNumber value to stabilise.
+    await expect(page.locator('.q-list')).toBeVisible();
+
+    // Initial total is 0 → formatTonnesCO2(0) = "0.0".
+    await expect(page.locator('.big-number__value')).toContainText('0.0');
+
+    // Expand Headcount module then member submodule.
+    await page.getByText('Headcount', { exact: true }).first().click();
+    await expect(page.getByText('Members (0)')).toBeVisible();
+    await page.getByText('Members (0)').click();
+    await expect(
+      page.getByRole('button', { name: 'Add', exact: true }),
+    ).toBeVisible();
+
+    // Submit an entry.
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    // Bug 2 regression guard: the breakdown total must update to 5 WITHOUT a
+    // page reload.  formatTonnesCO2(5) = "5".
+    await expect(page.locator('.big-number__value')).toContainText('5');
+  });
+});

--- a/frontend/tests/integration/simulator-explore.spec.ts
+++ b/frontend/tests/integration/simulator-explore.spec.ts
@@ -103,4 +103,64 @@ test.describe('simulation explore — reactive updates after adding entry', () =
     // page reload.  formatTonnesCO2(5) = "5".
     await expect(page.locator('.big-number__value')).toContainText('5');
   });
+
+  test('plane traveler dropdown populates after adding a headcount member', async ({
+    page,
+  }) => {
+    const { requests } = await mockSimulatorBackend(page);
+    await page.goto(SIMULATOR_URL);
+
+    await expect(page.locator('.q-list')).toBeVisible();
+
+    // Expand Professional travel → Plane so the traveler dropdown
+    // (HeadcountMemberSelect) mounts and performs its initial fetch.
+    const travelSection = page.locator('.q-expansion-item', {
+      has: page.getByText('Professional travel', { exact: true }),
+    });
+    await page.getByText('Professional travel', { exact: true }).click();
+    await travelSection.getByText('Plane Trips (0)').click();
+
+    // The traveler select is the field labelled "Name" inside the plane form.
+    const travelerField = travelSection
+      .locator('.q-field', {
+        has: page.locator('.q-field__label', { hasText: 'Name' }),
+      })
+      .first();
+    // Initially disabled — no members exist in the simulator report yet.
+    await expect(travelerField).toHaveClass(/q-field--disabled/);
+
+    // The simulator must read its OWN report: every members request carries
+    // carbon_project_type=1.  Guards against the original bug where the
+    // dropdown read the calculator report (no carbon_project_type).
+    await expect
+      .poll(() =>
+        requests.some(
+          (r) =>
+            r.url.includes('/headcount/members') &&
+            r.url.includes('carbon_project_type=1'),
+        ),
+      )
+      .toBe(true);
+
+    // Add a headcount member.
+    await page.getByText('Headcount', { exact: true }).first().click();
+    await page.getByText('Members (0)').click();
+    await expect(
+      page.getByRole('button', { name: 'Add', exact: true }),
+    ).toBeVisible();
+    await page.locator('input[type="text"]').first().fill('Test Member');
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    // Member count updates → HeadcountMemberSelect :key changes → it remounts
+    // and refetches.  The traveler dropdown must become enabled WITHOUT a
+    // page reload (refresh-as-soon-as-entry-created).
+    await expect(page.getByText('Member (1)')).toBeVisible();
+    await expect(travelerField).not.toHaveClass(/q-field--disabled/);
+
+    // The newly added member is now selectable in the plane traveler dropdown.
+    await travelerField.click();
+    await expect(
+      page.locator('.q-menu .q-item', { hasText: 'Test Member' }),
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
## What does this change?
Fixes two reactivity bugs in the Simulation Explore page (submodule counts and the carbon footprint chart not updating after adding an entry without a page reload), scopes the headcount member dropdown to the correct carbon report in simulator mode, excludes research facilities from the simulator's emission breakdown chart, and adds an integration test suite for the simulator. This branch also reverts several unrelated changes from `dev` (the row-loop profiler/progress-reporting work, the `310-e`/`310-f` implementation plan docs, the blank-row CSV skip guard, and the per-type/kind memoisation in CSV ingestion) and reverts the version bump back to `0.12.0`.

**Bug fixes — Simulation Explore reactivity (issue #856):**
- `modules.ts` (store): `getModuleTotals` now updates `state.moduleTotalsMap[moduleType]` from the response's `data_entry_types_total_items`, so submodule item counts refresh without a reload
- `ModuleCarbonFootprintChart.vue`: adds `:update-options="{ replaceMerge: ['dataset'] }"` to the ECharts component so a stale dataset is replaced rather than merged, fixing the chart/total not updating after a new entry
- `SimulationExplorePage.vue`: adds a `filteredBreakdown` computed that excludes `research_facilities` entries from the chart's `module_breakdown`, and passes it instead of the raw store breakdown
- `getHeadcountMembers` (`api/modules.ts`): adds a `carbonProjectType` parameter (0 = Calculator, 1 = Simulator Explore) sent as a `carbon_project_type` search param, so the lookup scopes to the correct carbon report
- `HeadcountMemberSelect.vue`, `ModuleCharts.vue`, `ModuleTable.vue`: all call sites of `getHeadcountMembers` now pass `moduleStore.carbonProjectType`
- `modules.ts` (store): exposes `carbonProjectType` from the store

**New tests:**
- `frontend/tests/integration/setup/simulator-mocks.ts`: new HTTP-boundary mock helper for the simulator-explore Playwright suite (mocks session, units, carbon reports, year configuration, module totals, headcount members/dropdown, emission breakdown) since `__LIGHTHOUSE_BYPASS__` can't be used (it skips `validateUnitGuard`, leaving `selectedUnit` null and causing a crash in `onMounted`)
- `frontend/tests/integration/simulator-explore.spec.ts`: three new Playwright tests — submodule count updates reactively after posting an entry, total CO₂eq updates reactively after posting an entry, and the plane traveler dropdown populates (and correctly requests `carbon_project_type=1`) after adding a headcount member

**Reverted from `dev` (unrelated to this fix, rolled back on this branch):**
- `base_csv_provider.py`, `base_factor_csv_provider.py`, `data_entry_repo.py`, `data_ingestion.py`, `logging.py`: reverts the row-loop profiling/timing instrumentation, throttled progress reporting, 100-row yield interval, blank-row skip guard, and httpcore/httpx/watchfiles log silencing
- `module_per_year.py`: reverts the `_get_factors_maps_by_type` memoisation and the `type_by_kind_cache` kind→type inference memoisation
- Deletes `docs/src/implementation-plans/310-e-async-loop-and-pipeline-worker.md` and `310-f-ingestion-per-row-efficiency.md`
- Reverts corresponding test files and the CSV fixture's trailing blank row
- `backoffice_data_management.ts`: reverts "Compute Missing Factors" labels back to "Compute Factors"
- `package.json`: version reverted from `1.0.0` to `0.12.0`; `CHANGELOG.md` 1.0.0 section removed

## Why is this needed?
The simulator page wasn't reflecting newly added entries in either the submodule counts or the carbon footprint chart without a manual reload, and the headcount member dropdown was reading from the wrong carbon report (the calculator's instead of the simulator's), leaving the traveler dropdown empty after adding a member. The reverted ingestion work was already merged separately on `dev` ahead of this branch and is being rolled back here, presumably to keep this PR focused on the simulator bug fix.

## Type of change
- [x] 🐛 Bug fix
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced