### PR TITLE
feat(carbon-report): update total calculation to exclude additional breakdown categories

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -48,6 +48,7 @@ from app.schemas.user import UserRead
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.services.data_entry_service import DataEntryService
+from app.utils.emission_category import is_additional_breakdown_emission
 from app.utils.request_context import extract_ip_address, extract_route_payload
 from app.workflows.carbon_report_module import CarbonReportModuleWorkflow
 from app.workflows.embodied_energy import EmbodiedEnergyWorkflow
@@ -308,12 +309,16 @@ async def get_module(
         module_data.stats = await DataEntryEmissionService(db).get_stats(
             carbon_report_module_id=carbon_report_module_id,
         )
-    # if need other subtotal do it here
-    total_kg_co2eq = (
-        sum(v for v in module_data.stats.values() if v is not None)
-        if module_data.stats
-        else None
-    )
+
+        total_kg_co2eq = (
+            sum(
+                v
+                for k, v in module_data.stats.items()
+                if v is not None and not is_additional_breakdown_emission(int(k))
+            )
+            if module_data.stats
+            else None
+        )
     module_data.totals = ModuleTotals(
         total_kg_co2eq=total_kg_co2eq,
         total_tonnes_co2eq=total_kg_co2eq / 1000.0

--- a/backend/app/utils/emission_category.py
+++ b/backend/app/utils/emission_category.py
@@ -107,6 +107,17 @@ def _resolve_emission_type(emission_type_id: int) -> EmissionType | None:
         return None
 
 
+def is_additional_breakdown_emission(emission_type_id: int) -> bool:
+    """True when an emission type belongs to an 'additional breakdown' category
+    (embodied_energy, commuting, food, waste). These are reported separately and
+    must be excluded from a module's headline total — matching build_chart_breakdown,
+    which routes them to additional_breakdown instead of module_totals_kg."""
+    emission_type = _resolve_emission_type(emission_type_id)
+    if emission_type is None:
+        return False
+    return emission_type.category in _ADDITIONAL_CATEGORIES
+
+
 def _build_emission_value(
     emission_type: EmissionType,
     kg_co2eq: float,

--- a/backend/tests/unit/repositories/test_data_entry_emission_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_emission_repo.py
@@ -11,6 +11,7 @@ from app.models.data_entry_emission import DataEntryEmission, EmissionType
 from app.models.module_type import ModuleTypeEnum
 from app.models.unit import Unit
 from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
+from app.utils.emission_category import is_additional_breakdown_emission
 
 # ======================================================================
 # CRUD Operation Tests
@@ -323,6 +324,73 @@ async def test_get_stats_empty_result(db_session: AsyncSession):
     result = await repo.get_stats(99999, "emission_type_id", "kg_co2eq")
 
     assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_buildings_banner_total_excludes_embodied_energy(
+    db_session: AsyncSession,
+):
+    """Regression for #1616: the buildings module banner total must exclude
+    embodied energy (an additional-breakdown category), matching the Results
+    module total. get_stats still returns the embodied row; the headline sum
+    filters it out via is_additional_breakdown_emission, exactly like the
+    GET /modules/{unit}/{year}/{module} endpoint does.
+    """
+    repo = DataEntryEmissionRepository(db_session)
+
+    module = CarbonReportModule(
+        carbon_report_id=1,
+        module_type_id=ModuleTypeEnum.buildings.value,
+        status="in_progress",
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    # Operational rooms + combustion (counted) vs embodied construction (separate).
+    seed = [
+        (DataEntryTypeEnum.building, EmissionType.buildings__rooms__lighting, 4_000.0),
+        (
+            DataEntryTypeEnum.energy_combustion,
+            EmissionType.buildings__combustion__natural_gas,
+            2_000.0,
+        ),
+        (
+            DataEntryTypeEnum.building_embodied_energy,
+            EmissionType.buildings__construction_and_renovation,
+            35_000.0,
+        ),
+    ]
+    for data_entry_type, emission_type, kg in seed:
+        entry = DataEntry(
+            carbon_report_module_id=module.id,
+            data_entry_type_id=data_entry_type,
+            status=DataEntryStatusEnum.PENDING,
+            data={},
+        )
+        db_session.add(entry)
+        await db_session.flush()
+        db_session.add(
+            DataEntryEmission(
+                data_entry_id=entry.id,
+                emission_type_id=emission_type,
+                kg_co2eq=kg,
+                scope=emission_type.scope,
+            )
+        )
+    await db_session.flush()
+
+    stats = await repo.get_stats(module.id, "emission_type_id", "kg_co2eq")
+
+    # Raw stats still include the embodied row.
+    assert str(EmissionType.buildings__construction_and_renovation.value) in stats
+
+    # Headline total mirrors the banner endpoint: drop additional categories.
+    banner_total = sum(
+        v
+        for k, v in stats.items()
+        if v is not None and not is_additional_breakdown_emission(int(k))
+    )
+    assert banner_total == pytest.approx(6_000.0)  # rooms + combustion, no embodied
 
 
 # ======================================================================

--- a/backend/tests/unit/utils/test_emission_category.py
+++ b/backend/tests/unit/utils/test_emission_category.py
@@ -9,6 +9,7 @@ from app.utils.emission_category import (
     additional_value_unit,
     build_chart_breakdown,
     build_treemap,
+    is_additional_breakdown_emission,
 )
 
 EXPECTED_MODULE_BREAKDOWN_ORDER = [
@@ -319,3 +320,33 @@ def test_additional_value_unit_infers_from_tree():
     assert additional_value_unit(EmissionType.food__vegetarian) == "kg"
     assert additional_value_unit(EmissionType.professional_travel__plane__eco) == "km"
     assert additional_value_unit(EmissionType.equipment__scientific) is None
+
+
+def test_is_additional_breakdown_emission_flags_embodied_energy():
+    # Embodied energy (construction/renovation) is reported separately and must
+    # be excluded from a module's headline total — see #1616.
+    assert (
+        is_additional_breakdown_emission(
+            EmissionType.buildings__construction_and_renovation.value
+        )
+        is True
+    )
+
+
+def test_is_additional_breakdown_emission_false_for_operational_buildings():
+    # Rooms (operational energy) and combustion belong to the buildings module
+    # headline total, not the additional breakdown.
+    assert (
+        is_additional_breakdown_emission(EmissionType.buildings__rooms__lighting.value)
+        is False
+    )
+    assert (
+        is_additional_breakdown_emission(
+            EmissionType.buildings__combustion__natural_gas.value
+        )
+        is False
+    )
+
+
+def test_is_additional_breakdown_emission_false_for_unknown_id():
+    assert is_additional_breakdown_emission(999999) is False


### PR DESCRIPTION
## What does this change?
Fixes the buildings module banner total incorrectly including embodied energy (construction & renovation) in its headline CO₂ figure.

- `emission_category.py`: adds `is_additional_breakdown_emission(emission_type_id)` — returns `True` when an emission type belongs to an "additional breakdown" category (embodied energy, commuting, food, waste), mirroring the logic in `build_chart_breakdown` which routes those to `additional_breakdown` rather than `module_totals_kg`
- `carbon_report_module.py` (`get_module`): changes the headline total sum to filter out additional-breakdown emission types via the new helper, so the banner total matches the Results page module total
- New unit tests in `test_emission_category.py`: pins that `buildings__construction_and_renovation` is flagged as additional, that operational buildings emissions (rooms lighting, combustion natural gas) are not, and that an unknown ID returns `False`
- New unit test `test_buildings_banner_total_excludes_embodied_energy` in `test_data_entry_emission_repo.py`: seeds a buildings module with rooms (4000 kg), combustion (2000 kg), and embodied energy (35000 kg); verifies that raw `get_stats` still returns all three rows, and that the headline filter produces 6000 kg (rooms + combustion only)

## Why is this needed?
The buildings module sidebar banner was summing all emission types returned by `get_stats`, including `buildings__construction_and_renovation`. The Results page reports that category under "additional breakdown" separately from the operational module total, so the banner and Results page showed different numbers for the same module.

## Type of change
- [x] 🐛 Bug fix

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced