### PR TITLE
fix(carbon-report): prevent NameError for headcount module by initializing total_kg_co2eq

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -287,6 +287,7 @@ async def get_module(
 
     # if headcount compute FTE here
     total_annual_fte = None
+    total_kg_co2eq = None
     if module_id == "headcount":
         total_annual_fte = await DataEntryService(db).get_total_per_field(
             field_name="fte",

--- a/backend/tests/unit/v1/test_carbon_report_module.py
+++ b/backend/tests/unit/v1/test_carbon_report_module.py
@@ -447,3 +447,51 @@ def test_module_top_class_group_field_mapping():
 
 def test_module_top_class_label_field_mapping():
     assert ModuleTypeEnum.purchase in crm._MODULE_TOP_CLASS_LABEL_FIELD
+
+
+# ── get_module: headcount 500 regression ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_module_headcount_does_not_raise_name_error():
+    """get_module must not raise NameError (→ 500) for headcount.
+
+    Before the fix, total_kg_co2eq was only assigned in the else-branch
+    (non-headcount path) but used unconditionally when building ModuleTotals,
+    causing NameError on the headcount page.
+    """
+    user = _user(roles=[_principal(UNIT_IID)])
+    db = _mock_db(UNIT_IID)
+
+    module_data = MagicMock()
+    module_data.stats = {}
+
+    data_svc = MagicMock()
+    data_svc.get_module_data = AsyncMock(return_value=module_data)
+    data_svc.get_total_per_field = AsyncMock(return_value=10.0)
+    data_svc.get_stats = AsyncMock(return_value={"10208": 5.0})
+
+    unit = MagicMock()
+    unit.institutional_id = UNIT_IID
+
+    with (
+        patch.object(
+            crm,
+            "check_module_permission_for_unit",
+            AsyncMock(return_value=unit),
+        ),
+        patch.object(crm, "get_carbon_report_id", AsyncMock(return_value=99)),
+        patch.object(crm, "DataEntryService", return_value=data_svc),
+    ):
+        result = await crm.get_module(
+            unit_id=1,
+            year=2024,
+            module_id="headcount",
+            preview_limit=20,
+            carbon_project_type=0,
+            db=db,
+            current_user=user,
+        )
+
+    assert result.totals.total_kg_co2eq is None
+    assert result.totals.total_annual_fte == 10.0


### PR DESCRIPTION
## What does this change?
Fixes a `NameError` (→ HTTP 500) on the headcount module page caused by `total_kg_co2eq` being used before assignment.

- `carbon_report_module.py` (`get_module`): initialises `total_kg_co2eq = None` before the `if module_id == "headcount"` branch — previously the variable was only assigned in the else-branch (non-headcount path) but referenced unconditionally when constructing `ModuleTotals`, raising a `NameError` for headcount requests
- New unit test `test_get_module_headcount_does_not_raise_name_error`: verifies that `get_module` called with `module_id="headcount"` completes without raising, and that the returned totals have `total_kg_co2eq=None` and the correct `total_annual_fte`

## Why is this needed?
Any request to the headcount module page triggered a `NameError` on the backend, returning a 500 to the frontend and making the page unusable.

## Type of change
- [x] 🐛 Bug fix
