### PR TITLE
fix(1721): sort/search coverage — 6 module map gaps + matrix regression test

### DIFF
--- a/backend/app/modules/buildings/schemas.py
+++ b/backend/app/modules/buildings/schemas.py
@@ -6,6 +6,7 @@ from pydantic import (
     ValidationInfo,
     field_validator,
 )
+from sqlalchemy import func
 
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
@@ -485,7 +486,12 @@ class EnergyCombustionModuleHandler(BaseModuleHandler):
     }
 
     filter_map = {
-        "name": Factor.classification["name"].as_string(),
+        # Factor value when matched, entry data otherwise — search must find
+        # the same value the row displays.
+        "name": func.coalesce(
+            Factor.classification["name"].as_string(),
+            DataEntry.data["name"].as_string(),
+        ),
     }
 
     def resolve_computations(
@@ -624,7 +630,10 @@ class BuildingEmbodiedEnergyModuleHandler(BaseModuleHandler):
     }
 
     filter_map = {
-        "building_name": Factor.classification["building_name"].as_string(),
+        "building_name": func.coalesce(
+            Factor.classification["building_name"].as_string(),
+            DataEntry.data["building_name"].as_string(),
+        ),
     }
 
     def to_response(

--- a/backend/app/modules/external_cloud_and_ai/schemas.py
+++ b/backend/app/modules/external_cloud_and_ai/schemas.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from pydantic import ValidationInfo, field_validator, model_validator
-from sqlalchemy import case
+from sqlalchemy import case, func
 from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.logging import get_logger
@@ -212,8 +212,16 @@ class ExternalCloudModuleHandler(BaseModuleHandler):
     }
 
     filter_map = {
-        "service_type": Factor.classification[subkind_field].as_string(),
-        "provider": Factor.classification[kind_field].as_string(),
+        # Factor value when matched, entry data otherwise — search must find
+        # the same value the row displays (see to_response's fallbacks).
+        "service_type": func.coalesce(
+            Factor.classification[subkind_field].as_string(),
+            DataEntry.data["service_type"].as_string(),
+        ),
+        "provider": func.coalesce(
+            Factor.classification[kind_field].as_string(),
+            DataEntry.data["provider"].as_string(),
+        ),
     }
 
     def to_response(
@@ -390,16 +398,28 @@ class ExternalAIModuleHandler(BaseModuleHandler):
     subkind_field: str = "usage_type"
     sort_map = {
         "id": DataEntry.id,
-        "provider": Factor.classification["provider"].as_string(),
-        "usage_type": Factor.classification["usage_type"].as_string(),
+        "provider": func.coalesce(
+            Factor.classification["provider"].as_string(),
+            DataEntry.data["provider"].as_string(),
+        ),
+        "usage_type": func.coalesce(
+            Factor.classification["usage_type"].as_string(),
+            DataEntry.data["usage_type"].as_string(),
+        ),
         "requests_per_user_per_day": _requests_frequency_sort_expr(),
         "fte_count": DataEntry.data["fte_count"].as_float(),
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
     filter_map = {
-        "provider": Factor.classification["provider"].as_string(),
-        "usage_type": Factor.classification["usage_type"].as_string(),
+        "provider": func.coalesce(
+            Factor.classification["provider"].as_string(),
+            DataEntry.data["provider"].as_string(),
+        ),
+        "usage_type": func.coalesce(
+            Factor.classification["usage_type"].as_string(),
+            DataEntry.data["usage_type"].as_string(),
+        ),
     }
 
     def to_response(

--- a/backend/app/modules/process_emissions/schemas.py
+++ b/backend/app/modules/process_emissions/schemas.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from pydantic import ValidationInfo, field_validator
+from sqlalchemy import func
 
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
@@ -83,15 +84,27 @@ class ProcessEmissionsModuleHandler(BaseModuleHandler):
 
     sort_map = {
         "id": DataEntry.id,
-        "category": Factor.classification[kind_field].as_string(),
-        "subcategory": Factor.classification[subkind_field].as_string(),
+        "category": func.coalesce(
+            Factor.classification[kind_field].as_string(),
+            DataEntry.data["category"].as_string(),
+        ),
+        "subcategory": func.coalesce(
+            Factor.classification[subkind_field].as_string(),
+            DataEntry.data["subcategory"].as_string(),
+        ),
         "quantity": DataEntry.data["quantity"].as_float(),
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
     filter_map = {
-        "category": Factor.classification[kind_field].as_string(),
-        "subcategory": Factor.classification[subkind_field].as_string(),
+        "category": func.coalesce(
+            Factor.classification[kind_field].as_string(),
+            DataEntry.data["category"].as_string(),
+        ),
+        "subcategory": func.coalesce(
+            Factor.classification[subkind_field].as_string(),
+            DataEntry.data["subcategory"].as_string(),
+        ),
     }
 
     def to_response(

--- a/backend/app/modules/purchase/schemas.py
+++ b/backend/app/modules/purchase/schemas.py
@@ -267,6 +267,7 @@ class PurchaseModuleHandler(BaseModuleHandler):
         "supplier": DataEntry.data["supplier"].as_string(),
         "quantity": DataEntry.data["quantity"].as_float(),
         "total_spent_amount": DataEntry.data["total_spent_amount"].as_float(),
+        "currency": DataEntry.data["currency"].as_string(),
         "purchase_institutional_code": DataEntry.data[
             "purchase_institutional_code"
         ].as_string(),

--- a/backend/app/modules/research_facilities/animals_schemas.py
+++ b/backend/app/modules/research_facilities/animals_schemas.py
@@ -77,10 +77,19 @@ class ResearchFacilitiesAnimalModuleHandler(BaseModuleHandler):
 
     sort_map = {
         "id": DataEntry.id,
+        "researchfacility_id": DataEntry.data["researchfacility_id"].as_string(),
+        "researchfacility_name": DataEntry.data["researchfacility_name"].as_string(),
+        "researchfacility_type": DataEntry.data["researchfacility_type"].as_string(),
+        "use": DataEntry.data["use"].as_float(),
+        "use_unit": DataEntry.data["use_unit"].as_string(),
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
-    filter_map: dict = {}
+    filter_map: dict = {
+        "researchfacility_id": DataEntry.data["researchfacility_id"].as_string(),
+        "researchfacility_name": DataEntry.data["researchfacility_name"].as_string(),
+        "researchfacility_type": DataEntry.data["researchfacility_type"].as_string(),
+    }
 
     def to_response(
         self,

--- a/backend/app/modules/research_facilities/common_schemas.py
+++ b/backend/app/modules/research_facilities/common_schemas.py
@@ -114,10 +114,17 @@ class ResearchFacilitiesCommonModuleHandler(BaseModuleHandler):
 
     sort_map = {
         "id": DataEntry.id,
+        "researchfacility_id": DataEntry.data["researchfacility_id"].as_string(),
+        "researchfacility_name": DataEntry.data["researchfacility_name"].as_string(),
+        "use": DataEntry.data["use"].as_float(),
+        "use_unit": DataEntry.data["use_unit"].as_string(),
         "kg_co2eq": DataEntryEmission.kg_co2eq,
     }
 
-    filter_map: dict = {}
+    filter_map: dict = {
+        "researchfacility_id": DataEntry.data["researchfacility_id"].as_string(),
+        "researchfacility_name": DataEntry.data["researchfacility_name"].as_string(),
+    }
 
     def to_response(
         self,

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -546,6 +546,11 @@ class DataEntryRepository:
         # headcount derive their kind at compute time, so their factor display
         # keeps coming from the computed emission rows below.
         resolved_factor_id: Any = None
+        # Filter conditions may reference Factor columns; the count query
+        # must join Factor exactly like the page query or it degenerates to
+        # an implicit cross join (0 or inflated counts). Each branch records
+        # its join chain here.
+        count_factor_joins: list[tuple[Any, Any]] = []
         if (
             not is_travel_entry
             and not is_headcount_entry
@@ -613,6 +618,14 @@ class DataEntryRepository:
                 )
             )
             kg_sort_expr = building_total_kg_expr
+            count_factor_joins = [
+                (Factor, col(Factor.id) == resolved_factor_id),
+                (
+                    BuildingRoom,
+                    DataEntry.data["room_name"].as_string()
+                    == col(BuildingRoom.room_name),
+                ),
+            ]
         elif is_headcount_entry:
             # --- Direct JOIN on rollup row (avoids GROUP BY, prevents double-count) ---
             # Headcount entries (member/student) produce multiple leaf emissions
@@ -643,6 +656,15 @@ class DataEntryRepository:
                 )
             )
             kg_sort_expr = RollupEmission.kg_co2eq
+            count_factor_joins = [
+                (
+                    RollupEmission,
+                    (col(RollupEmission.data_entry_id) == col(DataEntry.id))
+                    & (col(RollupEmission.emission_type_id) == rollup_et_id)
+                    & (col(RollupEmission.scope).is_(None)),
+                ),
+                (Factor, col(RollupEmission.primary_factor_id) == col(Factor.id)),
+            ]
         else:
             # --- Aggregation subquery for multi-emission entries ---
             # Exclude rollup rows so future rollup types are never double-counted.
@@ -679,6 +701,14 @@ class DataEntryRepository:
                 else emission_agg.c.primary_factor_id == col(Factor.id)
             )
             statement = statement.join(Factor, factor_on, isouter=True)
+            count_factor_joins = (
+                [(Factor, factor_on)]
+                if resolved_factor_id is not None
+                else [
+                    (emission_agg, col(DataEntry.id) == emission_agg.c.data_entry_id),
+                    (Factor, factor_on),
+                ]
+            )
 
             if is_travel_entry:
                 statement = statement.join(
@@ -768,6 +798,15 @@ class DataEntryRepository:
             handler.sort_map
         )  # shallow copy — don't mutate the class-level dict
         sort_map["kg_co2eq"] = kg_sort_expr
+        if is_buildings_entry:
+            # Surface lives on the joined building_rooms row (synced from the
+            # buildings source), not in entry data — the class-level map entry
+            # would sort all-NULL. Entry data stays as fallback for rows
+            # carrying an inline value.
+            sort_map["room_surface_square_meter"] = func.coalesce(
+                col(BuildingRoom.room_surface_square_meter),
+                DataEntry.data["room_surface_square_meter"].as_float(),
+            )
         if is_travel_entry:
             sort_map["distance_km"] = func.coalesce(
                 DataEntryEmission.additional_value,
@@ -794,15 +833,14 @@ class DataEntryRepository:
         if handler_default:
             count_stmt = count_stmt.where(*handler_default)
         if filter_pattern != "":
-            if resolved_factor_id is not None:
-                # Filter conditions may reference Factor columns — join the
-                # resolved factor so the count sees the same rows as the
-                # page query (replaces the old implicit factors cross-join).
-                count_stmt = count_stmt.select_from(DataEntry).join(
-                    Factor,
-                    col(Factor.id) == resolved_factor_id,
-                    isouter=True,
-                )
+            if count_factor_joins:
+                # Join Factor (and whatever it hangs off) exactly like the
+                # page query so the count sees the same rows — without this
+                # a Factor-referencing filter degenerates into an implicit
+                # cross join (0 or inflated counts).
+                count_stmt = count_stmt.select_from(DataEntry)
+                for target, onclause in count_factor_joins:
+                    count_stmt = count_stmt.join(target, onclause, isouter=True)
             conditions = [
                 filter_expr.ilike(filter_pattern) for filter_expr in filter_map.values()
             ]

--- a/backend/tests/integration/services/data_ingestion/test_submodule_sort_search_matrix_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_submodule_sort_search_matrix_pg.py
@@ -1,0 +1,333 @@
+"""Sort / search / pagination matrix over EVERY registered module handler.
+
+Regression net for the class of bugs found while testing #1721:
+
+- buildings couldn't sort by ``room_surface_square_meter`` (the value lives
+  on the joined ``building_rooms`` row, not in entry data);
+- purchase couldn't sort by ``currency`` (key missing from ``sort_map`` →
+  "Cannot sort by unknown field");
+- research facilities couldn't sort or search at all (``sort_map`` had only
+  id/kg_co2eq, ``filter_map`` was empty).
+
+Instead of hand-writing per-module cases, this drives
+``DataEntryRepository.get_submodule_data`` for every det in
+``MODULE_HANDLERS`` with two synthesized entries and asserts, for each det:
+
+- every ``sort_map`` key works asc AND desc (no "unknown field", no SQL
+  error) and returns both rows;
+- for every data-backed sort key the ordering actually follows the
+  synthesized values (A < B);
+- every ``filter_map`` key finds exactly the matching row;
+- pagination (limit=1, offset sweep) partitions the rows without dupes.
+
+Entry data is synthesized FROM the maps themselves (float-typed exprs get
+1.0/2.0, everything else gets "alpha-…"/"zulu-…"), so a new sort/filter key
+is covered the moment it is added to a handler — and a key pointing at a
+column the query never joins fails here immediately.
+
+Requires Docker — see ``conftest.py``'s ``postgres_container`` fixture.
+"""
+
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.building_room import BuildingRoom
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.unit import Unit
+from app.repositories.data_entry_repo import DataEntryRepository
+from app.schemas.data_entry import MODULE_HANDLERS
+
+_YEAR = 2025
+
+# Values chosen so ascending order is deterministic: A < B for both the
+# numeric and the string synthesis ("alpha" < "zulu").
+_A_NUM, _B_NUM = 1.0, 2.0
+_A_STR, _B_STR = "alpha", "zulu"
+
+# Per-det extras for response-DTO required fields that no sort/filter map
+# references (the maps drive the synthesis; DTO validation needs the rest).
+_EXTRA_DATA: dict[DataEntryTypeEnum, dict[str, Any]] = {
+    DataEntryTypeEnum.plane: {"user_institutional_id": "U-MATRIX"},
+    DataEntryTypeEnum.train: {"user_institutional_id": "U-MATRIX"},
+}
+
+# Keys whose values must be domain-shaped rather than generic strings.
+# (A, B) pairs still sort A < B.
+_KEY_VALUES: dict[str, tuple[Any, Any]] = {
+    "departure_date": ("2025-01-02", "2025-11-30"),
+    # Sorted via a CASE over the frequency enum, not lexically.
+    "requests_per_user_per_day": ("1_5", "gt_100"),
+}
+
+
+def _is_float_expr(expr: Any) -> bool:
+    try:
+        return isinstance(expr.type, (sa.Float, sa.Numeric, sa.Integer))
+    except AttributeError:
+        return False
+
+
+def _is_data_backed(expr: Any) -> bool:
+    """True when the sort expression reads (at least partly) from
+    ``data_entries.data`` — those keys must order by the synthesized values
+    even with no factors/emissions seeded (coalesce fallbacks included)."""
+    try:
+        return "data_entries.data" in str(
+            expr.compile(compile_kwargs={"literal_binds": False})
+        )
+    except Exception:
+        return False
+
+
+def _synth_data(handler: Any, det: DataEntryTypeEnum, variant: str) -> dict:
+    """Build entry data from the handler's own maps: every mapped key gets a
+    deterministic value; floats sort numerically, strings alphabetically."""
+    is_a = variant == "A"
+    data: dict[str, Any] = dict(_EXTRA_DATA.get(det, {}))
+    for key, expr in {**handler.sort_map, **handler.filter_map}.items():
+        if key in ("id", "kg_co2eq"):
+            continue
+        if key in _KEY_VALUES:
+            data[key] = _KEY_VALUES[key][0] if is_a else _KEY_VALUES[key][1]
+        elif _is_float_expr(expr):
+            data[key] = _A_NUM if is_a else _B_NUM
+        else:
+            data[key] = f"{_A_STR}-{key}" if is_a else f"{_B_STR}-{key}"
+    return data
+
+
+async def _seed_det(
+    session: AsyncSession, module_id: int, det: DataEntryTypeEnum, handler: Any
+) -> tuple[int, int]:
+    """Two entries per det: A sorts before B on every synthesized key."""
+    entry_a = DataEntry(
+        carbon_report_module_id=module_id,
+        data_entry_type_id=det.value,
+        data=_synth_data(handler, det, "A"),
+        year=_YEAR,
+    )
+    entry_b = DataEntry(
+        carbon_report_module_id=module_id,
+        data_entry_type_id=det.value,
+        data=_synth_data(handler, det, "B"),
+        year=_YEAR,
+    )
+    session.add_all([entry_a, entry_b])
+    await session.commit()
+    if entry_a.id is None or entry_b.id is None:
+        raise ValueError("seeded entries must have ids")
+    return entry_a.id, entry_b.id
+
+
+async def _fetch(
+    repo: DataEntryRepository,
+    module_id: int,
+    det: DataEntryTypeEnum,
+    **kwargs: Any,
+):
+    params: dict[str, Any] = {
+        "carbon_report_module_id": module_id,
+        "data_entry_type_id": det.value,
+        "limit": 10,
+        "offset": 0,
+        "sort_by": "id",
+        "sort_order": "asc",
+    }
+    params.update(kwargs)
+    return await repo.get_submodule_data(**params)
+
+
+@pytest.mark.asyncio
+async def test_sort_search_pagination_matrix_all_modules(pg_dsn):
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    failures: list[str] = []
+    try:
+        async with Sf() as s:
+            unit = Unit(
+                institutional_code="TEST-MATRIX",
+                institutional_id="TEST-UNIT-MATRIX",
+                name="Matrix Unit",
+                level=1,
+            )
+            s.add(unit)
+            await s.commit()
+            report = CarbonReport(year=_YEAR, unit_id=unit.id)
+            s.add(report)
+            await s.commit()
+            assert report.id is not None
+
+            modules: dict[int, int] = {}  # module_type_id → module id
+            repo = DataEntryRepository(s)
+
+            for det, handler in sorted(
+                MODULE_HANDLERS.items(), key=lambda kv: kv[0].value
+            ):
+                mt = handler.module_type.value
+                if mt not in modules:
+                    module = CarbonReportModule(
+                        carbon_report_id=report.id, module_type_id=mt
+                    )
+                    s.add(module)
+                    await s.commit()
+                    if module.id is None:
+                        raise ValueError("module must have an id")
+                    modules[mt] = module.id
+                module_id = modules[mt]
+
+                id_a, id_b = await _seed_det(s, module_id, det, handler)
+
+                # ── every sort key, both directions ─────────────────────
+                for key, expr in handler.sort_map.items():
+                    for order in ("asc", "desc"):
+                        try:
+                            resp = await _fetch(
+                                repo,
+                                module_id,
+                                det,
+                                sort_by=key,
+                                sort_order=order,
+                            )
+                        except Exception as exc:  # noqa: BLE001 — matrix report
+                            failures.append(f"{det.name}: sort {key} {order}: {exc!r}")
+                            continue
+                        if len(resp.items) != 2:
+                            failures.append(
+                                f"{det.name}: sort {key} {order}: expected 2 rows, "
+                                f"got {len(resp.items)}"
+                            )
+                            continue
+                        if key != "kg_co2eq" and _is_data_backed(expr):
+                            got = [item.id for item in resp.items]
+                            want = [id_a, id_b] if order == "asc" else [id_b, id_a]
+                            if got != want:
+                                failures.append(
+                                    f"{det.name}: sort {key} {order}: "
+                                    f"order {got}, expected {want}"
+                                )
+
+                # ── every filter key finds exactly the matching row ─────
+                for key in handler.filter_map:
+                    needle = f"{_A_STR}-{key}"
+                    try:
+                        resp = await _fetch(repo, module_id, det, filter=needle)
+                    except Exception as exc:  # noqa: BLE001 — matrix report
+                        failures.append(f"{det.name}: search {key}: {exc!r}")
+                        continue
+                    got_ids = {item.id for item in resp.items}
+                    if got_ids != {id_a} or resp.summary.total_items != 1:
+                        failures.append(
+                            f"{det.name}: search {key}={needle!r}: ids={got_ids} "
+                            f"total={resp.summary.total_items}, expected only entry A"
+                        )
+
+                # ── pagination partitions without dupes ─────────────────
+                try:
+                    page1 = await _fetch(repo, module_id, det, limit=1, offset=0)
+                    page2 = await _fetch(repo, module_id, det, limit=1, offset=1)
+                except Exception as exc:  # noqa: BLE001 — matrix report
+                    failures.append(f"{det.name}: pagination: {exc!r}")
+                else:
+                    ids = [i.id for i in page1.items] + [i.id for i in page2.items]
+                    totals = (page1.summary.total_items, page2.summary.total_items)
+                    if sorted(ids) != sorted([id_a, id_b]) or totals != (2, 2):
+                        failures.append(
+                            f"{det.name}: pagination: pages={ids} totals={totals}"
+                        )
+    finally:
+        await engine.dispose()
+
+    assert not failures, "matrix failures:\n" + "\n".join(failures)
+
+
+@pytest.mark.asyncio
+async def test_buildings_sort_by_surface_from_building_rooms(pg_dsn):
+    """#1721 report 1: surface lives on the joined ``building_rooms`` row —
+    sorting must follow it even though entry data carries no surface."""
+    engine = create_async_engine(pg_dsn, future=True)
+    Sf = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with Sf() as s:
+            unit = Unit(
+                institutional_code="TEST-SURF",
+                institutional_id="TEST-UNIT-SURF",
+                name="Surface Unit",
+                level=1,
+            )
+            s.add(unit)
+            await s.commit()
+            report = CarbonReport(year=_YEAR, unit_id=unit.id)
+            s.add(report)
+            await s.commit()
+            module = CarbonReportModule(
+                carbon_report_id=report.id,
+                module_type_id=MODULE_HANDLERS[
+                    DataEntryTypeEnum.building
+                ].module_type.value,
+            )
+            s.add(module)
+            await s.commit()
+            assert module.id is not None
+
+            s.add_all(
+                [
+                    BuildingRoom(
+                        room_name="R-SMALL",
+                        building_location="LOC",
+                        building_name="GC",
+                        room_type="office",
+                        room_surface_square_meter=10.0,
+                    ),
+                    BuildingRoom(
+                        room_name="R-BIG",
+                        building_location="LOC",
+                        building_name="GC",
+                        room_type="office",
+                        room_surface_square_meter=99.0,
+                    ),
+                ]
+            )
+            small = DataEntry(
+                carbon_report_module_id=module.id,
+                data_entry_type_id=DataEntryTypeEnum.building.value,
+                data={
+                    "building_name": "GC",
+                    "room_name": "R-SMALL",
+                    "room_type": "office",
+                },
+                year=_YEAR,
+            )
+            big = DataEntry(
+                carbon_report_module_id=module.id,
+                data_entry_type_id=DataEntryTypeEnum.building.value,
+                data={
+                    "building_name": "GC",
+                    "room_name": "R-BIG",
+                    "room_type": "office",
+                },
+                year=_YEAR,
+            )
+            s.add_all([small, big])
+            await s.commit()
+
+            repo = DataEntryRepository(s)
+            resp = await repo.get_submodule_data(
+                carbon_report_module_id=module.id,
+                data_entry_type_id=DataEntryTypeEnum.building.value,
+                limit=10,
+                offset=0,
+                sort_by="room_surface_square_meter",
+                sort_order="desc",
+            )
+    finally:
+        await engine.dispose()
+
+    names = [item.room_name for item in resp.items]
+    assert names == ["R-BIG", "R-SMALL"], (
+        f"desc surface sort must order by the building_rooms value; got {names}"
+    )


### PR DESCRIPTION
Stacks on #1721. Fixes found while testing:

- **buildings**: surface sort now reads the joined `building_rooms` row (was all-NULL from entry data)
- **purchase**: `currency` added to sort_map (was 'Cannot sort by unknown field')
- **research facilities** (common + animals): full sort_map/filter_map (was id+kg only / empty)
- **energy_combustion, building_embodied_energy, external_clouds, external_ai, process_emissions**: Factor-only sort/filter expressions now coalesce with entry data — search finds what the row displays even when no factor matched
- **count query**: joins Factor exactly like the page query per branch (was an implicit cross join for Factor-referencing filters → 0 or inflated totals; found by the matrix on embodied)

New `test_submodule_sort_search_matrix_pg.py`: drives every registered handler with synthesized entries and asserts **every sort key (asc+desc), every filter key, and pagination** — new map keys are covered the moment they're added. Plus a targeted buildings-surface regression test.

Verified: unit 1747 + ruff + mypy green; matrix + sort integration files green.