### PR TITLE
[Task]: (Helm) Add NetworkPolicies to prevent lateral attacks

### DIFF
--- a/helm/templates/network-policies.yaml
+++ b/helm/templates/network-policies.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.networkPolicies.enabled }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  podSelector: {}
+
+  policyTypes:
+    - Ingress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-route
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "co2-calculator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        {{- toYaml .Values.networkPolicies.ingressFromRoutes | nindent 8 }}
+
+      ports:
+        - protocol: TCP
+          port: {{ .Values.backend.service.targetPort }}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-route
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "co2-calculator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        {{- toYaml .Values.networkPolicies.ingressFromRoutes | nindent 8 }}
+
+      ports:
+        - protocol: TCP
+          port: {{ .Values.frontend.service.targetPort }}
+
+{{- if .Values.docs.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-docs-route
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "co2-calculator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: docs
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        {{- toYaml .Values.networkPolicies.ingressFromRoutes | nindent 8 }}
+
+      ports:
+        - protocol: TCP
+          port: {{ .Values.docs.service.targetPort }}
+{{- end }}
+
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -385,9 +385,16 @@ podDisruptionBudget:
   minAvailable: 1
   maxUnavailable: ""
 
-networkPolicy:
+networkPolicies:
   enabled: false
-  ingress: []
+  ingressFromRoutes: [] # Define allowed ingress sources (e.g., namespaces, pods) for network policies
+    # Example
+    # - namespaceSelector:
+    #     matchLabels:
+    #       kubernetes.io/metadata.name: openshift-ingress
+    #   podSelector:
+    #     matchLabels:
+    #       ingresscontroller.operator.openshift.io/deployment-ingresscontroller: ingress-private
 
 # -----------------------------------------------------------------------------
 # Documentation deployment


### PR DESCRIPTION
## What does this change?

Only allow legitimate traffic to reach the pods, including inter-pod traffic. The goal is to block lateral attacks between pods.

## Why is this needed?

Implement NetworkPolicies:
- By default, block all pods incoming traffic
- Allow route/ingress controllers to backend, frontend and docs pods, on specific ports


## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1647 
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
