### PR TITLE
feat/1565 feat add missing backoffice documentation button

### DIFF
--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -118,20 +118,6 @@ const logoRoute = computed(() => {
         :to="{ name: 'back-office' }"
       />
       <q-btn
-        v-if="isInBackOfficeRoute"
-        icon="o_article"
-        color="grey-4"
-        text-color="primary"
-        :label="$t('backoffice_documentation_button_label')"
-        unelevated
-        no-caps
-        outline
-        size="sm"
-        class="text-weight-medium q-ml-xl"
-        href="https://epfl-enac.github.io/co2-calculator-back-office-doc/"
-        target="_blank"
-      />
-      <q-btn
         v-if="hasBackOfficeAccess && isInBackOfficeRoute"
         color="grey-4"
         text-color="primary"

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -118,6 +118,20 @@ const logoRoute = computed(() => {
         :to="{ name: 'back-office' }"
       />
       <q-btn
+        v-if="isInBackOfficeRoute"
+        icon="o_article"
+        color="grey-4"
+        text-color="primary"
+        :label="$t('backoffice_documentation_button_label')"
+        unelevated
+        no-caps
+        outline
+        size="sm"
+        class="text-weight-medium q-ml-xl"
+        href="https://epfl-enac.github.io/co2-calculator-back-office-doc/"
+        target="_blank"
+      />
+      <q-btn
         v-if="hasBackOfficeAccess && isInBackOfficeRoute"
         color="grey-4"
         text-color="primary"

--- a/frontend/src/components/layout/Co2Sidebar.vue
+++ b/frontend/src/components/layout/Co2Sidebar.vue
@@ -61,5 +61,29 @@ function isItemDisabled(item: NavItem): boolean {
         </q-tooltip>
       </q-item>
     </q-list>
+    <div class="co2-sidebar-docs-wrapper">
+      <q-separator />
+      <q-item
+        class="co2-sidebar-item"
+        tag="a"
+        :href="$t('header_backoffice_documentation_link')"
+        target="_blank"
+        clickable
+      >
+        <q-icon name="o_article" size="sm" />
+        <q-item-label v-show="!collapsed" class="text-body2">{{
+          $t('backoffice_documentation_button_label')
+        }}</q-item-label>
+      </q-item>
+    </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.co2-sidebar-docs-wrapper {
+  margin-top: auto;
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/i18n/backoffice.ts
+++ b/frontend/src/i18n/backoffice.ts
@@ -53,4 +53,8 @@ export default {
     en: 'Back to Calculator',
     fr: 'Retour au calculateur',
   },
+  backoffice_documentation_button_label: {
+    en: 'Backoffice guide',
+    fr: 'Guide back-office',
+  },
 } as const;


### PR DESCRIPTION
## What does this change?
Adds a pinned "Backoffice guide" link at the bottom of the back-office sidebar, and a blank-line formatting fix in the header.

- `Co2Sidebar.vue`: adds a documentation link item pinned to the bottom of the nav list (separator above, `margin-top: auto` + `flex-shrink: 0` to keep it anchored); shows the label when expanded and a tooltip when collapsed; links to the external back-office documentation site in a new tab
- `backoffice.ts`: adds `backoffice_documentation_button_label` (EN: "Backoffice guide", FR: "Guide back-office")

## Why is this needed?
Back-office users had no direct in-app link to the external documentation guide while working in the back-office interface.

## Type of change
- [x] ✨ New feature

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced