### PR TITLE
feat(ItFocusBreakdownChart): 1568 remove ModuleIcon component and update legend styling

### DIFF
--- a/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
+++ b/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
@@ -19,7 +19,6 @@ import {
 } from 'echarts/components';
 import VChart from 'vue-echarts';
 
-import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import TooltipEcharts from 'src/components/charts/results/TooltipEcharts.vue';
 import { useEchartsTooltip } from 'src/components/charts/results/useEchartsTooltip';
 import {
@@ -391,16 +390,10 @@ defineExpose({ downloadPNG });
           :key="cat.key"
           class="waffle-legend-item"
         >
-          <ModuleIcon
+          <span
             v-if="cat.isIT"
-            :name="IT_FOCUS_CATEGORY_TO_MODULE[cat.key]"
-            size="sm"
-            color=""
-            :style="{
-              color: isTinyNonZeroPercent(cat.units)
-                ? 'var(--semantic-color-text-muted)'
-                : cat.color,
-            }"
+            class="waffle-swatch"
+            :style="{ backgroundColor: cat.color }"
           />
           <span
             v-else
@@ -474,11 +467,11 @@ defineExpose({ downloadPNG });
 }
 
 .waffle-swatch {
-  width: dec.$spacing-sm;
-  height: dec.$spacing-sm;
-  border-radius: dec.$radius-default-px;
+  width: dec.$spacing-md;
+  height: dec.$spacing-md;
   flex-shrink: 0;
   display: inline-block;
+  margin-right: dec.$spacing-xs;
 }
 
 .waffle-swatch--outlined {


### PR DESCRIPTION
## What does this change?
Replaces the `ModuleIcon` component in the IT focus breakdown chart legend with a plain colored square swatch.

- `ItFocusBreakdownChart.vue`: removes the `ModuleIcon` import and replaces the `<ModuleIcon>` element (used when `cat.isIT`) with a `<span class="waffle-swatch">` whose `backgroundColor` is set to `cat.color`
- `.waffle-swatch` CSS: increases the swatch from `spacing-sm` to `spacing-md` in both width and height, removes the border-radius, and adds a right margin

## Why is this needed?
The module icons in the IT breakdown chart legend were visually inconsistent and harder to read at small sizes. A solid colored square matches the waffle chart cells directly, making the legend easier to interpret.

## Type of change
- [x] 🎨 Design/UI improvement

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1568