### PR TITLE
feat 1208: add simulation explore print functionality with data handling and UI components

### DIFF
--- a/frontend/src/composables/print/useSimulationExplorePrintData.ts
+++ b/frontend/src/composables/print/useSimulationExplorePrintData.ts
@@ -1,0 +1,97 @@
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useModuleStore } from 'src/stores/modules';
+import { useWorkspaceStore } from 'src/stores/workspace';
+
+export function useSimulationExplorePrintData() {
+  const route = useRoute();
+  const workspaceStore = useWorkspaceStore();
+  const moduleStore = useModuleStore();
+
+  const unitParam = computed(() => String(route.params.unit ?? ''));
+  const yearParam = computed(() =>
+    parseInt(String(route.params.year ?? '0'), 10),
+  );
+  const currentYear = computed(
+    () => yearParam.value || new Date().getFullYear(),
+  );
+
+  const loading = ref(true);
+
+  const totalTonnesCo2eq = computed(() => {
+    const breakdown = moduleStore.state.emissionBreakdown;
+    if (!breakdown) return 0;
+    const moduleTotal = (breakdown.module_breakdown ?? []).reduce(
+      (sum, row) => {
+        const rowTotal = (row.emissions ?? []).reduce((rowSum, e) => {
+          return rowSum + (typeof e.value === 'number' ? e.value : 0);
+        }, 0);
+        return sum + rowTotal;
+      },
+      0,
+    );
+    return moduleTotal || breakdown.total_tonnes_co2eq || 0;
+  });
+
+  const filteredBreakdown = computed(() => {
+    const bd = moduleStore.state.emissionBreakdown;
+    if (!bd) return bd;
+    return {
+      ...bd,
+      module_breakdown: bd.module_breakdown.filter(
+        (entry) => entry.category !== 'research_facilities',
+      ),
+    };
+  });
+
+  async function initWorkspaceFromRoute() {
+    workspaceStore.setSelectedParams({
+      unit: unitParam.value,
+      year: yearParam.value,
+    });
+
+    await workspaceStore.getUnits();
+
+    const routeUnit = String(workspaceStore.selectedParams?.unit || '');
+    const unitIdFromRoute = routeUnit.split('-')[0];
+    const validUnit = workspaceStore.units.find(
+      (unit) =>
+        unit.id === parseInt(unitIdFromRoute, 10) || unit.name === routeUnit,
+    );
+
+    if (!validUnit) {
+      workspaceStore.setUnit(null);
+      workspaceStore.setYear(null);
+      return null;
+    }
+
+    workspaceStore.setUnit(validUnit);
+    workspaceStore.setYear(workspaceStore.selectedParams?.year || null);
+
+    const carbonReport =
+      await workspaceStore.selectSimulatorExploreCarbonReport(
+        workspaceStore.selectedUnit.id,
+        workspaceStore.selectedYear,
+      );
+
+    return carbonReport?.id ?? null;
+  }
+
+  async function fetchAllData(carbonReportId: number) {
+    try {
+      loading.value = true;
+      await moduleStore.getEmissionBreakdown(carbonReportId, []);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return {
+    currentYear,
+    loading,
+    totalTonnesCo2eq,
+    filteredBreakdown,
+    initWorkspaceFromRoute,
+    fetchAllData,
+  };
+}

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -91,4 +91,8 @@ export default {
     en: 'Convert to Plan',
     fr: 'Convertir en planification',
   },
+  simulation_explore_print_subtitle: {
+    en: 'Simulation carbon footprint {year}',
+    fr: 'Empreinte carbone de la simulation {year}',
+  },
 };

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -114,6 +114,7 @@
               size="md"
               color="accent"
               class="text-weight-medium"
+              @click="downloadReport"
             />
           </q-card>
         </q-card>
@@ -150,6 +151,8 @@
 
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
 import SubModuleSection from 'src/components/organisms/module/SubModuleSection.vue';
@@ -168,9 +171,25 @@ import { formatTonnesCO2 } from 'src/utils/number';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
 
+const router = useRouter();
+const route = useRoute();
+const { locale } = useI18n();
+
 const workspaceStore = useWorkspaceStore();
 const yearConfigStore = useYearConfigStore();
 const moduleStore = useModuleStore();
+
+function downloadReport() {
+  const url = router.resolve({
+    name: 'simulation-explore-print',
+    params: {
+      language: locale.value.split('-')[0],
+      unit: route.params.unit,
+      year: route.params.year,
+    },
+  }).href;
+  window.open(url, '_blank');
+}
 
 // validateUnitGuard ensures selectedUnit and selectedYear are always set before
 // this route renders. The non-null assertions are safe here; the ready guard

--- a/frontend/src/pages/app/SimulationExplorePrintPage.vue
+++ b/frontend/src/pages/app/SimulationExplorePrintPage.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import BigNumber from 'src/components/molecules/BigNumber.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import { useSimulationExplorePrintData } from 'src/composables/print/useSimulationExplorePrintData';
+import { formatTonnesCO2 } from 'src/utils/number';
+
+const {
+  currentYear,
+  loading,
+  totalTonnesCo2eq,
+  filteredBreakdown,
+  initWorkspaceFromRoute,
+  fetchAllData,
+} = useSimulationExplorePrintData();
+
+function printReport() {
+  window.print();
+}
+
+onMounted(async () => {
+  const carbonReportId = await initWorkspaceFromRoute();
+  if (!carbonReportId) return;
+  await fetchAllData(carbonReportId);
+});
+</script>
+
+<template>
+  <div class="bg-grey-2 print-report">
+    <q-toolbar class="bg-ac text-primary q-py-sm print-hide">
+      <q-space />
+      <q-btn
+        color="accent"
+        icon="o_print"
+        size="md"
+        class="text-weight-medium"
+        :label="$t('results_print')"
+        @click="printReport"
+      />
+    </q-toolbar>
+
+    <div v-if="!loading" class="report-container">
+      <ReportPage
+        :title="$t('simulation_explore_page_title')"
+        :page-number="1"
+        :is-first="true"
+      >
+        <h2 class="text-h5 q-mt-none">
+          {{ $t('simulation_explore_page_title') }}
+        </h2>
+        <div class="text-body2 text-secondary q-mb-lg">
+          {{ $t('simulation_explore_print_subtitle', { year: currentYear }) }}
+        </div>
+
+        <div class="q-mb-lg">
+          <BigNumber
+            :title="$t('simulation_explore_page_results_total_tonnes_co2eq')"
+            :number="formatTonnesCO2(totalTonnesCo2eq)"
+            color="accent"
+            :print-mode="true"
+          />
+        </div>
+
+        <section>
+          <ModuleCarbonFootprintChart :breakdown-data="filteredBreakdown" />
+        </section>
+      </ReportPage>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.report-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: tokens.$print-report-container-padding;
+  color: tokens.$color-text !important;
+}
+
+@media print {
+  .bg-grey-3 {
+    background: white !important;
+  }
+}
+</style>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -64,6 +64,23 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // Simulation explore print preview — own layout, no header/sidebar
+  {
+    path: `/:language(${LANGUAGE_PATTERN})/:unit(${UNIT_PATTERN})/:year(${YEAR_PATTERN})/simulation/explore/print`,
+    component: () => import('layouts/PrintLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: 'simulation-explore-print',
+        component: () => import('pages/app/SimulationExplorePrintPage.vue'),
+        meta: {
+          requiresAuth: true,
+          note: 'Simulation Explore – Print/PDF preview (no chrome)',
+          breadcrumb: false,
+        },
+      },
+    ],
+  },
   // Backoffice reporting print previews — own layout, no header/sidebar
   {
     path: `/:language(${LANGUAGE_PATTERN})/back-office/reporting/print`,


### PR DESCRIPTION
## What does this change?
Adds a print/PDF export page for the Simulation Explore view.

**New composable `useSimulationExplorePrintData.ts`:**
- Initialises workspace state from route params (unit, year) without relying on the navigation guards that run on the main route
- Fetches the simulator explore carbon report and then the emission breakdown
- Exposes `totalTonnesCo2eq` (summed from `module_breakdown`) and `filteredBreakdown` (research facilities excluded, mirroring the main page)

**New page `SimulationExplorePrintPage.vue`:**
- Standalone print layout (no header/sidebar) with a print button
- Shows the simulation title, a `BigNumber` total CO₂eq, and a `ModuleCarbonFootprintChart`; uses `ReportPage` wrapper for consistent print formatting
- Fetches all data on mount via the new composable

**`SimulationExplorePage.vue`:**
- Wires the existing "download report" button to `downloadReport()`, which opens the new print route in a new tab

**Router (`routes.ts`):**
- Adds the `simulation-explore-print` route under `PrintLayout` at `/:language/:unit/:year/simulation/explore/print`

**i18n (`simulation.ts`):**
- Adds `simulation_explore_print_subtitle` (EN/FR) used as the subtitle on the print page

**`package.json`:** version reverted from `1.0.7` to `1.0.6`.

## Why is this needed?
The simulation explore page had no export/print capability. Users needed a way to generate a PDF snapshot of their simulation results.

## Type of change
- [x] ✨ New feature
