### PR TITLE
fix: apply filter of plane/travels by their origin or destination

### DIFF
--- a/backend/app/modules/professional_travel/schemas.py
+++ b/backend/app/modules/professional_travel/schemas.py
@@ -280,6 +280,11 @@ class ProfessionalTravelPlaneModuleHandler(ProfessionalTravelBaseModuleHandler):
     kind_field: str = "category"
     subkind_field: str = "cabin_class"
 
+    filter_map = {
+        "origin_iata": DataEntry.data["origin_iata"].as_string(),
+        "destination_iata": DataEntry.data["destination_iata"].as_string(),
+    }
+
     async def prefetch_slice(
         self,
         entries: list[Any],
@@ -465,6 +470,11 @@ class ProfessionalTravelTrainModuleHandler(ProfessionalTravelBaseModuleHandler):
     create_dto = ProfessionalTravelTrainHandlerCreate
     update_dto = ProfessionalTravelTrainHandlerUpdate
     response_dto = ProfessionalTravelTrainHandlerResponse
+
+    filter_map = {
+        "origin_name": DataEntry.data["origin_name"].as_string(),
+        "destination_name": DataEntry.data["destination_name"].as_string(),
+    }
 
     async def enrich_csv_row(
         self,

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -1056,6 +1056,16 @@ function renderCell(
     optionsId?: string;
   },
 ) {
+  if (col.field === 'origin_name') {
+    const name = row['origin_name'] as string | undefined;
+    const iata = row['origin_iata'] as string | undefined;
+    return iata ? `${name ?? iata} (${iata})` : (name ?? '-');
+  }
+  if (col.field === 'destination_name') {
+    const name = row['destination_name'] as string | undefined;
+    const iata = row['destination_iata'] as string | undefined;
+    return iata ? `${name ?? iata} (${iata})` : (name ?? '-');
+  }
   // Resolve traveler name from loaded headcount members (user_institutional_id is the source of truth)
   if (col.field === 'traveler_name') {
     const user_institutional_id = row['user_institutional_id'] as


### PR DESCRIPTION
## What does this change?

Filter planes and trains data entries by their origin/destination:
* plane: IATA code (because name is not stored in the db)
* train: name

Added IATA code to origin/destination name in table:

<img width="431" height="195" alt="image" src="https://github.com/user-attachments/assets/92fd61a4-02cf-4959-94f9-967e33ed4199" />


## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1436 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
