### PR TITLE
fix(i18n): update class labels for professional travel to use ordinal numbers

### DIFF
--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -177,8 +177,8 @@ export default {
     fr: '2ème classe',
   },
   first: {
-    en: 'First',
-    fr: 'Première',
+    en: '1st class',
+    fr: '1ère classe',
   },
   business: {
     en: 'Business',


### PR DESCRIPTION
## What does this change?
Updates the `first` cabin class label to use an ordinal format consistent with the existing `second` label.

- `professional_travel.ts`: changes `first` from "First" / "Première" to "1st class" / "1ère classe", matching the style of the `second` key ("2nd class" / "2ème classe")

## Why is this needed?
The `first` label used a different format ("First") from `second` ("2nd class"), creating an inconsistent dropdown in the plane travel form.

## Type of change
- [x] 🐛 Bug fix
