### PR TITLE
fix(deps): clear gitpython high-severity alerts (docs, transitive)

### DIFF
--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -378,14 +378,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Dependabot flags **gitpython 3.1.45** with **5 high-severity alerts**, recommending 3.1.50.

It's a **transitive, build-time-only** dependency: pulled in by `mkdocs-git-revision-date-localized-plugin` in `docs/uv.lock`. It runs at `mkdocs build` over our own git history — not present in the backend or frontend runtime — so real-world exposure is low, but the advisories are worth clearing.

## Fix

```
cd docs && uv lock --upgrade-package gitpython   # 3.1.45 -> 3.1.50
```

Touches only `docs/uv.lock` (transitive bump; no manifest change). 3.1.50 is the version GitHub indicates clears all 5 alerts.

## Verification

`uv lock --upgrade-package gitpython` resolved with exit 0; lockfile shows gitpython `3.1.50` and no remaining `3.1.45`.