### PR TITLE
fix: add missing subcategory translations for building combustion chart; add propane fuel type

### DIFF
--- a/backend/app/models/data_entry_emission.py
+++ b/backend/app/models/data_entry_emission.py
@@ -164,6 +164,7 @@ class EmissionType(int, Enum):
     buildings__combustion__pellets = 60204
     buildings__combustion__forest_chips = 60205
     buildings__combustion__wood_logs = 60206
+    buildings__combustion__propane = 60207
     buildings__construction_and_renovation = (
         60300  # scope 3 — embodied emissions of construction materials
     )
@@ -441,6 +442,9 @@ _PARENT_MAP: dict[int, int] = {
         EmissionType.buildings__combustion.value
     ),
     EmissionType.buildings__combustion__wood_logs.value: (
+        EmissionType.buildings__combustion.value
+    ),
+    EmissionType.buildings__combustion__propane.value: (
         EmissionType.buildings__combustion.value
     ),
     EmissionType.buildings__construction_and_renovation.value: (
@@ -816,6 +820,10 @@ _SCOPE_CATEGORY_MAP: dict[int, EmissionMeta] = {
         "category": EmissionCategory.buildings_energy_combustion,
     },
     EmissionType.buildings__combustion__wood_logs.value: {
+        "scope": Scope.scope1,
+        "category": EmissionCategory.buildings_energy_combustion,
+    },
+    EmissionType.buildings__combustion__propane.value: {
         "scope": Scope.scope1,
         "category": EmissionCategory.buildings_energy_combustion,
     },

--- a/backend/app/utils/data_entry_emission_type_map.py
+++ b/backend/app/utils/data_entry_emission_type_map.py
@@ -299,6 +299,7 @@ _COMBUSTION_FUEL_MAP: dict[str, EmissionType] = {
     "pellets": EmissionType.buildings__combustion__pellets,
     "forest_chips": EmissionType.buildings__combustion__forest_chips,
     "wood_logs": EmissionType.buildings__combustion__wood_logs,
+    "propane": EmissionType.buildings__combustion__propane,
 }
 
 

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -35,6 +35,13 @@ const LABEL_KEY_MAP: Record<string, string> = {
   refrigerant: 'process-emissions.category.refrigerants',
   // buildings
   combustion: 'charts-energy-combustion-subcategory',
+  natural_gas: 'charts-natural-gas-subcategory',
+  heating_oil: 'charts-heating-oil-subcategory',
+  biomethane: 'charts-biomethane-subcategory',
+  propane: 'charts-propane-subcategory',
+  pellets: 'charts-pellets-subcategory',
+  forest_chips: 'charts-forest-chips-subcategory',
+  wood_logs: 'charts-wood-logs-subcategory',
   heating_thermal: 'charts-heating-thermal-subcategory',
   heating_electric: 'charts-heating-elec-subcategory',
   lighting: 'charts-lighting-subcategory',

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -64,6 +64,7 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   miscellaneous: 'charts-miscellaneous-subcategory',
   combustion: 'charts-energy-combustion-subcategory',
   natural_gas: 'charts-natural-gas-subcategory',
+  propane: 'charts-propane-subcategory',
   heating_oil: 'charts-heating-oil-subcategory',
   biomethane: 'charts-biomethane-subcategory',
   pellets: 'charts-pellets-subcategory',

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -438,6 +438,7 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
       combustion: colors.value.apricot.darker,
       heating_thermal: colors.value.apricot.dark,
       natural_gas: colors.value.apricot.default,
+      propane: colors.value.apricot.dark,
       heating_oil: colors.value.apricot.light,
       biomethane: colors.value.apricot.default,
       pellets: colors.value.apricot.light,

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -405,6 +405,10 @@ export default {
     en: 'Natural Gas',
     fr: 'Gaz naturel',
   },
+  'charts-propane-subcategory': {
+    en: 'Propane',
+    fr: 'Propane',
+  },
   'charts-heating-oil-subcategory': {
     en: 'Heating Oil',
     fr: 'Mazout',


### PR DESCRIPTION
## What does this change?
Fixes missing translations for building energy subcategories in the results charts. Adds the fuel-type subcategories (`natural_gas`, `heating_oil`, `biomethane`, `propane`, `pellets`, `forest_chips`, `wood_logs`) to the label key map in `GenericEmissionTreeMapChart.vue`, adds a new `propane` subcategory with its EN/FR translation (`charts-propane-subcategory`), its label mapping in `EmissionTypeBreakdownChart.vue`, and its color in the chart subcategory color scheme. Also regenerates the OpenAPI spec (`openapi.json` / `openapi.d.ts`) against the latest backend (stale-factors endpoint, BFF session exchange, permission renames, `completion_status` filter rename).

## Why is this needed?
Building module treemap and emission-type breakdown charts were displaying raw subcategory keys (e.g. `natural_gas`, `propane`) instead of translated labels, because these keys were missing from the label maps. Propane additionally had no translation string or chart color at all. This fixes the untranslated labels reported in #1465.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues
- Related to #1465

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.