### PR TITLE
Fix/security

### DIFF
--- a/.github/workflows/publish_chart.yaml
+++ b/.github/workflows/publish_chart.yaml
@@ -39,7 +39,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Render Chart
-        run: helm template .
+        # Smoke-test both secret paths. Default (external) needs a Secret name;
+        # chart-managed (dev) needs a throwaway SECRET_KEY. Real deploys inject
+        # the real values.
+        run: |
+          helm template . --set backend.existingSecret.name=ci-existing-secret
+          helm template . --set backend.existingSecret.enabled=false --set backend.secrets.SECRET_KEY=ci-render-check
 
       - name: Set Helm chart version based on branch
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.3
         with:
           path: ./
           base: ${{ github.event.pull_request.base.ref }}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,8 @@
 # -----------------------------------------------------------------------------
 APP_NAME=CO2 Calculator API
 APP_VERSION=0.1.0
+# Local development only. DEBUG enables the /login-test auth bypass and drops
+# the session cookie's Secure flag — NEVER set True on stage/prod.
 DEBUG=True
 # Set to True for local development environment
 LOCAL_ENVIRONMENT=True

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,6 +24,10 @@ class Settings(BaseSettings):
     # Application
     APP_NAME: str = "CO2 Calculator API"
     APP_VERSION: str = "0.1.0"
+    # SECURITY: must stay False on stage/prod. DEBUG drops the session cookie's
+    # Secure flag (main.py) and registers the /login-test auth bypass (auth.py).
+    # One image ships to every env; DEBUG is set per-platform in gitops
+    # (dev=true, stage/prod=false). Never flip this default to True.
     DEBUG: bool = False
     LOCAL_ENVIRONMENT: bool = Field(
         default=False, description="Set to True for local development environment"

--- a/backend/tests/unit/core/test_config_security.py
+++ b/backend/tests/unit/core/test_config_security.py
@@ -1,0 +1,22 @@
+"""Regression test: the DEBUG setting must default to False in code.
+
+DEBUG is security-critical. It controls the OAuth session cookie's Secure
+flag (`app/main.py`: ``https_only=not settings.DEBUG``) and whether the
+``/login-test`` auth-bypass route is registered (`app/api/v1/auth.py`). One
+image ships to dev/stage/prod with DEBUG set per-environment in the gitops
+repo, so the code default is the safety net: it must stay False so a missing
+or empty ``DEBUG`` env var can never silently enable debug behaviour in
+production.
+"""
+
+from app.core.config import Settings
+
+
+def test_debug_defaults_to_false():
+    """The DEBUG field default must be False (fail-safe for stage/prod).
+
+    Asserts the declared field default rather than ``Settings().DEBUG`` so the
+    check is independent of whatever DEBUG is set to in the test environment —
+    it pins the source-code default, which is the thing that must not regress.
+    """
+    assert Settings.model_fields["DEBUG"].default is False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "80:80"
-      - "8080:8833"
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:8080:8833"
     expose:
       - "80"
       - "8833"
@@ -41,7 +41,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     labels:
       - "traefik.enable=false"
     volumes:
@@ -65,7 +65,7 @@ services:
     volumes:
       - pgadmin_data:/var/lib/pgadmin
     ports:
-      - "5050:80"
+      - "127.0.0.1:5050:80"
     depends_on:
       - postgres
 
@@ -119,7 +119,7 @@ services:
       dockerfile: Dockerfile
     container_name: co2-frontend
     ports:
-      - "3000:8080"
+      - "127.0.0.1:3000:8080"
     # Match the k8s pod's securityContext (readOnlyRootFilesystem: true plus
     # the three emptyDir mounts in helm/templates/frontend-deployment.yaml).
     # Catches read-only-fs regressions locally before they ship to a cluster
@@ -153,8 +153,8 @@ services:
     labels:
       - "traefik.enable=false"
     ports:
-      - "9464:9464"   # Prometheus — host access
-      - "4317:4317"   # gRPC OTLP — add if you need host access too
+      - "127.0.0.1:9464:9464"   # Prometheus — host access
+      - "127.0.0.1:4317:4317"   # gRPC OTLP — add if you need host access too
     expose:
       - "4317"        # gRPC OTLP — makes it reachable by other containers
       - "4318"        # HTTP OTLP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       dockerfile: Dockerfile
     container_name: co2-backend
     environment:
+      # Local compose only — never True on stage/prod (see app/core/config.py).
       DEBUG: "True"
       HOST: "0.0.0.0"
       PORT: "8000"

--- a/frontend/src/components/atoms/ModuleIcon.vue
+++ b/frontend/src/components/atoms/ModuleIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watchEffect } from 'vue';
+import { computed, type Directive } from 'vue';
 import { icons } from 'src/plugin/module-icon';
 
 const props = withDefaults(
@@ -14,17 +14,23 @@ const props = withDefaults(
   },
 );
 
-const iconRef = ref<HTMLElement>();
 const svgContent = computed(() => icons[props.name] || '');
 
-watchEffect(
-  () => {
-    if (iconRef.value && svgContent.value) {
-      iconRef.value.innerHTML = svgContent.value;
-    }
-  },
-  { flush: 'post' },
-);
+// Render trusted, build-time SVG strings without innerHTML: DOMParser builds an
+// inert document, so parsed <script> nodes never execute when inserted.
+const renderSvg = (el: HTMLElement, svg: string) => {
+  if (!svg) {
+    el.replaceChildren();
+    return;
+  }
+  const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  el.replaceChildren(document.importNode(doc.documentElement, true));
+};
+
+const vSvg: Directive<HTMLElement, string> = {
+  mounted: (el, binding) => renderSvg(el, binding.value),
+  updated: (el, binding) => renderSvg(el, binding.value),
+};
 
 const iconClass = computed(() => [
   'module-icon',
@@ -34,5 +40,5 @@ const iconClass = computed(() => [
 </script>
 
 <template>
-  <span ref="iconRef" :class="iconClass" />
+  <span v-svg="svgContent" :class="iconClass" />
 </template>

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -59,8 +59,8 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
 {{- define "co2-calculator.backendSecretName" -}}
-{{- if and .Values.backend.existingSecret.enabled .Values.backend.existingSecret.name -}}
-{{- .Values.backend.existingSecret.name -}}
+{{- if .Values.backend.existingSecret.enabled -}}
+{{- required "backend.existingSecret.enabled=true but backend.existingSecret.name is empty. Set it to your pre-existing Secret's name, or set backend.existingSecret.enabled=false to use a chart-managed secret." .Values.backend.existingSecret.name -}}
 {{- else -}}
 {{ include "co2-calculator.fullname" . }}-backend
 {{- end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -129,8 +129,11 @@ backend:
   tolerations: []
   affinity: {}
   existingSecret:
-    enabled: false
-    name: "" # Name of the existing secret containing backend secrets
+    # Default: reference a pre-existing Secret (production path).
+    # For local/dev chart-managed secrets, set enabled=false and provide
+    # backend.secrets.SECRET_KEY.
+    enabled: true
+    name: "" # REQUIRED when enabled=true: name of the pre-existing Secret
     keys:
       secretKeyKey: SECRET_KEY # Key in the existing secret for SECRET_KEY
       oauthClientIdKey: OAUTH_CLIENT_ID # Key in the existing secret for OAuth client ID


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the development workflow, application configuration, security, and frontend code. The most significant changes enhance security defaults, improve local development safety, and refactor frontend SVG rendering for safety and clarity.

**Security and Configuration Improvements:**

* Ensured the `DEBUG` setting in `backend/app/core/config.py` explicitly defaults to `False` for production safety, with clear comments warning against enabling it outside development. This prevents accidental security issues if the environment variable is missing or unset.
* Added a regression test in `backend/tests/unit/core/test_config_security.py` to guarantee that the `DEBUG` setting's default remains `False` in code, acting as a fail-safe for production deployments.
* Updated the `.env.example` and `docker-compose.yml` to clarify the use of `DEBUG` and ensure it's only enabled for local development, never for stage or production. [[1]](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080R15-R16) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R79)

**Local Development and Security Hardening:**

* Modified all service port mappings in `docker-compose.yml` to bind to `127.0.0.1` instead of all interfaces, reducing exposure of development services to the host network. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R27) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L44-R44) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L68-R68) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L122-R123) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L156-R158)

**Helm Chart and CI/CD Enhancements:**

* Improved Helm chart secret handling: the chart now requires a pre-existing secret name when `existingSecret.enabled=true`, and the error message is more explicit if it’s missing. The default for `existingSecret.enabled` is now `true` (production path), making the intent clearer and safer for new deployments. [[1]](diffhunk://#diff-f1a6324c375e55f92a8e4e1e5cc78ba3cc846c4869deb2d1659841257a325bceL62-R63) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L132-R136)
* Updated the Helm chart CI workflow to smoke-test both secret-handling paths, ensuring both production and development configurations are validated during CI runs.

**Frontend Refactor:**

* Refactored `ModuleIcon.vue` to safely render SVG icons using a custom directive and `DOMParser`, eliminating the use of `innerHTML` and reducing XSS risk. [[1]](diffhunk://#diff-7cb496d8ceeaea6bae57341f80cf03e8a60fca99749ab4ae8325989ec8fdef3dL2-R2) [[2]](diffhunk://#diff-7cb496d8ceeaea6bae57341f80cf03e8a60fca99749ab4ae8325989ec8fdef3dL17-R33) [[3]](diffhunk://#diff-7cb496d8ceeaea6bae57341f80cf03e8a60fca99749ab4ae8325989ec8fdef3dL37-R43)

**Dependency and Workflow Updates:**

* Pinned the TruffleHog security scanning action in `.github/workflows/security.yml` to a specific version (`v3.95.3`) for more predictable and stable CI runs.