### PR TITLE
feat: update French translations for user roles and add CO₂ Calculator title in workspace setup

### DIFF
--- a/frontend/src/i18n/roles.ts
+++ b/frontend/src/i18n/roles.ts
@@ -5,11 +5,11 @@ import { ROLES } from 'src/constant/roles';
 export default {
   [ROLES.StandardUser]: {
     en: 'Standard User',
-    fr: 'Utilisateur Standard',
+    fr: 'Utilisateur·rice Standard',
   },
   [ROLES.PrincipalUser]: {
     en: 'Principal User',
-    fr: 'Utilisateur Principal',
+    fr: 'Utilisateur·rice Principal·e',
   },
   [ROLES.BackOfficeMetier]: {
     en: 'Back-Office Standard',
@@ -25,7 +25,7 @@ export default {
   },
   role_principal_description: {
     en: 'Unit manager with full access to all modules for their unit, and can assign Standard User roles',
-    fr: 'Responsable d’unité avec accès complet à tous les modules de son unité, et pouvant attribuer le rôle Utilisateur Standard',
+    fr: 'Responsable d’unité avec accès complet à tous les modules de son unité, et pouvant attribuer le rôle Utilisateur·rice Standard',
   },
   role_backoffice_description: {
     en: 'Day-to-day back-office operations: reporting, user management, documentation',

--- a/frontend/src/i18n/workspace_setup.ts
+++ b/frontend/src/i18n/workspace_setup.ts
@@ -103,6 +103,10 @@ export default {
     en: "Calculate your unit's carbon footprint",
     fr: "Calculez l'empreinte carbone de votre unité",
   },
+  workspace_setup_calculator_title: {
+    en: 'CO₂ Calculator',
+    fr: 'Calculateur CO₂',
+  },
   workspace_setup_simulator_title: {
     en: 'CO₂ Simulator',
     fr: 'Simulateur CO₂',

--- a/frontend/src/pages/app/WorkspaceSetupPage.vue
+++ b/frontend/src/pages/app/WorkspaceSetupPage.vue
@@ -231,7 +231,7 @@ onMounted(async () => {
             <div class="row items-center q-gutter-sm">
               <q-icon name="o_calculate" size="sm" color="accent" />
               <h3 class="text-h4 text-weight-bold">
-                {{ $t('calculator_title') }}
+                {{ $t('workspace_setup_calculator_title') }}
               </h3>
             </div>
             <p class="text-body2 text-secondary q-mt-sm q-mb-none">


### PR DESCRIPTION
## What does this change?
Updates French role labels to use inclusive writing and adds a dedicated i18n key for the CO₂ Calculator title on the workspace setup page.

- `roles.ts`: updates French translations for `StandardUser` ("Utilisateur Standard" → "Utilisateur·rice Standard"), `PrincipalUser` ("Utilisateur Principal" → "Utilisateur·rice Principal·e"), and the `role_principal_description` body text to use the inclusive form
- `workspace_setup.ts`: adds `workspace_setup_calculator_title` (EN: "CO₂ Calculator", FR: "Calculateur CO₂")
- `WorkspaceSetupPage.vue`: switches the calculator card heading from `$t('calculator_title')` to `$t('workspace_setup_calculator_title')`, scoping the key to the workspace setup context

## Why is this needed?
French role labels used gendered masculine forms; inclusive writing (·rice, ·e) makes the UI more welcoming to all users. The calculator title key change avoids relying on a generic shared key that may be reused elsewhere with a different context.

## Type of change
- [x] 🎨 Design/UI improvement
