### PR TITLE
feat 834: add compare years chart

### DIFF
--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -17,11 +17,13 @@ from app.core.constants import ModuleStatus
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import check_module_permission as _check_module_permission
+from app.core.policy import require_unit_access
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportModule, CarbonReportType
 from app.models.module_type import ModuleTypeEnum
 from app.models.unit import Unit
 from app.models.user import User
+from app.repositories.carbon_report_repo import CarbonReportRepository
 from app.schemas.carbon_report import CarbonReportModuleRead
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.data_entry_service import DataEntryService
@@ -30,6 +32,7 @@ from app.utils.report_computations import (
     compute_results_summary,
     compute_validated_totals,
 )
+from app.utils.report_stats import build_year_comparison, merge_report_stats
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -147,6 +150,50 @@ async def get_module_stats(
     logger.info(f"Module stats returned: {stats}")
 
     return stats
+
+
+# Declared before the ``/{carbon_report_id}/...`` dynamic routes so the literal
+# ``unit`` segment is matched first and never captured as a carbon_report_id.
+@router.get("/unit/{unit_id}/multi-year-report-stats", response_model=dict)
+async def get_multi_year_breakdown(
+    unit_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Return per-year emission breakdown (by module and by scope) for a unit.
+
+    Feeds the "Compare Years" pop-up: one entry per year with stat-bucket
+    totals (``modules``) and scope totals (``scopes``) in tonnes CO2eq, read
+    straight off each report's persisted stats.
+
+    Returns:
+        {"years": [{"year": 2023, "total_tonnes_co2eq": 61.7,
+                    "modules": {...}, "scopes": {...}}, ...]}
+    """
+    logger.info(f"GET multi-year breakdown: unit_id={sanitize(unit_id)}")
+
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
+
+    reports = await CarbonReportRepository(db).list_by_unit(unit_id)
+
+    # A unit can own more than one Calculator project, and uniqueness is on
+    # (carbon_project_id, year) -- not (unit_id, year) -- so a year may map to
+    # several reports. Fold them into one aggregate of the same stats shape.
+    stats_by_year: dict[int, list[dict]] = {}
+    for report in reports:
+        if report.stats:
+            stats_by_year.setdefault(report.year, []).append(report.stats)
+
+    years = []
+    for year in sorted(stats_by_year):
+        stats_list = stats_by_year[year]
+        stats = (
+            stats_list[0] if len(stats_list) == 1 else merge_report_stats(stats_list)
+        )
+        years.append({"year": year, **build_year_comparison(stats)})
+
+    return {"years": years}
 
 
 @router.get("/{carbon_report_id}/report-stats", response_model=dict)

--- a/backend/app/utils/report_stats.py
+++ b/backend/app/utils/report_stats.py
@@ -3,7 +3,8 @@
 ``derive_report_sections`` computes the display-derived sections (scope
 totals, per-FTE, IT rollup) from merged buckets; ``merge_report_stats``
 combines several reports' stats into one aggregate of the same shape
-(backoffice multi-unit views). Neither touches the database.
+(backoffice multi-unit views); ``build_year_comparison`` reshapes one
+report's stats into the compare-years payload. None touch the database.
 """
 
 from app.modules.emissions.registry import ORDERED_STAT_BUCKETS
@@ -60,6 +61,52 @@ def derive_report_sections(
         "top_class_detail": top_class_detail,
     }
     return {**scope_totals, "per_fte": per_fte, "it": it_stats}
+
+
+def build_year_comparison(stats: dict) -> dict:
+    """Reshape one report's persisted stats into a compare-years year entry.
+
+    Args:
+        stats: a persisted ``carbon_report.stats`` dict (or a
+            ``merge_report_stats`` aggregate, which has the same shape).
+
+    Returns:
+        ``{"modules": {bucket_key: tonnes}, "scopes": {"1": t, "2": t,
+        "3": t}, "total_tonnes_co2eq": t}``. ``modules`` is keyed by stat-bucket
+        key -- including the additional buckets (commuting, food, waste,
+        embodied_energy) -- so the stacked-bar segments match the Results
+        category palette.
+
+    Only buckets whose module is validated are counted, so a year's total
+    matches the validated-only Results headline. An in-progress module is
+    absent rather than zero, which keeps it out of the objective baselines
+    too. Note this means the current year can read lower here than in the
+    unit carbon footprint chart behind the dialog, which shows every module.
+
+    Scopes are summed from the buckets rather than read off ``scope1/2/3``,
+    which cover every module validated or not, so they stay consistent with
+    the filtered ``modules`` above.
+    """
+    modules: dict[str, float] = {}
+    scopes: dict[str, float] = {"1": 0.0, "2": 0.0, "3": 0.0}
+    validated_keys = set(stats.get("validated_buckets") or [])
+
+    for key, bucket in (stats.get("buckets") or {}).items():
+        if key not in validated_keys:
+            continue
+        bucket_kg = bucket.get("total_kg", 0.0) or 0.0
+        if bucket_kg <= 0:
+            continue
+        tonnes = bucket_kg / 1000.0
+        modules[key] = tonnes
+        scope_key = str(bucket.get("scope", 3))
+        scopes[scope_key] = scopes.get(scope_key, 0.0) + tonnes
+
+    return {
+        "modules": modules,
+        "scopes": scopes,
+        "total_tonnes_co2eq": sum(modules.values()),
+    }
 
 
 def _merge_bucket_into(target: dict, bucket: dict) -> None:

--- a/backend/tests/unit/utils/test_report_stats.py
+++ b/backend/tests/unit/utils/test_report_stats.py
@@ -16,7 +16,7 @@ from app.modules.emissions.registry import (
 from app.modules.emissions.taxonomy import EmissionType
 from app.services.carbon_report_module_service import compute_module_stats
 from app.services.carbon_report_service import _build_report_stats
-from app.utils.report_stats import merge_report_stats
+from app.utils.report_stats import build_year_comparison, merge_report_stats
 
 
 def _buildings_stats() -> dict:
@@ -145,3 +145,62 @@ def test_merge_report_stats_empty_input():
     assert merged["buckets"] == {}
     assert merged["total"] == 0.0
     assert merged["it"]["total_kg"] == 0.0
+
+
+def test_year_comparison_buckets_to_tonnes_by_module_and_scope():
+    entry = build_year_comparison(_build_report_stats(_modules()))
+    # equipment is IN_PROGRESS, so it is absent rather than zero
+    assert entry["modules"] == {
+        "buildings_energy_combustion": 0.150,
+        "buildings_room": 0.030,
+        "commuting": 0.005,
+        "food": 0.020,
+        "embodied_energy": 0.007,
+    }
+    assert entry["scopes"] == {"1": 0.150, "2": 0.030, "3": 0.032}
+    # "waste" has no emissions in the fixture, so it never reaches the payload
+    assert "waste" not in entry["modules"]
+
+
+def test_year_comparison_total_is_validated_only_and_counts_additional():
+    report = _build_report_stats(_modules())
+    entry = build_year_comparison(report)
+    # matches the validated-only Results headline, not the all-module total
+    assert entry["total_tonnes_co2eq"] == report["validated_total"] / 1000.0
+    assert entry["total_tonnes_co2eq"] != report["total"] / 1000.0
+    # additional buckets (commuting/food/embodied_energy) are in the total
+    assert entry["total_tonnes_co2eq"] == sum(entry["modules"].values())
+    assert abs(sum(entry["scopes"].values()) - entry["total_tonnes_co2eq"]) < 1e-12
+
+
+def test_year_comparison_simulator_reports_count_every_module():
+    # simulator reports have no validation step, so equipment counts there
+    report = _build_report_stats(_modules(), is_simulator=True)
+    entry = build_year_comparison(report)
+    assert entry["modules"]["equipment"] == 1.0
+    assert entry["total_tonnes_co2eq"] == report["total"] / 1000.0
+
+
+def test_year_comparison_skips_non_positive_and_unvalidated_buckets():
+    entry = build_year_comparison(
+        {
+            "validated_buckets": ["equipment", "purchases", "food"],
+            "buckets": {
+                "equipment": {"total_kg": 0.0, "scope": 2},
+                "purchases": {"total_kg": -5.0, "scope": 3},
+                "food": {"total_kg": 1000.0, "scope": 3, "additional": True},
+                # positive, but its module is not validated
+                "professional_travel": {"total_kg": 500.0, "scope": 3},
+            },
+        }
+    )
+    assert entry["modules"] == {"food": 1.0}
+    assert entry["scopes"] == {"1": 0.0, "2": 0.0, "3": 1.0}
+    assert entry["total_tonnes_co2eq"] == 1.0
+
+
+def test_year_comparison_empty_stats():
+    entry = build_year_comparison({})
+    assert entry["modules"] == {}
+    assert entry["scopes"] == {"1": 0.0, "2": 0.0, "3": 0.0}
+    assert entry["total_tonnes_co2eq"] == 0.0

--- a/frontend/src/components/charts/results/CompareYearsChart.vue
+++ b/frontend/src/components/charts/results/CompareYearsChart.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, type PropType } from 'vue';
+import { use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { BarChart } from 'echarts/charts';
+import type { EChartsOption } from 'echarts';
+import { TooltipComponent, GridComponent } from 'echarts/components';
+import VChart from 'vue-echarts';
+import TooltipEcharts from './TooltipEcharts.vue';
+import { useEchartsTooltip } from './useEchartsTooltip';
+import type { TooltipRow, TooltipState } from 'src/types/chartTooltip';
+import {
+  normalizeAxisParams,
+  extractSeriesValue,
+  formatTooltipTonnes,
+} from 'src/utils/chart-tooltip-extractors';
+
+use([CanvasRenderer, BarChart, TooltipComponent, GridComponent]);
+
+// Keep the bars readable when only a couple of years are shown.
+const MAX_BAR_WIDTH = 96;
+
+export interface CompareYearsSeries {
+  key: string;
+  label: string;
+  color: string;
+}
+
+/** A single solid bar appended after the year bars (e.g. reduction objective). */
+export interface CompareYearsObjectiveBar {
+  label: string;
+  value: number;
+  color: string;
+}
+
+const props = defineProps({
+  years: {
+    type: Array as PropType<number[]>,
+    required: true,
+  },
+  series: {
+    type: Array as PropType<CompareYearsSeries[]>,
+    required: true,
+  },
+  /** year → (series key → tonnes CO2eq). */
+  dataByYear: {
+    type: Object as PropType<Record<number, Record<string, number>>>,
+    required: true,
+  },
+  /** Optional trailing single-value bar with its own category tick. */
+  objective: {
+    type: Object as PropType<CompareYearsObjectiveBar | null>,
+    default: null,
+  },
+});
+
+// ── Teleport tooltip composable (shared look & feel with the result charts) ──
+const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
+
+const chartRef = ref<InstanceType<typeof VChart>>();
+
+const onChartReady = async () => {
+  await nextTick();
+  const chart = chartRef.value?.chart;
+  if (!chart) return;
+  attach(chart);
+};
+
+// series label → swatch colour, for the teleport tooltip dots.
+const colorByName = computed<Record<string, string>>(() => {
+  const map: Record<string, string> = {};
+  for (const s of props.series) map[s.label] = s.color;
+  if (props.objective) map[props.objective.label] = props.objective.color;
+  return map;
+});
+
+function buildTooltipState(rawParams: unknown): TooltipState {
+  const params = normalizeAxisParams(rawParams);
+  if (!params.length) return null;
+
+  const title = String(params[0]?.axisValue ?? '');
+
+  // Only the categories that actually contribute at the hovered bar.
+  const rows: TooltipRow[] = params
+    .map((p) => ({ p, value: extractSeriesValue(p.value) }))
+    .filter(({ value }) => typeof value === 'number' && value > 0)
+    .map(
+      ({ p, value }): TooltipRow => ({
+        label: String(p.seriesName ?? ''),
+        value: formatTooltipTonnes(value),
+        color: colorByName.value[String(p.seriesName ?? '')],
+      }),
+    );
+
+  if (!rows.length) return null;
+  return { title, rows };
+}
+
+const chartOption = computed<EChartsOption>(() => {
+  // Only keep series that contribute a non-zero value across the shown years.
+  const visibleSeries = props.series.filter((s) =>
+    props.years.some((y) => (props.dataByYear[y]?.[s.key] ?? 0) > 0),
+  );
+
+  const objective = props.objective;
+
+  const categories = objective
+    ? [...props.years.map((y) => String(y)), objective.label]
+    : props.years.map((y) => String(y));
+
+  const stackedSeries = visibleSeries.map((s) => ({
+    name: s.label,
+    type: 'bar' as const,
+    stack: 'total',
+    barMaxWidth: MAX_BAR_WIDTH,
+    itemStyle: { color: s.color },
+    emphasis: { focus: 'series' as const },
+    // Trailing `null` leaves the objective slot empty for stacked categories.
+    data: [
+      ...props.years.map((y) => props.dataByYear[y]?.[s.key] ?? 0),
+      ...(objective ? [null] : []),
+    ],
+  }));
+
+  // Same stack name as the year bars so every category slot holds a single,
+  // centered bar group (a distinct stack would render them side-by-side).
+  const objectiveSeries = objective
+    ? [
+        {
+          name: objective.label,
+          type: 'bar' as const,
+          stack: 'total',
+          barMaxWidth: MAX_BAR_WIDTH,
+          itemStyle: { color: objective.color },
+          data: [...props.years.map(() => null), objective.value],
+        },
+      ]
+    : [];
+
+  return {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (rawParams: unknown) => {
+        emitTooltip(buildTooltipState(rawParams));
+        return '';
+      },
+    },
+    grid: { left: 8, right: 16, top: 12, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+    },
+    series: [...stackedSeries, ...objectiveSeries],
+  };
+});
+</script>
+
+<template>
+  <v-chart
+    ref="chartRef"
+    class="compare-years-chart"
+    autoresize
+    :option="chartOption"
+    :update-options="{ replaceMerge: ['series'] }"
+    @vue:mounted="onChartReady"
+  />
+  <Teleport to="body">
+    <tooltip-echarts
+      v-if="tooltip.visible"
+      :tooltip-state="tooltip.data"
+      :style="style"
+    />
+  </Teleport>
+</template>
+
+<style scoped>
+.compare-years-chart {
+  width: 100%;
+  height: 240px;
+}
+</style>

--- a/frontend/src/components/charts/results/CompareYearsChart.vue
+++ b/frontend/src/components/charts/results/CompareYearsChart.vue
@@ -47,10 +47,10 @@ const props = defineProps({
     type: Object as PropType<Record<number, Record<string, number>>>,
     required: true,
   },
-  /** Optional trailing single-value bar with its own category tick. */
-  objective: {
-    type: Object as PropType<CompareYearsObjectiveBar | null>,
-    default: null,
+  /** Optional trailing single-value bars, each with its own category tick. */
+  objectives: {
+    type: Array as PropType<CompareYearsObjectiveBar[]>,
+    default: () => [],
   },
 });
 
@@ -70,7 +70,7 @@ const onChartReady = async () => {
 const colorByName = computed<Record<string, string>>(() => {
   const map: Record<string, string> = {};
   for (const s of props.series) map[s.label] = s.color;
-  if (props.objective) map[props.objective.label] = props.objective.color;
+  for (const o of props.objectives) map[o.label] = o.color;
   return map;
 });
 
@@ -102,11 +102,12 @@ const chartOption = computed<EChartsOption>(() => {
     props.years.some((y) => (props.dataByYear[y]?.[s.key] ?? 0) > 0),
   );
 
-  const objective = props.objective;
+  const objectives = props.objectives;
 
-  const categories = objective
-    ? [...props.years.map((y) => String(y)), objective.label]
-    : props.years.map((y) => String(y));
+  const categories = [
+    ...props.years.map((y) => String(y)),
+    ...objectives.map((o) => o.label),
+  ];
 
   const stackedSeries = visibleSeries.map((s) => ({
     name: s.label,
@@ -115,27 +116,27 @@ const chartOption = computed<EChartsOption>(() => {
     barMaxWidth: MAX_BAR_WIDTH,
     itemStyle: { color: s.color },
     emphasis: { focus: 'series' as const },
-    // Trailing `null` leaves the objective slot empty for stacked categories.
+    // Trailing `null`s leave the objective slots empty for stacked categories.
     data: [
       ...props.years.map((y) => props.dataByYear[y]?.[s.key] ?? 0),
-      ...(objective ? [null] : []),
+      ...objectives.map(() => null),
     ],
   }));
 
-  // Same stack name as the year bars so every category slot holds a single,
-  // centered bar group (a distinct stack would render them side-by-side).
-  const objectiveSeries = objective
-    ? [
-        {
-          name: objective.label,
-          type: 'bar' as const,
-          stack: 'total',
-          barMaxWidth: MAX_BAR_WIDTH,
-          itemStyle: { color: objective.color },
-          data: [...props.years.map(() => null), objective.value],
-        },
-      ]
-    : [];
+  // One series per objective, sharing the year bars' stack name so each slot
+  // holds a single, centered bar (a distinct stack would render them
+  // side-by-side). Each series is null everywhere except its own trailing slot.
+  const objectiveSeries = objectives.map((o, i) => ({
+    name: o.label,
+    type: 'bar' as const,
+    stack: 'total',
+    barMaxWidth: MAX_BAR_WIDTH,
+    itemStyle: { color: o.color },
+    data: [
+      ...props.years.map(() => null),
+      ...objectives.map((_, j) => (j === i ? o.value : null)),
+    ],
+  }));
 
   return {
     tooltip: {

--- a/frontend/src/components/charts/results/CompareYearsChart.vue
+++ b/frontend/src/components/charts/results/CompareYearsChart.vue
@@ -84,13 +84,11 @@ function buildTooltipState(rawParams: unknown): TooltipState {
   const rows: TooltipRow[] = params
     .map((p) => ({ p, value: extractSeriesValue(p.value) }))
     .filter(({ value }) => typeof value === 'number' && value > 0)
-    .map(
-      ({ p, value }): TooltipRow => ({
-        label: String(p.seriesName ?? ''),
-        value: formatTooltipTonnes(value),
-        color: colorByName.value[String(p.seriesName ?? '')],
-      }),
-    );
+    .map(({ p, value }): TooltipRow => ({
+      label: String(p.seriesName ?? ''),
+      value: formatTooltipTonnes(value),
+      color: colorByName.value[String(p.seriesName ?? '')],
+    }));
 
   if (!rows.length) return null;
   return { title, rows };

--- a/frontend/src/components/charts/results/CompareYearsDialog.vue
+++ b/frontend/src/components/charts/results/CompareYearsDialog.vue
@@ -14,8 +14,7 @@ import {
   defaultSelectedYears,
   presentCategories,
   computeCompareYearsTotal,
-  computeCompareYearsObjective,
-  type CompareYearsObjective,
+  computeCompareYearsObjectives,
 } from 'src/utils/compareYears';
 import { nOrDash } from 'src/utils/number';
 import CompareYearsChart, {
@@ -212,22 +211,39 @@ function formatTonnes(value: number): string {
   });
 }
 
-// Latest reduction goal applied to the latest selected year's
-// selected-category total. Shared by the KPI band and the chart bar.
-const objective = computed<CompareYearsObjective | null>(() => {
-  const goals =
-    yearConfigStore.config?.config?.reduction_objectives?.goals ?? [];
-  return computeCompareYearsObjective(
-    data.value?.years ?? [],
-    selectedYears.value,
-    selectedCategories.value,
-    goals,
-  );
-});
+const goals = computed(
+  () => yearConfigStore.config?.config?.reduction_objectives?.goals ?? [],
+);
 
-// KPI: how far the latest selected year sits above/below its objective.
+// One objective per reduction goal, each baselined on the unit's year closest
+// to that goal's institution reference_year. Selection-aware: the by-category
+// chart uses the selected categories, the by-scope chart the selected scopes.
+const categoryObjectives = computed(() =>
+  computeCompareYearsObjectives(
+    data.value?.years ?? [],
+    selectedCategories.value,
+    goals.value,
+    'modules',
+  ),
+);
+
+const scopeObjectives = computed(() =>
+  computeCompareYearsObjectives(
+    data.value?.years ?? [],
+    selectedScopes.value,
+    goals.value,
+    'scopes',
+  ),
+);
+
+// The latest reduction goal (highest target year) drives the KPI band.
+const latestObjective = computed(() => categoryObjectives.value.at(-1) ?? null);
+
+// KPI: how far the latest selected year sits from its objective, framed as the
+// reduction still missing to reach the target. Over target → `missing` with a
+// positive magnitude (e.g. "Missing 11 %"); at/below target → already reached.
 const objectiveGap = computed(() => {
-  const obj = objective.value;
+  const obj = latestObjective.value;
   if (!obj || obj.valueTonnes <= 0 || selectedYears.value.length === 0) {
     return null;
   }
@@ -239,22 +255,28 @@ const objectiveGap = computed(() => {
   return {
     targetYear: obj.targetYear,
     objectiveTonnes: obj.valueTonnes,
-    pct: (latestTonnes - obj.valueTonnes) / obj.valueTonnes,
+    missing: latestTonnes > obj.valueTonnes,
+    pctMagnitude: Math.abs(latestTonnes - obj.valueTonnes) / obj.valueTonnes,
   };
 });
 
-const objectiveBar = computed<CompareYearsObjectiveBar | null>(() => {
-  if (!showObjective.value) return null;
-  const obj = objective.value;
-  if (!obj) return null;
-  return {
-    label: t('results_compare_years_objective_tick', {
-      year: obj.targetYear,
-    }),
+function toObjectiveBars(
+  objectives: { targetYear: number; valueTonnes: number }[],
+): CompareYearsObjectiveBar[] {
+  if (!showObjective.value) return [];
+  return objectives.map((obj) => ({
+    label: t('results_compare_years_objective_tick', { year: obj.targetYear }),
     value: obj.valueTonnes,
     color: infoColorHex.value ?? '#1976d2',
-  };
-});
+  }));
+}
+
+const categoryObjectiveBars = computed(() =>
+  toObjectiveBars(categoryObjectives.value),
+);
+const scopeObjectiveBars = computed(() =>
+  toObjectiveBars(scopeObjectives.value),
+);
 </script>
 
 <template>
@@ -311,19 +333,21 @@ const objectiveBar = computed<CompareYearsObjectiveBar | null>(() => {
             <div v-if="objectiveGap" class="compare-years-kpi">
               <div class="compare-years-kpi__label">
                 {{
-                  $t('results_compare_years_gap_label', {
-                    year: objectiveGap.targetYear,
-                  })
+                  $t(
+                    objectiveGap.missing
+                      ? 'results_compare_years_gap_label'
+                      : 'results_compare_years_gap_beaten_label',
+                    { year: objectiveGap.targetYear },
+                  )
                 }}
               </div>
               <div class="compare-years-kpi__gap">
                 <span
                   class="compare-years-kpi__delta"
-                  :class="objectiveGap.pct > 0 ? 'text-negative' : 'text-info'"
+                  :class="objectiveGap.missing ? 'text-negative' : 'text-info'"
                 >
-                  {{ objectiveGap.pct > 0 ? '+' : ''
-                  }}{{
-                    $nOrDash(objectiveGap.pct * 100, {
+                  {{
+                    $nOrDash(objectiveGap.pctMagnitude * 100, {
                       options: { maximumFractionDigits: 0 },
                     })
                   }}%
@@ -378,7 +402,11 @@ const objectiveBar = computed<CompareYearsObjectiveBar | null>(() => {
                 </q-item>
               </template>
               <template #after-options>
-                <q-item v-ripple clickable @click="showObjective = !showObjective">
+                <q-item
+                  v-ripple
+                  clickable
+                  @click="showObjective = !showObjective"
+                >
                   <q-item-section side>
                     <q-checkbox
                       v-model="showObjective"
@@ -474,7 +502,7 @@ const objectiveBar = computed<CompareYearsObjectiveBar | null>(() => {
               :years="sortedSelectedYears"
               :series="moduleSeries"
               :data-by-year="moduleDataByYear"
-              :objective="objectiveBar"
+              :objectives="categoryObjectiveBars"
             />
           </div>
         </q-card-section>
@@ -534,6 +562,7 @@ const objectiveBar = computed<CompareYearsObjectiveBar | null>(() => {
               :years="sortedSelectedYears"
               :series="scopeSeries"
               :data-by-year="scopeDataByYear"
+              :objectives="scopeObjectiveBars"
             />
           </div>
         </q-card-section>

--- a/frontend/src/components/charts/results/CompareYearsDialog.vue
+++ b/frontend/src/components/charts/results/CompareYearsDialog.vue
@@ -1,0 +1,631 @@
+<script setup lang="ts">
+import { computed, ref, watch, type PropType } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useModuleStore } from 'src/stores/modules';
+import type { CompareYearsResponse } from 'src/stores/modules';
+import { useWorkspaceStore } from 'src/stores/workspace';
+import { useYearConfigStore } from 'src/stores/yearConfig';
+import {
+  RESULTS_CATEGORY_ORDER,
+  RESULTS_CATEGORY_LABEL_KEYS,
+  CHART_CATEGORY_COLOR_SCHEMES,
+} from 'src/constant/charts';
+import {
+  defaultSelectedYears,
+  presentCategories,
+  computeCompareYearsTotal,
+  computeCompareYearsObjective,
+  type CompareYearsObjective,
+} from 'src/utils/compareYears';
+import { nOrDash } from 'src/utils/number';
+import CompareYearsChart, {
+  type CompareYearsSeries,
+  type CompareYearsObjectiveBar,
+} from './CompareYearsChart.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  unitId: {
+    type: Number as PropType<number | null | undefined>,
+    default: null,
+  },
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+
+const { t } = useI18n();
+const moduleStore = useModuleStore();
+const workspaceStore = useWorkspaceStore();
+const yearConfigStore = useYearConfigStore();
+
+function readCssVarHex(name: string): string | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+// Quasar's `info` colour for the objective bar (distinct from the category palette).
+const infoColorHex = ref<string | null>(null);
+
+// Scope colours from the shared specification document.
+const SCOPE_COLORS: Record<string, string> = {
+  '1': '#E2E4F4',
+  '2': '#D5D7EF',
+  '3': '#C5CAE9',
+};
+
+const data = ref<CompareYearsResponse | null>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const SCOPE_KEYS = ['1', '2', '3'] as const;
+
+const selectedYears = ref<number[]>([]);
+const selectedCategories = ref<string[]>([]);
+const selectedScopes = ref<string[]>([...SCOPE_KEYS]);
+// Toggle for the trailing objective bar in the by-category chart. Surfaced as
+// an extra "Objective"/"Total" item at the bottom of the year & category lists.
+const showObjective = ref(true);
+
+async function load() {
+  if (props.unitId == null) return;
+  loading.value = true;
+  error.value = null;
+  infoColorHex.value = readCssVarHex('--q-info');
+  try {
+    const year = workspaceStore.selectedYear ?? new Date().getFullYear();
+    const [res] = await Promise.all([
+      moduleStore.getMultiYearBreakdown(props.unitId),
+      // Populate reduction_objectives.goals for the objective bar.
+      yearConfigStore.fetchConfig(year),
+    ]);
+    data.value = res;
+    // Default selection: every year that actually has emissions, all
+    // categories that appear in any year.
+    selectedYears.value = defaultSelectedYears(res.years);
+    selectedCategories.value = presentCategories(
+      res.years,
+      RESULTS_CATEGORY_ORDER,
+    );
+    selectedScopes.value = [...SCOPE_KEYS];
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Unknown error';
+    data.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) void load();
+  },
+);
+
+const yearOptions = computed(() =>
+  (data.value?.years ?? []).map((y) => y.year),
+);
+
+const categoryOptions = computed(() =>
+  presentCategories(data.value?.years ?? [], RESULTS_CATEGORY_ORDER).map(
+    (key) => ({
+      value: key,
+      label: t(
+        RESULTS_CATEGORY_LABEL_KEYS[
+          key as keyof typeof RESULTS_CATEGORY_LABEL_KEYS
+        ],
+      ),
+    }),
+  ),
+);
+
+const sortedSelectedYears = computed(() =>
+  [...selectedYears.value].sort((a, b) => a - b),
+);
+
+function categoryColor(key: string): string {
+  return CHART_CATEGORY_COLOR_SCHEMES.value[
+    key as keyof typeof CHART_CATEGORY_COLOR_SCHEMES.value
+  ];
+}
+
+const scopeOptions = computed(() =>
+  SCOPE_KEYS.map((scope) => ({
+    value: scope,
+    label: `${t('charts-scope')} ${scope}`,
+  })),
+);
+
+const moduleSeries = computed<CompareYearsSeries[]>(() =>
+  RESULTS_CATEGORY_ORDER.filter((key) =>
+    selectedCategories.value.includes(key),
+  ).map((key) => ({
+    key,
+    label: t(RESULTS_CATEGORY_LABEL_KEYS[key]),
+    color: CHART_CATEGORY_COLOR_SCHEMES.value[key],
+  })),
+);
+
+const scopeSeries = computed<CompareYearsSeries[]>(() =>
+  SCOPE_KEYS.filter((scope) => selectedScopes.value.includes(scope)).map(
+    (scope) => ({
+      key: scope,
+      label: `${t('charts-scope')} ${scope}`,
+      color: SCOPE_COLORS[scope],
+    }),
+  ),
+);
+
+const moduleDataByYear = computed<Record<number, Record<string, number>>>(
+  () => {
+    const map: Record<number, Record<string, number>> = {};
+    for (const entry of data.value?.years ?? []) {
+      map[entry.year] = entry.modules;
+    }
+    return map;
+  },
+);
+
+const scopeDataByYear = computed<Record<number, Record<string, number>>>(() => {
+  const map: Record<number, Record<string, number>> = {};
+  for (const entry of data.value?.years ?? []) {
+    map[entry.year] = entry.scopes;
+  }
+  return map;
+});
+
+// Total reflects the active selection: selected years × selected categories.
+const totalTonnes = computed(() =>
+  computeCompareYearsTotal(
+    data.value?.years ?? [],
+    selectedYears.value,
+    selectedCategories.value,
+  ),
+);
+
+const hasData = computed(() => (data.value?.years.length ?? 0) > 0);
+
+// Compact "YYYY–YYYY" (or single year) label for the KPI band.
+const yearRangeLabel = computed(() => {
+  const years = sortedSelectedYears.value;
+  if (years.length === 0) return '';
+  const first = years[0];
+  const last = years[years.length - 1];
+  return first === last ? String(first) : `${first}–${last}`;
+});
+
+function formatTonnes(value: number): string {
+  return nOrDash(value, {
+    options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+  });
+}
+
+// Latest reduction goal applied to the latest selected year's
+// selected-category total. Shared by the KPI band and the chart bar.
+const objective = computed<CompareYearsObjective | null>(() => {
+  const goals =
+    yearConfigStore.config?.config?.reduction_objectives?.goals ?? [];
+  return computeCompareYearsObjective(
+    data.value?.years ?? [],
+    selectedYears.value,
+    selectedCategories.value,
+    goals,
+  );
+});
+
+// KPI: how far the latest selected year sits above/below its objective.
+const objectiveGap = computed(() => {
+  const obj = objective.value;
+  if (!obj || obj.valueTonnes <= 0 || selectedYears.value.length === 0) {
+    return null;
+  }
+  const latestTonnes = computeCompareYearsTotal(
+    data.value?.years ?? [],
+    [Math.max(...selectedYears.value)],
+    selectedCategories.value,
+  );
+  return {
+    targetYear: obj.targetYear,
+    objectiveTonnes: obj.valueTonnes,
+    pct: (latestTonnes - obj.valueTonnes) / obj.valueTonnes,
+  };
+});
+
+const objectiveBar = computed<CompareYearsObjectiveBar | null>(() => {
+  if (!showObjective.value) return null;
+  const obj = objective.value;
+  if (!obj) return null;
+  return {
+    label: t('results_compare_years_objective_tick', {
+      year: obj.targetYear,
+    }),
+    value: obj.valueTonnes,
+    color: infoColorHex.value ?? '#1976d2',
+  };
+});
+</script>
+
+<template>
+  <q-dialog
+    :model-value="modelValue"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <q-card class="compare-years-dialog">
+      <q-card-section class="row items-center q-pb-none">
+        <div class="text-h4 text-weight-medium">
+          {{ $t('results_compare_years_title') }}
+        </div>
+        <q-space />
+        <q-btn v-close-popup flat round dense icon="o_close" color="grey-6" />
+      </q-card-section>
+
+      <q-separator class="q-mt-sm" />
+
+      <q-card-section v-if="loading" class="flex justify-center q-py-xl">
+        <q-spinner color="info" size="2rem" />
+      </q-card-section>
+
+      <q-card-section v-else-if="error" class="text-negative">
+        {{ error }}
+      </q-card-section>
+
+      <q-card-section v-else-if="!hasData" class="text-secondary">
+        {{ $t('results_compare_years_no_data') }}
+      </q-card-section>
+
+      <template v-else>
+        <q-card-section class="q-py-none">
+          <div class="compare-years-kpis">
+            <!-- Total for the active year × category selection -->
+            <div class="compare-years-kpi">
+              <div class="compare-years-kpi__label">
+                {{ $t('results_compare_years_total') }} · {{ yearRangeLabel }}
+              </div>
+              <div class="compare-years-kpi__value">
+                {{ formatTonnes(totalTonnes) }}
+                <span class="compare-years-kpi__unit">
+                  {{ $t('results_units_tonnes') }}
+                </span>
+              </div>
+            </div>
+
+            <q-separator
+              v-if="objectiveGap"
+              vertical
+              class="compare-years-kpi__divider"
+            />
+
+            <!-- Gap of the latest selected year to its reduction objective -->
+            <div v-if="objectiveGap" class="compare-years-kpi">
+              <div class="compare-years-kpi__label">
+                {{
+                  $t('results_compare_years_gap_label', {
+                    year: objectiveGap.targetYear,
+                  })
+                }}
+              </div>
+              <div class="compare-years-kpi__gap">
+                <span
+                  class="compare-years-kpi__delta"
+                  :class="objectiveGap.pct > 0 ? 'text-negative' : 'text-info'"
+                >
+                  {{ objectiveGap.pct > 0 ? '+' : ''
+                  }}{{
+                    $nOrDash(objectiveGap.pct * 100, {
+                      options: { maximumFractionDigits: 0 },
+                    })
+                  }}%
+                </span>
+                <span class="compare-years-kpi__sub">
+                  {{
+                    $t('results_compare_years_gap_target', {
+                      value: `${formatTonnes(objectiveGap.objectiveTonnes)} ${$t(
+                        'results_units_tonnes',
+                      )}`,
+                    })
+                  }}
+                </span>
+              </div>
+            </div>
+
+            <q-separator
+              v-if="objectiveGap"
+              vertical
+              class="compare-years-kpi__divider"
+            />
+
+            <q-space />
+
+            <!-- Global years filter -->
+            <q-select
+              v-model="selectedYears"
+              :options="yearOptions"
+              :label="$t('results_compare_years_filter_years')"
+              class="compare-years-kpi__years"
+              multiple
+              outlined
+              dense
+              options-dense
+            >
+              <template #selected>
+                {{ sortedSelectedYears.join(', ') }}
+              </template>
+              <template #option="{ itemProps, opt, selected, toggleOption }">
+                <q-item v-bind="itemProps">
+                  <q-item-section side>
+                    <q-checkbox
+                      :model-value="selected"
+                      size="sm"
+                      color="info"
+                      @update:model-value="toggleOption(opt)"
+                    />
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>{{ opt }}</q-item-label>
+                  </q-item-section>
+                </q-item>
+              </template>
+              <template #after-options>
+                <q-item v-ripple clickable @click="showObjective = !showObjective">
+                  <q-item-section side>
+                    <q-checkbox
+                      v-model="showObjective"
+                      size="sm"
+                      class="compare-years-category-checkbox"
+                      :style="{ color: 'var(--q-info)' }"
+                    />
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>
+                      {{ $t('results_compare_years_objective_option') }}
+                    </q-item-label>
+                  </q-item-section>
+                </q-item>
+              </template>
+            </q-select>
+          </div>
+        </q-card-section>
+
+        <q-separator />
+
+        <q-card-section>
+          <div class="row items-end justify-between q-col-gutter-md q-mb-sm">
+            <div class="col-12 col-sm">
+              <div class="text-body1 text-weight-medium">
+                {{ $t('results_compare_years_by_module') }}
+                <span class="text-caption text-secondary">
+                  ({{ $t('results_units_tonnes') }})
+                </span>
+              </div>
+            </div>
+            <div class="col-12 col-sm-3">
+              <q-select
+                v-model="selectedCategories"
+                :options="categoryOptions"
+                :label="$t('results_compare_years_filter_modules')"
+                multiple
+                emit-value
+                map-options
+                outlined
+                dense
+                options-dense
+              >
+                <template #selected>
+                  {{
+                    $t('results_compare_years_selected_count', {
+                      count: selectedCategories.length,
+                    })
+                  }}
+                </template>
+                <template #option="{ itemProps, opt, selected, toggleOption }">
+                  <q-item v-bind="itemProps">
+                    <q-item-section side>
+                      <q-checkbox
+                        :model-value="selected"
+                        size="sm"
+                        class="compare-years-category-checkbox"
+                        :style="{ color: categoryColor(opt.value) }"
+                        @update:model-value="toggleOption(opt)"
+                      />
+                    </q-item-section>
+                    <q-item-section>
+                      <q-item-label>{{ opt.label }}</q-item-label>
+                    </q-item-section>
+                  </q-item>
+                </template>
+                <template #after-options>
+                  <q-item
+                    v-ripple
+                    clickable
+                    @click="showObjective = !showObjective"
+                  >
+                    <q-item-section side>
+                      <q-checkbox
+                        v-model="showObjective"
+                        size="sm"
+                        class="compare-years-category-checkbox"
+                        :style="{ color: 'var(--q-info)' }"
+                      />
+                    </q-item-section>
+                    <q-item-section>
+                      <q-item-label>
+                        {{ $t('results_compare_years_total') }}
+                      </q-item-label>
+                    </q-item-section>
+                  </q-item>
+                </template>
+              </q-select>
+            </div>
+          </div>
+          <div class="compare-years-chart-box">
+            <CompareYearsChart
+              :years="sortedSelectedYears"
+              :series="moduleSeries"
+              :data-by-year="moduleDataByYear"
+              :objective="objectiveBar"
+            />
+          </div>
+        </q-card-section>
+
+        <q-separator />
+
+        <q-card-section>
+          <div class="row items-end justify-between q-col-gutter-md q-mb-sm">
+            <div class="col-12 col-sm">
+              <div class="text-body1 text-weight-medium">
+                {{ $t('results_compare_years_by_scope') }}
+                <span class="text-caption text-secondary">
+                  ({{ $t('results_units_tonnes') }})
+                </span>
+              </div>
+            </div>
+            <div class="col-12 col-sm-3">
+              <q-select
+                v-model="selectedScopes"
+                :options="scopeOptions"
+                :label="$t('results_compare_years_filter_scopes')"
+                multiple
+                emit-value
+                map-options
+                outlined
+                dense
+                options-dense
+              >
+                <template #selected>
+                  {{
+                    $t('results_compare_years_selected_count', {
+                      count: selectedScopes.length,
+                    })
+                  }}
+                </template>
+                <template #option="{ itemProps, opt, selected, toggleOption }">
+                  <q-item v-bind="itemProps">
+                    <q-item-section side>
+                      <q-checkbox
+                        :model-value="selected"
+                        size="sm"
+                        class="compare-years-category-checkbox"
+                        :style="{ color: SCOPE_COLORS[opt.value] }"
+                        @update:model-value="toggleOption(opt)"
+                      />
+                    </q-item-section>
+                    <q-item-section>
+                      <q-item-label>{{ opt.label }}</q-item-label>
+                    </q-item-section>
+                  </q-item>
+                </template>
+              </q-select>
+            </div>
+          </div>
+          <div class="compare-years-chart-box">
+            <CompareYearsChart
+              :years="sortedSelectedYears"
+              :series="scopeSeries"
+              :data-by-year="scopeDataByYear"
+            />
+          </div>
+        </q-card-section>
+      </template>
+    </q-card>
+  </q-dialog>
+</template>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.compare-years-dialog {
+  width: 100%;
+  max-width: tokens.$modal-width-lg;
+  max-height: 90vh;
+}
+
+/* Roomier outer margins around the dialog content. */
+.compare-years-dialog :deep(.q-card-section) {
+  padding-left: tokens.$spacing-xxl;
+  padding-right: tokens.$spacing-xxl;
+}
+
+/* Compact KPI band: total + objective gap on the left, years filter right. */
+.compare-years-kpis {
+  display: flex;
+  align-items: stretch;
+  gap: 40px;
+  flex-wrap: wrap;
+}
+
+/* Padding lives on the KPI items (not the band) so the vertical separators,
+   which are bare flex children, stretch the full height and touch top/bottom. */
+.compare-years-kpi {
+  padding: tokens.$spacing-lg 0;
+}
+
+.compare-years-kpi__label {
+  letter-spacing: 0.06em;
+  font-size: 11px;
+  color: var(--semantic-color-text-muted);
+  margin-bottom: tokens.$spacing-xs;
+}
+
+.compare-years-kpi__value {
+  font-size: 26px;
+  line-height: 1.1;
+  color: var(--semantic-color-text);
+}
+
+.compare-years-kpi__unit {
+  font-size: 13px;
+  font-weight: tokens.$text-weight-regular;
+  color: var(--semantic-color-text-muted);
+}
+
+.compare-years-kpi__gap {
+  display: flex;
+  align-items: baseline;
+  gap: tokens.$spacing-sm;
+}
+
+.compare-years-kpi__delta {
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.compare-years-kpi__sub {
+  font-size: 13px;
+  color: var(--semantic-color-text-muted);
+}
+
+.compare-years-kpi__divider {
+  height: auto;
+  align-self: stretch;
+}
+
+/* Years filter sits as a compact pill on the right of the KPI band. */
+.compare-years-kpi__years {
+  width: 180px;
+  max-width: 100%;
+  align-self: center;
+}
+
+/* Breathing room around each chart inside its section. */
+.compare-years-chart-box {
+  padding: tokens.$spacing-sm tokens.$spacing-sm 0;
+}
+
+/* Tint each category checkbox with its chart colour (set via inline `color`)
+   so the legend-less charts stay readable from the filter. */
+.compare-years-category-checkbox :deep(.q-checkbox__inner) {
+  color: inherit;
+}
+</style>

--- a/frontend/src/components/charts/results/CompareYearsDialog.vue
+++ b/frontend/src/components/charts/results/CompareYearsDialog.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch, type PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useModuleStore } from 'src/stores/modules';
-import type { CompareYearsResponse } from 'src/stores/modules';
+import type { MultiYearReportStatsResponse } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import {
@@ -64,7 +64,7 @@ const SCOPE_COLORS: Record<string, string> = {
   '3': '#C5CAE9',
 };
 
-const data = ref<CompareYearsResponse | null>(null);
+const data = ref<MultiYearReportStatsResponse | null>(null);
 const loading = ref(false);
 const error = ref<string | null>(null);
 
@@ -85,7 +85,7 @@ async function load() {
   try {
     const year = workspaceStore.selectedYear ?? new Date().getFullYear();
     const [res] = await Promise.all([
-      moduleStore.getMultiYearBreakdown(props.unitId),
+      moduleStore.getMultiYearReportStats(props.unitId),
       // Populate reduction_objectives.goals for the objective bar.
       yearConfigStore.fetchConfig(year),
     ]);

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -83,7 +83,13 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  enableCompareYears: {
+    type: Boolean,
+    default: false,
+  },
 });
+
+const emit = defineEmits<{ (e: 'compareYears'): void }>();
 
 const { t, locale } = useI18n();
 const isPrintMode = usePrintMode();
@@ -1549,13 +1555,24 @@ const downloadCSV = () => {
         </q-icon>
       </div>
 
-      <div v-if="!isPrintMode">
+      <div v-if="!isPrintMode" class="flex items-center q-gutter-sm">
         <q-checkbox
           v-if="props.viewAdditionalData === undefined"
           v-model="toggleAdditionalData"
           :label="$t('results_module_carbon_toggle_additional_data')"
           size="xs"
           color="accent"
+        />
+        <q-btn
+          v-if="props.enableCompareYears"
+          color="black"
+          icon="o_bar_chart"
+          :label="$t('results_compare_years')"
+          outline
+          no-caps
+          size="sm"
+          class="text-weight-medium"
+          @click="emit('compareYears')"
         />
       </div>
     </q-card-section>

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -55,6 +55,58 @@ export default {
     en: 'Compare years',
     fr: 'Comparer les années',
   },
+  results_compare_years_title: {
+    en: 'Compare years',
+    fr: 'Comparer les années',
+  },
+  results_compare_years_no_data: {
+    en: 'No emission data available to compare.',
+    fr: 'Aucune donnée d’émission disponible pour la comparaison.',
+  },
+  results_compare_years_filter_years: {
+    en: 'Years',
+    fr: 'Années',
+  },
+  results_compare_years_filter_modules: {
+    en: 'Categories',
+    fr: 'Catégories',
+  },
+  results_compare_years_filter_scopes: {
+    en: 'Scopes',
+    fr: 'Scopes',
+  },
+  results_compare_years_selected_count: {
+    en: '{count} selected',
+    fr: '{count} sélectionné(s)',
+  },
+  results_compare_years_total: {
+    en: 'Total',
+    fr: 'Total',
+  },
+  results_compare_years_objective_option: {
+    en: 'Objective',
+    fr: 'Objectif',
+  },
+  results_compare_years_gap_label: {
+    en: 'Gap to {year} objective',
+    fr: 'Écart à l’objectif {year}',
+  },
+  results_compare_years_gap_target: {
+    en: 'target {value}',
+    fr: 'cible {value}',
+  },
+  results_compare_years_by_module: {
+    en: 'Emissions by category',
+    fr: 'Émissions par catégorie',
+  },
+  results_compare_years_by_scope: {
+    en: 'Emissions by scope',
+    fr: 'Émissions par scope',
+  },
+  results_compare_years_objective_tick: {
+    en: 'objective ({year})',
+    fr: 'objectif ({year})',
+  },
   results_units_kg: {
     en: 'kg CO₂-eq',
     fr: 'kg CO₂-eq',

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -88,8 +88,12 @@ export default {
     fr: 'Objectif',
   },
   results_compare_years_gap_label: {
-    en: 'Gap to {year} objective',
-    fr: 'Écart à l’objectif {year}',
+    en: 'Missing to reach {year} target',
+    fr: 'Manque pour atteindre l’objectif {year}',
+  },
+  results_compare_years_gap_beaten_label: {
+    en: 'Below {year} target',
+    fr: 'Sous l’objectif {year}',
   },
   results_compare_years_gap_target: {
     en: 'target {value}',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -58,6 +58,10 @@ const CarbonFootPrintPerPersonChart = defineAsyncComponent({
   delay: 0,
 });
 
+const CompareYearsDialog = defineAsyncComponent(
+  () => import('src/components/charts/results/CompareYearsDialog.vue'),
+);
+
 const ModuleCharts = defineAsyncComponent({
   loader: () => import('src/components/organisms/module/ModuleCharts.vue'),
   loadingComponent: ChartChunkSkeleton,
@@ -336,7 +340,10 @@ function getModuleCarComparison(module: string): string | undefined {
 
 const viewUncertainties = ref(false);
 const viewAdditionalData = computed(() => !hideAdditionalData.value);
-const compareYears = ref(false);
+const compareYearsOpen = ref(false);
+const compareYearsUnitId = computed(
+  () => workspaceStore.selectedCarbonReport?.unit_id ?? null,
+);
 
 const additionalBreakdown = computed(
   () => moduleStore.state.emissionBreakdown?.additional_breakdown ?? [],
@@ -464,15 +471,6 @@ const getUncertainty = (
               class="text-weight-medium q-mb-md"
               @click="downloadPDF"
             />
-            <div class="flex column">
-              <q-checkbox
-                v-model="compareYears"
-                :label="$t('results_compare_years')"
-                color="info"
-                class="text-weight-medium"
-                size="xs"
-              />
-            </div>
           </div>
         </div>
       </q-card>
@@ -577,6 +575,8 @@ const getUncertainty = (
                 <ModuleCarbonFootprintChart
                   :breakdown-data="moduleStore.state.emissionBreakdown"
                   :view-additional-data="viewAdditionalData"
+                  enable-compare-years
+                  @compare-years="compareYearsOpen = true"
                 />
               </template>
               <q-skeleton
@@ -883,6 +883,11 @@ const getUncertainty = (
         </q-card>
       </div>
     </div>
+
+    <CompareYearsDialog
+      v-model="compareYearsOpen"
+      :unit-id="compareYearsUnitId"
+    />
   </q-page>
 </template>
 

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -100,7 +100,7 @@ export interface EmissionBreakdownResponse {
   module_states?: { module_type_id: number; status: number }[];
 }
 
-export interface CompareYearsEntry {
+export interface MultiYearReportStatsEntry {
   year: number;
   total_tonnes_co2eq: number;
   /** Category key (RESULTS_CATEGORY_ORDER) → tonnes CO2eq. */
@@ -109,8 +109,8 @@ export interface CompareYearsEntry {
   scopes: Record<string, number>;
 }
 
-export interface CompareYearsResponse {
-  years: CompareYearsEntry[];
+export interface MultiYearReportStatsResponse {
+  years: MultiYearReportStatsEntry[];
 }
 
 export interface ItBreakdownEmission {
@@ -1116,11 +1116,11 @@ export const useModuleStore = defineStore('modules', () => {
     }
   }
 
-  async function getMultiYearBreakdown(
+  async function getMultiYearReportStats(
     unitId: number,
-  ): Promise<CompareYearsResponse> {
-    const path = `modules-stats/unit/${encodeURIComponent(unitId)}/multi-year-breakdown`;
-    return api.get(path).json<CompareYearsResponse>();
+  ): Promise<MultiYearReportStatsResponse> {
+    const path = `modules-stats/unit/${encodeURIComponent(unitId)}/multi-year-report-stats`;
+    return api.get(path).json<MultiYearReportStatsResponse>();
   }
 
   // Track which carbon report the cached validated totals belong to
@@ -1213,7 +1213,7 @@ export const useModuleStore = defineStore('modules', () => {
     getValidatedTotals,
     invalidateValidatedTotals,
     getEmissionBreakdown,
-    getMultiYearBreakdown,
+    getMultiYearReportStats,
     invalidateEmissionBreakdown,
     setEmissionBreakdown,
     refreshEmissionBreakdownIfNeeded,

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -100,6 +100,19 @@ export interface EmissionBreakdownResponse {
   module_states?: { module_type_id: number; status: number }[];
 }
 
+export interface CompareYearsEntry {
+  year: number;
+  total_tonnes_co2eq: number;
+  /** Category key (RESULTS_CATEGORY_ORDER) → tonnes CO2eq. */
+  modules: Record<string, number>;
+  /** Scope number ("1" | "2" | "3") → tonnes CO2eq. */
+  scopes: Record<string, number>;
+}
+
+export interface CompareYearsResponse {
+  years: CompareYearsEntry[];
+}
+
 export interface ItBreakdownEmission {
   key: string;
   value: number;
@@ -1103,6 +1116,13 @@ export const useModuleStore = defineStore('modules', () => {
     }
   }
 
+  async function getMultiYearBreakdown(
+    unitId: number,
+  ): Promise<CompareYearsResponse> {
+    const path = `modules-stats/unit/${encodeURIComponent(unitId)}/multi-year-breakdown`;
+    return api.get(path).json<CompareYearsResponse>();
+  }
+
   // Track which carbon report the cached validated totals belong to
   const validatedTotalsCarbonReportId = ref<number | null>(null);
 
@@ -1193,6 +1213,7 @@ export const useModuleStore = defineStore('modules', () => {
     getValidatedTotals,
     invalidateValidatedTotals,
     getEmissionBreakdown,
+    getMultiYearBreakdown,
     invalidateEmissionBreakdown,
     setEmissionBreakdown,
     refreshEmissionBreakdownIfNeeded,

--- a/frontend/src/utils/compareYears.ts
+++ b/frontend/src/utils/compareYears.ts
@@ -22,6 +22,31 @@ export function presentCategories(
   return order.filter((key) => years.some((y) => (y.modules[key] ?? 0) > 0));
 }
 
+/** The per-year dimension a selection is summed over. */
+export type CompareYearsDimension = 'modules' | 'scopes';
+
+/**
+ * Sum tonnes CO2eq over selected years × selected keys for a given dimension
+ * (`modules` = category keys, `scopes` = "1" | "2" | "3").
+ */
+function sumSelected(
+  years: CompareYearsEntry[],
+  selectedYears: number[],
+  selectedKeys: string[],
+  dimension: CompareYearsDimension,
+): number {
+  const yearSet = new Set(selectedYears);
+  let total = 0;
+  for (const entry of years) {
+    if (!yearSet.has(entry.year)) continue;
+    const bucket = dimension === 'scopes' ? entry.scopes : entry.modules;
+    for (const key of selectedKeys) {
+      total += bucket[key] ?? 0;
+    }
+  }
+  return total;
+}
+
 /**
  * Total tonnes CO2eq for the active selection: selected years × selected
  * categories. Deselecting a category lowers the total, matching the stacked bar
@@ -32,46 +57,77 @@ export function computeCompareYearsTotal(
   selectedYears: number[],
   selectedCategories: string[],
 ): number {
-  const yearSet = new Set(selectedYears);
-  let total = 0;
-  for (const entry of years) {
-    if (!yearSet.has(entry.year)) continue;
-    for (const key of selectedCategories) {
-      total += entry.modules[key] ?? 0;
-    }
-  }
-  return total;
+  return sumSelected(years, selectedYears, selectedCategories, 'modules');
 }
 
 export interface CompareYearsObjective {
   targetYear: number;
+  /** Closest available unit year used as the reduction baseline. */
+  referenceYear: number;
   valueTonnes: number;
 }
 
 /**
- * The "objective" bar appended to the by-module chart: the latest reduction
- * goal (last entry in `goals`) applied to the latest selected year's
- * selected-category total — i.e. `baseline × (1 − reduction_percentage)`.
- * Returns `null` when there is no goal, no selected year, or a zero baseline,
- * so the caller simply omits the bar.
+ * The unit's baseline year for a goal: among breakdown years whose selected-key
+ * total (in the given dimension) is positive, the one closest to the goal's
+ * institution `referenceYear`. Ties resolve to the earlier year. Returns `null`
+ * when no year carries a positive baseline for the selection.
  */
-export function computeCompareYearsObjective(
+export function closestAvailableYear(
   years: CompareYearsEntry[],
-  selectedYears: number[],
-  selectedCategories: string[],
+  referenceYear: number,
+  selectedKeys: string[],
+  dimension: CompareYearsDimension = 'modules',
+): number | null {
+  let best: number | null = null;
+  let bestDist = Infinity;
+  for (const entry of years) {
+    if (sumSelected(years, [entry.year], selectedKeys, dimension) <= 0)
+      continue;
+    const dist = Math.abs(entry.year - referenceYear);
+    // Strictly-less keeps the earliest year on ties (years may arrive unsorted).
+    if (
+      dist < bestDist ||
+      (dist === bestDist && best != null && entry.year < best)
+    ) {
+      best = entry.year;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
+/**
+ * One objective bar per reduction goal, sorted ascending by target year. For
+ * each goal the target is the unit's baseline at the year closest to that
+ * goal's institution `reference_year`, reduced by its percentage —
+ * `baseline × (1 − reduction_percentage)`. The baseline is selection-aware
+ * (restricted to `selectedKeys` in the given dimension), so the bars stay
+ * comparable to the visible stacked bars. Goals with no positive baseline year
+ * are skipped.
+ */
+export function computeCompareYearsObjectives(
+  years: CompareYearsEntry[],
+  selectedKeys: string[],
   goals: ReductionObjectiveGoal[],
-): CompareYearsObjective | null {
-  const goal = goals.at(-1);
-  if (!goal || selectedYears.length === 0) return null;
-  const latestYear = Math.max(...selectedYears);
-  const baseline = computeCompareYearsTotal(
-    years,
-    [latestYear],
-    selectedCategories,
-  );
-  if (baseline <= 0) return null;
-  return {
-    targetYear: goal.target_year,
-    valueTonnes: baseline * (1 - goal.reduction_percentage),
-  };
+  dimension: CompareYearsDimension = 'modules',
+): CompareYearsObjective[] {
+  const objectives: CompareYearsObjective[] = [];
+  for (const goal of goals) {
+    const refYear = closestAvailableYear(
+      years,
+      goal.reference_year,
+      selectedKeys,
+      dimension,
+    );
+    if (refYear == null) continue;
+    const baseline = sumSelected(years, [refYear], selectedKeys, dimension);
+    if (baseline <= 0) continue;
+    objectives.push({
+      targetYear: goal.target_year,
+      referenceYear: refYear,
+      valueTonnes: baseline * (1 - goal.reduction_percentage),
+    });
+  }
+  return objectives.sort((a, b) => a.targetYear - b.targetYear);
 }

--- a/frontend/src/utils/compareYears.ts
+++ b/frontend/src/utils/compareYears.ts
@@ -1,0 +1,77 @@
+import type { CompareYearsEntry } from 'src/stores/modules';
+import type { ReductionObjectiveGoal } from 'src/stores/yearConfig';
+
+/**
+ * Pure helpers for the "Compare Years" dialog. Kept out of the component so the
+ * selection/total logic is unit-testable without mounting Vue.
+ */
+
+/** Years that carry any emissions — the default year selection. */
+export function defaultSelectedYears(years: CompareYearsEntry[]): number[] {
+  return years.filter((y) => y.total_tonnes_co2eq > 0).map((y) => y.year);
+}
+
+/**
+ * Category keys (in the supplied order) that appear with a positive value in at
+ * least one year — the default category selection / available options.
+ */
+export function presentCategories(
+  years: CompareYearsEntry[],
+  order: readonly string[],
+): string[] {
+  return order.filter((key) => years.some((y) => (y.modules[key] ?? 0) > 0));
+}
+
+/**
+ * Total tonnes CO2eq for the active selection: selected years × selected
+ * categories. Deselecting a category lowers the total, matching the stacked bar
+ * chart it drives.
+ */
+export function computeCompareYearsTotal(
+  years: CompareYearsEntry[],
+  selectedYears: number[],
+  selectedCategories: string[],
+): number {
+  const yearSet = new Set(selectedYears);
+  let total = 0;
+  for (const entry of years) {
+    if (!yearSet.has(entry.year)) continue;
+    for (const key of selectedCategories) {
+      total += entry.modules[key] ?? 0;
+    }
+  }
+  return total;
+}
+
+export interface CompareYearsObjective {
+  targetYear: number;
+  valueTonnes: number;
+}
+
+/**
+ * The "objective" bar appended to the by-module chart: the latest reduction
+ * goal (last entry in `goals`) applied to the latest selected year's
+ * selected-category total — i.e. `baseline × (1 − reduction_percentage)`.
+ * Returns `null` when there is no goal, no selected year, or a zero baseline,
+ * so the caller simply omits the bar.
+ */
+export function computeCompareYearsObjective(
+  years: CompareYearsEntry[],
+  selectedYears: number[],
+  selectedCategories: string[],
+  goals: ReductionObjectiveGoal[],
+): CompareYearsObjective | null {
+  const goal = goals.at(-1);
+  if (!goal || selectedYears.length === 0) return null;
+  const latestYear = Math.max(...selectedYears);
+  const baseline = computeCompareYearsTotal(
+    years,
+    [latestYear],
+    selectedCategories,
+  );
+  if (baseline <= 0) return null;
+  return {
+    targetYear: goal.target_year,
+    valueTonnes: baseline * (1 - goal.reduction_percentage),
+  };
+}

--- a/frontend/src/utils/compareYears.ts
+++ b/frontend/src/utils/compareYears.ts
@@ -1,4 +1,4 @@
-import type { CompareYearsEntry } from 'src/stores/modules';
+import type { MultiYearReportStatsEntry } from 'src/stores/modules';
 import type { ReductionObjectiveGoal } from 'src/stores/yearConfig';
 
 /**
@@ -7,7 +7,9 @@ import type { ReductionObjectiveGoal } from 'src/stores/yearConfig';
  */
 
 /** Years that carry any emissions — the default year selection. */
-export function defaultSelectedYears(years: CompareYearsEntry[]): number[] {
+export function defaultSelectedYears(
+  years: MultiYearReportStatsEntry[],
+): number[] {
   return years.filter((y) => y.total_tonnes_co2eq > 0).map((y) => y.year);
 }
 
@@ -16,7 +18,7 @@ export function defaultSelectedYears(years: CompareYearsEntry[]): number[] {
  * least one year — the default category selection / available options.
  */
 export function presentCategories(
-  years: CompareYearsEntry[],
+  years: MultiYearReportStatsEntry[],
   order: readonly string[],
 ): string[] {
   return order.filter((key) => years.some((y) => (y.modules[key] ?? 0) > 0));
@@ -30,7 +32,7 @@ export type CompareYearsDimension = 'modules' | 'scopes';
  * (`modules` = category keys, `scopes` = "1" | "2" | "3").
  */
 function sumSelected(
-  years: CompareYearsEntry[],
+  years: MultiYearReportStatsEntry[],
   selectedYears: number[],
   selectedKeys: string[],
   dimension: CompareYearsDimension,
@@ -53,7 +55,7 @@ function sumSelected(
  * chart it drives.
  */
 export function computeCompareYearsTotal(
-  years: CompareYearsEntry[],
+  years: MultiYearReportStatsEntry[],
   selectedYears: number[],
   selectedCategories: string[],
 ): number {
@@ -74,7 +76,7 @@ export interface CompareYearsObjective {
  * when no year carries a positive baseline for the selection.
  */
 export function closestAvailableYear(
-  years: CompareYearsEntry[],
+  years: MultiYearReportStatsEntry[],
   referenceYear: number,
   selectedKeys: string[],
   dimension: CompareYearsDimension = 'modules',
@@ -107,7 +109,7 @@ export function closestAvailableYear(
  * are skipped.
  */
 export function computeCompareYearsObjectives(
-  years: CompareYearsEntry[],
+  years: MultiYearReportStatsEntry[],
   selectedKeys: string[],
   goals: ReductionObjectiveGoal[],
   dimension: CompareYearsDimension = 'modules',

--- a/frontend/tests/unit/compare-years.spec.ts
+++ b/frontend/tests/unit/compare-years.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the "Compare Years" selection/total helpers (issue #834).
+ *
+ * Pins the pure logic behind the Compare Years dialog: the default year and
+ * category selection (only dimensions that carry emissions) and the headline
+ * total, which reflects selected years × selected categories so that
+ * deselecting a category lowers the displayed total in step with the chart.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import type { CompareYearsEntry } from '../../src/stores/modules';
+import type { ReductionObjectiveGoal } from '../../src/stores/yearConfig';
+import {
+  defaultSelectedYears,
+  presentCategories,
+  computeCompareYearsTotal,
+  computeCompareYearsObjective,
+} from '../../src/utils/compareYears';
+
+const ORDER = ['equipment', 'professional_travel', 'commuting'] as const;
+
+const YEARS: CompareYearsEntry[] = [
+  {
+    year: 2022,
+    total_tonnes_co2eq: 0,
+    modules: {},
+    scopes: {},
+  },
+  {
+    year: 2023,
+    total_tonnes_co2eq: 30,
+    modules: { equipment: 20, professional_travel: 10 },
+    scopes: { '2': 20, '3': 10 },
+  },
+  {
+    year: 2024,
+    total_tonnes_co2eq: 16,
+    modules: { equipment: 12, commuting: 4 },
+    scopes: { '2': 12, '3': 4 },
+  },
+];
+
+test('default year selection skips years with no emissions', () => {
+  expect(defaultSelectedYears(YEARS)).toEqual([2023, 2024]);
+});
+
+test('present categories follow the given order and drop absent ones', () => {
+  // "professional_travel" appears only in 2023, "commuting" only in 2024.
+  expect(presentCategories(YEARS, ORDER)).toEqual([
+    'equipment',
+    'professional_travel',
+    'commuting',
+  ]);
+  // A category never present is excluded.
+  expect(presentCategories(YEARS, [...ORDER, 'food'])).not.toContain('food');
+});
+
+test('total sums selected years × selected categories', () => {
+  // All selected: 20 + 10 + 12 + 4 = 46.
+  expect(
+    computeCompareYearsTotal(YEARS, [2023, 2024], [...ORDER]),
+  ).toBeCloseTo(46);
+
+  // Deselect "equipment": 10 (2023 travel) + 4 (2024 commuting) = 14.
+  expect(
+    computeCompareYearsTotal(YEARS, [2023, 2024], [
+      'professional_travel',
+      'commuting',
+    ]),
+  ).toBeCloseTo(14);
+
+  // Deselect a year: only 2023 equipment + travel = 30.
+  expect(
+    computeCompareYearsTotal(YEARS, [2023], [...ORDER]),
+  ).toBeCloseTo(30);
+
+  // Empty selection → 0.
+  expect(computeCompareYearsTotal(YEARS, [], [...ORDER])).toBe(0);
+  expect(computeCompareYearsTotal(YEARS, [2023, 2024], [])).toBe(0);
+});
+
+const GOALS: ReductionObjectiveGoal[] = [
+  { target_year: 2030, reduction_percentage: 0.3, reference_year: 2023 },
+  { target_year: 2040, reduction_percentage: 0.5, reference_year: 2023 },
+];
+
+test('objective bar uses the last goal on the latest selected year', () => {
+  // Latest selected year = 2024, all categories: total 16; last goal 50% → 8.
+  const objective = computeCompareYearsObjective(
+    YEARS,
+    [2023, 2024],
+    [...ORDER],
+    GOALS,
+  );
+  expect(objective).toEqual({ targetYear: 2040, valueTonnes: 8 });
+});
+
+test('objective baseline tracks selected categories', () => {
+  // Latest selected year 2024 with only "equipment" (12) → 12 × 0.5 = 6.
+  const objective = computeCompareYearsObjective(
+    YEARS,
+    [2023, 2024],
+    ['equipment'],
+    GOALS,
+  );
+  expect(objective?.valueTonnes).toBeCloseTo(6);
+});
+
+test('objective is null without a goal, year, or baseline', () => {
+  expect(
+    computeCompareYearsObjective(YEARS, [2023, 2024], [...ORDER], []),
+  ).toBeNull();
+  expect(
+    computeCompareYearsObjective(YEARS, [], [...ORDER], GOALS),
+  ).toBeNull();
+  // 2022 has no emissions → zero baseline → no bar.
+  expect(
+    computeCompareYearsObjective(YEARS, [2022], [...ORDER], GOALS),
+  ).toBeNull();
+});

--- a/frontend/tests/unit/compare-years.spec.ts
+++ b/frontend/tests/unit/compare-years.spec.ts
@@ -15,7 +15,8 @@ import {
   defaultSelectedYears,
   presentCategories,
   computeCompareYearsTotal,
-  computeCompareYearsObjective,
+  computeCompareYearsObjectives,
+  closestAvailableYear,
 } from '../../src/utils/compareYears';
 
 const ORDER = ['equipment', 'professional_travel', 'commuting'] as const;
@@ -58,22 +59,21 @@ test('present categories follow the given order and drop absent ones', () => {
 
 test('total sums selected years × selected categories', () => {
   // All selected: 20 + 10 + 12 + 4 = 46.
-  expect(
-    computeCompareYearsTotal(YEARS, [2023, 2024], [...ORDER]),
-  ).toBeCloseTo(46);
+  expect(computeCompareYearsTotal(YEARS, [2023, 2024], [...ORDER])).toBeCloseTo(
+    46,
+  );
 
   // Deselect "equipment": 10 (2023 travel) + 4 (2024 commuting) = 14.
   expect(
-    computeCompareYearsTotal(YEARS, [2023, 2024], [
-      'professional_travel',
-      'commuting',
-    ]),
+    computeCompareYearsTotal(
+      YEARS,
+      [2023, 2024],
+      ['professional_travel', 'commuting'],
+    ),
   ).toBeCloseTo(14);
 
   // Deselect a year: only 2023 equipment + travel = 30.
-  expect(
-    computeCompareYearsTotal(YEARS, [2023], [...ORDER]),
-  ).toBeCloseTo(30);
+  expect(computeCompareYearsTotal(YEARS, [2023], [...ORDER])).toBeCloseTo(30);
 
   // Empty selection → 0.
   expect(computeCompareYearsTotal(YEARS, [], [...ORDER])).toBe(0);
@@ -85,37 +85,54 @@ const GOALS: ReductionObjectiveGoal[] = [
   { target_year: 2040, reduction_percentage: 0.5, reference_year: 2023 },
 ];
 
-test('objective bar uses the last goal on the latest selected year', () => {
-  // Latest selected year = 2024, all categories: total 16; last goal 50% → 8.
-  const objective = computeCompareYearsObjective(
-    YEARS,
-    [2023, 2024],
-    [...ORDER],
-    GOALS,
-  );
-  expect(objective).toEqual({ targetYear: 2040, valueTonnes: 8 });
+test('closest available year picks the nearest year with a positive baseline', () => {
+  // reference 2023 → 2023 itself (distance 0).
+  expect(closestAvailableYear(YEARS, 2023, [...ORDER])).toBe(2023);
+  // reference far in the future → 2024 (closest with data). 2022 has none.
+  expect(closestAvailableYear(YEARS, 2030, [...ORDER])).toBe(2024);
+  // Only "commuting" has data in 2024 → that's the only positive year.
+  expect(closestAvailableYear(YEARS, 2023, ['commuting'])).toBe(2024);
+  // No category with data → null.
+  expect(closestAvailableYear(YEARS, 2023, ['food'])).toBeNull();
 });
 
-test('objective baseline tracks selected categories', () => {
-  // Latest selected year 2024 with only "equipment" (12) → 12 × 0.5 = 6.
-  const objective = computeCompareYearsObjective(
-    YEARS,
-    [2023, 2024],
-    ['equipment'],
-    GOALS,
-  );
-  expect(objective?.valueTonnes).toBeCloseTo(6);
+test('closest available year resolves ties to the earlier year', () => {
+  // reference 2023.5 is equidistant from 2023 and 2024 → earlier (2023).
+  expect(closestAvailableYear(YEARS, 2023.5, [...ORDER])).toBe(2023);
 });
 
-test('objective is null without a goal, year, or baseline', () => {
-  expect(
-    computeCompareYearsObjective(YEARS, [2023, 2024], [...ORDER], []),
-  ).toBeNull();
-  expect(
-    computeCompareYearsObjective(YEARS, [], [...ORDER], GOALS),
-  ).toBeNull();
-  // 2022 has no emissions → zero baseline → no bar.
-  expect(
-    computeCompareYearsObjective(YEARS, [2022], [...ORDER], GOALS),
-  ).toBeNull();
+test('one objective per goal, sorted by target year, baselined on closest year', () => {
+  // Both goals reference 2023 (total 30). 2030 → 30×0.7 = 21; 2040 → 30×0.5 = 15.
+  const objectives = computeCompareYearsObjectives(YEARS, [...ORDER], GOALS);
+  expect(objectives).toEqual([
+    { targetYear: 2030, referenceYear: 2023, valueTonnes: 21 },
+    { targetYear: 2040, referenceYear: 2023, valueTonnes: 15 },
+  ]);
+});
+
+test('objective baseline tracks the selected categories', () => {
+  // Only "equipment" selected → 2023 baseline 20; last goal 50% → 10.
+  const objectives = computeCompareYearsObjectives(YEARS, ['equipment'], GOALS);
+  expect(objectives.at(-1)?.valueTonnes).toBeCloseTo(10);
+});
+
+test('objectives can be computed over the scope dimension', () => {
+  // Scope "2" in 2023 is 20; last goal 50% → 10.
+  const objectives = computeCompareYearsObjectives(
+    YEARS,
+    ['2'],
+    GOALS,
+    'scopes',
+  );
+  expect(objectives.at(-1)).toEqual({
+    targetYear: 2040,
+    referenceYear: 2023,
+    valueTonnes: 10,
+  });
+});
+
+test('objectives is empty without goals or without any positive baseline year', () => {
+  expect(computeCompareYearsObjectives(YEARS, [...ORDER], [])).toEqual([]);
+  // No category with data anywhere → every goal skipped.
+  expect(computeCompareYearsObjectives(YEARS, ['food'], GOALS)).toEqual([]);
 });

--- a/frontend/tests/unit/compare-years.spec.ts
+++ b/frontend/tests/unit/compare-years.spec.ts
@@ -9,7 +9,7 @@
 
 import { test, expect } from '@playwright/test';
 
-import type { CompareYearsEntry } from '../../src/stores/modules';
+import type { MultiYearReportStatsEntry } from '../../src/stores/modules';
 import type { ReductionObjectiveGoal } from '../../src/stores/yearConfig';
 import {
   defaultSelectedYears,
@@ -21,7 +21,7 @@ import {
 
 const ORDER = ['equipment', 'professional_travel', 'commuting'] as const;
 
-const YEARS: CompareYearsEntry[] = [
+const YEARS: MultiYearReportStatsEntry[] = [
   {
     year: 2022,
     total_tonnes_co2eq: 0,


### PR DESCRIPTION
## What does this change?
Adds a "Compare Years" feature to the Results page: a new backend endpoint aggregating per-year emission totals by category and scope for a unit, and a frontend dialog with stacked bar charts and filters.

**Backend:**
- `carbon_report_module_stats.py`: new `GET /modules-stats/unit/{unit_id}/multi-year-breakdown` endpoint (declared before the dynamic `/{carbon_report_id}/...` routes to avoid route-matching collisions), gated by `require_unit_access`; returns per-year category and scope totals in tonnes
- `data_entry_emission_repo.py`: refactors the shared per-unit leaf-emission aggregation into `_build_unit_emission_query` (used by both the existing validated-totals query and the new breakdown query); adds `get_emission_breakdown_by_unit`, which sums leaf `kg_co2eq` grouped by `(year, emission_type_id)` across all of a unit's carbon reports, mirroring the non-validated single-year chart data
- `data_entry_emission_service.py`: adds `get_year_comparison_by_unit`, which buckets the repo rows by year and delegates to a new `build_year_comparison` utility
- `emission_category.py`: adds `build_year_comparison(rows)` — aggregates one year's leaf emission rows into `modules` (snake_case category key → tonnes) and `scopes` (scope number → tonnes) buckets, ignoring unknown/non-positive/scope-less/category-less entries
- New unit tests in `test_emission_category.py`: verify category/scope bucketing and totals, and that unknown/non-positive rows are ignored

**Frontend:**
- `CompareYearsChart.vue` (new): a stacked bar chart component (years on the x-axis, optional trailing "objective" bar) with a teleported tooltip matching the existing result charts' look
- `CompareYearsDialog.vue` (new): the main dialog — fetches multi-year breakdown data and the year's reduction objective config; KPI band (total for the active selection, gap to the latest reduction objective); year/category/scope multi-select filters; two `CompareYearsChart` instances (by category, by scope); an "Objective" toggle that appends a target bar computed from the latest reduction goal
- `ModuleCarbonFootprintChart.vue`: adds `enableCompareYears` prop and a `compareYears` emit; renders a "Compare years" button in the header next to the additional-data checkbox
- `ResultsPage.vue`: removes the old non-functional `compareYears` checkbox; wires the new button to open `CompareYearsDialog`, lazy-loaded via `defineAsyncComponent`
- `modules.ts` (store): adds `CompareYearsEntry`/`CompareYearsResponse` types and `getMultiYearBreakdown(unitId)` calling the new endpoint
- `utils/compareYears.ts` (new): pure helper functions — `defaultSelectedYears` (years with emissions), `presentCategories` (categories appearing in any year), `computeCompareYearsTotal` (sum for the active year×category selection), `computeCompareYearsObjective` (applies the latest reduction goal to the latest selected year's baseline)
- `results.ts`: adds `results_compare_years_*` i18n keys (title, filters, KPI labels, chart section titles)
- New unit test `compare-years.spec.ts`: covers default selection, category presence, total computation across selection changes, and objective bar computation including null cases

## Why is this needed?
Users had no way to compare emissions across multiple assessment years on the Results page — the existing "Compare years" checkbox was a UI stub with no backing data or chart. This adds the full feature: a backend aggregation endpoint and an interactive dialog with category/scope breakdowns and a reduction-objective reference bar.

## Type of change
- [x] ✨ New feature