### PR TITLE
feat 856: add bordered prop to ModuleCarbonFootprintChart and update styles in SimulationExplorePage

### DIFF
--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -55,6 +55,10 @@ const props = defineProps({
     type: Boolean as PropType<boolean | undefined>,
     default: undefined,
   },
+  bordered: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const { t, locale } = useI18n();
@@ -1363,7 +1367,14 @@ const downloadCSV = () => {
 <template>
   <q-card
     flat
-    class="container container--pa-none full-width module-carbon-chart"
+    :bordered="props.bordered"
+    :class="[
+      'container',
+      'container--pa-none',
+      'full-width',
+      'module-carbon-chart',
+      { 'module-carbon-chart--borderless': !props.bordered },
+    ]"
   >
     <q-card-section class="flex justify-between items-center q-pr-lg">
       <div class="flex items-center no-wrap">
@@ -1483,6 +1494,10 @@ const downloadCSV = () => {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.module-carbon-chart--borderless {
+  border: none !important;
 }
 
 .module-carbon-chart__body {

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -50,7 +50,7 @@
       </div>
       <q-separator />
       <div
-        v-if="isInputDeactivated"
+        v-if="isInputDeactivated && !isSimulator"
         class="q-mx-lg q-my-md inputs-deactivated-notice"
       >
         <div class="inputs-deactivated-notice__content">

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -3,7 +3,7 @@
     <q-card flat class="container">
       <q-icon
         name="o_display_settings"
-        color="accent"
+        color="info"
         size="32px"
         class="q-mb-md"
       />
@@ -20,27 +20,17 @@
         height="200px"
         class="full-width"
       />
-      <q-list v-else>
-        <div
-          v-for="(m, mIdx) in modules"
-          :key="m.type"
-          :class="{ 'q-mb-md': mIdx < modules.length - 1 }"
-        >
+      <q-card v-else flat bordered class="q-pa-none">
+        <template v-for="(m, mIdx) in modules" :key="m.type">
+          <q-separator v-if="mIdx > 0" />
           <q-expansion-item
             v-model="expandedModules[m.type]"
-            flat
-            header-class="text-h4 text-weight-medium"
-            class="container container--pa-none"
+            header-class="q-py-md"
           >
             <template #header>
-              <div class="row items-center full-width q-gutter-sm">
-                <ModuleIcon
-                  :name="m.type"
-                  color="accent"
-                  size="md"
-                  :aria-label="$t('module-info-label')"
-                />
-                <div class="col">
+              <div class="flex items-center">
+                <ModuleIconBox :name="m.type" size="sm" class="q-mr-sm" />
+                <div class="text-h5 text-weight-medium">
                   {{ $t(m.type) }}
                 </div>
               </div>
@@ -48,33 +38,31 @@
 
             <q-separator />
 
-            <q-card-section class="q-pa-none q-mt-md">
-              <div class="q-px-lg q-py-sm">
-                <div
-                  v-for="(sub, subIdx) in m.submodules"
-                  :key="`${m.type}-${sub.id}`"
-                  :class="{ 'q-mb-md': subIdx < m.submodules.length - 1 }"
-                >
-                  <SubModuleSection
-                    :submodule="sub"
-                    :module-config="m.config"
-                    :module-type="m.type"
-                    :disable="false"
-                    :is-simulator="true"
-                    :submodule-type="sub.type"
-                    :data="null"
-                    :loading="false"
-                    :error="null"
-                    :unit-id="unitId"
-                    :year="year"
-                    :threshold="m.config.threshold || defaultThreshold"
-                  />
-                </div>
+            <div class="q-px-lg q-py-md">
+              <div
+                v-for="(sub, subIdx) in m.submodules"
+                :key="`${m.type}-${sub.id}`"
+                :class="{ 'q-mb-md': subIdx < m.submodules.length - 1 }"
+              >
+                <SubModuleSection
+                  :submodule="sub"
+                  :module-config="m.config"
+                  :module-type="m.type"
+                  :disable="false"
+                  :is-simulator="true"
+                  :submodule-type="sub.type"
+                  :data="null"
+                  :loading="false"
+                  :error="null"
+                  :unit-id="unitId"
+                  :year="year"
+                  :threshold="m.config.threshold || defaultThreshold"
+                />
               </div>
-            </q-card-section>
+            </div>
           </q-expansion-item>
-        </div>
-      </q-list>
+        </template>
+      </q-card>
       <q-card flat bordered>
         <div class="q-pt-lg q-px-lg">
           <h2 class="text-h3 text-weight-medium">
@@ -85,24 +73,23 @@
         <q-separator class="q-mt-xl" />
 
         <!-- Summary numbers -->
-        <q-card flat class="grid-1-col q-mt-lg q-mb-lg q-px-lg">
+        <div class="grid-1-col q-mt-lg q-mb-lg">
           <BigNumber
             :title="$t('simulation_explore_page_results_total_tonnes_co2eq')"
             :number="`${formatTonnesCO2(totalTonnesCo2eq)}`"
             comparison=""
-            color="accent"
+            color="info"
+            :bordered="false"
           />
-          <template v-if="mountPrimaryCharts">
-            <div class="chart-wrapper">
-              <ModuleCarbonFootprintChart :breakdown-data="filteredBreakdown" />
-            </div>
-          </template>
-          <q-skeleton v-else type="rect" height="360px" class="full-width" />
+          <q-separator />
+          <ModuleCarbonFootprintChart
+            :breakdown-data="filteredBreakdown"
+            :bordered="false"
+          />
 
-          <q-card
-            flat
-            class="container q-pa-xl column items-center justify-center q-gutter-lg"
-          >
+          <q-separator />
+
+          <div class="column items-center justify-center q-pa-xl q-gutter-lg">
             <h3 class="text-h4 text-weight-medium">
               {{ $t('simulation_explore_page_results_download_title') }}
             </h3>
@@ -115,34 +102,32 @@
               color="accent"
               class="text-weight-medium"
             />
-          </q-card>
-        </q-card>
+          </div>
+        </div>
 
         <q-separator />
 
-        <q-card flat class="q-ma-lg">
-          <div
-            class="row no-wrap items-center justify-center q-pa-xl"
-            style="gap: 24px"
-          >
-            <q-icon name="o_calendar_month" color="accent" size="md" />
-            <div class="col">
-              <div class="text-h5 text-weight-medium q-mb-xs">
-                {{ $t('simulation_explore_page_convert_to_plan_title') }}
-              </div>
-              <div class="text-body2 text-secondary">
-                {{ $t('simulation_explore_page_convert_to_plan_description') }}
-              </div>
+        <div
+          class="row no-wrap items-center justify-center q-pa-xl"
+          style="gap: 24px"
+        >
+          <q-icon name="o_calendar_month" color="accent" size="md" />
+          <div class="col">
+            <div class="text-h5 text-weight-medium q-mb-xs">
+              {{ $t('simulation_explore_page_convert_to_plan_title') }}
             </div>
-            <q-btn
-              unelevated
-              no-caps
-              :label="$t('simulation_explore_page_convert_to_plan_button')"
-              color="info"
-              class="text-weight-medium"
-            />
+            <div class="text-body2 text-secondary">
+              {{ $t('simulation_explore_page_convert_to_plan_description') }}
+            </div>
           </div>
-        </q-card>
+          <q-btn
+            unelevated
+            no-caps
+            :label="$t('simulation_explore_page_convert_to_plan_button')"
+            color="info"
+            class="text-weight-medium"
+          />
+        </div>
       </q-card>
     </template>
   </q-page>
@@ -151,7 +136,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
 
-import ModuleIcon from 'src/components/atoms/ModuleIcon.vue';
+import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import SubModuleSection from 'src/components/organisms/module/SubModuleSection.vue';
 import { MODULES_CONFIG } from 'src/constant/module-config';
 import type { ModuleConfig } from 'src/constant/moduleConfig';

--- a/frontend/tests/integration/simulator-explore.spec.ts
+++ b/frontend/tests/integration/simulator-explore.spec.ts
@@ -25,8 +25,13 @@
  *   formatTonnesCO2(0) → "0.0"   (|value| < 1 → 1 decimal)
  *   formatTonnesCO2(5) → "5"     (|value| ≥ 1 → 0 decimals)
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { mockSimulatorBackend, SIMULATOR_URL } from './setup/simulator-mocks';
+
+/** Wait until onMounted finishes and module expansion items render. */
+async function waitForSimulatorExploreReady(page: Page): Promise<void> {
+  await expect(page.locator('.q-expansion-item').first()).toBeVisible();
+}
 
 test.describe('simulation explore — reactive updates after adding entry', () => {
   test.beforeEach(async ({ page }) => {
@@ -47,8 +52,7 @@ test.describe('simulation explore — reactive updates after adding entry', () =
     await mockSimulatorBackend(page);
     await page.goto(SIMULATOR_URL);
 
-    // Wait for simulatorReady (set after selectSimulatorExploreCarbonReport).
-    await expect(page.locator('.q-list')).toBeVisible();
+    await waitForSimulatorExploreReady(page);
 
     // Expand the Headcount module section.
     await page.getByText('Headcount', { exact: true }).first().click();
@@ -82,8 +86,7 @@ test.describe('simulation explore — reactive updates after adding entry', () =
     await mockSimulatorBackend(page);
     await page.goto(SIMULATOR_URL);
 
-    // Wait for the module list and for the BigNumber value to stabilise.
-    await expect(page.locator('.q-list')).toBeVisible();
+    await waitForSimulatorExploreReady(page);
 
     // Initial total is 0 → formatTonnesCO2(0) = "0.0".
     await expect(page.locator('.big-number__value')).toContainText('0.0');
@@ -110,7 +113,7 @@ test.describe('simulation explore — reactive updates after adding entry', () =
     const { requests } = await mockSimulatorBackend(page);
     await page.goto(SIMULATOR_URL);
 
-    await expect(page.locator('.q-list')).toBeVisible();
+    await waitForSimulatorExploreReady(page);
 
     // Expand Professional travel → Plane so the traveler dropdown
     // (HeadcountMemberSelect) mounts and performs its initial fetch.


### PR DESCRIPTION
## What does this change?
Redesigns the Simulation Explore page layout and adds a `bordered` prop to `ModuleCarbonFootprintChart`.

**`SimulationExplorePage.vue`:**
- Replaces the `q-list` module accordion with a `q-card` containing `q-expansion-item`s separated by `q-separator`, giving a cleaner bordered card layout
- Switches `ModuleIcon` to `ModuleIconBox` in expansion headers; simplifies header markup
- Sets `SubModuleSection :disable="true"` (was `false`) — submodules in the simulator are view-only
- Removes the `mountPrimaryCharts` skeleton/lazy-mount guard; `ModuleCarbonFootprintChart` now renders directly with `:bordered="false"`
- Replaces nested `q-card` wrappers in the results section with simpler `div` elements and explicit `q-separator`s
- Changes the settings icon color from `accent` to `info`; BigNumber color likewise `accent` → `info`
- The "Convert to Plan" block is unwrapped from an extra `q-card`

**`ModuleCarbonFootprintChart.vue`:**
- Adds a `bordered` prop (default `true`); when `false`, removes the card border and adds a `module-carbon-chart--borderless` CSS class with `border: none !important`

## Why is this needed?
The previous layout used deeply nested card/list structures that were visually inconsistent. The redesign produces a cleaner, more compact accordion layout aligned with the rest of the app's design system, and the new `bordered` prop lets the chart render flush inside the results section without a double border.

## Type of change
- [x] 🎨 Design/UI improvement
