### PR TITLE
feat: update home localization keys for consistency and clarity

### DIFF
--- a/frontend/src/i18n/home.ts
+++ b/frontend/src/i18n/home.ts
@@ -23,35 +23,35 @@ export default {
     en: "Click 'Start' to complete the various modules and receive a full estimate of your unit's CO₂​-equivalent emissions, view your results, and export your data!",
     fr: 'Cliquez sur ""démarrer "" pour remplir les différents modules et obtenir une estimation complète des émissions de CO₂-équivalent de votre unité, consultez vos résultats, et exportez vos données !',
   },
-  home_intro_4: {
+  home_intro_3: {
     en: 'Only the main user has full access to all the features of the calculator but can delegate access to other team members by assigning them the role of main user or standard user via Accred. The majority of the data is uploaded automatically, but some can be entered manually or imported via a CSV file. You can switch to "color-blind" mode by clicking on your first and last name and activating the mode.',
     fr: "Seul le responsable d'unité a un accès complet à toutes les fonctionnalités du CO₂ calculateur mais peut déléguer l'accès à d'autres membres de l'équipe en leur attribuant le rôle d'utilisateur principal via Accred. La majorité des données remontent automatiquement mais certaines peuvent être saisies manuellement ou importées via un fichier CSV. Vous pouvez passer en mode \"color-blind\" en cliquant sur votre prénom et nom et en activant le mode.",
   },
-  home_intro_5_part_1: {
+  home_intro_4_part_1: {
     en: "For more information on the methodology and EPFL's Climate and Sustainability Strategy, see our ",
     fr: "Pour plus d'informations sur la méthodologie et la Stratégie Climat et Durabilité de l'EPFL, consultez notre ",
   },
-  home_intro_5_link_text: {
+  home_intro_4_link_text: {
     en: 'page',
     fr: 'page',
   },
-  home_intro_5_link_url: {
+  home_intro_4_link_url: {
     en: 'https://www.epfl.ch/about/sustainability/strategy/',
     fr: 'https://www.epfl.ch/about/sustainability/fr/strategie/',
   },
-  home_intro_5_part_2: {
+  home_intro_4_part_2: {
     en: '. If you need help, please ',
     fr: ". Si vous avez besoin d'aide, veuillez ",
   },
-  home_intro_5_contact_link_text: {
+  home_intro_4_contact_link_text: {
     en: 'contact us',
     fr: 'nous contacter',
   },
-  home_intro_5_contact_link_url: {
+  home_intro_4_contact_link_url: {
     en: 'mailto:sustainability%40epfl.ch',
     fr: 'mailto:sustainability%40epfl.ch',
   },
-  home_intro_5_part_3: {
+  home_intro_4_part_3: {
     en: '.',
     fr: '.',
   },

--- a/frontend/src/pages/app/HomePage.vue
+++ b/frontend/src/pages/app/HomePage.vue
@@ -108,22 +108,20 @@ function getStatusLabelKey(moduleLink: Module): string {
       </p>
       <p class="text-body1">{{ $t('home_intro_2') }}</p>
       <p class="text-body1">{{ $t('home_intro_3') }}</p>
-      <p class="text-body1">{{ $t('home_intro_4') }}</p>
-      <p class="text-body1">
-        {{ $t('home_intro_5_part_1')
+      <p class="text-body1 q-mb-none">
+        {{ $t('home_intro_4_part_1')
         }}<a
-          :href="$t('home_intro_5_link_url')"
+          :href="$t('home_intro_4_link_url')"
           target="_blank"
           rel="noopener noreferrer"
           class="link"
-          >{{ $t('home_intro_5_link_text') }}</a
-        >{{ $t('home_intro_5_part_2')
-        }}<a :href="$t('home_intro_5_contact_link_url')" class="link">{{
-          $t('home_intro_5_contact_link_text')
+          >{{ $t('home_intro_4_link_text') }}</a
+        >{{ $t('home_intro_4_part_2')
+        }}<a :href="$t('home_intro_4_contact_link_url')" class="link">{{
+          $t('home_intro_4_contact_link_text')
         }}</a
-        >{{ $t('home_intro_5_part_3') }}
+        >{{ $t('home_intro_4_part_3') }}
       </p>
-      <p class="text-body1 q-mb-none">{{ $t('home_intro_6') }}</p>
       <q-btn
         color="info"
         :label="$t('home_start_button')"


### PR DESCRIPTION
## What does this change?
Renumbers the home page intro i18n keys and removes one paragraph from the welcome page.

- `home.ts`: renames `home_intro_4` → `home_intro_3`, and all `home_intro_5_*` keys → `home_intro_4_*` (part_1, link_text, link_url, part_2, contact_link_text, contact_link_url, part_3) — closing the gap left by a previously removed paragraph
- `HomePage.vue`: updates all template references to match the new key names; removes the `home_intro_4` paragraph (the one about main user/delegation/CSV/color-blind mode) and the `home_intro_6` paragraph; adds `q-mb-none` to the methodology/contact paragraph

## Why is this needed?
The intro key numbering had a gap (skipped `home_intro_3`) and there was a stale `home_intro_6` reference after one paragraph was removed, leaving the welcome page with inconsistently numbered keys and an extra paragraph.

## Type of change
- [x] 🧹 Code cleanup
- [x] 🎨 Design/UI improvement