### PR TITLE
feat(i18n): add new refrigerant category translations for emissions module

### DIFF
--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -57,6 +57,10 @@ export default {
     en: 'Refrigerant',
     fr: 'Fluide Frigorigène',
   },
+  [`${MODULES.ProcessEmissions}.category.Refrigerant`]: {
+    en: 'Refrigerant',
+    fr: 'Fluide Frigorigène',
+  },
   // Factor taxonomy / CSV use singular "refrigerant"; same label as plural key above.
   [`${MODULES.ProcessEmissions}.category.refrigerant`]: {
     en: 'Refrigerant',


### PR DESCRIPTION
## What does this change?
Adds a capitalized-key variant of the Refrigerant i18n entry in `process_emissions.ts`.

- Adds `process-emissions.category.Refrigerant` (capital R) alongside the existing `process-emissions.category.refrigerants` and `process-emissions.category.refrigerant` (lowercase) keys, all mapping to the same EN/FR label

## Why is this needed?
The CSV import uses `"Refrigerant"` (capital R) as the category value, but the i18n lookup was only registered for the lowercase variants. The missing key caused the label to fall back to the raw key string in the UI after import.

## Type of change
- [x] 🐛 Bug fix