### PR TITLE
fix(1530): correct professional_travel_api

### DIFF
--- a/backend/app/modules/professional_travel/schemas.py
+++ b/backend/app/modules/professional_travel/schemas.py
@@ -280,9 +280,55 @@ class ProfessionalTravelPlaneModuleHandler(ProfessionalTravelBaseModuleHandler):
     kind_field: str = "category"
     subkind_field: str = "cabin_class"
 
-    async def pre_compute(self, data_entry: Any, session: Any) -> dict:
+    async def prefetch_slice(
+        self,
+        entries: list[Any],
+        session: Any,
+        *,
+        year: int | None = None,
+    ) -> dict:
+        """Bulk-load the slice's airports + plane factors once per recalc.
+
+        Without this, ``pre_compute`` does two airport point-lookups, a year
+        lookup and a full plane-factor reload *per entry* — ~4 DB round-trips
+        × every flight in the slice. All three are constant across a
+        ``(plane, year)`` slice, so we resolve them here in two queries and
+        ``pre_compute`` reads them in-memory. Returns ``{}`` when the slice
+        has no year (``pre_compute`` then keeps its per-entry fallback).
+        """
+        if year is None:
+            return {}
+        iata_codes: set[str] = set()
+        for entry in entries:
+            origin = entry.data.get("origin_iata")
+            destination = entry.data.get("destination_iata")
+            if origin:
+                iata_codes.add(origin)
+            if destination:
+                iata_codes.add(destination)
+        locations = await LocationService(session).get_locations_by_iata(
+            list(iata_codes)
+        )
+        plane_factors = await FactorService(session).list_by_data_entry_type(
+            DataEntryTypeEnum.plane,
+            year=year,
+        )
+        return {
+            "locations": {loc.iata_code: loc for loc in locations},
+            "plane_factors": plane_factors,
+            "year": year,
+        }
+
+    async def pre_compute(
+        self, data_entry: Any, session: Any, *, slice_cache: dict | None = None
+    ) -> dict:
         """Compute flight distance and haul category
-        from origin/destination airports."""
+        from origin/destination airports.
+
+        ``slice_cache`` (from ``prefetch_slice``) supplies airports, year and
+        plane factors in-memory during a recalc; absent it (single-entry
+        create/update), the per-entry DB lookups below run unchanged.
+        """
         origin_iata = data_entry.data.get("origin_iata")
         destination_iata = data_entry.data.get("destination_iata")
         number_of_trips = data_entry.data.get("number_of_trips", 1)
@@ -300,9 +346,9 @@ class ProfessionalTravelPlaneModuleHandler(ProfessionalTravelBaseModuleHandler):
             )
             return {}
 
-        loc_service = LocationService(session)
-        origin = await loc_service.get_location_by_iata(origin_iata)
-        dest = await loc_service.get_location_by_iata(destination_iata)
+        origin, dest = await self._lookup_airports(
+            session, origin_iata, destination_iata, slice_cache
+        )
         if not origin or not dest:
             logger.warning(
                 "plane.pre_compute: skipping entry id=%s — IATA not found "
@@ -328,12 +374,8 @@ class ProfessionalTravelPlaneModuleHandler(ProfessionalTravelBaseModuleHandler):
                 destination_iata,
             )
             return {}
-        year = await _get_report_year_for_module(
-            session, data_entry.carbon_report_module_id
-        )
-        plane_factors = await FactorService(session).list_by_data_entry_type(
-            DataEntryTypeEnum.plane,
-            year=year,
+        year, plane_factors = await self._year_and_plane_factors(
+            session, data_entry, slice_cache
         )
         haul_category = get_haul_category(distance_one_trip_km, plane_factors)
         if haul_category is None:
@@ -351,6 +393,42 @@ class ProfessionalTravelPlaneModuleHandler(ProfessionalTravelBaseModuleHandler):
             "haul_category": haul_category,
             "distance_km": distance_km,
         }
+
+    async def _lookup_airports(
+        self,
+        session: Any,
+        origin_iata: str,
+        destination_iata: str,
+        slice_cache: dict | None,
+    ) -> tuple[Any, Any]:
+        """Origin/destination ``Location`` from the slice cache, else two
+        per-entry point lookups (single-entry path)."""
+        if slice_cache is not None:
+            locations = slice_cache["locations"]
+            return locations.get(origin_iata), locations.get(destination_iata)
+        loc_service = LocationService(session)
+        return (
+            await loc_service.get_location_by_iata(origin_iata),
+            await loc_service.get_location_by_iata(destination_iata),
+        )
+
+    async def _year_and_plane_factors(
+        self,
+        session: Any,
+        data_entry: Any,
+        slice_cache: dict | None,
+    ) -> tuple[int | None, list]:
+        """Slice year + plane factors from the cache, else per-entry lookups."""
+        if slice_cache is not None:
+            return slice_cache["year"], slice_cache["plane_factors"]
+        year = await _get_report_year_for_module(
+            session, data_entry.carbon_report_module_id
+        )
+        plane_factors = await FactorService(session).list_by_data_entry_type(
+            DataEntryTypeEnum.plane,
+            year=year,
+        )
+        return year, plane_factors
 
     def resolve_computations(
         self, data_entry: Any, emission_type: Any, ctx: dict

--- a/backend/app/repositories/location_repo.py
+++ b/backend/app/repositories/location_repo.py
@@ -171,6 +171,18 @@ class LocationRepository:
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
+    async def get_by_iata_codes(self, iata_codes: List[str]) -> List[Location]:
+        """Bulk-fetch locations for a set of IATA codes in one query.
+
+        Lets the recalc slice resolve every flight's airports up front
+        instead of two point lookups per entry. Empty input short-circuits.
+        """
+        if not iata_codes:
+            return []
+        statement = select(Location).where(col(Location.iata_code).in_(iata_codes))
+        result = await self.session.execute(statement)
+        return list(result.scalars().all())
+
     async def find_train_stations_by_name(
         self,
         name: str,

--- a/backend/app/schemas/data_entry.py
+++ b/backend/app/schemas/data_entry.py
@@ -159,6 +159,13 @@ class ModuleHandler(Protocol[T]):
         data_entry: Any,
         session: AsyncSession,
     ) -> dict: ...
+    async def prefetch_slice(
+        self,
+        entries: list[Any],
+        session: AsyncSession,
+        *,
+        year: Optional[int] = None,
+    ) -> dict: ...
     def resolve_computations(
         self,
         data_entry: Any,
@@ -282,6 +289,24 @@ class BaseModuleHandler(metaclass=ModuleHandlerMeta):
 
         Returns:
             Dict of additional context keys (empty by default).
+        """
+        return {}
+
+    async def prefetch_slice(
+        self,
+        entries: list[Any],
+        session: AsyncSession,
+        *,
+        year: Optional[int] = None,
+    ) -> dict:
+        """Per-slice prefetch hook called once before a recalc loops entries.
+
+        Override to bulk-load data that is constant across the whole
+        ``(data_entry_type, year)`` slice (e.g. all airports for plane
+        travel) so ``pre_compute`` reads it from the returned cache instead
+        of re-querying per entry. The dict is passed back into
+        ``pre_compute`` via ``slice_cache``. Empty by default — handlers
+        whose ``pre_compute`` needs no shared state ignore it.
         """
         return {}
 

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -234,6 +234,7 @@ class DataEntryEmissionService:
         year: int | None = None,
         factor_cache: dict[int, Factor] | None = None,
         factor_query_cache: dict | None = None,
+        slice_cache: dict | None = None,
     ) -> list[DataEntryEmission]:
         """Prepare emission records for any data entry type.
 
@@ -309,7 +310,13 @@ class DataEntryEmissionService:
         # data entry is left intact so re-runs remain idempotent.
         ctx: dict = {**data_entry.data}
         ctx.pop(KG_CO2EQ_OVERRIDE_KEY, None)
-        ctx.update(await handler.pre_compute(data_entry, self.session))
+        # Forward the slice prefetch only when a caller (the recalc workflow)
+        # actually preloaded one — keeps handlers whose pre_compute takes no
+        # slice_cache (the base + non-plane modules) callable as-is.
+        pre_compute_kwargs = {"slice_cache": slice_cache} if slice_cache else {}
+        ctx.update(
+            await handler.pre_compute(data_entry, self.session, **pre_compute_kwargs)
+        )
 
         # Prefer using the lightweight hook that tests commonly patch.
         # This avoids unnecessary DB calls to fetch the report when tests

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -759,12 +759,16 @@ class ProfessionalTravelApiProvider(DataIngestionProvider):
         return datetime.strptime(date_str, "%Y%m%d")
 
     def _normalize_class(self, class_str: str) -> str:
+        # Canonical cabin_class vocabulary ("economy"/"business"/"first") —
+        # the value resolve_emission_types and factor classification key on.
+        # Must NOT emit "eco": the resolver rejects it (the old wrong value),
+        # so economy flights would resolve to no emission type.
         mapping = {
-            "AIR ECONOMY CLASS": "eco",
+            "AIR ECONOMY CLASS": "economy",
             "AIR BUSINESS CLASS": "business",
             "AIR FIRST CLASS": "first",
         }
-        return mapping.get(class_str, "eco")
+        return mapping.get(class_str, "economy")
 
     async def _resolve_carbon_report_modules(
         self,

--- a/backend/app/services/location_service.py
+++ b/backend/app/services/location_service.py
@@ -96,6 +96,13 @@ class LocationService:
         """
         return await self.repo.get_by_iata(iata_code)
 
+    async def get_locations_by_iata(self, iata_codes: List[str]) -> List[Location]:
+        """Bulk-fetch locations for many IATA codes in one query.
+
+        Used by the plane recalc slice to resolve all airports up front.
+        """
+        return await self.repo.get_by_iata_codes(iata_codes)
+
     async def resolve_train_station_for_csv(
         self,
         name: str,

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -138,6 +138,13 @@ class EmissionRecalculationWorkflow:
                 # callers don't depend on ordering when the index is consistent.
                 factor_lookup.setdefault((kind_value, subkind_value), factor.id)
 
+        # Plan 310D — per-slice prefetch: handlers that otherwise re-query
+        # slice-constant data per entry (plane reloads airports + the full
+        # plane-factor set on every entry) bulk-load it once here; pre_compute
+        # then reads it from slice_cache in-memory. Empty for handlers that
+        # don't override the hook, so their per-entry path is unchanged.
+        slice_cache = await handler.prefetch_slice(entries, self.session, year=year)
+
         recalculated = 0
         errors = 0
         error_details: list[dict] = []
@@ -228,6 +235,7 @@ class EmissionRecalculationWorkflow:
                     year=year,
                     factor_cache=factor_cache,
                     factor_query_cache=factor_query_cache,
+                    slice_cache=slice_cache,
                 )
                 seg["prepare"] += time.perf_counter() - _t
                 if entry.id is not None:

--- a/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
@@ -9,11 +9,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.data_entry import DataEntryTypeEnum
 from app.services.data_ingestion.api_providers.professional_travel_api_provider import (
     ProfessionalTravelApiProvider,
     normalize_vds_payload,
     to_bool,
 )
+from app.utils.data_entry_emission_type_map import resolve_emission_types
 
 # ---------------------------------------------------------------------------
 # to_bool
@@ -140,7 +142,7 @@ class TestParseDate:
 class TestNormalizeClass:
     def test_economy(self):
         p = _make_provider()
-        assert p._normalize_class("AIR ECONOMY CLASS") == "eco"
+        assert p._normalize_class("AIR ECONOMY CLASS") == "economy"
 
     def test_business(self):
         p = _make_provider()
@@ -150,10 +152,50 @@ class TestNormalizeClass:
         p = _make_provider()
         assert p._normalize_class("AIR FIRST CLASS") == "first"
 
-    def test_unknown_defaults_to_eco(self):
+    def test_unknown_defaults_to_economy(self):
         p = _make_provider()
-        assert p._normalize_class("SOMETHING ELSE") == "eco"
-        assert p._normalize_class("") == "eco"
+        assert p._normalize_class("SOMETHING ELSE") == "economy"
+        assert p._normalize_class("") == "economy"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_class ↔ resolve_emission_types contract (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizedCabinClassResolves:
+    """The cabin_class the provider writes MUST be a key the emission-type
+    resolver accepts for plane.
+
+    Commit 0d7e1575 renamed the resolver map key ``eco`` → ``economy`` (the
+    canonical value used by the manual-entry validator and the UI) but left
+    ``_normalize_class`` emitting ``eco``. Result: every economy-class flight
+    resolved to ``None`` ("Unhandled type: plane") and produced zero emission
+    rows — the override at prepare_create was never reached. The per-side unit
+    tests both passed because neither checked the value across the boundary;
+    this test pins the two sides together so they can't drift again.
+    """
+
+    @pytest.mark.parametrize(
+        "tableau_class",
+        [
+            "AIR ECONOMY CLASS",
+            "AIR BUSINESS CLASS",
+            "AIR FIRST CLASS",
+            "SOMETHING ELSE",  # default branch must also be resolvable
+        ],
+    )
+    def test_normalized_cabin_class_is_resolvable(self, tableau_class):
+        p = _make_provider()
+        normalized = p._normalize_class(tableau_class)
+        emission_types = resolve_emission_types(
+            DataEntryTypeEnum.plane, {"cabin_class": normalized}
+        )
+        assert emission_types, (
+            f"cabin_class={normalized!r} (from {tableau_class!r}) did not resolve "
+            f"to an emission type — provider vocabulary drifted from the resolver "
+            f"map; resolve_emission_types returned {emission_types!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -292,7 +334,7 @@ class TestTransformData:
         assert entry["user_institutional_id"] == "123456"
         assert entry["origin_iata"] == "GVA"
         assert entry["destination_iata"] == "CDG"
-        assert entry["cabin_class"] == "eco"
+        assert entry["cabin_class"] == "economy"
         assert entry["number_of_trips"] == 2
         assert entry["round_trip"] is True
         assert entry["kg_co2eq"] == 150.5

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -18,6 +18,14 @@ def _make_mock_entry(entry_id: int, module_id: int) -> MagicMock:
     return entry
 
 
+def _make_mock_handler() -> MagicMock:
+    """Handler mock whose async ``prefetch_slice`` hook returns an empty
+    slice cache — the workflow awaits it once before looping entries."""
+    handler = MagicMock()
+    handler.prefetch_slice = AsyncMock(return_value={})
+    return handler
+
+
 # ======================================================================
 # recalculate_for_data_entry_type Tests
 # ======================================================================
@@ -49,7 +57,7 @@ async def test_recalculate_all_success():
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
     ):
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -105,7 +113,7 @@ async def test_recalculate_partial_error():
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
     ):
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -181,7 +189,7 @@ async def test_recalculate_aborts_batch_on_connection_invalidated():
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
     ):
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -255,7 +263,7 @@ async def test_recalculate_aborts_batch_on_pending_rollback():
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
     ):
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -366,7 +374,7 @@ async def test_recalculate_rematches_primary_factor_id_when_changed():
         )
         # Strategy A handler: kind_field maps to a key in entry.data so
         # the gate ``handler.kind_field in entry.data`` evaluates True.
-        strategy_a_handler = MagicMock()
+        strategy_a_handler = _make_mock_handler()
         strategy_a_handler.kind_field = "equipment_class"
         strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
@@ -416,7 +424,7 @@ async def test_recalculate_does_not_touch_entry_when_factor_unchanged():
         )
         # Handler with no kind_field (MagicMock attr is not in entry.data
         # so the rematch gate fails) — entry.data stays untouched.
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
 
         await svc.recalculate_for_data_entry_type(DataEntryTypeEnum.plane, 2025)
 
@@ -458,7 +466,7 @@ async def test_recalculate_reports_affected_module_ids_for_chain():
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
     ):
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )
@@ -530,7 +538,7 @@ async def test_recalculate_skips_rematch_for_strategy_b_handlers():
         )
         # Strategy B handler shape: kind_field set, but its value isn't
         # present in entry.data (would be derived via pre_compute).
-        strategy_b_handler = MagicMock()
+        strategy_b_handler = _make_mock_handler()
         strategy_b_handler.kind_field = "kind"  # NOT a key on entry.data
         strategy_b_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_b_handler
@@ -604,7 +612,7 @@ async def test_recalculate_rolls_back_entry_data_on_upsert_failure():
         mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
             return_value=0
         )
-        strategy_a_handler = MagicMock()
+        strategy_a_handler = _make_mock_handler()
         strategy_a_handler.kind_field = "equipment_class"
         strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
@@ -680,7 +688,7 @@ async def test_recalculate_uses_single_factor_bulk_fetch():
         mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
             return_value=0
         )
-        strategy_a_handler = MagicMock()
+        strategy_a_handler = _make_mock_handler()
         strategy_a_handler.kind_field = "equipment_class"
         strategy_a_handler.subkind_field = None
         mock_handler_cls.get_by_type.return_value = strategy_a_handler
@@ -749,7 +757,7 @@ async def test_recalculate_kind_only_fallback_in_dict():
         mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
             return_value=0
         )
-        handler = MagicMock()
+        handler = _make_mock_handler()
         handler.kind_field = "equipment_class"
         handler.subkind_field = "sub_class"
         mock_handler_cls.get_by_type.return_value = handler
@@ -793,7 +801,7 @@ async def test_recalculate_reports_progress_at_interval(monkeypatch):
             "app.workflows.emission_recalculation.BaseModuleHandler"
         ) as mock_handler_cls,
     ):
-        mock_handler_cls.get_by_type.return_value = MagicMock()
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
         mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
             return_value=entries
         )


### PR DESCRIPTION
## What does this change?

This pull request introduces a performance optimization for emission recalculation of professional travel (plane) entries by adding a per-slice prefetching mechanism. This allows constant data (like airports and plane factors) to be loaded once per batch instead of repeatedly per entry, significantly reducing database queries. Additionally, it standardizes the vocabulary for cabin class values and adds robust tests to prevent future mismatches between data ingestion and emission type resolution.

Key changes include:

### Performance Improvements: Per-slice Prefetching

* Added a `prefetch_slice` async hook to `ProfessionalTravelPlaneModuleHandler` and the base handler, which bulk-loads airports and plane factors for all entries in a slice, reducing redundant DB queries during emission recalculation. The `pre_compute` method now consumes this cache for efficient lookups. [[1]](diffhunk://#diff-ff389b624da453983b8f1ca55f37dd35ae65af2755d80c6659a10a27ea1353f4L283-R331) [[2]](diffhunk://#diff-ff389b624da453983b8f1ca55f37dd35ae65af2755d80c6659a10a27ea1353f4L303-R351) [[3]](diffhunk://#diff-ff389b624da453983b8f1ca55f37dd35ae65af2755d80c6659a10a27ea1353f4L331-R378) [[4]](diffhunk://#diff-77f3a24c4e087bc668434960a259696e7d461f42f3d570c88591a6007cdc07fcR162-R168) [[5]](diffhunk://#diff-77f3a24c4e087bc668434960a259696e7d461f42f3d570c88591a6007cdc07fcR295-R312)
* Updated the emission recalculation workflow to call `prefetch_slice` once per slice and pass the resulting cache into each call to `prepare_create` and `pre_compute`. [[1]](diffhunk://#diff-2b2f985f621998dc851a91e6c3fbac24429a98f612c30fe0e55ecd9e17c9db8eR141-R147) [[2]](diffhunk://#diff-2b2f985f621998dc851a91e6c3fbac24429a98f612c30fe0e55ecd9e17c9db8eR238) [[3]](diffhunk://#diff-cf815b8fa438e7d1f29490ed6419bc1fc6b94d2ba2351b663ccf46fb96c01e36R237) [[4]](diffhunk://#diff-cf815b8fa438e7d1f29490ed6419bc1fc6b94d2ba2351b663ccf46fb96c01e36L312-R319)

### Bulk Airport Lookup

* Implemented `get_by_iata_codes` in `LocationRepository` and `get_locations_by_iata` in `LocationService` to efficiently fetch multiple airport locations in a single query. [[1]](diffhunk://#diff-ae3f3f10dbbbe3b2e9111d867a02e5eb4ee30000a8e6bfd630e70cda94bbb0c7R174-R185) [[2]](diffhunk://#diff-6ba103541b5645faacbb25a06f72c4f3c6307a318bb427b32840818e8ed2f5f5R99-R105)

### Data Consistency and Vocabulary Standardization

* Changed the canonical cabin class value from `"eco"` to `"economy"` in the professional travel API provider, aligning with the emission type resolver and preventing mismatches that previously caused economy flights to be skipped.
* Updated corresponding unit tests and added a regression test to ensure the provider and resolver remain in sync for cabin class values. [[1]](diffhunk://#diff-1e1cc2f7b7a8dcb925250245bda68d34988f2009440a6afac92cafe751acbfd3R12-R18) [[2]](diffhunk://#diff-1e1cc2f7b7a8dcb925250245bda68d34988f2009440a6afac92cafe751acbfd3L143-R145) [[3]](diffhunk://#diff-1e1cc2f7b7a8dcb925250245bda68d34988f2009440a6afac92cafe751acbfd3L153-R198) [[4]](diffhunk://#diff-1e1cc2f7b7a8dcb925250245bda68d34988f2009440a6afac92cafe751acbfd3L295-R337)

### Test Suite Enhancements

* Improved emission recalculation workflow tests to use a handler mock with the new `prefetch_slice` hook, ensuring the new prefetching logic is exercised and compatible with existing test cases. [[1]](diffhunk://#diff-90045f8c3114e9ab199752fbab5817438579ee5071cd609dd0245a8d214765feR21-R28) [[2]](diffhunk://#diff-90045f8c3114e9ab199752fbab5817438579ee5071cd609dd0245a8d214765feL52-R60) [[3]](diffhunk://#diff-90045f8c3114e9ab199752fbab5817438579ee5071cd609dd0245a8d214765feL108-R116) [[4]](diffhunk://#diff-90045f8c3114e9ab199752fbab5817438579ee5071cd609dd0245a8d214765feL184-R192) [[5]](diffhunk://#diff-90045f8c3114e9ab199752fbab5817438579ee5071cd609dd0245a8d214765feL258-R266) [[6]](diffhunk://#diff-90045f8c3114e9ab199752fbab5817438579ee5071cd609dd0245a8d214765feL369-R377)
## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Closes #
- Related to #1532 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
