### PR TITLE
feat: separate emissions and cabin class fields

### DIFF
--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -110,82 +110,78 @@ const commonTravelFields: ModuleField[] = [
     readOnly: true,
     disable: true,
   },
-  {
-    id: 'kg_co2eq',
-    labelKey: `${MODULES.ProfessionalTravel}-field-emissions`,
-    type: 'number',
-    unit: 'kg CO₂-eq',
-    sortable: true,
-    ratio: '1/1',
-    editableInline: false,
-    readOnly: true,
-    hideIn: {
-      form: true,
-    },
-  },
 ];
 
-const planeFields: ModuleField[] = [
-  ...buildTravelFields(
-    { id: 'origin_name', labelKey: `${MODULES.ProfessionalTravel}-field-from` },
-    {
-      id: 'destination_name',
-      labelKey: `${MODULES.ProfessionalTravel}-field-to`,
-    },
-  ),
-  {
-    id: 'cabin_class',
-    labelKey: `${MODULES.ProfessionalTravel}-field-class`,
-    type: 'select',
-    required: true,
-    sortable: true,
-    ratio: '1/1',
-    editableInline: false,
-    hideIn: {
-      table: true,
-    },
-    options: [
-      { value: 'first', label: 'First' },
-      { value: 'business', label: 'Business' },
-      { value: 'economy', label: 'Economy' },
-    ],
+// Emissions column, kept separate so the class column can be placed just before it.
+const emissionsField: ModuleField = {
+  id: 'kg_co2eq',
+  labelKey: `${MODULES.ProfessionalTravel}-field-emissions`,
+  type: 'number',
+  unit: 'kg CO₂-eq',
+  sortable: true,
+  ratio: '1/1',
+  editableInline: false,
+  readOnly: true,
+  hideIn: {
+    form: true,
   },
-];
+};
+
+const planeCabinClassField: ModuleField = {
+  id: 'cabin_class',
+  labelKey: `${MODULES.ProfessionalTravel}-field-class`,
+  type: 'select',
+  required: true,
+  sortable: true,
+  ratio: '1/1',
+  editableInline: true,
+  options: [
+    { value: 'first', label: 'First' },
+    { value: 'business', label: 'Business' },
+    { value: 'economy', label: 'Economy' },
+  ],
+};
+
+const planeFields: ModuleField[] = buildTravelFields(
+  { id: 'origin_name', labelKey: `${MODULES.ProfessionalTravel}-field-from` },
+  {
+    id: 'destination_name',
+    labelKey: `${MODULES.ProfessionalTravel}-field-to`,
+  },
+  planeCabinClassField,
+);
 
 const trainLocationTooltip = `${MODULES.ProfessionalTravel}-train-location-local-language-tooltip`;
 
-const trainFields: ModuleField[] = [
-  ...buildTravelFields(
-    {
-      id: 'origin_name',
-      labelKey: `${MODULES.ProfessionalTravel}-field-from`,
-      tooltip: trainLocationTooltip,
-    },
-    {
-      id: 'destination_name',
-      labelKey: `${MODULES.ProfessionalTravel}-field-to`,
-      tooltip: trainLocationTooltip,
-    },
-    { directionInputTooltip: trainLocationTooltip },
-  ),
+const trainCabinClassField: ModuleField = {
+  id: 'cabin_class',
+  labelKey: `${MODULES.ProfessionalTravel}-field-class`,
+  type: 'select',
+  required: true,
+  sortable: true,
+  ratio: '1/1',
+  editableInline: true,
+  optionLabelsAreKeys: true,
+  options: [
+    { value: 'first', label: 'class_1' },
+    { value: 'second', label: 'class_2' },
+  ],
+};
+
+const trainFields: ModuleField[] = buildTravelFields(
   {
-    id: 'cabin_class',
-    labelKey: `${MODULES.ProfessionalTravel}-field-class`,
-    type: 'select',
-    required: true,
-    sortable: true,
-    ratio: '1/1',
-    editableInline: false,
-    hideIn: {
-      table: true,
-    },
-    optionLabelsAreKeys: true,
-    options: [
-      { value: 'first', label: 'class_1' },
-      { value: 'second', label: 'class_2' },
-    ],
+    id: 'origin_name',
+    labelKey: `${MODULES.ProfessionalTravel}-field-from`,
+    tooltip: trainLocationTooltip,
   },
-];
+  {
+    id: 'destination_name',
+    labelKey: `${MODULES.ProfessionalTravel}-field-to`,
+    tooltip: trainLocationTooltip,
+  },
+  trainCabinClassField,
+  { directionInputTooltip: trainLocationTooltip },
+);
 
 export const professionalTravel: ModuleConfig = {
   id: 'module_travel_001',
@@ -269,6 +265,7 @@ function buildTravelFields(
     labelKey: string;
     tooltip?: string;
   },
+  classField: ModuleField,
   options?: { directionInputTooltip?: string },
 ): ModuleField[] {
   return [
@@ -309,5 +306,7 @@ function buildTravelFields(
       tooltip: destination.tooltip,
     },
     ...commonTravelFields.slice(3),
+    classField,
+    emissionsField,
   ];
 }


### PR DESCRIPTION
## What does this change?
Reworks the professional travel module config so the cabin class (`cabin_class`) column is now shown in the table view, positioned just before the emissions column. Previously, `cabin_class` was hidden from the table (`hideIn: { table: true }`) and `editableInline: false`; now it's inline-editable and visible in the table for both plane and train travel. The `emissionsField` was extracted from `commonTravelFields` into its own constant and is now appended after the class field via a shared `buildTravelFields` helper, which now takes a `classField` parameter.

## Why is this needed?
To surface the travel class (first/business/economy for planes, first/second for trains) directly in the travel table alongside emissions, instead of only in the form — likely so users can see and edit the class inline without opening the record.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1595

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.