### PR TITLE
feat: add  404 error page with improved UI

### DIFF
--- a/frontend/src/i18n/not_found.ts
+++ b/frontend/src/i18n/not_found.ts
@@ -1,0 +1,14 @@
+export default {
+  not_found_title: {
+    en: '404: Page Not Found',
+    fr: '404 : Page introuvable',
+  },
+  not_found_message: {
+    en: "The page you are looking for doesn't exist or may have been moved. Check the URL or head back to a familiar place.",
+    fr: "La page que vous recherchez n'existe pas ou a peut-être été déplacée. Vérifiez l'URL ou retournez à un endroit familier.",
+  },
+  not_found_contact_message: {
+    en: 'If you think this is a mistake, please contact your administrator or the support team.',
+    fr: "Si vous pensez qu'il s'agit d'une erreur, veuillez contacter votre administrateur ou l'équipe de support.",
+  },
+} as const;

--- a/frontend/src/pages/ErrorNotFound.vue
+++ b/frontend/src/pages/ErrorNotFound.vue
@@ -1,21 +1,84 @@
 <template>
-  <div
-    class="fullscreen q-gutter-sm bg-blue text-white text-center q-pa-md flex flex-center"
-  >
-    <div style="font-size: 30vh">404</div>
+  <div class="fullscreen bg-grey-1 flex flex-center q-pa-md">
+    <div class="col-12 col-md-10 col-lg-8 col-xl-8">
+      <q-card
+        bordered
+        flat
+        class="q-px-lg text-center"
+        style="padding: 3rem"
+        padding-top="1rem"
+      >
+        <div class="column items-center q-gutter-y-xl">
+          <!-- Error Code and Icon -->
+          <div class="column items-center q-gutter-y-md">
+            <q-icon name="o_search_off" size="lg" color="accent" />
+            <div class="text-h4 text-weight-medium text-dark">
+              {{ t('not_found_title') }}
+            </div>
+          </div>
 
-    <div class="text-h2" style="opacity: 0.4">Oops. Nothing here...</div>
+          <div class="q-px-lg" style="max-width: 600px">
+            <p class="text-body1 text-grey-6 q-ma-none">
+              {{ t('not_found_message') }}
+            </p>
+          </div>
 
-    <q-btn
-      class=""
-      color="white"
-      text-color="blue"
-      unelevated
-      to="/"
-      label="Go Home"
-      no-caps
-    />
+          <div>
+            <q-btn
+              color="accent"
+              :to="homeRoute"
+              :label="t('home')"
+              unelevated
+              no-caps
+              size="md"
+              class="text-weight-medium q-px-xl"
+            />
+          </div>
+
+          <div class="q-px-lg" style="max-width: 600px">
+            <div class="row items-center q-gutter-x-sm justify-center">
+              <p class="text-caption text-grey-7 q-ma-none">
+                {{ t('contact') }}: {{ t('not_found_contact_message') }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </q-card>
+    </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { HOME_ROUTE_NAME, WORKSPACE_SETUP_ROUTE_NAME } from 'src/router/routes';
+import { i18n } from 'src/boot/i18n';
+import { useWorkspaceStore } from 'src/stores/workspace';
+
+const { t } = useI18n();
+const workspaceStore = useWorkspaceStore();
+
+const homeRoute = computed(() => {
+  const currentLocale = i18n.global.locale.value;
+  const language = currentLocale.split('-')[0] || 'en';
+
+  // Go straight to the workspace home when a unit/year is selected;
+  // otherwise fall back to workspace setup so the required params exist.
+  const params = workspaceStore.selectedParams;
+  if (params) {
+    return {
+      name: HOME_ROUTE_NAME,
+      params: {
+        language,
+        unit: encodeURIComponent(params.unit),
+        year: params.year,
+      },
+    };
+  }
+
+  return {
+    name: WORKSPACE_SETUP_ROUTE_NAME,
+    params: { language },
+  };
+});
+</script>


### PR DESCRIPTION
## What does this change?
Redesigns the 404 "Not Found" page with improved styling and a smarter home navigation link.

- `ErrorNotFound.vue`: replaces the plain full-bleed blue "404 / Oops" page with a centered, bordered card containing a search-off icon, title, descriptive message, a "Go home" button, and a contact message
- A new `homeRoute` computed resolves the home button's destination based on the current locale and the workspace store's `selectedParams`: if a unit/year is already selected it links directly to the workspace home, otherwise it falls back to the workspace setup route
- `frontend/src/i18n/not_found.ts` (new): adds `not_found_title`, `not_found_message`, and `not_found_contact_message` translation keys (EN/FR)

## Why is this needed?
The previous 404 page was a generic placeholder with a hardcoded "Go Home" link that didn't account for the user's current workspace context (unit/year selection), and lacked any guidance for users who land there by mistake.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced
