### PR TITLE
fix(1661): v1.0 data migration — strip legacy entry-json keys

### DIFF
--- a/backend/alembic/versions/2026_07_06_1124-954eac6c95da_strip_legacy_primary_factor_id_and_null_.py
+++ b/backend/alembic/versions/2026_07_06_1124-954eac6c95da_strip_legacy_primary_factor_id_and_null_.py
@@ -1,0 +1,62 @@
+# codeql[py/unused-global-variable]
+"""strip legacy primary_factor_id and null purchase codes from entry json
+
+Revision ID: 954eac6c95da
+Revises: d88cd2f143bf
+Create Date: 2026-07-06 11:24:26.373936
+
+Data-only migration (plan 1661, v1.0 follow-up — the DB persists across
+deploys now, so rows written before the primary_factor_id removal must be
+cleaned in place instead of waiting for a reseed that no longer happens):
+
+- ``data_entries.data.primary_factor_id`` is a dead denormalization: no
+  code reads it since the 1661 refactor (factors are resolved on demand),
+  but report exports would expose the stale key.
+- A purchase entry persisted with an explicit-null
+  ``purchase_institutional_code`` would be rejected by the new update
+  validator on EVERY PATCH (present-but-null is invalid; key-absent means
+  "not updating"), making the row permanently un-editable. Stripping the
+  null key restores the key-absent shape the CSV ingest always wrote.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "954eac6c95da"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "d88cd2f143bf"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Strip dead/poisonous legacy keys from data_entries.data (JSON column)."""
+    op.execute(
+        """
+        UPDATE data_entries
+        SET data = (data::jsonb - 'primary_factor_id')::json
+        WHERE data::jsonb ? 'primary_factor_id'
+        """
+    )
+    op.execute(
+        """
+        UPDATE data_entries
+        SET data = (data::jsonb - 'purchase_institutional_code')::json
+        WHERE data::jsonb ? 'purchase_institutional_code'
+          AND data::jsonb ->> 'purchase_institutional_code' IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op: both keys are dead weight the current code never reads or
+    writes; the removed values are not recoverable and not needed."""

--- a/docs/src/implementation-plans/1661-remove-primary-factor-id-plan.md
+++ b/docs/src/implementation-plans/1661-remove-primary-factor-id-plan.md
@@ -886,11 +886,12 @@ async def delete_stale_for_year(
   from the resolver pre-branch; briefly a silent emission wipe mid-branch,
   caught in review). Key-absent still means "not updating".
 - **Legacy data:** report exports no longer scrub `primary_factor_id` from
-  entry JSON; pre-branch rows on non-reseeded DBs expose the stale key until
-  the next reseed (v0.x drops the DB, so this self-heals).
-- **Known asymmetry (moot post-reseed):** `PurchaseHandlerCreate` accepts
-  whitespace-only codes while update rejects them; a legacy entry persisted
-  with a null code would 400 on every PATCH until reseeded.
+  entry JSON; migration `954eac6c95da` strips the stale keys in place
+  (v1.0: the DB persists across deploys — no more reseed self-healing).
+- **Known asymmetry:** `PurchaseHandlerCreate` accepts whitespace-only
+  codes while update rejects them. Legacy entries persisted with a null
+  code (which would 400 on every PATCH) are cleaned by migration
+  `954eac6c95da`.
 - **Follow-ups (not this PR):** `_detach` resolver-loaded factors in the
   list-enrichment fallback (defense-in-depth symmetry); split
   `recalculate_for_data_entry_type` (~230 lines) via a `_process_entry`

--- a/docs/src/implementation-plans/1661-remove-primary-factor-id.md
+++ b/docs/src/implementation-plans/1661-remove-primary-factor-id.md
@@ -91,8 +91,13 @@ into `app/services/factor_resolver.py`:
 - **Cleanup** — remove the export scrub (`carbon_report_module_repo.py:1238`)
   and every remaining read/write of `data["primary_factor_id"]`.
 
-No migration: v0.x reseeds drop the DB; leftover keys in old dev rows are
-dead weight ignored by all code paths.
+Data migration (added at v1.0, when "reseeds drop the DB" stopped being
+true): revision ``954eac6c95da`` strips the dead ``primary_factor_id`` keys
+from ``data_entries.data`` and removes explicit-null
+``purchase_institutional_code`` keys (which the new update validator would
+otherwise reject on every PATCH). Post-deploy operator step: re-upload the
+current factor CSVs per module/year so the replace-semantics sweep deletes
+stale factor generations that accumulated before this shipped.
 
 ## Design — Phase 2: replace-semantics factor ingest
 


### PR DESCRIPTION
**Stacks on #1719** (merge into it or after it — one commit).

At v1.0 the DB persists across deploys, so two #1719 decisions that leaned on "moot after the next reseed" need a real data migration (`954eac6c95da`, data-only, no-op downgrade):

- strips the dead `primary_factor_id` key from `data_entries.data` (nothing reads it since #1719; report exports would expose it)
- strips explicit-null `purchase_institutional_code` keys — under #1719's validator those rows would 400 on **every** PATCH, i.e. become permanently un-editable

Also updates the 1661 spec/plan docs accordingly and records the post-deploy operator step: **re-upload the current factor CSVs per module/year** so the replace-semantics sweep deletes stale factor generations that accumulated in prod before #1719 (the sweep only fires on new uploads; without this, pre-existing 2-key/3-key duplicates keep 500-ing `/values`).

Verified: `test_alembic_migrations.py` green; ruff clean.

Note: generated with plain `alembic revision` (no `--autogenerate`) — a data-only migration has no schema diff, and autogenerate would only produce false positives to prune.
