### PR TITLE
fix(deps): unblock Dependabot — use $vue-i18n self-reference in npm override

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
     "esbuild": "=0.28.1",
     "minimatch": "=10.2.4",
     "serialize-javascript": "=7.0.5",
-    "vue-i18n": "=11.4.2",
+    "vue-i18n": "$vue-i18n",
     "js-yaml": "=4.2.0"
   },
   "type": "module",


### PR DESCRIPTION
## Problem

Dependabot's frontend job fails:

> Override for vue-i18n@11.4.6 conflicts with direct dependency.

`vue-i18n` is declared **both** as a direct dependency (`=11.4.2`) and as an `overrides` entry with a literal version (`=11.4.2`). npm forbids a literal-version override for a package that is also a direct dependency, so when Dependabot tries to bump the direct dep to `11.4.6` the pinned override conflicts and the whole resolution aborts.

## Fix

Switch the override to npm's self-reference syntax:

```diff
-    "vue-i18n": "=11.4.2",
+    "vue-i18n": "$vue-i18n",
```

`$vue-i18n` forces every transitive `vue-i18n` to match the **direct** dependency's version — preserving the original dedupe intent while letting Dependabot bump the direct dep freely. The other overrides (`esbuild`, `minimatch`, `serialize-javascript`, `js-yaml`) are override-only (not direct deps) and are unaffected.

## Verification

`npm install --package-lock-only --ignore-scripts` resolves with exit 0 and no lockfile changes (`$vue-i18n` resolves to the same `11.4.2`). CI's install step exercises this on every run.