### PR TITLE
fix: added kind field override logic to emission recalculation #1480

### DIFF
--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -617,6 +617,12 @@ class FactorRepository:
         handler = BaseModuleHandler.get_by_type(data_entry_type)
         kind_field = handler.kind_field or ""
         subkind_field = handler.subkind_field or ""
+        # When the handler declares kind_field_override (e.g. purchase), several
+        # factors can share the same kind value — they differ only by the override
+        # key (e.g. purchase_additional_code).  Callers of get_by_classification
+        # never supply the override value, so restrict to "average" rows (those
+        # where the override key is absent/NULL) to keep one_or_none() safe.
+        override_field: str | None = handler.kind_field_override
 
         if year is None:
             raise ValueError(
@@ -634,6 +640,10 @@ class FactorRepository:
                 Factor.classification[kind_field].as_string() == kind,
                 Factor.classification[subkind_field].as_string() == subkind,
             ]
+            if override_field:
+                conditions.append(
+                    Factor.classification[override_field].as_string().is_(None)
+                )
             stmt = select(Factor).where(*conditions)
             result = await self.session.exec(stmt)
             factor = result.one_or_none()
@@ -645,6 +655,10 @@ class FactorRepository:
             Factor.classification[kind_field].as_string() == kind,
             Factor.classification[subkind_field].as_string().is_(None),
         ]
+        if override_field:
+            conditions.append(
+                Factor.classification[override_field].as_string().is_(None)
+            )
         stmt = select(Factor).where(*conditions)
         result = await self.session.exec(stmt)
         return result.one_or_none()

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -103,11 +103,17 @@ class EmissionRecalculationWorkflow:
         # which itself does a kind-only fallback when the exact
         # (kind, subkind) row is absent.
         factor_lookup: dict[tuple[str, str | None], int] = {}
+        # override-key-first lookup structures (populated only for handlers with
+        # kind_field_override, mirroring _resolve_with_kind_override):
+        # override_lookup: override_code → [(factor_id, kind_value)]
+        # kind_lookup:     kind_value    → [(factor_id, override_code | None)]
+        override_lookup: dict[str, list[tuple[int, str]]] = {}
+        kind_lookup: dict[str, list[tuple[int, str | None]]] = {}
         # One bulk SELECT for the slice's factors.  Feeds two caches:
         # ``factor_cache`` (id → Factor) short-circuits Strategy A
-        # lookups inside ``prepare_create`` for every entry, and
-        # ``factor_lookup`` ((kind, subkind) → id) backs the rematch
-        # below (only built when the handler actually rematches).
+        # lookups inside ``prepare_create`` for every entry, and the
+        # rematch lookup dicts back the per-entry factor relink below
+        # (only built when the handler actually rematches).
         factors = await factor_repo.list_by_data_entry_type(data_entry_type_id, year)
         factor_cache: dict[int, Factor] = {f.id: f for f in factors if f.id is not None}
         # Strategy-B (classification-query) factor lookups hit the DB once per
@@ -121,22 +127,42 @@ class EmissionRecalculationWorkflow:
             handler.kind_field in e.data for e in entries
         ):
             kind_field = handler.kind_field
-            subkind_field = handler.subkind_field
-            for factor in factors:
-                if factor.id is None:
-                    continue
-                classification = factor.classification or {}
-                kind_value = classification.get(kind_field)
-                if kind_value is None or kind_value == "":
-                    continue
-                subkind_value: str | None = None
-                if subkind_field:
-                    raw = classification.get(subkind_field)
-                    subkind_value = raw if raw else None
-                # First writer wins on duplicate keys; ``get_by_classification``
-                # uses ``one_or_none`` which raises on duplicates anyway, so
-                # callers don't depend on ordering when the index is consistent.
-                factor_lookup.setdefault((kind_value, subkind_value), factor.id)
+            if handler.kind_field_override is not None:
+                # Override-key-first path: mirrors _resolve_with_kind_override.
+                # Lookup-key matches that method: override_field value is the
+                # primary key; kind_field is the fallback, restricted to factors
+                # that carry no override code (those are the implicit averages).
+                override_field = handler.kind_field_override
+                for factor in factors:
+                    if factor.id is None:
+                        continue
+                    classification = factor.classification or {}
+                    kind_value = classification.get(kind_field)
+                    if not kind_value:
+                        continue
+                    ov_code: str | None = classification.get(override_field) or None
+                    kind_lookup.setdefault(kind_value, []).append((factor.id, ov_code))
+                    if ov_code:
+                        override_lookup.setdefault(ov_code, []).append(
+                            (factor.id, kind_value)
+                        )
+            else:
+                subkind_field = handler.subkind_field
+                for factor in factors:
+                    if factor.id is None:
+                        continue
+                    classification = factor.classification or {}
+                    kind_value = classification.get(kind_field)
+                    if kind_value is None or kind_value == "":
+                        continue
+                    subkind_value: str | None = None
+                    if subkind_field:
+                        raw = classification.get(subkind_field)
+                        subkind_value = raw if raw else None
+                    # First writer wins on duplicate keys; ``get_by_classification``
+                    # uses ``one_or_none`` which raises on duplicates anyway, so
+                    # callers don't depend on ordering when the index is consistent.
+                    factor_lookup.setdefault((kind_value, subkind_value), factor.id)
 
         # Plan 310D — per-slice prefetch: handlers that otherwise re-query
         # slice-constant data per entry (plane reloads airports + the full
@@ -199,6 +225,7 @@ class EmissionRecalculationWorkflow:
             # Also avoids an ``assert`` (bandit B101 — asserts are stripped
             # under ``python -O``).
             entry_kind_field: str | None = handler.kind_field
+            entry_kind_field_override: str | None = handler.kind_field_override
             old_data = entry.data
             try:
                 # Compute-only: ``prepare_create`` does reads (handler
@@ -208,12 +235,21 @@ class EmissionRecalculationWorkflow:
                 # reverts the in-memory factor swap and moves on.
                 _t = time.perf_counter()
                 if entry_kind_field is not None and entry_kind_field in entry.data:
-                    new_factor_id = self._lookup_factor_id(
-                        entry_data=entry.data,
-                        kind_field=entry_kind_field,
-                        subkind_field=handler.subkind_field,
-                        factor_lookup=factor_lookup,
-                    )
+                    if entry_kind_field_override is not None:
+                        new_factor_id = self._lookup_factor_id_with_override(
+                            entry_data=entry.data,
+                            kind_field=entry_kind_field,
+                            override_field=entry_kind_field_override,
+                            override_lookup=override_lookup,
+                            kind_lookup=kind_lookup,
+                        )
+                    else:
+                        new_factor_id = self._lookup_factor_id(
+                            entry_data=entry.data,
+                            kind_field=entry_kind_field,
+                            subkind_field=handler.subkind_field,
+                            factor_lookup=factor_lookup,
+                        )
                     if new_factor_id != entry.data.get("primary_factor_id"):
                         # Tentative swap so DataEntryResponse +
                         # prepare_create see the refreshed factor (or
@@ -401,3 +437,63 @@ class EmissionRecalculationWorkflow:
         if subkind is not None:
             return factor_lookup.get((kind, None))
         return None
+
+    @staticmethod
+    def _lookup_factor_id_with_override(
+        entry_data: dict,
+        kind_field: str,
+        override_field: str,
+        override_lookup: dict[str, list[tuple[int, str]]],
+        kind_lookup: dict[str, list[tuple[int, str | None]]],
+    ) -> int | None:
+        """Resolve ``primary_factor_id`` using the override-key-first rule.
+
+        Mirrors ``ModuleHandlerService._resolve_with_kind_override`` in-memory:
+
+        1. If the entry carries a value for ``override_field``, look it up in
+           ``override_lookup`` (override_code → [(factor_id, kind_value)]).
+           A single match wins; multiple matches are disambiguated by kind.
+        2. Kind-only fallback via ``kind_lookup`` (kind_value →
+           [(factor_id, override_code | None)]): if one row matches, return
+           it; if several rows share the kind, only the "average" rows (those
+           without an override code) may stand in — there must be exactly one.
+
+        Returns ``None`` when the factor is absent from the current slice.
+        Raises ``ValueError`` on ambiguous data (matches the service behaviour
+        so the per-entry error path records the same signal as a live update).
+        """
+        kind = entry_data.get(kind_field)
+        if not kind:
+            return None
+
+        code: str | None = entry_data.get(override_field) or None
+        if code:
+            matches = override_lookup.get(code, [])
+            if len(matches) == 1:
+                return matches[0][0]
+            if len(matches) > 1:
+                same_kind = [fid for fid, kv in matches if kv == kind]
+                if len(same_kind) == 1:
+                    return same_kind[0]
+                raise ValueError(
+                    f"Ambiguous factor data: {len(matches)} factors match "
+                    f"{override_field}={code!r} and {kind_field}={kind!r} "
+                    f"cannot disambiguate"
+                )
+            # code present but no factor carries it → fall through to kind fallback
+
+        kind_matches = kind_lookup.get(kind, [])
+        if not kind_matches:
+            return None
+        if len(kind_matches) == 1:
+            return kind_matches[0][0]
+        # Several rows share this kind: only "average" rows (no override code)
+        # may stand in for all of them.
+        averages = [fid for fid, ov in kind_matches if ov is None]
+        if len(averages) == 1:
+            return averages[0]
+        raise ValueError(
+            f"Ambiguous factor data: {len(kind_matches)} factors match "
+            f"{kind_field}={kind!r} with {len(averages)} average rows "
+            f"(need exactly 1)"
+        )

--- a/backend/tests/unit/repositories/test_factor_repo.py
+++ b/backend/tests/unit/repositories/test_factor_repo.py
@@ -1,7 +1,7 @@
 """Tests for FactorRepository."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -211,3 +211,105 @@ async def test_get_factors_with_fallback(repo):
 
     assert result == [factor]
     assert repo.session.exec.await_count == 2
+
+
+# ======================================================================
+# get_by_classification — kind_field_override guard
+# ======================================================================
+
+
+def _override_handler() -> MagicMock:
+    """A handler mock that declares kind_field_override (purchase-style)."""
+    h = MagicMock()
+    h.kind_field = "purchase_institutional_code"
+    h.subkind_field = ""
+    h.kind_field_override = "purchase_additional_code"
+    return h
+
+
+@pytest.mark.asyncio
+async def test_get_by_classification_override_handler_no_subkind(repo):
+    """Handler with kind_field_override, no subkind supplied → single exec
+    call that targets only 'average' rows (override key absent)."""
+    factor = SimpleNamespace(id=42)
+    result_mock = MagicMock()
+    result_mock.one_or_none.return_value = factor
+    repo.session.exec = AsyncMock(return_value=result_mock)
+
+    with patch("app.repositories.factor_repo.BaseModuleHandler") as mock_cls:
+        mock_cls.get_by_type.return_value = _override_handler()
+        result = await repo.get_by_classification(
+            DataEntryTypeEnum.consumable_accessories,
+            kind="FOOD",
+            year=2025,
+        )
+
+    assert result is factor
+    assert repo.session.exec.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_by_classification_override_handler_subkind_miss_fallback(repo):
+    """Handler with kind_field_override, subkind supplied but first query
+    misses → falls back to kind-only query; both queries should include
+    the override-null guard."""
+    factor = SimpleNamespace(id=43)
+    result_miss = MagicMock()
+    result_miss.one_or_none.return_value = None
+    result_hit = MagicMock()
+    result_hit.one_or_none.return_value = factor
+    repo.session.exec = AsyncMock(side_effect=[result_miss, result_hit])
+
+    with patch("app.repositories.factor_repo.BaseModuleHandler") as mock_cls:
+        mock_cls.get_by_type.return_value = _override_handler()
+        result = await repo.get_by_classification(
+            DataEntryTypeEnum.consumable_accessories,
+            kind="FOOD",
+            subkind="sub1",
+            year=2025,
+        )
+
+    assert result is factor
+    assert repo.session.exec.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_by_classification_override_handler_sql_includes_override_null(repo):
+    """The WHERE clause for an override-handler query must include an IS NULL
+    condition on the override field.
+
+    This prevents MultipleResultsFound when several factors share the same
+    kind value but carry different override codes — without this guard,
+    one_or_none() raises on the second (or more) matching rows.
+    """
+    from sqlalchemy.dialects.postgresql import dialect as pg_dialect
+
+    captured: list = []
+
+    async def capturing_exec(stmt):
+        captured.append(stmt)
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = None
+        return mock_result
+
+    repo.session.exec = capturing_exec
+
+    with patch("app.repositories.factor_repo.BaseModuleHandler") as mock_cls:
+        mock_cls.get_by_type.return_value = _override_handler()
+        await repo.get_by_classification(
+            DataEntryTypeEnum.consumable_accessories,
+            kind="FOOD",
+            year=2025,
+        )
+
+    assert len(captured) == 1
+    sql = str(
+        captured[0].compile(
+            dialect=pg_dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    # The compiled SQL must contain the override field null guard so that only
+    # "average" rows (those without purchase_additional_code) are eligible.
+    assert "purchase_additional_code" in sql
+    assert "IS NULL" in sql.upper()

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -818,3 +818,287 @@ async def test_recalculate_reports_progress_at_interval(monkeypatch):
         )
 
     assert progress_calls == [(1, 2), (2, 2)]
+
+
+# ======================================================================
+# _lookup_factor_id_with_override unit tests
+# ======================================================================
+
+# Shorthand for the static method under test.
+_lookup_with_override = EmissionRecalculationWorkflow._lookup_factor_id_with_override
+
+_KIND = "purchase_institutional_code"
+_OVERRIDE = "purchase_additional_code"
+
+
+def test_lookup_with_override_missing_kind_returns_none():
+    """No kind value in entry → None without touching any lookup."""
+    assert _lookup_with_override({}, _KIND, _OVERRIDE, {}, {}) is None
+
+
+def test_lookup_with_override_empty_kind_returns_none():
+    assert _lookup_with_override({_KIND: ""}, _KIND, _OVERRIDE, {}, {}) is None
+
+
+def test_lookup_with_override_code_single_match():
+    """Override code present and matches exactly one factor → return it."""
+    override_lookup = {"FR-001": [(10, "FOOD")]}
+    kind_lookup = {"FOOD": [(10, "FR-001"), (20, None)]}
+    entry = {_KIND: "FOOD", _OVERRIDE: "FR-001"}
+    assert (
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+        == 10
+    )
+
+
+def test_lookup_with_override_code_multiple_disambiguated_by_kind():
+    """Same code on two different kinds → entry's kind narrows to one."""
+    override_lookup = {"FR-001": [(10, "FOOD"), (11, "TRAVEL")]}
+    kind_lookup = {"FOOD": [(10, "FR-001")], "TRAVEL": [(11, "FR-001")]}
+    entry = {_KIND: "FOOD", _OVERRIDE: "FR-001"}
+    assert (
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+        == 10
+    )
+
+
+def test_lookup_with_override_code_multiple_ambiguous_raises():
+    """Two factors share the same code AND the same kind → ValueError."""
+    override_lookup = {"FR-001": [(10, "FOOD"), (11, "FOOD")]}
+    kind_lookup = {"FOOD": [(10, "FR-001"), (11, "FR-001")]}
+    entry = {_KIND: "FOOD", _OVERRIDE: "FR-001"}
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+
+
+def test_lookup_with_override_code_miss_falls_back_to_kind_average():
+    """Code set on entry but absent from factors → fall through to kind fallback."""
+    override_lookup: dict = {}  # XX-999 not present
+    kind_lookup = {"FOOD": [(10, "FR-001"), (20, None)]}  # 20 is the average
+    entry = {_KIND: "FOOD", _OVERRIDE: "XX-999"}
+    assert (
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+        == 20
+    )
+
+
+def test_lookup_with_override_no_code_single_kind_match():
+    """Entry has no override code; single factor for the kind → return it."""
+    kind_lookup = {"FOOD": [(20, None)]}
+    entry = {_KIND: "FOOD"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) == 20
+
+
+def test_lookup_with_override_no_code_single_factor_that_carries_code():
+    """Single factor row for the kind even though it has an override code is
+    authoritative — mirrors _resolve_with_kind_override's 'len(factors)==1' rule."""
+    kind_lookup = {"FOOD": [(10, "FR-001")]}
+    entry = {_KIND: "FOOD"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) == 10
+
+
+def test_lookup_with_override_no_code_kind_average_among_multiple():
+    """Several factors share the kind; entry has no code → average row wins."""
+    kind_lookup = {"FOOD": [(10, "FR-001"), (11, "DE-002"), (20, None)]}
+    entry = {_KIND: "FOOD"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) == 20
+
+
+def test_lookup_with_override_no_code_kind_miss_returns_none():
+    """Kind not in lookup at all → None (strict drop)."""
+    kind_lookup = {"FOOD": [(20, None)]}
+    entry = {_KIND: "OFFICE_SUPPLY"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) is None
+
+
+def test_lookup_with_override_no_code_ambiguous_averages_raises():
+    """Multiple average rows (no override code) for the same kind → ValueError."""
+    kind_lookup = {"FOOD": [(20, None), (21, None)]}
+    entry = {_KIND: "FOOD"}
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup)
+
+
+# ======================================================================
+# recalculate_for_data_entry_type — override-key-first rematch
+# ======================================================================
+
+
+def _make_override_handler() -> MagicMock:
+    """Handler with kind_field_override (purchase-style)."""
+    handler = MagicMock()
+    handler.prefetch_slice = AsyncMock(return_value={})
+    handler.kind_field = "purchase_institutional_code"
+    handler.kind_field_override = "purchase_additional_code"
+    handler.subkind_field = None
+    return handler
+
+
+def _make_factor(factor_id: int, classification: dict) -> MagicMock:
+    f = MagicMock()
+    f.id = factor_id
+    f.classification = classification
+    return f
+
+
+@pytest.mark.asyncio
+async def test_recalculate_override_handler_resolves_by_code():
+    """Override-key-first rematch: entry carries purchase_additional_code → that
+    code wins over the generic average for the same institutional code."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 0,
+        "purchase_institutional_code": "FOOD",
+        "purchase_additional_code": "FR-001",
+    }
+
+    # Factor 10: code-specific (FR-001 for FOOD)
+    # Factor 20: average for FOOD (no code) — should NOT win here
+    factor_specific = _make_factor(
+        10,
+        {"purchase_institutional_code": "FOOD", "purchase_additional_code": "FR-001"},
+    )
+    factor_average = _make_factor(20, {"purchase_institutional_code": "FOOD"})
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_override_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[factor_specific, factor_average]
+        )
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.consumable_accessories, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_recalculate_override_handler_falls_back_to_average():
+    """Entry has no purchase_additional_code → average factor for the kind
+    is selected (the row without the override code among multiple rows)."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 0,
+        "purchase_institutional_code": "FOOD",
+        # no purchase_additional_code
+    }
+
+    factor_specific = _make_factor(
+        10,
+        {"purchase_institutional_code": "FOOD", "purchase_additional_code": "FR-001"},
+    )
+    factor_average = _make_factor(20, {"purchase_institutional_code": "FOOD"})
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_override_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[factor_specific, factor_average]
+        )
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.consumable_accessories, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] == 20
+
+
+@pytest.mark.asyncio
+async def test_recalculate_override_handler_strict_drop_on_miss():
+    """Entry's institutional code has no matching factor at all →
+    strict-drop: primary_factor_id cleared to None."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 99,
+        "purchase_institutional_code": "UNKNOWN",
+    }
+
+    # Only a factor for FOOD — UNKNOWN has nothing in the slice.
+    factor_food = _make_factor(20, {"purchase_institutional_code": "FOOD"})
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_override_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[factor_food]
+        )
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.consumable_accessories, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] is None


### PR DESCRIPTION
## What does this change?

* kind field override logic was not applied in emission recalculation, resulting that the additional pruchase code was ignored when uploading data/factors 

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1480

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
