### PR TITLE
perf(frontend): drop Material Icons webfonts for tree-shaken SVG icons

### DIFF
--- a/docs/src/implementation-plans/frontend-svg-icons-drop-webfonts.md
+++ b/docs/src/implementation-plans/frontend-svg-icons-drop-webfonts.md
@@ -1,0 +1,563 @@
+---
+status: in-progress
+last_updated: 2026-06-19
+title: "Drop Material Icons webfonts in favour of tree-shaken SVG icons"
+summary: "Replace the two Quasar Material Icons webfonts (~278 KiB, render-/LCP-blocking, font-display:block FOIT) with in-component SVG imports from @quasar/extras and the svg-material-icons icon set, so only the icons actually used are bundled and no icon webfont is shipped."
+---
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the app with **zero icon webfonts** — every icon rendered as an inline SVG, tree-shaken so only the ~111 icons in use are bundled.
+
+**Architecture:** Two icon surfaces must both move to SVG: (1) **Quasar's internal component icons** (dropdown arrows, sort carets, checkboxes, stepper, pagination, close buttons inside `q-select`/`q-chip`, etc.) — switched in one line via `framework.iconSet: 'svg-material-icons'`; (2) **app-authored icons** — every `<q-icon name="…">`, `icon="…"` prop, and config `icon: '…'` field — converted to in-component named imports from `@quasar/extras/material-icons` (`mat*`) and `@quasar/extras/material-icons-outlined` (`outlined*`). The two webfonts are removed from `extras` only after every call site is converted, so the app renders correctly at every commit. A temporary dev-mode `iconMapFn` guard catches any string icon name that slips through.
+
+**Tech Stack:** Vue 3.5, Quasar 2.19 (`@quasar/app-vite` 2.6), `@quasar/extras` (SVG icon exports), Vite, `vue-tsc` 3.3.5.
+
+## Global Constraints
+
+- **Never remove the fonts before all call sites are converted.** While both fonts remain in `extras`, unconverted string-name icons still render — this is the safety net for incremental conversion. Removing `extras` fonts is the _last_ task.
+- **Do not touch `ModuleIcon` / `ModuleIconBox` / `module-icon` plugin usages** (`:name="module"`, `:name="moduleCard.module"`, `:name="row.module"`, …). Those render custom module SVGs (`src/assets/icons/modules/*.svg` via `import.meta.glob` raw import) and are **unaffected** by webfont removal.
+- **Do not touch i18n keys, domain strings, or any non-icon `name:`/`icon:` object property.** Many snake_case strings (`room_name`, `results_units_kg`, …) are translation keys, not icons.
+- **Backend / API unchanged.** Frontend-only change. PR targets `dev`.
+- **Verification gate per task:** `cd frontend && make type-check` (runs `npx vue-tsc --noEmit -p tsconfig.typecheck.json`). There is **no JS unit-test harness** for icons, so the type-checker is the test: a wrong or non-existent export name (e.g. `matInfoOutline`) fails compilation. Plus the per-area grep guard (below). The user runs the full test/e2e suite — stop at type-check + build.
+- **Lint:** `cd frontend && npm run lint` must stay green (catches unused imports if a conversion is half-done).
+
+---
+
+## Background — current state (measured 2026-06-18)
+
+Lighthouse on `…/2025/equipment`:
+
+- `flUhRq6tz…woff2` — **126 KiB**, Material Icons, `font-display: block` (FOIT), on LCP critical path (~1,020 ms).
+- `gok-H7zzD…woff2` — **152 KiB**, Material Icons Outlined, `font-display: block`, on LCP critical path (~1,249 ms).
+- Both injected unconditionally by `quasar.config.js → framework... ` no — by the top-level `extras: ['material-icons', 'material-icons-outlined']`.
+
+Call-site inventory (frontend `src/`):
+
+- `73` `<q-icon name="…">` tags, `88` `icon="…"` literal props, `65` config `icon: '…'` fields, `4` icon literals hidden inside `:name`/`:icon` ternaries (`chevron_left/right`, `lock`, `lock_open`).
+- `111` distinct icon names total: **45** base material + **66** outlined.
+- **~80 files** across `components/`, `pages/`, `constant/`.
+- `:name="…"` bindings that target `ModuleIcon`/`ModuleIconBox` are **out of scope** (custom SVGs).
+
+---
+
+## Conversion recipe (applies to every Task 2–7)
+
+For each affected file:
+
+1. **Template literal → bound SVG import.**
+   ```vue
+   <!-- before -->
+   <!-- after -->
+   <q-icon name="close" />
+   <q-icon :name="matClose" />
+   <q-btn icon="o_info" />
+   <q-btn :icon="outlinedInfo" />
+   ```
+2. **Ternary literal → bound import (import both branches).**
+   ```vue
+   <!-- before -->
+   <q-icon :name="collapsed ? 'chevron_right' : 'chevron_left'" />
+   <!-- after -->
+   <q-icon :name="collapsed ? matChevronRight : matChevronLeft" />
+   ```
+3. **Config object field (`.ts` / `<script>`).**
+   ```ts
+   // before
+   { label: 'Close', icon: 'o_close' }
+   // after
+   import { outlinedClose } from '@quasar/extras/material-icons-outlined'
+   { label: 'Close', icon: outlinedClose }
+   ```
+   The consuming template (`:icon="item.icon"`) stays unchanged — SVG exports are plain `string`s (`"path…|viewBox"`), so existing `icon: string` types still hold.
+4. **Add imports at the top of the file**, grouped by source:
+   ```ts
+   import { matClose, matRefresh } from "@quasar/extras/material-icons";
+   import {
+     outlinedInfo,
+     outlinedClose,
+   } from "@quasar/extras/material-icons-outlined";
+   ```
+5. **Look up the export name in the Mapping Table below.** `o_`-prefixed names → `outlined*` (from `material-icons-outlined`); all others → `mat*` (from `material-icons`).
+6. **Do not convert** `ModuleIcon`/`ModuleIconBox`/`module-icon` `:name` bindings, or non-icon properties.
+
+After editing a file, the `name=`/`icon=`/`icon:` literal must be gone (it is now `:name`/`:icon` bound, or `icon: <import>`).
+
+### What NOT to touch (explicit allow-list of survivors)
+
+- `<ModuleIcon :name="…">`, `<ModuleIconBox :name="…">`, `module-icon` — custom module SVGs.
+- `:name="icon"` where `icon` is a prop/variable (e.g. `EssentialLink.vue`, `VirtualSelectField.vue`) — already dynamic; the source value gets converted at its origin (config / computed), not here.
+- Any `name:`/`icon:` that is not an icon (i18n keys, type discriminators, API fields).
+
+---
+
+## Authoritative Mapping Table
+
+Generated and verified against `@quasar/extras` (every export confirmed to exist). Five names have no exact export — the closest visual match is given and flagged ⚠ for a visual confirm during review.
+
+### material-icons → `@quasar/extras/material-icons` (45)
+
+| name string               | SVG export                  | note                                                |
+| ------------------------- | --------------------------- | --------------------------------------------------- |
+| `add`                     | `matAdd`                    |                                                     |
+| `add_circle`              | `matAddCircle`              |                                                     |
+| `adjust`                  | `matAdjust`                 |                                                     |
+| `badge`                   | `matBadge`                  |                                                     |
+| `bar_chart`               | `matBarChart`               |                                                     |
+| `calculate`               | `matCalculate`              |                                                     |
+| `calendar_month`          | `matCalendarMonth`          |                                                     |
+| `calendar_today`          | `matCalendarToday`          |                                                     |
+| `cancel`                  | `matCancel`                 |                                                     |
+| `category`                | `matCategory`               |                                                     |
+| `check`                   | `matCheck`                  |                                                     |
+| `check_box_outline_blank` | `matCheckBoxOutlineBlank`   |                                                     |
+| `check_circle`            | `matCheckCircle`            |                                                     |
+| `chevron_left`            | `matChevronLeft`            |                                                     |
+| `chevron_right`           | `matChevronRight`           |                                                     |
+| `circle`                  | `matCircle`                 |                                                     |
+| `close`                   | `matClose`                  |                                                     |
+| `content_copy`            | `matContentCopy`            |                                                     |
+| `data_object`             | `matDataObject`             |                                                     |
+| `delete`                  | `matDelete`                 |                                                     |
+| `download`                | `matDownload`               |                                                     |
+| `edit`                    | `matEdit`                   |                                                     |
+| `edit_note`               | `matEditNote`               |                                                     |
+| `edit_off`                | `matEditOff`                |                                                     |
+| `error`                   | `matError`                  |                                                     |
+| `event`                   | `matEvent`                  |                                                     |
+| `file_upload`             | `matFileUpload`             |                                                     |
+| `grid_view`               | `matGridView`               |                                                     |
+| `hourglass_empty`         | `matHourglassEmpty`         |                                                     |
+| `lock`                    | `matLock`                   |                                                     |
+| `lock_open`               | `matLockOpen`               |                                                     |
+| `manufacturing`           | `matPrecisionManufacturing` | ⚠ no exact export — closest match, confirm visually |
+| `map`                     | `matMap`                    |                                                     |
+| `refresh`                 | `matRefresh`                |                                                     |
+| `report`                  | `matReport`                 |                                                     |
+| `report_problem`          | `matReportProblem`          |                                                     |
+| `restart_alt`             | `matRestartAlt`             |                                                     |
+| `search`                  | `matSearch`                 |                                                     |
+| `search_off`              | `matSearchOff`              |                                                     |
+| `stacked_bar_chart`       | `matStackedBarChart`        |                                                     |
+| `sync`                    | `matSync`                   |                                                     |
+| `unfold_more`             | `matUnfoldMore`             |                                                     |
+| `upload`                  | `matUpload`                 |                                                     |
+| `view_module`             | `matViewModule`             |                                                     |
+| `warning`                 | `matWarning`                |                                                     |
+
+### material-icons-outlined → `@quasar/extras/material-icons-outlined` (66)
+
+| name string               | SVG export                    | note                                                |
+| ------------------------- | ----------------------------- | --------------------------------------------------- |
+| `info_outline`            | `outlinedInfo`                | ⚠ no exact export — closest match, confirm visually |
+| `o_ac_unit`               | `outlinedAcUnit`              |                                                     |
+| `o_account_tree`          | `outlinedAccountTree`         |                                                     |
+| `o_add_box`               | `outlinedAddBox`              |                                                     |
+| `o_add_circle`            | `outlinedAddCircle`           |                                                     |
+| `o_add_comment`           | `outlinedAddComment`          |                                                     |
+| `o_air`                   | `outlinedAir`                 |                                                     |
+| `o_apartment`             | `outlinedApartment`           |                                                     |
+| `o_apps`                  | `outlinedApps`                |                                                     |
+| `o_article`               | `outlinedArticle`             |                                                     |
+| `o_assessment`            | `outlinedAssessment`          |                                                     |
+| `o_assignment`            | `outlinedAssignment`          |                                                     |
+| `o_assignment_ind`        | `outlinedAssignmentInd`       |                                                     |
+| `o_autorenew`             | `outlinedAutorenew`           |                                                     |
+| `o_bar_chart`             | `outlinedBarChart`            |                                                     |
+| `o_bolt`                  | `outlinedBolt`                |                                                     |
+| `o_business`              | `outlinedBusiness`            |                                                     |
+| `o_calculate`             | `outlinedCalculate`           |                                                     |
+| `o_calendar_month`        | `outlinedCalendarMonth`       |                                                     |
+| `o_category`              | `outlinedCategory`            |                                                     |
+| `o_check_circle`          | `outlinedCheckCircle`         |                                                     |
+| `o_check_small`           | `outlinedCheck`               | ⚠ no exact export — closest match, confirm visually |
+| `o_close`                 | `outlinedClose`               |                                                     |
+| `o_content_copy`          | `outlinedContentCopy`         |                                                     |
+| `o_delete`                | `outlinedDelete`              |                                                     |
+| `o_diversity_2`           | `outlinedDiversity2`          |                                                     |
+| `o_donut_large`           | `outlinedDonutLarge`          |                                                     |
+| `o_download`              | `outlinedDownload`            |                                                     |
+| `o_edit`                  | `outlinedEdit`                |                                                     |
+| `o_edit_document`         | `outlinedEditNote`            | ⚠ no exact export — closest match, confirm visually |
+| `o_electric_bolt`         | `outlinedElectricBolt`        |                                                     |
+| `o_error`                 | `outlinedError`               |                                                     |
+| `o_event`                 | `outlinedEvent`               |                                                     |
+| `o_filter_drama`          | `outlinedFilterDrama`         |                                                     |
+| `o_flight`                | `outlinedFlight`              |                                                     |
+| `o_help_center`           | `outlinedHelpCenter`          |                                                     |
+| `o_image_aspect_ratio`    | `outlinedImageAspectRatio`    |                                                     |
+| `o_info`                  | `outlinedInfo`                |                                                     |
+| `o_light_mode`            | `outlinedLightMode`           |                                                     |
+| `o_list_alt`              | `outlinedListAlt`             |                                                     |
+| `o_local_fire_department` | `outlinedLocalFireDepartment` |                                                     |
+| `o_lock`                  | `outlinedLock`                |                                                     |
+| `o_mail`                  | `outlinedMail`                |                                                     |
+| `o_meeting_room`          | `outlinedMeetingRoom`         |                                                     |
+| `o_notifications`         | `outlinedNotifications`       |                                                     |
+| `o_pending`               | `outlinedPending`             |                                                     |
+| `o_people`                | `outlinedPeople`              |                                                     |
+| `o_picture_as_pdf`        | `outlinedPictureAsPdf`        |                                                     |
+| `o_pie_chart`             | `outlinedPieChart`            |                                                     |
+| `o_print`                 | `outlinedPrint`               |                                                     |
+| `o_report_problem`        | `outlinedReportProblem`       |                                                     |
+| `o_save`                  | `outlinedSave`                |                                                     |
+| `o_schema`                | `outlinedSchema`              |                                                     |
+| `o_science`               | `outlinedScience`             |                                                     |
+| `o_search`                | `outlinedSearch`              |                                                     |
+| `o_search_off`            | `outlinedSearchOff`           |                                                     |
+| `o_sell`                  | `outlinedSell`                |                                                     |
+| `o_straighten`            | `outlinedStraighten`          |                                                     |
+| `o_swap_horiz`            | `outlinedSwapHoriz`           |                                                     |
+| `o_table`                 | `outlinedTableChart`          | ⚠ no exact export — closest match, confirm visually |
+| `o_thermostat`            | `outlinedThermostat`          |                                                     |
+| `o_timer`                 | `outlinedTimer`               |                                                     |
+| `o_view_cozy`             | `outlinedViewCozy`            |                                                     |
+| `o_view_list`             | `outlinedViewList`            |                                                     |
+| `o_visibility`            | `outlinedVisibility`          |                                                     |
+| `o_warning`               | `outlinedWarning`             |                                                     |
+
+> If a name appears in code that is **not** in this table, do not guess: derive the export with the rule (`o_x_y → outlinedXY`, else `matXY`), confirm it exists with
+> `node -e "console.log('matFoo' in require('@quasar/extras/material-icons'))"`, add a table row, and only then convert.
+
+---
+
+## Per-area grep guard
+
+Run after each Task 2–7 against that task's files (and globally before Task 8). It must print **nothing** for converted files:
+
+```bash
+cd frontend
+# remaining literal icon names (excludes ModuleIcon's :name bindings, which have no quotes)
+grep -rnE "<q-icon[^>]*\bname=\"[a-z]|\bicon=\"[a-z][a-z_0-9]+\"|\bicon:[[:space:]]*['\"][a-z][a-z_0-9]+['\"]|['\"]o_[a-z]" <FILES>
+# literal icon names hidden in bound expressions
+grep -rnE ":(icon|name)=\"[^\"]*'(lock|lock_open|chevron_left|chevron_right)'" <FILES>
+```
+
+---
+
+### Task 1: Switch Quasar internal icons to the SVG icon set
+
+**Files:**
+
+- Modify: `frontend/quasar.config.js` (the `framework: { … }` block, ~line 214)
+
+**Interfaces:**
+
+- Produces: Quasar's built-in component icons now resolve from `quasar/icon-set/svg-material-icons` (inline SVG) instead of the Material Icons font. The `extras` fonts remain, so app string-name icons are unaffected.
+
+- [ ] **Step 1: Add the SVG icon set to the framework config**
+
+```js
+    // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework
+    framework: {
+      iconSet: 'svg-material-icons',
+      plugins: [
+        'Dialog',
+        'Loading',
+        'Notify',
+        'LocalStorage',
+        'SessionStorage',
+        'Meta',
+      ],
+      cssAddon: false,
+    },
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && make type-check`
+Expected: PASS (config change only; no TS impact).
+
+- [ ] **Step 3: Build + visual smoke**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds. Serve the build (or `quasar dev`) and confirm Quasar **internal** icons render as SVG: `q-select` dropdown arrow, `q-table` sort caret, `q-checkbox`/`q-radio`, `q-expansion-item` chevron, `q-pagination` arrows, the `×` in `q-chip`/closable notifications. (App-authored icons still use the font here — that's expected.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/guilbert/works/git/github/co2-calculator
+git add frontend/quasar.config.js
+git commit -m "feat(frontend): use svg-material-icons icon set for Quasar internals"
+```
+
+---
+
+### Task 2: Convert `constant/` config files
+
+**Files (11):**
+
+- Modify: `frontend/src/constant/module-config/buildings.ts`, `equipment.ts`, `headcount.ts`, `process_emissions.ts`, `external-cloud-and-ai.ts`, `purchase.ts`
+- Modify: `frontend/src/constant/navigation.ts`, `timelineItems.ts`, `report.ts`, `moduleStates.ts`, `backoffice-module-config.ts`
+
+**Interfaces:**
+
+- Consumes: the Mapping Table.
+- Produces: every `icon:` field in these modules holds an imported SVG export (a `string`), so all `:icon="cfg.icon"` / `:name="item.icon"` template bindings downstream render SVG. Field types stay `string` — no interface changes.
+
+- [ ] **Step 1: Convert each file per the recipe** — replace every `icon: '<name>'` with `icon: <export>`, add the grouped imports at the top. Use the Mapping Table for export names. `navigation.ts` uses `o_edit_document` (×2) → `outlinedEditNote` (⚠ confirm visually).
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && make type-check`
+Expected: PASS. A typo'd or non-existent export fails here.
+
+- [ ] **Step 3: Lint (catch unused/forgotten imports)**
+
+Run: `cd frontend && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Grep guard**
+
+Run the per-area grep guard with `<FILES>` = the 11 files above.
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/constant
+git commit -m "feat(frontend): convert constant/ icon config to SVG imports"
+```
+
+---
+
+### Task 3: Convert `components/molecules`, `components/atoms`, `components/layout`, `components/charts`, `components/EssentialLink.vue`
+
+**Files (~26):** all `.vue` under `frontend/src/components/molecules/` (14), `frontend/src/components/atoms/` (1), `frontend/src/components/layout/` (3), `frontend/src/components/charts/` (7), and `frontend/src/components/EssentialLink.vue` that contain an icon literal per the guard.
+
+**Interfaces:**
+
+- Consumes: the Mapping Table. Note `charts/EmissionBreakdownChart.vue` uses `info_outline` → `outlinedInfo` (⚠).
+- Produces: all icon literals in these files converted to bound SVG imports.
+
+- [ ] **Step 1: Find the exact files**
+
+Run:
+
+```bash
+cd frontend && grep -rlE "(\bicon=\"[a-z]|<q-icon[^>]*name=\"[a-z]|['\"]o_[a-z]|\bicon:[[:space:]]*['\"][a-z]|:(icon|name)=\"[^\"]*'(lock|lock_open|chevron_left|chevron_right)')" \
+  src/components/molecules src/components/atoms src/components/layout src/components/charts src/components/EssentialLink.vue
+```
+
+- [ ] **Step 2: Convert each file per the recipe.** Leave `EssentialLink.vue`'s `:name="icon"` (bound prop) alone — only convert any literal there, if present.
+
+- [ ] **Step 3: Type-check** — `cd frontend && make type-check` → PASS.
+- [ ] **Step 4: Lint** — `cd frontend && npm run lint` → PASS.
+- [ ] **Step 5: Grep guard** over the Step-1 file list → no output.
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/molecules frontend/src/components/atoms frontend/src/components/layout frontend/src/components/charts frontend/src/components/EssentialLink.vue
+git commit -m "feat(frontend): convert molecule/atom/layout/chart icons to SVG imports"
+```
+
+---
+
+### Task 4: Convert `components/organisms`
+
+**Files (~20):** all `.vue` under `frontend/src/components/organisms/` matching the guard (module, backoffice/reporting, data-management subtrees). `ModuleCharts.vue` uses `info_outline` → `outlinedInfo` (⚠); `backoffice/reporting/ReportExport.vue` uses `o_table` → `outlinedTableChart` (⚠); `backoffice/reporting/ReportingFilters.vue` uses `o_check_small` → `outlinedCheck` (⚠).
+
+**Interfaces:** Consumes the Mapping Table.
+
+- [ ] **Step 1: List files** — `cd frontend && grep -rlE "(\bicon=\"[a-z]|<q-icon[^>]*name=\"[a-z]|['\"]o_[a-z]|\bicon:[[:space:]]*['\"][a-z])" src/components/organisms`
+- [ ] **Step 2: Convert per recipe.** Do **not** touch `ModuleIcon`/`ModuleIconBox`/`module-icon` `:name` bindings.
+- [ ] **Step 3: Type-check** → PASS.
+- [ ] **Step 4: Lint** → PASS.
+- [ ] **Step 5: Grep guard** over those files → no output.
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/organisms
+git commit -m "feat(frontend): convert organism icons to SVG imports"
+```
+
+---
+
+### Task 5: Convert `components/audit`
+
+**Files (~6):** all `.vue` under `frontend/src/components/audit/` matching the guard. `AuditFilterBar.vue` uses `manufacturing` → `matPrecisionManufacturing` (⚠).
+
+**Interfaces:** Consumes the Mapping Table.
+
+- [ ] **Step 1: List files** — `cd frontend && grep -rlE "(\bicon=\"[a-z]|<q-icon[^>]*name=\"[a-z]|['\"]o_[a-z]|\bicon:[[:space:]]*['\"][a-z])" src/components/audit`
+- [ ] **Step 2: Convert per recipe.**
+- [ ] **Step 3: Type-check** → PASS.
+- [ ] **Step 4: Lint** → PASS.
+- [ ] **Step 5: Grep guard** → no output.
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/audit
+git commit -m "feat(frontend): convert audit icons to SVG imports"
+```
+
+---
+
+### Task 6: Convert `pages/`
+
+**Files (~16):** all `.vue` under `frontend/src/pages/app/` (7), `frontend/src/pages/back-office/` (7), plus `frontend/src/pages/ErrorUnauthorized.vue`, `frontend/src/pages/ErrorNotFound.vue` matching the guard. `back-office/PipelineOperationsConsolePage.vue` holds `icon:` config literals; `ResultsPage.vue`/`HomePage.vue` use `ModuleIconBox`/`module-icon` `:name="module"` bindings which must be **left untouched**.
+
+**Interfaces:** Consumes the Mapping Table.
+
+- [ ] **Step 1: List files** — `cd frontend && grep -rlE "(\bicon=\"[a-z]|<q-icon[^>]*name=\"[a-z]|['\"]o_[a-z]|\bicon:[[:space:]]*['\"][a-z]|:(icon|name)=\"[^\"]*'(lock|lock_open|chevron_left|chevron_right)')" src/pages`
+- [ ] **Step 2: Convert per recipe.** Includes ternary literals (`:icon="… ? 'lock_open' : 'lock'"` → `matLockOpen`/`matLock`).
+- [ ] **Step 3: Type-check** → PASS.
+- [ ] **Step 4: Lint** → PASS.
+- [ ] **Step 5: Grep guard** → no output.
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages
+git commit -m "feat(frontend): convert page icons to SVG imports"
+```
+
+---
+
+### Task 7: Convert remaining `.ts` icon strings (Notify/Dialog/util call sites)
+
+**Files (3):**
+
+- Modify: `frontend/src/utils/errors.ts`, `frontend/src/api/http.ts`, `frontend/src/boot/sentry.ts`
+
+These hold `icon: '<name>'` passed to `Notify.create` / `Dialog.create` / error helpers.
+
+**Interfaces:** Consumes the Mapping Table.
+
+- [ ] **Step 1: Convert each `icon: '<name>'` to `icon: <export>` with a top-of-file import.**
+- [ ] **Step 2: Type-check** → PASS.
+- [ ] **Step 3: Lint** → PASS.
+- [ ] **Step 4: Grep guard** over the 3 files → no output.
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/errors.ts frontend/src/api/http.ts frontend/src/boot/sentry.ts
+git commit -m "feat(frontend): convert Notify/Dialog icon strings to SVG imports"
+```
+
+---
+
+### Task 8: Drop both webfonts + add dev-mode guard
+
+**Files:**
+
+- Create: `frontend/src/boot/icon-guard.ts`
+- Modify: `frontend/quasar.config.js` (remove fonts from `extras`; register the new boot file)
+
+**Interfaces:**
+
+- Consumes: all of Tasks 1–7 complete (no string icon literals remain anywhere).
+- Produces: no icon webfont shipped; a dev-only `iconMapFn` that surfaces any string icon name still reaching a Quasar component.
+
+- [ ] **Step 1: Global grep guard (whole `src/`) must be clean**
+
+Run:
+
+```bash
+cd frontend
+grep -rnE "<q-icon[^>]*\bname=\"[a-z]|\bicon=\"[a-z][a-z_0-9]+\"|\bicon:[[:space:]]*['\"][a-z][a-z_0-9]+['\"]|['\"]o_[a-z]" src --include='*.vue' --include='*.ts'
+grep -rnE ":(icon|name)=\"[^\"]*'(lock|lock_open|chevron_left|chevron_right)'" src --include='*.vue'
+```
+
+Expected: **no output**. If anything prints, convert it (Tasks 2–7 recipe) before continuing.
+
+- [ ] **Step 2: Add the dev-mode guard boot file**
+
+Create `frontend/src/boot/icon-guard.ts`:
+
+```ts
+import { boot } from "quasar/wrappers";
+
+// Dev-only safety net for the SVG-icon migration: any *string* icon name that
+// still reaches a Quasar component (q-icon, q-btn icon, Notify, ...) means a
+// call site was missed and would render blank now that the webfonts are gone.
+// SVG icons arrive as a path string starting with "M"/"m" or an "img:" / "svguse:"
+// reference, so a bare word like "close" is the tell.
+export default boot(({ app }) => {
+  if (!import.meta.env.DEV) return;
+  const looksLikeName = (s: string) =>
+    /^[a-z][a-z0-9_]*$/.test(s) &&
+    !s.startsWith("img:") &&
+    !s.startsWith("svguse:");
+  app.config.globalProperties.$q.iconMapFn = (iconName: string) => {
+    if (typeof iconName === "string" && looksLikeName(iconName)) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[icon-guard] unconverted string icon name reached a component: "${iconName}"`,
+      );
+    }
+    return undefined; // let Quasar handle it normally
+  };
+});
+```
+
+> Quasar's `iconMapFn` runs for every icon resolution; returning `undefined` is a no-op pass-through. This stays in the codebase (dev-only, tree-shaken out of prod by the `import.meta.env.DEV` guard) as a regression net.
+
+- [ ] **Step 3: Register the boot file and remove the fonts**
+
+In `frontend/quasar.config.js`:
+
+```js
+    // boot files
+    boot: ['sentry', 'i18n', 'router', 'icons', 'icon-guard'],
+
+    // extras — icon webfonts removed; icons now ship as tree-shaken SVG
+    extras: [],
+```
+
+(If `extras: []` ends up empty and Quasar/lint complains, leave the key as `extras: []` — it is valid. Keep any non-icon entries if present; there are none today.)
+
+- [ ] **Step 4: Type-check + lint**
+
+Run: `cd frontend && make type-check && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Build and verify no icon webfont is emitted**
+
+Run:
+
+```bash
+cd frontend && npm run build
+# no Material Icons woff2 in the build output:
+find dist -name '*.woff2' | xargs -I{} basename {}
+```
+
+Expected: build succeeds; the listed `.woff2` are **only** the SuisseIntl text fonts (`SuisseIntlEPFL-*`). No `flUhRq6tz…` / `gok-H7zzD…` (Material Icons) woff2.
+
+- [ ] **Step 6: Runtime visual sweep (dev)**
+
+Run `cd frontend && quasar dev`, open the console, and click through the highest-icon-density pages: the equipment/results module page, a module form, backoffice reporting (filters, export, stat cards), audit filter bar, navigation drawer, error pages. Confirm:
+
+- No blank/missing icons.
+- **Zero** `[icon-guard]` console errors.
+- The five ⚠ substitutions look right: `outlinedInfo` (info_outline), `matPrecisionManufacturing` (manufacturing), `outlinedCheck` (o_check_small), `outlinedEditNote` (o_edit_document), `outlinedTableChart` (o_table).
+
+- [ ] **Step 7: Update this plan's status to `delivered` and commit**
+
+```bash
+# set frontmatter status: delivered, last_updated: <today>
+git add frontend/quasar.config.js frontend/src/boot/icon-guard.ts docs/src/implementation-plans/frontend-svg-icons-drop-webfonts.md
+git commit -m "feat(frontend): drop Material Icons webfonts, ship SVG icons only"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- "Genuinely use in-component SVG imports for tree-shaking" → Tasks 2–7 convert every app call site to named `@quasar/extras` imports; Vite bundles only referenced exports. ✓
+- "Drop both fonts, only SVG icons" → Task 1 (internals via `svg-material-icons`) + Task 8 (`extras: []`, build asserts no Material Icons woff2). ✓
+- Quasar internal icons (not call sites) → Task 1. ✓
+- Hidden ternary/computed literals → covered by recipe step 2, the per-area guards, and the Task 8 runtime `iconMapFn` guard. ✓
+- Module/custom SVG icons untouched → stated in Global Constraints + every task. ✓
+
+**Placeholder scan:** Mapping Table fully enumerated (111 rows, all exports verified to exist); five no-exact-export names resolved to a named closest match and flagged. No "TBD"/"handle edge cases". ✓
+
+**Type consistency:** Export-name convention (`o_x → outlinedX`, else `matX`) is applied uniformly; config `icon:` fields stay typed `string` (SVG exports are strings), so no interface drift. Guard `iconMapFn` signature matches Quasar's `(name: string) => IconMapEntry | void`. ✓
+
+**Ordering safety:** Fonts removed only in Task 8, after every site is converted and the global guard is clean; the app renders at every intermediate commit. ✓
+
+## Notes / follow-ups (out of scope here)
+
+- After merge, re-run Lighthouse on `…/2025/equipment` to confirm the 278 KiB icon-font payload and its FOIT are gone from the LCP critical path.
+- The `index.html` SuisseIntl preloads + `injectEnv.js defer` (shipped separately) remain valid and unrelated.

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -212,6 +212,7 @@ export default defineConfig(function () {
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework
     framework: {
+      iconSet: 'svg-material-icons',
       plugins: [
         'Dialog',
         'Loading',

--- a/frontend/src/components/atoms/CO2DestinationInput.vue
+++ b/frontend/src/components/atoms/CO2DestinationInput.vue
@@ -8,7 +8,7 @@
     >
       <q-icon
         v-if="hint"
-        name="o_info"
+        :name="outlinedInfo"
         size="xs"
         color="grey-6"
         class="destination-input-hint-icon cursor-pointer"
@@ -142,7 +142,7 @@
           :disable="disable || !transportMode"
           @click="swapValues"
         >
-          <q-icon name="o_swap_horiz" size="xs" />
+          <q-icon :name="outlinedSwapHoriz" size="xs" />
         </q-btn>
       </q-card-section>
       <q-separator class="destination-separator" color="grey-4" />
@@ -156,6 +156,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
+import { outlinedInfo, outlinedSwapHoriz } from '@quasar/extras/material-icons-outlined';
 import { MODULES } from 'src/constant/modules';
 import { useI18n } from 'vue-i18n';
 import { searchLocations } from 'src/api/locations';

--- a/frontend/src/components/atoms/CO2DestinationInput.vue
+++ b/frontend/src/components/atoms/CO2DestinationInput.vue
@@ -156,7 +156,10 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
-import { outlinedInfo, outlinedSwapHoriz } from '@quasar/extras/material-icons-outlined';
+import {
+  outlinedInfo,
+  outlinedSwapHoriz,
+} from '@quasar/extras/material-icons-outlined';
 import { MODULES } from 'src/constant/modules';
 import { useI18n } from 'vue-i18n';
 import { searchLocations } from 'src/api/locations';

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { matGridView, matStackedBarChart } from '@quasar/extras/material-icons';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTreeMapChart.vue';
@@ -249,7 +251,7 @@ const emissionTypeInfoKey = computed(() =>
           flat
           round
           dense
-          icon="info_outline"
+          :icon="outlinedInfo"
           size="sm"
           class="text-grey-7"
           :aria-label="t('emission-type-breakdown-info-aria')"
@@ -274,7 +276,7 @@ const emissionTypeInfoKey = computed(() =>
                 : {}
             "
             :class="chartView !== 'type' ? 'toggle-inactive' : ''"
-            icon="stacked_bar_chart"
+            :icon="matStackedBarChart"
             size="sm"
             @click="chartView = 'type'"
           />
@@ -287,7 +289,7 @@ const emissionTypeInfoKey = computed(() =>
                 : {}
             "
             :class="chartView !== 'breakdown' ? 'toggle-inactive' : ''"
-            icon="grid_view"
+            :icon="matGridView"
             size="sm"
             @click="chartView = 'breakdown'"
           />

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, ref, nextTick } from 'vue';
-import { outlinedDownload, outlinedInfo } from '@quasar/extras/material-icons-outlined';
+import {
+  outlinedDownload,
+  outlinedInfo,
+} from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -557,7 +560,12 @@ const downloadCSV = () => {
       <q-card-section class="col validation-placeholder">
         <div class="validation-required-card">
           <div class="validation-required-card__content">
-            <q-icon :name="outlinedInfo" size="md" color="accent" class="q-mb-md" />
+            <q-icon
+              :name="outlinedInfo"
+              size="md"
+              color="accent"
+              class="q-mb-md"
+            />
             <div class="text-h6 text-weight-medium text-center q-mb-sm">
               {{
                 $t('results_validate_module_title', { module: $t('headcount') })

--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, nextTick } from 'vue';
+import { outlinedDownload, outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -531,7 +532,7 @@ const downloadCSV = () => {
           unelevated
           no-caps
           outline
-          icon="o_download"
+          :icon="outlinedDownload"
           :label="$t('common_download_as_png')"
           size="xs"
           dense
@@ -542,7 +543,7 @@ const downloadCSV = () => {
           unelevated
           no-caps
           outline
-          icon="o_download"
+          :icon="outlinedDownload"
           :label="$t('common_download_as_csv')"
           size="xs"
           dense
@@ -556,7 +557,7 @@ const downloadCSV = () => {
       <q-card-section class="col validation-placeholder">
         <div class="validation-required-card">
           <div class="validation-required-card__content">
-            <q-icon name="o_info" size="md" color="accent" class="q-mb-md" />
+            <q-icon :name="outlinedInfo" size="md" color="accent" class="q-mb-md" />
             <div class="text-h6 text-weight-medium text-center q-mb-sm">
               {{
                 $t('results_validate_module_title', { module: $t('headcount') })

--- a/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
+++ b/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
@@ -7,6 +7,7 @@ import {
   ref,
   watch,
 } from 'vue';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -349,7 +350,7 @@ defineExpose({ downloadPNG });
           $t('it-focus-breakdown-bar-title')
         }}</span>
         <q-icon
-          name="o_info"
+          :name="outlinedInfo"
           size="14px"
           color="grey-5"
           class="cursor-pointer q-ml-xs"

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, type PropType, nextTick, ref } from 'vue';
-import { outlinedDownload, outlinedInfo } from '@quasar/extras/material-icons-outlined';
+import {
+  outlinedDownload,
+  outlinedInfo,
+} from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, type PropType, nextTick, ref } from 'vue';
+import { outlinedDownload, outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -1372,7 +1373,7 @@ const downloadCSV = () => {
         </span>
         <q-icon
           v-if="!isPrintMode"
-          name="o_info"
+          :name="outlinedInfo"
           size="xs"
           color="primary"
           class="cursor-pointer"
@@ -1456,7 +1457,7 @@ const downloadCSV = () => {
         unelevated
         no-caps
         outline
-        icon="o_download"
+        :icon="outlinedDownload"
         :label="$t('common_download_as_png')"
         size="xs"
         dense
@@ -1467,7 +1468,7 @@ const downloadCSV = () => {
         unelevated
         no-caps
         outline
-        icon="o_download"
+        :icon="outlinedDownload"
         :label="$t('common_download_as_csv')"
         size="xs"
         dense

--- a/frontend/src/components/charts/results/ReductionObjectiveChart.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveChart.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { outlinedDownload, outlinedInfo } from '@quasar/extras/material-icons-outlined';
+import {
+  outlinedDownload,
+  outlinedInfo,
+} from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import ReductionObjectiveEpflView from 'src/components/charts/results/ReductionObjectiveEpflView.vue';
 import ReductionObjectiveUnitView from 'src/components/charts/results/ReductionObjectiveUnitView.vue';

--- a/frontend/src/components/charts/results/ReductionObjectiveChart.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { outlinedDownload, outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import ReductionObjectiveEpflView from 'src/components/charts/results/ReductionObjectiveEpflView.vue';
 import ReductionObjectiveUnitView from 'src/components/charts/results/ReductionObjectiveUnitView.vue';
@@ -50,7 +51,7 @@ const chartTitle = computed(() =>
         <h2 class="text-h2 text-weight-medium q-mb-none">
           {{ $t('results_objectives_2040_title') }}
         </h2>
-        <q-icon name="o_info" size="sm" class="text-primary">
+        <q-icon :name="outlinedInfo" size="sm" class="text-primary">
           <q-tooltip class="text-body2 text-black" max-width="320px">
             {{ $t('results-reduction-title') }}
           </q-tooltip>
@@ -141,7 +142,7 @@ const chartTitle = computed(() =>
       unelevated
       no-caps
       outline
-      icon="o_download"
+      :icon="outlinedDownload"
       :label="$t('common_download_as_png')"
       size="xs"
       dense

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUpdated, ref } from 'vue';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -708,7 +709,7 @@ const chartOption = computed<EChartsOption | null>(() => {
     />
     <q-card v-else flat class="objective-empty-card">
       <q-card-section class="objective-empty-card__content">
-        <q-icon name="o_info" size="md" color="accent" class="q-mb-md" />
+        <q-icon :name="outlinedInfo" size="md" color="accent" class="q-mb-md" />
         <div class="text-h6 text-weight-medium text-center q-mb-sm">
           {{ $t('results_objectives_epfl_no_data_title') }}
         </div>

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -520,7 +520,12 @@ const chartOption = computed<EChartsOption | null>(() => {
     <div v-if="showUnitEmptyState" class="col-12">
       <q-card flat class="objective-empty-card">
         <q-card-section class="objective-empty-card__content">
-          <q-icon :name="outlinedInfo" size="md" color="accent" class="q-mb-md" />
+          <q-icon
+            :name="outlinedInfo"
+            size="md"
+            color="accent"
+            class="q-mb-md"
+          />
           <div class="text-h6 text-weight-medium text-center q-mb-sm">
             {{ $t('results_objectives_unit_no_validated_title') }}
           </div>

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUpdated, ref } from 'vue';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -519,7 +520,7 @@ const chartOption = computed<EChartsOption | null>(() => {
     <div v-if="showUnitEmptyState" class="col-12">
       <q-card flat class="objective-empty-card">
         <q-card-section class="objective-empty-card__content">
-          <q-icon name="o_info" size="md" color="accent" class="q-mb-md" />
+          <q-icon :name="outlinedInfo" size="md" color="accent" class="q-mb-md" />
           <div class="text-h6 text-weight-medium text-center q-mb-sm">
             {{ $t('results_objectives_unit_no_validated_title') }}
           </div>
@@ -594,7 +595,7 @@ const chartOption = computed<EChartsOption | null>(() => {
                     {{ categoryLabel(cat) }}
                   </span>
                   <q-icon
-                    name="o_info"
+                    :name="outlinedInfo"
                     size="14px"
                     class="objective-slider__label-info text-secondary"
                   >

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { outlinedAutorenew } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import Co2LanguageSelector from 'src/components/atoms/Co2LanguageSelector.vue';
 import { useAuthStore } from 'src/stores/auth';
@@ -144,7 +145,7 @@ const logoRoute = computed(() => {
         </span>
 
         <q-btn
-          icon="o_autorenew"
+          :icon="outlinedAutorenew"
           color="grey-4"
           text-color="primary"
           :label="$t('workspace_change_btn')"

--- a/frontend/src/components/layout/Co2Sidebar.vue
+++ b/frontend/src/components/layout/Co2Sidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
+import { matChevronLeft, matChevronRight } from '@quasar/extras/material-icons';
 import { NavItem } from 'src/constant/navigation';
 import { useRouter } from 'vue-router';
 import { useAuthStore } from 'src/stores/auth';
@@ -37,7 +38,7 @@ function isItemDisabled(item: NavItem): boolean {
 <template>
   <div class="co2-sidebar" :class="{ 'co2-sidebar--collapsed': collapsed }">
     <div class="co2-sidebar-toggle" @click="collapsed = !collapsed">
-      <q-icon :name="collapsed ? 'chevron_right' : 'chevron_left'" size="xs" />
+      <q-icon :name="collapsed ? matChevronRight : matChevronLeft" size="xs" />
     </div>
     <q-list class="co2-sidebar-items">
       <q-item

--- a/frontend/src/components/layout/ResultsFilterPanel.vue
+++ b/frontend/src/components/layout/ResultsFilterPanel.vue
@@ -24,7 +24,12 @@
       >
         {{ row.label }}
       </span>
-      <q-icon :name="outlinedInfo" size="14px" class="filter-panel__info" @click.stop>
+      <q-icon
+        :name="outlinedInfo"
+        size="14px"
+        class="filter-panel__info"
+        @click.stop
+      >
         <q-tooltip class="text-body2 text-black">{{ row.tooltip }}</q-tooltip>
       </q-icon>
     </div>

--- a/frontend/src/components/layout/ResultsFilterPanel.vue
+++ b/frontend/src/components/layout/ResultsFilterPanel.vue
@@ -24,7 +24,7 @@
       >
         {{ row.label }}
       </span>
-      <q-icon name="o_info" size="14px" class="filter-panel__info" @click.stop>
+      <q-icon :name="outlinedInfo" size="14px" class="filter-panel__info" @click.stop>
         <q-tooltip class="text-body2 text-black">{{ row.tooltip }}</q-tooltip>
       </q-icon>
     </div>
@@ -61,6 +61,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import { useResultsFiltersStore } from 'src/stores/resultsFilters';
 import { CHART_CATEGORY_COLOR_SCHEMES } from 'src/constant/charts';

--- a/frontend/src/components/molecules/BigNumber.vue
+++ b/frontend/src/components/molecules/BigNumber.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 
 const props = withDefaults(
@@ -90,7 +91,7 @@ const comparisonParts = computed(() => {
       </span>
       <q-icon
         v-if="$slots.tooltip && tooltipPlacement === 'title' && !printMode"
-        name="o_info"
+        :name="outlinedInfo"
         size="xs"
         color="primary"
       >
@@ -123,7 +124,7 @@ const comparisonParts = computed(() => {
           v-if="
             $slots.tooltip && tooltipPlacement === 'comparison' && !printMode
           "
-          name="o_info"
+          :name="outlinedInfo"
           size="xs"
           color="primary"
           class="q-mr-xs"

--- a/frontend/src/components/molecules/ChartContainer.vue
+++ b/frontend/src/components/molecules/ChartContainer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
 defineProps<{
   title: string;
 }>();
@@ -6,7 +7,7 @@ defineProps<{
 <template>
   <q-card flat class="container container--pa-none">
     <q-card-section class="flex items-center">
-      <q-icon name="o_info" size="xs" color="primary">
+      <q-icon :name="outlinedInfo" size="xs" color="primary">
         <q-tooltip
           v-if="$slots.tooltip"
           anchor="center right"

--- a/frontend/src/components/molecules/NoteDialog.vue
+++ b/frontend/src/components/molecules/NoteDialog.vue
@@ -10,7 +10,13 @@
           {{ title }}
         </div>
         <q-space />
-        <q-btn v-close-popup flat size="md" :icon="outlinedClose" color="grey-6" />
+        <q-btn
+          v-close-popup
+          flat
+          size="md"
+          :icon="outlinedClose"
+          color="grey-6"
+        />
       </q-card-section>
 
       <q-separator class="q-mt-sm" />
@@ -55,7 +61,11 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
-import { outlinedAddComment, outlinedClose, outlinedEditNote } from '@quasar/extras/material-icons-outlined';
+import {
+  outlinedAddComment,
+  outlinedClose,
+  outlinedEditNote,
+} from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 
 const { t: $t } = useI18n();

--- a/frontend/src/components/molecules/NoteDialog.vue
+++ b/frontend/src/components/molecules/NoteDialog.vue
@@ -10,7 +10,7 @@
           {{ title }}
         </div>
         <q-space />
-        <q-btn v-close-popup flat size="md" icon="o_close" color="grey-6" />
+        <q-btn v-close-popup flat size="md" :icon="outlinedClose" color="grey-6" />
       </q-card-section>
 
       <q-separator class="q-mt-sm" />
@@ -55,6 +55,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
+import { outlinedAddComment, outlinedClose, outlinedEditNote } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 
 const { t: $t } = useI18n();
@@ -85,7 +86,7 @@ const localNote = ref(props.note ?? '');
 
 const isEdit = computed(() => props.mode === 'edit');
 const iconName = computed(() =>
-  isEdit.value ? 'o_edit_note' : 'o_add_comment',
+  isEdit.value ? outlinedEditNote : outlinedAddComment,
 );
 const title = computed(() =>
   isEdit.value

--- a/frontend/src/components/molecules/TripsMap.vue
+++ b/frontend/src/components/molecules/TripsMap.vue
@@ -12,7 +12,7 @@
         v-else-if="!visibleLegs.length"
         class="column flex-center full-height text-center q-pa-md text-body2 text-secondary"
       >
-        <q-icon name="map" size="lg" class="text-grey-6 q-mb-sm" />
+        <q-icon :name="matMap" size="lg" class="text-grey-6 q-mb-sm" />
         {{ t(`${MODULES.ProfessionalTravel}-trips-map-empty`) }}
       </div>
       <template v-else>
@@ -74,8 +74,8 @@
               <q-icon
                 :name="
                   isModeSelected('plane')
-                    ? 'check_box'
-                    : 'check_box_outline_blank'
+                    ? matCheckBox
+                    : matCheckBoxOutlineBlank
                 "
                 :color="isModeSelected('plane') ? 'primary' : 'grey-7'"
                 size="15px"
@@ -102,8 +102,8 @@
               <q-icon
                 :name="
                   isModeSelected('train')
-                    ? 'check_box'
-                    : 'check_box_outline_blank'
+                    ? matCheckBox
+                    : matCheckBoxOutlineBlank
                 "
                 :color="isModeSelected('train') ? 'primary' : 'grey-7'"
                 size="15px"
@@ -220,8 +220,8 @@
           <q-icon
             :name="
               isTravelerSelected(tr.id)
-                ? 'check_circle'
-                : 'radio_button_unchecked'
+                ? matCheckCircle
+                : matRadioButtonUnchecked
             "
             :color="isTravelerSelected(tr.id) ? 'primary' : 'grey-5'"
             size="13px"
@@ -238,6 +238,13 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import {
+  matCheckBox,
+  matCheckBoxOutlineBlank,
+  matCheckCircle,
+  matMap,
+  matRadioButtonUnchecked,
+} from '@quasar/extras/material-icons';
 import { useI18n } from 'vue-i18n';
 import { MODULES } from 'src/constant/modules';
 import type { TripLeg } from 'src/stores/modules';

--- a/frontend/src/components/molecules/data-management/ComputedFactorDialog.vue
+++ b/frontend/src/components/molecules/data-management/ComputedFactorDialog.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { matCalculate } from '@quasar/extras/material-icons';
+import { outlinedClose } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 
 interface Props {
@@ -33,7 +35,7 @@ function handleConfirm() {
   >
     <q-card style="min-width: 420px">
       <q-card-section class="row items-center q-pb-none">
-        <q-icon name="calculate" color="accent" size="sm" class="q-mr-sm" />
+        <q-icon :name="matCalculate" color="accent" size="sm" class="q-mr-sm" />
         <div class="text-h6">
           {{ $t('data_management_compute_factors_confirm_title') }}
         </div>
@@ -41,7 +43,7 @@ function handleConfirm() {
         <q-btn
           flat
           size="md"
-          icon="o_close"
+          :icon="outlinedClose"
           color="grey-6"
           @click="handleClose"
         />

--- a/frontend/src/components/molecules/data-management/DataEntryDialogContent.vue
+++ b/frontend/src/components/molecules/data-management/DataEntryDialogContent.vue
@@ -6,6 +6,8 @@ import type {
 } from 'src/stores/backofficeDataManagement';
 import { TargetType } from 'src/stores/backofficeDataManagement';
 import { watch, toRef } from 'vue';
+import { matCalendarToday, matWarning } from '@quasar/extras/material-icons';
+import { outlinedClose } from '@quasar/extras/material-icons-outlined';
 
 interface Props {
   modelValue: boolean;
@@ -116,7 +118,7 @@ watch(showDialog, (newVal) => {
           v-close-popup
           flat
           size="md"
-          icon="o_close"
+          :icon="outlinedClose"
           color="grey-6"
           class="text-weight-medium"
         />
@@ -133,7 +135,7 @@ watch(showDialog, (newVal) => {
           class="q-mb-sm"
           inline-action
         >
-          <q-icon name="warning" size="sm" class="q-mr-sm" />
+          <q-icon :name="matWarning" size="sm" class="q-mr-sm" />
           {{ $t('data_management_last_upload_overwrite') }}
         </q-banner>
         <div data-testid="data-entry-file-input">
@@ -167,7 +169,7 @@ watch(showDialog, (newVal) => {
               class="q-mb-sm"
               inline-action
             >
-              <q-icon name="warning" size="sm" class="q-mr-sm" />
+              <q-icon :name="matWarning" size="sm" class="q-mr-sm" />
               {{ $t('data_management_last_upload_overwrite') }}
             </q-banner>
             <div class="q-gutter-sm q-mt-sm">
@@ -219,7 +221,7 @@ watch(showDialog, (newVal) => {
             dense
             outline
             color="black"
-            icon="calendar_today"
+            :icon="matCalendarToday"
             class="full-width text-weight-medium text-capitalize"
             disabled
           />
@@ -247,7 +249,7 @@ watch(showDialog, (newVal) => {
             unelevated
             color="grey-3"
             text-color="dark"
-            icon="calendar_today"
+            :icon="matCalendarToday"
             class="full-width"
             :loading="isCopying"
             :disable="!selectedPreviousJob || isCopying"

--- a/frontend/src/components/molecules/data-management/ModuleConfigSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleConfigSection.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { matPowerSettingsNew } from '@quasar/extras/material-icons';
+import { outlinedHelpCenter } from '@quasar/extras/material-icons-outlined';
 import { useModuleConfig } from 'src/composables/useModuleConfig';
 import { useI18n } from 'vue-i18n';
 
@@ -24,7 +26,7 @@ const {
     <q-card flat class="col q-px-lg q-pt-xl q-pb-md border-right">
       <div class="row items-center q-mb-xs">
         <q-icon
-          name="power_settings_new"
+          :name="matPowerSettingsNew"
           color="accent"
           size="xs"
           class="q-mr-sm"
@@ -61,7 +63,7 @@ const {
   >
     <q-card flat class="col q-px-lg q-pt-xl q-pb-md border-right">
       <div class="row items-center q-mb-xs">
-        <q-icon name="o_help_center" color="accent" size="xs" class="q-mr-sm" />
+        <q-icon :name="outlinedHelpCenter" color="accent" size="xs" class="q-mr-sm" />
         <div class="text-body1 text-weight-medium">
           {{ $t('data_management_uncertainty_title') }}
         </div>

--- a/frontend/src/components/molecules/data-management/ModuleConfigSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleConfigSection.vue
@@ -63,7 +63,12 @@ const {
   >
     <q-card flat class="col q-px-lg q-pt-xl q-pb-md border-right">
       <div class="row items-center q-mb-xs">
-        <q-icon :name="outlinedHelpCenter" color="accent" size="xs" class="q-mr-sm" />
+        <q-icon
+          :name="outlinedHelpCenter"
+          color="accent"
+          size="xs"
+          class="q-mr-sm"
+        />
         <div class="text-body1 text-weight-medium">
           {{ $t('data_management_uncertainty_title') }}
         </div>

--- a/frontend/src/components/molecules/data-management/ModuleRecalculationDialog.vue
+++ b/frontend/src/components/molecules/data-management/ModuleRecalculationDialog.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { matRefresh } from '@quasar/extras/material-icons';
+import { outlinedClose } from '@quasar/extras/material-icons-outlined';
 import { useI18n } from 'vue-i18n';
 import type { RecalculationStatusEntry } from 'src/stores/yearConfig';
 
@@ -38,7 +40,7 @@ function handleConfirm() {
   >
     <q-card style="min-width: 480px">
       <q-card-section class="row items-center q-pb-none">
-        <q-icon name="refresh" color="accent" size="sm" class="q-mr-sm" />
+        <q-icon :name="matRefresh" color="accent" size="sm" class="q-mr-sm" />
         <div class="text-h6">
           {{ $t('data_management_recalculate_emissions_title') }}
         </div>
@@ -46,7 +48,7 @@ function handleConfirm() {
         <q-btn
           flat
           size="md"
-          icon="o_close"
+          :icon="outlinedClose"
           color="grey-6"
           @click="handleClose"
         />

--- a/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
@@ -124,7 +124,12 @@ async function handleAbortPipeline() {
     <template v-if="submodules.length > 0">
       <div class="q-px-lg q-pt-md q-pb-sm">
         <div class="row items-center q-mb-xs">
-          <q-icon :name="outlinedViewCozy" color="accent" size="xs" class="q-mr-sm" />
+          <q-icon
+            :name="outlinedViewCozy"
+            color="accent"
+            size="xs"
+            class="q-mr-sm"
+          />
           <div class="text-body1 text-weight-medium">
             {{ $t('data_management_submodules_configuration_title') }}
           </div>

--- a/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
+++ b/frontend/src/components/molecules/data-management/ModuleUploadsSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, type ComputedRef } from 'vue';
+import { outlinedViewCozy } from '@quasar/extras/material-icons-outlined';
 import type { PipelineProgress } from 'src/stores/pipelineStream';
 import { useModuleConfig } from 'src/composables/useModuleConfig';
 import { useRecalculation } from 'src/composables/useRecalculation';
@@ -123,7 +124,7 @@ async function handleAbortPipeline() {
     <template v-if="submodules.length > 0">
       <div class="q-px-lg q-pt-md q-pb-sm">
         <div class="row items-center q-mb-xs">
-          <q-icon name="o_view_cozy" color="accent" size="xs" class="q-mr-sm" />
+          <q-icon :name="outlinedViewCozy" color="accent" size="xs" class="q-mr-sm" />
           <div class="text-body1 text-weight-medium">
             {{ $t('data_management_submodules_configuration_title') }}
           </div>

--- a/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
+++ b/frontend/src/components/molecules/data-management/PipelineDiagnosticTooltip.vue
@@ -17,6 +17,7 @@
  */
 
 import { computed, ref } from 'vue';
+import { matCircle, matContentCopy } from '@quasar/extras/material-icons';
 import { copyToClipboard, Notify, type QTooltip } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import { usePipelineStreamStore } from 'src/stores/pipelineStream';
@@ -121,7 +122,7 @@ function formatRelative(iso: string | null): string | null {
           flat
           dense
           size="xs"
-          icon="content_copy"
+          :icon="matContentCopy"
           color="white"
           @click.stop.prevent="copyPipelineId"
         >
@@ -143,7 +144,7 @@ function formatRelative(iso: string | null): string | null {
           class="row items-start q-gutter-xs"
         >
           <q-icon
-            name="circle"
+            :name="matCircle"
             size="xs"
             :color="jobColor(job.state, job.result)"
             class="q-mt-xs"

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -10,7 +10,11 @@ import {
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import type { SubmoduleConfig } from 'src/constant/backoffice-module-config';
 import type { PipelineProgress } from 'src/stores/pipelineStream';
-import { matEditOff, matLegendToggle, matPowerSettingsNew } from '@quasar/extras/material-icons';
+import {
+  matEditOff,
+  matLegendToggle,
+  matPowerSettingsNew,
+} from '@quasar/extras/material-icons';
 import UploadCardData from 'src/components/molecules/data-management/UploadCardData.vue';
 import UploadCardFactors from 'src/components/molecules/data-management/UploadCardFactors.vue';
 import UploadCardReferences from 'src/components/molecules/data-management/UploadCardReferences.vue';

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -10,6 +10,7 @@ import {
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import type { SubmoduleConfig } from 'src/constant/backoffice-module-config';
 import type { PipelineProgress } from 'src/stores/pipelineStream';
+import { matEditOff, matLegendToggle, matPowerSettingsNew } from '@quasar/extras/material-icons';
 import UploadCardData from 'src/components/molecules/data-management/UploadCardData.vue';
 import UploadCardFactors from 'src/components/molecules/data-management/UploadCardFactors.vue';
 import UploadCardReferences from 'src/components/molecules/data-management/UploadCardReferences.vue';
@@ -152,7 +153,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
       <q-card flat class="col q-px-lg q-pt-lg q-pb-md">
         <div class="row items-center q-mb-xs">
           <q-icon
-            name="power_settings_new"
+            :name="matPowerSettingsNew"
             color="accent"
             size="xs"
             class="q-mr-sm"
@@ -181,7 +182,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         :class="{ 'submodule-item--disabled': isSubmoduleDisabled(submodule) }"
       >
         <div class="row items-center q-mb-xs">
-          <q-icon name="edit_off" color="accent" size="xs" class="q-mr-sm" />
+          <q-icon :name="matEditOff" color="accent" size="xs" class="q-mr-sm" />
           <div class="text-body2 text-weight-medium">
             {{ $t('data_management_submodule_inputs_deactivation_title') }}
           </div>
@@ -215,7 +216,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         >
           <div class="row items-center q-mb-xs">
             <q-icon
-              name="legend_toggle"
+              :name="matLegendToggle"
               color="accent"
               size="xs"
               class="q-mr-sm"

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, type ComputedRef } from 'vue';
+import { matCalculate, matCancel, matInfo } from '@quasar/extras/material-icons';
+import { outlinedDownload } from '@quasar/extras/material-icons-outlined';
 import { useUploadCard } from 'src/composables/useUploadCard';
 import {
   TargetType,
@@ -251,7 +253,7 @@ function handleAbort() {
             v-else
             color="accent"
             outline
-            icon="calculate"
+            :icon="matCalculate"
             size="sm"
             :label="$t('data_management_compute_factors')"
             class="text-weight-medium"
@@ -300,7 +302,7 @@ function handleAbort() {
         <q-btn
           v-if="lastJob?.ingestion_method !== IngestionMethod.API"
           color="positive"
-          icon="o_download"
+          :icon="outlinedDownload"
           size="sm"
           unelevated
           dense
@@ -310,7 +312,7 @@ function handleAbort() {
         </q-btn>
         <q-icon
           v-if="hasErrorOrWarn"
-          name="info"
+          :name="matInfo"
           size="sm"
           class="cursor-pointer"
         >
@@ -362,7 +364,7 @@ function handleAbort() {
       <q-btn
         color="negative"
         outline
-        icon="cancel"
+        :icon="matCancel"
         size="sm"
         :label="$t('data_management_cancel_job')"
         class="text-weight-medium q-ml-sm"

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { computed, inject, type ComputedRef } from 'vue';
-import { matCalculate, matCancel, matInfo } from '@quasar/extras/material-icons';
+import {
+  matCalculate,
+  matCancel,
+  matInfo,
+} from '@quasar/extras/material-icons';
 import { outlinedDownload } from '@quasar/extras/material-icons-outlined';
 import { useUploadCard } from 'src/composables/useUploadCard';
 import {

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { computed, inject, ref, type ComputedRef } from 'vue';
-import { matCancel, matFileUpload, matInfo } from '@quasar/extras/material-icons';
+import {
+  matCancel,
+  matFileUpload,
+  matInfo,
+} from '@quasar/extras/material-icons';
 import { outlinedDownload } from '@quasar/extras/material-icons-outlined';
 import { useUploadCard } from 'src/composables/useUploadCard';
 import { mergeLivePipelineJob } from 'src/composables/useModuleConfig';

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, ref, type ComputedRef } from 'vue';
+import { matCancel, matFileUpload, matInfo } from '@quasar/extras/material-icons';
+import { outlinedDownload } from '@quasar/extras/material-icons-outlined';
 import { useUploadCard } from 'src/composables/useUploadCard';
 import { mergeLivePipelineJob } from 'src/composables/useModuleConfig';
 import { useI18n } from 'vue-i18n';
@@ -367,7 +369,7 @@ function isErrorOrWarning(): boolean {
         <q-btn
           no-caps
           :color="buttonColor()"
-          icon="file_upload"
+          :icon="matFileUpload"
           size="sm"
           :label="buttonLabel()"
           class="text-weight-medium"
@@ -392,7 +394,7 @@ function isErrorOrWarning(): boolean {
         <q-btn
           color="negative"
           outline
-          icon="cancel"
+          :icon="matCancel"
           size="sm"
           :label="$t('data_management_cancel_job')"
           class="text-weight-medium"
@@ -420,7 +422,7 @@ function isErrorOrWarning(): boolean {
         </div>
         <q-btn
           color="positive"
-          icon="o_download"
+          :icon="outlinedDownload"
           size="sm"
           unelevated
           dense
@@ -430,7 +432,7 @@ function isErrorOrWarning(): boolean {
         </q-btn>
         <q-icon
           v-if="isErrorOrWarning()"
-          name="info"
+          :name="matInfo"
           size="sm"
           class="cursor-pointer"
         >

--- a/frontend/src/constant/backoffice-module-config.ts
+++ b/frontend/src/constant/backoffice-module-config.ts
@@ -1,4 +1,5 @@
 import { MODULES } from 'src/constant/modules';
+import { outlinedFolderShared } from '@quasar/extras/material-icons-outlined';
 
 export type SubmoduleConfig = {
   key: string;
@@ -223,7 +224,7 @@ export const MODULE_COMMON_UPLOADS: Partial<
       key: 'equipment',
       labelKey: `${MODULES.Equipment}-common`,
       moduleTypeId: 4,
-      headerIcon: 'o_folder_shared',
+      headerIcon: outlinedFolderShared,
       descriptionKey: 'data_management_equipment_common_description',
     },
   ],
@@ -232,7 +233,7 @@ export const MODULE_COMMON_UPLOADS: Partial<
       key: 'purchases_common',
       labelKey: `${MODULES.Purchase}-common`,
       moduleTypeId: 5,
-      headerIcon: 'o_folder_shared',
+      headerIcon: outlinedFolderShared,
       descriptionKey: 'data_management_purchase_common_description',
     },
   ],

--- a/frontend/src/constant/module-config/buildings.ts
+++ b/frontend/src/constant/module-config/buildings.ts
@@ -3,6 +3,18 @@ import { SUBMODULE_BUILDINGS_TYPES, MODULES } from 'src/constant/modules';
 import type { BuildingsSubType, Module } from 'src/constant/modules';
 import { formatTonnesCO2 } from 'src/utils/number';
 import type { AllSubmoduleTypes } from 'src/constant/modules';
+import {
+  outlinedApartment,
+  outlinedMeetingRoom,
+  outlinedCategory,
+  outlinedStraighten,
+  outlinedImageAspectRatio,
+  outlinedThermostat,
+  outlinedAcUnit,
+  outlinedAir,
+  outlinedLightMode,
+  outlinedLocalFireDepartment,
+} from '@quasar/extras/material-icons-outlined';
 
 const roomFields: ModuleField[] = [
   {
@@ -16,7 +28,7 @@ const roomFields: ModuleField[] = [
     inputTypeName: 'QSelect',
     align: 'left',
     ratio: '1/3',
-    icon: 'o_apartment',
+    icon: outlinedApartment,
     columnSize: 'sm',
     tooltip: 'module-buildings-submodule-building-table-building_name',
   },
@@ -31,7 +43,7 @@ const roomFields: ModuleField[] = [
     inputTypeName: 'QSelect',
     align: 'left',
     ratio: '1/3',
-    icon: 'o_meeting_room',
+    icon: outlinedMeetingRoom,
     columnSize: 'md',
     tooltip: 'module-buildings-submodule-building-table-room_name',
   },
@@ -44,7 +56,7 @@ const roomFields: ModuleField[] = [
     inputTypeName: 'QSelect',
     align: 'left',
     ratio: '1/3',
-    icon: 'o_category',
+    icon: outlinedCategory,
     columnSize: 'md',
     disableUntilField: 'room_name',
     // IMPORTANT: these values are backend emission-factor lookup keys.
@@ -71,7 +83,7 @@ const roomFields: ModuleField[] = [
     unit: 'm²',
     ratio: '1/6',
     disableUntilField: 'room_name',
-    icon: 'o_straighten',
+    icon: outlinedStraighten,
     tooltip:
       'module-buildings-submodule-building-table-room_surface_square_meter',
   },
@@ -85,7 +97,7 @@ const roomFields: ModuleField[] = [
     default: 1,
     ratio: '1/6',
     disableUntilField: 'room_name',
-    icon: 'o_image_aspect_ratio',
+    icon: outlinedImageAspectRatio,
     tooltip: 'module-buildings-submodule-building-table-room_allocation_ratio',
     columnSize: 'md',
   },
@@ -98,7 +110,7 @@ const roomFields: ModuleField[] = [
     unit: 'kWh/m²',
     ratio: '1/6',
     disableUntilField: 'room_name',
-    icon: 'o_thermostat',
+    icon: outlinedThermostat,
     tooltip:
       'module-buildings-submodule-building-table-heating_kwh_per_square_meter',
     maxColumnWidth: 120,
@@ -112,7 +124,7 @@ const roomFields: ModuleField[] = [
     unit: 'kWh/m²',
     ratio: '1/6',
     disableUntilField: 'room_name',
-    icon: 'o_ac_unit',
+    icon: outlinedAcUnit,
     tooltip:
       'module-buildings-submodule-building-table-cooling_kwh_per_square_meter',
     maxColumnWidth: 120,
@@ -126,7 +138,7 @@ const roomFields: ModuleField[] = [
     unit: 'kWh/m²',
     ratio: '1/6',
     disableUntilField: 'room_name',
-    icon: 'o_air',
+    icon: outlinedAir,
     tooltip:
       'module-buildings-submodule-building-table-ventilation_kwh_per_square_meter',
     maxColumnWidth: 120,
@@ -140,7 +152,7 @@ const roomFields: ModuleField[] = [
     unit: 'kWh/m²',
     ratio: '1/6',
     disableUntilField: 'room_name',
-    icon: 'o_light_mode',
+    icon: outlinedLightMode,
     tooltip:
       'module-buildings-submodule-building-table-lighting_kwh_per_square_meter',
     maxColumnWidth: 120,
@@ -168,7 +180,7 @@ const energyCombustionFields: ModuleField[] = [
     inputTypeName: 'QSelect',
     align: 'left',
     ratio: '1/3',
-    icon: 'o_local_fire_department',
+    icon: outlinedLocalFireDepartment,
     hideIn: { form: false },
     columnSize: 'lg',
     tooltip: 'module-buildings-submodule-energy_combustion-table-name',

--- a/frontend/src/constant/module-config/equipment.ts
+++ b/frontend/src/constant/module-config/equipment.ts
@@ -1,6 +1,11 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { formatTonnesCO2 } from 'src/utils/number';
 import type { Module, EquipmentSubType } from 'src/constant/modules';
+import {
+  outlinedCategory,
+  outlinedDonutLarge,
+  outlinedElectricBolt,
+} from '@quasar/extras/material-icons-outlined';
 
 import {
   MODULES,
@@ -59,7 +64,7 @@ const baseModuleFields: ModuleField[] = [
     readOnly: false,
     editableInline: true,
     ratio: '1/2',
-    icon: 'o_category',
+    icon: outlinedCategory,
     columnSize: 'lg',
   },
   {
@@ -77,7 +82,7 @@ const baseModuleFields: ModuleField[] = [
     editableInline: true,
     readOnly: false,
     ratio: '1/2',
-    icon: 'o_category',
+    icon: outlinedCategory,
     columnSize: 'lg',
   },
   {
@@ -97,7 +102,7 @@ const baseModuleFields: ModuleField[] = [
     inputTypeName: 'QInput',
     editableInline: true,
     ratio: '3/12',
-    icon: 'o_donut_large',
+    icon: outlinedDonutLarge,
   },
   {
     id: 'standby_usage_hours_per_week',
@@ -116,7 +121,7 @@ const baseModuleFields: ModuleField[] = [
     inputTypeName: 'QInput',
     editableInline: true,
     ratio: '3/12',
-    icon: 'o_donut_large',
+    icon: outlinedDonutLarge,
   },
   {
     id: 'active_power_w',
@@ -131,7 +136,7 @@ const baseModuleFields: ModuleField[] = [
     tooltip: 'module-equipment-submodule-scientific-table-active_power_w',
     readOnly: true,
     ratio: '3/12',
-    icon: 'o_electric_bolt',
+    icon: outlinedElectricBolt,
     hideIn: {
       form: false,
     },
@@ -154,7 +159,7 @@ const baseModuleFields: ModuleField[] = [
     },
     editableInline: false,
     ratio: '3/12',
-    icon: 'o_electric_bolt',
+    icon: outlinedElectricBolt,
     maxColumnWidth: 150,
   },
   {

--- a/frontend/src/constant/module-config/external-cloud-and-ai.ts
+++ b/frontend/src/constant/module-config/external-cloud-and-ai.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { formatTonnesCO2 } from 'src/utils/number';
+import { outlinedCategory } from '@quasar/extras/material-icons-outlined';
 import {
   SUBMODULE_EXTERNAL_CLOUD_TYPES,
   MODULES,
@@ -22,7 +23,7 @@ const cloudFields: ModuleField[] = [
     readOnly: false,
     editableInline: true,
     ratio: '1/2',
-    icon: 'o_category',
+    icon: outlinedCategory,
     columnSize: 'md',
     tooltip:
       'module-external-cloud-and-ai-submodule-external_clouds-table-provider',
@@ -42,7 +43,7 @@ const cloudFields: ModuleField[] = [
     readOnly: false,
     editableInline: true,
     ratio: '1/2',
-    icon: 'o_category',
+    icon: outlinedCategory,
     columnSize: 'md',
     tooltip:
       'module-external-cloud-and-ai-submodule-external_clouds-table-service_type',

--- a/frontend/src/constant/module-config/headcount.ts
+++ b/frontend/src/constant/module-config/headcount.ts
@@ -3,19 +3,11 @@ import { MODULES, MODULES_THRESHOLD_TYPES } from 'src/constant/modules';
 import { formatFTE } from 'src/utils/number';
 import type { Module } from 'src/constant/modules';
 
-// Define an icon map to convert string keys to SVG icons
 import {
   outlinedFilterDrama,
   outlinedAssignmentInd,
   outlinedTimer,
 } from '@quasar/extras/material-icons-outlined';
-
-export const iconMap: Record<string, string> = {
-  o_filter_drama: outlinedFilterDrama,
-  o_assignment_ind: outlinedAssignmentInd,
-  o_timer: outlinedTimer,
-  // Add more mappings as needed
-};
 
 // EN : Name | Function | Full-Time Equivalent (FTE)
 // FR : Nom | Fonction | Équivalent plein-temps (EPT)
@@ -26,7 +18,7 @@ const memberFields: ModuleField[] = [
     type: 'text',
     sortable: true,
     ratio: '1/4',
-    icon: 'o_filter_drama',
+    icon: outlinedFilterDrama,
     columnSize: 'sm',
   },
   {
@@ -35,7 +27,7 @@ const memberFields: ModuleField[] = [
     type: 'select',
     sortable: true,
     ratio: '1/4',
-    icon: 'o_assignment_ind',
+    icon: outlinedAssignmentInd,
     optionLabelsAreKeys: true,
     columnSize: 'sm',
 
@@ -66,14 +58,9 @@ const memberFields: ModuleField[] = [
     step: 0.1,
     sortable: false,
     ratio: '1/4',
-    icon: 'o_timer',
+    icon: outlinedTimer,
   },
 ];
-
-const memberFieldDynamicIcons = memberFields.map((field) => ({
-  ...field,
-  icon: iconMap[field.icon],
-}));
 
 const studentFields: ModuleField[] = [
   {
@@ -84,7 +71,7 @@ const studentFields: ModuleField[] = [
     step: 0.1,
     sortable: true,
     ratio: '12/12',
-    icon: iconMap['o_timer'],
+    icon: outlinedTimer,
     tooltip: 'module-headcount-submodule-student-table-fte',
   },
 ];
@@ -113,7 +100,7 @@ export const headcount: ModuleConfig = {
       id: 'member',
       type: 'member',
       tableNameKey: 'headcount-member-table-title',
-      moduleFields: memberFieldDynamicIcons,
+      moduleFields: memberFields,
       csvTemplateHeaders: [
         'name',
         'sius_code',

--- a/frontend/src/constant/module-config/process_emissions.ts
+++ b/frontend/src/constant/module-config/process_emissions.ts
@@ -2,6 +2,10 @@ import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { SUBMODULE_PROCESSES_TYPES, MODULES } from 'src/constant/modules';
 import type { ProcessesSubType, Module } from 'src/constant/modules';
 import { formatTonnesCO2 } from 'src/utils/number';
+import {
+  outlinedScience,
+  outlinedCategory,
+} from '@quasar/extras/material-icons-outlined';
 const processEmissionsFields: ModuleField[] = [
   {
     id: 'category',
@@ -16,7 +20,7 @@ const processEmissionsFields: ModuleField[] = [
     align: 'left',
     ratio: '1/3',
     hideIn: { form: false },
-    icon: 'o_science',
+    icon: outlinedScience,
     columnSize: 'lg',
     tooltip:
       'module-process-emissions-submodule-process_emissions-table-category',
@@ -40,7 +44,7 @@ const processEmissionsFields: ModuleField[] = [
         value: 'Refrigerant',
       },
     },
-    icon: 'o_category',
+    icon: outlinedCategory,
     tooltip:
       'module-process-emissions-submodule-process_emissions-table-subcategory',
   },

--- a/frontend/src/constant/module-config/purchase.ts
+++ b/frontend/src/constant/module-config/purchase.ts
@@ -1,5 +1,6 @@
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { formatTonnesCO2 } from 'src/utils/number';
+import { outlinedCategory } from '@quasar/extras/material-icons-outlined';
 import {
   SUBMODULE_PURCHASE_TYPES,
   MODULES,
@@ -42,7 +43,7 @@ const purchaseFields: ModuleField[] = [
     readOnly: false,
     editableInline: true,
     ratio: '1/4',
-    icon: 'o_category',
+    icon: outlinedCategory,
     columnSize: 'md',
   },
   {

--- a/frontend/src/constant/moduleStates.ts
+++ b/frontend/src/constant/moduleStates.ts
@@ -1,5 +1,9 @@
 import { MODULES, type Module } from './modules';
 import type { ModuleCardBadge } from './moduleCards';
+import {
+  outlinedPending,
+  outlinedCheckCircle,
+} from '@quasar/extras/material-icons-outlined';
 
 /**
  * Module status values matching backend ModuleStatus enum.
@@ -99,12 +103,12 @@ export const MODULE_STATUS_DISPLAY: Record<ModuleState, ModuleStatusDisplay> = {
   },
   [MODULE_STATES.InProgress]: {
     color: 'warning',
-    icon: 'o_pending',
+    icon: outlinedPending,
     label: 'module_status_in_progress',
   },
   [MODULE_STATES.Validated]: {
     color: 'positive',
-    icon: 'o_check_circle',
+    icon: outlinedCheckCircle,
     label: 'module_status_validated',
   },
 };

--- a/frontend/src/constant/navigation.ts
+++ b/frontend/src/constant/navigation.ts
@@ -1,3 +1,12 @@
+import { matDataObject } from '@quasar/extras/material-icons';
+import {
+  outlinedAssessment,
+  outlinedPeople,
+  outlinedEditNote,
+  outlinedListAlt,
+  outlinedAccountTree,
+} from '@quasar/extras/material-icons-outlined';
+
 export interface NavItem {
   routeName: string;
   icon: string;
@@ -11,36 +20,36 @@ export const BACKOFFICE_NAV: Record<string, NavItem> = {
   BACKOFFICE_REPORTING: {
     routeName: 'backoffice-reporting',
     description: 'backoffice-reporting-description',
-    icon: 'o_assessment',
+    icon: outlinedAssessment,
   },
   BACKOFFICE_USER_MANAGEMENT: {
     routeName: 'backoffice-user-management',
     description: 'backoffice-user-management-description',
-    icon: 'o_people',
+    icon: outlinedPeople,
   },
   BACKOFFICE_DOCUMENTATION_EDITING: {
     routeName: 'backoffice-documentation-editing',
     description: 'backoffice-documentation-editing-description',
-    icon: 'o_edit_document',
+    icon: outlinedEditNote,
   },
   BACKOFFICE_UI_TEXTS_EDITING: {
     routeName: 'backoffice-ui-texts-editing',
     description: 'backoffice-ui-texts-editing-description',
-    icon: 'o_edit_document',
+    icon: outlinedEditNote,
   },
   BACKOFFICE_DATA_MANAGEMENT: {
     routeName: 'backoffice-data-management',
     description: 'backoffice-data-management-description',
-    icon: 'data_object',
+    icon: matDataObject,
   },
   BACKOFFICE_LOGS: {
     routeName: 'backoffice-logs',
     description: 'backoffice-logs-description',
-    icon: 'o_list_alt',
+    icon: outlinedListAlt,
   },
   BACKOFFICE_PIPELINE_OPERATIONS: {
     routeName: 'backoffice-pipeline-operations',
     description: 'backoffice-pipeline-operations-description',
-    icon: 'o_account_tree',
+    icon: outlinedAccountTree,
   },
 };

--- a/frontend/src/constant/report.ts
+++ b/frontend/src/constant/report.ts
@@ -1,28 +1,34 @@
 // export type ReportType = 'usage' | 'results' | 'combined';
 import type { ReportType } from 'src/api/backoffice';
+import {
+  outlinedBarChart,
+  outlinedAssignment,
+  outlinedPieChart,
+  outlinedAddBox,
+} from '@quasar/extras/material-icons-outlined';
 
 export const REPORT_TYPES = [
   {
     value: 'results' as ReportType,
-    icon: 'o_bar_chart',
+    icon: outlinedBarChart,
     titleKey: 'backoffice_reporting_generate_results_title',
     descriptionKey: 'backoffice_reporting_generate_results_description',
   },
   {
     value: 'detailed' as ReportType,
-    icon: 'o_assignment',
+    icon: outlinedAssignment,
     titleKey: 'backoffice_reporting_generate_detailed_title',
     descriptionKey: 'backoffice_reporting_generate_detailed_description',
   },
   {
     value: 'usage' as ReportType,
-    icon: 'o_pie_chart',
+    icon: outlinedPieChart,
     titleKey: 'backoffice_reporting_generate_usage_title',
     descriptionKey: 'backoffice_reporting_generate_usage_description',
   },
   {
     value: 'combined' as ReportType,
-    icon: 'o_add_box',
+    icon: outlinedAddBox,
     titleKey: 'backoffice_reporting_generate_combined_title',
     descriptionKey: 'backoffice_reporting_generate_combined_description',
   },

--- a/frontend/src/constant/timelineItems.ts
+++ b/frontend/src/constant/timelineItems.ts
@@ -1,41 +1,51 @@
 import type { Module } from 'src/constant/modules';
+import {
+  outlinedDiversity2,
+  outlinedScience,
+  outlinedApartment,
+  outlinedBolt,
+  outlinedFilterDrama,
+  outlinedFlight,
+  outlinedSell,
+  outlinedApps,
+} from '@quasar/extras/material-icons-outlined';
 
 export type { Module };
 
 export const timelineItems = [
   {
-    icon: 'o_diversity_2',
+    icon: outlinedDiversity2,
     link: 'headcount' as Module,
   },
 
   {
-    icon: 'o_science',
+    icon: outlinedScience,
     link: 'process-emissions' as Module,
   },
   {
-    icon: 'o_apartment',
+    icon: outlinedApartment,
     link: 'buildings' as Module,
   },
   {
-    icon: 'o_bolt',
+    icon: outlinedBolt,
     link: 'equipment' as Module,
   },
   {
-    icon: 'o_filter_drama',
+    icon: outlinedFilterDrama,
     link: 'external-cloud-and-ai' as Module,
   },
   {
-    icon: 'o_flight',
+    icon: outlinedFlight,
     link: 'professional-travel' as Module,
   },
 
   {
-    icon: 'o_sell',
+    icon: outlinedSell,
     link: 'purchase' as Module,
   },
 
   {
-    icon: 'o_apps',
+    icon: outlinedApps,
     link: 'research-facilities' as Module,
   },
 ];


### PR DESCRIPTION
## Why

The two Quasar Material Icons webfonts are **~278 KiB** combined (`flUhRq6tz…woff2` 126 KiB + `gok-H7zzD…woff2` 152 KiB), ship with `font-display: block` (FOIT), and sit on the LCP critical path (~1,020–1,249 ms in Lighthouse on `…/2025/equipment`). They're injected unconditionally by `extras: ['material-icons', 'material-icons-outlined']`.

## Goal

Ship the app with **zero icon webfonts** — every icon as inline SVG, tree-shaken so only the ~111 icons actually in use are bundled.

## Approach

Two icon surfaces both move to SVG:
1. **Quasar internal icons** (dropdown arrows, sort carets, checkboxes…) → `framework.iconSet: 'svg-material-icons'` (one line).
2. **App-authored icons** (~226 call sites / ~80 files) → in-component named imports from `@quasar/extras/material-icons` (`mat*`) and `material-icons-outlined` (`outlined*`).

Fonts are removed from `extras` **last**, after every call site is converted, so the app renders at every commit. A dev-only `iconMapFn` guard catches any string name that slips through.

## This PR so far

- 📄 **Implementation plan** — `docs/src/implementation-plans/frontend-svg-icons-drop-webfonts.md`: 8 sequenced tasks, an **authoritative 111-icon name→SVG-export mapping table** (every export verified to exist; 5 no-exact-export names flagged with closest match), per-area grep guards, and the font-drop + guard finale.

Implementation tasks (1–8) will be pushed to this branch.

## Out of scope (already on `dev`)

The `index.html` font preloads + `injectEnv.js defer` quick wins shipped separately (`3b88d6b`). `ModuleIcon`/custom module SVGs are unaffected.

## Verification

`make type-check` (vue-tsc — a wrong export name fails to compile) + per-area grep guard + `npm run build` asserting no Material Icons woff2 in `dist/` + runtime visual sweep with zero `[icon-guard]` warnings.