### PR TITLE
fix: updated building rooms emissions calculation using energy type and conversion factor

### DIFF
--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -237,7 +237,30 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
         # set a default value of 1.0 if not provided
         ratio_nb = float(ratio) if ratio is not None else 1.0
 
-        conversion_factor = factor_values.get("conversion_factor") or 1.0
+        # conversion factor only applies to electric or thermal energy types,
+        # default to 1.0 if not provided
+        if kwh_field == "heating_kwh_per_square_meter":
+            emission_type: EmissionType = ctx["emission_type"]
+            energy_type = factor_values.get("energy_type")
+            if (
+                emission_type.parent is not None
+                and emission_type.parent == EmissionType.buildings__rooms__heating_elec
+                and energy_type == "electric"
+            ):
+                conversion_factor = factor_values.get("conversion_factor") or 1.0
+            elif (
+                emission_type.parent is not None
+                and emission_type.parent
+                == EmissionType.buildings__rooms__heating_thermal
+                and energy_type == "thermal"
+            ):
+                conversion_factor = factor_values.get("conversion_factor") or 1.0
+            else:
+                # does not apply to this emission type,
+                # set to 0 to avoid double counting
+                conversion_factor = 0
+        else:
+            conversion_factor = 1.0
         kwh = float(surface) * float(kwh_per_m2) * ratio_nb
         return kwh * float(ef) * float(conversion_factor)
 
@@ -247,6 +270,9 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
         factor_id = ctx.get("primary_factor_id")
         if factor_id is None:
             return []
+
+        # Add emission type to context for use in formula_func
+        ctx["emission_type"] = emission_type
 
         # Try direct match, then fall back to parent (WW→ZZ)
         kwh_field = self._EMISSION_TO_KWH_FIELD.get(emission_type)
@@ -310,7 +336,6 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
 buildings_classification_fields: list[str] = [
     "building_name",
     "room_type",
-    "energy_type",
 ]
 buildings_value_fields: list[str] = [
     "ef_kg_co2eq_per_kwh",
@@ -318,6 +343,7 @@ buildings_value_fields: list[str] = [
     "cooling_kwh_per_square_meter",
     "ventilation_kwh_per_square_meter",
     "lighting_kwh_per_square_meter",
+    "energy_type",
     "conversion_factor",
 ]
 

--- a/backend/tests/unit/modules/test_buildings_schemas.py
+++ b/backend/tests/unit/modules/test_buildings_schemas.py
@@ -1,0 +1,249 @@
+"""Unit tests for BuildingRoomModuleHandler._compute_kwh_emission.
+
+Formula: kwh = surface × kwh_per_m² × ratio
+         result = kwh × ef × conversion_factor
+
+conversion_factor rules (only applies when kwh_field == "heating_kwh_per_square_meter"):
+  - emission_type.parent == heating_elec AND energy_type == "electric"
+    → factor_values["conversion_factor"] or 1.0
+  - emission_type.parent == heating_thermal AND energy_type == "thermal"
+    → factor_values["conversion_factor"] or 1.0
+  - otherwise → 0  (avoids double-counting the other heating branch)
+For non-heating fields, conversion_factor is always 1.0.
+"""
+
+import pytest
+
+from app.models.data_entry_emission import EmissionType
+from app.modules.buildings.schemas import BuildingRoomModuleHandler
+
+_HANDLER = BuildingRoomModuleHandler()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ELEC_LEAF = EmissionType.buildings__rooms__heating_elec__office
+_THERMAL_LEAF = EmissionType.buildings__rooms__heating_thermal__office
+_ELEC_PARENT = EmissionType.buildings__rooms__heating_elec
+
+
+def _ctx(
+    *,
+    surface: float | None = 100.0,
+    ratio: float | None = 0.5,
+    emission_type: EmissionType = _ELEC_LEAF,
+) -> dict:
+    return {
+        "room_surface_square_meter": surface,
+        "room_allocation_ratio": ratio,
+        "emission_type": emission_type,
+    }
+
+
+def _fv(
+    *,
+    kwh_per_m2: float | None = 10.0,
+    ef: float | None = 0.2,
+    energy_type: str | None = "electric",
+    conversion_factor: float | None = 2.0,
+    kwh_field: str = "lighting_kwh_per_square_meter",
+) -> dict:
+    values: dict = {
+        "ef_kg_co2eq_per_kwh": ef,
+        kwh_field: kwh_per_m2,
+    }
+    if energy_type is not None:
+        values["energy_type"] = energy_type
+    if conversion_factor is not None:
+        values["conversion_factor"] = conversion_factor
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Non-heating kwh fields — conversion_factor is always 1.0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwh_field,expected",
+    [
+        pytest.param(
+            "lighting_kwh_per_square_meter",
+            100.0 * 10.0 * 0.5 * 0.2 * 1.0,
+            id="lighting-full",
+        ),
+        pytest.param(
+            "cooling_kwh_per_square_meter",
+            100.0 * 10.0 * 0.5 * 0.2 * 1.0,
+            id="cooling-full",
+        ),
+        pytest.param(
+            "ventilation_kwh_per_square_meter",
+            100.0 * 10.0 * 0.5 * 0.2 * 1.0,
+            id="ventilation-full",
+        ),
+    ],
+)
+def test_non_heating_fields_compute_correctly(kwh_field: str, expected: float) -> None:
+    ctx = _ctx()
+    fv = _fv(kwh_field=kwh_field)
+    result = _HANDLER._compute_kwh_emission(ctx, fv, kwh_field)
+    assert result == pytest.approx(expected)
+
+
+def test_non_heating_ratio_defaults_to_one() -> None:
+    ctx = _ctx(ratio=None)
+    fv = _fv(kwh_field="lighting_kwh_per_square_meter")
+    # ratio defaults to 1.0, so: 100 * 10 * 1.0 * 0.2
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "lighting_kwh_per_square_meter"
+    ) == pytest.approx(200.0)
+
+
+# ---------------------------------------------------------------------------
+# Missing required values → None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "surface,kwh_per_m2,ef",
+    [
+        pytest.param(None, 10.0, 0.2, id="missing-surface"),
+        pytest.param(100.0, None, 0.2, id="missing-kwh_per_m2"),
+        pytest.param(100.0, 10.0, None, id="missing-ef"),
+    ],
+)
+def test_missing_required_value_returns_none(
+    surface: float | None,
+    kwh_per_m2: float | None,
+    ef: float | None,
+) -> None:
+    ctx = _ctx(surface=surface)
+    fv: dict = {
+        "lighting_kwh_per_square_meter": kwh_per_m2,
+        "ef_kg_co2eq_per_kwh": ef,
+    }
+    result = _HANDLER._compute_kwh_emission(ctx, fv, "lighting_kwh_per_square_meter")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Heating electric leaf — emission_type.parent == heating_elec
+# ---------------------------------------------------------------------------
+
+
+def test_heating_elec_with_conversion_factor() -> None:
+    # surface=100, kwh/m2=10, ratio=0.5, ef=0.2, cf=2.0
+    # kwh = 100 * 10 * 0.5 = 500
+    # result = 500 * 0.2 * 2.0 = 200.0
+    ctx = _ctx(emission_type=_ELEC_LEAF)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="electric",
+        conversion_factor=2.0,
+    )
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(200.0)
+
+
+def test_heating_elec_missing_conversion_factor_defaults_to_one() -> None:
+    # conversion_factor absent → defaults to 1.0
+    ctx = _ctx(emission_type=_ELEC_LEAF)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="electric",
+        conversion_factor=None,
+    )
+    # kwh = 100 * 10 * 0.5 = 500; result = 500 * 0.2 * 1.0 = 100.0
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(100.0)
+
+
+def test_heating_elec_conversion_factor_none_defaults_to_one() -> None:
+    # conversion_factor explicitly None in factor_values → `or 1.0` kicks in
+    ctx = _ctx(emission_type=_ELEC_LEAF)
+    fv = {
+        "heating_kwh_per_square_meter": 10.0,
+        "ef_kg_co2eq_per_kwh": 0.2,
+        "energy_type": "electric",
+        "conversion_factor": None,
+    }
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(100.0)
+
+
+def test_heating_elec_leaf_wrong_energy_type_gives_zero() -> None:
+    # energy_type="thermal" on an elec leaf → neither branch matches → cf=0 → result=0
+    ctx = _ctx(emission_type=_ELEC_LEAF)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="thermal",
+        conversion_factor=2.0,
+    )
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Heating thermal leaf — emission_type.parent == heating_thermal
+# ---------------------------------------------------------------------------
+
+
+def test_heating_thermal_with_conversion_factor() -> None:
+    ctx = _ctx(emission_type=_THERMAL_LEAF)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="thermal",
+        conversion_factor=3.0,
+    )
+    # kwh = 100 * 10 * 0.5 = 500; result = 500 * 0.2 * 3.0 = 300.0
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(300.0)
+
+
+def test_heating_thermal_leaf_wrong_energy_type_gives_zero() -> None:
+    ctx = _ctx(emission_type=_THERMAL_LEAF)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="electric",
+        conversion_factor=3.0,
+    )
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(0.0)
+
+
+def test_heating_thermal_missing_conversion_factor_defaults_to_one() -> None:
+    ctx = _ctx(emission_type=_THERMAL_LEAF)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="thermal",
+        conversion_factor=None,
+    )
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# Heating with top-level parent (not a leaf) — parent check fails → cf=0
+# ---------------------------------------------------------------------------
+
+
+def test_heating_elec_top_level_emission_type_gives_zero() -> None:
+    # _ELEC_PARENT.parent == buildings__rooms, not heating_elec → cf=0
+    ctx = _ctx(emission_type=_ELEC_PARENT)
+    fv = _fv(
+        kwh_field="heating_kwh_per_square_meter",
+        energy_type="electric",
+        conversion_factor=2.0,
+    )
+    assert _HANDLER._compute_kwh_emission(
+        ctx, fv, "heating_kwh_per_square_meter"
+    ) == pytest.approx(0.0)


### PR DESCRIPTION
## What does this change?

* energy type was not used to discriminate between thermal and elec heating emissions
* conversion factor applies to heating only

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1575

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
