### PR TITLE
fix(i18n): unify role display names into single source of truth (#1531)

### DIFF
--- a/frontend/src/components/organisms/backoffice/reporting/UnitsTable.vue
+++ b/frontend/src/components/organisms/backoffice/reporting/UnitsTable.vue
@@ -4,6 +4,7 @@ import type { QTableColumn } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import { formatRelativeTime } from 'src/utils/date';
 import { useBackofficeStore } from 'src/stores/backoffice';
+import { ROLES } from 'src/constant/roles';
 
 interface UnitReportingData {
   id: string | number;
@@ -138,7 +139,7 @@ const columns = computed<QTableColumn[]>(() => [
   },
   {
     name: 'principal_user',
-    label: t('backoffice_reporting_column_principal_user'),
+    label: t(ROLES.PrincipalUser),
     field: 'principal_user',
     align: 'left',
     sortable: true,

--- a/frontend/src/components/organisms/login/LoginCard.vue
+++ b/frontend/src/components/organisms/login/LoginCard.vue
@@ -21,10 +21,10 @@ const form = ref(null);
 const role = ref(ROLES.StandardUser);
 
 const roleOptions = computed(() => [
-  { value: ROLES.StandardUser, label: 'User Standard' },
-  { value: ROLES.PrincipalUser, label: 'Unit Manager' },
-  { value: ROLES.BackOfficeMetier, label: 'Back-Office Standard' },
-  { value: ROLES.SuperAdmin, label: 'Back-Office Admin' },
+  { value: ROLES.StandardUser, label: t(ROLES.StandardUser) },
+  { value: ROLES.PrincipalUser, label: t(ROLES.PrincipalUser) },
+  { value: ROLES.BackOfficeMetier, label: t(ROLES.BackOfficeMetier) },
+  { value: ROLES.SuperAdmin, label: t(ROLES.SuperAdmin) },
 ]);
 const isTestMode = computed(() => props.mode === 'test');
 

--- a/frontend/src/components/organisms/workspace-selector/LabSelectorItem.vue
+++ b/frontend/src/components/organisms/workspace-selector/LabSelectorItem.vue
@@ -46,7 +46,7 @@ const completedModules = 0;
     </div>
     <div class="row items-center justify-between q-mt-xl">
       <span class="text-body2 text-weight-medium">{{
-        $t('workspace_setup_unit_manager')
+        $t(ROLES.PrincipalUser)
       }}</span>
       <span class="text-body2 text-weight-bold">{{
         unit.principal_user_name

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -111,10 +111,6 @@ export default {
     en: 'Years completed',
     fr: 'Années complétées',
   },
-  backoffice_reporting_column_principal_user: {
-    en: 'Unit manager',
-    fr: "Responsable de l'unité",
-  },
   backoffice_reporting_column_last_update: {
     en: 'Last update',
     fr: 'Dernière mise à jour',

--- a/frontend/src/i18n/backoffice_user_management.ts
+++ b/frontend/src/i18n/backoffice_user_management.ts
@@ -3,38 +3,6 @@ export default {
     en: 'Roles & Permissions',
     fr: 'Rôles et permissions',
   },
-  user_management_role_standard_name: {
-    en: 'User Standard',
-    fr: 'Utilisateur standard',
-  },
-  user_management_role_standard_description: {
-    en: 'Standard EPFL personnel (member of unit). Read-only access to their unit\u2019s data.',
-    fr: 'Personnel EPFL standard (membre d\u2019unité). Accès en lecture seule aux données de leur unité.',
-  },
-  user_management_role_principal_name: {
-    en: 'Unit Manager',
-    fr: "Responsable d'unité",
-  },
-  user_management_role_principal_description: {
-    en: 'Can manage and validate CO\u2082 data for their unit.',
-    fr: 'Peut gérer et valider les données CO\u2082 de leur unité.',
-  },
-  user_management_role_backoffice_name: {
-    en: 'Backoffice Administrator',
-    fr: 'Administrateur métier',
-  },
-  user_management_role_backoffice_description: {
-    en: 'Can manage emission factors, categories, and back-office configuration across all units.',
-    fr: 'Peut gérer les facteurs d\u2019émission, les catégories et la configuration du back-office pour toutes les unités.',
-  },
-  user_management_role_superadmin_name: {
-    en: 'Super Admin',
-    fr: 'Super Admin',
-  },
-  user_management_role_superadmin_description: {
-    en: 'Full system access, including user role assignment and system-level settings.',
-    fr: 'Accès complet au système, y compris l\u2019attribution des rôles et les paramètres système.',
-  },
   user_management_page_description: {
     en: 'User management at EPFL is handled via Accred.',
     fr: "La gestion des utilisateurs à l'EPFL est gérée via Accred.",

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -1,4 +1,3 @@
-import { ROLES } from 'src/constant/roles';
 import { MODULES } from 'src/constant/modules';
 
 export default {
@@ -57,22 +56,6 @@ export default {
   tco2eq: {
     en: 't CO₂-eq',
     fr: 't CO₂-eq',
-  },
-  [ROLES.StandardUser]: {
-    en: 'Standard User',
-    fr: 'Utilisateur Standard',
-  },
-  [ROLES.PrincipalUser]: {
-    en: 'Principal User',
-    fr: 'Utilisateur Principal',
-  },
-  [ROLES.BackOfficeMetier]: {
-    en: 'Back-Office Standard',
-    fr: 'Back-Office Standard',
-  },
-  [ROLES.SuperAdmin]: {
-    en: 'Back-Office Admin',
-    fr: 'Back-Office Admin',
   },
   info_with_link: {
     en: '<span>For more information, visit <a href="{url}" target="_blank">{linkText}</a>.</span>',

--- a/frontend/src/i18n/roles.ts
+++ b/frontend/src/i18n/roles.ts
@@ -1,0 +1,38 @@
+import { ROLES } from 'src/constant/roles';
+
+// Single source of truth for role display names and descriptions.
+// Names are keyed by the role string so `$t(role)` resolves directly.
+export default {
+  [ROLES.StandardUser]: {
+    en: 'Standard User',
+    fr: 'Utilisateur Standard',
+  },
+  [ROLES.PrincipalUser]: {
+    en: 'Principal User',
+    fr: 'Utilisateur Principal',
+  },
+  [ROLES.BackOfficeMetier]: {
+    en: 'Back-Office Standard',
+    fr: 'Back-Office Standard',
+  },
+  [ROLES.SuperAdmin]: {
+    en: 'Back-Office Admin',
+    fr: 'Back-Office Admin',
+  },
+  role_standard_description: {
+    en: 'Unit member with access to their own travel and cloud/AI module entries',
+    fr: 'Membre d’unité ayant accès à ses propres saisies des modules déplacements et cloud/IA',
+  },
+  role_principal_description: {
+    en: 'Unit manager with full access to all modules for their unit, and can assign Standard User roles',
+    fr: 'Responsable d’unité avec accès complet à tous les modules de son unité, et pouvant attribuer le rôle Utilisateur Standard',
+  },
+  role_backoffice_description: {
+    en: 'Day-to-day back-office operations: reporting, user management, documentation',
+    fr: 'Opérations courantes du back-office : reporting, gestion des utilisateurs, documentation',
+  },
+  role_superadmin_description: {
+    en: 'Full back-office access including sensitive configuration and pipeline controls',
+    fr: 'Accès complet au back-office, y compris la configuration sensible et les contrôles du pipeline',
+  },
+} as const;

--- a/frontend/src/i18n/workspace_setup.ts
+++ b/frontend/src/i18n/workspace_setup.ts
@@ -91,10 +91,6 @@ export default {
     en: 'Start Over',
     fr: 'Recommencer',
   },
-  workspace_setup_unit_manager: {
-    en: 'Unit Manager',
-    fr: "Responsable d'unité",
-  },
   workspace_setup_unit_affiliation: {
     en: 'Affiliation',
     fr: 'Affiliation',

--- a/frontend/src/pages/back-office/UserManagementPage.vue
+++ b/frontend/src/pages/back-office/UserManagementPage.vue
@@ -9,24 +9,24 @@ const { t } = useI18n();
 
 const roles = computed(() => [
   {
-    name: t('user_management_role_standard_name'),
+    name: t(ROLES.StandardUser),
     id: ROLES.StandardUser,
-    description: t('user_management_role_standard_description'),
+    description: t('role_standard_description'),
   },
   {
-    name: t('user_management_role_principal_name'),
+    name: t(ROLES.PrincipalUser),
     id: ROLES.PrincipalUser,
-    description: t('user_management_role_principal_description'),
+    description: t('role_principal_description'),
   },
   {
-    name: t('user_management_role_backoffice_name'),
+    name: t(ROLES.BackOfficeMetier),
     id: ROLES.BackOfficeMetier,
-    description: t('user_management_role_backoffice_description'),
+    description: t('role_backoffice_description'),
   },
   {
-    name: t('user_management_role_superadmin_name'),
+    name: t(ROLES.SuperAdmin),
     id: ROLES.SuperAdmin,
-    description: t('user_management_role_superadmin_description'),
+    description: t('role_superadmin_description'),
   },
 ]);
 </script>


### PR DESCRIPTION
Add frontend/src/i18n/roles.ts as the canonical source for the four role display names (keyed by role string so $t(role) resolves) and descriptions. Remove divergent definitions from common.ts, backoffice_user_management.ts, workspace_setup.ts and backoffice_reporting.ts, and the hardcoded labels in LoginCard.vue; repoint all consumers at the shared keys.

## What does this change?

<!-- Briefly describe what you're adding, fixing, or improving -->

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
