### PR TITLE
fix: use of the carbon report stats to get emissions breakdown

### DIFF
--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
@@ -12,7 +12,6 @@ from app.core.logging import get_logger
 from app.models.data_entry_emission import EmissionType, get_all_nodes
 from app.models.factor import Factor
 from app.repositories.carbon_report_repo import CarbonReportRepository
-from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
 from app.repositories.unit_repo import UnitRepository
 from app.services.data_ingestion.factor_update_provider import BaseFactorUpdateProvider
 
@@ -121,18 +120,21 @@ class ResearchFacilitiesAnimalFactorUpdateProvider(BaseFactorUpdateProvider):
                 f"CarbonReport has no database id for unit_id={unit.id}, year={year}"
             )
 
-        # 3. Aggregate all emissions across the entire CarbonReport, broken
+        # 3. Aggregate some emissions across the entire CarbonReport, broken
         #    down by (module_type_id, emission_type_id).  We use all modules so
         #    that process, buildings, equipment, and purchase contributions are
         #    captured regardless of which CarbonReportModule they live in.
-        breakdown = await DataEntryEmissionRepository(session).get_emission_breakdown(
-            carbon_report.id
-        )
-        # breakdown: list of (module_type_id, emission_type_id, kg_co2eq_sum)
+        stats = carbon_report.stats or {}
+        by_emission_type = stats.get("by_emission_type", {})
+        breakdown = [
+            (int(emission_type_id), float(kg_co2eq_sum))
+            for emission_type_id, kg_co2eq_sum in by_emission_type.items()
+        ]
+        # breakdown: list of (emission_type_id, kg_co2eq_sum)
 
         # 4. Aggregate per source using the SOURCE_EMISSION_MAP
         source_totals: Dict[str, float] = {src: 0.0 for src in SOURCE_EMISSION_MAP}
-        for _module_type_id, emission_type_id, kg in breakdown:
+        for emission_type_id, kg in breakdown:
             for source, valid_ids in SOURCE_EMISSION_MAP.items():
                 if emission_type_id in valid_ids:
                     source_totals[source] += kg

--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_common.py
@@ -13,7 +13,6 @@ from app.core.logging import get_logger
 from app.models.data_entry_emission import EmissionType
 from app.models.factor import Factor
 from app.repositories.carbon_report_repo import CarbonReportRepository
-from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
 from app.repositories.unit_repo import UnitRepository
 from app.services.data_ingestion.factor_update_provider import BaseFactorUpdateProvider
 
@@ -98,22 +97,29 @@ class ResearchFacilitiesCommonFactorUpdateProvider(BaseFactorUpdateProvider):
                 f"CarbonReport has no database id for unit_id={unit.id}, year={year}"
             )
 
-        # 3. Aggregate ALL emissions across the entire CarbonReport into one total
-        breakdown = await DataEntryEmissionRepository(session).get_emission_breakdown(
-            carbon_report.id
-        )
+        # 3. Aggregate some emissions across the entire CarbonReport into one total
+        stats = carbon_report.stats or {}
+        by_emission_type = stats.get("by_emission_type", {})
+        breakdown = [
+            (int(emission_type_id), float(kg_co2eq_sum))
+            for emission_type_id, kg_co2eq_sum in by_emission_type.items()
+        ]
         # Filter per emission type: process_emissions, buildings, equipment, purchases
         included_emission_type_ids = [
+            # All process emissions types
             EmissionType.process_emissions.value,
+            # All building emissions types
             EmissionType.buildings.value,
+            # All equipment emissions types
             EmissionType.equipment.value,
+            # All purchases emissions types
             EmissionType.purchases.value,
         ]
-        # breakdown: list of (module_type_id, emission_type_id, kg_co2eq_sum)
+        # breakdown: list of (emission_type_id, kg_co2eq_sum)
         total: float = sum(
             kg
-            for _module_type_id, _emission_type_id, kg in breakdown
-            if _emission_type_id in included_emission_type_ids
+            for emission_type_id, kg in breakdown
+            if emission_type_id in included_emission_type_ids
         )
 
         return {"kg_co2eq_sum": total}

--- a/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
+++ b/backend/tests/unit/services/data_ingestion/test_research_facilities_common_factor_update.py
@@ -35,8 +35,10 @@ def _make_unit(unit_id: int = 1) -> SimpleNamespace:
     return SimpleNamespace(id=unit_id)
 
 
-def _make_carbon_report(report_id: int = 10) -> SimpleNamespace:
-    return SimpleNamespace(id=report_id)
+def _make_carbon_report(
+    report_id: int = 10, stats: dict | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(id=report_id, stats=stats)
 
 
 @pytest.mark.asyncio
@@ -48,10 +50,10 @@ async def test_happy_path_sums_all_valid_emissions():
     session = MagicMock()
 
     breakdown = [
-        (1, EmissionType.process_emissions.value, 500.0),
-        (2, EmissionType.buildings.value, 300.0),
-        (3, EmissionType.equipment.value, 200.0),
-        (4, EmissionType.research_facilities.value, 600.0),  # Not included in sum
+        (EmissionType.process_emissions.value, 500.0),
+        (EmissionType.buildings.value, 300.0),
+        (EmissionType.equipment.value, 200.0),
+        (EmissionType.research_facilities.value, 600.0),  # Not included in sum
     ]
 
     with (
@@ -61,18 +63,14 @@ async def test_happy_path_sums_all_valid_emissions():
         patch(
             "app.services.data_ingestion.computed_providers.research_facilities_common.CarbonReportRepository"
         ) as MockCRRepo,
-        patch(
-            "app.services.data_ingestion.computed_providers.research_facilities_common.DataEntryEmissionRepository"
-        ) as MockDEERepo,
     ):
         MockUnitRepo.return_value.get_by_institutional_id = AsyncMock(
             return_value=_make_unit(1)
         )
         MockCRRepo.return_value.get_by_unit_and_year = AsyncMock(
-            return_value=_make_carbon_report(10)
-        )
-        MockDEERepo.return_value.get_emission_breakdown = AsyncMock(
-            return_value=breakdown
+            return_value=_make_carbon_report(
+                10, {"by_emission_type": {str(id): amount for id, amount in breakdown}}
+            )
         )
 
         result = await provider.compute_factor_values(factor, 2025, session)
@@ -134,9 +132,6 @@ async def test_zero_emissions_returns_zero_sum():
         patch(
             "app.services.data_ingestion.computed_providers.research_facilities_common.CarbonReportRepository"
         ) as MockCRRepo,
-        patch(
-            "app.services.data_ingestion.computed_providers.research_facilities_common.DataEntryEmissionRepository"
-        ) as MockDEERepo,
     ):
         MockUnitRepo.return_value.get_by_institutional_id = AsyncMock(
             return_value=_make_unit(1)
@@ -144,7 +139,6 @@ async def test_zero_emissions_returns_zero_sum():
         MockCRRepo.return_value.get_by_unit_and_year = AsyncMock(
             return_value=_make_carbon_report(10)
         )
-        MockDEERepo.return_value.get_emission_breakdown = AsyncMock(return_value=[])
 
         result = await provider.compute_factor_values(factor, 2025, session)
 


### PR DESCRIPTION
## What does this change?

* use emissions breakdown from carbon report stats instead of making a query.

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #1414

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
