### PR TITLE
chore(release): v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.0.7](https://github.com/EPFL-ENAC/co2-calculator/compare/v1.0.6...v1.0.7) (2026-06-22)
+
+
+### Bug Fixes
+
+* added kind field override logic to emission recalculation [#1480](https://github.com/EPFL-ENAC/co2-calculator/issues/1480) ([879ef92](https://github.com/EPFL-ENAC/co2-calculator/commit/879ef92565244c148d28a89d4bb6d118d663e0f5))
+* handle factor lookup by kind value when kind override field is defined ([57b70a6](https://github.com/EPFL-ENAC/co2-calculator/commit/57b70a6f78d0778aeb85d8a075aa0a7469a0f17e))
+* **i18n:** update class labels for professional travel to use ordinal numbers ([9b9c37d](https://github.com/EPFL-ENAC/co2-calculator/commit/9b9c37d5a1f6cf783aaeb380855c05623f251c14))
+* syntax error ([56764f3](https://github.com/EPFL-ENAC/co2-calculator/commit/56764f32c8d37244f06ee4af79fce3a70ef0ea9e))
+* typo ([003efb3](https://github.com/EPFL-ENAC/co2-calculator/commit/003efb32b599b4afdb4fe208aafcb66226f996dd))
+
+
+### Features
+
+* add backoffice documentation button to Co2Header ([df1065e](https://github.com/EPFL-ENAC/co2-calculator/commit/df1065efb83bfec65df678669e238a4a54e886a7))
+* add documentation link to Co2Sidebar ([a3c35f7](https://github.com/EPFL-ENAC/co2-calculator/commit/a3c35f708ac657b9df8a232cfb9d4057a53699af))
+* **i18n:** add new refrigerant category translations for emissions module ([6a6ec9c](https://github.com/EPFL-ENAC/co2-calculator/commit/6a6ec9c9deb5f4f8b2ec15bbd6aa6f204d643198))
 ## [1.0.6](https://github.com/EPFL-ENAC/co2-calculator/compare/v1.0.5...v1.0.6) (2026-06-22)
 
 

--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -617,6 +617,12 @@ class FactorRepository:
         handler = BaseModuleHandler.get_by_type(data_entry_type)
         kind_field = handler.kind_field or ""
         subkind_field = handler.subkind_field or ""
+        # When the handler declares kind_field_override (e.g. purchase), several
+        # factors can share the same kind value — they differ only by the override
+        # key (e.g. purchase_additional_code).  Callers of get_by_classification
+        # never supply the override value, so restrict to "average" rows (those
+        # where the override key is absent/NULL) to keep one_or_none() safe.
+        override_field: str | None = handler.kind_field_override
 
         if year is None:
             raise ValueError(
@@ -634,6 +640,10 @@ class FactorRepository:
                 Factor.classification[kind_field].as_string() == kind,
                 Factor.classification[subkind_field].as_string() == subkind,
             ]
+            if override_field:
+                conditions.append(
+                    Factor.classification[override_field].as_string().is_(None)
+                )
             stmt = select(Factor).where(*conditions)
             result = await self.session.exec(stmt)
             factor = result.one_or_none()
@@ -645,6 +655,10 @@ class FactorRepository:
             Factor.classification[kind_field].as_string() == kind,
             Factor.classification[subkind_field].as_string().is_(None),
         ]
+        if override_field:
+            conditions.append(
+                Factor.classification[override_field].as_string().is_(None)
+            )
         stmt = select(Factor).where(*conditions)
         result = await self.session.exec(stmt)
         return result.one_or_none()

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -103,11 +103,17 @@ class EmissionRecalculationWorkflow:
         # which itself does a kind-only fallback when the exact
         # (kind, subkind) row is absent.
         factor_lookup: dict[tuple[str, str | None], int] = {}
+        # override-key-first lookup structures (populated only for handlers with
+        # kind_field_override, mirroring _resolve_with_kind_override):
+        # override_lookup: override_code → [(factor_id, kind_value)]
+        # kind_lookup:     kind_value    → [(factor_id, override_code | None)]
+        override_lookup: dict[str, list[tuple[int, str]]] = {}
+        kind_lookup: dict[str, list[tuple[int, str | None]]] = {}
         # One bulk SELECT for the slice's factors.  Feeds two caches:
         # ``factor_cache`` (id → Factor) short-circuits Strategy A
-        # lookups inside ``prepare_create`` for every entry, and
-        # ``factor_lookup`` ((kind, subkind) → id) backs the rematch
-        # below (only built when the handler actually rematches).
+        # lookups inside ``prepare_create`` for every entry, and the
+        # rematch lookup dicts back the per-entry factor relink below
+        # (only built when the handler actually rematches).
         factors = await factor_repo.list_by_data_entry_type(data_entry_type_id, year)
         factor_cache: dict[int, Factor] = {f.id: f for f in factors if f.id is not None}
         # Strategy-B (classification-query) factor lookups hit the DB once per
@@ -121,22 +127,42 @@ class EmissionRecalculationWorkflow:
             handler.kind_field in e.data for e in entries
         ):
             kind_field = handler.kind_field
-            subkind_field = handler.subkind_field
-            for factor in factors:
-                if factor.id is None:
-                    continue
-                classification = factor.classification or {}
-                kind_value = classification.get(kind_field)
-                if kind_value is None or kind_value == "":
-                    continue
-                subkind_value: str | None = None
-                if subkind_field:
-                    raw = classification.get(subkind_field)
-                    subkind_value = raw if raw else None
-                # First writer wins on duplicate keys; ``get_by_classification``
-                # uses ``one_or_none`` which raises on duplicates anyway, so
-                # callers don't depend on ordering when the index is consistent.
-                factor_lookup.setdefault((kind_value, subkind_value), factor.id)
+            if handler.kind_field_override is not None:
+                # Override-key-first path: mirrors _resolve_with_kind_override.
+                # Lookup-key matches that method: override_field value is the
+                # primary key; kind_field is the fallback, restricted to factors
+                # that carry no override code (those are the implicit averages).
+                override_field = handler.kind_field_override
+                for factor in factors:
+                    if factor.id is None:
+                        continue
+                    classification = factor.classification or {}
+                    kind_value = classification.get(kind_field)
+                    if not kind_value:
+                        continue
+                    ov_code: str | None = classification.get(override_field) or None
+                    kind_lookup.setdefault(kind_value, []).append((factor.id, ov_code))
+                    if ov_code:
+                        override_lookup.setdefault(ov_code, []).append(
+                            (factor.id, kind_value)
+                        )
+            else:
+                subkind_field = handler.subkind_field
+                for factor in factors:
+                    if factor.id is None:
+                        continue
+                    classification = factor.classification or {}
+                    kind_value = classification.get(kind_field)
+                    if kind_value is None or kind_value == "":
+                        continue
+                    subkind_value: str | None = None
+                    if subkind_field:
+                        raw = classification.get(subkind_field)
+                        subkind_value = raw if raw else None
+                    # First writer wins on duplicate keys; ``get_by_classification``
+                    # uses ``one_or_none`` which raises on duplicates anyway, so
+                    # callers don't depend on ordering when the index is consistent.
+                    factor_lookup.setdefault((kind_value, subkind_value), factor.id)
 
         # Plan 310D — per-slice prefetch: handlers that otherwise re-query
         # slice-constant data per entry (plane reloads airports + the full
@@ -199,6 +225,7 @@ class EmissionRecalculationWorkflow:
             # Also avoids an ``assert`` (bandit B101 — asserts are stripped
             # under ``python -O``).
             entry_kind_field: str | None = handler.kind_field
+            entry_kind_field_override: str | None = handler.kind_field_override
             old_data = entry.data
             try:
                 # Compute-only: ``prepare_create`` does reads (handler
@@ -208,12 +235,21 @@ class EmissionRecalculationWorkflow:
                 # reverts the in-memory factor swap and moves on.
                 _t = time.perf_counter()
                 if entry_kind_field is not None and entry_kind_field in entry.data:
-                    new_factor_id = self._lookup_factor_id(
-                        entry_data=entry.data,
-                        kind_field=entry_kind_field,
-                        subkind_field=handler.subkind_field,
-                        factor_lookup=factor_lookup,
-                    )
+                    if entry_kind_field_override is not None:
+                        new_factor_id = self._lookup_factor_id_with_override(
+                            entry_data=entry.data,
+                            kind_field=entry_kind_field,
+                            override_field=entry_kind_field_override,
+                            override_lookup=override_lookup,
+                            kind_lookup=kind_lookup,
+                        )
+                    else:
+                        new_factor_id = self._lookup_factor_id(
+                            entry_data=entry.data,
+                            kind_field=entry_kind_field,
+                            subkind_field=handler.subkind_field,
+                            factor_lookup=factor_lookup,
+                        )
                     if new_factor_id != entry.data.get("primary_factor_id"):
                         # Tentative swap so DataEntryResponse +
                         # prepare_create see the refreshed factor (or
@@ -401,3 +437,63 @@ class EmissionRecalculationWorkflow:
         if subkind is not None:
             return factor_lookup.get((kind, None))
         return None
+
+    @staticmethod
+    def _lookup_factor_id_with_override(
+        entry_data: dict,
+        kind_field: str,
+        override_field: str,
+        override_lookup: dict[str, list[tuple[int, str]]],
+        kind_lookup: dict[str, list[tuple[int, str | None]]],
+    ) -> int | None:
+        """Resolve ``primary_factor_id`` using the override-key-first rule.
+
+        Mirrors ``ModuleHandlerService._resolve_with_kind_override`` in-memory:
+
+        1. If the entry carries a value for ``override_field``, look it up in
+           ``override_lookup`` (override_code → [(factor_id, kind_value)]).
+           A single match wins; multiple matches are disambiguated by kind.
+        2. Kind-only fallback via ``kind_lookup`` (kind_value →
+           [(factor_id, override_code | None)]): if one row matches, return
+           it; if several rows share the kind, only the "average" rows (those
+           without an override code) may stand in — there must be exactly one.
+
+        Returns ``None`` when the factor is absent from the current slice.
+        Raises ``ValueError`` on ambiguous data (matches the service behaviour
+        so the per-entry error path records the same signal as a live update).
+        """
+        kind = entry_data.get(kind_field)
+        if not kind:
+            return None
+
+        code: str | None = entry_data.get(override_field) or None
+        if code:
+            matches = override_lookup.get(code, [])
+            if len(matches) == 1:
+                return matches[0][0]
+            if len(matches) > 1:
+                same_kind = [fid for fid, kv in matches if kv == kind]
+                if len(same_kind) == 1:
+                    return same_kind[0]
+                raise ValueError(
+                    f"Ambiguous factor data: {len(matches)} factors match "
+                    f"{override_field}={code!r} and {kind_field}={kind!r} "
+                    f"cannot disambiguate"
+                )
+            # code present but no factor carries it → fall through to kind fallback
+
+        kind_matches = kind_lookup.get(kind, [])
+        if not kind_matches:
+            return None
+        if len(kind_matches) == 1:
+            return kind_matches[0][0]
+        # Several rows share this kind: only "average" rows (no override code)
+        # may stand in for all of them.
+        averages = [fid for fid, ov in kind_matches if ov is None]
+        if len(averages) == 1:
+            return averages[0]
+        raise ValueError(
+            f"Ambiguous factor data: {len(kind_matches)} factors match "
+            f"{kind_field}={kind!r} with {len(averages)} average rows "
+            f"(need exactly 1)"
+        )

--- a/backend/tests/unit/repositories/test_factor_repo.py
+++ b/backend/tests/unit/repositories/test_factor_repo.py
@@ -1,7 +1,7 @@
 """Tests for FactorRepository."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -211,3 +211,105 @@ async def test_get_factors_with_fallback(repo):
 
     assert result == [factor]
     assert repo.session.exec.await_count == 2
+
+
+# ======================================================================
+# get_by_classification — kind_field_override guard
+# ======================================================================
+
+
+def _override_handler() -> MagicMock:
+    """A handler mock that declares kind_field_override (purchase-style)."""
+    h = MagicMock()
+    h.kind_field = "purchase_institutional_code"
+    h.subkind_field = ""
+    h.kind_field_override = "purchase_additional_code"
+    return h
+
+
+@pytest.mark.asyncio
+async def test_get_by_classification_override_handler_no_subkind(repo):
+    """Handler with kind_field_override, no subkind supplied → single exec
+    call that targets only 'average' rows (override key absent)."""
+    factor = SimpleNamespace(id=42)
+    result_mock = MagicMock()
+    result_mock.one_or_none.return_value = factor
+    repo.session.exec = AsyncMock(return_value=result_mock)
+
+    with patch("app.repositories.factor_repo.BaseModuleHandler") as mock_cls:
+        mock_cls.get_by_type.return_value = _override_handler()
+        result = await repo.get_by_classification(
+            DataEntryTypeEnum.consumable_accessories,
+            kind="FOOD",
+            year=2025,
+        )
+
+    assert result is factor
+    assert repo.session.exec.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_by_classification_override_handler_subkind_miss_fallback(repo):
+    """Handler with kind_field_override, subkind supplied but first query
+    misses → falls back to kind-only query; both queries should include
+    the override-null guard."""
+    factor = SimpleNamespace(id=43)
+    result_miss = MagicMock()
+    result_miss.one_or_none.return_value = None
+    result_hit = MagicMock()
+    result_hit.one_or_none.return_value = factor
+    repo.session.exec = AsyncMock(side_effect=[result_miss, result_hit])
+
+    with patch("app.repositories.factor_repo.BaseModuleHandler") as mock_cls:
+        mock_cls.get_by_type.return_value = _override_handler()
+        result = await repo.get_by_classification(
+            DataEntryTypeEnum.consumable_accessories,
+            kind="FOOD",
+            subkind="sub1",
+            year=2025,
+        )
+
+    assert result is factor
+    assert repo.session.exec.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_by_classification_override_handler_sql_includes_override_null(repo):
+    """The WHERE clause for an override-handler query must include an IS NULL
+    condition on the override field.
+
+    This prevents MultipleResultsFound when several factors share the same
+    kind value but carry different override codes — without this guard,
+    one_or_none() raises on the second (or more) matching rows.
+    """
+    from sqlalchemy.dialects.postgresql import dialect as pg_dialect
+
+    captured: list = []
+
+    async def capturing_exec(stmt):
+        captured.append(stmt)
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = None
+        return mock_result
+
+    repo.session.exec = capturing_exec
+
+    with patch("app.repositories.factor_repo.BaseModuleHandler") as mock_cls:
+        mock_cls.get_by_type.return_value = _override_handler()
+        await repo.get_by_classification(
+            DataEntryTypeEnum.consumable_accessories,
+            kind="FOOD",
+            year=2025,
+        )
+
+    assert len(captured) == 1
+    sql = str(
+        captured[0].compile(
+            dialect=pg_dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    # The compiled SQL must contain the override field null guard so that only
+    # "average" rows (those without purchase_additional_code) are eligible.
+    assert "purchase_additional_code" in sql
+    assert "IS NULL" in sql.upper()

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -818,3 +818,287 @@ async def test_recalculate_reports_progress_at_interval(monkeypatch):
         )
 
     assert progress_calls == [(1, 2), (2, 2)]
+
+
+# ======================================================================
+# _lookup_factor_id_with_override unit tests
+# ======================================================================
+
+# Shorthand for the static method under test.
+_lookup_with_override = EmissionRecalculationWorkflow._lookup_factor_id_with_override
+
+_KIND = "purchase_institutional_code"
+_OVERRIDE = "purchase_additional_code"
+
+
+def test_lookup_with_override_missing_kind_returns_none():
+    """No kind value in entry → None without touching any lookup."""
+    assert _lookup_with_override({}, _KIND, _OVERRIDE, {}, {}) is None
+
+
+def test_lookup_with_override_empty_kind_returns_none():
+    assert _lookup_with_override({_KIND: ""}, _KIND, _OVERRIDE, {}, {}) is None
+
+
+def test_lookup_with_override_code_single_match():
+    """Override code present and matches exactly one factor → return it."""
+    override_lookup = {"FR-001": [(10, "FOOD")]}
+    kind_lookup = {"FOOD": [(10, "FR-001"), (20, None)]}
+    entry = {_KIND: "FOOD", _OVERRIDE: "FR-001"}
+    assert (
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+        == 10
+    )
+
+
+def test_lookup_with_override_code_multiple_disambiguated_by_kind():
+    """Same code on two different kinds → entry's kind narrows to one."""
+    override_lookup = {"FR-001": [(10, "FOOD"), (11, "TRAVEL")]}
+    kind_lookup = {"FOOD": [(10, "FR-001")], "TRAVEL": [(11, "FR-001")]}
+    entry = {_KIND: "FOOD", _OVERRIDE: "FR-001"}
+    assert (
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+        == 10
+    )
+
+
+def test_lookup_with_override_code_multiple_ambiguous_raises():
+    """Two factors share the same code AND the same kind → ValueError."""
+    override_lookup = {"FR-001": [(10, "FOOD"), (11, "FOOD")]}
+    kind_lookup = {"FOOD": [(10, "FR-001"), (11, "FR-001")]}
+    entry = {_KIND: "FOOD", _OVERRIDE: "FR-001"}
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+
+
+def test_lookup_with_override_code_miss_falls_back_to_kind_average():
+    """Code set on entry but absent from factors → fall through to kind fallback."""
+    override_lookup: dict = {}  # XX-999 not present
+    kind_lookup = {"FOOD": [(10, "FR-001"), (20, None)]}  # 20 is the average
+    entry = {_KIND: "FOOD", _OVERRIDE: "XX-999"}
+    assert (
+        _lookup_with_override(entry, _KIND, _OVERRIDE, override_lookup, kind_lookup)
+        == 20
+    )
+
+
+def test_lookup_with_override_no_code_single_kind_match():
+    """Entry has no override code; single factor for the kind → return it."""
+    kind_lookup = {"FOOD": [(20, None)]}
+    entry = {_KIND: "FOOD"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) == 20
+
+
+def test_lookup_with_override_no_code_single_factor_that_carries_code():
+    """Single factor row for the kind even though it has an override code is
+    authoritative — mirrors _resolve_with_kind_override's 'len(factors)==1' rule."""
+    kind_lookup = {"FOOD": [(10, "FR-001")]}
+    entry = {_KIND: "FOOD"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) == 10
+
+
+def test_lookup_with_override_no_code_kind_average_among_multiple():
+    """Several factors share the kind; entry has no code → average row wins."""
+    kind_lookup = {"FOOD": [(10, "FR-001"), (11, "DE-002"), (20, None)]}
+    entry = {_KIND: "FOOD"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) == 20
+
+
+def test_lookup_with_override_no_code_kind_miss_returns_none():
+    """Kind not in lookup at all → None (strict drop)."""
+    kind_lookup = {"FOOD": [(20, None)]}
+    entry = {_KIND: "OFFICE_SUPPLY"}
+    assert _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup) is None
+
+
+def test_lookup_with_override_no_code_ambiguous_averages_raises():
+    """Multiple average rows (no override code) for the same kind → ValueError."""
+    kind_lookup = {"FOOD": [(20, None), (21, None)]}
+    entry = {_KIND: "FOOD"}
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _lookup_with_override(entry, _KIND, _OVERRIDE, {}, kind_lookup)
+
+
+# ======================================================================
+# recalculate_for_data_entry_type — override-key-first rematch
+# ======================================================================
+
+
+def _make_override_handler() -> MagicMock:
+    """Handler with kind_field_override (purchase-style)."""
+    handler = MagicMock()
+    handler.prefetch_slice = AsyncMock(return_value={})
+    handler.kind_field = "purchase_institutional_code"
+    handler.kind_field_override = "purchase_additional_code"
+    handler.subkind_field = None
+    return handler
+
+
+def _make_factor(factor_id: int, classification: dict) -> MagicMock:
+    f = MagicMock()
+    f.id = factor_id
+    f.classification = classification
+    return f
+
+
+@pytest.mark.asyncio
+async def test_recalculate_override_handler_resolves_by_code():
+    """Override-key-first rematch: entry carries purchase_additional_code → that
+    code wins over the generic average for the same institutional code."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 0,
+        "purchase_institutional_code": "FOOD",
+        "purchase_additional_code": "FR-001",
+    }
+
+    # Factor 10: code-specific (FR-001 for FOOD)
+    # Factor 20: average for FOOD (no code) — should NOT win here
+    factor_specific = _make_factor(
+        10,
+        {"purchase_institutional_code": "FOOD", "purchase_additional_code": "FR-001"},
+    )
+    factor_average = _make_factor(20, {"purchase_institutional_code": "FOOD"})
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_override_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[factor_specific, factor_average]
+        )
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.consumable_accessories, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_recalculate_override_handler_falls_back_to_average():
+    """Entry has no purchase_additional_code → average factor for the kind
+    is selected (the row without the override code among multiple rows)."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 0,
+        "purchase_institutional_code": "FOOD",
+        # no purchase_additional_code
+    }
+
+    factor_specific = _make_factor(
+        10,
+        {"purchase_institutional_code": "FOOD", "purchase_additional_code": "FR-001"},
+    )
+    factor_average = _make_factor(20, {"purchase_institutional_code": "FOOD"})
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_override_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[factor_specific, factor_average]
+        )
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.consumable_accessories, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] == 20
+
+
+@pytest.mark.asyncio
+async def test_recalculate_override_handler_strict_drop_on_miss():
+    """Entry's institutional code has no matching factor at all →
+    strict-drop: primary_factor_id cleared to None."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entry = _make_mock_entry(1, 10)
+    entry.data = {
+        "primary_factor_id": 99,
+        "purchase_institutional_code": "UNKNOWN",
+    }
+
+    # Only a factor for FOOD — UNKNOWN has nothing in the slice.
+    factor_food = _make_factor(20, {"purchase_institutional_code": "FOOD"})
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorRepository"
+        ) as mock_factor_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_override_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=[entry]
+        )
+        mock_factor_repo_cls.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[factor_food]
+        )
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        result = await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.consumable_accessories, 2025
+        )
+
+    assert result["recalculated"] == 1
+    assert entry.data["primary_factor_id"] is None

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -118,20 +118,6 @@ const logoRoute = computed(() => {
         :to="{ name: 'back-office' }"
       />
       <q-btn
-        v-if="isInBackOfficeRoute"
-        icon="o_article"
-        color="grey-4"
-        text-color="primary"
-        :label="$t('backoffice_documentation_button_label')"
-        unelevated
-        no-caps
-        outline
-        size="sm"
-        class="text-weight-medium q-ml-xl"
-        href="https://epfl-enac.github.io/co2-calculator-back-office-doc/"
-        target="_blank"
-      />
-      <q-btn
         v-if="hasBackOfficeAccess && isInBackOfficeRoute"
         color="grey-4"
         text-color="primary"

--- a/frontend/src/components/layout/Co2Header.vue
+++ b/frontend/src/components/layout/Co2Header.vue
@@ -118,6 +118,20 @@ const logoRoute = computed(() => {
         :to="{ name: 'back-office' }"
       />
       <q-btn
+        v-if="isInBackOfficeRoute"
+        icon="o_article"
+        color="grey-4"
+        text-color="primary"
+        :label="$t('backoffice_documentation_button_label')"
+        unelevated
+        no-caps
+        outline
+        size="sm"
+        class="text-weight-medium q-ml-xl"
+        href="https://epfl-enac.github.io/co2-calculator-back-office-doc/"
+        target="_blank"
+      />
+      <q-btn
         v-if="hasBackOfficeAccess && isInBackOfficeRoute"
         color="grey-4"
         text-color="primary"

--- a/frontend/src/components/layout/Co2Sidebar.vue
+++ b/frontend/src/components/layout/Co2Sidebar.vue
@@ -61,5 +61,29 @@ function isItemDisabled(item: NavItem): boolean {
         </q-tooltip>
       </q-item>
     </q-list>
+    <div class="co2-sidebar-docs-wrapper">
+      <q-separator />
+      <q-item
+        class="co2-sidebar-item"
+        tag="a"
+        :href="$t('header_backoffice_documentation_link')"
+        target="_blank"
+        clickable
+      >
+        <q-icon name="o_article" size="sm" />
+        <q-item-label v-show="!collapsed" class="text-body2">{{
+          $t('backoffice_documentation_button_label')
+        }}</q-item-label>
+      </q-item>
+    </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.co2-sidebar-docs-wrapper {
+  margin-top: auto;
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/i18n/backoffice.ts
+++ b/frontend/src/i18n/backoffice.ts
@@ -53,4 +53,8 @@ export default {
     en: 'Back to Calculator',
     fr: 'Retour au calculateur',
   },
+  backoffice_documentation_button_label: {
+    en: 'Backoffice guide',
+    fr: 'Guide back-office',
+  },
 } as const;

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -8,11 +8,11 @@ export default {
   },
   [`${MODULES.Headcount}-description`]: {
     en: 'Verify team members and Full Time Equivalent (FTE) values for your unit',
-    fr: 'Vérifiez les membres de l’équipe et leurs équivalents plein-temps (EPT) pour votre unité',
+    fr: 'Vérifiez les membres de l’unité et leurs équivalents plein-temps (EPT)',
   },
   [`${MODULES.Headcount}-title-subtext`]: {
-    en: `This module automatically displays the names, roles, and FTE values of your unit’s personnel as of the end of the year. Review and make any necessary adjustments to ensure your team profile is complete. For student contributions, use the integrated Student FTE Calculator Helper to add their total FTE over the year.`,
-    fr: `Ce module affiche automatiquement les noms, rôles et EPT des membres de votre unité à la fin de l’année. Passez en revue ces informations et apportez les ajustements nécessaires pour garantir que le profil de votre équipe soit complet. Pour les contributions des étudiants, utilisez l’outil intégré Calculateur d’EPT étudiants afin d’ajouter leur EPT total sur l’année.`,
+    en: `This module automatically displays the names, functions, SCIPERs, and FTE values of your unit’s members as of the reference year. For student contributions, please manually add their total accumulated FTE over the year. The total number of FTEs is used to generate the indicators for the additional categories (Food, Commuting, and Waste), as well as the total carbon footprint per FTE for your unit. For more information: User Guide [headcount](https://epfl-enac.github.io/co2-calculator-user-doc/headcount/) and [additional categories ](https://epfl-enac.github.io/co2-calculator-user-doc/additional-categories/)`,
+    fr: `Ce module affiche automatiquement les noms, fonctions, SCIPERs et valeurs EPT des membres de votre unité pour l'année de référence. Pour les contributions des étudiant·e·s, veuillez ajouter manuellement leur EPT total sur l'ensemble de l'année. Le nombre total d'EPT est utilisé pour générer les indicateurs des catégories additionnelles (Alimentation, Pendularité et Déchets), ainsi que l'empreinte carbone totale par EPT pour votre unité. Pour plus d'information : Documentation utilisation [personnel](https://epfl-enac.github.io/co2-calculator-user-doc/fr/headcount/), et [catégories additionnelles](https://epfl-enac.github.io/co2-calculator-user-doc/fr/additional-categories/)`,
   },
   [`${MODULES.Headcount}-member`]: {
     en: 'Member| Members',
@@ -20,7 +20,7 @@ export default {
   },
   [`${MODULES.Headcount}-student`]: {
     en: 'Student| Students',
-    fr: 'Étudiant| Étudiants',
+    fr: 'Étudiant•e| Étudiant•e•s',
   },
   [`${MODULES.Headcount}-member-table-title`]: {
     en: 'Member ({count})| Members ({count})',
@@ -28,12 +28,12 @@ export default {
   },
   [`${MODULES.Headcount}-student-table-title`]: {
     en: 'Students',
-    fr: 'Étudiants',
+    fr: 'Étudiant•es',
   },
 
   [`${MODULES.Headcount}-student-table-title-info-label`]: {
     en: 'Students table information',
-    fr: 'Informations sur le tableau des étudiants',
+    fr: 'Informations sur le tableau des étudiant•es',
   },
   [`${MODULES.Headcount}-charts-title`]: {
     en: 'FTE per function',
@@ -58,7 +58,7 @@ export default {
 
   [`${MODULES.Headcount}-student-form-add-button`]: {
     en: 'Add Student FTE',
-    fr: 'Ajouter un EPT étudiant',
+    fr: 'Ajouter un EPT étudiant•e',
   },
   // module member
 
@@ -81,21 +81,21 @@ export default {
   // module_mylab_student_form_field_fte_label
   [`${MODULES.Headcount}-student_form_field_fte_label`]: {
     en: 'Total Student FTE',
-    fr: 'EPT étudiants total',
+    fr: 'EPT étudiant•es total',
   },
   [`${MODULES.Headcount}-student-form-title`]: {
     en: 'Add Student FTE',
-    fr: 'Ajouter un EPT étudiant',
+    fr: 'Ajouter un EPT étudiant•e',
   },
 
   [`${MODULES.Headcount}-student-form-subtitle`]: {
     en: 'Enter the aggregated student FTE for your unit over the year.',
-    fr: 'Entrez l’EPT étudiant agrégé pour votre unité sur l’année.',
+    fr: 'Entrez de manière agrégée les EPT des étudiant·es qui ont travaillé dans votre unité sur l’année.',
   },
 
   [`${MODULES.Headcount}-student-form-title-info-label`]: {
     en: 'fte student tooltip',
-    fr: 'info-bulle étudiant EPT',
+    fr: 'info-bulle étudiant•e EPT',
   },
   'headcount-member-function-required': {
     en: 'Function is required',
@@ -103,31 +103,31 @@ export default {
   },
   'headcount-member-error-duplicate-uid': {
     en: "This user's {label} already exists.",
-    fr: 'Le {label} de cet utilisateur existe déjà.',
+    fr: 'Le {label} de cet utilisateur•rice existe déjà.',
   },
   headcount_student: {
     en: 'Student',
-    fr: 'Étudiant',
+    fr: 'Étudiant•e',
   },
   headcount_professor: {
     en: 'Professor',
-    fr: 'Professeur',
+    fr: 'Professeur•e',
   },
   headcount_scientific_collaborator: {
     en: 'Scientific Collaborator',
-    fr: 'Collaborateur scientifique',
+    fr: 'Collaborateur•rice scientifique',
   },
   headcount_postdoctoral_researcher: {
     en: 'Postdoctoral Researcher',
-    fr: 'Chercheur postdoctoral',
+    fr: 'Chercheur•e postdoctoral•e',
   },
   headcount_postdoctoral_assistant: {
     en: 'Postdoctoral Assistant',
-    fr: 'Assistant postdoctoral',
+    fr: 'Assistant•e postdoctoral•e',
   },
   headcount_doctoral_assistant: {
     en: 'Doctoral Assistant',
-    fr: 'Assistant doctorant',
+    fr: 'Assistant•e doctorant•e',
   },
   headcount_trainee: {
     en: 'Trainee',

--- a/frontend/src/i18n/home.ts
+++ b/frontend/src/i18n/home.ts
@@ -20,16 +20,12 @@ export default {
     fr: '), la norme internationale pour le calcul des émissions de gaz à effet de serre.',
   },
   home_intro_2: {
-    en: "Fill in the various data entry modules according to your authorization level to obtain a complete estimate of your unit's CO₂ equivalent emissions CO₂-equivalent emissions for your unit (Staff, Professional Travel, Buildings, Equipment, Purchases, Internal Services, External Cloud), view and analyze your results, simulate the footprint of research projects, and export your data!",
-    fr: 'Remplissez les différents modules de saisie de données en fonction de votre niveau d’autorisation pour obtenir une estimation complète des émissions de CO₂-équivalent de votre unité (Personnel, Déplacements professionnels, Bâtiments, Consommation électrique des équipements, Achats, Services internes, Impact du cloud externe), consultez et analysez vos résultats, simulez l’empreinte de projets de recherche et exportez vos données !',
-  },
-  home_intro_3: {
-    en: 'Data can be entered manually or imported via a CSV file.',
-    fr: 'Les données peuvent être saisies manuellement ou importées via un fichier CSV.',
+    en: "Click 'Start' to complete the various modules and receive a full estimate of your unit's CO₂​-equivalent emissions, view your results, and export your data!",
+    fr: 'Cliquez sur ""démarrer "" pour remplir les différents modules et obtenir une estimation complète des émissions de CO₂-équivalent de votre unité, consultez vos résultats, et exportez vos données !',
   },
   home_intro_4: {
-    en: 'Only the main user has full access to all the features of the calculator but can delegate access to other team members by assigning them the role of main user or standard user via Accred.',
-    fr: "Seul l’utilisateur principal a un accès complet à toutes les fonctionnalités du calculateur mais peut déléguer l'accès à d'autres membres de l'équipe en leur attribuant le rôle d'utilisateur principal ou d'utilisateur standard via Accred.",
+    en: 'Only the main user has full access to all the features of the calculator but can delegate access to other team members by assigning them the role of main user or standard user via Accred. The majority of the data is uploaded automatically, but some can be entered manually or imported via a CSV file. You can switch to "color-blind" mode by clicking on your first and last name and activating the mode.',
+    fr: "Seul le responsable d'unité a un accès complet à toutes les fonctionnalités du CO₂ calculateur mais peut déléguer l'accès à d'autres membres de l'équipe en leur attribuant le rôle d'utilisateur principal via Accred. La majorité des données remontent automatiquement mais certaines peuvent être saisies manuellement ou importées via un fichier CSV. Vous pouvez passer en mode \"color-blind\" en cliquant sur votre prénom et nom et en activant le mode.",
   },
   home_intro_5_part_1: {
     en: "For more information on the methodology and EPFL's Climate and Sustainability Strategy, see our ",
@@ -59,45 +55,41 @@ export default {
     en: '.',
     fr: '.',
   },
-  home_intro_6: {
-    en: 'Click on the “Start” button below to begin filling in the modules in order or go directly to the individual modules in the section below. Once validated, your results will be available in the “view results” area.',
-    fr: "Cliquez sur le bouton « Démarrer » ci-dessous pour commencer à remplir les modules dans l'ordre, ou accédez directement aux modules individuels dans la section ci-dessous. Une fois validés, vos résultats seront disponibles dans l’espace « visualisation résultats ».",
-  },
   home_start_button: {
     en: 'Start',
     fr: 'Démarrer',
   },
   home_in_progress: {
-    en: 'In Progress',
-    fr: 'En Cours',
+    en: 'In progress',
+    fr: 'En cours',
   },
   home_validated: {
     en: 'Validated',
     fr: 'Validé',
   },
   home_results_title: {
-    en: 'Results Visualization',
-    fr: 'Visualisation des Résultats',
+    en: 'Results visualization',
+    fr: 'Visualisation des résultats',
   },
   home_results_subtitle: {
-    en: 'Annual CO₂ Assessment {year}',
-    fr: 'Bilan CO₂ Annuel {year}',
+    en: 'Annual CO₂ assessment {year}',
+    fr: 'Bilan CO₂ annuel {year}',
   },
   home_results_btn: {
-    en: 'View Full Results',
-    fr: 'Voir les Résultats Complets',
+    en: 'View full results',
+    fr: 'Voir les résultats complets',
   },
   home_simulations_title: {
-    en: 'Research Project Simulation',
-    fr: 'Simulation de Projet de Recherche',
+    en: 'Research project simulation',
+    fr: 'Simulation de projet de recherche',
   },
   home_simulations_subtitle: {
     en: 'Estimate project-specific carbon footprint ',
     fr: "Estimer l'empreinte carbone spécifique au projet",
   },
   home_simulations_btn: {
-    en: 'View Simulations',
-    fr: 'Voir les Simulations',
+    en: 'View simulations',
+    fr: 'Voir les simulations',
   },
   home_view_btn: {
     en: 'View',

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -57,6 +57,10 @@ export default {
     en: 'Refrigerant',
     fr: 'Fluide Frigorigène',
   },
+  [`${MODULES.ProcessEmissions}.category.Refrigerant`]: {
+    en: 'Refrigerant',
+    fr: 'Fluide Frigorigène',
+  },
   // Factor taxonomy / CSV use singular "refrigerant"; same label as plural key above.
   [`${MODULES.ProcessEmissions}.category.refrigerant`]: {
     en: 'Refrigerant',

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -18,7 +18,7 @@ export default {
     fr: 'Entrez les sources d’émissions de procédé de gaz utilisés dans ou issues de réactions chimiques ou physiques dans le laboratoire.',
   },
   [`${MODULES.ProcessEmissions}-title-subtext`]: {
-    en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module. For more information: For more information: [processes](https://epfl-enac.github.io/co2-calculator-user-doc/processes/)',
+    en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module. For more information: [processes](https://epfl-enac.github.io/co2-calculator-user-doc/processes/)',
     fr: "Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif. Pour plus d'information : [procédés](https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/)",
   },
   [`${MODULES.ProcessEmissions}-process_emissions-form-title`]: {

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -19,7 +19,7 @@ export default {
   },
   [`${MODULES.ProcessEmissions}-title-subtext`]: {
     en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module. For more information: For more information: [processes](https://epfl-enac.github.io/co2-calculator-user-doc/processes/)',
-    fr: 'Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif. Pour plus d'information : [procédés](https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/)',
+    fr: "Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif. Pour plus d'information : [procédés](https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/)",
   },
   [`${MODULES.ProcessEmissions}-process_emissions-form-title`]: {
     en: 'Add an emitted gas',

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -2,7 +2,7 @@ import { MODULES } from 'src/constant/modules';
 
 export default {
   documentation_editing_rows_process_emissions_topic: {
-    en: 'Process Emissions',
+    en: 'Process emissions',
     fr: 'Émissions de procédés',
   },
   documentation_editing_rows_process_emissions_description: {
@@ -18,16 +18,16 @@ export default {
     fr: 'Entrez les sources d’émissions de procédé de gaz utilisés dans ou issues de réactions chimiques ou physiques dans le laboratoire.',
   },
   [`${MODULES.ProcessEmissions}-title-subtext`]: {
-    en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some SV lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the research facilities footprint.',
-    fr: 'Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (par ex. émissions de CO₂ dans certaines activités de laboratoire SV, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans l’empreinte carbone des infrastructures de recherche.',
+    en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module. For more information: For more information: [processes](https://epfl-enac.github.io/co2-calculator-user-doc/processes/)',
+    fr: 'Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif. Pour plus d'information : [procédés](https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/)',
   },
   [`${MODULES.ProcessEmissions}-process_emissions-form-title`]: {
     en: 'Add an emitted gas',
-    fr: 'Ajouter un gaz émis',
+    fr: 'Ajoutez un gaz émis',
   },
   [`${MODULES.ProcessEmissions}-charts-title`]: {
-    en: 'Process emissions charts',
-    fr: 'Graphiques des émissions de procédés',
+    en: 'Process emission carbon footprint',
+    fr: 'Empreinte carbone emissions de procédés',
   },
   [`${MODULES.ProcessEmissions}-charts-no-data-message`]: {
     en: 'No process emission data available.',
@@ -38,7 +38,7 @@ export default {
     fr: 'Émission de procédé ({count}) | Émissions de procédés ({count})',
   },
   [`${MODULES.ProcessEmissions}.inputs.category`]: {
-    en: 'Emitted Gas',
+    en: 'Emitted gas',
     fr: 'Gaz émis',
   },
   [`${MODULES.ProcessEmissions}.category.co2`]: {
@@ -55,12 +55,12 @@ export default {
   },
   [`${MODULES.ProcessEmissions}.category.refrigerants`]: {
     en: 'Refrigerant',
-    fr: 'Fluide Frigorigène',
+    fr: 'Fluide frigorigène',
   },
   // Factor taxonomy / CSV use singular "refrigerant"; same label as plural key above.
   [`${MODULES.ProcessEmissions}.category.refrigerant`]: {
     en: 'Refrigerant',
-    fr: 'Fluide Frigorigène',
+    fr: 'Fluide frigorigène',
   },
   [`${MODULES.ProcessEmissions}.inputs.subcategory`]: {
     en: 'Sub-category',

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -177,8 +177,8 @@ export default {
     fr: '2ème classe',
   },
   first: {
-    en: 'First',
-    fr: 'Première',
+    en: '1st class',
+    fr: '1ère classe',
   },
   business: {
     en: 'Business',

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "@evilmartians/lefthook": "=1.13.6",
     "prettier": "=3.8.4"
   },
-  "version": "1.0.6"
+  "version": "1.0.7"
 }


### PR DESCRIPTION
- **Update process_emissions.ts**
- **feat(i18n): add new refrigerant category translations for emissions module**
- **fix(i18n): update class labels for professional travel to use ordinal numbers**
- **fix: syntax error**
- **fix: typo**
- **feat: add backoffice documentation button to Co2Header**
- **feat: add documentation link to Co2Sidebar**
- **Update home.ts**
- **fix: added kind field override logic to emission recalculation #1480**
- **chore: added tests for emission recalculation and kind field override**
- **fix: handle factor lookup by kind value when kind override field is defined**
- **Update headcount.ts**
- **chore: prepare v1.0.7**
- **docs(changelog): update changelog for v1.0.7**
