### PR TITLE
fix(1530): module status icons show on first navigation

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -72,7 +72,7 @@ class BackofficeFilters(NamedTuple):
 
     path_affiliation: Optional[List[str]]
     path_lvl4: Optional[List[str]]
-    completion_status: Optional[ModuleStatus]
+    overall_status: Optional[ModuleStatus]
     search: Optional[str]
     modules: Optional[List[str]]
     years: Optional[List[int]]
@@ -93,10 +93,10 @@ def get_backoffice_filters(
             "Returns exact matches only (not descendants)."
         ),
     ),
-    completion_status: Optional[ModuleStatus] = Query(
+    overall_status: Optional[ModuleStatus] = Query(
         None,
         description=(
-            "Filter by completion status: NOT_STARTED (0), IN_PROGRESS (1), "
+            "Filter by report overall status: NOT_STARTED (0), IN_PROGRESS (1), "
             "VALIDATED (2)"
         ),
     ),
@@ -119,7 +119,7 @@ def get_backoffice_filters(
     return BackofficeFilters(
         path_affiliation=path_affiliation,
         path_lvl4=path_lvl4,
-        completion_status=completion_status,
+        overall_status=overall_status,
         search=search,
         modules=modules,
         years=years,
@@ -273,7 +273,7 @@ async def list_backoffice_units(
         path_lvl4=filters.path_lvl4,
         is_global=is_global,
         scope_cfs=affiliations,
-        completion_status=filters.completion_status,
+        overall_status=filters.overall_status,
         search=filters.search,
         modules=filters.modules,
         years=filters.years,
@@ -287,12 +287,12 @@ async def list_backoffice_units(
     for item in result.get("data", []):
         if isinstance(item, dict):
             completion = item.get("completion_progress", DEFAULT_COMPLETION_PROGRESS)
-            completion_status = ModuleStatus.NOT_STARTED
+            overall_status = ModuleStatus.NOT_STARTED
             left, right = completion.split("/")
             if left == right and left != "0":
-                completion_status = ModuleStatus.VALIDATED
+                overall_status = ModuleStatus.VALIDATED
             elif left != "0":
-                completion_status = ModuleStatus.IN_PROGRESS
+                overall_status = ModuleStatus.IN_PROGRESS
             unit_reporting_data.append(
                 UnitReportingData(
                     id=item.get("id", -1),
@@ -307,7 +307,7 @@ async def list_backoffice_units(
                     ),
                     total_fte=item.get("total_fte"),
                     view_url=item.get("view_url"),
-                    completion=completion_status,
+                    completion=overall_status,
                     completion_progress=item.get("completion_progress"),
                 )
             )
@@ -455,7 +455,7 @@ async def report_usage(
                 path_lvl4=filters.path_lvl4,
                 is_global=is_global,
                 scope_cfs=affiliations,
-                completion_status=filters.completion_status,
+                overall_status=filters.overall_status,
                 search=filters.search,
                 modules=filters.modules,
                 years=filters.years,
@@ -532,7 +532,7 @@ async def report_detailed(
                         path_lvl4=filters.path_lvl4,
                         is_global=is_global,
                         scope_cfs=affiliations,
-                        completion_status=filters.completion_status,
+                        overall_status=filters.overall_status,
                         search=filters.search,
                         modules=filters.modules,
                         years=filters.years,
@@ -613,7 +613,7 @@ async def report_results(
                 path_lvl4=filters.path_lvl4,
                 is_global=is_global,
                 scope_cfs=affiliations,
-                completion_status=filters.completion_status,
+                overall_status=filters.overall_status,
                 search=filters.search,
                 years=filters.years,
             )

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -380,15 +380,13 @@ class CarbonReportModuleRepository:
     def _apply_report_filters(
         stmt: Any,
         hierarchy_unit_ids: Optional[set[int]],
-        completion_status: Optional["ModuleStatus"],
+        overall_status: Optional["ModuleStatus"],
     ) -> Any:
         """Apply hierarchy and completion-status filters to a statement."""
         if hierarchy_unit_ids is not None:
             stmt = stmt.where(col(Unit.id).in_(hierarchy_unit_ids))
-        if completion_status is not None:
-            stmt = stmt.where(
-                col(CarbonReport.overall_status) == int(completion_status)
-            )
+        if overall_status is not None:
+            stmt = stmt.where(col(CarbonReport.overall_status) == int(overall_status))
         return stmt
 
     @staticmethod
@@ -417,7 +415,7 @@ class CarbonReportModuleRepository:
         path_lvl4: Optional[List[str]] = None,
         is_global: bool = True,
         scope_cfs: Optional[set[str]] = None,
-        completion_status: Optional[ModuleStatus] = None,
+        overall_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
         years: Optional[List[int]] = None,
@@ -538,11 +536,11 @@ class CarbonReportModuleRepository:
                 col(Unit.id).in_(hierarchy_unit_ids)
             )
 
-        # Filtered count (adds optional completion_status filter for the table).
+        # Filtered count (adds optional overall_status filter for the table).
         count_statement = base_count_stmt
-        if completion_status is not None:
+        if overall_status is not None:
             count_statement = count_statement.where(
-                col(CarbonReport.overall_status) == int(completion_status)
+                col(CarbonReport.overall_status) == int(overall_status)
             )
 
         total = (await self.session.exec(count_statement)).one()
@@ -627,7 +625,7 @@ class CarbonReportModuleRepository:
             )
 
         units_stmt = self._apply_report_filters(
-            units_stmt, hierarchy_unit_ids, completion_status
+            units_stmt, hierarchy_unit_ids, overall_status
         )
 
         filtered_report_ids_stmt = self._apply_report_filters(
@@ -635,7 +633,7 @@ class CarbonReportModuleRepository:
             .join(Unit, col(CarbonReport.unit_id) == col(Unit.id))
             .where(col(CarbonReport.year).in_(years)),
             hierarchy_unit_ids,
-            completion_status,
+            overall_status,
         )
 
         # Use a subquery instead of materializing the full list of report IDs
@@ -899,7 +897,7 @@ class CarbonReportModuleRepository:
         path_lvl4: Optional[List[str]] = None,
         is_global: bool = True,
         scope_cfs: Optional[set[str]] = None,
-        completion_status: Optional[ModuleStatus] = None,
+        overall_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
         years: Optional[List[int]] = None,
@@ -911,7 +909,7 @@ class CarbonReportModuleRepository:
         Args:
             path_affiliation: Optional list of affiliation filters (unit names or IDs)
             path_lvl4: Optional list of hierarchy level 4 filters (unit names or IDs)
-            completion_status: Optional filter for report-level completion status.
+            overall_status: Optional filter for report-level completion status.
             search: Optional search term to filter results.
             modules: Optional filter for specific module types (ModuleTypeEnum names)
               and statuses (e.g., ["headcount:2", "professional_travel:1"])
@@ -952,9 +950,9 @@ class CarbonReportModuleRepository:
         )
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
-        if completion_status is not None:
+        if overall_status is not None:
             statement = statement.where(
-                col(CarbonReport.overall_status) == int(completion_status)
+                col(CarbonReport.overall_status) == int(overall_status)
             )
         if search:
             search_term = f"%{search.strip().lower()}%"
@@ -1030,7 +1028,7 @@ class CarbonReportModuleRepository:
         path_lvl4: Optional[List[str]] = None,
         is_global: bool = True,
         scope_cfs: Optional[set[str]] = None,
-        completion_status: Optional[ModuleStatus] = None,
+        overall_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
         years: Optional[List[int]] = None,
@@ -1043,7 +1041,7 @@ class CarbonReportModuleRepository:
             data_entry_type: The type of data entry to filter by
             path_affiliation: Optional list of affiliation filters (unit names or IDs)
             path_lvl4: Optional list of hierarchy level 4 filters (unit names or IDs)
-            completion_status: Optional filter for report-level completion status.
+            overall_status: Optional filter for report-level completion status.
             search: Optional search term to filter results.
             modules: Optional filter for specific module types (ModuleTypeEnum names)
               and statuses (e.g., ["headcount:2", "professional_travel:1"])
@@ -1169,9 +1167,9 @@ class CarbonReportModuleRepository:
         # Additional filters based on provided parameters
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
-        if completion_status is not None:
+        if overall_status is not None:
             statement = statement.where(
-                col(CarbonReport.overall_status) == int(completion_status)
+                col(CarbonReport.overall_status) == int(overall_status)
             )
         if search:
             search_term = f"%{search.strip().lower()}%"
@@ -1265,7 +1263,7 @@ class CarbonReportModuleRepository:
         path_lvl4: Optional[List[str]] = None,
         is_global: bool = True,
         scope_cfs: Optional[set[str]] = None,
-        completion_status: Optional[ModuleStatus] = None,
+        overall_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         years: Optional[List[int]] = None,
     ) -> list[dict]:
@@ -1276,7 +1274,7 @@ class CarbonReportModuleRepository:
         Args:
             path_affiliation: Optional list of affiliation filters (unit names or IDs)
             path_lvl4: Optional list of hierarchy level 4 filters (unit names or IDs)
-            completion_status: Optional filter for report-level completion status.
+            overall_status: Optional filter for report-level completion status.
             search: Optional search term to filter results.
             years: Optional filter for specific years (e.g., [2024, 2025])
         Returns:
@@ -1308,9 +1306,9 @@ class CarbonReportModuleRepository:
         )
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
-        if completion_status is not None:
+        if overall_status is not None:
             statement = statement.where(
-                col(CarbonReport.overall_status) == int(completion_status)
+                col(CarbonReport.overall_status) == int(overall_status)
             )
         if search:
             search_term = f"%{search.strip().lower()}%"

--- a/backend/app/repositories/carbon_report_repo.py
+++ b/backend/app/repositories/carbon_report_repo.py
@@ -148,7 +148,7 @@ class CarbonReportRepository:
         path_lvl2: Optional[List[str]] = None,
         path_lvl3: Optional[List[str]] = None,
         path_lvl4: Optional[List[str]] = None,
-        completion_status: Optional[ModuleStatus] = None,
+        overall_status: Optional[ModuleStatus] = None,
         search: Optional[str] = None,
         modules: Optional[List[str]] = None,
         years: Optional[List[int]] = None,

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -276,7 +276,9 @@ class CarbonReportModuleService:
         module) with: 1 module load, 1 grouped emissions query, 1 grouped
         entry-count query, then one batched report rollup
         (``recompute_report_stats_many``) over the distinct parent
-        reports.  Returns the number of modules refreshed.
+        reports.  Each refreshed module is also marked IN_PROGRESS (data
+        changed → prior validation is stale).  Returns the number of
+        modules refreshed.
         """
         if not carbon_report_module_ids:
             return 0
@@ -333,6 +335,10 @@ class CarbonReportModuleService:
                 entry_count=counts.get(module.id, 0),
             )
             module.last_updated = now_utc
+            # Recomputing means the underlying data changed, so the module is
+            # back in progress: any prior validation is now stale. The report
+            # rollup below re-derives overall_status from these statuses.
+            module.status = ModuleStatus.IN_PROGRESS
             self.session.add(module)
             report_ids.add(module.carbon_report_id)
             refreshed += 1
@@ -347,66 +353,15 @@ class CarbonReportModuleService:
         return refreshed
 
     async def recompute_stats(self, carbon_report_module_id: int) -> None:
-        """Recompute and persist the stats JSON for a module."""
-        module = await self.repo.get(carbon_report_module_id)
-        if module is None:
-            logger.warning(
-                f"recompute_stats: module {sanitize(carbon_report_module_id)} "
-                "not found, skipping"
-            )
-            return
+        """Recompute and persist the stats JSON for a single module.
 
-        emission_roots = MODULE_TYPE_TO_EMISSION_ROOTS.get(
-            ModuleTypeEnum(module.module_type_id)
-        )
-        if not emission_roots:
-            # Module type has no emission mapping (e.g. global_energy)
-            return
-
-        emission_repo = DataEntryEmissionRepository(self.session)
-        leaf_emissions, additional_values = await emission_repo.get_stats_pair(
-            carbon_report_module_id=carbon_report_module_id,
-            aggregate_by="emission_type_id",
-            primary_field="kg_co2eq",
-            secondary_field="additional_value",
-        )
-
-        # entry_count: count data entries for this module
-        from sqlmodel import func, select
-
-        from app.models.data_entry import DataEntry
-
-        result = await self.session.execute(
-            select(func.count()).where(
-                DataEntry.carbon_report_module_id == carbon_report_module_id
-            )
-        )
-        entry_count = result.scalar_one()
-
-        stats = compute_module_stats(
-            leaf_emissions=leaf_emissions,
-            additional_values=additional_values,
-            emission_roots=emission_roots,
-            entry_count=entry_count,
-        )
-
-        await self.repo.update_stats(carbon_report_module_id, stats)
-
-        now_utc = int(datetime.now(timezone.utc).timestamp())
-        module.last_updated = now_utc
-        self.session.add(module)
-
-        logger.info(
-            f"Stats recomputed for module {sanitize(carbon_report_module_id)}: "
-            f"total={stats['total']:.2f} kgCO2eq, "
-            f"{len(stats['by_emission_type'])} emission types, "
-            f"last_updated={now_utc}"
-        )
-
-        from app.services.carbon_report_service import CarbonReportService
-
-        report_service = CarbonReportService(self.session)
-        await report_service.recompute_report_stats(module.carbon_report_id)
+        Thin wrapper over the set-based :meth:`recompute_stats_many` so the
+        single- and many-module paths share one implementation: stats math,
+        the IN_PROGRESS status bump, and the report rollup. A missing or
+        unmapped module is skipped there (no stats written), matching the
+        prior early-return behaviour.
+        """
+        await self.recompute_stats_many([carbon_report_module_id])
 
     async def delete_all_modules_for_report(self, carbon_report_id: int) -> int:
         """Delete all modules for a carbon report. Returns count deleted."""

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -276,46 +276,15 @@ class CarbonReportService:
         await self.module_service.ensure_modules_for_reports(carbon_reports)
 
     async def recompute_report_stats(self, carbon_report_id: int) -> None:
+        """Recompute and persist the aggregated stats JSON for a carbon report.
+
+        Aggregates child ``CarbonReportModule`` stats (scope sums, merged
+        ``by_emission_type``, entry counts) and refreshes the report's
+        ``completion_progress`` / ``overall_status``.  Thin wrapper over the
+        set-based :meth:`recompute_report_stats_many` so the single- and
+        many-report paths share one implementation.
         """
-        Recompute and persist the aggregated stats JSON for a carbon report.
-
-        Aggregates stats from all child CarbonReportModule records:
-        - Sum scope1, scope2, scope3, total across all modules
-        - Merge by_emission_type dicts (grouping by emission_type_id)
-        - Sum entry_count across all modules
-        - Update computed_at timestamp
-
-        Args:
-            carbon_report_id: The carbon report ID to recompute stats for
-        """
-        modules = await self.module_service.list_modules(carbon_report_id)
-
-        if not modules:
-            logger.warning(
-                f"recompute_report_stats: no modules found for report "
-                f"{sanitize(carbon_report_id)}, skipping"
-            )
-            return
-
-        stats = _build_report_stats(modules)
-
-        report = await self.repo.get(carbon_report_id)
-        report_id_sanitized = sanitize(carbon_report_id)
-        if report:
-            report.stats = stats
-            report.last_updated = int(datetime.now(timezone.utc).timestamp())
-            await self.session.flush()
-            await self.recompute_report_progress(carbon_report_id)
-            logger.info(
-                f"Report stats recomputed for carbon_report_id={report_id_sanitized}: "
-                f"total={stats['total']:.2f} kgCO2eq, "
-                f"{len(stats['by_emission_type'])} emission types, "
-                f"{stats['entry_count']} entries"
-            )
-        else:
-            logger.warning(
-                f"recompute_report_stats: report {report_id_sanitized} not found"
-            )
+        await self.recompute_report_stats_many([carbon_report_id])
 
     async def recompute_report_stats_many(self, carbon_report_ids: list[int]) -> None:
         """Batched report rollup for the aggregation job.

--- a/backend/tests/integration/services/data_ingestion/test_stats_json_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_stats_json_pg.py
@@ -68,6 +68,7 @@ from app.models.module_type import (
     ModuleTypeEnum,
 )
 from app.services.carbon_report_module_service import CarbonReportModuleService
+from app.services.carbon_report_service import CarbonReportService
 from app.utils.it_breakdown import IT_EMISSION_TYPES
 
 from .conftest import seeded_year_with_units
@@ -672,16 +673,18 @@ async def test_report_stats_rollup_sums_modules_and_adds_it_total(seeded) -> Non
         )
 
     # Second inspection: validate process_emissions (largest total at
-    # 100.0); rollup must surface it as the highest category.
+    # 100.0); the report rollup must surface it as the highest category.
+    # recompute_stats now resets a module to IN_PROGRESS (data changed →
+    # validation is stale), so validate first, then drive the report-level
+    # rollup directly to assert highest-category derivation from a validated
+    # module.
     async with Sf() as s:
         fresh_proc = await s.get(CarbonReportModule, proc_crm.id)
         assert fresh_proc is not None
         fresh_proc.status = ModuleStatus.VALIDATED
         s.add(fresh_proc)
-        await s.commit()
-
-        svc = CarbonReportModuleService(s)
-        await svc.recompute_stats(proc_crm.id)
+        await s.flush()
+        await CarbonReportService(s).recompute_report_stats(report.id)
         await s.commit()
 
     async with Sf() as s:
@@ -697,3 +700,89 @@ async def test_report_stats_rollup_sums_modules_and_adds_it_total(seeded) -> Non
             f"{int(ModuleTypeEnum.process_emissions)}; "
             f"got {stats['highest_category_module_id']!r}"
         )
+
+
+# ===========================================================================
+# 4. Status bump — recompute marks a module IN_PROGRESS
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_recompute_stats_marks_module_in_progress(seeded) -> None:
+    """A single recompute flips the module to IN_PROGRESS, even from a
+    previously VALIDATED state — recomputed numbers make any prior
+    validation stale (the bug: modules with data still read NOT_STARTED).
+    """
+    seed, Sf = seeded
+    unit_id = seed.units[0].id
+    crm = seed.modules_by_unit_and_type[
+        (unit_id, int(ModuleTypeEnum.process_emissions))
+    ]
+
+    async with Sf() as s:
+        await _seed_emission(
+            s,
+            crm_id=crm.id,
+            data_entry_type=DataEntryTypeEnum.process_emissions,
+            emission_type=EmissionType.process_emissions__co2,
+            kg_co2eq=100.0,
+        )
+        # Pre-validate to prove recompute downgrades a stale validation.
+        fresh = await s.get(CarbonReportModule, crm.id)
+        assert fresh is not None
+        fresh.status = ModuleStatus.VALIDATED
+        s.add(fresh)
+        await s.commit()
+
+    async with Sf() as s:
+        await CarbonReportModuleService(s).recompute_stats(crm.id)
+        await s.commit()
+
+    async with Sf() as s:
+        fresh = await s.get(CarbonReportModule, crm.id)
+        assert fresh is not None
+        assert fresh.status == ModuleStatus.IN_PROGRESS, (
+            f"recompute_stats must mark the module IN_PROGRESS; "
+            f"got {ModuleStatus(fresh.status).name}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_recompute_stats_many_marks_all_modules_in_progress(seeded) -> None:
+    """The batch path bumps every refreshed module to IN_PROGRESS in one call."""
+    seed, Sf = seeded
+    unit_id = seed.units[0].id
+    eq_crm = seed.modules_by_unit_and_type[(unit_id, int(ModuleTypeEnum.equipment))]
+    proc_crm = seed.modules_by_unit_and_type[
+        (unit_id, int(ModuleTypeEnum.process_emissions))
+    ]
+
+    async with Sf() as s:
+        await _seed_emission(
+            s,
+            crm_id=eq_crm.id,
+            data_entry_type=DataEntryTypeEnum.it,
+            emission_type=EmissionType.equipment__it,
+            kg_co2eq=60.0,
+        )
+        await _seed_emission(
+            s,
+            crm_id=proc_crm.id,
+            data_entry_type=DataEntryTypeEnum.process_emissions,
+            emission_type=EmissionType.process_emissions__co2,
+            kg_co2eq=100.0,
+        )
+        await s.commit()
+
+    async with Sf() as s:
+        refreshed = await CarbonReportModuleService(s).recompute_stats_many(
+            [eq_crm.id, proc_crm.id]
+        )
+        await s.commit()
+        assert refreshed == 2
+
+    async with Sf() as s:
+        for crm_id in (eq_crm.id, proc_crm.id):
+            fresh = await s.get(CarbonReportModule, crm_id)
+            assert fresh is not None
+            assert fresh.status == ModuleStatus.IN_PROGRESS

--- a/frontend/src/components/organisms/layout/Co2ModuleSidebar.vue
+++ b/frontend/src/components/organisms/layout/Co2ModuleSidebar.vue
@@ -5,7 +5,7 @@ import { useAuthStore } from 'src/stores/auth';
 import { useTimelineStore, useModuleStore } from 'src/stores/modules';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { PermissionAction } from 'src/stores/auth';
-import { MODULE_STATES } from 'src/constant/moduleStates';
+import { MODULE_STATUS_DISPLAY } from 'src/constant/moduleStates';
 import { timelineItems } from 'src/constant/timelineItems';
 import { MODULES, type Module } from 'src/constant/modules';
 import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
@@ -40,27 +40,26 @@ const currentTotalResult = computed(() => {
   return moduleStore.state.data?.totals?.total_tonnes_co2eq;
 });
 
-const visibleItems = computed(() =>
-  timelineItems.filter(
-    (item) =>
-      yearConfigStore.isModuleVisible(item.link as Module) &&
-      authStore.canUserAccessModule(item.link as Module),
-  ),
+// Decorate each visible module with its backend-driven status display so the
+// template reads precomputed values instead of re-invoking helpers per render.
+// An empty `statusColor` means "not started" — no dot/icon is shown.
+const sidebarItems = computed(() =>
+  timelineItems
+    .filter(
+      (item) =>
+        yearConfigStore.isModuleVisible(item.link as Module) &&
+        authStore.canUserAccessModule(item.link as Module),
+    )
+    .map((item) => {
+      const display =
+        MODULE_STATUS_DISPLAY[timelineStore.itemStates[item.link as Module]];
+      return {
+        link: item.link,
+        statusColor: display.color,
+        statusIcon: display.icon,
+      };
+    }),
 );
-
-function getStatusColor(moduleLink: string): string {
-  const state = timelineStore.itemStates[moduleLink as Module];
-  if (state === MODULE_STATES.Validated) return 'positive';
-  if (state === MODULE_STATES.InProgress) return 'warning';
-  return '';
-}
-
-function getStatusIcon(moduleLink: string): string {
-  const state = timelineStore.itemStates[moduleLink as Module];
-  if (state === MODULE_STATES.Validated) return 'o_check_circle';
-  if (state === MODULE_STATES.InProgress) return 'o_pending';
-  return '';
-}
 
 function hasPermission(moduleLink: string): boolean {
   return authStore.hasUserModulePermission(
@@ -106,7 +105,7 @@ function navigateToResults() {
     />
     <q-list class="sidebar-items">
       <q-item
-        v-for="item in visibleItems"
+        v-for="item in sidebarItems"
         :key="item.link"
         class="sidebar-item"
         :class="{ 'sidebar-item--selected': isModuleSelected(item.link) }"
@@ -118,9 +117,9 @@ function navigateToResults() {
           <ModuleIconBox :name="item.link" size="md" />
           <!-- Collapsed: small dot at bottom-right of icon box -->
           <span
-            v-if="getStatusColor(item.link) && collapsed"
+            v-if="item.statusColor && collapsed"
             class="status-dot"
-            :class="`bg-${getStatusColor(item.link)}`"
+            :class="`bg-${item.statusColor}`"
           />
         </span>
         <q-item-label
@@ -130,9 +129,9 @@ function navigateToResults() {
         >
         <!-- Expanded: status icon pushed to far right -->
         <q-icon
-          v-if="getStatusColor(item.link) && !collapsed"
-          :name="getStatusIcon(item.link)"
-          :color="getStatusColor(item.link)"
+          v-if="item.statusColor && !collapsed"
+          :name="item.statusIcon"
+          :color="item.statusColor"
           class="status-icon"
           size="xs"
         />

--- a/frontend/src/components/organisms/module/ModuleTotalResult.vue
+++ b/frontend/src/components/organisms/module/ModuleTotalResult.vue
@@ -42,7 +42,11 @@
       <!-- header: status badge -->
       <div class="mtr-sidebar__header">
         <span class="mtr-sidebar__badge" :class="badgeClass">
-          <q-icon v-if="statusDisplay.icon" :name="statusDisplay.icon" size="xs" />
+          <q-icon
+            v-if="statusDisplay.icon"
+            :name="statusDisplay.icon"
+            size="xs"
+          />
           {{ $t(statusDisplay.label) }}
         </span>
       </div>
@@ -144,7 +148,10 @@ import { useTimelineStore } from 'src/stores/modules';
 import { useAuthStore } from 'src/stores/auth';
 import { Module } from 'src/constant/modules';
 import { ModuleConfig } from 'src/constant/moduleConfig';
-import { MODULE_STATES, MODULE_STATUS_DISPLAY } from 'src/constant/moduleStates';
+import {
+  MODULE_STATES,
+  MODULE_STATUS_DISPLAY,
+} from 'src/constant/moduleStates';
 import { getModuleIconColors } from 'src/composables/useModuleIconColors';
 
 const props = defineProps<{
@@ -178,8 +185,10 @@ const toggleIcon = computed(() =>
 const statusDisplay = computed(() => MODULE_STATUS_DISPLAY[moduleState.value]);
 
 const badgeClass = computed(() => ({
-  'mtr-sidebar__badge--validated': moduleState.value === MODULE_STATES.Validated,
-  'mtr-sidebar__badge--progress': moduleState.value === MODULE_STATES.InProgress,
+  'mtr-sidebar__badge--validated':
+    moduleState.value === MODULE_STATES.Validated,
+  'mtr-sidebar__badge--progress':
+    moduleState.value === MODULE_STATES.InProgress,
   'mtr-sidebar__badge--not-started':
     moduleState.value === MODULE_STATES.Default,
 }));

--- a/frontend/src/components/organisms/module/ModuleTotalResult.vue
+++ b/frontend/src/components/organisms/module/ModuleTotalResult.vue
@@ -41,15 +41,9 @@
     <div class="mtr-sidebar__body">
       <!-- header: status badge -->
       <div class="mtr-sidebar__header">
-        <span
-          class="mtr-sidebar__badge"
-          :class="{
-            'mtr-sidebar__badge--validated': isValidated,
-            'mtr-sidebar__badge--progress': !isValidated,
-          }"
-        >
-          <q-icon :name="statusIcon" size="xs" />
-          {{ statusLabel }}
+        <span class="mtr-sidebar__badge" :class="badgeClass">
+          <q-icon v-if="statusDisplay.icon" :name="statusDisplay.icon" size="xs" />
+          {{ $t(statusDisplay.label) }}
         </span>
       </div>
 
@@ -150,7 +144,7 @@ import { useTimelineStore } from 'src/stores/modules';
 import { useAuthStore } from 'src/stores/auth';
 import { Module } from 'src/constant/modules';
 import { ModuleConfig } from 'src/constant/moduleConfig';
-import { MODULE_STATES } from 'src/constant/moduleStates';
+import { MODULE_STATES, MODULE_STATUS_DISPLAY } from 'src/constant/moduleStates';
 import { getModuleIconColors } from 'src/composables/useModuleIconColors';
 
 const props = defineProps<{
@@ -169,23 +163,26 @@ const moduleColors = computed(() => getModuleIconColors(props.type));
 // standard (own-scope) users, who never hold the `module.status` permission.
 const canValidate = computed(() => authStore.hasUserCanValidateModuleStatus());
 
+const moduleState = computed(() => timelineStore.itemStates[props.type]);
+
 const isValidated = computed(
-  () => timelineStore.itemStates[props.type] === MODULE_STATES.Validated,
+  () => moduleState.value === MODULE_STATES.Validated,
 );
 
 const toggleIcon = computed(() =>
   isValidated.value ? 'o_remove_circle' : 'o_check_circle',
 );
 
-const statusIcon = computed(() =>
-  isValidated.value ? 'o_check_circle' : 'o_pending',
-);
+// Three-state badge: validated / in progress / not started. Not started has no
+// icon, so the template guards on `statusDisplay.icon` before rendering one.
+const statusDisplay = computed(() => MODULE_STATUS_DISPLAY[moduleState.value]);
 
-const statusLabel = computed(() =>
-  isValidated.value
-    ? t('module_status_validated')
-    : t('module_status_in_progress'),
-);
+const badgeClass = computed(() => ({
+  'mtr-sidebar__badge--validated': moduleState.value === MODULE_STATES.Validated,
+  'mtr-sidebar__badge--progress': moduleState.value === MODULE_STATES.InProgress,
+  'mtr-sidebar__badge--not-started':
+    moduleState.value === MODULE_STATES.Default,
+}));
 
 const validationShortActionLabel = computed(() => {
   const action = isValidated.value
@@ -329,6 +326,12 @@ function toggleValidation() {
         tokens.$mtr-sidebar-badge-bg-opacity-progress
       );
       color: var(--q-warning);
+    }
+
+    // Not started: neutral, no icon — distinct from the in-progress badge.
+    &--not-started {
+      background-color: rgba(0, 0, 0, 0.06);
+      color: tokens.$mtr-color-muted;
     }
   }
 

--- a/frontend/src/constant/moduleStates.ts
+++ b/frontend/src/constant/moduleStates.ts
@@ -76,3 +76,35 @@ export const MODULE_STATUS_BADGES: Record<ModuleState, ModuleCardBadge | null> =
 export function getBadgeForStatus(status: ModuleState): ModuleCardBadge | null {
   return MODULE_STATUS_BADGES[status] ?? null;
 }
+
+/**
+ * Visual representation of a module's validation status (icon, color, label),
+ * derived from the backend ModuleStatus source of truth. Shared by the module
+ * sidebar and total-result badge so the three states render consistently.
+ */
+export interface ModuleStatusDisplay {
+  /** Quasar color name for the indicator; empty = no indicator (not started). */
+  color: string;
+  /** Quasar icon name; empty = no icon (not started). */
+  icon: string;
+  /** i18n key for the status label. */
+  label: string;
+}
+
+export const MODULE_STATUS_DISPLAY: Record<ModuleState, ModuleStatusDisplay> = {
+  [MODULE_STATES.Default]: {
+    color: '',
+    icon: '',
+    label: 'module_status_not_started',
+  },
+  [MODULE_STATES.InProgress]: {
+    color: 'warning',
+    icon: 'o_pending',
+    label: 'module_status_in_progress',
+  },
+  [MODULE_STATES.Validated]: {
+    color: 'positive',
+    icon: 'o_check_circle',
+    label: 'module_status_validated',
+  },
+};

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -123,6 +123,10 @@ export default {
     en: 'In progress',
     fr: 'En cours',
   },
+  module_status_not_started: {
+    en: 'Not started',
+    fr: 'Non commencé',
+  },
   common_filter_all: {
     en: 'All',
     fr: 'Tous',

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -607,7 +607,9 @@ export const useModuleStore = defineStore('modules', () => {
   async function refreshModuleStates() {
     const timelineStore = useTimelineStore();
     if (timelineStore.currentCarbonReportId !== null) {
-      await timelineStore.fetchModuleStates(timelineStore.currentCarbonReportId);
+      await timelineStore.fetchModuleStates(
+        timelineStore.currentCarbonReportId,
+      );
     }
   }
 

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -601,6 +601,16 @@ export const useModuleStore = defineStore('modules', () => {
     value: string;
   }
   type FieldValue = string | number | boolean | null | Option;
+  // A create/patch/delete recomputes module stats on the backend, which flips
+  // the module to IN_PROGRESS. Refresh the timeline statuses so the sidebar
+  // status icon updates live instead of staying stale until the next navigation.
+  async function refreshModuleStates() {
+    const timelineStore = useTimelineStore();
+    if (timelineStore.currentCarbonReportId !== null) {
+      await timelineStore.fetchModuleStates(timelineStore.currentCarbonReportId);
+    }
+  }
+
   async function postItem(
     moduleType: Module,
     unitId: number,
@@ -707,6 +717,7 @@ export const useModuleStore = defineStore('modules', () => {
       invalidateEmissionBreakdown();
       await refreshEmissionBreakdownIfNeeded();
       await refreshTopClassBreakdownIfNeeded(moduleType, unitId, year);
+      await refreshModuleStates();
     } catch (err: unknown) {
       if (err instanceof Error) state.error = err.message ?? 'Unknown error';
       else state.error = 'Unknown error';
@@ -764,6 +775,7 @@ export const useModuleStore = defineStore('modules', () => {
       invalidateEmissionBreakdown();
       await refreshEmissionBreakdownIfNeeded();
       await refreshTopClassBreakdownIfNeeded(moduleType, unit, year);
+      await refreshModuleStates();
     } catch (err: unknown) {
       if (err instanceof Error) state.error = err.message ?? 'Unknown error';
       else state.error = 'Unknown error';
@@ -802,6 +814,7 @@ export const useModuleStore = defineStore('modules', () => {
       invalidateEmissionBreakdown();
       await refreshEmissionBreakdownIfNeeded();
       await refreshTopClassBreakdownIfNeeded(moduleType, unit, year);
+      await refreshModuleStates();
     } catch (err: unknown) {
       if (err instanceof Error) state.error = err.message ?? 'Unknown error';
       else state.error = 'Unknown error';


### PR DESCRIPTION
Closes #1530.

## Problem

On first navigation to a module with backoffice-loaded data, the orange "in progress" status icon was missing in the nav bar until the user validated the module once. The top-left also showed "In progress" while the sidebar showed no icon — the two disagreed.

## Root cause

Two halves:
1. **Backend** never marked a module `IN_PROGRESS` when data was loaded — it stayed `NOT_STARTED (0)`, so the sidebar (correctly) drew no icon for status 0.
2. **Frontend** `ModuleTotalResult` was *binary* (`validated` vs everything-else), so it mislabeled status 0 as "In progress" — producing the text/icon mismatch.

## Changes

### Backend
- Stats recompute (`recompute_stats` / `recompute_stats_many`, used by data-entry CUD and the backoffice aggregation job) now flips each refreshed module to `IN_PROGRESS` in the same transaction. The parent report's `overall_status` / `completion_progress` roll up from the updated child statuses via the existing `recompute_report_stats_many` call.
- **DRY**: `recompute_stats` is now a thin wrapper over `recompute_stats_many`, and `recompute_report_stats` over `recompute_report_stats_many` (single is a subset of many — no duplicated stats/status/rollup logic).
- **Rename**: report-level status filter param `completion_status` → `overall_status` across the backoffice API + repositories, to match the `CarbonReport.overall_status` column. One public query param renamed; no DB migration.
- Regression tests pin the `IN_PROGRESS` bump (incl. downgrading a stale `VALIDATED` module).

### Frontend
- `ModuleTotalResult` badge is now 3-state: **Not started** (grey, no icon) / **In progress** (orange `o_pending`) / **Validated** (green check). Adds `module_status_not_started` i18n.
- `Co2ModuleSidebar` derives status from a single `sidebarItems` computed off backend-sourced `itemStates` instead of per-row helper calls.
- Centralized the `state → {color, icon, label}` mapping in `MODULE_STATUS_DISPLAY` (one source of truth for sidebar + total result).
- Module statuses now refresh after a data-entry create/patch/delete, so the sidebar icon updates **live** instead of staying stale until navigation.

## Verification
- `vue-tsc`, `ruff`, `mypy` green; backend tests pass (incl. new regression tests).
- Manual: load backoffice data → navigate to module fresh → orange icon shows without validating; add/edit/delete a row → icon updates live.

## Follow-up
- #1559 — discovered during this work: the `tmp → processing` ingestion file move isn't idempotent and fails on job retry after a restart. Filed separately, not fixed here.