### PR TITLE
feat(auth): integrate user permission checks for module breakdown fetching

### DIFF
--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -178,6 +178,8 @@ import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTr
 import EmissionTypeBreakdownChart from 'src/components/charts/results/EmissionTypeBreakdownChart.vue';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { useAuthStore } from 'src/stores/auth';
+import { PermissionAction } from 'src/utils/permission';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
 import {
   buildModuleTreemapData,
@@ -308,6 +310,7 @@ const TOP_CLASS_MODULES: Module[] = [
 
 const moduleStore = useModuleStore();
 const workspaceStore = useWorkspaceStore();
+const authStore = useAuthStore();
 
 const supportsTopClassBreakdown = computed(() =>
   TOP_CLASS_MODULES.includes(props.type),
@@ -316,6 +319,10 @@ const supportsTopClassBreakdown = computed(() =>
 function fetchTopClassBreakdownIfNeeded() {
   const unitId = workspaceStore.selectedUnit?.id;
   const year = workspaceStore.selectedYear;
+
+  if (!authStore.hasUserModulePermission(props.type, PermissionAction.VIEW)) {
+    return;
+  }
   if (unitId && year && supportsTopClassBreakdown.value) {
     void moduleStore.getTopClassBreakdown(unitId, String(year), props.type);
   }

--- a/frontend/tests/unit/results-top-class-permission.spec.ts
+++ b/frontend/tests/unit/results-top-class-permission.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for #1596 — standard users get a 403 "Unauthorized Access"
+ * redirect on the Results page.
+ *
+ * Root cause: when a category is expanded on Results, ``ModuleCharts`` eagerly
+ * fetches the per-module ``top-class-breakdown`` for the three top-class modules
+ * (Equipment, Purchase, Research facilities). That endpoint is permission-gated
+ * (``modules.<type>.view``); a standard user lacks ``view`` on those modules, so
+ * the call 403s and the global HTTP hook bounces the whole page to
+ * ``/unauthorized``.
+ *
+ * The fix guards the call with ``authStore.hasUserModulePermission(type, VIEW)``
+ * (``stores/auth.ts``), which resolves the workspace-scoped permission. This
+ * test pins that decision: standard users must resolve to "no view" on the
+ * top-class modules (→ call skipped), while principals resolve to "view"
+ * (→ call proceeds). It also pins that own-scoped modules a standard user *can*
+ * view are never fetched anyway because they are not top-class.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { MODULES, type Module } from '../../src/constant/modules';
+import {
+  getModulePermissionPath,
+  hasPermission,
+  PermissionAction,
+  type FlatUserPermissions,
+} from '../../src/utils/permission';
+
+/** Mirrors ``TOP_CLASS_MODULES`` in ``ModuleCharts.vue``. */
+const TOP_CLASS_MODULES: Module[] = [
+  MODULES.Equipment,
+  MODULES.Purchase,
+  MODULES.ResearchFacilities,
+];
+
+/**
+ * Mirrors ``hasUserPermission`` in ``stores/auth.ts``: a bare/global grant, OR
+ * the unit-scoped key (principal), OR the own-scoped key (standard user).
+ */
+function canViewModuleForUnit(
+  perms: FlatUserPermissions,
+  module: Module,
+  institutionalId: string,
+): boolean {
+  const path = getModulePermissionPath(module);
+  if (!path) return false;
+  const unitPath = `${path}/${institutionalId}`;
+  return (
+    hasPermission(perms, path, PermissionAction.VIEW) ||
+    hasPermission(perms, unitPath, PermissionAction.VIEW) ||
+    hasPermission(perms, `${unitPath}/own`, PermissionAction.VIEW)
+  );
+}
+
+/** The guard added to ``fetchTopClassBreakdownIfNeeded`` in ``ModuleCharts.vue``. */
+function shouldFetchTopClassBreakdown(
+  perms: FlatUserPermissions,
+  module: Module,
+  institutionalId: string,
+): boolean {
+  return (
+    TOP_CLASS_MODULES.includes(module) &&
+    canViewModuleForUnit(perms, module, institutionalId)
+  );
+}
+
+const INST = '0184';
+
+// A standard user: own-scoped grants on travel + external cloud/AI only.
+// Critically, NO purchase/equipment/research_facilities keys of any scope.
+const STANDARD_USER: FlatUserPermissions = {
+  'modules.professional_travel/0184/own': ['view', 'edit'],
+  'modules.external_cloud_and_ai/0184/own': ['view', 'edit'],
+} as never;
+
+// A principal (unit manager): unit-scoped view on every module.
+const PRINCIPAL: FlatUserPermissions = {
+  'modules.equipment/0184': ['view', 'edit'],
+  'modules.purchase/0184': ['view', 'edit'],
+  'modules.research_facilities/0184': ['view', 'edit'],
+  'modules.external_cloud_and_ai/0184': ['view', 'edit'],
+} as never;
+
+for (const module of TOP_CLASS_MODULES) {
+  test(`#1596: standard user does NOT fetch top-class breakdown for ${module}`, () => {
+    expect(shouldFetchTopClassBreakdown(STANDARD_USER, module, INST)).toBe(
+      false,
+    );
+  });
+
+  test(`principal DOES fetch top-class breakdown for ${module}`, () => {
+    expect(shouldFetchTopClassBreakdown(PRINCIPAL, module, INST)).toBe(true);
+  });
+}
+
+test('own-scoped module a standard user can view is still not fetched (not top-class)', () => {
+  // The standard user holds `external_cloud_and_ai/own` view, so the scope
+  // check passes — but the module is not top-class, so no gated call is made.
+  expect(
+    canViewModuleForUnit(STANDARD_USER, MODULES.ExternalCloudAndAI, INST),
+  ).toBe(true);
+  expect(
+    shouldFetchTopClassBreakdown(
+      STANDARD_USER,
+      MODULES.ExternalCloudAndAI,
+      INST,
+    ),
+  ).toBe(false);
+});
+
+test('non-top-class module never triggers a fetch even for a principal', () => {
+  expect(shouldFetchTopClassBreakdown(PRINCIPAL, MODULES.Headcount, INST)).toBe(
+    false,
+  );
+});


### PR DESCRIPTION
## What does this change?
Guards the top-class breakdown fetch in `ModuleCharts` behind a view-permission check, preventing standard users from triggering a 403 that bounced them to `/unauthorized`.

- `ModuleCharts.vue`: imports `useAuthStore` and `PermissionAction`; adds an early return in `fetchTopClassBreakdownIfNeeded` when the current user lacks `VIEW` permission on the module — the `getTopClassBreakdown` call is skipped entirely for users without the right
- New unit test `results-top-class-permission.spec.ts`: pins the permission logic for the three top-class modules (Equipment, Purchase, Research facilities) — standard users (own-scoped travel/cloud grants only) must resolve to "no fetch", principals (unit-scoped grants) must resolve to "fetch"; also confirms that an own-scoped module the standard user can view (ExternalCloudAndAI) is still never fetched because it isn't a top-class module, and that non-top-class modules are never fetched even for principals

## Why is this needed?
When a category was expanded on the Results page, `ModuleCharts` eagerly called the per-module `top-class-breakdown` endpoint for Equipment, Purchase, and Research facilities. That endpoint is permission-gated; standard users lack view permission on those modules, so the call returned 403 and the global HTTP interceptor redirected the whole page to `/unauthorized`.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced