### PR TITLE
feat(frontend): replace @sentry/vue with minimal GlitchTip client

### DIFF
--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -80,9 +80,15 @@ Strings `new_version_available` / `reload` added to `src/i18n/common.ts`.
 `scripts/glitchtip.js`. No prod Docker/Helm change — `docker/entrypoint.sh` writes
 any `APP_*` var into `injectEnv.js` generically.
 
-**Trade-off (in scope):** loses performance tracing / slow-route visibility,
-session replay, and server-side source-map frame resolution. Scoped to "errors
-only".
+A `contexts.trace` (trace_id rotated per navigation + span_id) tags every event
+so errors within one navigation group together (Tier A). No transaction/span
+events are emitted — GlitchTip's Performance tab stays empty by design. See the
+header comment in `glitchtip.ts` for what full performance / distributed tracing
+would require (out of scope).
+
+**Trade-off (in scope):** no performance/transaction tracing (only the trace
+IDs above), no session replay, no server-side source-map frame resolution.
+Scoped to "errors only".
 
 ## 3. Configuration
 

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -38,6 +38,10 @@ GlitchTip accepts). No-op without a DSN, so dev/CI stay silent.
   per-capture `mechanism { type, handled }`.
 - Retained from the draft: consecutive-error dedupe, best-effort `localStorage`
   offline buffer + flush on init, `keepalive` POST.
+- Context parity with the SDK: ships `request.headers["User-Agent"]` so
+  GlitchTip derives the `browser` / `os` / `device` tags (+ icons) server-side;
+  and auto-records breadcrumbs (`fetch` — skipping its own ingest POSTs —
+  `console.error/warn`, `ui.click`; `navigation` from `router.afterEach`).
 
 **Rewired — `frontend/src/boot/sentry.ts`** (boot slot name kept as `sentry`;
 the `APP_SENTRY_DSN` env name is wired through `runtime.ts`, `quasar.config.js`,

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -45,19 +45,19 @@ the `APP_SENTRY_DSN` env name is wired through `runtime.ts`, `quasar.config.js`,
 set and wires every source to `captureError`, keeping the existing `ignoreErrors`
 list and user-facing toasts:
 
-| Source                          | Hook                      | mechanism    |
-| ------------------------------- | ------------------------- | ------------ |
-| Vue component errors            | `app.config.errorHandler` | `vue`        |
-| Vue Router (chunk load, guards) | `router.onError` _(new)_  | `vue-router` |
+| Source                          | Hook                                         | mechanism                              |
+| ------------------------------- | -------------------------------------------- | -------------------------------------- |
+| Vue component errors            | `app.config.errorHandler`                    | `vue`                                  |
+| Vue Router (chunk load, guards) | `router.onError` _(new)_                     | `vue-router`                           |
+| Global synchronous / DOM-event  | `window 'error'` (ResizeObserver suppressed) | `onerror`                              |
+| Unhandled promise rejection     | `window 'unhandledrejection'`                | `onunhandledrejection` (handled:false) |
+| ky HTTP 5xx                     | `afterResponse` in `src/api/http.ts`         | `generic`                              |
 
 `router.onError` also detects stale route-chunk load failures (cross-engine
 message match) and shows a single sticky "new version available — reload"
 toast, so a client holding an old `index.html` after a deploy can recover in
 one click instead of hitting a dead navigation. The error is still captured.
 Strings `new_version_available` / `reload` added to `src/i18n/common.ts`.
-| Global synchronous / DOM-event | `window 'error'` (ResizeObserver suppressed) | `onerror` |
-| Unhandled promise rejection | `window 'unhandledrejection'` | `onunhandledrejection` (handled:false) |
-| ky HTTP 5xx | `afterResponse` in `src/api/http.ts` | `generic` |
 
 **Removed:** `@sentry/vue` dependency (`package.json`) and both its usages
 (`boot/sentry.ts`, `api/http.ts`'s lazy `captureMessage`); deleted the dead
@@ -77,8 +77,11 @@ Prod: `APP_SENTRY_DSN` from the pod env via Helm → `injectEnv.js`.
 
 - `make type-check` (vue-tsc) and `npm run lint` — both green; no `@sentry`
   imports remain.
-- Manual (`quasar dev`): console `throw new Error('aefaef')` produces a
+- Manual (`quasar dev`, with the DSN in `.env.local` and the dev server
+  restarted): `setTimeout(() => { throw new Error('x') }, 0)` and
+  `Promise.reject(new Error('y'))` each produce a
   `POST …/api/<projectId>/envelope/?sentry_key=…` → 200 and a visible GlitchTip
-  event. Exercise each source (component throw, `Promise.reject`, route error,
-  backend 500); confirm ResizeObserver / `AbortError` / `Failed to fetch` are
-  not sent.
+  event. (A bare `throw` typed at the console REPL does **not** fire
+  `window.onerror` in WebKit — use `setTimeout`.) Exercise each source
+  (component throw, rejection, route error, backend 500); confirm ResizeObserver
+  / `AbortError` / `Failed to fetch` are not sent.

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -1,0 +1,78 @@
+---
+status: delivered
+last_updated: 2026-06-18
+title: "Frontend error reporting — minimal GlitchTip client (drop @sentry/vue)"
+summary: "Replaces the @sentry/vue SDK with a ~2 KB dependency-free GlitchTip-compatible reporter (src/utils/glitchtip.ts). Captures Vue component, router, global, DOM-event, unhandled-rejection and ky 5xx errors. Fixes the two protocol bugs (missing envelope item header, missing DSN public key) that stopped events ingesting, and documents that the DSN must live in .env.local."
+---
+
+# Frontend error reporting — minimal GlitchTip client
+
+## 1. Problem
+
+The frontend shipped a full `@sentry/vue` integration plus a dead, half-written
+custom reporter at `frontend/scripts/glitchtip.js`. Goals: keep crash visibility
+only (no tracing/replay), shrink to a tiny dependency-free client, and capture
+every error source. Two things blocked any event from reaching GlitchTip:
+
+1. **DSN never loaded.** `quasar.config.js` loads only `.env.local` (gitignored)
+   into `process.env.APP_*`. The DSN had been placed in `.env`, which neither that
+   loader nor Vite reads, so `runtimeConfig.sentryDsn` was empty and init was
+   skipped — `throw new Error(...)` went nowhere.
+2. **The draft client could not ingest.** Its envelope omitted the mandatory
+   `{"type":"event"}` item-header line, and it discarded the DSN public key during
+   parse, so GlitchTip rejected the request.
+
+## 2. Solution
+
+A module-level singleton client speaking the Sentry envelope protocol (which
+GlitchTip accepts). No-op without a DSN, so dev/CI stay silent.
+
+**New — `frontend/src/utils/glitchtip.ts`:**
+
+- `initGlitchTip({ dsn, release, environment, ignoreErrors, maxBreadcrumbs })`,
+  `captureError(error, ctx?)`, `addBreadcrumb(message, category?)`.
+- Protocol fixes vs the draft: keeps the public key and sends it as
+  `?sentry_key=` (+ `dsn` in the envelope header); emits the 3-line envelope
+  (envelope header / item header / payload); breadcrumbs as `{ values: [...] }`;
+  minimal Chrome+Firefox stack parser → `stacktrace.frames` (oldest-first);
+  per-capture `mechanism { type, handled }`.
+- Retained from the draft: consecutive-error dedupe, best-effort `localStorage`
+  offline buffer + flush on init, `keepalive` POST.
+
+**Rewired — `frontend/src/boot/sentry.ts`** (boot slot name kept as `sentry`;
+the `APP_SENTRY_DSN` env name is wired through `runtime.ts`, `quasar.config.js`,
+`docker/entrypoint.sh` and Helm — unchanged). Calls `initGlitchTip` when a DSN is
+set and wires every source to `captureError`, keeping the existing `ignoreErrors`
+list and user-facing toasts:
+
+| Source                          | Hook                                         | mechanism                              |
+| ------------------------------- | -------------------------------------------- | -------------------------------------- |
+| Vue component errors            | `app.config.errorHandler`                    | `vue`                                  |
+| Vue Router (chunk load, guards) | `router.onError` _(new)_                     | `vue-router`                           |
+| Global synchronous / DOM-event  | `window 'error'` (ResizeObserver suppressed) | `onerror`                              |
+| Unhandled promise rejection     | `window 'unhandledrejection'`                | `onunhandledrejection` (handled:false) |
+| ky HTTP 5xx                     | `afterResponse` in `src/api/http.ts`         | `generic`                              |
+
+**Removed:** `@sentry/vue` dependency (`package.json`) and both its usages
+(`boot/sentry.ts`, `api/http.ts`'s lazy `captureMessage`); deleted the dead
+`scripts/glitchtip.js`. No prod Docker/Helm change — `docker/entrypoint.sh` writes
+any `APP_*` var into `injectEnv.js` generically.
+
+**Trade-off (in scope):** loses performance tracing / slow-route visibility,
+session replay, and server-side source-map frame resolution. Scoped to "errors
+only".
+
+## 3. Configuration
+
+Dev: `cp .env .env.local` (DSN must be in `.env.local` — `.env` is not loaded).
+Prod: `APP_SENTRY_DSN` from the pod env via Helm → `injectEnv.js`.
+
+## 4. Verification
+
+- `make type-check` (vue-tsc) and `npm run lint` — both green; no `@sentry`
+  imports remain.
+- Manual (`quasar dev`): console `throw new Error('aefaef')` produces a
+  `POST …/api/<projectId>/envelope/?sentry_key=…` → 200 and a visible GlitchTip
+  event. Exercise each source (component throw, `Promise.reject`, route error,
+  backend 500); confirm ResizeObserver / `AbortError` / `Failed to fetch` are
+  not sent.

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -42,6 +42,12 @@ GlitchTip accepts). No-op without a DSN, so dev/CI stay silent.
   GlitchTip derives the `browser` / `os` / `device` tags (+ icons) server-side;
   and auto-records breadcrumbs (`fetch` — skipping its own ingest POSTs —
   `console.error/warn`, `ui.click`; `navigation` from `router.afterEach`).
+- Non-Error rejections (`Promise.reject({...})`, numbers) keep their payload in
+  the title (`NonError: Non-Error rejection: …`) instead of "Unknown error".
+  Real Errors carry their throw/reject-site stack; synthesized stacks (string /
+  non-Error captures) are flagged `mechanism.synthetic = true` — the browser
+  retains no origin trace for a plain-value rejection, so reject with an `Error`
+  to keep one.
 
 **Rewired — `frontend/src/boot/sentry.ts`** (boot slot name kept as `sentry`;
 the `APP_SENTRY_DSN` env name is wired through `runtime.ts`, `quasar.config.js`,
@@ -82,10 +88,12 @@ Prod: `APP_SENTRY_DSN` from the pod env via Helm → `injectEnv.js`.
 - `make type-check` (vue-tsc) and `npm run lint` — both green; no `@sentry`
   imports remain.
 - Manual (`quasar dev`, with the DSN in `.env.local` and the dev server
-  restarted): `setTimeout(() => { throw new Error('x') }, 0)` and
-  `Promise.reject(new Error('y'))` each produce a
-  `POST …/api/<projectId>/envelope/?sentry_key=…` → 200 and a visible GlitchTip
-  event. (A bare `throw` typed at the console REPL does **not** fire
-  `window.onerror` in WebKit — use `setTimeout`.) Exercise each source
-  (component throw, rejection, route error, backend 500); confirm ResizeObserver
-  / `AbortError` / `Failed to fetch` are not sent.
+  restarted): from the console call `window.__gtTest('<kind>')` — kinds:
+  `throw` | `reject` | `reject-nonerror` | `capture` | `chunk` — to fire each
+  path; each produces a `POST …/api/<projectId>/envelope/?sentry_key=…` → 200
+  and a visible GlitchTip event with browser/os tags and a breadcrumb trail.
+  (`__gtTest` is dev-only, stripped from prod. A bare `throw` typed at the
+  console REPL does **not** fire `window.onerror` in WebKit — hence `setTimeout`
+  inside the helper.) Confirm ResizeObserver / `AbortError` / `Failed to fetch`
+  are not sent. HTTP 5xx capture needs a backend endpoint that genuinely 500s,
+  called via the `api` ky instance (4xx is intentionally not reported).

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -63,6 +63,11 @@ list and user-facing toasts:
 | Unhandled promise rejection     | `window 'unhandledrejection'`                | `onunhandledrejection` (handled:false) |
 | ky HTTP 5xx                     | `afterResponse` in `src/api/http.ts`         | `generic`                              |
 
+Vue component errors also attach a `contexts.vue` panel (component name,
+lifecycle hook, depth-1 props — nested values collapse to `[Object]`/`[Array]`
+to dodge circular refs) — the `@sentry/vue` equivalent. `captureError` accepts
+an optional `contexts` map for this.
+
 `router.onError` also detects stale route-chunk load failures (cross-engine
 message match) and shows a single sticky "new version available — reload"
 toast, so a client holding an old `index.html` after a deploy can recover in

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -40,7 +40,8 @@ GlitchTip accepts). No-op without a DSN, so dev/CI stay silent.
   offline buffer + flush on init, `keepalive` POST.
 - Context parity with the SDK: ships `request.headers["User-Agent"]` so
   GlitchTip derives the `browser` / `os` / `device` tags (+ icons) server-side;
-  and auto-records breadcrumbs (`fetch` — skipping its own ingest POSTs —
+  sends a `culture` panel (locale / timezone / calendar from `Intl`) on every
+  event; and auto-records breadcrumbs (`fetch` — skipping its own ingest POSTs —
   `console.error/warn`, `ui.click`; `navigation` from `router.afterEach`).
 - Non-Error rejections (`Promise.reject({...})`, numbers) keep their payload in
   the title (`NonError: Non-Error rejection: …`) instead of "Unknown error".

--- a/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
+++ b/docs/src/implementation-plans/frontend-glitchtip-error-reporting.md
@@ -45,13 +45,19 @@ the `APP_SENTRY_DSN` env name is wired through `runtime.ts`, `quasar.config.js`,
 set and wires every source to `captureError`, keeping the existing `ignoreErrors`
 list and user-facing toasts:
 
-| Source                          | Hook                                         | mechanism                              |
-| ------------------------------- | -------------------------------------------- | -------------------------------------- |
-| Vue component errors            | `app.config.errorHandler`                    | `vue`                                  |
-| Vue Router (chunk load, guards) | `router.onError` _(new)_                     | `vue-router`                           |
-| Global synchronous / DOM-event  | `window 'error'` (ResizeObserver suppressed) | `onerror`                              |
-| Unhandled promise rejection     | `window 'unhandledrejection'`                | `onunhandledrejection` (handled:false) |
-| ky HTTP 5xx                     | `afterResponse` in `src/api/http.ts`         | `generic`                              |
+| Source                          | Hook                      | mechanism    |
+| ------------------------------- | ------------------------- | ------------ |
+| Vue component errors            | `app.config.errorHandler` | `vue`        |
+| Vue Router (chunk load, guards) | `router.onError` _(new)_  | `vue-router` |
+
+`router.onError` also detects stale route-chunk load failures (cross-engine
+message match) and shows a single sticky "new version available — reload"
+toast, so a client holding an old `index.html` after a deploy can recover in
+one click instead of hitting a dead navigation. The error is still captured.
+Strings `new_version_available` / `reload` added to `src/i18n/common.ts`.
+| Global synchronous / DOM-event | `window 'error'` (ResizeObserver suppressed) | `onerror` |
+| Unhandled promise rejection | `window 'unhandledrejection'` | `onunhandledrejection` (handled:false) |
+| ky HTTP 5xx | `afterResponse` in `src/api/http.ts` | `generic` |
 
 **Removed:** `@sentry/vue` dependency (`package.json`) and both its usages
 (`boot/sentry.ts`, `api/http.ts`'s lazy `captureMessage`); deleted the dead

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@quasar/extras": "=1.18.0",
-        "@sentry/vue": "=10.56.0",
         "echarts": "=6.1.0",
         "ky": "=1.14.0",
         "maplibre-gl": "=5.24.0",
@@ -3581,107 +3580,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.56.0.tgz",
-      "integrity": "sha512-I8tZWAFg8SZpD8BFUpglEtSTzhZjacmcThB5/Mlq/iFiiT8mBPG4ZWDWssSfmIBKvZywJZJ83uDA0+uiJU73Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.56.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.56.0.tgz",
-      "integrity": "sha512-fkRR9JroESTIlErkht3OrH4DXKd/DbPozr2KLdX7boMo31hPu4cL9fuqzwOrwyDPRq9B4j+qEgIWB8JrTbgvmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.56.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.56.0.tgz",
-      "integrity": "sha512-DjF09hpy3TF7Km/kOZc73YJmBqcbPCxuZ5rtRs+KtVHu3Vq48xeW83qKUcFEZv20ur9UD99OAJ/gaEt//1Qbwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.56.0",
-        "@sentry/core": "10.56.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.56.0.tgz",
-      "integrity": "sha512-SDg2K0CAZT/TnhrixQGwXoi6ZsWUB+DQy3UUk0bSQm6c/5k5zFBpGOiughQN+DYsDilKREfPKmUEEnqvUjm1HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.56.0",
-        "@sentry/core": "10.56.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.56.0.tgz",
-      "integrity": "sha512-80X3NmsGB6tLmfzXYdjzWWdVAdL5CRukGKLcRWIcNhgGjtskOmnzaGb93egEZGI5bUTbtONJ0oyscQ3Z9yoAtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.56.0",
-        "@sentry-internal/feedback": "10.56.0",
-        "@sentry-internal/replay": "10.56.0",
-        "@sentry-internal/replay-canvas": "10.56.0",
-        "@sentry/core": "10.56.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
-      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/vue": {
-      "version": "10.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.56.0.tgz",
-      "integrity": "sha512-bDQ+RNPc/D9ZkFj/iK+IDYYxlQNJFYPQx9YEq1TNCKHudZrhc4AXnXxY7COmre0CQOXrVkuc6vYOGJnbB460Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.56.0",
-        "@sentry/core": "10.56.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@tanstack/vue-router": "^1.64.0",
-        "pinia": "2.x || 3.x",
-        "vue": "2.x || 3.x"
-      },
-      "peerDependenciesMeta": {
-        "@tanstack/vue-router": {
-          "optional": true
-        },
-        "pinia": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@quasar/extras": "=1.18.0",
-    "@sentry/vue": "=10.56.0",
     "echarts": "=6.1.0",
     "ky": "=1.14.0",
     "maplibre-gl": "=5.24.0",

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -214,17 +214,20 @@ export const api = ky.create({
             } catch {
               // Body already consumed elsewhere; not fatal for the report.
             }
-            captureError(new Error(`HTTP ${res.status} ${req.method} ${req.url}`), {
-              extra: {
-                status: res.status,
-                statusText: res.statusText,
-                url: req.url,
-                method: req.method,
-                // Truncate to keep events small; full body rarely fits in
-                // GlitchTip's payload limit and isn't usually needed for triage.
-                body: body?.slice(0, 2000),
+            captureError(
+              new Error(`HTTP ${res.status} ${req.method} ${req.url}`),
+              {
+                extra: {
+                  status: res.status,
+                  statusText: res.statusText,
+                  url: req.url,
+                  method: req.method,
+                  // Truncate to keep events small; full body rarely fits in
+                  // GlitchTip's payload limit and isn't usually needed for triage.
+                  body: body?.slice(0, 2000),
+                },
               },
-            });
+            );
           }
 
           const skipCodes = (options as ApiOptions).skipErrorCodes ?? [];

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,6 +1,7 @@
 import ky, { type Options } from 'ky';
 import { Notify } from 'quasar';
 import { i18n } from 'src/boot/i18n';
+import { captureError } from 'src/utils/glitchtip';
 
 declare module 'ky' {
   interface Options {
@@ -202,14 +203,10 @@ export const api = ky.create({
             : '/unauthorized';
           location.replace(redirectUrl);
         } else if (!res.ok) {
-          // Capture 5xx in Sentry. 4xx is usually client/business-logic
+          // Capture 5xx in GlitchTip. 4xx is usually client/business-logic
           // (validation, "not found", etc.) and not worth exception noise;
           // 5xx means our backend or infra failed and we want to know.
-          //
-          // Dynamic import so the @sentry/vue chunk stays lazy (the boot
-          // file uses dynamic import too — see boot/sentry.ts). On the first
-          // 5xx of a session this incurs one async chunk load; subsequent
-          // captures hit cache. A fast no-op when no DSN is configured.
+          // captureError is a fast no-op when no DSN is configured.
           if (res.status >= 500) {
             let body: string | undefined;
             try {
@@ -217,20 +214,16 @@ export const api = ky.create({
             } catch {
               // Body already consumed elsewhere; not fatal for the report.
             }
-            void import('@sentry/vue').then(({ captureMessage }) => {
-              captureMessage(`HTTP ${res.status} ${req.method} ${req.url}`, {
-                level: 'error',
-                extra: {
-                  status: res.status,
-                  statusText: res.statusText,
-                  url: req.url,
-                  method: req.method,
-                  // Truncate to keep events small; full body rarely fits in
-                  // GlitchTip's payload limit and isn't usually needed for
-                  // triage.
-                  body: body?.slice(0, 2000),
-                },
-              });
+            captureError(new Error(`HTTP ${res.status} ${req.method} ${req.url}`), {
+              extra: {
+                status: res.status,
+                statusText: res.statusText,
+                url: req.url,
+                method: req.method,
+                // Truncate to keep events small; full body rarely fits in
+                // GlitchTip's payload limit and isn't usually needed for triage.
+                body: body?.slice(0, 2000),
+              },
             });
           }
 

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -171,4 +171,48 @@ export default boot(({ app, router }) => {
           String(reason ?? 'Unhandled rejection'));
     notifyError(message);
   });
+
+  // -------------------------------------------------------------------------
+  // Dev-only manual trigger: `window.__gtTest('<kind>')` from the console to
+  // fire each error path and confirm it reaches GlitchTip. Stripped from prod
+  // builds by the import.meta.env.DEV guard (dead-code eliminated).
+  // -------------------------------------------------------------------------
+  if (import.meta.env.DEV) {
+    const triggers: Record<string, () => void> = {
+      // Real trace (Error captured at the throw site).
+      throw: () =>
+        setTimeout(() => {
+          throw new Error('[__gtTest] thrown error');
+        }, 0),
+      // Real trace (Error captured at the reject site).
+      reject: () => void Promise.reject(new Error('[__gtTest] rejected Error')),
+      // No origin trace exists → reported as a synthetic "NonError".
+      'reject-nonerror': () =>
+        void Promise.reject({ code: 'E_TEST', detail: 'plain object payload' }),
+      // Direct capture, e.g. the path api/http.ts uses for HTTP 5xx.
+      capture: () =>
+        captureError(new Error('[__gtTest] manual capture'), {
+          mechanism: 'manual',
+          extra: { hint: 'this is what the ky 5xx path sends' },
+        }),
+      // Stale-chunk router error → also shows the reload prompt.
+      chunk: () => {
+        captureError(new Error('Importing a module script failed.'), {
+          mechanism: 'vue-router',
+        });
+        notifyReloadOnce();
+      },
+    };
+    (window as unknown as { __gtTest: (kind?: string) => void }).__gtTest = (
+      kind = 'throw',
+    ) => {
+      const run = triggers[kind];
+      if (!run) {
+        console.warn(`[__gtTest] kinds: ${Object.keys(triggers).join(' | ')}`);
+        return;
+      }
+      run();
+      console.log(`[__gtTest] fired "${kind}"`);
+    };
+  }
 });

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -1,12 +1,11 @@
 import { boot } from 'quasar/wrappers';
 import { Notify } from 'quasar';
 import { HTTPError } from 'ky';
-import type { App } from 'vue';
-import type { Router } from 'vue-router';
 import { runtimeConfig } from 'src/config/runtime';
+import { captureError, initGlitchTip } from 'src/utils/glitchtip';
 
 // Errors that are not actionable (browser quirks, user-driven aborts).
-// Sentry drops events whose message matches any of these.
+// captureError() drops events whose message matches any of these.
 const ignoreErrors: (string | RegExp)[] = [
   // Harmless browser-bug noise from libraries that observe element sizes.
   // See https://github.com/vuejs/vue-cli/issues/7431
@@ -32,65 +31,26 @@ function notifyError(message: string, caption?: string) {
   });
 }
 
-// Sentry init is split out and dynamic-imported so the @sentry/vue chunk
-// (~900 KiB unminified, drags replay+feedback+browser-utils via transitive
-// deps) is NOT in the eager bundle. Without DSN — i.e. dev, CI Lighthouse
-// runs, any unconfigured deploy — the chunk never loads at all. With DSN it
-// loads asynchronously, parallel with app startup, instead of blocking LCP.
-async function initSentry(
-  app: App,
-  router: Router,
-  dsn: string,
-  environment: string,
-  release: string | undefined,
-) {
-  const Sentry = await import('@sentry/vue');
-  Sentry.init({
-    app,
-    dsn,
-    environment,
-    release,
-    ignoreErrors,
-    integrations: [
-      // Auto-instruments vue-router navigations + fetch/XHR as Sentry
-      // transactions. This is what gives GlitchTip "slow route" visibility.
-      Sentry.browserTracingIntegration({ router }),
-    ],
-    // Same bundle hits dev/stage/prod via runtime DSN, so this rate applies
-    // everywhere. 5% balances signal on rare slow routes against GlitchTip
-    // ingestion cost.
-    tracesSampleRate: 0.05,
-    // Only attach trace headers (sentry-trace, baggage) to our own backend.
-    // Never propagate to third-party endpoints (CDNs, analytics) — they'll
-    // reject CORS preflights and pollute their logs.
-    tracePropagationTargets: ['localhost', /^\/api\//],
-  });
-}
-
 export default boot(({ app, router }) => {
   const { sentryDsn, environment, release } = runtimeConfig;
 
-  // Fire-and-forget: don't block app mount on Sentry loading. Worst case is
-  // a sub-second window after first paint where Sentry isn't capturing yet
-  // — acceptable cost for keeping the SDK off the critical path.
+  // Init is a no-op without a DSN (dev, CI Lighthouse, unconfigured deploys),
+  // so the handlers below simply report nowhere in those environments.
   if (sentryDsn) {
-    void initSentry(app, router, sentryDsn, environment, release);
+    initGlitchTip({ dsn: sentryDsn, release, environment, ignoreErrors });
   }
 
   // -------------------------------------------------------------------------
-  // Vue-level uncaught errors.
-  //
-  // Fires for errors thrown inside component lifecycle hooks, watchers,
-  // computeds, etc. @sentry/vue wires its own capture via `attachErrorHandler`
-  // when init runs (which preserves any prior handler). We layer a Notify
-  // toast on top so users see *something* when a render fails instead of a
-  // silent broken UI.
+  // Vue-level uncaught errors: thrown inside component lifecycle hooks,
+  // watchers, computeds, render, etc. We report them and layer a toast so
+  // users see *something* when a render fails instead of a silent broken UI.
   // -------------------------------------------------------------------------
   const previousVueHandler = app.config.errorHandler;
   app.config.errorHandler = (err, instance, info) => {
     if (typeof previousVueHandler === 'function') {
       previousVueHandler(err, instance, info);
     }
+    captureError(err, { mechanism: 'vue', extra: { info } });
     if (import.meta.env.DEV) {
       console.error('[vue errorHandler]', err, info);
     }
@@ -101,22 +61,28 @@ export default boot(({ app, router }) => {
   };
 
   // -------------------------------------------------------------------------
-  // Browser-level synchronous errors.
-  //
-  // Catches errors thrown outside Vue (third-party libs, setTimeout callbacks,
-  // event handlers attached directly to DOM). Sentry auto-captures these via
-  // its global handler once init runs; we add ResizeObserver suppression and
-  // a user-facing toast unconditionally.
+  // Vue Router errors: failed dynamic-import of a route chunk, errors thrown
+  // in navigation guards/resolvers. These never reach the Vue error handler.
+  // -------------------------------------------------------------------------
+  router.onError((err) => {
+    captureError(err, { mechanism: 'vue-router' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Browser-level synchronous errors: thrown outside Vue (third-party libs,
+  // setTimeout callbacks, DOM event handlers). Suppress ResizeObserver noise
+  // entirely; report and toast everything else.
   // -------------------------------------------------------------------------
   window.addEventListener('error', (event) => {
     if (event.message?.includes('ResizeObserver loop')) {
-      // Browser bug, not a real failure. Stop propagation so neither Sentry
-      // nor the toast layer treats it as one.
+      // Browser bug, not a real failure. Stop propagation so nothing treats it
+      // as one.
       event.stopImmediatePropagation();
       event.stopPropagation();
       event.preventDefault();
       return;
     }
+    captureError(event.error ?? event.message, { mechanism: 'onerror' });
     if (import.meta.env.DEV) {
       console.error('[window error]', event.error ?? event.message);
     }
@@ -127,14 +93,17 @@ export default boot(({ app, router }) => {
   });
 
   // -------------------------------------------------------------------------
-  // Unhandled promise rejections.
-  //
-  // Sentry auto-captures the reason. We skip notifying when the reason is a
-  // ky HTTPError — api/http.ts's afterResponse hook already toasted it, and
+  // Unhandled promise rejections. We still report ky HTTPErrors (an unhandled
+  // one means a caller forgot to await/catch — worth knowing) but skip the
+  // toast: api/http.ts's afterResponse hook already toasted it, and
   // double-toasting is worse than missing one.
   // -------------------------------------------------------------------------
   window.addEventListener('unhandledrejection', (event) => {
     const reason = event.reason;
+    captureError(reason, {
+      mechanism: 'onunhandledrejection',
+      handled: false,
+    });
     if (reason instanceof HTTPError) {
       return;
     }

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -3,7 +3,11 @@ import { Notify } from 'quasar';
 import { HTTPError } from 'ky';
 import { runtimeConfig } from 'src/config/runtime';
 import { i18n } from 'src/boot/i18n';
-import { captureError, initGlitchTip } from 'src/utils/glitchtip';
+import {
+  addBreadcrumb,
+  captureError,
+  initGlitchTip,
+} from 'src/utils/glitchtip';
 
 // Errors that are not actionable (browser quirks, user-driven aborts).
 // captureError() drops events whose message matches any of these.
@@ -110,6 +114,12 @@ export default boot(({ app, router }) => {
     if (isChunkLoadError(err)) {
       notifyReloadOnce();
     }
+  });
+
+  // Navigation breadcrumbs: the "how did the user get here" trail attached to
+  // any later crash. No-op until a DSN is configured.
+  router.afterEach((to, from) => {
+    addBreadcrumb(`${from.fullPath} → ${to.fullPath}`, 'navigation');
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -2,6 +2,7 @@ import { boot } from 'quasar/wrappers';
 import { Notify } from 'quasar';
 import { HTTPError } from 'ky';
 import { runtimeConfig } from 'src/config/runtime';
+import { i18n } from 'src/boot/i18n';
 import { captureError, initGlitchTip } from 'src/utils/glitchtip';
 
 // Errors that are not actionable (browser quirks, user-driven aborts).
@@ -28,6 +29,44 @@ function notifyError(message: string, caption?: string) {
     position: 'top',
     timeout: 5000,
     actions: [{ icon: 'close', color: 'white' }],
+  });
+}
+
+// A route's lazy chunk (or its CSS) failed to load. After a deploy, clients
+// holding an old index.html request hashed chunks that no longer exist on the
+// server — the dynamic import rejects. Messages differ per engine, hence the
+// broad match (WebKit: "Importing a module script failed."; Chromium: "Failed
+// to fetch dynamically imported module"; Firefox/Vite variants below).
+function isChunkLoadError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) ||
+    /Unable to preload CSS/i.test(message) ||
+    /Loading chunk \S+ failed/i.test(message)
+  );
+}
+
+// Persistent "reload to get the new version" prompt. Guarded so a burst of
+// chunk errors (one per failed prefetch) shows a single toast. We prompt
+// rather than auto-reload to avoid clobbering unsaved work.
+let reloadPromptShown = false;
+function notifyReloadOnce() {
+  if (reloadPromptShown) return;
+  reloadPromptShown = true;
+  Notify.create({
+    color: 'info',
+    message: i18n.global.t('new_version_available'),
+    position: 'top',
+    timeout: 0, // sticky until the user acts
+    actions: [
+      {
+        label: i18n.global.t('reload'),
+        color: 'white',
+        handler: () => window.location.reload(),
+      },
+    ],
   });
 }
 
@@ -63,9 +102,14 @@ export default boot(({ app, router }) => {
   // -------------------------------------------------------------------------
   // Vue Router errors: failed dynamic-import of a route chunk, errors thrown
   // in navigation guards/resolvers. These never reach the Vue error handler.
+  // A chunk-load failure is usually a stale client after a deploy, not a code
+  // bug — surface a reload prompt so the user can recover in one click.
   // -------------------------------------------------------------------------
   router.onError((err) => {
     captureError(err, { mechanism: 'vue-router' });
+    if (isChunkLoadError(err)) {
+      notifyReloadOnce();
+    }
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -1,6 +1,7 @@
 import { boot } from 'quasar/wrappers';
 import { Notify } from 'quasar';
 import { HTTPError } from 'ky';
+import type { ComponentPublicInstance } from 'vue';
 import { runtimeConfig } from 'src/config/runtime';
 import { i18n } from 'src/boot/i18n';
 import {
@@ -8,6 +9,41 @@ import {
   captureError,
   initGlitchTip,
 } from 'src/utils/glitchtip';
+
+// Shallow (depth-1) copy of a component's props for the report: nested values
+// collapse to "[Object]" / "[Array]". Avoids circular refs (which would make
+// JSON.stringify throw on the whole event) and giant payloads — matches what
+// @sentry/vue sends.
+function shallowProps(
+  props: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(props ?? {})) {
+    out[key] =
+      value === null || typeof value !== 'object'
+        ? value
+        : Array.isArray(value)
+          ? '[Array]'
+          : '[Object]';
+  }
+  return out;
+}
+
+// The `contexts.vue` panel GlitchTip renders: which component threw, in which
+// lifecycle hook, with which props — the @sentry/vue equivalent.
+function vueErrorContext(
+  instance: ComponentPublicInstance | null,
+  info: string,
+): Record<string, unknown> {
+  const type = instance?.$?.type as
+    | { name?: string; __name?: string }
+    | undefined;
+  return {
+    componentName: type?.name || type?.__name || 'Anonymous Component',
+    lifecycleHook: info,
+    propsData: shallowProps(instance?.$props),
+  };
+}
 
 // Errors that are not actionable (browser quirks, user-driven aborts).
 // captureError() drops events whose message matches any of these.
@@ -93,7 +129,10 @@ export default boot(({ app, router }) => {
     if (typeof previousVueHandler === 'function') {
       previousVueHandler(err, instance, info);
     }
-    captureError(err, { mechanism: 'vue', extra: { info } });
+    captureError(err, {
+      mechanism: 'vue',
+      contexts: { vue: vueErrorContext(instance, info) },
+    });
     if (import.meta.env.DEV) {
       console.error('[vue errorHandler]', err, info);
     }

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -8,6 +8,7 @@ import {
   addBreadcrumb,
   captureError,
   initGlitchTip,
+  startNavigationTrace,
 } from 'src/utils/glitchtip';
 
 // Shallow (depth-1) copy of a component's props for the report: nested values
@@ -156,8 +157,10 @@ export default boot(({ app, router }) => {
   });
 
   // Navigation breadcrumbs: the "how did the user get here" trail attached to
-  // any later crash. No-op until a DSN is configured.
+  // any later crash. Also start a fresh trace so errors on the new page group
+  // under one trace_id. No-op until a DSN is configured.
   router.afterEach((to, from) => {
+    startNavigationTrace();
     addBreadcrumb(`${from.fullPath} → ${to.fullPath}`, 'navigation');
   });
 

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -523,4 +523,12 @@ export default {
     en: 'Records per page',
     fr: 'Entrées par page',
   },
+  new_version_available: {
+    en: 'A new version is available. Reload to continue.',
+    fr: 'Une nouvelle version est disponible. Rechargez pour continuer.',
+  },
+  reload: {
+    en: 'Reload',
+    fr: 'Recharger',
+  },
 };

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -162,6 +162,13 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
       level: ctx?.level ?? 'error',
       release,
       environment,
+      // GlitchTip parses the User-Agent server-side into browser/os/device
+      // tags (+ icons) — the same way the Sentry SDK gets them. We just have
+      // to ship the header in the request context.
+      request: {
+        url: location.href,
+        headers: { 'User-Agent': navigator.userAgent },
+      },
       breadcrumbs: { values: breadcrumbs.slice() },
       exception: {
         values: [
@@ -197,7 +204,85 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
   };
 
   client = { capture, breadcrumb };
+  installInstrumentation(breadcrumb, host);
   flush();
+}
+
+// Auto-record the actions leading up to a crash — the Sentry SDK's default
+// breadcrumbs (fetch, console, ui.click; navigation is wired from the router
+// in boot/sentry.ts). Installed once, best-effort: a wrapper must never throw
+// into the app's own fetch/console.
+let instrumented = false;
+function installInstrumentation(
+  record: (message: string, category: string) => void,
+  ingestHost: string,
+): void {
+  if (instrumented) return;
+  instrumented = true;
+
+  // fetch — covers all ky/API traffic. Skip our own ingest POSTs (else every
+  // captured error spawns a self-referential breadcrumb).
+  const origFetch = window.fetch.bind(window);
+  window.fetch = (...args: Parameters<typeof fetch>) => {
+    const [input, init] = args;
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : String(input);
+    const method = (
+      init?.method ?? (input instanceof Request ? input.method : 'GET')
+    ).toUpperCase();
+    const promise = origFetch(...args);
+    if (!url.includes(ingestHost)) {
+      promise.then(
+        (res) => record(`${method} ${url} [${res.status}]`, 'fetch'),
+        () => record(`${method} ${url} [failed]`, 'fetch'),
+      );
+    }
+    return promise;
+  };
+
+  // console.error / warn — the signals devs already emit when things go wrong.
+  (['error', 'warn'] as const).forEach((level) => {
+    const orig = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      record(
+        args
+          .map((a) => String(a))
+          .join(' ')
+          .slice(0, 200),
+        'console',
+      );
+      orig(...args);
+    };
+  });
+
+  // ui.click — capture phase, so we still see it if a handler stops propagation.
+  window.addEventListener(
+    'click',
+    (e) => {
+      if (e.target instanceof Element) {
+        record(describeTarget(e.target), 'ui.click');
+      }
+    },
+    { capture: true, passive: true },
+  );
+}
+
+// Compact CSS-ish description of a clicked element for the breadcrumb trail,
+// e.g. `button#save.btn.primary "Save changes"`.
+function describeTarget(el: Element): string {
+  const sel = [el.tagName.toLowerCase()];
+  if (el.id) sel.push(`#${el.id}`);
+  const cls =
+    typeof el.className === 'string'
+      ? el.className.trim().split(/\s+/).filter(Boolean).slice(0, 2)
+      : [];
+  if (cls.length) sel.push('.' + cls.join('.'));
+  const text = (el.textContent ?? '').trim().slice(0, 30);
+  return text ? `${sel.join('')} "${text}"` : sel.join('');
 }
 
 // No-ops until initGlitchTip runs (no DSN → no reporting), so callers never

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -131,6 +131,18 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
   const [, publicKey, host, projectId] = parsed;
   const url = `https://${host}/api/${projectId}/envelope/?sentry_key=${publicKey}&sentry_version=7`;
 
+  // Locale / timezone / calendar of the user's browser, sent on every event as
+  // the `culture` panel (the @sentry/vue equivalent, which reads it from Intl).
+  // Resolved once — it doesn't change over a session.
+  const culture = (() => {
+    try {
+      const o = Intl.DateTimeFormat().resolvedOptions();
+      return { locale: o.locale, timezone: o.timeZone, calendar: o.calendar };
+    } catch {
+      return undefined;
+    }
+  })();
+
   const breadcrumbs: Breadcrumb[] = [];
   let lastSig: string | null = null;
 
@@ -199,7 +211,7 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
         headers: { 'User-Agent': navigator.userAgent },
       },
       breadcrumbs: { values: breadcrumbs.slice() },
-      contexts: ctx?.contexts,
+      contexts: { ...(culture ? { culture } : {}), ...ctx?.contexts },
       exception: {
         values: [
           {

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -15,6 +15,9 @@ export interface CaptureContext {
   handled?: boolean;
   level?: 'error' | 'warning' | 'info';
   extra?: Record<string, unknown>;
+  // Structured context sections (e.g. `{ vue: { componentName, … } }`), each
+  // rendered as its own panel in GlitchTip alongside browser/os/device.
+  contexts?: Record<string, Record<string, unknown>>;
 }
 
 export interface GlitchTipOptions {
@@ -196,6 +199,7 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
         headers: { 'User-Agent': navigator.userAgent },
       },
       breadcrumbs: { values: breadcrumbs.slice() },
+      contexts: ctx?.contexts,
       exception: {
         values: [
           {

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -115,6 +115,39 @@ interface Client {
 
 let client: Client | null = null;
 
+// --- Trace context (Tier A: IDs only, no spans emitted) --------------------
+// Every event is tagged with a trace_id (rotated per navigation) + span_id, so
+// errors that happen within the same navigation group under one trace. We do
+// NOT emit transaction/span events, so GlitchTip's Performance tab stays empty
+// — that is deliberately out of scope.
+//
+// To go further (NOT done here):
+//   • Performance monitoring: emit `transaction` envelope items per
+//     pageload/navigation with real span timings (PerformanceObserver +
+//     performance.now()/timeOrigin), gated by a tracesSampleRate to cap ingest.
+//     ~250–400 lines — this is the bulk of @sentry/vue's tracing and the
+//     subtle, bug-prone part (span lifecycles, sampling, clocks). Prefer
+//     lazily re-adding @sentry/vue for tracing only over hand-rolling it.
+//   • Distributed tracing: inject `sentry-trace` + `baggage` headers on /api
+//     requests (a ky beforeRequest hook) AND run a Sentry/OTel SDK on the
+//     backend reporting to the same GlitchTip — only then do these IDs link a
+//     request across front ↔ back. Without the backend half, the IDs alone
+//     just group front-end errors.
+function randomHex(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+let traceId = randomHex(16); // 32 hex chars; stable for the current navigation
+let spanId = randomHex(8); // 16 hex chars
+
+// Begin a fresh trace for a new route navigation (called from boot/sentry.ts).
+export function startNavigationTrace(): void {
+  traceId = randomHex(16);
+  spanId = randomHex(8);
+}
+
 export function initGlitchTip(opts: GlitchTipOptions): void {
   const { dsn, release, environment, maxBreadcrumbs = 15 } = opts;
   const ignoreErrors = opts.ignoreErrors ?? [];
@@ -211,7 +244,11 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
         headers: { 'User-Agent': navigator.userAgent },
       },
       breadcrumbs: { values: breadcrumbs.slice() },
-      contexts: { ...(culture ? { culture } : {}), ...ctx?.contexts },
+      contexts: {
+        trace: { trace_id: traceId, span_id: spanId },
+        ...(culture ? { culture } : {}),
+        ...ctx?.contexts,
+      },
       exception: {
         values: [
           {

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -112,7 +112,9 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
 
   const storeOffline = (body: string) => {
     try {
-      const q = JSON.parse(localStorage.getItem(OFFLINE_KEY) || '[]') as string[];
+      const q = JSON.parse(
+        localStorage.getItem(OFFLINE_KEY) || '[]',
+      ) as string[];
       q.push(body);
       localStorage.setItem(OFFLINE_KEY, JSON.stringify(q.slice(-10)));
     } catch {
@@ -132,7 +134,9 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
 
   const flush = () => {
     try {
-      const q = JSON.parse(localStorage.getItem(OFFLINE_KEY) || '[]') as string[];
+      const q = JSON.parse(
+        localStorage.getItem(OFFLINE_KEY) || '[]',
+      ) as string[];
       localStorage.removeItem(OFFLINE_KEY);
       q.forEach(send);
     } catch {

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -1,0 +1,207 @@
+// Minimal GlitchTip/Sentry-compatible error reporter (~1–2 KB).
+//
+// We deliberately avoid @sentry/vue: this app only needs crash visibility, not
+// tracing/replay/feedback. The client speaks the Sentry "envelope" ingest
+// protocol, which GlitchTip accepts. It is a module-level singleton so any
+// module (api/http.ts, the router, the global handlers in boot/sentry.ts) can
+// report via captureError() without prop-drilling — the role @sentry/vue's
+// global captureMessage used to play. Without a DSN, init is a no-op, so dev
+// and CI stay silent.
+
+export interface CaptureContext {
+  // Sentry "mechanism": how the error surfaced (onerror, vue, vue-router, …).
+  // Drives grouping and the handled/unhandled badge in the GlitchTip UI.
+  mechanism?: string;
+  handled?: boolean;
+  level?: 'error' | 'warning' | 'info';
+  extra?: Record<string, unknown>;
+}
+
+export interface GlitchTipOptions {
+  dsn: string;
+  release?: string;
+  environment?: string;
+  // Messages matching any entry are dropped before sending (browser noise,
+  // user-driven aborts). Mirrors @sentry/vue's `ignoreErrors`.
+  ignoreErrors?: (string | RegExp)[];
+  maxBreadcrumbs?: number;
+}
+
+interface Breadcrumb {
+  timestamp: number;
+  message: string;
+  category: string;
+}
+
+interface StackFrame {
+  function: string;
+  filename: string;
+  lineno: number;
+  colno: number;
+  in_app: boolean;
+}
+
+const OFFLINE_KEY = 'gtq';
+
+// Normalize anything thrown (Error, string, ErrorEvent.message, rejection
+// reason) into an Error so we always have name/message/stack to report.
+function toError(raw: unknown): Error {
+  if (raw instanceof Error) return raw;
+  if (typeof raw === 'string') return new Error(raw);
+  const message = (raw as { message?: unknown } | null)?.message;
+  return new Error(message != null ? String(message) : 'Unknown error');
+}
+
+// Best-effort parse of an Error.stack into Sentry frames. Handles Chrome
+// ("at fn (url:line:col)") and Firefox/Safari ("fn@url:line:col"). The leading
+// "Error: message" line and any unparseable line are dropped. Frames are
+// reversed because Sentry renders them oldest-call-first.
+function parseStack(stack?: string): { frames: StackFrame[] } | undefined {
+  if (!stack) return undefined;
+  const frames = stack
+    .split('\n')
+    .map((raw): StackFrame | null => {
+      const m = raw
+        .trim()
+        .match(/^(?:at\s+)?(?:(.+?)\s*[(@])?\s*(.+?):(\d+):(\d+)\)?$/);
+      if (!m) return null;
+      return {
+        function: m[1] || '<anonymous>',
+        filename: m[2],
+        lineno: Number(m[3]),
+        colno: Number(m[4]),
+        in_app: true,
+      };
+    })
+    .filter((f): f is StackFrame => f !== null)
+    .reverse();
+  return frames.length ? { frames } : undefined;
+}
+
+function matchesAny(message: string, patterns: (string | RegExp)[]): boolean {
+  return patterns.some((p) =>
+    typeof p === 'string' ? message.includes(p) : p.test(message),
+  );
+}
+
+interface Client {
+  capture: (raw: unknown, ctx?: CaptureContext) => void;
+  breadcrumb: (message: string, category?: string) => void;
+}
+
+let client: Client | null = null;
+
+export function initGlitchTip(opts: GlitchTipOptions): void {
+  const { dsn, release, environment, maxBreadcrumbs = 15 } = opts;
+  const ignoreErrors = opts.ignoreErrors ?? [];
+
+  // DSN shape: https://<publicKey>@<host>/<projectId>. The public key
+  // authenticates ingest (sent as ?sentry_key) — the draft client dropped it,
+  // which is why GlitchTip rejected its events.
+  const parsed = dsn.match(/^https:\/\/(.+?)@(.+?)\/(\d+)\/?$/);
+  if (!parsed) {
+    // No silent fallback: a malformed DSN is a config error worth surfacing.
+    console.error('[glitchtip] invalid DSN, error reporting disabled:', dsn);
+    return;
+  }
+  const [, publicKey, host, projectId] = parsed;
+  const url = `https://${host}/api/${projectId}/envelope/?sentry_key=${publicKey}&sentry_version=7`;
+
+  const breadcrumbs: Breadcrumb[] = [];
+  let lastSig: string | null = null;
+
+  const storeOffline = (body: string) => {
+    try {
+      const q = JSON.parse(localStorage.getItem(OFFLINE_KEY) || '[]') as string[];
+      q.push(body);
+      localStorage.setItem(OFFLINE_KEY, JSON.stringify(q.slice(-10)));
+    } catch {
+      // localStorage unavailable/full — dropping the event is acceptable.
+    }
+  };
+
+  const send = (body: string) => {
+    // keepalive lets the POST outlive a page unload (errors thrown on navigation).
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-sentry-envelope' },
+      body,
+      keepalive: true,
+    }).catch(() => storeOffline(body));
+  };
+
+  const flush = () => {
+    try {
+      const q = JSON.parse(localStorage.getItem(OFFLINE_KEY) || '[]') as string[];
+      localStorage.removeItem(OFFLINE_KEY);
+      q.forEach(send);
+    } catch {
+      // Nothing buffered or storage unavailable.
+    }
+  };
+
+  const capture = (raw: unknown, ctx?: CaptureContext) => {
+    const error = toError(raw);
+    if (matchesAny(error.message, ignoreErrors)) return;
+
+    // Cheap consecutive-dedupe: stops a single throw that hits two handlers
+    // (e.g. window.onerror + Vue) — or an error loop — from spamming ingest.
+    const sig = `${error.message}::${(error.stack || '').slice(0, 80)}`;
+    if (sig === lastSig) return;
+    lastSig = sig;
+
+    const id = crypto.randomUUID().replace(/-/g, '');
+    const event = {
+      event_id: id,
+      timestamp: Date.now() / 1000,
+      platform: 'javascript',
+      level: ctx?.level ?? 'error',
+      release,
+      environment,
+      breadcrumbs: { values: breadcrumbs.slice() },
+      exception: {
+        values: [
+          {
+            type: error.name || 'Error',
+            value: error.message || String(error),
+            stacktrace: parseStack(error.stack),
+            mechanism: {
+              type: ctx?.mechanism ?? 'generic',
+              handled: ctx?.handled ?? true,
+            },
+          },
+        ],
+      },
+      extra: ctx?.extra,
+    };
+
+    // Sentry envelope = 3 newline-delimited JSON lines: envelope header, item
+    // header, item payload. The draft client omitted the item header line,
+    // which made GlitchTip reject the whole envelope.
+    const body =
+      JSON.stringify({ event_id: id, sent_at: new Date().toISOString(), dsn }) +
+      '\n' +
+      JSON.stringify({ type: 'event' }) +
+      '\n' +
+      JSON.stringify(event);
+    send(body);
+  };
+
+  const breadcrumb = (message: string, category = 'app') => {
+    breadcrumbs.push({ timestamp: Date.now() / 1000, message, category });
+    if (breadcrumbs.length > maxBreadcrumbs) breadcrumbs.shift();
+  };
+
+  client = { capture, breadcrumb };
+  flush();
+}
+
+// No-ops until initGlitchTip runs (no DSN → no reporting), so callers never
+// need to null-check.
+export function captureError(error: unknown, ctx?: CaptureContext): void {
+  client?.capture(error, ctx);
+}
+
+export function addBreadcrumb(message: string, category?: string): void {
+  client?.breadcrumb(message, category);
+}

--- a/frontend/src/utils/glitchtip.ts
+++ b/frontend/src/utils/glitchtip.ts
@@ -43,13 +43,34 @@ interface StackFrame {
 
 const OFFLINE_KEY = 'gtq';
 
+// Compact, never-throwing string for a non-Error value (rejected object,
+// number, etc.) so its content survives into the report.
+function describeNonError(raw: unknown): string {
+  try {
+    return typeof raw === 'object' && raw !== null
+      ? JSON.stringify(raw)
+      : String(raw);
+  } catch {
+    // Circular/unserializable — fall back to the type tag, e.g. [object Object].
+    return Object.prototype.toString.call(raw);
+  }
+}
+
 // Normalize anything thrown (Error, string, ErrorEvent.message, rejection
 // reason) into an Error so we always have name/message/stack to report.
 function toError(raw: unknown): Error {
   if (raw instanceof Error) return raw;
   if (typeof raw === 'string') return new Error(raw);
+  // Objects with a string `message` (DOMException, custom error-likes).
   const message = (raw as { message?: unknown } | null)?.message;
-  return new Error(message != null ? String(message) : 'Unknown error');
+  if (typeof message === 'string' && message) return new Error(message);
+  // True non-Error rejection: keep the payload instead of "Unknown error",
+  // and tag it distinctly so GlitchTip groups these apart from real Errors.
+  const err = new Error(
+    `Non-Error rejection: ${describeNonError(raw).slice(0, 200)}`,
+  );
+  err.name = 'NonError';
+  return err;
 }
 
 // Best-effort parse of an Error.stack into Sentry frames. Handles Chrome
@@ -154,6 +175,11 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
     if (sig === lastSig) return;
     lastSig = sig;
 
+    // A real Error carries a stack from its throw/reject site. Anything else
+    // (string, rejected object/number) only gets the stack we synthesize here
+    // at capture time — flag it so the trace reads as synthetic, not real.
+    const synthetic = !(raw instanceof Error);
+
     const id = crypto.randomUUID().replace(/-/g, '');
     const event = {
       event_id: id,
@@ -179,6 +205,7 @@ export function initGlitchTip(opts: GlitchTipOptions): void {
             mechanism: {
               type: ctx?.mechanism ?? 'generic',
               handled: ctx?.handled ?? true,
+              ...(synthetic ? { synthetic: true } : {}),
             },
           },
         ],


### PR DESCRIPTION
## What

Replaces the `@sentry/vue` SDK (~900 KB lazy chunk) with a **small, dependency-free** GlitchTip-compatible error reporter (`src/utils/glitchtip.ts`), then rebuilds the context the SDK gave for free. Scope is **errors only** — no performance tracing, no replay.

## Why nothing reached GlitchTip before

Two independent causes, both fixed:

1. **DSN never loaded.** `quasar.config.js` reads only `.env.local`; the DSN was in `.env` (read by neither that loader nor Vite), so `runtimeConfig.sentryDsn` was empty and init was skipped.
2. **The prior draft (`scripts/glitchtip.js`) couldn't ingest.** Its envelope omitted the mandatory `{"type":"event"}` item-header line, and the DSN parse discarded the public key (no `sentry_key` auth) → GlitchTip rejected the request.

(Also discovered during testing: a bare `throw` typed at the **console REPL** does not fire `window.onerror` in WebKit — use `setTimeout(() => { throw … })`. Not a code bug.)

## Error capture — every source wired via `captureError`

| Source | Hook |
| --- | --- |
| Vue component errors | `app.config.errorHandler` |
| Vue Router (chunk load, guards) | `router.onError` |
| Global / DOM-event errors | `window 'error'` (ResizeObserver suppressed) |
| Unhandled promise rejections | `window 'unhandledrejection'` |
| ky HTTP 5xx | `afterResponse` in `api/http.ts` (4xx intentionally not reported) |

## Context parity with the SDK

- **browser / os / device** tags + icons — ships `request.headers["User-Agent"]`; GlitchTip derives them server-side.
- **culture** panel — locale / timezone / calendar from `Intl`, on every event.
- **vue** panel — `componentName`, `lifecycleHook`, depth-1 `propsData` (nested → `[Object]`/`[Array]` to avoid circular refs / huge payloads).
- **trace** context (Tier A) — `trace_id` rotated per navigation + `span_id`, so errors within one navigation group together. **No** transaction/span events emitted (Performance tab stays empty by design). The client header comment documents what full performance + distributed tracing would require — intentionally out of scope.
- **breadcrumbs** — auto-recorded: `fetch` (skips the client's own ingest POSTs), `console.error/warn`, `ui.click`, and `navigation` (via `router.afterEach`).

## Robustness

- **Non-Error rejections** (`Promise.reject({...})`, numbers) keep their serialized payload as the title with a distinct `NonError` type, instead of collapsing to "Unknown error".
- **Synthetic traces** flagged: real Errors carry their throw/reject-site stack; synthesized stacks (string / non-Error captures) set `mechanism.synthetic = true`. (The browser keeps no origin trace for a plain-value rejection — reject with an `Error` to keep one.)
- Stale **route-chunk load failures** show a single sticky "new version available — reload" toast (`router.onError`), so a client on an old `index.html` after a deploy recovers in one click. Strings `new_version_available` / `reload` added to `src/i18n/common.ts`.
- Best-effort `localStorage` offline buffer + flush; consecutive-error dedupe; `keepalive` POST.

## Dev ergonomics

`window.__gtTest('throw' | 'reject' | 'reject-nonerror' | 'capture' | 'chunk')` fires each path from the console. Guarded by `import.meta.env.DEV` → dead-code-eliminated from prod builds.

## Removed

`@sentry/vue` dependency (+7 transitive) and both its usages; deleted the dead `scripts/glitchtip.js`. No Docker/Helm change — `entrypoint.sh` injects any `APP_*` var generically.

## Verification

- `make type-check` (vue-tsc), `npm run lint`, `make format`, `npm run build` — all green; no `@sentry` imports remain.
- Verified end-to-end against the EPFL GlitchTip instance: events ingest with browser/os/culture/vue/trace context + breadcrumb trail.
- Manual: `cp .env .env.local`, restart `quasar dev`, then `window.__gtTest('<kind>')` per the table above.

## Config note

DSN must live in `.env.local` (dev) — `.env` is not loaded. In prod it comes from the pod env via Helm → `injectEnv.js`.

Implementation plan: `docs/src/implementation-plans/frontend-glitchtip-error-reporting.md`

## Open decisions (reviewer's call)

- Keep the `__gtTest` dev helper in the merge (zero prod cost, handy for regressions) or strip it?
- GlitchTip **Logs** tab is a separate structured-logs feature (different envelope item type) — left off intentionally; can be a follow-up PR if wanted.