### PR TITLE
feat: add backoffice documentation button to Co2Header

### DIFF
--- a/frontend/src/i18n/backoffice.ts
+++ b/frontend/src/i18n/backoffice.ts
@@ -18,8 +18,8 @@ export default {
     fr: 'backoffice-data-management-description',
   },
   [BACKOFFICE_NAV.BACKOFFICE_DOCUMENTATION_EDITING.routeName]: {
-    en: 'Documentation Editing',
-    fr: 'Édition de la documentation',
+    en: 'Documentation',
+    fr: 'Documentation',
   },
   [BACKOFFICE_NAV.BACKOFFICE_DOCUMENTATION_EDITING.description]: {
     en: 'Manage and update documentation and translation files.',

--- a/frontend/src/i18n/backoffice_documentation_editing.ts
+++ b/frontend/src/i18n/backoffice_documentation_editing.ts
@@ -62,7 +62,7 @@ export default {
   },
   documentation_editing_calculator_developer_documentation_title: {
     en: 'Developer Documentation',
-    fr: 'Documentation développeur',
+    fr: 'Documentation développeur·euse',
   },
   documentation_editing_calculator_developer_documentation_description: {
     en: 'Repository link to the developer documentation of the CO₂ calculator application.',

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -241,7 +241,7 @@ export default {
   },
   documentation_dev_button_label: {
     en: 'Developer Documentation',
-    fr: 'Documentation Développeur',
+    fr: 'Documentation développeur·euse',
   },
   common_add_button: {
     en: 'Add',

--- a/frontend/src/pages/back-office/DocumentationEditingPage.vue
+++ b/frontend/src/pages/back-office/DocumentationEditingPage.vue
@@ -13,6 +13,7 @@ const docRows = computed(() => [
     description: t(
       'documentation_editing_calculator_user_documentation_description',
     ),
+    docUrl: 'https://epfl-enac.github.io/co2-calculator-user-doc/',
     githubUrl:
       'https://github.com/EPFL-ENAC/co2-calculator-user-doc/tree/main/docs',
   },
@@ -21,6 +22,7 @@ const docRows = computed(() => [
     description: t(
       'documentation_editing_calculator_backoffice_documentation_description',
     ),
+    docUrl: 'https://epfl-enac.github.io/co2-calculator-back-office-doc/',
     githubUrl:
       'https://github.com/EPFL-ENAC/co2-calculator-back-office-doc/tree/main/docs',
   },
@@ -29,6 +31,7 @@ const docRows = computed(() => [
     description: t(
       'documentation_editing_calculator_developer_documentation_description',
     ),
+    docUrl: '/docs/',
     githubUrl: 'https://github.com/EPFL-ENAC/co2-calculator/tree/main/docs/src',
   },
 ]);
@@ -92,7 +95,13 @@ const columns: QTableColumn[] = [
           <template #body="props">
             <q-tr :props="props" class="q-tr--no-hover">
               <q-td key="topic" :props="props">
-                {{ props.row.topic }}
+                <a
+                  :href="props.row.docUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ props.row.topic }}
+                </a>
               </q-td>
               <q-td key="description" :props="props">
                 {{ props.row.description }}


### PR DESCRIPTION
## What does this change?
Adds a "Backoffice Guide" button to the header when the user is in a back-office route, linking out to the external back-office documentation site.

- `Co2Header.vue`: adds a new `q-btn` (shown when `isInBackOfficeRoute`) labelled via `backoffice_documentation_button_label`, opening `https://epfl-enac.github.io/co2-calculator-back-office-doc/` in a new tab
- `backoffice.ts`: adds the `backoffice_documentation_button_label` i18n key (EN/FR, both "Backoffice Guide")

## Why is this needed?
Back-office users had no direct link to the external documentation guide while working in the back-office, requiring them to navigate away manually to find help.

## Type of change
- [x] ✨ New feature

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced
