### PR TITLE
feat: enhance IT focus breakdown chart with validation logic

### DIFF
--- a/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
+++ b/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
@@ -169,9 +169,12 @@ interface WaffleCategory {
   color: string;
   units: number;
   isIT: boolean;
+  /** False for IT categories whose source module is not yet validated. */
+  validated: boolean;
 }
 
 function largestRemainder(values: number[], target: number): number[] {
+  if (values.length === 0) return [];
   const floors = values.map((v) => Math.floor(v));
   const remainder = target - floors.reduce((a, b) => a + b, 0);
   const indexed = values.map((v, i) => ({ i, frac: v - Math.floor(v) }));
@@ -194,6 +197,10 @@ function waffleUnitsToLegendLabel(units: number): string {
   return waffleUnitsToPercentLabel(units);
 }
 
+const validatedKeys = computed(
+  () => new Set(props.data.validated_sources ?? []),
+);
+
 const waffleCategoryData = computed<WaffleCategory[]>(() => {
   const totalItUnits = Math.min(
     WAFFLE_TOTAL_UNITS,
@@ -202,26 +209,38 @@ const waffleCategoryData = computed<WaffleCategory[]>(() => {
       Math.round((props.data.percentage_of_source_modules ?? 0) * 10),
     ),
   );
-  const totalItTonnes = props.data.total_it_tonnes_co2eq;
 
-  const rawUnits = Array.from(IT_FOCUS_CATEGORY_ORDER).map((key) => {
+  const validatedCategoryKeys = IT_FOCUS_CATEGORY_ORDER.filter((key) =>
+    validatedKeys.value.has(key),
+  );
+
+  const validatedTotalTonnes = validatedCategoryKeys.reduce((sum, key) => {
     const cat = props.data.categories.find((c) => c.category_key === key);
-    if (!cat || totalItTonnes <= 0) return 0;
-    return (cat.tonnes_co2eq / totalItTonnes) * totalItUnits;
+    return sum + (cat?.tonnes_co2eq ?? 0);
+  }, 0);
+
+  const rawUnits = validatedCategoryKeys.map((key) => {
+    const cat = props.data.categories.find((c) => c.category_key === key);
+    if (!cat || validatedTotalTonnes <= 0) return 0;
+    return (cat.tonnes_co2eq / validatedTotalTonnes) * totalItUnits;
   });
 
   const rounded = largestRemainder(rawUnits, totalItUnits);
-
-  const cats: WaffleCategory[] = Array.from(IT_FOCUS_CATEGORY_ORDER).map(
-    (key, i) => ({
-      key,
-      label: t(CATEGORY_LABEL_MAP[key] ?? key),
-      color:
-        categoryColor.value[key as keyof typeof categoryColor.value] ?? '#999',
-      units: rounded[i],
-      isIT: true,
-    }),
+  const unitsByKey = new Map(
+    validatedCategoryKeys.map((key, i) => [key, rounded[i]] as const),
   );
+
+  // Keep all IT categories in display order; unvalidated ones carry 0 units
+  // (no waffle cells) and are flagged so the legend can grey them out.
+  const cats: WaffleCategory[] = IT_FOCUS_CATEGORY_ORDER.map((key) => ({
+    key,
+    label: t(CATEGORY_LABEL_MAP[key] ?? key),
+    color:
+      categoryColor.value[key as keyof typeof categoryColor.value] ?? '#999',
+    units: unitsByKey.get(key) ?? 0,
+    isIT: true,
+    validated: validatedKeys.value.has(key),
+  }));
 
   cats.push({
     key: 'non_it',
@@ -229,6 +248,7 @@ const waffleCategoryData = computed<WaffleCategory[]>(() => {
     color: NON_IT_COLOR,
     units: WAFFLE_TOTAL_UNITS - totalItUnits,
     isIT: false,
+    validated: true,
   });
 
   return cats;
@@ -389,11 +409,16 @@ defineExpose({ downloadPNG });
           v-for="cat in waffleCategoryData"
           :key="cat.key"
           class="waffle-legend-item"
+          :class="{ 'waffle-legend-item--unvalidated': !cat.validated }"
         >
           <span
-            v-if="cat.isIT"
+            v-if="cat.isIT && cat.validated"
             class="waffle-swatch"
             :style="{ backgroundColor: cat.color }"
+          />
+          <span
+            v-else-if="cat.isIT"
+            class="waffle-swatch waffle-swatch--unvalidated"
           />
           <span
             v-else
@@ -423,7 +448,11 @@ defineExpose({ downloadPNG });
               );
             "
           >
-            {{ waffleUnitsToLegendLabel(cat.units) }}
+            {{
+              cat.validated
+                ? waffleUnitsToLegendLabel(cat.units)
+                : $t('it-focus-not-validated')
+            }}
           </span>
         </span>
       </div>
@@ -466,6 +495,10 @@ defineExpose({ downloadPNG });
   gap: dec.$spacing-xs;
 }
 
+.waffle-legend-item--unvalidated {
+  opacity: 0.45;
+}
+
 .waffle-swatch {
   width: dec.$spacing-md;
   height: dec.$spacing-md;
@@ -477,6 +510,16 @@ defineExpose({ downloadPNG });
 .waffle-swatch--outlined {
   border: 1.3px solid;
   opacity: 0.6;
+}
+
+.waffle-swatch--unvalidated {
+  background: repeating-linear-gradient(
+    45deg,
+    #c8c6be,
+    #c8c6be 2px,
+    #e4e2db 2px,
+    #e4e2db 4px
+  );
 }
 
 .waffle-legend-label {

--- a/frontend/src/components/organisms/ItFocusSection.vue
+++ b/frontend/src/components/organisms/ItFocusSection.vue
@@ -3,9 +3,6 @@ import { computed, ref } from 'vue';
 
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import ItFocusBreakdownChart from 'src/components/charts/results/ItFocusBreakdownChart.vue';
-import { IT_FOCUS_CATEGORY_TO_MODULE } from 'src/constant/itFocus';
-import { MODULE_STATES } from 'src/constant/moduleStates';
-import { useTimelineStore } from 'src/stores/modules';
 import { formatTonnesCO2 } from 'src/utils/number';
 import type { ItBreakdownResponse } from 'src/stores/modules';
 
@@ -29,8 +26,6 @@ const props = withDefaults(
   },
 );
 
-const timelineStore = useTimelineStore();
-
 const breakdownChartRef = ref<{ downloadPNG: () => Promise<void> } | null>(
   null,
 );
@@ -42,17 +37,15 @@ const IT_FOCUS_CATEGORY_ORDER = [
   'research_facilities_it',
 ] as const;
 
-function isItCategoryModuleValidated(categoryKey: string): boolean {
-  const mod = IT_FOCUS_CATEGORY_TO_MODULE[categoryKey];
-  if (!mod) return false;
-  return timelineStore.itemStates[mod] === MODULE_STATES.Validated;
-}
+const validatedKeys = computed(
+  () => new Set(props.data?.validated_sources ?? []),
+);
 
 const displayTotalItTonnes = computed(() => {
   if (!props.data) return 0;
   let sum = 0;
   for (const key of IT_FOCUS_CATEGORY_ORDER) {
-    if (isItCategoryModuleValidated(key)) {
+    if (validatedKeys.value.has(key)) {
       const cat = props.data.categories.find((c) => c.category_key === key);
       if (cat) sum += cat.tonnes_co2eq;
     }

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -950,6 +950,10 @@ export default {
     en: 'IT share',
     fr: 'Part IT',
   },
+  'it-focus-not-validated': {
+    en: 'not validated',
+    fr: 'non validé',
+  },
   'it-focus-equipment-it': {
     en: 'IT equipment',
     fr: 'Équipements IT',


### PR DESCRIPTION
## What does this change?
Makes the IT focus breakdown chart validation-aware: unvalidated source modules no longer contribute waffle cells or misleading percentages, and are visually distinguished in the legend.

**`ItFocusBreakdownChart.vue`:**
- Adds a `validated` field to `WaffleCategory`; unvalidated IT categories carry `units: 0` (no waffle cells) and `validated: false`
- New `validatedKeys` computed reads `props.data.validated_sources` as the single source of truth for which IT source modules are validated
- `waffleCategoryData` now splits only validated categories' tonnes when computing proportional units, so the waffle stays consistent with the validated-only headline total; all IT categories still appear in the legend in their standard order
- Fixes an edge case in `largestRemainder` — returns early on empty input
- Legend: validated IT categories get a colored swatch; unvalidated ones get a hatched grey `waffle-swatch--unvalidated` swatch at 45% opacity with the label replaced by `$t('it-focus-not-validated')` ("not validated" / "non validé")
- New CSS: `.waffle-legend-item--unvalidated` (opacity 0.45), `.waffle-swatch--unvalidated` (diagonal stripe pattern)

**`ItFocusSection.vue`:**
- Removes the local `isItCategoryModuleValidated` helper that read from `timelineStore.itemStates` (frontend-only, prone to race conditions); replaces it with a `validatedKeys` computed reading `props.data.validated_sources` — the same backend-authoritative field the chart uses
- Removes unused imports (`IT_FOCUS_CATEGORY_TO_MODULE`, `MODULE_STATES`, `useTimelineStore`)

**`results.ts`:**
- Adds `it-focus-not-validated` i18n key (EN/FR)

## Why is this needed?
The IT focus chart was including emissions from unvalidated modules in its waffle and percentage calculations, producing unstable/misleading numbers that changed as modules were validated. Using `validated_sources` from the backend as the single source of truth ensures the chart only shows confirmed data, and the greyed-out legend entries communicate clearly which modules still need validation.

## Type of change
- [x] 🐛 Bug fix
- [x] 🎨 Design/UI improvement