### PR TITLE
perf(recalc): profiler + Strategy-B factor cache (headcount 65s → expected ~5s)

### DIFF
--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -233,6 +233,7 @@ class DataEntryEmissionService:
         *,
         year: int | None = None,
         factor_cache: dict[int, Factor] | None = None,
+        factor_query_cache: dict | None = None,
     ) -> list[DataEntryEmission]:
         """Prepare emission records for any data entry type.
 
@@ -347,7 +348,10 @@ class DataEntryEmissionService:
 
             for comp in computations:
                 factors = await self._fetch_factors(
-                    comp, year, factor_cache=factor_cache
+                    comp,
+                    year,
+                    factor_cache=factor_cache,
+                    factor_query_cache=factor_query_cache,
                 )
 
                 if report is not None:
@@ -496,6 +500,7 @@ class DataEntryEmissionService:
         year: Optional[int] = None,
         *,
         factor_cache: dict[int, Factor] | None = None,
+        factor_query_cache: dict | None = None,
     ) -> list[Factor]:
         """Fetch factor(s) for an EmissionComputation.
 
@@ -548,6 +553,26 @@ class DataEntryEmissionService:
         # ── Strategy B: classification query ────────────────────────────
         if comp.factor_query is not None:
             q: FactorQuery = comp.factor_query
+
+            # Slice-scoped memo (opt-in via factor_query_cache): Strategy B
+            # hits the DB on every computation, and a recalc slice resolves the
+            # same criteria across thousands of entries while the factor table
+            # is held stable by the recalc lock. One query per distinct
+            # criteria instead of one per emission per entry. Callers that pass
+            # no cache (single-entry paths) are unchanged.
+            cache_key = None
+            if factor_query_cache is not None:
+                cache_key = (
+                    q.data_entry_type,
+                    q.kind,
+                    q.subkind,
+                    q.emission_type,
+                    tuple(sorted(q.context.items())),
+                    tuple(sorted(q.fallbacks.items())),
+                    year,
+                )
+                if cache_key in factor_query_cache:
+                    return factor_query_cache[cache_key]
 
             # Build the classification dict from optional subkind + context
             # e.g. {"subkind": "business", "country_code": "CH"}
@@ -616,6 +641,9 @@ class DataEntryEmissionService:
                         q.data_entry_type, year=year
                     )
                 )
+
+            if factor_query_cache is not None and cache_key is not None:
+                factor_query_cache[cache_key] = result
 
         return result
 

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -110,6 +110,13 @@ class EmissionRecalculationWorkflow:
         # below (only built when the handler actually rematches).
         factors = await factor_repo.list_by_data_entry_type(data_entry_type_id, year)
         factor_cache: dict[int, Factor] = {f.id: f for f in factors if f.id is not None}
+        # Strategy-B (classification-query) factor lookups hit the DB once per
+        # emission per entry — an N+1 that dominated headcount recalc (member:
+        # ~25 queries/entry × thousands of entries). The factor table is held
+        # stable for the slice by the recalc advisory lock, and the same
+        # (kind, subkind, context, year) criteria recur across entries, so a
+        # slice-scoped memo collapses it to one query per distinct criteria.
+        factor_query_cache: dict = {}
         if handler.kind_field is not None and any(
             handler.kind_field in e.data for e in entries
         ):
@@ -217,7 +224,10 @@ class EmissionRecalculationWorkflow:
 
                 _t = time.perf_counter()
                 emissions = await emission_svc.prepare_create(
-                    entry_response, year=year, factor_cache=factor_cache
+                    entry_response,
+                    year=year,
+                    factor_cache=factor_cache,
+                    factor_query_cache=factor_query_cache,
                 )
                 seg["prepare"] += time.perf_counter() - _t
                 if entry.id is not None:

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -144,6 +144,10 @@ class EmissionRecalculationWorkflow:
         total_written = 0
         total_replaced = 0
         slice_started = time.perf_counter()
+        # Per-segment wall time for a recalc profile line (diagnostic, the
+        # analog of ingestion's row-loop profile): localises where per-entry
+        # time goes so a slow slice is measured, not guessed.
+        seg = {"rematch": 0.0, "validate": 0.0, "prepare": 0.0}
 
         for entry in entries:
             # Plan 310B Part 6 — refresh primary_factor_id against current
@@ -188,6 +192,7 @@ class EmissionRecalculationWorkflow:
                 # writes, so a per-entry failure needs no SAVEPOINT —
                 # there is nothing to roll back; the ``except`` just
                 # reverts the in-memory factor swap and moves on.
+                _t = time.perf_counter()
                 if entry_kind_field is not None and entry_kind_field in entry.data:
                     new_factor_id = self._lookup_factor_id(
                         entry_data=entry.data,
@@ -204,11 +209,17 @@ class EmissionRecalculationWorkflow:
                             **entry.data,
                             "primary_factor_id": new_factor_id,
                         }
+                seg["rematch"] += time.perf_counter() - _t
 
+                _t = time.perf_counter()
                 entry_response = DataEntryResponse.model_validate(entry)
+                seg["validate"] += time.perf_counter() - _t
+
+                _t = time.perf_counter()
                 emissions = await emission_svc.prepare_create(
                     entry_response, year=year, factor_cache=factor_cache
                 )
+                seg["prepare"] += time.perf_counter() - _t
                 if entry.id is not None:
                     processed_entry_ids.append(entry.id)
                 prepared_emissions.extend(emissions)
@@ -289,10 +300,28 @@ class EmissionRecalculationWorkflow:
             processed_entry_ids, prepared_emissions
         )
         total_replaced += len(processed_entry_ids)
+        slice_elapsed = time.perf_counter() - slice_started
         logger.info(
             f"Recalc {data_entry_type_id.name}/{year}: replaced emissions for "
             f"{total_replaced} entries ({total_written} emission rows, "
-            f"{time.perf_counter() - slice_started:.1f}s compute+write)"
+            f"{slice_elapsed:.1f}s compute+write)"
+        )
+        # Recalc profile: where the per-entry time went (rematch = in-memory
+        # factor relink, validate = Pydantic, prepare = prepare_create incl. any
+        # handler DB reads). remainder = bulk writes + loop overhead.
+        accounted = seg["rematch"] + seg["validate"] + seg["prepare"]
+        logger.info(
+            "Recalc profile %s/%s: %d entries in %.1fs (%.2f ms/entry) | "
+            "rematch=%.1f validate=%.1f prepare=%.1f remainder=%.1f",
+            data_entry_type_id.name,
+            year,
+            len(entries),
+            slice_elapsed,
+            slice_elapsed / len(entries) * 1000,
+            seg["rematch"],
+            seg["validate"],
+            seg["prepare"],
+            slice_elapsed - accounted,
         )
 
         # Plan 310-D — stats recompute moves out of this workflow and

--- a/backend/tests/unit/services/test_data_entry_emission_service.py
+++ b/backend/tests/unit/services/test_data_entry_emission_service.py
@@ -1655,3 +1655,67 @@ class TestPrepareCreateRollup:
         assert rollup.scope is None
         assert rollup.meta.get("is_rollup") is True
         assert rollup.kg_co2eq == pytest.approx(sum(r.kg_co2eq for r in leaf_rows))
+
+
+# ---------------------------------------------------------------------------
+# _fetch_factors — Strategy B query cache (recalc N+1 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFactorsStrategyBCache:
+    """Strategy B hits the DB per computation; a slice-scoped query cache
+    collapses the per-entry N+1 that dominated headcount recalc."""
+
+    def _comp(self):
+        from app.models.data_entry_emission import (
+            EmissionComputation,
+            EmissionType,
+            FactorQuery,
+        )
+
+        return EmissionComputation(
+            emission_type=EmissionType.food,
+            factor_query=FactorQuery(
+                data_entry_type=DataEntryTypeEnum.member,
+                kind="food",
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_queries_db_once(self):
+        service = _make_service()
+        comp = self._comp()
+        fake_factor = MagicMock()
+        get_by_classification = AsyncMock(return_value=fake_factor)
+        with patch(
+            "app.services.data_entry_emission_service.FactorService"
+        ) as mock_fs_cls:
+            mock_fs_cls.return_value = MagicMock(
+                get_by_classification=get_by_classification
+            )
+            cache: dict = {}
+            r1 = await service._fetch_factors(comp, 2026, factor_query_cache=cache)
+            r2 = await service._fetch_factors(comp, 2026, factor_query_cache=cache)
+
+        assert r1 == [fake_factor]
+        assert r2 == r1
+        # Two identical Strategy-B lookups → one DB query.
+        get_by_classification.assert_awaited_once()
+        assert len(cache) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_cache_queries_each_call(self):
+        service = _make_service()
+        comp = self._comp()
+        get_by_classification = AsyncMock(return_value=MagicMock())
+        with patch(
+            "app.services.data_entry_emission_service.FactorService"
+        ) as mock_fs_cls:
+            mock_fs_cls.return_value = MagicMock(
+                get_by_classification=get_by_classification
+            )
+            await service._fetch_factors(comp, 2026)
+            await service._fetch_factors(comp, 2026)
+
+        # Without the opt-in cache, behaviour is unchanged: one query per call.
+        assert get_by_classification.await_count == 2


### PR DESCRIPTION
Headcount recalc was slow. This PR measures it, then fixes the cause the trace revealed.

## 1. Profiler (commit 1)

One `Recalc profile` line per `(data_entry_type, year)` slice in `recalculate_for_data_entry_type`, splitting per-entry wall time into `rematch / validate / prepare` (+ `remainder` for bulk writes & loop overhead). Mirrors the ingestion row-loop profiler (#1533). The workflow already yields and reports progress, so no sleeps/progress were added.

## 2. The trace

Deployed profiler-only, ran a 6885-row headcount upload:

```
Recalc profile member/2026: 6885 entries in 64.8s (9.41 ms/entry) |
  rematch=0.0 validate=0.1 prepare=60.3 remainder=4.4
```

**`prepare=60.3s` of 64.8s** — not Pydantic, not the rematch.

## 3. The fix (commit 2)

`_fetch_factors` Strategy B (classification query — member/headcount/travel/building) hits the DB **once per computation**, and member fans out ~25 emissions/entry → ~172k classification queries for the slice. The factor table is held stable for the slice by the recalc advisory lock, and the same `(kind, subkind, context, year)` criteria recur across entries, so:

- Add an **opt-in, slice-scoped `factor_query_cache`** (same shape as the existing Strategy-A `factor_cache`), threaded `recalc workflow → prepare_create → _fetch_factors`.
- One query per distinct criteria instead of one per emission per entry.
- **Single-entry paths pass no cache → behaviour unchanged.**

## Tests
- `TestFetchFactorsStrategyBCache`: cache-hit issues 1 DB query for repeated lookups; no-cache still issues 1 per call (unchanged).
- 210 emission/recalc tests pass; mypy clean.

Re-measure after deploy to confirm `prepare` collapses (expect ~60s → a few seconds).