### PR TITLE
feat: optimize home endpoint

### DIFF
--- a/backend/app/api/v1/workspace_home.py
+++ b/backend/app/api/v1/workspace_home.py
@@ -11,6 +11,16 @@ consume — nothing more:
   keyed by this id.
 - ``year_config`` — module visibility et al.; ``null`` mirrors the 404 of
   ``GET /year-configuration/{year}`` (frontend renders the "create year" state).
+  Unlike that route, home returns a slim ``{year, config}`` shape (see
+  ``HomeYearConfiguration``) with the *raw* stored config and **no** sync-job /
+  incomplete / recalculation enrichment, and it drops the top-level
+  ``is_started``/``updated_at``/``configuration_completed``/``pipeline_id``/
+  ``recalculation_status`` fields — the workspace pages only read module
+  ``enabled``/``uncertainty_tag`` and submodule ``enabled``/``threshold``/
+  ``inputs_deactivated``/``csv_deactivated`` (+ ``reduction_objectives``). All of
+  that is backoffice-only (data-management page, which refetches the full config),
+  so skipping it here drops two DB queries per load and the per-submodule
+  ``latest_*_job`` payload bloat.
 - ``emission_breakdown`` — chart data, augmented with
   ``total_tonnes_validated_co2eq`` (the validated-only headline figure, distinct
   from the breakdown's all-modules ``total_tonnes_co2eq``). Also carries
@@ -23,10 +33,11 @@ enforced, like ``results-summary``) so limited users can load their home page
 without tripping the global 403 → ``/unauthorized`` redirect.
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
@@ -34,23 +45,63 @@ from app.api.v1.carbon_report_module_stats import (
     build_emission_breakdown,
     build_validated_totals,
 )
-from app.api.v1.year_configuration import build_year_configuration_response
 from app.core.logging import get_logger
 from app.core.policy import require_unit_access
 from app.models.unit import Unit
 from app.models.user import User
-from app.schemas.year_configuration import YearConfigurationResponse
+from app.models.year_configuration import YearConfiguration
 from app.services.carbon_report_service import CarbonReportService
 
 logger = get_logger(__name__)
 router = APIRouter()
 
 
+class HomeYearConfiguration(BaseModel):
+    """Slim year-config for the home aggregate — only what workspace pages read.
+
+    The workspace pages (home / module / results / sidebar) read module
+    ``enabled``/``uncertainty_tag`` and submodule
+    ``enabled``/``threshold``/``inputs_deactivated``/``csv_deactivated`` (plus
+    ``reduction_objectives``) — all of which live under ``config``. Every other
+    field of the full ``YearConfigurationResponse`` (``is_started``,
+    ``updated_at``, ``configuration_completed``, ``pipeline_id``,
+    ``recalculation_status``) is read only on the backoffice data-management page,
+    which refetches the full config via ``GET /year-configuration/{year}``. So
+    home omits them entirely.
+    """
+
+    year: int
+    config: Dict[str, Any]
+
+
+async def build_home_year_configuration(
+    db: AsyncSession, year: int, provider
+) -> Optional[HomeYearConfiguration]:
+    """Slim year-configuration for the home aggregate — no job/recalc enrichment.
+
+    Returns the raw stored config (or ``None`` if no row exists for
+    ``(year, provider)``). Deliberately does NOT run the sync-job / incomplete /
+    recalculation enrichment that ``build_year_configuration_response`` does for
+    the backoffice data-management page: the workspace pages never read those
+    fields, so skipping them avoids two extra DB queries and a large per-submodule
+    ``latest_*_job`` payload.
+    """
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == provider,
+    )
+    result = (await db.exec(stmt)).first()
+    if not result:
+        return None
+
+    return HomeYearConfiguration(year=result.year, config=result.config)
+
+
 class WorkspaceHomeResponse(BaseModel):
     """Minimal aggregate payload the frontend fans out across its stores."""
 
     carbon_report_id: int
-    year_config: Optional[YearConfigurationResponse] = None
+    year_config: Optional[HomeYearConfiguration] = None
     emission_breakdown: dict
 
 
@@ -77,9 +128,7 @@ async def get_workspace_home(
             status_code=status.HTTP_404_NOT_FOUND, detail="Carbon report not found"
         )
 
-    year_config = await build_year_configuration_response(
-        db, year, current_user.provider
-    )
+    year_config = await build_home_year_configuration(db, year, current_user.provider)
 
     emission_breakdown = await build_emission_breakdown(db, report.id)
     # The headline needs the validated-only total, which differs from the

--- a/backend/tests/unit/v1/test_workspace_home.py
+++ b/backend/tests/unit/v1/test_workspace_home.py
@@ -36,7 +36,7 @@ def _patch_common(monkeypatch, *, existing_report):
     monkeypatch.setattr(wh_module, "CarbonReportService", lambda _db: report_service)
     monkeypatch.setattr(
         wh_module,
-        "build_year_configuration_response",
+        "build_home_year_configuration",
         AsyncMock(return_value=None),
     )
     monkeypatch.setattr(

--- a/frontend/src/api/audit.ts
+++ b/frontend/src/api/audit.ts
@@ -3,12 +3,7 @@ import { api } from 'src/api/http';
 // ── Types ───────────────────────────────────────────────────────────
 
 export type AuditAction =
-  | 'CREATE'
-  | 'READ'
-  | 'UPDATE'
-  | 'DELETE'
-  | 'ROLLBACK'
-  | 'TRANSFER';
+  'CREATE' | 'READ' | 'UPDATE' | 'DELETE' | 'ROLLBACK' | 'TRANSFER';
 
 export interface AuditLogEntry {
   id: number;

--- a/frontend/src/boot/sentry.ts
+++ b/frontend/src/boot/sentry.ts
@@ -37,8 +37,7 @@ function vueErrorContext(
   info: string,
 ): Record<string, unknown> {
   const type = instance?.$?.type as
-    | { name?: string; __name?: string }
-    | undefined;
+    { name?: string; __name?: string } | undefined;
   return {
     componentName: type?.name || type?.__name || 'Anonymous Component',
     lifecycleHook: info,

--- a/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveEpflView.vue
@@ -311,13 +311,11 @@ function buildTooltipState(rawParams: unknown): TooltipState {
         tooltipSortIndex(String(a.seriesName ?? '')) -
         tooltipSortIndex(String(b.seriesName ?? '')),
     )
-    .map(
-      (p): TooltipRow => ({
-        label: categoryLabel(String(p.seriesName)),
-        value: formatTooltipTonnes(extractSeriesValue(p.value)),
-        color: categoryColor(String(p.seriesName)),
-      }),
-    );
+    .map((p): TooltipRow => ({
+      label: categoryLabel(String(p.seriesName)),
+      value: formatTooltipTonnes(extractSeriesValue(p.value)),
+      color: categoryColor(String(p.seriesName)),
+    }));
 
   rows.push(...categoryRows);
 

--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -179,13 +179,11 @@ function buildTooltipState(rawParams: unknown): TooltipState {
         tooltipSortIndex(String(a.seriesName ?? '')) -
         tooltipSortIndex(String(b.seriesName ?? '')),
     )
-    .map(
-      (p): TooltipRow => ({
-        label: categoryLabel(String(p.seriesName)),
-        value: formatTooltipTonnes(extractSeriesValue(p.value)),
-        color: categoryColor(String(p.seriesName)),
-      }),
-    );
+    .map((p): TooltipRow => ({
+      label: categoryLabel(String(p.seriesName)),
+      value: formatTooltipTonnes(extractSeriesValue(p.value)),
+      color: categoryColor(String(p.seriesName)),
+    }));
 
   const separatorRow: TooltipRow | undefined = populationParam
     ? {

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -229,8 +229,7 @@ async function uploadSelectedFile(file: File) {
       (payload?: JobUpdatePayload) => {
         const result = payload?.result;
         const rowsProcessed = payload?.meta?.rows_processed as
-          | number
-          | undefined;
+          number | undefined;
 
         let color: string;
         let message: string;

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -1081,8 +1081,7 @@ function renderCell(
   // Resolve traveler name from loaded headcount members (user_institutional_id is the source of truth)
   if (col.field === 'traveler_name') {
     const user_institutional_id = row['user_institutional_id'] as
-      | string
-      | undefined;
+      string | undefined;
     if (user_institutional_id != null) {
       return headcountMembersMap.value.get(user_institutional_id) ?? '-';
     }

--- a/frontend/src/composables/results/useAdditionalCategoryCharts.ts
+++ b/frontend/src/composables/results/useAdditionalCategoryCharts.ts
@@ -7,10 +7,7 @@ import {
 import type { TooltipState } from 'src/types/chartTooltip';
 
 export type AdditionalCategoryKey =
-  | 'commuting'
-  | 'food'
-  | 'waste'
-  | 'embodied_energy';
+  'commuting' | 'food' | 'waste' | 'embodied_energy';
 
 export type DisplayEntry = {
   key: string;

--- a/frontend/src/composables/useDataEntryDialog.ts
+++ b/frontend/src/composables/useDataEntryDialog.ts
@@ -191,8 +191,7 @@ export function useDataEntryDialog(options: UseDataEntryDialogOptions) {
 
     if (options.row.value.reductionObjectiveTypeId !== undefined) {
       const existingConfig = syncParams.config as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       syncParams.config = {
         ...existingConfig,
         reduction_objective_type_id: options.row.value.reductionObjectiveTypeId,
@@ -201,8 +200,7 @@ export function useDataEntryDialog(options: UseDataEntryDialogOptions) {
 
     if (options.row.value.factorVariant !== undefined) {
       const existingConfig = syncParams.config as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       syncParams.config = {
         ...existingConfig,
         factor_variant: options.row.value.factorVariant,
@@ -215,8 +213,7 @@ export function useDataEntryDialog(options: UseDataEntryDialogOptions) {
 
     if (sourceJobId && providerType === 'copy') {
       const existingConfig = syncParams.config as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       syncParams.config = {
         ...(existingConfig || {}),
         source_job_id: sourceJobId,
@@ -240,8 +237,7 @@ export function useDataEntryDialog(options: UseDataEntryDialogOptions) {
       (payload?: JobUpdatePayload) => {
         const result = payload?.result;
         const rowsProcessed = payload?.meta?.rows_processed as
-          | number
-          | undefined;
+          number | undefined;
         const rowsSkipped = payload?.meta?.rows_skipped as number | undefined;
 
         let color: string;

--- a/frontend/src/composables/useUploadCard.ts
+++ b/frontend/src/composables/useUploadCard.ts
@@ -67,8 +67,7 @@ export function useUploadCard() {
 
   function safeFileName(meta: unknown): string | undefined {
     const fp = (meta as Record<string, unknown>)?.file_path as
-      | string
-      | undefined;
+      string | undefined;
     if (!fp) return undefined;
     const parts = fp.split('/');
     return parts.length ? parts[parts.length - 1] : fp;
@@ -114,8 +113,7 @@ export function useUploadCard() {
     const rowsProcessed = (job.meta as Record<string, unknown>)
       ?.rows_processed as number | undefined;
     const timestampStr = (job.meta as Record<string, unknown>)?.timestamp as
-      | string
-      | undefined;
+      string | undefined;
     const timestamp = timestampStr ? new Date(timestampStr) : undefined;
 
     return { fileName, rowsProcessed, timestamp };

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -556,18 +556,16 @@ export function getChartSubcategoryColor(
 }
 
 // Maps Module enum value → category names present in module_breakdown
-export const MODULE_TO_CATEGORIES = computed(
-  (): Record<string, string[]> => ({
-    [MODULES.Headcount]: ['headcount'],
-    [MODULES.ProcessEmissions]: ['process_emissions'],
-    [MODULES.Buildings]: ['buildings_room', 'buildings_energy_combustion'],
-    [MODULES.Equipment]: ['equipment'],
-    [MODULES.ExternalCloudAndAI]: ['external_cloud_and_ai'],
-    [MODULES.Purchase]: ['purchases'],
-    [MODULES.ProfessionalTravel]: ['professional_travel'],
-    [MODULES.ResearchFacilities]: ['research_facilities'],
-  }),
-);
+export const MODULE_TO_CATEGORIES = computed((): Record<string, string[]> => ({
+  [MODULES.Headcount]: ['headcount'],
+  [MODULES.ProcessEmissions]: ['process_emissions'],
+  [MODULES.Buildings]: ['buildings_room', 'buildings_energy_combustion'],
+  [MODULES.Equipment]: ['equipment'],
+  [MODULES.ExternalCloudAndAI]: ['external_cloud_and_ai'],
+  [MODULES.Purchase]: ['purchases'],
+  [MODULES.ProfessionalTravel]: ['professional_travel'],
+  [MODULES.ResearchFacilities]: ['research_facilities'],
+}));
 
 export function getModuleForCategoryKey(categoryKey: string): Module | null {
   for (const [mod, categories] of Object.entries(MODULE_TO_CATEGORIES.value)) {

--- a/frontend/src/constant/moduleConfig.ts
+++ b/frontend/src/constant/moduleConfig.ts
@@ -51,8 +51,7 @@ export interface ConditionalOptions {
 
 // Support multiple conditional options - first matching condition wins
 export type ConditionalOptionsConfig =
-  | ConditionalOptions
-  | ConditionalOptions[];
+  ConditionalOptions | ConditionalOptions[];
 
 export interface ModuleField {
   id: string;

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -962,8 +962,7 @@ onUnmounted(() => {
               overflow: auto;
               margin: 0;
             "
-            >{{ msgText }}</pre
-          >
+            >{{ msgText }}</pre>
         </q-card-section>
         <q-card-actions class="q-px-md q-pb-md">
           <q-btn

--- a/frontend/storybook/.storybook/README.md
+++ b/frontend/storybook/.storybook/README.md
@@ -150,9 +150,7 @@ export const WithCustomState: Story = {
   decorators: [
     withMockStore((pinia) => {
       const myStore = useMyStore(pinia);
-      myStore.$patch({
-        /* mock state */
-      });
+      myStore.$patch({/* mock state */});
     }),
   ],
   render: () => ({

--- a/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
+++ b/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
@@ -65,8 +65,7 @@ async function dispatchPipelineUpdate(
       if (!map) return false;
       const url = `/api/v1/sync/pipelines/${pipelineId}/stream`;
       const pipe = map.get(url) as
-        | { dispatch(eventName: string, payload: unknown): void }
-        | undefined;
+        { dispatch(eventName: string, payload: unknown): void } | undefined;
       if (!pipe) return false;
       pipe.dispatch('pipeline-update', payload);
       return true;


### PR DESCRIPTION
## What does this change?
Replaces the full `build_year_configuration_response` call in the `GET /workspace-home` aggregate with a new slim `build_home_year_configuration` helper. The home endpoint now returns a minimal `HomeYearConfiguration` (`{year, config}`) containing the raw stored config, instead of the full `YearConfigurationResponse` with sync-job / incomplete / recalculation enrichment. Unit tests updated to patch the new helper.

## Why is this needed?
The workspace pages (home / module / results / sidebar) only read module `enabled`/`uncertainty_tag` and submodule `enabled`/`threshold`/`inputs_deactivated`/`csv_deactivated` (plus `reduction_objectives`) — all under `config`. The dropped fields (`is_started`, `updated_at`, `configuration_completed`, `pipeline_id`, `recalculation_status`) are only read on the backoffice data-management page, which refetches the full config anyway. Skipping the enrichment saves two DB queries per home-page load and removes the per-submodule `latest_*_job` payload bloat.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1416

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.