### PR TITLE
feat(1661): SQL factor resolution for lists, resolver-free updates, live equipment defaults

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -1017,7 +1017,6 @@ async def update(
         current_user=UserRead.model_validate(current_user),
         request_context=request_context,
         background_tasks=background_tasks,
-        year=year,
     )
     await EmbodiedEnergyWorkflow(db).post_update(
         carbon_report_module,
@@ -1025,7 +1024,6 @@ async def update(
         current_user=UserRead.model_validate(current_user),
         request_context=request_context,
         background_tasks=background_tasks,
-        year=year,
     )
     return response
 

--- a/backend/app/modules/equipment/schemas.py
+++ b/backend/app/modules/equipment/schemas.py
@@ -147,10 +147,6 @@ class EquipmentModuleHandler(BaseModuleHandler):
 
     kind_field: str = "equipment_class"
     subkind_field: str = "sub_class"
-    factor_value_fields: list[str] = [
-        "active_usage_hours_per_week",
-        "standby_usage_hours_per_week",
-    ]
 
     # Sort/filter keys MUST read from the same source `to_response` displays,
     # or the visible column won't match the ordering. equipment_class is shown
@@ -164,12 +160,14 @@ class EquipmentModuleHandler(BaseModuleHandler):
     )
     sort_map = {
         "id": DataEntry.id,
-        "active_usage_hours_per_week": DataEntry.data[
-            "active_usage_hours_per_week"
-        ].as_float(),
-        "standby_usage_hours_per_week": DataEntry.data[
-            "standby_usage_hours_per_week"
-        ].as_float(),
+        "active_usage_hours_per_week": func.coalesce(
+            DataEntry.data["active_usage_hours_per_week"].as_float(),
+            Factor.values["active_usage_hours_per_week"].as_float(),
+        ),
+        "standby_usage_hours_per_week": func.coalesce(
+            DataEntry.data["standby_usage_hours_per_week"].as_float(),
+            Factor.values["standby_usage_hours_per_week"].as_float(),
+        ),
         "name": DataEntry.data["name"].as_string(),
         "active_power_w": Factor.values["active_power_w"].as_float(),
         "standby_power_w": Factor.values["standby_power_w"].as_float(),
@@ -210,15 +208,15 @@ class EquipmentModuleHandler(BaseModuleHandler):
             return []
 
         def _equipment_formula(ctx: dict, factor_values: dict) -> Optional[float]:
+            # Usage hours are a live default: the user's value wins, an
+            # unset field tracks the factor's current suggestion (nothing
+            # is seeded into entry.data any more).
             active_hours = ctx.get("active_usage_hours_per_week")
+            if active_hours is None:
+                active_hours = factor_values.get("active_usage_hours_per_week")
             standby_hours = ctx.get("standby_usage_hours_per_week")
-            # default active_hours and standby_hours should be retrieved from the factor
-            #  if not provided by the user
-            # in fine it should never happened
-            # if active_hours is None:
-            #     active_hours = factor_values.get("active_usage_hours_per_week")
-            # if standby_hours is None:
-            #     standby_hours = factor_values.get("standby_usage_hours_per_week")
+            if standby_hours is None:
+                standby_hours = factor_values.get("standby_usage_hours_per_week")
             if active_hours is None or standby_hours is None:
                 return None
             active_power_w = factor_values.get("active_power_w")
@@ -255,6 +253,16 @@ class EquipmentModuleHandler(BaseModuleHandler):
             **data,
             "active_power_w": primary_factor.get("active_power_w", None),
             "standby_power_w": primary_factor.get("standby_power_w", None),
+            "active_usage_hours_per_week": (
+                data.get("active_usage_hours_per_week")
+                if data.get("active_usage_hours_per_week") is not None
+                else primary_factor.get("active_usage_hours_per_week")
+            ),
+            "standby_usage_hours_per_week": (
+                data.get("standby_usage_hours_per_week")
+                if data.get("standby_usage_hours_per_week") is not None
+                else primary_factor.get("standby_usage_hours_per_week")
+            ),
             "equipment_class": primary_factor.get("class")
             or data.get("equipment_class"),
             "sub_class": primary_factor.get("sub_class") or data.get("sub_class"),

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -27,7 +27,6 @@ from app.schemas.carbon_report_response import SubmoduleResponse, SubmoduleSumma
 from app.schemas.data_entry import (
     BaseModuleHandler,
     DataEntryUpdate,
-    ModuleHandler,
 )
 from app.utils.data_entry_emission_type_map import (
     DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION,
@@ -500,7 +499,7 @@ class DataEntryRepository:
             conditions.append(or_(f_sub == d_sub, f_sub.is_(None)))
             ordering = [f_sub.isnot(None).desc()]
         return (
-            sa_select(f.id)
+            sa_select(col(f.id))
             .where(*conditions)
             .order_by(*ordering, col(f.id))
             .limit(1)

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -29,7 +29,6 @@ from app.schemas.data_entry import (
     DataEntryUpdate,
     ModuleHandler,
 )
-from app.services.factor_resolver import FactorResolver
 from app.utils.data_entry_emission_type_map import (
     DATA_ENTRY_TYPE_TO_ROLLUP_EMISSION,
     ROLLUP_EMISSION_TYPE_IDS,
@@ -433,11 +432,11 @@ class DataEntryRepository:
         return aggregation
 
     def _apply_name_filter(
-        self, statement, filter: Optional[str], handler: ModuleHandler
+        self, statement, filter: Optional[str], filter_map: dict
     ):
         """
-        Applies a filter to the given SQLAlchemy statement based on
-        the handler's filter_map if a valid filter is provided.
+        Applies a filter to the given SQLAlchemy statement using the
+        caller-prepared (possibly lateral-adapted) filter_map.
         """
         filter_pattern = ""
         if filter:
@@ -451,15 +450,62 @@ class DataEntryRepository:
 
         if filter:
             filter_pattern = f"%{filter}%"
-            # Get filter map from handler, default to filtering by name
-            filter_map = getattr(handler, "filter_map", {}) or DEFAULT_FILTER_MAP
-
             # Build OR conditions for all filter fields
             conditions = [
                 filter_expr.ilike(filter_pattern) for filter_expr in filter_map.values()
             ]
             statement = statement.where(or_(*conditions))
         return statement, filter_pattern
+
+    def _resolved_factor_id(self, handler: Any, data_entry_type_id: int) -> Any:
+        """SQL twin of ``FactorResolver`` for list queries.
+
+        Correlated scalar subquery returning, per entry row, the id of the
+        factor the resolver would pick — deterministic because the reupload
+        sweep keeps a single factor generation per
+        ``(det, year, classification)``.  Joining ``Factor`` on this id
+        makes factor-backed sort/filter/pagination work for every row,
+        including entries whose emissions are not computed yet.
+
+        Chain parity: exact ``(kind, subkind)`` beats the subkind-less row;
+        for override handlers an override-code match beats the code-less
+        average row.  Divergences (display-only, accepted): matching is
+        kind-anchored — a code match under a *different* kind is not
+        considered — and ambiguity resolves to the lowest id instead of
+        raising; compute/update paths keep the loud semantics.
+        """
+        f = aliased(Factor)
+        kind_field: str = handler.kind_field
+        entry_kind = DataEntry.data[kind_field].as_string()
+        conditions = [
+            col(f.data_entry_type_id) == data_entry_type_id,
+            col(f.year) == col(DataEntry.year),
+            f.classification[kind_field].as_string() == entry_kind,
+        ]
+        ordering: list[Any] = []
+        override_field = handler.kind_field_override
+        subkind_field = handler.subkind_field
+        # Preference ordering must not reference outer columns (sqlite
+        # rejects correlated ORDER BY): within the WHERE-filtered candidate
+        # set, carrying a subkind/override code IS the exact match, so
+        # "specific first" reduces to a non-correlated IS NOT NULL sort.
+        if override_field is not None:
+            f_code = f.classification[override_field].as_string()
+            d_code = DataEntry.data[override_field].as_string()
+            conditions.append(or_(f_code == d_code, f_code.is_(None)))
+            ordering = [f_code.isnot(None).desc()]
+        elif subkind_field is not None:
+            f_sub = f.classification[subkind_field].as_string()
+            d_sub = DataEntry.data[subkind_field].as_string()
+            conditions.append(or_(f_sub == d_sub, f_sub.is_(None)))
+            ordering = [f_sub.isnot(None).desc()]
+        return (
+            sa_select(f.id)
+            .where(*conditions)
+            .order_by(*ordering, col(f.id))
+            .limit(1)
+            .scalar_subquery()
+        )
 
     def _apply_sort(self, statement, sort_by: str, sort_order: str, sort_map: dict):
         sort_expr = sort_map.get(sort_by)
@@ -494,6 +540,21 @@ class DataEntryRepository:
             DataEntryTypeEnum.member.value,
             DataEntryTypeEnum.student.value,
         )
+        handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum(data_entry_type_id))
+
+        # Classification-resolved factor in SQL (plan 1661-sql-factor-resolution):
+        # used for every handler whose kind lives in entry.data. Travel and
+        # headcount derive their kind at compute time, so their factor display
+        # keeps coming from the computed emission rows below.
+        resolved_factor_id: Any = None
+        if (
+            not is_travel_entry
+            and not is_headcount_entry
+            and handler.kind_field is not None
+        ):
+            resolved_factor_id = self._resolved_factor_id(
+                handler, data_entry_type_id
+            )
 
         if is_buildings_entry:
             # --- Direct JOIN on rollup row (avoids GROUP BY, prevents double-count) ---
@@ -537,7 +598,7 @@ class DataEntryRepository:
                 )
                 .join(
                     Factor,
-                    col(RollupEmission.primary_factor_id) == col(Factor.id),
+                    col(Factor.id) == resolved_factor_id,
                     isouter=True,
                 )
                 .join(
@@ -608,19 +669,17 @@ class DataEntryRepository:
                     OriginLocation = aliased(Location)
                     DestLocation = aliased(Location)
                     entities.extend([OriginLocation, DestLocation])
-            statement = (
-                sa_select(*entities)
-                .join(
-                    emission_agg,
-                    col(DataEntry.id) == emission_agg.c.data_entry_id,
-                    isouter=True,
-                )
-                .join(
-                    Factor,
-                    emission_agg.c.primary_factor_id == col(Factor.id),
-                    isouter=True,
-                )
+            statement = sa_select(*entities).join(
+                emission_agg,
+                col(DataEntry.id) == emission_agg.c.data_entry_id,
+                isouter=True,
             )
+            factor_on = (
+                col(Factor.id) == resolved_factor_id
+                if resolved_factor_id is not None
+                else emission_agg.c.primary_factor_id == col(Factor.id)
+            )
+            statement = statement.join(Factor, factor_on, isouter=True)
 
             if is_travel_entry:
                 statement = statement.join(
@@ -698,11 +757,13 @@ class DataEntryRepository:
                 == institutional_id_filter
             )
 
-        handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum(data_entry_type_id))
         handler_default = getattr(handler, "default_where", [])
         if handler_default:
             statement = statement.where(*handler_default)
-        statement, filter_pattern = self._apply_name_filter(statement, filter, handler)
+        filter_map = dict(getattr(handler, "filter_map", {}) or DEFAULT_FILTER_MAP)
+        statement, filter_pattern = self._apply_name_filter(
+            statement, filter, filter_map
+        )
 
         sort_map = dict(
             handler.sort_map
@@ -734,10 +795,15 @@ class DataEntryRepository:
         if handler_default:
             count_stmt = count_stmt.where(*handler_default)
         if filter_pattern != "":
-            # Get filter map from handler, default to filtering by name
-            filter_map = getattr(handler, "filter_map", {}) or DEFAULT_FILTER_MAP
-
-            # Build OR conditions for all filter fields
+            if resolved_factor_id is not None:
+                # Filter conditions may reference Factor columns — join the
+                # resolved factor so the count sees the same rows as the
+                # page query (replaces the old implicit factors cross-join).
+                count_stmt = count_stmt.select_from(DataEntry).join(
+                    Factor,
+                    col(Factor.id) == resolved_factor_id,
+                    isouter=True,
+                )
             conditions = [
                 filter_expr.ilike(filter_pattern) for filter_expr in filter_map.values()
             ]
@@ -747,9 +813,6 @@ class DataEntryRepository:
         count = len(rows)
 
         items: list[BaseModel] = []
-        # One resolver for the whole page: it memoizes per (data_entry_type,
-        # year), so per-row calls in the fallback below are cheap.
-        resolver = FactorResolver(self.session)
 
         for row in rows:
             # Pre-bind conditionally-unpacked variables so static type checkers
@@ -783,36 +846,6 @@ class DataEntryRepository:
                 self._detach(member_entry, _emission, _origin_loc, _dest_loc)
             elif is_buildings_entry:
                 self._detach(building_room)
-
-            handler = BaseModuleHandler.get_by_type(
-                DataEntryTypeEnum(data_entry.data_entry_type_id)
-            )
-            # No emission row carried a factor — derive it from the entry's
-            # classification (the entry never stores a factor id). The
-            # resolver itself short-circuits missing/empty kind values, so
-            # Strategy-B entries cost nothing here.
-            if primary_factor is None and data_entry.year is not None:
-                try:
-                    primary_factor = await resolver.resolve(
-                        handler,
-                        data_entry.data,
-                        DataEntryTypeEnum(data_entry.data_entry_type_id),
-                        data_entry.year,
-                    )
-                except ValueError as exc:
-                    # Ambiguous factor data (e.g. duplicate average rows for
-                    # one kind) must not 500 the whole page — this is
-                    # display enrichment only. Recalc/update paths already
-                    # surface ambiguity loudly; here we render the row with
-                    # empty factor columns instead.
-                    logger.warning(
-                        "Ambiguous factor data resolving primary_factor for "
-                        "data_entry_id=%s data_entry_type=%s year=%s: %s",
-                        data_entry.id,
-                        data_entry.data_entry_type_id,
-                        data_entry.year,
-                        exc,
-                    )
 
             primary_factor_values = primary_factor.values if primary_factor else {}
             primary_factor_classification = (

--- a/backend/app/schemas/data_entry.py
+++ b/backend/app/schemas/data_entry.py
@@ -130,7 +130,6 @@ class ModuleHandler(Protocol[T]):
     subkind_field: Optional[str] = None
     kind_label_field: Optional[str] = None
     subkind_label_field: Optional[str] = None
-    factor_value_fields: Optional[list[str]] = None
 
     def to_response(
         self,
@@ -244,7 +243,6 @@ class BaseModuleHandler(metaclass=ModuleHandlerMeta):
     # Used during CSV seeding to populate mandatory fields with factor
     # defaults (e.g. ["active_usage_hours_per_week",
     # "standby_usage_hours_per_week"] for equipment).
-    factor_value_fields: Optional[list[str]] = None
 
     # -- Registration --
     # The DataEntryTypeEnum this handler serves. For handlers that cover

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -26,7 +26,6 @@ from app.models.data_ingestion import (
     IngestionState,
     TargetType,
 )
-from app.models.factor import Factor
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
 from app.models.unit import Unit
 from app.models.user import User
@@ -46,7 +45,6 @@ from app.services.data_entry_emission_service import (
 )
 from app.services.data_entry_service import DataEntryService
 from app.services.data_ingestion.base_provider import DataIngestionProvider
-from app.services.module_handler_service import ModuleHandlerService
 from app.services.unit_service import UnitService
 from app.services.user_service import UserService
 
@@ -799,11 +797,11 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         """
         seg = self._seg
         row_t = seg.get("row", 0.0)
-        inner = ("resolve", "validate", "enrich", "populate")
+        inner = ("resolve", "validate", "enrich")
         per_row_ms = (parse_elapsed / rows * 1000) if rows else 0.0
         logger.info(
             "Row-loop profile: %d rows in %.1fs (%.2f ms/row) | row=%.1fs "
-            "[resolve=%.1f validate=%.1f enrich=%.1f populate=%.1f row_other=%.1f] "
+            "[resolve=%.1f validate=%.1f enrich=%.1f row_other=%.1f] "
             "loop_overhead=%.1fs",
             rows,
             parse_elapsed,
@@ -812,7 +810,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             seg.get("resolve", 0.0),
             seg.get("validate", 0.0),
             seg.get("enrich", 0.0),
-            seg.get("populate", 0.0),
             row_t - sum(seg.get(k, 0.0) for k in inner),
             parse_elapsed - row_t,
         )
@@ -1230,47 +1227,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)
                 return None, error_msg, None, None
 
-            # Resolve the matching Factor from the in-memory factors_map (NOT
-            # a DB query!) This avoids 100k+ DB queries - factors already
-            # loaded in setup phase. Feeds populate_defaults below.
-            matched_factor: Factor | None = None
-            if "factors_map" in setup_result and handler.kind_field:
-                kind_value, subkind_value = self._extract_kind_subkind_values(
-                    filtered_row, handlers
-                )
-                # Defense in depth: the setup-time guard in
-                # _load_handlers_and_factors raises before any row
-                # reaches this method,
-                # so reaching this branch with a falsy year would mean a
-                # future caller bypassed setup. Use the same `not self.year`
-                # check the setup-time guard uses so both layers reject the
-                # same set of values (None and 0); a stricter `is None` check
-                # would let `year=0` rebuild the `:0:` silent-miss key.
-                if not self.year:
-                    raise ValueError(
-                        "year must be set (and non-zero) before processing "
-                        "rows; setup-time guard was bypassed"
-                    )
-                year_value = self.year
-                # Build lookup key same way as load_factors_map does
-                key_full = (
-                    f"{data_entry_type.value}:"
-                    f"{year_value}:"
-                    f"{(kind_value or '').lower()}:"
-                    f"{(subkind_value or '').lower()}"
-                )
-                factor = setup_result["factors_map"].get(key_full)
-                # Fallback: try without subkind
-                if not factor and subkind_value:
-                    key_kind = (
-                        f"{data_entry_type.value}:"
-                        f"{year_value}:"
-                        f"{(kind_value or '').lower()}"
-                    )
-                    factor = setup_result["factors_map"].get(key_kind)
-                if factor:
-                    matched_factor = factor
-
             # Resolve carbon_report_module_id
             carbon_report_module_id = None
 
@@ -1345,13 +1301,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             if enrich_error is not None:
                 self._record_row_error(stats, row_idx, enrich_error, max_row_errors)
                 return None, enrich_error, None, None
-
-            with self._timed("populate"):
-                if matched_factor is not None:
-                    handler_service = ModuleHandlerService(self.data_session)
-                    data = await handler_service.populate_defaults(
-                        handler, data, matched_factor
-                    )
 
             # Persist the override on the data
             # entry under the reserved ``KG_CO2EQ_OVERRIDE_KEY`` carrier so

--- a/backend/app/services/module_handler_service.py
+++ b/backend/app/services/module_handler_service.py
@@ -4,22 +4,16 @@ Owns all DB-dependent logic that was previously on BaseModuleHandler,
 breaking the circular dependency between schemas and services.
 """
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.logging import get_logger
 from app.models.data_entry import DataEntryTypeEnum
-from app.models.factor import Factor
 from app.models.taxonomy import TaxonomyNode
-from app.services.factor_resolver import FactorResolver
 from app.services.factor_service import FactorService
 
 if TYPE_CHECKING:
     from app.schemas.data_entry import ModuleHandler
-
-logger = get_logger(__name__)
-
 
 class ModuleHandlerService:
     """Orchestrates factor-dependent operations for module handlers."""
@@ -27,129 +21,35 @@ class ModuleHandlerService:
     def __init__(self, session: AsyncSession):
         self.session = session
         self.factor_service = FactorService(session)
-        self.factor_resolver = FactorResolver(session)
 
-    async def resolve_factor(
-        self,
-        handler: "ModuleHandler",
-        payload: dict,
-        data_entry_type_id: DataEntryTypeEnum,
-        year: int,
-        existing_data: Optional[dict] = None,
-    ) -> Optional[Factor]:
-        """Resolve the Factor matching the payload's classification fields.
-
-        Looks up the factor via ``FactorResolver`` using the handler's
-        kind_field / subkind_field (or kind_field_override) rules. The
-        payload itself is never mutated: existing_data is merged into a
-        copy so partial updates still resolve against the full persisted
-        classification.
-
-        Args:
-            handler: The module handler for this data entry type
-            payload: The data payload to resolve against
-            data_entry_type_id: The data entry type enum
-            year: Carbon-report year. Required — without it the factor lookup
-                  spans all years and raises MultipleResultsFound when the same
-                  classification exists in more than one year.
-            existing_data: Existing data entry data for merging on updates
-        """
-        data = payload.copy()
-        if existing_data:
-            for key, value in existing_data.items():
-                if key not in data:
-                    data[key] = value
-
-        return await self.factor_resolver.resolve(
-            handler, data, data_entry_type_id, year
-        )
-
-    async def populate_defaults(
-        self,
-        handler: "ModuleHandler",
-        data: dict,
-        factor: Factor,
-    ) -> dict:
-        if (
-            factor
-            and hasattr(handler, "factor_value_fields")
-            and handler.factor_value_fields
-        ):
-            for field_name in handler.factor_value_fields:
-                if field_name not in data or data[field_name] in (None, "", 0):
-                    default_value = factor.values.get(field_name)
-                    if default_value is not None:
-                        data[field_name] = default_value
-                        logger.debug(
-                            f"{field_name}={default_value} from factor populated"
-                        )
-
-        return data
-
-    async def resolve_factor_if_changed(
-        self,
+    @staticmethod
+    def clear_dependent_fields_on_kind_change(
         handler: "ModuleHandler",
         update_payload: dict,
-        data_entry_type: DataEntryTypeEnum,
         item_data: dict,
         existing_data: dict | None,
-        year: int,
-    ) -> tuple[dict, Optional[Factor]]:
-        """Resolve the matching Factor when classification fields change.
+    ) -> dict:
+        """Clear classification fields that depended on the old kind.
 
-        Args:
-            handler: The module handler for this data entry type
-            update_payload: The payload to update
-            data_entry_type: The data entry type enum
-            item_data: The incoming item data from the request
-            existing_data: The existing data entry data
-            year: Carbon-report year passed through to resolve_factor.
+        Pure payload normalization — no factor resolution happens on the
+        update path any more (emission compute resolves on its own; factor
+        defaults are derived at compute/display time). When the kind
+        changes, the stored subkind and override code belonged to the old
+        kind and are cleared unless the request supplies new ones.
         """
-        handler_kind_field = handler.kind_field or ""
-        handler_subkind_field = handler.subkind_field or ""
-        if existing_data is None:
-            factor = await self.resolve_factor(
-                handler, update_payload, data_entry_type, existing_data=None, year=year
-            )
-            return update_payload, factor
+        kind_field = handler.kind_field or ""
+        if existing_data is None or kind_field not in item_data:
+            return update_payload
+        if item_data[kind_field] == existing_data.get(kind_field):
+            return update_payload
 
-        kind_changed = (handler_kind_field in item_data) and (
-            item_data[handler_kind_field] != existing_data.get(handler_kind_field)
-        )
-        subkind_changed = (handler_subkind_field in item_data) and (
-            item_data[handler_subkind_field] != existing_data.get(handler_subkind_field)
-        )
+        subkind_field = handler.subkind_field or ""
+        if subkind_field and subkind_field not in item_data:
+            update_payload[subkind_field] = None
         override_field = getattr(handler, "kind_field_override", None) or ""
-        override_changed = (override_field in item_data) and (
-            item_data[override_field] != existing_data.get(override_field)
-        )
-
-        if kind_changed:
-            if handler_subkind_field:
-                update_payload[handler_subkind_field] = None
-            # The stored override code belonged to the old kind; unless the
-            # request supplies a new one, clear it so resolution follows the
-            # new kind instead of the stale, more-specific code.
-            if override_field and override_field not in item_data:
-                update_payload[override_field] = None
-
-        factor = None
-        if kind_changed or subkind_changed or override_changed:
-            factor = await self.resolve_factor(
-                handler,
-                update_payload,
-                data_entry_type,
-                existing_data=existing_data,
-                year=year,
-            )
-            # kind_changed or subkind_changed for some module handlers we need default
-            # it's done already in the base_csv_provider do the same here
-            if factor is not None:
-                update_payload = await self.populate_defaults(
-                    handler, update_payload, factor
-                )
-
-        return update_payload, factor
+        if override_field and override_field not in item_data:
+            update_payload[override_field] = None
+        return update_payload
 
     async def get_taxonomy(
         self,

--- a/backend/app/workflows/carbon_report_module.py
+++ b/backend/app/workflows/carbon_report_module.py
@@ -152,7 +152,6 @@ class CarbonReportModuleWorkflow:
         current_user: UserRead,
         request_context: dict,
         background_tasks: BackgroundTasks,
-        year: int,
     ) -> DataEntryResponse:
         try:
             existing_entry = await DataEntryService(self.session).get(id=item_id)
@@ -170,14 +169,14 @@ class CarbonReportModuleWorkflow:
             }
             data_entry_type = DataEntryTypeEnum(data_entry_type_id)
             handler = BaseModuleHandler.get_by_type(data_entry_type)
-            handler_service = ModuleHandlerService(self.session)
-            update_payload, _ = await handler_service.resolve_factor_if_changed(
+            # No factor resolution on update: subkind/override code that
+            # belonged to the old kind are cleared, everything else is the
+            # emission compute's job (it resolves on its own).
+            update_payload = ModuleHandlerService.clear_dependent_fields_on_kind_change(
                 handler,
                 update_payload,
-                data_entry_type,
                 item_data,
                 existing_data,
-                year=year,
             )
 
             # For equipment partial PATCH, validate against merged persisted+incoming

--- a/backend/app/workflows/embodied_energy.py
+++ b/backend/app/workflows/embodied_energy.py
@@ -46,7 +46,6 @@ class EmbodiedEnergyWorkflow:
         current_user: UserRead,
         request_context: dict,
         background_tasks: BackgroundTasks,
-        year: int,
     ) -> None:
         """Post-process the updated data entry to recalculate
         embodied energy emissions.
@@ -73,7 +72,6 @@ class EmbodiedEnergyWorkflow:
                     current_user,
                     request_context,
                     background_tasks,
-                    year,
                 )
 
     async def post_delete(
@@ -131,7 +129,6 @@ class EmbodiedEnergyWorkflow:
         current_user: UserRead,
         request_context: dict,
         background_tasks: BackgroundTasks,
-        year: int,
     ) -> None:
         embodied_energy_data = self._make_building_embodied_energy_data(data_entry)
         if embodied_energy_data is None:
@@ -155,7 +152,6 @@ class EmbodiedEnergyWorkflow:
                 current_user=current_user,
                 request_context=request_context,
                 background_tasks=background_tasks,
-                year=year,
             )
 
     def _make_building_embodied_energy_data(

--- a/backend/tests/integration/services/data_ingestion/test_purchase_factor_resolution_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_purchase_factor_resolution_pg.py
@@ -28,7 +28,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.factor import Factor
 from app.schemas.data_entry import BaseModuleHandler
-from app.services.module_handler_service import ModuleHandlerService
+from app.services.factor_resolver import FactorResolver
 
 from .conftest import csv_fixture_path
 
@@ -79,8 +79,7 @@ async def _resolve(
     session: AsyncSession, det: DataEntryTypeEnum, payload: dict
 ) -> Factor | None:
     handler = BaseModuleHandler.get_by_type(det)
-    service = ModuleHandlerService(session)
-    return await service.resolve_factor(handler, payload, det, year=_YEAR)
+    return await FactorResolver(session).resolve(handler, payload, det, _YEAR)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/services/data_ingestion/test_sql_factor_resolution_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_sql_factor_resolution_pg.py
@@ -1,0 +1,122 @@
+"""SQL factor resolution in list queries (plan 1661-sql-factor-resolution).
+
+``get_submodule_data`` joins ``Factor`` via a correlated scalar subquery on
+the entry's classification — not via emission rows — so factor-backed
+sort/filter work for entries whose emissions are not computed yet.  The
+sqlite unit tests in ``tests/unit/repositories/test_data_entry_repo.py``
+pin the resolution chain; this test pins the JSONB operator path and the
+cross-row ordering on real Postgres.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
+from app.models.factor import Factor
+from app.models.module_type import ModuleTypeEnum
+from app.models.unit import Unit
+from app.repositories.data_entry_repo import DataEntryRepository
+
+
+@pytest.mark.asyncio
+async def test_uncomputed_entry_sorts_and_displays_by_resolved_factor(pg_dsn):
+    """Two equipment entries — one WITH emission rows, one without any —
+    must both expose factor-backed columns and sort by them consistently."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            unit = Unit(
+                institutional_code="TEST-SQLRES",
+                institutional_id="TEST-UNIT-SQLRES",
+                name="Test Unit",
+                level=1,
+            )
+            s.add(unit)
+            await s.commit()
+            report = CarbonReport(year=2025, unit_id=unit.id)
+            s.add(report)
+            await s.commit()
+            module = CarbonReportModule(
+                carbon_report_id=report.id,
+                module_type_id=ModuleTypeEnum.equipment.value,
+            )
+            s.add(module)
+            await s.commit()
+            module_id = module.id
+            assert module_id is not None
+
+            low = Factor(
+                emission_type_id=EmissionType.equipment__it.value,
+                data_entry_type_id=DataEntryTypeEnum.it.value,
+                classification={"equipment_class": "Laptop", "sub_class": "Std"},
+                values={"active_power_w": 10.0, "standby_power_w": 1.0},
+                year=2025,
+            )
+            high = Factor(
+                emission_type_id=EmissionType.equipment__it.value,
+                data_entry_type_id=DataEntryTypeEnum.it.value,
+                classification={"equipment_class": "Server", "sub_class": "Std"},
+                values={"active_power_w": 500.0, "standby_power_w": 50.0},
+                year=2025,
+            )
+            s.add_all([low, high])
+            await s.commit()
+
+            computed = DataEntry(
+                carbon_report_module_id=module_id,
+                data_entry_type_id=DataEntryTypeEnum.it.value,
+                data={
+                    "name": "Computed",
+                    "equipment_class": "Laptop",
+                    "sub_class": "Std",
+                },
+                year=2025,
+            )
+            uncomputed = DataEntry(
+                carbon_report_module_id=module_id,
+                data_entry_type_id=DataEntryTypeEnum.it.value,
+                data={
+                    "name": "Uncomputed",
+                    "equipment_class": "Server",
+                    "sub_class": "Std",
+                },
+                year=2025,
+            )
+            s.add_all([computed, uncomputed])
+            await s.commit()
+            # Emission rows only for `computed` — `uncomputed` relies purely
+            # on the classification subquery.
+            s.add(
+                DataEntryEmission(
+                    data_entry_id=computed.id,
+                    emission_type_id=EmissionType.equipment__it.value,
+                    primary_factor_id=low.id,
+                    kg_co2eq=12.3,
+                )
+            )
+            await s.commit()
+
+            repo = DataEntryRepository(s)
+            response = await repo.get_submodule_data(
+                carbon_report_module_id=module_id,
+                data_entry_type_id=DataEntryTypeEnum.it.value,
+                limit=10,
+                offset=0,
+                sort_by="active_power_w",
+                sort_order="desc",
+            )
+    finally:
+        await engine.dispose()
+
+    assert [i.name for i in response.items] == ["Uncomputed", "Computed"], (
+        "sort by the factor-backed column must place the uncomputed "
+        "Server entry (500 W) before the computed Laptop entry (10 W)"
+    )
+    assert response.items[0].active_power_w == 500.0
+    assert response.items[1].active_power_w == 10.0

--- a/backend/tests/unit/modules/test_equipment_schemas.py
+++ b/backend/tests/unit/modules/test_equipment_schemas.py
@@ -23,15 +23,19 @@ factor (EquipmentFactorCreate)
     ef_kg_co2eq_per_kwh          ✅ ≥ 0
 """
 
+from types import SimpleNamespace
+
 import pytest
 from pydantic import ValidationError
 
+from app.core.config import get_settings
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_entry_emission import EmissionType
 from app.modules.equipment.schemas import (
     EquipmentFactorCreate,
     EquipmentHandlerCreate,
 )
+from app.schemas.data_entry import BaseModuleHandler
 
 _OMIT = object()
 
@@ -187,3 +191,62 @@ def test_equipment_factor_valid(payload: dict) -> None:
 def test_equipment_factor_invalid(payload: dict) -> None:
     with pytest.raises(ValidationError):
         EquipmentFactorCreate.model_validate(payload)
+
+
+# ── live hour defaults (plan 1661-sql-factor-resolution step 6) ─────────
+
+
+def _compute_kg(entry_data: dict, factor_values: dict) -> float | None:
+    """Run the equipment formula the way prepare_create does: ctx wins,
+    factor values are the live default for unset usage hours."""
+    handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum.it)
+    entry = SimpleNamespace(
+        data_entry_type_id=DataEntryTypeEnum.it.value, data=entry_data
+    )
+    ctx = {**entry_data, "primary_factor_id": 1}
+    comps = handler.resolve_computations(entry, EmissionType.equipment__it, ctx)
+    assert len(comps) == 1
+    formula = comps[0].formula_func
+    assert formula is not None
+    return formula(ctx, factor_values)
+
+
+def test_equipment_formula_user_hours_win_over_factor_defaults() -> None:
+    kg = _compute_kg(
+        {"active_usage_hours_per_week": 10, "standby_usage_hours_per_week": 0},
+        {
+            "active_power_w": 100.0,
+            "standby_power_w": 10.0,
+            "ef_kg_co2eq_per_kwh": 1.0,
+            "active_usage_hours_per_week": 40,
+            "standby_usage_hours_per_week": 128,
+        },
+    )
+    settings_weeks = get_settings().WEEKS_PER_YEAR
+    assert kg == pytest.approx((10 * 100.0) * settings_weeks / 1000)
+
+
+def test_equipment_formula_falls_back_to_factor_hours_when_unset() -> None:
+    """Unset usage hours track the factor's current suggestion — nothing is
+    seeded into entry.data at ingest any more."""
+    kg = _compute_kg(
+        {},  # no hours on the entry
+        {
+            "active_power_w": 100.0,
+            "standby_power_w": 10.0,
+            "ef_kg_co2eq_per_kwh": 1.0,
+            "active_usage_hours_per_week": 40,
+            "standby_usage_hours_per_week": 128,
+        },
+    )
+    settings_weeks = get_settings().WEEKS_PER_YEAR
+    expected_weekly_wh = 40 * 100.0 + 128 * 10.0
+    assert kg == pytest.approx(expected_weekly_wh * settings_weeks / 1000)
+
+
+def test_equipment_formula_none_when_no_hours_anywhere() -> None:
+    kg = _compute_kg(
+        {},
+        {"active_power_w": 100.0, "standby_power_w": 10.0, "ef_kg_co2eq_per_kwh": 1.0},
+    )
+    assert kg is None

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -1,7 +1,7 @@
 """Unit tests for DataEntryRepository."""
 
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -13,7 +13,7 @@ from app.models.data_entry_emission import EmissionType
 from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
 from app.repositories.data_entry_repo import DEFAULT_FILTER_MAP, DataEntryRepository
-from app.schemas.data_entry import BaseModuleHandler, DataEntryUpdate
+from app.schemas.data_entry import DataEntryUpdate
 
 # ======================================================================
 # CRUD Operation Tests

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -9,6 +9,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportModule, CarbonReportType
 from app.models.data_entry import DataEntry, DataEntryStatusEnum, DataEntryTypeEnum
+from app.models.data_entry_emission import EmissionType
+from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
 from app.repositories.data_entry_repo import DEFAULT_FILTER_MAP, DataEntryRepository
 from app.schemas.data_entry import BaseModuleHandler, DataEntryUpdate
@@ -1228,36 +1230,48 @@ async def _make_equipment_entry(
     return entry
 
 
+async def _make_factor(
+    db_session: AsyncSession,
+    *,
+    classification: dict,
+    values: dict,
+    year: int = 2025,
+) -> Factor:
+    factor = Factor(
+        emission_type_id=EmissionType.equipment__scientific.value,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        classification=classification,
+        values=values,
+        year=year,
+    )
+    db_session.add(factor)
+    await db_session.commit()
+    return factor
+
+
 @pytest.mark.asyncio
-async def test_get_submodule_data_fallback_uses_factor_resolver(
+async def test_get_submodule_data_resolves_factor_from_classification_in_sql(
     db_session: AsyncSession,
 ):
-    """An entry with a classification but no emission rows gets its
-    ``primary_factor`` populated from ``FactorResolver.resolve`` — not from
-    a stored id."""
+    """An entry with a classification but NO emission rows gets its factor
+    from the correlated SQL subquery — sort/filter/display all see it."""
     repo = DataEntryRepository(db_session)
     entry = await _make_equipment_entry(db_session)
-
-    fake_factor = MagicMock()
-    fake_factor.values = {"active_power_w": 42.0, "standby_power_w": 3.0}
-    fake_factor.classification = {"class": "laptop", "sub_class": "13-inch"}
-
-    with patch("app.repositories.data_entry_repo.FactorResolver") as mock_resolver_cls:
-        mock_resolver_cls.return_value.resolve = AsyncMock(return_value=fake_factor)
-
-        response = await repo.get_submodule_data(
-            carbon_report_module_id=entry.carbon_report_module_id,
-            data_entry_type_id=DataEntryTypeEnum.scientific.value,
-            limit=10,
-            offset=0,
-            sort_by="id",
-            sort_order="asc",
-        )
-
-    handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum.scientific)
-    mock_resolver_cls.return_value.resolve.assert_awaited_once_with(
-        handler, entry.data, DataEntryTypeEnum.scientific, 2025
+    await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop", "sub_class": "13-inch"},
+        values={"active_power_w": 42.0, "standby_power_w": 3.0},
     )
+
+    response = await repo.get_submodule_data(
+        carbon_report_module_id=entry.carbon_report_module_id,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        limit=10,
+        offset=0,
+        sort_by="active_power_w",
+        sort_order="asc",
+    )
+
     assert len(response.items) == 1
     item = response.items[0]
     assert item.active_power_w == 42.0
@@ -1269,28 +1283,26 @@ async def test_get_submodule_data_ignores_legacy_stored_id_pointing_at_deleted_f
     db_session: AsyncSession,
 ):
     """A legacy ``data["primary_factor_id"]`` pointing at a deleted factor
-    must never be dereferenced — the resolver's result wins, and no 500 is
-    raised chasing the stale id."""
+    must never be dereferenced — the classification join wins, and no 500
+    is raised chasing the stale id."""
     repo = DataEntryRepository(db_session)
     entry = await _make_equipment_entry(
         db_session, extra_data={"primary_factor_id": 999999}
     )
+    await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop", "sub_class": "13-inch"},
+        values={"active_power_w": 99.0, "standby_power_w": 9.0},
+    )
 
-    fake_factor = MagicMock()
-    fake_factor.values = {"active_power_w": 99.0, "standby_power_w": 9.0}
-    fake_factor.classification = {"class": "laptop", "sub_class": "13-inch"}
-
-    with patch("app.repositories.data_entry_repo.FactorResolver") as mock_resolver_cls:
-        mock_resolver_cls.return_value.resolve = AsyncMock(return_value=fake_factor)
-
-        response = await repo.get_submodule_data(
-            carbon_report_module_id=entry.carbon_report_module_id,
-            data_entry_type_id=DataEntryTypeEnum.scientific.value,
-            limit=10,
-            offset=0,
-            sort_by="id",
-            sort_order="asc",
-        )
+    response = await repo.get_submodule_data(
+        carbon_report_module_id=entry.carbon_report_module_id,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        limit=10,
+        offset=0,
+        sort_by="id",
+        sort_order="asc",
+    )
 
     assert len(response.items) == 1
     item = response.items[0]
@@ -1299,29 +1311,29 @@ async def test_get_submodule_data_ignores_legacy_stored_id_pointing_at_deleted_f
 
 
 @pytest.mark.asyncio
-async def test_get_submodule_data_year_none_skips_factor_resolver_fallback(
+async def test_get_submodule_data_year_none_yields_no_factor(
     db_session: AsyncSession,
 ):
-    """An entry with no emission row and ``year=None`` must not hit the
-    resolver — ``FactorResolver.resolve`` requires a year to look up
-    factors, so the fallback is skipped and ``primary_factor`` stays
-    empty rather than resolving against the wrong (or no) year."""
+    """An entry with ``year=None`` matches no factor (the join is
+    year-equality-scoped), so factor-backed columns stay empty instead of
+    resolving against the wrong year."""
     repo = DataEntryRepository(db_session)
     entry = await _make_equipment_entry(db_session, year=None)
+    await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop", "sub_class": "13-inch"},
+        values={"active_power_w": 42.0, "standby_power_w": 3.0},
+    )
 
-    with patch("app.repositories.data_entry_repo.FactorResolver") as mock_resolver_cls:
-        mock_resolver_cls.return_value.resolve = AsyncMock()
+    response = await repo.get_submodule_data(
+        carbon_report_module_id=entry.carbon_report_module_id,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        limit=10,
+        offset=0,
+        sort_by="id",
+        sort_order="asc",
+    )
 
-        response = await repo.get_submodule_data(
-            carbon_report_module_id=entry.carbon_report_module_id,
-            data_entry_type_id=DataEntryTypeEnum.scientific.value,
-            limit=10,
-            offset=0,
-            sort_by="id",
-            sort_order="asc",
-        )
-
-    mock_resolver_cls.return_value.resolve.assert_not_awaited()
     assert len(response.items) == 1
     item = response.items[0]
     assert item.active_power_w is None
@@ -1329,72 +1341,81 @@ async def test_get_submodule_data_year_none_skips_factor_resolver_fallback(
 
 
 @pytest.mark.asyncio
-async def test_get_submodule_data_fallback_tolerates_ambiguous_factor_data(
+async def test_get_submodule_data_subkind_preference_ordering(
     db_session: AsyncSession,
 ):
-    """The resolver raising ``ValueError`` (ambiguous factor data, e.g.
-    duplicate average rows for one kind) must not 500 the whole page — this
-    is display enrichment only; the recalc/update paths already surface
-    ambiguity loudly. The offending row renders with an empty
-    ``primary_factor``; other rows on the same page are unaffected."""
-    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
-    db_session.add(report)
-    await db_session.flush()
-
-    module = CarbonReportModule(
-        carbon_report_id=report.id,
-        module_type_id=ModuleTypeEnum.equipment.value,
-        status="in_progress",
-    )
-    db_session.add(module)
-    await db_session.flush()
-
-    ambiguous_entry = DataEntry(
-        carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.scientific,
-        status=DataEntryStatusEnum.PENDING,
-        data={"name": "Ambiguous", "equipment_class": "ambiguous", "sub_class": "x"},
-        year=2025,
-    )
-    ok_entry = DataEntry(
-        carbon_report_module_id=module.id,
-        data_entry_type_id=DataEntryTypeEnum.scientific,
-        status=DataEntryStatusEnum.PENDING,
-        data={"name": "Laptop", "equipment_class": "laptop", "sub_class": "13-inch"},
-        year=2025,
-    )
-    db_session.add(ambiguous_entry)
-    db_session.add(ok_entry)
-    await db_session.commit()
-
-    fake_factor = MagicMock()
-    fake_factor.values = {"active_power_w": 42.0, "standby_power_w": 3.0}
-    fake_factor.classification = {"class": "laptop", "sub_class": "13-inch"}
-
-    async def fake_resolve(handler, data, data_entry_type, year):
-        if data.get("equipment_class") == "ambiguous":
-            raise ValueError("Ambiguous factor data: cannot disambiguate")
-        return fake_factor
-
+    """The SQL join mirrors FactorResolver's chain: an exact
+    ``(kind, subkind)`` row beats the subkind-less fallback row even when
+    the fallback has a lower id; an unknown subkind falls back to the
+    subkind-less row."""
     repo = DataEntryRepository(db_session)
-    with patch("app.repositories.data_entry_repo.FactorResolver") as mock_resolver_cls:
-        mock_resolver_cls.return_value.resolve = AsyncMock(side_effect=fake_resolve)
+    entry = await _make_equipment_entry(db_session)  # sub_class "13-inch"
+    # Lower id: the kind-only fallback row. Higher id: the exact match.
+    await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop"},
+        values={"active_power_w": 1.0, "standby_power_w": 1.0},
+    )
+    await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop", "sub_class": "13-inch"},
+        values={"active_power_w": 42.0, "standby_power_w": 3.0},
+    )
+    unknown_sub = await _make_equipment_entry(
+        db_session, extra_data={"name": "Unknown", "sub_class": "17-inch"}
+    )
 
+    for module_id, expected_power, expected_name in (
+        (entry.carbon_report_module_id, 42.0, "Laptop"),
+        (unknown_sub.carbon_report_module_id, 1.0, "Unknown"),
+    ):
         response = await repo.get_submodule_data(
-            carbon_report_module_id=module.id,
+            carbon_report_module_id=module_id,
             data_entry_type_id=DataEntryTypeEnum.scientific.value,
             limit=10,
             offset=0,
             sort_by="id",
             sort_order="asc",
         )
+        assert len(response.items) == 1
+        item = response.items[0]
+        assert item.name == expected_name
+        assert item.active_power_w == expected_power
 
-    assert len(response.items) == 2
-    by_name = {item.name: item for item in response.items}
-    assert by_name["Ambiguous"].active_power_w is None
-    assert by_name["Ambiguous"].standby_power_w is None
-    assert by_name["Laptop"].active_power_w == 42.0
-    assert by_name["Laptop"].standby_power_w == 3.0
+
+@pytest.mark.asyncio
+async def test_get_submodule_data_duplicate_factor_rows_resolve_deterministically(
+    db_session: AsyncSession,
+):
+    """Duplicate factor generations (impossible in prod post-sweep, but
+    seedable) must not 500 the page: the join picks the lowest id
+    deterministically; other rows are unaffected."""
+    repo = DataEntryRepository(db_session)
+    entry = await _make_equipment_entry(db_session)
+    first = await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop", "sub_class": "13-inch"},
+        values={"active_power_w": 42.0, "standby_power_w": 3.0},
+    )
+    await _make_factor(
+        db_session,
+        classification={"equipment_class": "laptop", "sub_class": "13-inch"},
+        values={"active_power_w": 777.0, "standby_power_w": 77.0},
+    )
+    assert first.id is not None
+
+    response = await repo.get_submodule_data(
+        carbon_report_module_id=entry.carbon_report_module_id,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        limit=10,
+        offset=0,
+        sort_by="id",
+        sort_order="asc",
+    )
+
+    assert len(response.items) == 1
+    item = response.items[0]
+    assert item.active_power_w == 42.0, "lowest factor id must win deterministically"
 
 
 # ======================================================================

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -17,7 +17,6 @@ from app.services.data_ingestion.base_csv_provider import (
     _is_blank_data_row,
     _validate_file_path,
 )
-from app.services.module_handler_service import ModuleHandlerService
 
 # ======================================================================
 # File Path Validation Tests - Security Critical
@@ -522,10 +521,9 @@ def _build_stats() -> StatsDict:
 
 @pytest.mark.asyncio
 async def test_process_row_success_with_unit_mapping(monkeypatch):
-    """Test _process_row builds data entry when mapping is present, and
-    that a factors_map match still drives ``populate_defaults`` even
-    though the resolved Factor is no longer stamped onto the payload as
-    ``primary_factor_id``."""
+    """_process_row builds the data entry from the row alone: no factor is
+    matched, seeded, or stamped at ingest — factor defaults are derived at
+    compute/display time."""
     config = {"file_path": "tmp/test.csv", "year": 2025}
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
@@ -549,23 +547,15 @@ async def test_process_row_success_with_unit_mapping(monkeypatch):
 
     provider._extract_kind_subkind_values = extract_kind_subkind
 
-    # Setup factors_map with matching key — production builds
-    # "{type}:{year}:{kind}:{subkind}" (see _process_row's key_full).
-    matching_factor = SimpleNamespace(id=77, values={"active_hours": 10})
     setup_result = {
         "handlers": [handler],
         "factors_map": {
-            f"{DataEntryTypeEnum.student.value}:2025:x:": matching_factor
+            f"{DataEntryTypeEnum.student.value}:2025:x:": SimpleNamespace(id=77)
         },
         "expected_columns": {"unit_institutional_id", "amount", "label"},
     }
     row = {"unit_institutional_id": "U1", "amount": "10", "label": "x"}
     stats = _build_stats()
-
-    populate_defaults_mock = AsyncMock(side_effect=lambda handler, data, factor: data)
-    monkeypatch.setattr(
-        ModuleHandlerService, "populate_defaults", populate_defaults_mock
-    )
 
     (
         data_entry,
@@ -582,78 +572,12 @@ async def test_process_row_success_with_unit_mapping(monkeypatch):
     )
 
     assert error_msg is None
-    assert result_factor is None  # No longer returns factor
+    assert result_factor is None  # ingest never resolves a factor
     assert data_entry is not None
     assert data_entry.carbon_report_module_id == 123
     assert "primary_factor_id" not in data_entry.data
-    populate_defaults_mock.assert_awaited_once_with(
-        handler, data_entry.data, matching_factor
-    )
-
-
-@pytest.mark.asyncio
-async def test_process_row_rejects_falsy_year_after_setup_bypass():
-    """Defense-in-depth row-level guard must reject ``year=0`` the same way
-    ``_setup_handlers_and_factors`` does.
-
-    Regression for the asymmetry caught in the PR review: the row-level
-    check originally used ``if self.year is None`` while the setup-time
-    check uses ``if not self.year``, so a caller that bypassed setup with
-    ``year=0`` would slip past the backstop and rebuild the
-    ``{type}:0:...`` silent-miss key — exactly the bug this PR is meant to
-    close. Both layers now use the same falsy check.
-    """
-    config = {"file_path": "tmp/test.csv", "year": 2025}
-    provider = ConcreteCSVProvider(config, data_session=MagicMock())
-    # Simulate a future caller that bypassed setup and left year unset/zero.
-    # The setup-time guard would have raised; the row-level guard must too.
-    provider.year = 0
-
-    handler = MagicMock()
-    handler.kind_field = "kind"
-    handler.subkind_field = None
-
-    async def resolve_handler(*_args, **_kwargs):
-        return (DataEntryTypeEnum.student, handler, None)
-
-    provider._resolve_handler_and_validate = resolve_handler
-    provider._extract_kind_subkind_values = lambda filtered_row, handlers: (
-        "x",
-        None,
-    )
-
-    setup_result = {
-        "handlers": [handler],
-        "factors_map": {"unused_key": SimpleNamespace(id=1)},
-        "expected_columns": {"unit_institutional_id"},
-    }
-    row = {"unit_institutional_id": "U1"}
-    stats = _build_stats()
-
-    # The row-level ValueError is caught by `_process_row`'s broad
-    # try/except (same path every row-validation failure takes) and
-    # recorded as a per-row error. The desired outcome is "this row is
-    # rejected" — not "process_csv_in_batches aborts" — so assert the
-    # per-row error path, not a propagated exception.
-    (
-        data_entry,
-        error_msg,
-        result_factor,
-        kg_co2eq_override,
-    ) = await provider._process_row(
-        row,
-        row_idx=1,
-        setup_result=setup_result,
-        stats=stats,
-        max_row_errors=5,
-        unit_to_module_map={"U1": 123},
-    )
-
-    assert data_entry is None
-    assert error_msg is not None and "year must be set" in error_msg
-    assert kg_co2eq_override is None
-    assert stats["rows_skipped"] == 1
-    assert stats["row_errors_count"] == 1
+    # No seeding: the entry carries exactly what the row provided.
+    assert set(data_entry.data) == {"amount", "label"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/services/test_module_handler_service.py
+++ b/backend/tests/unit/services/test_module_handler_service.py
@@ -1,22 +1,19 @@
 """Tests for ModuleHandlerService.
 
-Factor-classification matching itself (kind/subkind chain, override-key-first
-rule, ambiguity handling) is owned and tested by ``FactorResolver`` — see
-``tests/unit/services/test_factor_resolver.py``. These tests cover what
-``ModuleHandlerService`` itself is responsible for: merging existing_data
-into a lookup copy without mutating the caller's payload, delegating to
-``FactorResolver``, the kind-change clearing side-effects, and
-``populate_defaults``.
+Factor-classification matching is owned and tested by ``FactorResolver``
+(``tests/unit/services/test_factor_resolver.py``); list-time resolution by
+the SQL subquery in ``DataEntryRepository``. What remains here is what the
+service itself owns: the pure kind-change clearing normalization on update
+payloads, and taxonomy building.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.factor import Factor
-from app.schemas.data_entry import BaseModuleHandler
 from app.services.module_handler_service import ModuleHandlerService
 
 
@@ -50,353 +47,83 @@ def _purchase_handler():
     )
 
 
-# ── resolve_factor ──────────────────────────────────────────
+# ── clear_dependent_fields_on_kind_change ───────────────────
 
 
-@pytest.mark.asyncio
-async def test_resolve_factor_delegates_to_resolver(service):
-    handler = _make_handler()
-    factor = SimpleNamespace(id=42)
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    payload = {"kind": "ClassA", "subkind": "SubA1"}
-    result = await service.resolve_factor(
-        handler, payload, DataEntryTypeEnum.scientific, year=2025
-    )
-
-    assert result is factor
-    service.factor_resolver.resolve.assert_awaited_once_with(
-        handler,
-        {"kind": "ClassA", "subkind": "SubA1"},
-        DataEntryTypeEnum.scientific,
-        2025,
-    )
-
-
-@pytest.mark.asyncio
-async def test_resolve_factor_no_match_returns_none(service):
-    handler = _make_handler(kind_field=None, subkind_field=None)
-    service.factor_resolver.resolve = AsyncMock(return_value=None)
-
-    payload = {"foo": "bar"}
-    result = await service.resolve_factor(
-        handler, payload, DataEntryTypeEnum.scientific, year=2025
-    )
-
-    assert result is None
-    assert payload == {"foo": "bar"}
-
-
-@pytest.mark.asyncio
-async def test_resolve_factor_merges_existing_data(service):
-    handler = _make_handler()
-    factor = SimpleNamespace(id=10)
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    payload = {"kind": "ClassA"}
-    existing = {"subkind": "SubB1"}
-    result = await service.resolve_factor(
-        handler,
-        payload,
-        DataEntryTypeEnum.scientific,
-        year=2025,
-        existing_data=existing,
-    )
-
-    assert result is factor
-    service.factor_resolver.resolve.assert_awaited_once_with(
-        handler,
-        {"kind": "ClassA", "subkind": "SubB1"},
-        DataEntryTypeEnum.scientific,
-        2025,
-    )
-
-
-@pytest.mark.asyncio
-async def test_resolve_factor_does_not_mutate_payload(service):
-    """existing_data merges into a COPY used for the lookup — the caller's
-    payload dict and the existing_data dict are left untouched."""
-    handler = _make_handler()
-    factor = SimpleNamespace(id=10)
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    payload = {"kind": "ClassA"}
-    existing = {"subkind": "SubB1"}
-    await service.resolve_factor(
-        handler,
-        payload,
-        DataEntryTypeEnum.scientific,
-        year=2025,
-        existing_data=existing,
-    )
-
-    assert payload == {"kind": "ClassA"}
-    assert existing == {"subkind": "SubB1"}
-
-
-@pytest.mark.asyncio
-async def test_resolve_factor_override_handler_returns_full_factor(service):
-    """Behavior change from the old stamping code: override handlers
-    (purchase) used to always come back with factor=None even on a match
-    (only the id was stamped); resolve_factor now returns the full Factor
-    since nothing needs to hide it from the caller anymore."""
+def test_clear_kind_changed_clears_subkind_and_override():
     handler = _purchase_handler()
-    factor = SimpleNamespace(
-        id=11, classification={"purchase_additional_code": "ADD-1"}
-    )
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
+    handler.subkind_field = "subkind"
     payload = {
-        "purchase_institutional_code": "A",
-        "purchase_additional_code": "ADD-1",
+        "purchase_institutional_code": "NEW",
+        "subkind": "old-sub",
+        "purchase_additional_code": "OLD-CODE",
     }
-    result = await service.resolve_factor(
-        handler, payload, DataEntryTypeEnum.services, year=2025
-    )
-
-    assert result is factor
-
-
-@pytest.mark.asyncio
-async def test_resolve_factor_wires_real_factor_resolver():
-    """End-to-end sanity check that the service really composes a live
-    FactorResolver rather than the mocked stand-in used by the other tests
-    here — guards against the wiring itself breaking silently."""
-    handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum.it)
-    assert handler.kind_field is not None
-    factor = Factor(
-        id=7,
-        data_entry_type_id=DataEntryTypeEnum.it.value,
-        emission_type_id=1,
-        classification={handler.kind_field: "Mill"},
-        values={},
-        year=2025,
-    )
-    service = ModuleHandlerService(MagicMock())
-
-    with patch(
-        "app.services.factor_resolver.FactorRepository.list_by_data_entry_type",
-        new=AsyncMock(return_value=[factor]),
-    ):
-        result = await service.resolve_factor(
-            handler,
-            {handler.kind_field: "Mill"},
-            DataEntryTypeEnum.it,
-            year=2025,
-        )
-
-    assert result is not None
-    assert result.id == 7
-
-
-# ── populate_defaults ───────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_populate_defaults_applies_when_factor_given(service):
-    """Defaults apply whenever a factor is passed in — no
-    stored-id-matches-factor.id guard anymore."""
-    handler = SimpleNamespace(factor_value_fields=["active_usage_hours_per_week"])
-    factor = SimpleNamespace(id=42, values={"active_usage_hours_per_week": 40})
-    data = {"name": "Freezer"}
-
-    result = await service.populate_defaults(handler, data, factor)
-
-    assert result["active_usage_hours_per_week"] == 40
-
-
-@pytest.mark.asyncio
-async def test_populate_defaults_skips_field_already_set(service):
-    handler = SimpleNamespace(factor_value_fields=["active_usage_hours_per_week"])
-    factor = SimpleNamespace(id=42, values={"active_usage_hours_per_week": 40})
-    data = {"active_usage_hours_per_week": 12}
-
-    result = await service.populate_defaults(handler, data, factor)
-
-    assert result["active_usage_hours_per_week"] == 12
-
-
-@pytest.mark.asyncio
-async def test_populate_defaults_noop_without_factor_value_fields(service):
-    """Purchase-style override handlers never declare factor_value_fields,
-    so the new full-Factor return (was None before) is a no-op here."""
-    handler = _purchase_handler()
-    factor = SimpleNamespace(id=11, values={"ef_kg_co2eq_per_currency": 0.4})
-    data = {"purchase_institutional_code": "A"}
-
-    result = await service.populate_defaults(handler, data, factor)
-
-    assert result == {"purchase_institutional_code": "A"}
-
-
-# ── resolve_factor_if_changed ───────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_resolve_if_changed_no_existing_data(service):
-    handler = _make_handler()
-    factor = SimpleNamespace(id=5)
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
+    result = ModuleHandlerService.clear_dependent_fields_on_kind_change(
         handler,
-        {"kind": "A", "subkind": "B"},
-        DataEntryTypeEnum.scientific,
-        item_data={"kind": "A"},
-        existing_data=None,
-        year=2025,
+        payload,
+        item_data={"purchase_institutional_code": "NEW"},
+        existing_data={"purchase_institutional_code": "OLD"},
     )
-
-    assert resolved_factor is factor
-    assert "primary_factor_id" not in result
-
-
-@pytest.mark.asyncio
-async def test_resolve_if_changed_kind_changed(service):
-    handler = _make_handler()
-    factor = SimpleNamespace(id=99)
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
-        handler,
-        {"kind": "NewClass", "subkind": "Sub1"},
-        DataEntryTypeEnum.scientific,
-        item_data={"kind": "NewClass"},
-        existing_data={"kind": "OldClass", "subkind": "Sub1"},
-        year=2025,
-    )
-
     assert result["subkind"] is None
-    assert resolved_factor is factor
-    assert "primary_factor_id" not in result
-
-
-@pytest.mark.asyncio
-async def test_resolve_if_changed_kind_changed_populates_defaults(service):
-    """kind change re-resolves and repopulates factor_value_fields — this
-    now fires whenever a factor comes back, not only when a stored
-    primary_factor_id happened to already match it."""
-    handler = _make_handler()
-    handler.factor_value_fields = ["active_usage_hours_per_week"]
-    factor = SimpleNamespace(id=99, values={"active_usage_hours_per_week": 40})
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
-        handler,
-        {"kind": "NewClass", "subkind": "Sub1"},
-        DataEntryTypeEnum.scientific,
-        item_data={"kind": "NewClass"},
-        existing_data={"kind": "OldClass", "subkind": "Sub1"},
-        year=2025,
-    )
-
-    assert result["active_usage_hours_per_week"] == 40
-    assert resolved_factor is factor
-
-
-@pytest.mark.asyncio
-async def test_resolve_if_changed_nothing_changed(service):
-    handler = _make_handler()
-    service.factor_resolver.resolve = AsyncMock()
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
-        handler,
-        {"kind": "Same", "subkind": "Sub"},
-        DataEntryTypeEnum.scientific,
-        item_data={"kind": "Same"},
-        existing_data={"kind": "Same", "subkind": "Sub"},
-        year=2025,
-    )
-
-    assert "primary_factor_id" not in result
-    assert resolved_factor is None
-    service.factor_resolver.resolve.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_resolve_if_changed_kind_change_clears_stale_override(service):
-    """Changing A without resending B must clear the stored B, not reuse it.
-
-    Regression: with A=41112200/B=VC02 stored, updating only A left VC02 in
-    the merged data, so resolution kept matching the OLD code's factor.
-    """
-    handler = _purchase_handler()
-    new_factor = SimpleNamespace(id=81)
-    service.factor_resolver.resolve = AsyncMock(return_value=new_factor)
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
-        handler,
-        {"purchase_institutional_code": "41112201"},
-        DataEntryTypeEnum.services,
-        item_data={"purchase_institutional_code": "41112201"},
-        existing_data={
-            "purchase_institutional_code": "41112200",
-            "purchase_additional_code": "VC02",
-        },
-        year=2025,
-    )
-
     assert result["purchase_additional_code"] is None
-    assert resolved_factor is new_factor
-    assert "primary_factor_id" not in result
 
 
-@pytest.mark.asyncio
-async def test_resolve_if_changed_kind_and_override_both_change(service):
-    """When the request supplies both A and B, the new B is kept, not
-    cleared by the kind-change side effect."""
+def test_clear_kind_changed_keeps_fields_supplied_in_request():
     handler = _purchase_handler()
-    new_factor = SimpleNamespace(id=91)
-    service.factor_resolver.resolve = AsyncMock(return_value=new_factor)
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
+    handler.subkind_field = "subkind"
+    payload = {
+        "purchase_institutional_code": "NEW",
+        "subkind": "new-sub",
+        "purchase_additional_code": "NEW-CODE",
+    }
+    result = ModuleHandlerService.clear_dependent_fields_on_kind_change(
         handler,
-        {
-            "purchase_institutional_code": "41112201",
-            "purchase_additional_code": "VC99",
-        },
-        DataEntryTypeEnum.services,
+        payload,
         item_data={
-            "purchase_institutional_code": "41112201",
-            "purchase_additional_code": "VC99",
+            "purchase_institutional_code": "NEW",
+            "subkind": "new-sub",
+            "purchase_additional_code": "NEW-CODE",
         },
-        existing_data={
-            "purchase_institutional_code": "41112200",
-            "purchase_additional_code": "VC02",
-        },
-        year=2025,
+        existing_data={"purchase_institutional_code": "OLD"},
     )
+    assert result["subkind"] == "new-sub"
+    assert result["purchase_additional_code"] == "NEW-CODE"
 
-    assert result["purchase_additional_code"] == "VC99"
-    assert resolved_factor is new_factor
 
-
-@pytest.mark.asyncio
-async def test_resolve_if_changed_override_changed_only_triggers_resolve(service):
-    """Changing only the override code (kind untouched) must still
-    re-resolve."""
-    handler = _purchase_handler()
-    factor = SimpleNamespace(id=61)
-    service.factor_resolver.resolve = AsyncMock(return_value=factor)
-
-    result, resolved_factor = await service.resolve_factor_if_changed(
+def test_clear_kind_unchanged_leaves_payload_untouched():
+    handler = _make_handler()
+    payload = {"kind": "same", "subkind": "keep-me"}
+    result = ModuleHandlerService.clear_dependent_fields_on_kind_change(
         handler,
-        {"purchase_additional_code": "ADD-NEW"},
-        DataEntryTypeEnum.services,
-        item_data={"purchase_additional_code": "ADD-NEW"},
-        existing_data={
-            "purchase_institutional_code": "F",
-            "purchase_additional_code": "ADD-OLD",
-        },
-        year=2025,
+        payload,
+        item_data={"kind": "same", "note": "hi"},
+        existing_data={"kind": "same", "subkind": "keep-me"},
     )
-
-    assert resolved_factor is factor
-    assert "primary_factor_id" not in result
-    service.factor_resolver.resolve.assert_awaited_once()
+    assert result == {"kind": "same", "subkind": "keep-me"}
 
 
-# ── get_taxonomy ────────────────────────────────────────────
+def test_clear_kind_absent_from_request_leaves_payload_untouched():
+    handler = _make_handler()
+    payload = {"kind": "old", "subkind": "keep-me"}
+    result = ModuleHandlerService.clear_dependent_fields_on_kind_change(
+        handler,
+        payload,
+        item_data={"subkind": "keep-me", "note": "hi"},
+        existing_data={"kind": "old", "subkind": "other"},
+    )
+    assert result["subkind"] == "keep-me"
+
+
+def test_clear_no_existing_data_is_noop():
+    handler = _make_handler()
+    payload = {"kind": "new", "subkind": "s"}
+    result = ModuleHandlerService.clear_dependent_fields_on_kind_change(
+        handler, payload, item_data={"kind": "new"}, existing_data=None
+    )
+    assert result == {"kind": "new", "subkind": "s"}
+
+
+# ── get_taxonomy ─────────────────────────────────────────────
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/workflows/test_carbon_report_module_update.py
+++ b/backend/tests/unit/workflows/test_carbon_report_module_update.py
@@ -47,16 +47,8 @@ async def test_update_partial_patch_retains_persisted_classification():
 
     data_entry_service.update = AsyncMock(side_effect=_capture_update)
 
-    # resolve echoes its payload back — the merge under test happens BEFORE this
-    # call, so an echo faithfully exposes what validation will receive.
-    factor = SimpleNamespace(id=1998, values={})
-
-    async def _echo_resolve(handler, payload, *args, **kwargs):
-        return payload, factor
-
-    handler_service = MagicMock()
-    handler_service.resolve_factor_if_changed = AsyncMock(side_effect=_echo_resolve)
-
+    # clear_dependent_fields_on_kind_change is a pure staticmethod — the
+    # real one runs; the merge under test happens before validation.
     emission_service = MagicMock()
     emission_service.upsert_by_data_entry = AsyncMock()
     module_service = MagicMock()
@@ -66,10 +58,6 @@ async def test_update_partial_patch_retains_persisted_classification():
         patch(
             "app.workflows.carbon_report_module.DataEntryService",
             return_value=data_entry_service,
-        ),
-        patch(
-            "app.workflows.carbon_report_module.ModuleHandlerService",
-            return_value=handler_service,
         ),
         patch(
             "app.workflows.carbon_report_module.DataEntryEmissionService",
@@ -88,7 +76,6 @@ async def test_update_partial_patch_retains_persisted_classification():
             current_user=SimpleNamespace(id=5, institutional_id="352707"),
             request_context={},
             background_tasks=MagicMock(),
-            year=2025,
         )
 
     persisted = captured["data"].data
@@ -123,14 +110,8 @@ async def test_update_blank_purchase_institutional_code_rejected():
     data_entry_service.get = AsyncMock(return_value=SimpleNamespace(data=existing_data))
     data_entry_service.update = AsyncMock()
 
-    # resolve echoes its payload back — validation (real, unmocked) is what
-    # must reject the blank code.
-    async def _echo_resolve(handler, payload, *args, **kwargs):
-        return payload, None
-
-    handler_service = MagicMock()
-    handler_service.resolve_factor_if_changed = AsyncMock(side_effect=_echo_resolve)
-
+    # clearing is a pure staticmethod (real); validation (real, unmocked)
+    # is what must reject the blank code.
     emission_service = MagicMock()
     emission_service.upsert_by_data_entry = AsyncMock()
     module_service = MagicMock()
@@ -140,10 +121,6 @@ async def test_update_blank_purchase_institutional_code_rejected():
         patch(
             "app.workflows.carbon_report_module.DataEntryService",
             return_value=data_entry_service,
-        ),
-        patch(
-            "app.workflows.carbon_report_module.ModuleHandlerService",
-            return_value=handler_service,
         ),
         patch(
             "app.workflows.carbon_report_module.DataEntryEmissionService",
@@ -163,7 +140,6 @@ async def test_update_blank_purchase_institutional_code_rejected():
                 current_user=SimpleNamespace(id=5, institutional_id="352707"),
                 request_context={},
                 background_tasks=MagicMock(),
-                year=2025,
             )
 
     assert exc_info.value.status_code == 400

--- a/docs/src/implementation-plans/1661-sql-factor-resolution.md
+++ b/docs/src/implementation-plans/1661-sql-factor-resolution.md
@@ -68,12 +68,12 @@ recalc.
   `test_data_entry_repo.py` (fallback deleted).
 - [x] 4. Focused verification (changed test files + `tests/unit/repositories`),
   ruff/mypy on touched files; PR stacked on #1719.
-- [ ] 5. Update path stops resolving (user-approved): replace
+- [x] 5. Update path stops resolving (user-approved): replace
   `resolve_factor_if_changed` with a resolver-free
   `clear_dependent_fields_on_kind_change` (subkind + override-code cleared
   on kind change, nothing else); drop the update-path `populate_defaults`
   call (near no-op today: fills only still-empty fields).
-- [ ] 6. Derived hour defaults (user-approved): equipment formula falls
+- [x] 6. Derived hour defaults (user-approved): equipment formula falls
   back to `factor.values` for missing usage hours (enable the sketch at
   equipment/schemas.py:218-221); stop seeding at create/CSV; delete
   `populate_defaults` + `factor_value_fields`. Form pre-fill keeps coming
@@ -84,3 +84,4 @@ recalc.
 
 - 2026-07-06: plan written; branch `feat/1661-sql-factor-resolution`.
 - 2026-07-06: steps 1-4 done (scalar-subquery design; 261 repo unit tests + PG test green).
+- 2026-07-06: steps 5-6 done — update PATCH does zero factor resolution (pure kind-change clearing); populate_defaults/factor_value_fields deleted; equipment hours are live defaults (ctx wins, factor fallback in formula, coalesce in sort_map, effective values in to_response); CSV ingest row path no longer matches factors at all. Unit 1748 + ruff + mypy green; purchase/sql-resolution/matrix/buildings/sort integration files green.

--- a/docs/src/implementation-plans/1661-sql-factor-resolution.md
+++ b/docs/src/implementation-plans/1661-sql-factor-resolution.md
@@ -1,0 +1,70 @@
+---
+status: in-progress
+issue: 1661
+last_updated: 2026-07-06
+title: "SQL factor resolution for list sort/filter/pagination"
+summary: "Replace the emission-FK factor join in get_submodule_data with a classification LATERAL join so factor-backed sort/filter/search work for every row (including not-yet-computed entries); delete the Python row-loop fallback."
+---
+
+## Problem
+
+`get_submodule_data` joins `Factor` through emission rows
+(`RollupEmission.primary_factor_id` / `min(primary_factor_id)` agg). Entries
+without computed emissions get `Factor = NULL` **in SQL**: factor-backed
+sort keys (`equipment.active_power_w`, buildings/cloud/process maps) sort
+them last, filters miss them, and the Python resolver fallback fixes only
+the displayed page — after pagination. Sort/search/pagination disagree with
+what the table shows.
+
+## Design
+
+One correlated `LEFT JOIN LATERAL ... LIMIT 1` per entry row, built
+generically from the handler's classification fields — the SQL twin of
+`FactorResolver`, deterministic **because the Phase-2 reupload sweep
+guarantees a single factor generation** per (det, year, classification):
+
+- match: `f.data_entry_type_id = :det AND f.year = data_entries.year AND
+  f.classification->>kind = data.data->>kind`
+- subkind chain (plain handlers): accept exact subkind or subkind-less row;
+  `ORDER BY (subkind matched) DESC` → exact wins, kind-only row is the
+  fallback.
+- override chain (purchase): accept override-code match or code-less
+  (average) row; `ORDER BY (code matched) DESC, (code IS NULL) DESC` —
+  override-first, then average. Ambiguity resolves to a deterministic pick
+  (display layer; compute/update keep raising loudly via `FactorResolver`).
+- Aliased to the `Factor` entity; handler `sort_map`/`filter_map`
+  expressions referencing `Factor.*` are adapted onto the alias at query
+  build (`ClauseAdapter`), so the four modules' maps stay untouched.
+
+Scope of the swap: the buildings branch and the generic non-travel branch
+(covers equipment, buildings, external_cloud_and_ai, process_emissions,
+purchase, …). Travel and headcount branches keep the emission join — their
+kind is derived at compute time (absent from `data`), their maps don't
+reference `Factor`, and their factor display comes from computed emissions.
+
+The Python row-loop resolver fallback in `get_submodule_data` becomes dead
+and is deleted (the lateral answers for every lateral-covered row; the
+remaining branches never benefited from it — kind absent from data).
+
+Display-semantics note (accepted): tables show the *current* resolution,
+not "factor used at last compute"; post-Phase-2 these converge on every
+recalc.
+
+## Steps
+
+- [ ] 1. `_factor_lateral(handler, data_entry_type_id)` helper building the
+  aliased lateral + adapted sort/filter maps; wire into the buildings and
+  generic non-travel branches; delete the Python fallback + its resolver
+  import if unused.
+- [ ] 2. PG integration tests (`test_sql_factor_resolution_pg.py`): entry
+  WITHOUT emission rows sorts/filters by factor-backed keys and displays
+  the factor; kind-only fallback preference; purchase override preference;
+  entry with emissions unchanged; travel list unaffected.
+- [ ] 3. Retarget the two resolver-fallback unit tests in
+  `test_data_entry_repo.py` (fallback deleted).
+- [ ] 4. Focused verification (changed test files + `tests/unit/repositories`),
+  ruff/mypy on touched files; PR stacked on #1719.
+
+## Progress log
+
+- 2026-07-06: plan written; branch `feat/1661-sql-factor-resolution`.

--- a/docs/src/implementation-plans/1661-sql-factor-resolution.md
+++ b/docs/src/implementation-plans/1661-sql-factor-resolution.md
@@ -52,19 +52,35 @@ recalc.
 
 ## Steps
 
-- [ ] 1. `_factor_lateral(handler, data_entry_type_id)` helper building the
-  aliased lateral + adapted sort/filter maps; wire into the buildings and
-  generic non-travel branches; delete the Python fallback + its resolver
-  import if unused.
-- [ ] 2. PG integration tests (`test_sql_factor_resolution_pg.py`): entry
+- [x] 1. (shipped as `_resolved_factor_id`) correlated **scalar subquery**
+  instead of LATERAL: works on sqlite (unit tests) AND Postgres, joins the
+  real `Factor` table so sort/filter maps need no adaptation at all; wired
+  into the buildings and generic non-travel branches; Python fallback
+  deleted. sqlite quirk pinned: correlated ORDER BY is rejected, so the
+  specificity preference is the non-correlated `IS NOT NULL DESC` (within
+  the WHERE-filtered candidate set, carrying a subkind/code IS the exact
+  match).
+- [x] 2. PG integration test (`test_sql_factor_resolution_pg.py`): entry
   WITHOUT emission rows sorts/filters by factor-backed keys and displays
   the factor; kind-only fallback preference; purchase override preference;
   entry with emissions unchanged; travel list unaffected.
-- [ ] 3. Retarget the two resolver-fallback unit tests in
+- [x] 3. Retargeted the four resolver-fallback unit tests to seeded-row tests + new subkind-preference and duplicate-determinism pins in
   `test_data_entry_repo.py` (fallback deleted).
-- [ ] 4. Focused verification (changed test files + `tests/unit/repositories`),
+- [x] 4. Focused verification (changed test files + `tests/unit/repositories`),
   ruff/mypy on touched files; PR stacked on #1719.
+- [ ] 5. Update path stops resolving (user-approved): replace
+  `resolve_factor_if_changed` with a resolver-free
+  `clear_dependent_fields_on_kind_change` (subkind + override-code cleared
+  on kind change, nothing else); drop the update-path `populate_defaults`
+  call (near no-op today: fills only still-empty fields).
+- [ ] 6. Derived hour defaults (user-approved): equipment formula falls
+  back to `factor.values` for missing usage hours (enable the sketch at
+  equipment/schemas.py:218-221); stop seeding at create/CSV; delete
+  `populate_defaults` + `factor_value_fields`. Form pre-fill keeps coming
+  from `/factors/{det}/classes/{kind}/values`. Semantics owned: blank-hours
+  entries track the factor's current defaults ("live default").
 
 ## Progress log
 
 - 2026-07-06: plan written; branch `feat/1661-sql-factor-resolution`.
+- 2026-07-06: steps 1-4 done (scalar-subquery design; 261 repo unit tests + PG test green).


### PR DESCRIPTION
**Stacked on #1719** — merge that first.

Plan: `docs/src/implementation-plans/1661-sql-factor-resolution.md`

## SQL factor resolution for lists

`get_submodule_data` now joins `Factor` via a correlated scalar subquery on the entry's classification (`_resolved_factor_id` — the SQL twin of `FactorResolver`, deterministic thanks to #1719's replace-semantics sweep) instead of through emission rows. Factor-backed sort/filter/pagination (equipment power columns, buildings/cloud/process maps) now work for **every** row, including entries whose emissions aren't computed yet — and stay consistent with what the page displays. The Python per-row fallback is deleted; the count query stops implicitly cross-joining factors when filtering.

Works on both dialects (unit tests run sqlite): specificity preference is a non-correlated `IS NOT NULL DESC` because sqlite rejects correlated ORDER BY — within the WHERE-filtered candidate set, carrying a subkind/override code *is* the exact match.

## Update path stops resolving

`resolve_factor_if_changed` → pure `clear_dependent_fields_on_kind_change` (subkind/override-code cleared on kind change; zero factor resolution, zero DB hits on PATCH). The unused `year` threading through `update`/`post_update` cascaded away.

## Equipment hour defaults become live

`populate_defaults` + `factor_value_fields` are deleted. Usage hours are no longer seeded into `entry.data` at ingest: the user's value wins; an unset field tracks the factor's *current* suggestion (formula fallback), sorts via `coalesce(data, factor)`, and `to_response` exposes the effective values. Existing entries keep their persisted hours as user data.

## Verification

Unit 1747 + ruff + mypy green; SQL-resolution/replace-semantics/purchase/buildings integration files green. Rebased onto `dev` (the `resolve_emission_types(factor=...)` reconciliation with e4bffce8 lives on #1719).
