### PR TITLE
fix: allow user.principal to access sync pipelines they own

### DIFF
--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -1678,9 +1678,7 @@ async def list_pipelines(
 async def get_pipeline_jobs(
     pipeline_id: UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(
-        require_any_scope("view", "backoffice.pipeline_operations")
-    ),
+    current_user: User = Depends(require_module_or_config_view()),
 ) -> PipelineResponse:
     """Return every job in a multi-step pipeline run, ordered by id.
 
@@ -1733,9 +1731,7 @@ async def get_pipeline_jobs(
 async def pipeline_stream_by_id(
     pipeline_id: UUID,
     request: Request,
-    current_user: User = Depends(
-        require_any_scope("view", "backoffice.pipeline_operations")
-    ),
+    current_user: User = Depends(require_module_or_config_view()),
 ):
     """Server-Sent Events stream for every job sharing a ``pipeline_id``.
 


### PR DESCRIPTION
## Summary

Replace the overly restrictive `require_any_scope('view', 'backoffice.pipeline_operations')` gate on `GET /sync/pipelines/{id}` and `GET /sync/pipelines/{id}/stream` with `require_module_or_config_view()`, which allows any user holding a `modules.*.sync` permission (like `calco2.user.principal`).

The existing `_check_pipeline_scope_from_jobs` call inside each handler already enforces that the user can only access pipelines belonging to their own unit, so this change correctly allows principal users to see their own pipelines while maintaining the unit-scoped boundary.

## Files Changed

- `backend/app/api/v1/data_sync.py` — two dependency replacements