### PR TITLE
feat(module-table): 1587 remove module upload visibility by adding CSV tools permission check

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -1,6 +1,9 @@
 <template>
   <div v-if="hasTopBar" class="q-mb-md flex justify-between items-center wrap">
-    <div v-if="hasModuleUpload && !isInputDeactivated" class="q-gutter-sm">
+    <div
+      v-if="hasModuleUpload && !isInputDeactivated && canUseCsvTools"
+      class="q-gutter-sm"
+    >
       <q-btn
         outline
         icon="o_view_list"
@@ -787,6 +790,10 @@ const hasModuleUpload = computed(() => {
     props.moduleFields.filter((field) => !field.hideIn?.form).length > 0
   );
 });
+
+const canUseCsvTools = computed(() =>
+  authStore.hasUserCanValidateModuleStatus(),
+);
 
 // Permission check: can user edit this module?
 const canEdit = computed(() => {


### PR DESCRIPTION
## What does this change?
Hides the CSV upload/download toolbar from standard users by gating it on a new `canUseCsvTools` permission check.

- `ModuleTable.vue`: adds `&& canUseCsvTools` to the `v-if` condition on the upload toolbar `div`
- New `canUseCsvTools` computed: delegates to `authStore.hasUserCanValidateModuleStatus()`, reusing the existing "can validate module status" permission as the gate for CSV tool access

## Why is this needed?
Standard users (without validation rights) were seeing the CSV upload/download template buttons even though they should not have access to bulk data ingestion tools. This restricts the toolbar to users who already have the validation permission, matching the intended access model.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- related to #1587