### PR TITLE
feat: add equipment power feedback mailto dialog

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -20,3 +20,4 @@ APP_ENVIRONMENT=development
 # per-env in the ops repo to rebrand for another institution.
 APP_ACCESS_MANAGEMENT_PROVIDER_NAME=xxx
 APP_ACCESS_MANAGEMENT_PROVIDER_URL=xxx
+APP_EQUIPMENT_POWER_FEEDBACK_EMAIL=xxx

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -134,6 +134,11 @@ export default defineConfig(function () {
           process.env.APP_ACCESS_MANAGEMENT_PROVIDER_NAME || '',
         APP_ACCESS_MANAGEMENT_PROVIDER_URL:
           process.env.APP_ACCESS_MANAGEMENT_PROVIDER_URL || '',
+        // Recipient for the Equipment power-feedback mailto (see
+        // src/config/runtime.ts). Empty string in dev falls back to the default
+        // in runtimeConfig; in production it comes from /injectEnv.js.
+        APP_EQUIPMENT_POWER_FEEDBACK_EMAIL:
+          process.env.APP_EQUIPMENT_POWER_FEEDBACK_EMAIL || '',
       },
       // rawDefine: {}
       // ignorePublicFolder: true,

--- a/frontend/src/components/molecules/EquipmentPowerFeedbackDialog.vue
+++ b/frontend/src/components/molecules/EquipmentPowerFeedbackDialog.vue
@@ -1,0 +1,242 @@
+<template>
+  <q-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    @before-show="resetState"
+  >
+    <q-card style="min-width: 520px; max-width: 90vw">
+      <q-card-section class="row items-center q-pb-none">
+        <q-icon :name="headerIcon" size="sm" class="q-mr-sm" />
+        <div class="text-h4 text-weight-medium">
+          {{ headerTitle }}
+        </div>
+        <q-space />
+        <q-btn v-close-popup flat size="md" icon="o_close" color="grey-6" />
+      </q-card-section>
+
+      <q-separator class="q-mt-sm" />
+
+      <q-tabs
+        v-model="activeTab"
+        no-caps
+        align="left"
+        class="feedback-tabs text-grey-7"
+        :style="{ '--tab-accent': tabAccentColor }"
+      >
+        <q-tab
+          name="comment"
+          :label="$t('equipment-power-feedback-tab-comment')"
+        />
+        <q-tab name="power" :label="$t('equipment-power-feedback-tab-power')" />
+      </q-tabs>
+
+      <q-separator />
+
+      <q-tab-panels v-model="activeTab" animated>
+        <!-- Tab 1: Comment (mirrors NoteDialog) -->
+        <q-tab-panel name="comment">
+          <q-input
+            v-model="localNote"
+            type="textarea"
+            :placeholder="$t('common_comment_placeholder')"
+            outlined
+            rows="4"
+          />
+          <div class="text-caption text-grey q-mt-sm">
+            {{ $t('common_note_hint') }}
+          </div>
+          <div class="q-mt-md">
+            <q-btn
+              :label="
+                mode === 'edit' ? $t('common_edit') : $t('common_add_button')
+              "
+              :color="submitBtnColor"
+              :style="submitBtnStyle"
+              unelevated
+              no-caps
+              class="text-weight-medium q-mr-sm"
+              @click="onSaveComment"
+            />
+            <q-btn
+              v-if="mode === 'edit'"
+              :label="$t('common_delete')"
+              color="primary"
+              unelevated
+              no-caps
+              outline
+              class="text-weight-medium"
+              @click="onDeleteComment"
+            />
+          </div>
+        </q-tab-panel>
+
+        <!-- Tab 2: Power change request -->
+        <q-tab-panel name="power">
+          <q-input
+            v-model="requestText"
+            type="textarea"
+            outlined
+            rows="12"
+            autogrow
+          />
+          <div class="q-mt-md">
+            <q-btn
+              :href="feedbackMailtoHref"
+              :label="$t('equipment-power-feedback-send')"
+              :color="submitBtnColor"
+              :style="submitBtnStyle"
+              icon="o_mail"
+              unelevated
+              no-caps
+              class="text-weight-medium"
+              @click="onSendRequest"
+            />
+          </div>
+        </q-tab-panel>
+      </q-tab-panels>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { runtimeConfig } from 'src/config/runtime';
+import {
+  buildPowerRequestBody,
+  buildMailtoUrl,
+} from 'src/utils/equipmentPowerFeedbackMail';
+
+const { t: $t } = useI18n();
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean;
+    note?: string;
+    mode?: 'add' | 'edit';
+    equipmentName: string;
+    equipmentClass: string;
+    subClass?: string | null;
+    currentActivePowerW?: number | null;
+    currentStandbyPowerW?: number | null;
+    unitName: string;
+    year: string | number;
+    moduleColor?: string;
+    moduleTextColor?: string;
+    moduleAccentColor?: string;
+  }>(),
+  {
+    note: undefined,
+    mode: 'add',
+    subClass: null,
+    currentActivePowerW: null,
+    currentStandbyPowerW: null,
+    moduleColor: undefined,
+    moduleTextColor: undefined,
+    moduleAccentColor: undefined,
+  },
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'save', note: string): void;
+  (e: 'delete'): void;
+}>();
+
+const activeTab = ref<'comment' | 'power'>('comment');
+const localNote = ref(props.note ?? '');
+const requestText = ref('');
+
+const headerIcon = computed(() =>
+  activeTab.value === 'power' ? 'o_electric_bolt' : 'o_add_comment',
+);
+const headerTitle = computed(() =>
+  activeTab.value === 'power'
+    ? $t('equipment-power-feedback-title')
+    : $t('common_comment_entry_title'),
+);
+
+const tabAccentColor = computed(
+  () => props.moduleAccentColor ?? props.moduleTextColor ?? 'var(--q-primary)',
+);
+
+const submitBtnColor = computed(() =>
+  props.moduleColor ? undefined : 'accent',
+);
+
+const submitBtnStyle = computed(() =>
+  props.moduleColor
+    ? {
+        background: props.moduleColor,
+        color: props.moduleTextColor ?? 'white',
+        border: `1px solid ${props.moduleTextColor ?? 'white'}`,
+      }
+    : undefined,
+);
+
+function computeRequestText(): string {
+  return buildPowerRequestBody(
+    {
+      equipmentName: props.equipmentName,
+      equipmentClass: props.equipmentClass,
+      subClass: props.subClass,
+      currentActivePowerW: props.currentActivePowerW,
+      currentStandbyPowerW: props.currentStandbyPowerW,
+      unitName: props.unitName,
+      year: props.year,
+    },
+    $t,
+  );
+}
+
+function resetState() {
+  activeTab.value = 'comment';
+  localNote.value = props.note ?? '';
+  requestText.value = computeRequestText();
+}
+
+function onSaveComment() {
+  emit('save', localNote.value.trim());
+  emit('update:modelValue', false);
+}
+
+function onDeleteComment() {
+  emit('delete');
+  emit('update:modelValue', false);
+}
+
+const feedbackMailtoHref = computed(() => {
+  const subject = $t('equipment-power-feedback-email-subject', {
+    equipmentName: props.equipmentName,
+  });
+  return buildMailtoUrl(
+    runtimeConfig.equipmentPowerFeedbackEmail,
+    subject,
+    requestText.value,
+  );
+});
+
+function onSendRequest() {
+  emit('update:modelValue', false);
+}
+</script>
+
+<style scoped lang="scss">
+.feedback-tabs {
+  :deep(.q-tabs__arrow) {
+    display: none;
+  }
+
+  :deep(.q-tab__label) {
+    font-weight: 400;
+  }
+
+  :deep(.q-tab--active) {
+    color: var(--tab-accent);
+  }
+
+  :deep(.q-tab__indicator) {
+    background: var(--tab-accent);
+  }
+}
+</style>

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -300,6 +300,24 @@
     @delete="deleteNote"
   />
 
+  <EquipmentPowerFeedbackDialog
+    v-model="powerFeedbackDialogOpen"
+    :note="noteDialogCurrentNote"
+    :mode="noteDialogMode"
+    :equipment-name="powerFeedbackRow.equipmentName"
+    :equipment-class="powerFeedbackRow.equipmentClass"
+    :sub-class="powerFeedbackRow.subClass"
+    :current-active-power-w="powerFeedbackRow.currentActivePowerW"
+    :current-standby-power-w="powerFeedbackRow.currentStandbyPowerW"
+    :unit-name="powerFeedbackUnitName"
+    :year="year"
+    :module-color="moduleColors.bgColorLighter"
+    :module-text-color="moduleColors.buttonTextColor"
+    :module-accent-color="moduleColors.borderColor"
+    @save="saveNote"
+    @delete="deleteNote"
+  />
+
   <q-dialog v-model="confirmDelete" class="modal modal--md" persistent>
     <q-card class="column">
       <q-card-section class="flex justify-between items-center">
@@ -380,6 +398,8 @@ import { useI18n } from 'vue-i18n';
 import ModuleForm from './ModuleForm.vue';
 import ModuleInlineSelect from './ModuleInlineSelect.vue';
 import NoteDialog from 'src/components/molecules/NoteDialog.vue';
+import EquipmentPowerFeedbackDialog from 'src/components/molecules/EquipmentPowerFeedbackDialog.vue';
+import { useWorkspaceStore } from 'src/stores/workspace';
 import { QInput, QSelect, useQuasar } from 'quasar';
 import { useModuleStore, useTimelineStore } from 'src/stores/modules';
 import { useYearConfigStore } from 'src/stores/yearConfig';
@@ -456,9 +476,47 @@ const noteDialogOpen = ref(false);
 const noteDialogCurrentNote = ref('');
 const noteDialogRowId = ref<number | null>(null);
 
+// The per-row Comment button. For Equipment (issue #266) it opens a 2-tab dialog
+// (Comment + "Demande de modification de puissance") that can email a power-change
+// request to the business admin, who edits the reference Factor manually. Other
+// modules keep the plain NoteDialog. Both share the same note state so saving a
+// comment persists identically.
+const workspaceStore = useWorkspaceStore();
+const isEquipmentModule = computed(
+  () => props.moduleType === MODULES.Equipment,
+);
+const powerFeedbackDialogOpen = ref(false);
+const powerFeedbackRow = ref<{
+  equipmentName: string;
+  equipmentClass: string;
+  subClass: string | null;
+  currentActivePowerW: number | null;
+  currentStandbyPowerW: number | null;
+}>({
+  equipmentName: '',
+  equipmentClass: '',
+  subClass: null,
+  currentActivePowerW: null,
+  currentStandbyPowerW: null,
+});
+const powerFeedbackUnitName = computed(
+  () => workspaceStore.selectedUnit?.name ?? String(props.unitId),
+);
+
 function openNoteDialog(row: ModuleRow) {
   noteDialogRowId.value = getRowId(row);
   noteDialogCurrentNote.value = (row.note as string) ?? '';
+  if (isEquipmentModule.value) {
+    powerFeedbackRow.value = {
+      equipmentName: (row.name as string) ?? '',
+      equipmentClass: (row.equipment_class as string) ?? '',
+      subClass: (row.sub_class as string) ?? null,
+      currentActivePowerW: (row.active_power_w as number) ?? null,
+      currentStandbyPowerW: (row.standby_power_w as number) ?? null,
+    };
+    powerFeedbackDialogOpen.value = true;
+    return;
+  }
   noteDialogOpen.value = true;
 }
 

--- a/frontend/src/config/runtime.ts
+++ b/frontend/src/config/runtime.ts
@@ -54,4 +54,11 @@ export const runtimeConfig = {
     injected.APP_ACCESS_MANAGEMENT_PROVIDER_URL ||
     process.env.APP_ACCESS_MANAGEMENT_PROVIDER_URL ||
     '',
+  // Recipient for the Equipment "power feedback" mailto (issue #266). The address
+  // can depend on the institution, so it is configurable per-pod via
+  // APP_EQUIPMENT_POWER_FEEDBACK_EMAIL on /injectEnv.js rather than hardcoded.
+  equipmentPowerFeedbackEmail:
+    injected.APP_EQUIPMENT_POWER_FEEDBACK_EMAIL ||
+    process.env.APP_EQUIPMENT_POWER_FEEDBACK_EMAIL ||
+    '',
 } as const;

--- a/frontend/src/i18n/equipment.ts
+++ b/frontend/src/i18n/equipment.ts
@@ -134,6 +134,73 @@ Pour plus d'information : [équipments](https://epfl-enac.github.io/co2-calculat
     en: `Remember to update your inventory: if you add an item manually this year, it will not be carried over next year unless you have included it in your inventory.`,
     fr: `Pensez à mettre à jour votre inventaire : si vous ajoutez un élément manuellement cette année, il ne sera pas repris l’année prochaine, sauf si vous l’avez intégré dans votre inventaire.`,
   },
+  // Equipment power-change request (issue #266): the per-row Comment dialog gains
+  // a second tab with a pre-filled, editable request text; "Envoyer demande"
+  // opens a mailto to the business admin, who edits the reference Factor manually.
+  'equipment-power-feedback-title': {
+    en: 'Power change request',
+    fr: 'Demande de modification de puissance',
+  },
+  'equipment-power-feedback-tab-comment': {
+    en: 'Comment',
+    fr: 'Commentaire',
+  },
+  'equipment-power-feedback-tab-power': {
+    en: 'Power change request',
+    fr: 'Demande de modification de puissance',
+  },
+  'equipment-power-feedback-send': {
+    en: 'Send request',
+    fr: 'Envoyer demande',
+  },
+  'equipment-power-feedback-email-subject': {
+    en: 'Equipment power change request — {equipmentName}',
+    fr: 'Demande de modification de puissance — {equipmentName}',
+  },
+  // Pre-filled body of the Tab-2 textarea. Equipment context is filled in; the
+  // suggested-value lines are intentionally left blank for the user to complete.
+  'equipment-power-feedback-request-template': {
+    en: `Hello,
+
+I believe the estimated power for the following equipment is not representative and should be reviewed:
+
+Unit: {unitName}
+Year: {year}
+Equipment: {equipmentName}
+Class: {equipmentClass}
+Sub-class: {subClass}
+
+Current estimated active power (W): {currentActivePowerW}
+Current estimated standby power (W): {currentStandbyPowerW}
+
+Suggested active power (W):
+Suggested standby power (W):
+Data source:
+
+Additional comment:
+
+Thank you.`,
+    fr: `Bonjour,
+
+Je pense que la puissance estimée pour l'équipement suivant n'est pas représentative et devrait être revue :
+
+Unité : {unitName}
+Année : {year}
+Équipement : {equipmentName}
+Classe : {equipmentClass}
+Sous-classe : {subClass}
+
+Puissance active estimée actuelle (W) : {currentActivePowerW}
+Puissance standby estimée actuelle (W) : {currentStandbyPowerW}
+
+Puissance active suggérée (W) :
+Puissance standby suggérée (W) :
+Source de donnée :
+
+Commentaire additionnel :
+
+Merci.`,
+  },
   [`${MODULES.Equipment}-results-total-electricity-use`]: {
     en: 'Total Electricity Use',
     fr: 'Consommation électrique totale',

--- a/frontend/src/i18n/tooltips.ts
+++ b/frontend/src/i18n/tooltips.ts
@@ -372,12 +372,12 @@ export default {
     fr: 'Nombre d’heures par semaine pendant lesquelles l’équipement est utilisé en mode standby. Certaines valeurs génériques ont été préremplies. Veuillez les mettre à jour afin qu’elles correspondent plus précisément à l’utilisation de votre équipement. Le total des heures actives et des heures en veille ne peut pas dépasser 168 h/semaine.',
   },
   'module-equipment-submodule-scientific-table-active_power_w': {
-    en: 'The average active power is indicated by class. It may not fully represent the power of your equipment, in which case please contact us. Please note that we do not want the maximum power value, which can be very different from the average power.',
-    fr: "La puissance active moyenne est indiquée par classe. il est possible qu'elle ne soit pas totalement représentative de celle de votre équipement, auquel cas merci de nous contacter. Attention, nous ne voulons pas avoir la valeur de puissance maximale qui peut être très différente de la puissance moyenne.",
+    en: 'The average active power is indicated by class. It may not fully represent the power of your equipment, in which case you can request a change via the Comment button  on that row. Please note that we do not want the maximum power value, which can be very different from the average power.',
+    fr: "La puissance active moyenne est indiquée par classe. il est possible qu'elle ne soit pas totalement représentative de celle de votre équipement, auquel cas vous pouvez demander une modification via le bouton Commentaire  de la ligne concernée. Attention, nous ne voulons pas avoir la valeur de puissance maximale qui peut être très différente de la puissance moyenne.",
   },
   'module-equipment-submodule-scientific-table-standby_power_w': {
-    en: 'The average standby power is indicated by class. It may not fully represent the power of your equipment, in which case please contact us.',
-    fr: "La puissance standby moyenne est indiquée par classe. il est possible qu'elle ne soit pas totalement représentative de celle de votre équipement, auquel cas merci de nous contacter.",
+    en: 'The average standby power is indicated by class. It may not fully represent the power of your equipment, in which case you can request a change via the Comment button on that row.',
+    fr: "La puissance standby moyenne est indiquée par classe. il est possible qu'elle ne soit pas totalement représentative de celle de votre équipement, auquel cas vous pouvez demander une modification via le bouton Commentaire de la ligne concernée.",
   },
   'module-equipment-submodule-scientific-table-kg_co2eq': {
     en: 'The uncertainty of these values may be high and depends on the representativeness of the power, the hours of use, and the use parameters.',

--- a/frontend/src/utils/equipmentPowerFeedbackMail.ts
+++ b/frontend/src/utils/equipmentPowerFeedbackMail.ts
@@ -1,0 +1,69 @@
+// Equipment "power change request" mailto helpers (issue #266).
+//
+// When a user spots a wrong estimated power value on an equipment row, the second
+// tab of the Comment dialog ("Demande de modification de puissance") shows a
+// pre-filled, editable request text. On "Envoyer demande" we open a `mailto:` to
+// an env-configured business admin, who updates the reference `Factor` manually.
+//
+// Both functions are pure (the body builder takes an injected translator) so they
+// can be unit-tested for both locales without a live i18n runtime or a browser
+// mail client.
+
+export interface EquipmentPowerRequestData {
+  equipmentName: string;
+  equipmentClass: string;
+  subClass?: string | null;
+  currentActivePowerW?: number | null;
+  currentStandbyPowerW?: number | null;
+  unitName: string;
+  year: string | number;
+}
+
+export type MailTranslate = (
+  key: string,
+  named?: Record<string, unknown>,
+) => string;
+
+const EM_DASH = '—';
+
+function orDash(value: unknown): string {
+  if (value === null || value === undefined) return EM_DASH;
+  const str = String(value).trim();
+  return str.length > 0 ? str : EM_DASH;
+}
+
+/**
+ * Build the localized, pre-filled request text shown in the Tab-2 textarea. The
+ * equipment context is filled in; the "new" active/standby power lines are left
+ * blank for the user to complete (handled by the i18n template).
+ */
+export function buildPowerRequestBody(
+  data: EquipmentPowerRequestData,
+  t: MailTranslate,
+): string {
+  return t('equipment-power-feedback-request-template', {
+    unitName: orDash(data.unitName),
+    year: orDash(data.year),
+    equipmentName: orDash(data.equipmentName),
+    equipmentClass: orDash(data.equipmentClass),
+    subClass: orDash(data.subClass),
+    currentActivePowerW: orDash(data.currentActivePowerW),
+    currentStandbyPowerW: orDash(data.currentStandbyPowerW),
+  });
+}
+
+/**
+ * Assemble a `mailto:` URL. The recipient is a plain email address (left raw,
+ * matching the existing `mailto:${headOfUnitEmail}` usage); subject and body are
+ * percent-encoded query values.
+ */
+export function buildMailtoUrl(
+  recipient: string,
+  subject: string,
+  body: string,
+): string {
+  const query = `subject=${encodeURIComponent(
+    subject,
+  )}&body=${encodeURIComponent(body)}`;
+  return `mailto:${recipient}?${query}`;
+}

--- a/frontend/tests/unit/equipment-power-feedback-mail.spec.ts
+++ b/frontend/tests/unit/equipment-power-feedback-mail.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit test for the Equipment power-change-request mailto helpers (#266).
+ *
+ * ``buildPowerRequestBody`` produces the localized pre-filled textarea text
+ * (equipment context filled in, suggested-value lines left blank).
+ * ``buildMailtoUrl`` assembles the ``mailto:`` (recipient raw, subject/body
+ * percent-encoded). Both are pure; the body builder takes an injected translator
+ * so it can be tested for both locales without a live i18n runtime.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import {
+  buildPowerRequestBody,
+  buildMailtoUrl,
+  type MailTranslate,
+  type EquipmentPowerRequestData,
+} from '../../src/utils/equipmentPowerFeedbackMail';
+
+// Minimal fakes mirroring the real i18n templates in src/i18n/equipment.ts.
+function makeTranslate(locale: 'en' | 'fr'): MailTranslate {
+  const dict: Record<'en' | 'fr', Record<string, string>> = {
+    en: {
+      'equipment-power-feedback-request-template':
+        'Unit: {unitName}\nYear: {year}\nEquipment: {equipmentName}\n' +
+        'Class: {equipmentClass}\nSub-class: {subClass}\n' +
+        'Current estimated active power (W): {currentActivePowerW}\n' +
+        'Current estimated standby power (W): {currentStandbyPowerW}\n' +
+        'Suggested active power (W):\nSuggested standby power (W):\n' +
+        'Data source:',
+    },
+    fr: {
+      'equipment-power-feedback-request-template':
+        'Unité : {unitName}\nAnnée : {year}\nÉquipement : {equipmentName}\n' +
+        'Classe : {equipmentClass}\nSous-classe : {subClass}\n' +
+        'Puissance active estimée actuelle (W) : {currentActivePowerW}\n' +
+        'Puissance active suggérée (W) :',
+    },
+  };
+  return (key, named) => {
+    let out = dict[locale][key] ?? key;
+    if (named) {
+      for (const [k, v] of Object.entries(named)) {
+        out = out.replaceAll(`{${k}}`, String(v));
+      }
+    }
+    return out;
+  };
+}
+
+const RECIPIENT = 'admin@example.org';
+
+const DATA: EquipmentPowerRequestData = {
+  equipmentName: 'Centrifuge X',
+  equipmentClass: 'centrifuge',
+  subClass: 'benchtop',
+  currentActivePowerW: 1300,
+  currentStandbyPowerW: 130,
+  unitName: 'Lab ABC',
+  year: 2026,
+};
+
+test('prefilled body embeds equipment context and leaves suggested values blank (EN)', () => {
+  const body = buildPowerRequestBody(DATA, makeTranslate('en'));
+  expect(body).toContain('Lab ABC');
+  expect(body).toContain('2026');
+  expect(body).toContain('Centrifuge X');
+  expect(body).toContain('centrifuge');
+  expect(body).toContain('benchtop');
+  expect(body).toContain('Current estimated active power (W): 1300');
+  // Suggested-value lines have no value after the colon.
+  expect(body).toContain('Suggested active power (W):\n');
+});
+
+test('prefilled body localises and missing values become em-dash (FR)', () => {
+  const body = buildPowerRequestBody(
+    { ...DATA, subClass: null },
+    makeTranslate('fr'),
+  );
+  expect(body).toContain('Équipement : Centrifuge X');
+  expect(body).toContain('Sous-classe : —');
+});
+
+test('buildMailtoUrl keeps recipient raw and encodes subject/body', () => {
+  const url = buildMailtoUrl(
+    RECIPIENT,
+    'Equipment power change request — Centrifuge X',
+    'line one\nline two with spaces',
+  );
+  expect(url.startsWith(`mailto:${RECIPIENT}?subject=`)).toBe(true);
+  expect(url).toContain('&body=');
+  // Spaces/newlines must be percent-encoded, not raw.
+  expect(url).not.toContain(' ');
+  expect(url).not.toContain('\n');
+
+  const subject = decodeURIComponent(
+    url.split('?subject=')[1].split('&body=')[0],
+  );
+  const body = decodeURIComponent(url.split('&body=')[1]);
+  expect(subject).toBe('Equipment power change request — Centrifuge X');
+  expect(body).toBe('line one\nline two with spaces');
+});
+
+test('end-to-end: prefilled body round-trips through the mailto', () => {
+  const body = buildPowerRequestBody(DATA, makeTranslate('en'));
+  const url = buildMailtoUrl(RECIPIENT, 'Subject', body);
+  expect(decodeURIComponent(url.split('&body=')[1])).toBe(body);
+});


### PR DESCRIPTION
## What does this change?
Adds a "power change request" workflow to the Equipment module (#266). The per-row Comment button on Equipment rows now opens a new two-tab dialog (`EquipmentPowerFeedbackDialog.vue`): Tab 1 keeps the existing comment behavior (mirrors `NoteDialog`), and Tab 2 shows a pre-filled, editable power-change request (unit, year, equipment name/class/sub-class, current active/standby power) with blank lines for suggested values. "Send request" opens a `mailto:` to a business admin configured via a new `APP_EQUIPMENT_POWER_FEEDBACK_EMAIL` runtime env var. Other modules keep the plain `NoteDialog`.

Also includes:
- Pure, unit-testable mailto helpers (`buildPowerRequestBody`, `buildMailtoUrl`) in `src/utils/equipmentPowerFeedbackMail.ts`, with Playwright unit tests covering EN/FR bodies, missing-value fallback (em-dash), and mailto encoding
- New EN/FR i18n strings for the dialog, email subject, and request template
- Updated active/standby power tooltips to point users to the Comment button instead of "please contact us"
- New env var wired through `.env.example`, `quasar.config.js`, and `src/config/runtime.ts` (falls back to `/injectEnv.js` injection in production)

## Why is this needed?
Estimated power values for equipment are averages by class and may not be representative of a user's actual equipment. Previously the tooltips just said "please contact us" with no actionable path. This gives users a structured, low-friction way to request a power correction directly from the row concerned, and gives the business admin (who updates the reference `Factor` manually) all the context needed in a consistent format. The recipient address is institution-dependent, so it's configurable per-pod rather than hardcoded.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #266

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.