### PR TITLE
feat 504: add top-level emission category roots for results report

### DIFF
--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -28,6 +28,22 @@ from app.utils.it_breakdown import (
 
 logger = get_logger(__name__)
 
+# Top-level emission category roots exposed in the results report CSV/JSON, in
+
+RESULTS_REPORT_CATEGORY_ROOTS: list[EmissionType] = [
+    EmissionType.process_emissions,
+    EmissionType.buildings,
+    EmissionType.equipment,
+    EmissionType.external,
+    EmissionType.professional_travel,
+    EmissionType.purchases,
+    EmissionType.research_facilities,
+    EmissionType.commuting,
+    EmissionType.food,
+    EmissionType.waste,
+    EmissionType.buildings__construction_and_renovation,
+]
+
 
 class CarbonReportModuleRepository:
     """Repository for CarbonReportModule database operations."""
@@ -1326,17 +1342,11 @@ class CarbonReportModuleRepository:
             for row in partition:
                 stats = row.stats if isinstance(row.stats, dict) else {}
                 by_emission_type = stats.get("by_emission_type") or {}
-                # Convert emission type keys to names if possible
-                converted_by_emission_type: dict[str, Any] = {}
-                for k, v in by_emission_type.items():
-                    k_str = str(k)
-                    try:
-                        emission_type = EmissionType(int(k_str))
-                        key = emission_type.name.replace("__", "_")
-                    except (ValueError, TypeError):
-                        key = k_str
-                    converted_by_emission_type[key] = v
-                by_emission_type = converted_by_emission_type
+                # Keep only the top-level category scope totals
+                category_totals = {
+                    root.name: by_emission_type.get(str(root.value), 0)
+                    for root in RESULTS_REPORT_CATEGORY_ROOTS
+                }
                 report.append(
                     {
                         "year": row.year,
@@ -1346,8 +1356,7 @@ class CarbonReportModuleRepository:
                         "scope2": stats.get("scope2"),
                         "scope3": stats.get("scope3"),
                         "total": stats.get("total"),
-                        # Flatten by_emission_type into top-level keys
-                        **by_emission_type,
+                        **category_totals,
                     }
                 )
 

--- a/backend/tests/unit/repositories/test_carbon_report_module_repo.py
+++ b/backend/tests/unit/repositories/test_carbon_report_module_repo.py
@@ -452,7 +452,9 @@ class TestGetResultsReport:
                 "scope2": 200,
                 "scope3": 300,
                 "total": 600,
-                "by_emission_type": {"10000": 50, "50000": 150},
+                # Includes a category root rollup (10000), a sub-type leaf
+                # (50100, professional_travel__train) and its root (50000).
+                "by_emission_type": {"10000": 50, "50000": 150, "50100": 150},
             },
         )
         repo = CarbonReportModuleRepository(db_session)
@@ -461,9 +463,33 @@ class TestGetResultsReport:
         row = results[0]
         assert row["scope1"] == 100
         assert row["total"] == 600
-        # Emission types are flattened with underscored names
-        assert "food" in row
-        assert "professional_travel" in row
+        # Only the top-level category scope totals are exposed, in module order.
+        assert list(row.keys()) == [
+            "year",
+            "unit_institutional_id",
+            "unit_path_name",
+            "scope1",
+            "scope2",
+            "scope3",
+            "total",
+            "process_emissions",
+            "buildings",
+            "equipment",
+            "external",
+            "professional_travel",
+            "purchases",
+            "research_facilities",
+            "commuting",
+            "food",
+            "waste",
+            "buildings__construction_and_renovation",
+        ]
+        assert row["food"] == 50
+        assert row["professional_travel"] == 150
+        # Categories without data default to 0; sub-type leaves are dropped.
+        assert row["buildings"] == 0
+        assert row["buildings__construction_and_renovation"] == 0
+        assert "professional_travel__train" not in row
 
     async def test_empty_stats(self, db_session, make_unit, make_carbon_report):
         unit = await make_unit(db_session, name="LAB-E")


### PR DESCRIPTION
**## What does this change?
Restricts the results report export to only top-level emission category roots, in a fixed module order, instead of flattening every emission type leaf into its own column.

- `carbon_report_module_repo.py`: adds `RESULTS_REPORT_CATEGORY_ROOTS`, an ordered list of the top-level `EmissionType` roots matching the app sidebar module order (process emissions, buildings + construction/renovation, equipment, external cloud & AI, professional travel, purchases, research facilities, commuting, food, waste)
- `get_results_report` (or equivalent) no longer converts every `by_emission_type` key into a flattened column; instead it builds `category_totals` by looking up each root's value (defaulting to 0 when absent) and merges only those into each report row
- Sub-type leaves (e.g. `professional_travel__train`) are intentionally dropped from the export — each category now yields exactly one scope-total column

## Why is this needed?
The results report previously exposed one column per emission type leaf, producing inconsistent and excessively wide CSV/JSON exports where columns appeared or disappeared depending on which sub-types had data. Restricting to top-level category roots in a fixed order gives a stable, predictable schema matching the app's own module breakdown.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced
