### PR TITLE
feat/1456 backoffice turn off download csv template

### DIFF
--- a/backend/app/schemas/year_configuration.py
+++ b/backend/app/schemas/year_configuration.py
@@ -355,6 +355,12 @@ class SubmoduleConfig(BaseModel):
         default=False,
         description="When True, the data-entry input form is hidden for end-users",
     )
+    csv_deactivated: bool = Field(
+        default=False,
+        description=(
+            "When True, CSV upload & template download are hidden for end-users"
+        ),
+    )
     latest_data_job: Optional[SyncJobSummary] = Field(
         default=None,
         description="Latest data entries sync job (read-only, injected by API)",

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -191,29 +191,30 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         <div class="text-caption text-secondary q-mb-sm">
           {{ $t('data_management_submodule_inputs_deactivation_description') }}
         </div>
-        <q-checkbox
-          :model-value="
-            submodule.forceInputsDeactivated ||
-            isSubmoduleInputsDeactivated(submodule)
-          "
-          color="accent"
-          :disable="!!submodule.forceInputsDeactivated"
-          :label="$t('data_management_submodule_inputs_deactivation_label')"
-          @update:model-value="
-            (val: boolean) =>
-              !submodule.forceInputsDeactivated &&
-              updateSubmoduleInputsDeactivated(submodule, val)
-          "
-        />
-        <q-checkbox
-          :model-value="isSubmoduleCsvDeactivated(submodule)"
-          color="accent"
-          class="block q-mt-xs"
-          :label="$t('data_management_submodule_csv_deactivation_label')"
-          @update:model-value="
-            (val: boolean) => updateSubmoduleCsvDeactivated(submodule, val)
-          "
-        />
+        <div class="row items-center q-col-gutter-md">
+          <q-checkbox
+            :model-value="
+              submodule.forceInputsDeactivated ||
+              isSubmoduleInputsDeactivated(submodule)
+            "
+            color="accent"
+            :disable="!!submodule.forceInputsDeactivated"
+            :label="$t('data_management_submodule_inputs_deactivation_label')"
+            @update:model-value="
+              (val: boolean) =>
+                !submodule.forceInputsDeactivated &&
+                updateSubmoduleInputsDeactivated(submodule, val)
+            "
+          />
+          <q-checkbox
+            :model-value="isSubmoduleCsvDeactivated(submodule)"
+            color="accent"
+            :label="$t('data_management_submodule_csv_deactivation_label')"
+            @update:model-value="
+              (val: boolean) => updateSubmoduleCsvDeactivated(submodule, val)
+            "
+          />
+        </div>
       </q-card>
       <template v-if="!submodule.noThreshold">
         <q-separator class="q-my-xs" />

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -27,11 +27,13 @@ const {
   isSubmoduleEnabled,
   isSubmoduleIncomplete,
   isSubmoduleInputsDeactivated,
+  isSubmoduleCsvDeactivated,
   getImportRow,
   submoduleShowsImportRow,
   downloadLastCsv,
   updateSubmoduleEnabled,
   updateSubmoduleInputsDeactivated,
+  updateSubmoduleCsvDeactivated,
   getSubmoduleThreshold,
   updateSubmoduleThreshold,
   computedFactorRunning,
@@ -201,6 +203,15 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
             (val: boolean) =>
               !submodule.forceInputsDeactivated &&
               updateSubmoduleInputsDeactivated(submodule, val)
+          "
+        />
+        <q-checkbox
+          :model-value="isSubmoduleCsvDeactivated(submodule)"
+          color="accent"
+          class="block q-mt-xs"
+          :label="$t('data_management_submodule_csv_deactivation_label')"
+          @update:model-value="
+            (val: boolean) => updateSubmoduleCsvDeactivated(submodule, val)
           "
         />
       </q-card>

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -1,7 +1,12 @@
 <template>
   <div v-if="hasTopBar" class="q-mb-md flex justify-between items-center wrap">
     <div
-      v-if="hasModuleUpload && !isInputDeactivated && canUseCsvTools"
+      v-if="
+        hasModuleUpload &&
+        !isInputDeactivated &&
+        canUseCsvTools &&
+        !isCsvDeactivated
+      "
       class="q-gutter-sm"
     >
       <q-btn
@@ -727,6 +732,13 @@ const isInputDeactivated = computed(() => {
   if (!unifiedConfig) return false;
   const subConfig = unifiedConfig.submodules[props.submoduleType as string];
   return subConfig?.inputs_deactivated ?? false;
+});
+
+const isCsvDeactivated = computed(() => {
+  const unifiedConfig = yearConfigStore.getModule(props.moduleType as Module);
+  if (!unifiedConfig) return false;
+  const subConfig = unifiedConfig.submodules[props.submoduleType as string];
+  return subConfig?.csv_deactivated ?? false;
 });
 
 const moduleColors = computed(() =>

--- a/frontend/src/composables/useSubmoduleConfig.ts
+++ b/frontend/src/composables/useSubmoduleConfig.ts
@@ -21,6 +21,7 @@ export function useSubmoduleConfig() {
   const {
     isSubmoduleEnabled,
     isSubmoduleInputsDeactivated,
+    isSubmoduleCsvDeactivated,
     getModule,
     getModuleNameFromSubmodule,
   } = yearConfigStore;
@@ -164,6 +165,35 @@ export function useSubmoduleConfig() {
     }
   }
 
+  async function updateSubmoduleCsvDeactivated(
+    sub: SubmoduleConfig,
+    value: boolean,
+  ): Promise<void> {
+    const moduleKey = String(sub.moduleTypeId);
+    const subKey =
+      sub.dataEntryTypeId !== undefined
+        ? String(sub.dataEntryTypeId)
+        : undefined;
+    if (!subKey) return;
+    try {
+      await yearConfigStore.updateConfig(yearConfigStore.selectedYear, {
+        config: {
+          modules: {
+            [moduleKey]: {
+              submodules: { [subKey]: { csv_deactivated: value } },
+            },
+          },
+        },
+      });
+      Notify.create({ type: 'positive', message: $t('year_config_saved') });
+    } catch {
+      Notify.create({
+        type: 'negative',
+        message: $t('year_config_save_error'),
+      });
+    }
+  }
+
   function getSubmoduleThreshold(sub: SubmoduleConfig): number | null {
     const unifiedModule = getUnifiedModuleConfigFromSub(sub);
     return unifiedModule?.submodules[sub.key]?.threshold ?? null;
@@ -282,11 +312,13 @@ export function useSubmoduleConfig() {
     isSubmoduleEnabled,
     isSubmoduleIncomplete,
     isSubmoduleInputsDeactivated,
+    isSubmoduleCsvDeactivated,
     getImportRow,
     submoduleShowsImportRow,
     downloadLastCsv,
     updateSubmoduleEnabled,
     updateSubmoduleInputsDeactivated,
+    updateSubmoduleCsvDeactivated,
     getSubmoduleThreshold,
     updateSubmoduleThreshold,
     computedFactorRunning,

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -404,6 +404,10 @@ export default {
     en: 'Deactivate input form',
     fr: 'Désactiver le formulaire de saisie',
   },
+  data_management_submodule_csv_deactivation_label: {
+    en: 'Deactivate CSV upload & template',
+    fr: "Désactiver l'import CSV et le modèle",
+  },
   data_management_uncertainty_title: {
     en: 'Uncertainty',
     fr: 'Incertitude',

--- a/frontend/src/stores/yearConfig.ts
+++ b/frontend/src/stores/yearConfig.ts
@@ -37,6 +37,7 @@ export interface SubmoduleConfig {
   enabled: boolean;
   threshold: number | null;
   inputs_deactivated?: boolean;
+  csv_deactivated?: boolean;
   latest_data_job?: SyncJobSummary | null;
   latest_api_data_job?: SyncJobSummary | null;
   latest_factor_job?: SyncJobSummary | null;
@@ -503,6 +504,16 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     return mod?.submodules?.[subKey]?.inputs_deactivated ?? false;
   }
 
+  function isSubmoduleCsvDeactivated(sub: ModuleUploadConfig): boolean {
+    const subKey =
+      sub.dataEntryTypeId !== undefined
+        ? String(sub.dataEntryTypeId)
+        : undefined;
+    if (!subKey) return false;
+    const mod = config.value?.config?.modules?.[String(sub.moduleTypeId)];
+    return mod?.submodules?.[subKey]?.csv_deactivated ?? false;
+  }
+
   /** True when reduction objectives goals or CSV files are not fully configured. */
   const isReductionObjectiveIncomplete = computed(() => {
     if (!config.value) return false;
@@ -586,6 +597,7 @@ export const useYearConfigStore = defineStore('yearConfig', () => {
     isModuleEnabled,
     isSubmoduleEnabled,
     isSubmoduleInputsDeactivated,
+    isSubmoduleCsvDeactivated,
     getModuleUncertaintyTag,
     // Methods
     fetchConfig,


### PR DESCRIPTION
## What does this change?
Adds a new `csv_deactivated` option for submodules that, when enabled, hides the CSV upload and template download controls from end-users. This includes:
- A new `csv_deactivated` field on the backend `SubmoduleConfig` schema
- A new checkbox in `SubmoduleItem.vue`, placed alongside the existing "deactivate input form" checkbox in a row layout, to toggle this setting
- Logic in `ModuleTable.vue` to hide the CSV upload/download UI when `csv_deactivated` is true
- New `isSubmoduleCsvDeactivated` / `updateSubmoduleCsvDeactivated` functions in the `useSubmoduleConfig` composable and `yearConfig` store
- New i18n labels (English/French) for the checkbox

## Why is this needed?
Backoffice admins need a way to disable CSV upload and template download for a submodule independently of disabling the data-entry input form, giving finer-grained control over how end-users can submit data.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1456

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.