### PR TITLE
fix(1575): emit a single heating leaf (electric OR thermal) per room

### DIFF
--- a/backend/app/models/data_entry_emission.py
+++ b/backend/app/models/data_entry_emission.py
@@ -141,13 +141,13 @@ class EmissionType(int, Enum):
     buildings__rooms__ventilation__auditoriums = 6010305
     buildings__rooms__ventilation__miscellaneous = 6010306
 
-    buildings__rooms__heating_elec = 60104
-    buildings__rooms__heating_elec__office = 6010401
-    buildings__rooms__heating_elec__laboratories = 6010402
-    buildings__rooms__heating_elec__archives = 6010403
-    buildings__rooms__heating_elec__libraries = 6010404
-    buildings__rooms__heating_elec__auditoriums = 6010405
-    buildings__rooms__heating_elec__miscellaneous = 6010406
+    buildings__rooms__heating_electric = 60104
+    buildings__rooms__heating_electric__office = 6010401
+    buildings__rooms__heating_electric__laboratories = 6010402
+    buildings__rooms__heating_electric__archives = 6010403
+    buildings__rooms__heating_electric__libraries = 6010404
+    buildings__rooms__heating_electric__auditoriums = 6010405
+    buildings__rooms__heating_electric__miscellaneous = 6010406
 
     buildings__rooms__heating_thermal = 60105
     buildings__rooms__heating_thermal__office = 6010501
@@ -382,26 +382,26 @@ _PARENT_MAP: dict[int, int] = {
     EmissionType.buildings__rooms__ventilation__miscellaneous.value: (
         EmissionType.buildings__rooms__ventilation.value
     ),
-    EmissionType.buildings__rooms__heating_elec.value: (
+    EmissionType.buildings__rooms__heating_electric.value: (
         EmissionType.buildings__rooms.value
     ),
-    EmissionType.buildings__rooms__heating_elec__office.value: (
-        EmissionType.buildings__rooms__heating_elec.value
+    EmissionType.buildings__rooms__heating_electric__office.value: (
+        EmissionType.buildings__rooms__heating_electric.value
     ),
-    EmissionType.buildings__rooms__heating_elec__laboratories.value: (
-        EmissionType.buildings__rooms__heating_elec.value
+    EmissionType.buildings__rooms__heating_electric__laboratories.value: (
+        EmissionType.buildings__rooms__heating_electric.value
     ),
-    EmissionType.buildings__rooms__heating_elec__archives.value: (
-        EmissionType.buildings__rooms__heating_elec.value
+    EmissionType.buildings__rooms__heating_electric__archives.value: (
+        EmissionType.buildings__rooms__heating_electric.value
     ),
-    EmissionType.buildings__rooms__heating_elec__libraries.value: (
-        EmissionType.buildings__rooms__heating_elec.value
+    EmissionType.buildings__rooms__heating_electric__libraries.value: (
+        EmissionType.buildings__rooms__heating_electric.value
     ),
-    EmissionType.buildings__rooms__heating_elec__auditoriums.value: (
-        EmissionType.buildings__rooms__heating_elec.value
+    EmissionType.buildings__rooms__heating_electric__auditoriums.value: (
+        EmissionType.buildings__rooms__heating_electric.value
     ),
-    EmissionType.buildings__rooms__heating_elec__miscellaneous.value: (
-        EmissionType.buildings__rooms__heating_elec.value
+    EmissionType.buildings__rooms__heating_electric__miscellaneous.value: (
+        EmissionType.buildings__rooms__heating_electric.value
     ),
     EmissionType.buildings__rooms__heating_thermal.value: (
         EmissionType.buildings__rooms.value
@@ -661,7 +661,7 @@ _SCOPE_CATEGORY_MAP: dict[int, EmissionMeta] = {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec.value: {
+    EmissionType.buildings__rooms__heating_electric.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
@@ -742,27 +742,27 @@ _SCOPE_CATEGORY_MAP: dict[int, EmissionMeta] = {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec__office.value: {
+    EmissionType.buildings__rooms__heating_electric__office.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec__laboratories.value: {
+    EmissionType.buildings__rooms__heating_electric__laboratories.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec__archives.value: {
+    EmissionType.buildings__rooms__heating_electric__archives.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec__libraries.value: {
+    EmissionType.buildings__rooms__heating_electric__libraries.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec__auditoriums.value: {
+    EmissionType.buildings__rooms__heating_electric__auditoriums.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },
-    EmissionType.buildings__rooms__heating_elec__miscellaneous.value: {
+    EmissionType.buildings__rooms__heating_electric__miscellaneous.value: {
         "scope": Scope.scope2,
         "category": EmissionCategory.buildings_room,
     },

--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -174,7 +174,7 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
         EmissionType.buildings__rooms__lighting: "lighting_kwh_per_square_meter",
         EmissionType.buildings__rooms__cooling: "cooling_kwh_per_square_meter",
         EmissionType.buildings__rooms__ventilation: "ventilation_kwh_per_square_meter",
-        EmissionType.buildings__rooms__heating_elec: "heating_kwh_per_square_meter",
+        EmissionType.buildings__rooms__heating_electric: "heating_kwh_per_square_meter",
         EmissionType.buildings__rooms__heating_thermal: "heating_kwh_per_square_meter",
     }
 
@@ -237,30 +237,16 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
         # set a default value of 1.0 if not provided
         ratio_nb = float(ratio) if ratio is not None else 1.0
 
-        # conversion factor only applies to electric or thermal energy types,
-        # default to 1.0 if not provided
+        # Heating carries a conversion_factor (primary energy → final energy);
+        # the correct electric/thermal leaf is already chosen upstream, so it
+        # applies directly. Other energy types have no conversion (default 1.0).
+        # An explicit `is None` check keeps a legitimate 0.0 (e.g. carbon-free
+        # network) from being silently coerced to 1.0.
+        conversion_factor = 1.0
         if kwh_field == "heating_kwh_per_square_meter":
-            emission_type: EmissionType = ctx["emission_type"]
-            energy_type = factor_values.get("energy_type")
-            if (
-                emission_type.parent is not None
-                and emission_type.parent == EmissionType.buildings__rooms__heating_elec
-                and energy_type == "electric"
-            ):
-                conversion_factor = factor_values.get("conversion_factor") or 1.0
-            elif (
-                emission_type.parent is not None
-                and emission_type.parent
-                == EmissionType.buildings__rooms__heating_thermal
-                and energy_type == "thermal"
-            ):
-                conversion_factor = factor_values.get("conversion_factor") or 1.0
-            else:
-                # does not apply to this emission type,
-                # set to 0 to avoid double counting
-                conversion_factor = 0
-        else:
-            conversion_factor = 1.0
+            override = factor_values.get("conversion_factor")
+            if override is not None:
+                conversion_factor = override
         kwh = float(surface) * float(kwh_per_m2) * ratio_nb
         return kwh * float(ef) * float(conversion_factor)
 
@@ -270,9 +256,6 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
         factor_id = ctx.get("primary_factor_id")
         if factor_id is None:
             return []
-
-        # Add emission type to context for use in formula_func
-        ctx["emission_type"] = emission_type
 
         # Try direct match, then fall back to parent (WW→ZZ)
         kwh_field = self._EMISSION_TO_KWH_FIELD.get(emission_type)
@@ -287,7 +270,7 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_building_formula,
             )
         ]
@@ -336,6 +319,7 @@ class BuildingRoomModuleHandler(BaseModuleHandler):
 buildings_classification_fields: list[str] = [
     "building_name",
     "room_type",
+    "energy_type",
 ]
 buildings_value_fields: list[str] = [
     "ef_kg_co2eq_per_kwh",
@@ -343,7 +327,6 @@ buildings_value_fields: list[str] = [
     "cooling_kwh_per_square_meter",
     "ventilation_kwh_per_square_meter",
     "lighting_kwh_per_square_meter",
-    "energy_type",
     "conversion_factor",
 ]
 
@@ -387,16 +370,9 @@ class _BuildingsFactorValidationMixin:
         valid_energy_types = [
             "electric",
             "thermal",
-            None,
         ]
         # Normalize aliases
-        energy_type_aliases = {
-            "electric": "electric",
-            "elec": "electric",
-            "electricity": "electric",
-            "therm": "thermal",
-        }
-        normalized = energy_type_aliases.get(v.lower() if v else v, v)
+        normalized = v.lower() if v else v
         if not normalized:
             raise ValueError("Energy type is required")
         if normalized not in valid_energy_types:
@@ -522,7 +498,7 @@ class EnergyCombustionModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_key="ef_kg_co2eq_per_unit",
                 quantity_key="quantity",
             )

--- a/backend/app/modules/equipment/schemas.py
+++ b/backend/app/modules/equipment/schemas.py
@@ -237,7 +237,7 @@ class EquipmentModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_equipment_formula,
             )
         ]

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -279,7 +279,7 @@ class ExternalCloudModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_cloud_formula,
             )
         ]
@@ -449,7 +449,7 @@ class ExternalAIModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_ai_formula,
             )
         ]

--- a/backend/app/modules/process_emissions/schemas.py
+++ b/backend/app/modules/process_emissions/schemas.py
@@ -136,7 +136,7 @@ class ProcessEmissionsModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_process_formula,
             )
         ]

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -323,7 +323,7 @@ class PurchaseModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_purchase_formula,
             )
         ]
@@ -396,7 +396,7 @@ class PurchaseAdditionalModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_additional_purchase_formula,
             )
         ]

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -156,7 +156,7 @@ class ResearchFacilitiesAnimalModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_research_facilities_formula,
             )
         ]

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -172,7 +172,7 @@ class ResearchFacilitiesCommonModuleHandler(BaseModuleHandler):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
                 formula_func=_research_facilities_formula,
             )
         ]

--- a/backend/app/schemas/data_entry.py
+++ b/backend/app/schemas/data_entry.py
@@ -359,7 +359,7 @@ class BaseModuleHandler(metaclass=ModuleHandlerMeta):
         return [
             EmissionComputation(
                 emission_type=emission_type,
-                factor_id=int(factor_id),
+                factor_id=factor_id,
             )
         ]
 

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -23,6 +23,7 @@ from app.repositories.data_entry_emission_repo import (
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.factor_service import FactorService
 from app.utils.data_entry_emission_type_map import (
+    BUILDING_ENERGY_TYPES,
     DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION,
     resolve_emission_types,
 )
@@ -226,6 +227,40 @@ class DataEntryEmissionService:
 
         return prev_kg * (percentage / 100.0)
 
+    async def _get_building_energy_type(
+        self,
+        primary_factor_id: int | None,
+        factor_cache: dict[int, Factor] | None,
+    ) -> str | None:
+        """Return the matched building factor's energy_type (electric/thermal).
+
+        The factor row selects which heating leaf a room entry emits. Reads the
+        prefetched cache when a bulk caller provided one, else a single DB get —
+        so both the recalc workflow and single-entry paths resolve it.
+
+        ``None`` means no factor matched (no emission to produce). A present id
+        that resolves to no factor, or a building factor whose ``energy_type`` is
+        missing or not electric/thermal, is corrupt data and fails loudly rather
+        than silently dropping heating.
+        """
+        if primary_factor_id is None:
+            return None
+        factor = factor_cache.get(primary_factor_id) if factor_cache else None
+        if factor is None:
+            factor = await FactorService(self.session).get(primary_factor_id)
+        if factor is None:
+            raise ValueError(
+                f"Building room entry references factor {primary_factor_id}, "
+                "which does not exist."
+            )
+        energy_type = factor.classification.get("energy_type")
+        if energy_type not in BUILDING_ENERGY_TYPES:
+            raise ValueError(
+                f"Building factor {primary_factor_id} has invalid energy_type "
+                f"{energy_type!r}; expected one of {sorted(BUILDING_ENERGY_TYPES)}."
+            )
+        return energy_type
+
     async def prepare_create(
         self,
         data_entry: DataEntry | DataEntryResponse,
@@ -237,8 +272,10 @@ class DataEntryEmissionService:
         slice_cache: dict | None = None,
     ) -> list[DataEntryEmission]:
         """Prepare emission records for any data entry type.
-
-        Pure orchestrator — zero branching on DataEntryType:
+        TODO: Make this function readable!
+        Orchestrates the pipeline below. Building entries first resolve their
+        matched factor's energy_type (electric/thermal) to select the single
+        heating leaf (#1575); every other type flows through unbranched:
 
         1. ``resolve_emission_types`` → which EmissionType leaves to produce
         2. ``handler.pre_compute``    → enrich ctx (DB calls, arithmetic)
@@ -269,8 +306,19 @@ class DataEntryEmissionService:
             logger.error("DataEntry must have a data_entry_type.")
             return []
 
+        # A building-room entry carries one primary factor whose energy_type
+        # (electric/thermal) selects the single heating leaf to emit. Resolve it
+        # once here and pass it explicitly — ``data_entry.data`` is left untouched
+        # so resolution never depends on a smuggled-in key. None for other types.
+        building_energy_type: str | None = None
+        if data_entry.data_entry_type is DataEntryTypeEnum.building:
+            building_energy_type = await self._get_building_energy_type(
+                data_entry.data.get("primary_factor_id"), factor_cache
+            )
         emission_types = resolve_emission_types(
-            data_entry.data_entry_type, data_entry.data
+            data_entry.data_entry_type,
+            data_entry.data,
+            building_energy_type=building_energy_type,
         )
         if emission_types is None:
             logger.warning(f"Unhandled type: {data_entry.data_entry_type}")

--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -223,43 +223,70 @@ _VALID_ROOM_TYPES: frozenset[str] = frozenset(
     }
 )
 
+_HEATING = "heating"
 _ENERGY_TYPES: list[str] = [
     "lighting",
     "cooling",
     "ventilation",
-    "heating_elec",
-    "heating_thermal",
+    _HEATING,
 ]
+
+# Heating is sourced from either electricity or a thermal network. The matched
+# factor's ``energy_type`` selects the single correct leaf — emitting both would
+# double-count the same kwh/m² (#1575).
+_HEATING_LEAF_BY_ENERGY: dict[str, str] = {
+    "electric": "heating_electric",
+    "thermal": "heating_thermal",
+}
+
+# Valid building-factor energy types = exactly the heating-leaf keys, so the
+# two can never drift. Used to reject corrupt factors at the source.
+BUILDING_ENERGY_TYPES: frozenset[str] = frozenset(_HEATING_LEAF_BY_ENERGY)
 
 
 def _resolve_building_rooms(
-    data: dict,
+    data: dict, energy_type: str | None
 ) -> list[EmissionType] | None:
     """Resolve building data entry to room-type-specific emission types.
 
     If room_type is set, returns 8-digit WW-level types (one per energy).
     Otherwise falls back to 6-digit ZZ-level types.
+
+    ``energy_type`` (electric/thermal) comes from the matched factor and is
+    passed explicitly by the caller — it is not read from ``data``. Heating
+    resolves to that single leaf; ``None`` (no matched factor) skips heating.
+    Invalid values never reach here — they are rejected upstream in
+    ``_get_building_energy_type``.
     """
     room_type = (data.get("room_type") or "").lower()
+    heating_leaf = _HEATING_LEAF_BY_ENERGY.get((energy_type or "").lower())
+
     if room_type in _VALID_ROOM_TYPES:
         result = []
         for energy in _ENERGY_TYPES:
-            name = f"buildings__rooms__{energy}__{room_type}"
+            leaf = f"buildings__rooms__{energy}__{room_type}"
+            parent = f"buildings__rooms__{energy}"
+            if energy == _HEATING:
+                if heating_leaf is None:
+                    continue
+                leaf = f"buildings__rooms__{heating_leaf}__{room_type}"
+                parent = f"buildings__rooms__{heating_leaf}"
             try:
-                result.append(EmissionType[name])
+                result.append(EmissionType[leaf])
             except KeyError:
                 # fallback to parent energy type
-                result.append(EmissionType[f"buildings__rooms__{energy}"])
+                result.append(EmissionType[parent])
         return result
 
     # No room_type — use generic ZZ-level types
-    return [
+    result = [
         EmissionType.buildings__rooms__lighting,
         EmissionType.buildings__rooms__cooling,
         EmissionType.buildings__rooms__ventilation,
-        EmissionType.buildings__rooms__heating_elec,
-        EmissionType.buildings__rooms__heating_thermal,
     ]
+    if heating_leaf is not None:
+        result.append(EmissionType[f"buildings__rooms__{heating_leaf}"])
+    return result
 
 
 _COMBUSTION_FUEL_MAP: dict[str, EmissionType] = {
@@ -358,10 +385,11 @@ def _resolve_headcount_factor(data: dict) -> list[EmissionType] | None:
         return None
 
 
+# NOTE: building is intentionally absent — it needs the factor's energy_type,
+# so ``resolve_emission_types`` dispatches it explicitly (see below).
 _RUNTIME_RESOLVERS = {
     DataEntryTypeEnum.plane: _resolve_plane,
     DataEntryTypeEnum.train: _resolve_train,
-    DataEntryTypeEnum.building: _resolve_building_rooms,
     DataEntryTypeEnum.energy_combustion: _resolve_combustion,
     DataEntryTypeEnum.additional_purchases: _resolve_additional_purchases,
     DataEntryTypeEnum.external_ai: _resolve_ai,
@@ -431,9 +459,15 @@ def resolve_factor_emission_type(
 def resolve_emission_types(
     data_entry_type: DataEntryTypeEnum,
     data: dict,
+    *,
+    building_energy_type: str | None = None,
 ) -> list[EmissionType] | None:
     """
     Returns the list of EmissionType leaves for a given DataEntryTypeEnum.
+
+    ``data`` is read-only entry payload. ``building_energy_type`` is the extra
+    factor-derived input building rooms need to pick their heating leaf; the
+    caller resolves it and passes it explicitly (never smuggled through ``data``).
 
     Returns:
       list[EmissionType]  — one or more emission types; create one row per entry
@@ -454,6 +488,10 @@ def resolve_emission_types(
     static = DATA_ENTRY_TO_EMISSION_TYPES.get(data_entry_type)
     if static is not None:
         return static  # covers both [] and [EmissionType, ...]
+
+    # Building rooms take an explicit factor-derived energy_type, not just data.
+    if data_entry_type is DataEntryTypeEnum.building:
+        return _resolve_building_rooms(data, building_energy_type)
 
     resolver = _RUNTIME_RESOLVERS.get(data_entry_type)
     if resolver:

--- a/backend/app/workflows/carbon_report_module.py
+++ b/backend/app/workflows/carbon_report_module.py
@@ -103,7 +103,7 @@ class CarbonReportModuleWorkflow:
                 )
 
             await DataEntryEmissionService(self.session).upsert_by_data_entry(
-                data_entry_response=item,
+                data_entry_response=item
             )
             await CarbonReportModuleService(self.session).recompute_stats(
                 carbon_report_module.id

--- a/backend/tests/integration/services/data_ingestion/test_buildings_csv_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_buildings_csv_pg.py
@@ -13,7 +13,8 @@ Buildings has three data-entry types (``MODULE_TYPE_TO_DATA_ENTRY_TYPES``):
 * ``building`` — rooms.  Handler reads ``BuildingRoom`` via
   ``BuildingRoomService.get_room`` and computes
   ``kg_co2eq = surface × kwh_per_m² × ef × conversion`` per energy leaf
-  (lighting, cooling, ventilation, heating_elec, heating_thermal).
+  (lighting, cooling, ventilation, and one heating leaf — electric or
+  thermal — selected by the factor's energy_type; #1575).
 * ``energy_combustion`` — straight ``quantity × ef`` formula keyed by
   ``(unit, name)`` factor classification.
 * ``building_embodied_energy`` — *derived*: rows are created post-hoc
@@ -243,25 +244,15 @@ async def test_building_room_with_ref_data_resolves_surface_and_computes_emissio
       lighting_kwh_per_m²=5     → 5.0
       cooling_kwh_per_m²=20     → 20.0
       ventilation_kwh_per_m²=10 → 10.0
-      heating_kwh_per_m²=30     → 30.0 (electric → heating_elec leaf)
+      heating_kwh_per_m²=30     → 30.0 (electric → heating_electric leaf only)
 
-    Discovery — buildings__rooms rollup is 95.0 (NOT 65.0)
-    ------------------------------------------------------
-    The rollup assertion at the end of this test sums the four leaves
-    above PLUS an extra 30.0 (heating_thermal), totalling 95.0.  We
-    only seed an electric heating factor; the +30 thermal contribution
-    appears regardless.  Reading the handler reveals
-    ``heating_kwh_per_square_meter`` is fanned out to BOTH the
-    ``heating_elec`` and ``heating_thermal`` leaves with the same
-    ef/ratio, so the rooms rollup double-counts heating energy when
-    only one heating mode actually applies to the room.
-
-    This test PINS the observed contract (rollup = 95.0) — a
-    regression-gate against silent changes to the handler's fan-out
-    logic — but the contract itself looks like a bug worth tracking.
-    Surfaced here so a future reader doesn't conflate "test passes" with
-    "math is correct".  See the rollup assertion comment further down
-    for the per-line breakdown.
+    Regression #1575 — heating is NOT double-counted
+    ------------------------------------------------
+    The factor's ``energy_type`` is "electric", so heating resolves to a
+    single ``heating_electric`` leaf. The ``heating_thermal`` leaf must be
+    absent, and the rooms rollup is 65.0 (5+20+10+30) — not 95.0, which is
+    what the old both-leaves fan-out produced by counting the same 30.0
+    kwh/m² of heating twice.
     """
     engine = create_async_engine(pg_dsn, future=True)
     Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -332,7 +323,7 @@ async def test_building_room_with_ref_data_resolves_surface_and_computes_emissio
         EmissionType.buildings__rooms__lighting__office.value: 5.0,
         EmissionType.buildings__rooms__cooling__office.value: 20.0,
         EmissionType.buildings__rooms__ventilation__office.value: 10.0,
-        EmissionType.buildings__rooms__heating_elec__office.value: 30.0,
+        EmissionType.buildings__rooms__heating_electric__office.value: 30.0,
     }
     for et_id, expected_kg in expected.items():
         assert et_id in by_leaf, f"missing leaf {et_id}: rows={by_leaf}"
@@ -340,16 +331,16 @@ async def test_building_room_with_ref_data_resolves_surface_and_computes_emissio
             f"leaf {et_id}: got {by_leaf[et_id]}, expected {expected_kg}"
         )
 
-    # The rollup row sums the four leaves (lighting+cooling+vent+heat = 65)
-    # — but the persisted rollup carries 95 because ``heating_elec`` and
-    # ``heating_thermal`` both map to ``heating_kwh_per_square_meter``,
-    # so the office "heating" energy contributes twice (electric + thermal
-    # = 30+30) when only the electric factor exists.  Pin the rollup
-    # value (95) exactly so a regression in the heating-leaf emission
-    # (e.g. consolidation into one row) gets caught.
+    # Regression #1575: the electric factor must NOT also produce a thermal
+    # heating leaf — heating is attributed to a single energy source.
+    assert (
+        EmissionType.buildings__rooms__heating_thermal__office.value not in by_leaf
+    ), f"heating_thermal leaf must be absent for an electric factor: {by_leaf}"
+
+    # The rollup sums the four leaves once each: 5+20+10+30 = 65.
     rollup = by_leaf.get(EmissionType.buildings__rooms.value)
-    assert rollup == pytest.approx(95.0, rel=1e-6), (
-        f"rollup buildings__rooms expected 95.0 (5+20+10+30+30), got {rollup}"
+    assert rollup == pytest.approx(65.0, rel=1e-6), (
+        f"rollup buildings__rooms expected 65.0 (5+20+10+30), got {rollup}"
     )
 
     await engine.dispose()

--- a/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_strategy_b_rematch_pg.py
@@ -830,11 +830,11 @@ async def test_building_room_factor_values_change_propagates_all_5_emissions(
     pg_dsn,
 ):
     """Building room is technically JSON-link (``kind_field='building_name'``
-    is on entry.data) but emits 5 leaf emissions per entry (one per
-    energy type: lighting, cooling, ventilation, heating_elec,
-    heating_thermal).  This regression net asserts that doubling
-    ``ef_kg_co2eq_per_kwh`` doubles **every** kg_co2eq leaf and that the
-    rollup row sums correctly.
+    is on entry.data) but emits 4 leaf emissions per entry: lighting,
+    cooling, ventilation, and a single heating leaf chosen by the factor's
+    ``energy_type`` (here electric → heating_electric; #1575).  This
+    regression net asserts that doubling ``ef_kg_co2eq_per_kwh`` doubles
+    **every** kg_co2eq leaf and that the rollup row sums correctly.
 
     The plan doc originally classified rooms as Strategy B; in fact the
     Strategy A bulk-prefetch covers it, because both ``kind_field`` and

--- a/backend/tests/unit/modules/test_buildings_schemas.py
+++ b/backend/tests/unit/modules/test_buildings_schemas.py
@@ -3,13 +3,12 @@
 Formula: kwh = surface × kwh_per_m² × ratio
          result = kwh × ef × conversion_factor
 
-conversion_factor rules (only applies when kwh_field == "heating_kwh_per_square_meter"):
-  - emission_type.parent == heating_elec AND energy_type == "electric"
-    → factor_values["conversion_factor"] or 1.0
-  - emission_type.parent == heating_thermal AND energy_type == "thermal"
-    → factor_values["conversion_factor"] or 1.0
-  - otherwise → 0  (avoids double-counting the other heating branch)
-For non-heating fields, conversion_factor is always 1.0.
+conversion_factor applies only to the heating field
+("heating_kwh_per_square_meter") — it converts primary energy to final
+energy — and defaults to 1.0 when absent. Which heating leaf (electric vs
+thermal) is emitted is decided upstream by ``_resolve_building_rooms``, so
+the formula no longer inspects energy_type. For non-heating fields,
+conversion_factor is always 1.0.
 """
 
 import pytest
@@ -23,21 +22,15 @@ _HANDLER = BuildingRoomModuleHandler()
 # Helpers
 # ---------------------------------------------------------------------------
 
-_ELEC_LEAF = EmissionType.buildings__rooms__heating_elec__office
-_THERMAL_LEAF = EmissionType.buildings__rooms__heating_thermal__office
-_ELEC_PARENT = EmissionType.buildings__rooms__heating_elec
-
 
 def _ctx(
     *,
     surface: float | None = 100.0,
     ratio: float | None = 0.5,
-    emission_type: EmissionType = _ELEC_LEAF,
 ) -> dict:
     return {
         "room_surface_square_meter": surface,
         "room_allocation_ratio": ratio,
-        "emission_type": emission_type,
     }
 
 
@@ -45,7 +38,6 @@ def _fv(
     *,
     kwh_per_m2: float | None = 10.0,
     ef: float | None = 0.2,
-    energy_type: str | None = "electric",
     conversion_factor: float | None = 2.0,
     kwh_field: str = "lighting_kwh_per_square_meter",
 ) -> dict:
@@ -53,8 +45,6 @@ def _fv(
         "ef_kg_co2eq_per_kwh": ef,
         kwh_field: kwh_per_m2,
     }
-    if energy_type is not None:
-        values["energy_type"] = energy_type
     if conversion_factor is not None:
         values["conversion_factor"] = conversion_factor
     return values
@@ -129,46 +119,36 @@ def test_missing_required_value_returns_none(
 
 
 # ---------------------------------------------------------------------------
-# Heating electric leaf — emission_type.parent == heating_elec
+# Heating field — conversion_factor applies (defaults to 1.0)
 # ---------------------------------------------------------------------------
 
 
-def test_heating_elec_with_conversion_factor() -> None:
+def test_heating_with_conversion_factor() -> None:
     # surface=100, kwh/m2=10, ratio=0.5, ef=0.2, cf=2.0
-    # kwh = 100 * 10 * 0.5 = 500
-    # result = 500 * 0.2 * 2.0 = 200.0
-    ctx = _ctx(emission_type=_ELEC_LEAF)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="electric",
-        conversion_factor=2.0,
-    )
+    # kwh = 100 * 10 * 0.5 = 500; result = 500 * 0.2 * 2.0 = 200.0
+    ctx = _ctx()
+    fv = _fv(kwh_field="heating_kwh_per_square_meter", conversion_factor=2.0)
     assert _HANDLER._compute_kwh_emission(
         ctx, fv, "heating_kwh_per_square_meter"
     ) == pytest.approx(200.0)
 
 
-def test_heating_elec_missing_conversion_factor_defaults_to_one() -> None:
+def test_heating_missing_conversion_factor_defaults_to_one() -> None:
     # conversion_factor absent → defaults to 1.0
-    ctx = _ctx(emission_type=_ELEC_LEAF)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="electric",
-        conversion_factor=None,
-    )
+    ctx = _ctx()
+    fv = _fv(kwh_field="heating_kwh_per_square_meter", conversion_factor=None)
     # kwh = 100 * 10 * 0.5 = 500; result = 500 * 0.2 * 1.0 = 100.0
     assert _HANDLER._compute_kwh_emission(
         ctx, fv, "heating_kwh_per_square_meter"
     ) == pytest.approx(100.0)
 
 
-def test_heating_elec_conversion_factor_none_defaults_to_one() -> None:
-    # conversion_factor explicitly None in factor_values → `or 1.0` kicks in
-    ctx = _ctx(emission_type=_ELEC_LEAF)
+def test_heating_conversion_factor_none_defaults_to_one() -> None:
+    # conversion_factor explicitly None in factor_values → default 1.0
+    ctx = _ctx()
     fv = {
         "heating_kwh_per_square_meter": 10.0,
         "ef_kg_co2eq_per_kwh": 0.2,
-        "energy_type": "electric",
         "conversion_factor": None,
     }
     assert _HANDLER._compute_kwh_emission(
@@ -176,74 +156,93 @@ def test_heating_elec_conversion_factor_none_defaults_to_one() -> None:
     ) == pytest.approx(100.0)
 
 
-def test_heating_elec_leaf_wrong_energy_type_gives_zero() -> None:
-    # energy_type="thermal" on an elec leaf → neither branch matches → cf=0 → result=0
-    ctx = _ctx(emission_type=_ELEC_LEAF)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="thermal",
-        conversion_factor=2.0,
-    )
+def test_heating_conversion_factor_zero_is_respected() -> None:
+    # A legitimate conversion_factor=0.0 (e.g. carbon-free network) must zero the
+    # heating emission — not be coerced to 1.0 by a falsy `or` default.
+    ctx = _ctx()
+    fv = _fv(kwh_field="heating_kwh_per_square_meter", conversion_factor=0.0)
     assert _HANDLER._compute_kwh_emission(
         ctx, fv, "heating_kwh_per_square_meter"
     ) == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------
-# Heating thermal leaf — emission_type.parent == heating_thermal
+# conversion_factor is heating-only — non-heating fields ignore it
 # ---------------------------------------------------------------------------
 
 
-def test_heating_thermal_with_conversion_factor() -> None:
-    ctx = _ctx(emission_type=_THERMAL_LEAF)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="thermal",
-        conversion_factor=3.0,
-    )
-    # kwh = 100 * 10 * 0.5 = 500; result = 500 * 0.2 * 3.0 = 300.0
-    assert _HANDLER._compute_kwh_emission(
-        ctx, fv, "heating_kwh_per_square_meter"
-    ) == pytest.approx(300.0)
+@pytest.mark.parametrize(
+    "kwh_field",
+    [
+        "lighting_kwh_per_square_meter",
+        "cooling_kwh_per_square_meter",
+        "ventilation_kwh_per_square_meter",
+    ],
+)
+def test_non_heating_field_ignores_conversion_factor(kwh_field: str) -> None:
+    # A non-1 conversion_factor must not affect non-heating leaves — the factor
+    # only converts heating primary→final energy. Result must equal the cf=1 case.
+    ctx = _ctx()
+    fv = _fv(kwh_field=kwh_field, conversion_factor=5.0)
+    # kwh = 100 * 10 * 0.5 = 500; result = 500 * 0.2 * 1.0 = 100.0 (cf ignored)
+    assert _HANDLER._compute_kwh_emission(ctx, fv, kwh_field) == pytest.approx(100.0)
 
 
-def test_heating_thermal_leaf_wrong_energy_type_gives_zero() -> None:
-    ctx = _ctx(emission_type=_THERMAL_LEAF)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="electric",
-        conversion_factor=3.0,
-    )
+# ---------------------------------------------------------------------------
+# Zero is a value, not "missing" — only None short-circuits to None
+# ---------------------------------------------------------------------------
+
+
+def test_zero_surface_returns_zero_not_none() -> None:
+    # surface=0.0 is a legitimate value (guard uses `is None`, not falsiness),
+    # so the formula returns 0.0 rather than None (which means "missing input").
+    ctx = _ctx(surface=0.0)
+    fv = _fv(kwh_field="lighting_kwh_per_square_meter")
     assert _HANDLER._compute_kwh_emission(
-        ctx, fv, "heating_kwh_per_square_meter"
+        ctx, fv, "lighting_kwh_per_square_meter"
     ) == pytest.approx(0.0)
 
 
-def test_heating_thermal_missing_conversion_factor_defaults_to_one() -> None:
-    ctx = _ctx(emission_type=_THERMAL_LEAF)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="thermal",
-        conversion_factor=None,
-    )
-    assert _HANDLER._compute_kwh_emission(
-        ctx, fv, "heating_kwh_per_square_meter"
-    ) == pytest.approx(100.0)
-
-
 # ---------------------------------------------------------------------------
-# Heating with top-level parent (not a leaf) — parent check fails → cf=0
+# resolve_computations — factor gating and kwh-field resolution
 # ---------------------------------------------------------------------------
 
 
-def test_heating_elec_top_level_emission_type_gives_zero() -> None:
-    # _ELEC_PARENT.parent == buildings__rooms, not heating_elec → cf=0
-    ctx = _ctx(emission_type=_ELEC_PARENT)
-    fv = _fv(
-        kwh_field="heating_kwh_per_square_meter",
-        energy_type="electric",
-        conversion_factor=2.0,
+def test_resolve_computations_without_factor_id_returns_empty() -> None:
+    # No primary_factor_id → no factor → no emission computation.
+    ctx = {"room_surface_square_meter": 100.0}
+    assert (
+        _HANDLER.resolve_computations(
+            None, EmissionType.buildings__rooms__lighting__office, ctx
+        )
+        == []
     )
-    assert _HANDLER._compute_kwh_emission(
-        ctx, fv, "heating_kwh_per_square_meter"
-    ) == pytest.approx(0.0)
+
+
+def test_resolve_computations_heating_leaf_formula_applies_conversion_factor() -> None:
+    ctx = {**_ctx(), "primary_factor_id": 5}
+    comps = _HANDLER.resolve_computations(
+        None, EmissionType.buildings__rooms__heating_electric, ctx
+    )
+    assert len(comps) == 1
+    fv = _fv(kwh_field="heating_kwh_per_square_meter", conversion_factor=2.0)
+    # heating leaf → heating field → cf applies: 100*10*0.5 * 0.2 * 2.0 = 200.0
+    assert comps[0].formula_func(ctx, fv) == pytest.approx(200.0)
+
+
+def test_resolve_computations_ww_leaf_falls_back_to_parent_kwh_field() -> None:
+    # heating_electric__office is not in _EMISSION_TO_KWH_FIELD; it must resolve
+    # via its parent (heating_electric) to the heating kwh field, so cf applies.
+    ctx = {**_ctx(), "primary_factor_id": 5}
+    comps = _HANDLER.resolve_computations(
+        None, EmissionType.buildings__rooms__heating_electric__office, ctx
+    )
+    assert len(comps) == 1
+    fv = _fv(kwh_field="heating_kwh_per_square_meter", conversion_factor=2.0)
+    assert comps[0].formula_func(ctx, fv) == pytest.approx(200.0)
+
+
+def test_resolve_computations_unmapped_emission_type_returns_empty() -> None:
+    # The rooms rollup parent has no kwh field and its parent isn't mapped either.
+    ctx = {**_ctx(), "primary_factor_id": 5}
+    assert _HANDLER.resolve_computations(None, EmissionType.buildings__rooms, ctx) == []

--- a/backend/tests/unit/repositories/test_data_entry_emission_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_emission_repo.py
@@ -1268,7 +1268,7 @@ async def _seed_building_with_rollup(
         EmissionType.buildings__rooms__lighting,
         EmissionType.buildings__rooms__cooling,
         EmissionType.buildings__rooms__ventilation,
-        EmissionType.buildings__rooms__heating_elec,
+        EmissionType.buildings__rooms__heating_electric,
         EmissionType.buildings__rooms__heating_thermal,
     ]
     for et in leaf_types:

--- a/backend/tests/unit/services/test_data_entry_emission_service.py
+++ b/backend/tests/unit/services/test_data_entry_emission_service.py
@@ -10,6 +10,7 @@ from app.models.data_entry_emission import (
     EmissionComputation,
     EmissionType,
 )
+from app.models.factor import Factor
 from app.schemas.data_entry import DataEntryResponse
 from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.utils.data_entry_emission_type_map import (
@@ -1719,3 +1720,68 @@ class TestFetchFactorsStrategyBCache:
 
         # Without the opt-in cache, behaviour is unchanged: one query per call.
         assert get_by_classification.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _get_building_energy_type — resolves the heating leaf, fails loud on corruption
+# ---------------------------------------------------------------------------
+
+
+class TestGetBuildingEnergyType:
+    """The matched building factor picks the single heating leaf (#1575).
+
+    A missing/unrecognized energy_type is corrupt data and must raise here,
+    not silently drop heating downstream in _resolve_building_rooms.
+    """
+
+    @staticmethod
+    def _factor(classification: dict) -> Factor:
+        factor = MagicMock(spec=Factor)
+        factor.classification = classification
+        return factor
+
+    @pytest.mark.asyncio
+    async def test_valid_electric_returns_electric(self):
+        service = _make_service()
+        cache = {5: self._factor({"energy_type": "electric"})}
+        assert await service._get_building_energy_type(5, cache) == "electric"
+
+    @pytest.mark.asyncio
+    async def test_valid_thermal_returns_thermal(self):
+        service = _make_service()
+        cache = {5: self._factor({"energy_type": "thermal"})}
+        assert await service._get_building_energy_type(5, cache) == "thermal"
+
+    @pytest.mark.asyncio
+    async def test_none_factor_id_returns_none(self):
+        # No matched factor = no emission to produce; a legitimate skip, not error.
+        service = _make_service()
+        assert await service._get_building_energy_type(None, {}) is None
+
+    @pytest.mark.asyncio
+    async def test_missing_energy_type_key_raises(self):
+        # classification without the key → descriptive ValueError, not bare KeyError.
+        service = _make_service()
+        cache = {5: self._factor({})}
+        with pytest.raises(ValueError, match="5"):
+            await service._get_building_energy_type(5, cache)
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_energy_type_raises(self):
+        # Regression #1575: a present-but-invalid value must fail loud here
+        # rather than resolve to None and silently drop the heating leaf.
+        service = _make_service()
+        cache = {5: self._factor({"energy_type": "electricity"})}
+        with pytest.raises(ValueError, match="electricity"):
+            await service._get_building_energy_type(5, cache)
+
+    @pytest.mark.asyncio
+    async def test_dangling_factor_id_raises(self):
+        # id present but resolves to no factor (dangling FK) = corruption → raise.
+        service = _make_service()
+        with patch(
+            "app.services.data_entry_emission_service.FactorService"
+        ) as mock_fs_cls:
+            mock_fs_cls.return_value = MagicMock(get=AsyncMock(return_value=None))
+            with pytest.raises(ValueError, match="does not exist"):
+                await service._get_building_energy_type(5, {})

--- a/backend/tests/unit/utils/test_building_rooms_resolver.py
+++ b/backend/tests/unit/utils/test_building_rooms_resolver.py
@@ -1,0 +1,55 @@
+"""Unit tests for building-room → EmissionType resolution.
+
+Verifies ``_resolve_building_rooms`` (used by ``resolve_emission_types`` at
+runtime) emits a *single* heating leaf chosen by the matched factor's
+``energy_type`` — the fix for the heating double-count (#1575). An
+absent/unknown ``energy_type`` skips heating rather than guessing.
+"""
+
+from app.models.data_entry_emission import EmissionType
+from app.utils.data_entry_emission_type_map import _resolve_building_rooms
+
+_HEATING_LEAVES = {
+    EmissionType.buildings__rooms__heating_electric,
+    EmissionType.buildings__rooms__heating_thermal,
+    EmissionType.buildings__rooms__heating_electric__office,
+    EmissionType.buildings__rooms__heating_thermal__office,
+}
+
+
+def _heating(result: list[EmissionType]) -> set[EmissionType]:
+    return set(result) & _HEATING_LEAVES
+
+
+def test_office_electric_emits_only_electric_leaf() -> None:
+    result = _resolve_building_rooms({"room_type": "office"}, "electric")
+    assert _heating(result) == {EmissionType.buildings__rooms__heating_electric__office}
+
+
+def test_office_thermal_emits_only_thermal_leaf() -> None:
+    result = _resolve_building_rooms({"room_type": "office"}, "thermal")
+    assert _heating(result) == {EmissionType.buildings__rooms__heating_thermal__office}
+
+
+def test_zz_level_electric_emits_only_electric_leaf() -> None:
+    # No room_type → generic ZZ-level leaves.
+    result = _resolve_building_rooms({}, "electric")
+    assert _heating(result) == {EmissionType.buildings__rooms__heating_electric}
+
+
+def test_never_emits_both_heating_leaves() -> None:
+    # Regression #1575: the same kwh/m² must never fan out to both heating
+    # branches, which double-counted heating emissions.
+    for energy_type in ("electric", "thermal"):
+        result = _resolve_building_rooms({"room_type": "office"}, energy_type)
+        assert len(_heating(result)) == 1
+
+
+def test_missing_or_unknown_energy_type_skips_heating() -> None:
+    for energy_type in (None, "", "solar"):
+        result = _resolve_building_rooms({"room_type": "office"}, energy_type)
+        assert _heating(result) == set(), (
+            f"energy_type={energy_type!r} should skip heating"
+        )
+        # Non-heating leaves are still produced.
+        assert EmissionType.buildings__rooms__lighting__office in result

--- a/docs/src/implementation-plans/1661-building-rooms-heating-split-refactor.md
+++ b/docs/src/implementation-plans/1661-building-rooms-heating-split-refactor.md
@@ -1,0 +1,83 @@
+---
+status: delivered
+issue: 1575
+last_updated: 2026-07-05
+title: "Building rooms: emit a single heating leaf (electric OR thermal) per room"
+summary: "Refactor the PR #1661 heating split so a room emits only the heating leaf matching its factor's energy_type, ending the thermal/electric double-count (#1575)."
+---
+
+# Building rooms: single heating leaf per room
+
+## Context
+
+Issue **#1575**: the building-rooms results graph showed the **same** quantity for
+centralized (thermal) and electric heating. Uploading only an electric factor
+should give **0 thermal / 100% electric**; instead both appeared equal.
+
+PR **#1661** first split heating into `heating_elec` / `heating_thermal` leaves,
+but emitted a room's `kwh/m²` against **both** leaves and zeroed the mismatched
+one with an overloaded `conversion_factor = 0`. That approach was wrong on four
+counts:
+
+1. It emitted a spurious `0.0` row for the non-applicable heating leaf.
+2. It overloaded `conversion_factor` as a kill-switch — and a legitimate `0.0`
+   (e.g. a carbon-free thermal network) was coerced to `1.0` by a falsy `or`.
+3. It silently dropped **all** heating at ZZ level (missing/invalid `room_type`),
+   because the gate keyed on `emission_type.parent`.
+4. `energy_type` was declared a value field yet read from a place inconsistent
+   with the classification-based ingestion.
+
+## Approach
+
+Decide the correct heating leaf **once, up front**, from the matched factor's
+`energy_type`, so a room emits **electric OR thermal — never both**. Selection
+moves out of the per-leaf formula and into emission-type resolution.
+
+### Changes
+
+- **`energy_type` → classification.** Moved back to
+  `buildings_classification_fields`; alias-normalization dropped (stored values
+  are already `electric` / `thermal`).
+- **Resolve the factor's energy type in the service.**
+  `DataEntryEmissionService._get_building_energy_type` reads the matched factor's
+  `classification.energy_type` — cache-aware for bulk recalc, single DB `get`
+  otherwise. It **fails loudly** on a missing factor or an invalid `energy_type`
+  rather than silently dropping heating. `None` means "no matched factor → no
+  heating".
+- **Explicit dispatch, no smuggling.** `resolve_emission_types` takes an explicit
+  keyword `building_energy_type` and routes building rooms through
+  `_resolve_building_rooms(data, energy_type)`, which appends only the matching
+  `heating_electric` / `heating_thermal` leaf (WW leaf when `room_type` is set,
+  ZZ parent otherwise). `data_entry.data` is never mutated.
+- **Enum rename.** `EmissionType.buildings__rooms__heating_elec` →
+  `heating_electric`; frontend chart constants updated to match.
+- **Formula simplified.** `_compute_kwh_emission` no longer inspects
+  `energy_type`. `conversion_factor` applies to heating only, defaults to `1.0`,
+  and an explicit `is None` check preserves a legitimate `0.0`.
+
+## Result
+
+- A room with only an electric factor emits `0` thermal / `100%` electric (and
+  vice-versa).
+- Rollup no longer double-counts: **65.0**, not 95.0.
+- Corrupt/missing building factors fail loudly instead of vanishing heating.
+
+## Tests
+
+- **Unit** — `test_buildings_schemas.py` (formula + `resolve_computations`
+  selection), `test_building_rooms_resolver.py` (leaf selection per energy type
+  and room-type presence), `test_data_entry_emission_service.py` (energy-type
+  resolution, cache path, loud failure on corrupt factor).
+- **Integration** — `test_buildings_csv_pg.py`: an electric factor emits only the
+  electric leaf, a thermal factor only the thermal leaf, no double-count;
+  `test_strategy_b_rematch_pg.py` updated for the enum rename.
+
+## Delivery
+
+- Branch `fix/1661-refactor` → commit `9f2d6bb8` (fix) + `206fdc8f`
+  (`int()`-cast cleanup on `primary_factor_id`).
+- PR **#1714** → `dev`, closes #1575.
+
+## Follow-up
+
+Frontend graph differentiation (issue **#1465**) is tracked separately.

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -36,7 +36,7 @@ const LABEL_KEY_MAP: Record<string, string> = {
   // buildings
   combustion: 'charts-energy-combustion-subcategory',
   heating_thermal: 'charts-heating-thermal-subcategory',
-  heating_elec: 'charts-heating-elec-subcategory',
+  heating_electric: 'charts-heating-elec-subcategory',
   lighting: 'charts-lighting-subcategory',
   cooling: 'charts-cooling-subcategory',
   ventilation: 'charts-ventilation-subcategory',

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -54,7 +54,7 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   lighting: 'charts-lighting-subcategory',
   cooling: 'charts-cooling-subcategory',
   ventilation: 'charts-ventilation-subcategory',
-  heating_elec: 'charts-heating-elec-subcategory',
+  heating_electric: 'charts-heating-elec-subcategory',
   heating_thermal: 'charts-heating-thermal-subcategory',
   laboratories: 'charts-laboratories-subcategory',
   office: 'charts-office-subcategory',

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -880,11 +880,11 @@ const chartOption = computed((): EChartsOption => {
       type: 'bar' as const,
       stack: 'total',
       animation: true,
-      encode: { x: 'category', y: 'heating_elec' },
+      encode: { x: 'category', y: 'heating_electric' },
       itemStyle: {
         color: getSubcategoryColor(
           'buildings_room',
-          'heating_elec',
+          'heating_electric',
           colors.value.lilac.light,
         ),
       },
@@ -1258,7 +1258,7 @@ const chartOption = computed((): EChartsOption => {
         'lighting',
         'cooling',
         'ventilation',
-        'heating_elec',
+        'heating_electric',
         'heating_thermal',
         'combustion',
         'scientific',

--- a/frontend/src/composables/useEmissionTreemap.ts
+++ b/frontend/src/composables/useEmissionTreemap.ts
@@ -61,7 +61,7 @@ export function normalizeParentKey(
 export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
   process_emissions: ['co2', 'ch4', 'n2o', 'refrigerants'],
   buildings_energy_combustion: ['combustion', 'heating_thermal'],
-  buildings_room: ['heating_elec', 'cooling', 'ventilation', 'lighting'],
+  buildings_room: ['heating_electric', 'cooling', 'ventilation', 'lighting'],
   equipment: ['scientific', 'it', 'other'],
   external_cloud_and_ai: ['clouds', 'ai'],
   purchases: [

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -419,7 +419,7 @@ export const CHART_CATEGORY_COLOR_SCALES = computed(() => ({
 export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
   (): Record<string, Record<string, string>> => ({
     buildings_room: {
-      heating_elec: colors.value.lilac.dark,
+      heating_electric: colors.value.lilac.dark,
       cooling: colors.value.lilac.default,
       ventilation: colors.value.lilac.light,
       lighting: colors.value.lilac.lighter,


### PR DESCRIPTION
## Why

PR #1661 (issue #1575) split building-room heating into electric vs thermal leaves, but a room's `kwh/m²` was emitted against **both** leaves and the mismatched one was zeroed via an overloaded `conversion_factor = 0`. That approach:

- emitted a spurious `0.0` row for the non-applicable heating leaf;
- overloaded `conversion_factor` as a kill-switch (and coerced a legitimate `0.0`, e.g. a carbon-free network, to `1.0` via a falsy `or`);
- silently dropped **all** heating at ZZ level (missing/invalid `room_type`).

## What

Select the single correct heating leaf up front from the matched factor's `energy_type`, so a room emits **electric OR thermal — never both**.

- `energy_type` moved back to the factor's **classification** fields; alias-normalization dropped (values are already `electric`/`thermal`).
- New `DataEntryEmissionService._get_building_energy_type` resolves the matched factor's `energy_type` (cache-aware for bulk recalc, single DB `get` otherwise) and **fails loudly** on a missing/corrupt factor rather than silently dropping heating.
- `resolve_emission_types` takes an explicit `building_energy_type` and dispatches building rooms through `_resolve_building_rooms`, which appends only the matching `heating_electric` / `heating_thermal` leaf (`None` → no heating). `data` is never mutated; the energy type is passed explicitly, not smuggled through the payload.
- `EmissionType.buildings__rooms__heating_elec` → `heating_electric`; frontend chart constants updated to match.
- `_compute_kwh_emission` simplified: `conversion_factor` applies to heating only, defaults to `1.0`, and an explicit `is None` check preserves a legitimate `0.0`.

## Result

A room with only an electric factor now emits **0 thermal / 100% electric** (and vice-versa); the rollup no longer double-counts (65.0, not 95.0).

## Tests

- Unit: `test_buildings_schemas.py` (formula + `resolve_computations` selection), new `test_building_rooms_resolver.py`, `test_data_entry_emission_service.py` energy-type resolution.
- Integration: `test_buildings_csv_pg.py` — electric factor emits only the electric leaf, thermal factor only the thermal leaf, no double-count; `test_strategy_b_rematch_pg.py` updated.

Closes #1575
