### PR TITLE
feat(659): readable CSV validation error messages

### DIFF
--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, TypedDict
 
+from pydantic import ValidationError
 from sqlmodel import col, select
 
 from app.api.v1.files import make_files_store
@@ -108,6 +109,26 @@ class StatsDict(TypedDict):
     batches_processed: int
     row_errors: list[dict[str, Any]]
     row_errors_count: int
+
+
+def _format_pydantic_validation_error(validation_error: ValidationError) -> str:
+    """Turn a ``handler.validate_create()`` ``ValidationError`` into a short,
+    readable message.
+
+    Pydantic's own ``str(validation_error)`` is a multi-line technical dump
+    (one paragraph per failing field, plus ``type=...``/``input_type=...``
+    noise) — unreadable to an operator uploading a CSV. Walk
+    ``.errors()`` instead and build one line per field, e.g.
+    ``co2_factor: Input should be a valid number, unable to parse string as
+    a number (got 'abc')``, joined with ``; `` for rows with more than one
+    bad field. Still pydantic's own wording (no new i18n/custom-copy layer
+    — deliberately out of scope), just on one line and free of the
+    ``type=...`` noise.
+    """
+    return "; ".join(
+        f"{err['loc'][-1]}: {err['msg']} (got {err['input']!r})"
+        for err in validation_error.errors()
+    )
 
 
 def _get_expected_columns_from_handlers(handlers: list[Any]) -> set[str]:
@@ -1295,6 +1316,10 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             try:
                 with self._timed("validate"):
                     validated = handler.validate_create(payload)
+            except ValidationError as validation_error:
+                error_msg = _format_pydantic_validation_error(validation_error)
+                self._record_row_error(stats, row_idx, error_msg, max_row_errors)
+                return None, error_msg, None, None
             except Exception as validation_error:
                 error_msg = f"Validation error: {validation_error}"
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -5,6 +5,8 @@ import urllib.parse
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, TypedDict
 
+from pydantic import ValidationError
+
 from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.models.data_entry import DataEntryTypeEnum
@@ -21,7 +23,10 @@ from app.models.user import User
 from app.repositories.factor_repo import FactorRepository
 from app.schemas.factor import BaseFactorHandler
 from app.seed.seed_helper import get_factor_emission_type_id
-from app.services.data_ingestion.base_csv_provider import _validate_file_path
+from app.services.data_ingestion.base_csv_provider import (
+    _format_pydantic_validation_error,
+    _validate_file_path,
+)
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 from app.services.factor_service import FactorService
 
@@ -387,6 +392,10 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
 
             try:
                 handler.validate_create(validation_payload)
+            except ValidationError as validation_error:
+                error_msg = _format_pydantic_validation_error(validation_error)
+                self._record_row_error(stats, row_idx, error_msg, max_row_errors)
+                return None, error_msg
             except Exception as validation_error:
                 error_msg = f"Validation error: {validation_error}"
                 self._record_row_error(stats, row_idx, error_msg, max_row_errors)

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -1,9 +1,11 @@
 """Unit tests for BaseCSVProvider."""
 
+import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
@@ -21,6 +23,16 @@ from app.services.data_ingestion.base_csv_provider import (
     _is_blank_data_row,
     _validate_file_path,
 )
+
+
+class _DummyDataEntryPayload(BaseModel):
+    """Minimal model used to trigger a real ``pydantic.ValidationError``
+    (float/date parsing failures) the same way a real handler's
+    ``create_dto`` would, without depending on a concrete handler."""
+
+    amount: float
+    date: datetime.date
+
 
 # ======================================================================
 # File Path Validation Tests - Security Critical
@@ -794,6 +806,108 @@ async def test_process_row_validation_error_records_error(monkeypatch):
 
     assert data_entry is None
     assert result_factor is None
+    assert stats["rows_skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_process_row_pydantic_validation_error_bad_float():
+    """A bad-float CSV value produces a readable ``field: reason (got
+    value)`` message instead of pydantic's raw multi-line dump (issue
+    #659), for the data-entry CSV path."""
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 99}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+
+    handler = MagicMock()
+    handler.kind_field = "kind"
+    handler.subkind_field = None
+
+    def fake_validate_create(payload):
+        return _DummyDataEntryPayload(amount="abc", date=datetime.date(2026, 1, 1))
+
+    handler.validate_create.side_effect = fake_validate_create
+    # Bypass handler resolution (covered by other tests) so this test
+    # exercises the validate_create/ValidationError path directly.
+    provider._resolve_handler_and_validate = AsyncMock(
+        return_value=(DataEntryTypeEnum.member, handler, None)
+    )
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {},
+        "expected_columns": {"amount"},
+    }
+    row = {"amount": "abc"}
+    stats = _build_stats()
+
+    (
+        data_entry,
+        error_msg,
+        result_factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
+        row,
+        row_idx=4,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=2,
+        unit_to_module_map=None,
+    )
+
+    assert data_entry is None
+    assert error_msg == (
+        "amount: Input should be a valid number, unable to parse "
+        "string as a number (got 'abc')"
+    )
+    assert stats["rows_skipped"] == 1
+    assert stats["row_errors"][0]["reason"] == error_msg
+
+
+@pytest.mark.asyncio
+async def test_process_row_pydantic_validation_error_bad_date():
+    """An invalid date CSV value produces a readable per-field message
+    (issue #659), for the data-entry CSV path."""
+    config = {"file_path": "tmp/test.csv", "carbon_report_module_id": 99}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+
+    handler = MagicMock()
+    handler.kind_field = "kind"
+    handler.subkind_field = None
+
+    def fake_validate_create(payload):
+        return _DummyDataEntryPayload(amount=1.0, date="2026-13-40")
+
+    handler.validate_create.side_effect = fake_validate_create
+    # Bypass handler resolution (covered by other tests) so this test
+    # exercises the validate_create/ValidationError path directly.
+    provider._resolve_handler_and_validate = AsyncMock(
+        return_value=(DataEntryTypeEnum.member, handler, None)
+    )
+
+    setup_result = {
+        "handlers": [handler],
+        "factors_map": {},
+        "expected_columns": {"amount"},
+    }
+    row = {"amount": "10"}
+    stats = _build_stats()
+
+    (
+        data_entry,
+        error_msg,
+        result_factor,
+        kg_co2eq_override,
+    ) = await provider._process_row(
+        row,
+        row_idx=5,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=2,
+        unit_to_module_map=None,
+    )
+
+    assert data_entry is None
+    assert error_msg.startswith("date: Input should be a valid date or datetime")
+    assert "(got '2026-13-40')" in error_msg
     assert stats["rows_skipped"] == 1
 
 

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -1,14 +1,25 @@
 """Tests for BaseFactorCSVProvider."""
 
+import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import EntityType, IngestionState
 from app.services.data_ingestion import base_factor_csv_provider
 from app.services.data_ingestion.base_factor_csv_provider import BaseFactorCSVProvider
+
+
+class _DummyFactorPayload(BaseModel):
+    """Minimal model used to trigger a real ``pydantic.ValidationError``
+    (float/date parsing failures) the same way ``BaseFactorHandler``'s real
+    ``create_dto`` would, without depending on the concrete handler."""
+
+    co2_factor: float
+    date: datetime.date
 
 
 class ConcreteFactorProvider(BaseFactorCSVProvider):
@@ -248,6 +259,106 @@ async def test_process_row_validation_error_records_error(monkeypatch):
 
     assert factor is None
     assert "Validation error" in error_msg
+    assert stats["rows_skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_process_row_pydantic_validation_error_bad_float(monkeypatch):
+    """A bad-float value produces a readable ``field: reason (got value)``
+    message instead of pydantic's raw multi-line dump (issue #659)."""
+    handler = MagicMock()
+    handler.category_field = "data_entry_type"
+    handler.classification_fields = ["kind"]
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv", "handlers": [handler]}, data_session=MagicMock()
+    )
+    stats = _build_stats()
+
+    def fake_validate_create(payload):
+        return _DummyFactorPayload(co2_factor="abc", date=datetime.date(2026, 1, 1))
+
+    handler.validate_create.side_effect = fake_validate_create
+
+    monkeypatch.setattr(
+        base_factor_csv_provider.BaseFactorHandler,
+        "get_by_type",
+        MagicMock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        base_factor_csv_provider,
+        "get_factor_emission_type_id",
+        lambda *args, **kwargs: 10000,
+    )
+
+    setup_result = {
+        "handlers": [handler],
+        "expected_columns": {"data_entry_type", "kind"},
+        "valid_entry_types": [DataEntryTypeEnum.member],
+    }
+
+    factor, error_msg = await provider._process_row(
+        row={"data_entry_type": "member", "kind": "x"},
+        row_idx=2,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=5,
+        factor_service=MagicMock(),
+    )
+
+    assert factor is None
+    assert error_msg == (
+        "co2_factor: Input should be a valid number, unable to parse "
+        "string as a number (got 'abc')"
+    )
+    assert stats["rows_skipped"] == 1
+    assert stats["row_errors"][0]["reason"] == error_msg
+
+
+@pytest.mark.asyncio
+async def test_process_row_pydantic_validation_error_bad_date(monkeypatch):
+    """An invalid date produces a readable per-field message (issue #659)."""
+    handler = MagicMock()
+    handler.category_field = "data_entry_type"
+    handler.classification_fields = ["kind"]
+    provider = ConcreteFactorProvider(
+        {"file_path": "tmp/test.csv", "handlers": [handler]}, data_session=MagicMock()
+    )
+    stats = _build_stats()
+
+    def fake_validate_create(payload):
+        return _DummyFactorPayload(co2_factor=1.0, date="2026-13-40")
+
+    handler.validate_create.side_effect = fake_validate_create
+
+    monkeypatch.setattr(
+        base_factor_csv_provider.BaseFactorHandler,
+        "get_by_type",
+        MagicMock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        base_factor_csv_provider,
+        "get_factor_emission_type_id",
+        lambda *args, **kwargs: 10000,
+    )
+
+    setup_result = {
+        "handlers": [handler],
+        "expected_columns": {"data_entry_type", "kind"},
+        "valid_entry_types": [DataEntryTypeEnum.member],
+    }
+
+    factor, error_msg = await provider._process_row(
+        row={"data_entry_type": "member", "kind": "x"},
+        row_idx=3,
+        setup_result=setup_result,
+        stats=stats,
+        max_row_errors=5,
+        factor_service=MagicMock(),
+    )
+
+    assert factor is None
+    assert error_msg.startswith("date: Input should be a valid date or datetime")
+    assert "(got '2026-13-40')" in error_msg
     assert stats["rows_skipped"] == 1
 
 

--- a/docs/src/implementation-plans/659-upload-csv-error-messages.md
+++ b/docs/src/implementation-plans/659-upload-csv-error-messages.md
@@ -1,7 +1,7 @@
 ---
-status: proposed
+status: delivered
 issue: 659
-last_updated: 2026-07-07
+last_updated: 2026-07-09
 title: "CSV upload: surface per-row validation errors with readable messages"
 summary: "Turn raw pydantic ValidationError dumps into readable field-level messages, and fix the upload-card UI which currently never renders them."
 ---
@@ -28,8 +28,8 @@ Two independent bugs, both confirmed in code:
 
 ## Steps
 
-- [ ] Backend: catch `pydantic.ValidationError` in `base_factor_csv_provider.py::_process_row`'s `validate_create` call and format a readable per-field message (see Design); keep the generic fallback for other exceptions.
-- [ ] Backend: apply the same fix at `base_csv_provider.py:1278`'s `validate_create` call site (data-entry CSV path — same `float_parsing`/`date_parsing` failure modes for `factor`/`date` columns).
-- [ ] Frontend: extract `formatRowErrors` (from `ModuleTable.vue`) into a shared helper reusable from `useUploadCard.ts`.
-- [ ] Frontend: wire `getErrorDetails()` (`useUploadCard.ts:130-143`) to expose formatted row errors, and update `UploadCard.vue`'s error tooltip (`:317-331`) to render them instead of dumping `errorDetails.stats` (excluding `row_errors`/`row_errors_count` from that dump).
-- [ ] Add/extend a backend unit test asserting a bad-float and a bad-date CSV row produce the new readable `row_errors` reason string (existing suites: `tests/unit/services/data_ingestion/test_base_factor_csv_provider.py`, `test_base_csv_provider.py`).
+- [x] Backend: catch `pydantic.ValidationError` in `base_factor_csv_provider.py::_process_row`'s `validate_create` call and format a readable per-field message (see Design); keep the generic fallback for other exceptions.
+- [x] Backend: apply the same fix at `base_csv_provider.py:1278`'s `validate_create` call site (data-entry CSV path — same `float_parsing`/`date_parsing` failure modes for `factor`/`date` columns).
+- [x] Frontend: extract `formatRowErrors` (from `ModuleTable.vue`) into a shared helper reusable from `useUploadCard.ts`.
+- [x] Frontend: wire `getErrorDetails()` (`useUploadCard.ts:130-143`) to expose formatted row errors, and update `UploadCard.vue`'s error tooltip (`:317-331`) to render them instead of dumping `errorDetails.stats` (excluding `row_errors`/`row_errors_count` from that dump).
+- [x] Add/extend a backend unit test asserting a bad-float and a bad-date CSV row produce the new readable `row_errors` reason string (existing suites: `tests/unit/services/data_ingestion/test_base_factor_csv_provider.py`, `test_base_csv_provider.py`).

--- a/docs/src/implementation-plans/659-upload-csv-error-messages.md
+++ b/docs/src/implementation-plans/659-upload-csv-error-messages.md
@@ -1,0 +1,35 @@
+---
+status: proposed
+issue: 659
+last_updated: 2026-07-07
+title: "CSV upload: surface per-row validation errors with readable messages"
+summary: "Turn raw pydantic ValidationError dumps into readable field-level messages, and fix the upload-card UI which currently never renders them."
+---
+
+# CSV upload: surface per-row validation errors with readable messages
+
+## Problem
+
+Issue body (FR): "todo: meilleur message d'erreur lorsque factor non valide (str/float) ou date non valid (l'erreur ne remonte pas dans l'interface)" — better error message when a factor value has a type mismatch (str/float) or a date is invalid, because right now the error doesn't reach the UI.
+
+Two independent bugs, both confirmed in code:
+
+1. **Raw pydantic dump as the error message.** Both CSV row-validation paths call `handler.validate_create(payload)` (`backend/app/services/data_ingestion/base_csv_provider.py:1278` for data-entries, `backend/app/services/data_ingestion/base_factor_csv_provider.py` `_process_row` for factors) inside a bare `except Exception`, and format it as `f"Validation error: {validation_error}"`. For a pydantic `ValidationError` this stringifies to a multi-line technical dump ("1 validation error for FactorCreate\nco2_factor\n Input should be a valid number... [type=float_parsing, input_value='abc', input_type=str]") — unreadable for an operator uploading a CSV, and not localized.
+
+2. **The message never reaches the UI for the main upload widget.** There are two different CSV-upload surfaces in the frontend:
+   - `ModuleTable.vue` (`formatRowErrors`, lines 570-598) _does_ read `payload.meta.row_errors` / `row_errors_count` and renders one line per row ("row X: reason") in a `$q.notify`.
+   - The primary "Add data" / "Add factors" cards (`UploadCard.vue` + `useUploadCard.ts`, used via `UploadCardFactors.vue` and the data-management upload flow) use `getErrorDetails()` (`frontend/src/composables/useUploadCard.ts:130-143`), which only reads `job.status_message` and `meta.error` (a job-level failure key, only set when the whole job throws) — it never reads `meta.row_errors`. The tooltip in `UploadCard.vue:317-331` then dumps the raw `stats` object with `v-for="(value, key) in errorDetails.stats"`, so the `row_errors` key renders as `row_errors: [object Object],[object Object]` — Vue's default array-of-objects stringification. The actual per-row reason ("Validation error: ...") never appears anywhere in this widget. This is the upload flow issue #659 is about.
+
+## Design
+
+**Backend** — replace the generic `except Exception` around `validate_create()` in both row-processing loops with a `pydantic.ValidationError`-specific branch that walks `validation_error.errors()` and builds one short message per field: `f"{err['loc'][-1]}: {err['msg']} (got {err['input']!r})"`, joined with `; `. This turns the dump into e.g. `co2_factor: Input should be a valid number (got 'abc')` / `date: Input should be a valid date or datetime (got '2026-13-40')` — still pydantic's wording (no new i18n layer, no per-field custom copy — that's scope creep for a "nice to have"), but on one line and free of the `type=...` / `input_type=...` noise. Non-`ValidationError` exceptions keep the existing `f"Validation error: {validation_error}"` fallback.
+
+**Frontend** — extract the row-error formatting already written once (`ModuleTable.vue`'s `formatRowErrors`) into a shared helper (e.g. add to `useUploadCard.ts` or a small `src/utils/rowErrors.ts`), and use it in `getErrorDetails()` so the tooltip built in `UploadCard.vue:317-331` shows real reasons instead of the raw stats dump. Concretely: `getErrorDetails` gains a `rowErrors: string[]` field (formatted `row N: reason`, capped like `MAX_DISPLAYED_ROW_ERRORS` in `ModuleTable.vue`), and `UploadCard.vue`'s tooltip renders that list instead of `v-for` over `errorDetails.stats`. Drop `row_errors`/`row_errors_count` from the raw stats dump loop so they don't double-render as `[object Object]`.
+
+## Steps
+
+- [ ] Backend: catch `pydantic.ValidationError` in `base_factor_csv_provider.py::_process_row`'s `validate_create` call and format a readable per-field message (see Design); keep the generic fallback for other exceptions.
+- [ ] Backend: apply the same fix at `base_csv_provider.py:1278`'s `validate_create` call site (data-entry CSV path — same `float_parsing`/`date_parsing` failure modes for `factor`/`date` columns).
+- [ ] Frontend: extract `formatRowErrors` (from `ModuleTable.vue`) into a shared helper reusable from `useUploadCard.ts`.
+- [ ] Frontend: wire `getErrorDetails()` (`useUploadCard.ts:130-143`) to expose formatted row errors, and update `UploadCard.vue`'s error tooltip (`:317-331`) to render them instead of dumping `errorDetails.stats` (excluding `row_errors`/`row_errors_count` from that dump).
+- [ ] Add/extend a backend unit test asserting a bad-float and a bad-date CSV row produce the new readable `row_errors` reason string (existing suites: `tests/unit/services/data_ingestion/test_base_factor_csv_provider.py`, `test_base_csv_provider.py`).

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -84,6 +84,20 @@ const apiJobInfo = computed(() => getJobInfo(props.apiJob));
 const hasApiErrorOrWarn = computed(() => hasErrorOrWarning(props.apiJob));
 const apiErrorDetails = computed(() => getErrorDetails(props.apiJob));
 
+// ``row_errors``/``row_errors_count`` are rendered separately via
+// ``errorDetails.rowErrors`` (formatted "row N: reason" lines) — drop them
+// here so the raw stats dump doesn't also render `row_errors:
+// [object Object],[object Object]` right below it.
+function statsWithoutRowErrors(
+  stats?: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!stats) return {};
+  const { row_errors, row_errors_count, ...rest } = stats;
+  void row_errors;
+  void row_errors_count;
+  return rest;
+}
+
 // Issue #1219 — live recalc-pipeline phase for this card.
 //
 // Pipeline progress is module-scoped (provided by ModuleConfig as the
@@ -321,8 +335,18 @@ function handleAbort() {
                 {{ errorDetails.error }}
               </span>
               <hr />
+              <div v-if="errorDetails.rowErrors.length">
+                <div
+                  v-for="(line, index) in errorDetails.rowErrors"
+                  :key="index"
+                >
+                  {{ line }}
+                </div>
+              </div>
               <div
-                v-for="(value, key, index) in errorDetails.stats || []"
+                v-for="(value, key, index) in statsWithoutRowErrors(
+                  errorDetails.stats,
+                )"
                 :key="index"
               >
                 {{ key }}: {{ value }}
@@ -402,7 +426,15 @@ function handleAbort() {
         {{ errorDetails.error }}
       </div>
       <div
-        v-for="(value, key, index) in errorDetails.stats || []"
+        v-if="errorDetails.rowErrors.length"
+        class="text-caption text-grey-7"
+      >
+        <div v-for="(line, index) in errorDetails.rowErrors" :key="index">
+          {{ line }}
+        </div>
+      </div>
+      <div
+        v-for="(value, key, index) in statsWithoutRowErrors(errorDetails.stats)"
         :key="index"
         class="text-caption text-grey-7"
       >

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -432,6 +432,7 @@ import {
 import { getModuleTypeId, MODULE_STATES } from 'src/constant/moduleStates';
 import { nOrDash } from 'src/utils/number';
 import { getModuleIconColors } from 'src/composables/useModuleIconColors';
+import { formatRowErrorLines } from 'src/utils/rowErrors';
 
 function getNumericRules(col: TableViewColumn) {
   const rules = [];
@@ -567,34 +568,13 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100, 200, 1000];
 
 const showUploadDialog = ref<boolean>(false);
 
-const MAX_DISPLAYED_ROW_ERRORS = 5;
-
 const formatRowErrors = (payload?: JobUpdatePayload): string | undefined => {
-  const rowErrors = payload?.meta?.row_errors ?? [];
-  if (rowErrors.length === 0) return undefined;
-  const totalErrorCount = payload?.meta?.row_errors_count ?? rowErrors.length;
-  const lines = rowErrors.slice(0, MAX_DISPLAYED_ROW_ERRORS).map((e) => {
-    let reason = e.reason;
-
-    // Special handling for headcount duplicate institutional ID error to provide a more user-friendly message
-    if (reason === 'DUPLICATE_INSTITUTIONAL_ID') {
-      reason = $t('headcount-member-error-duplicate-uid', {
-        label:
-          typeof INSTITUTIONAL_ID_LABEL !== 'undefined'
-            ? INSTITUTIONAL_ID_LABEL
-            : '',
-      });
-    }
-    return $t('csv_sync_row_error', { row: e.row, reason });
-  });
-  if (totalErrorCount > MAX_DISPLAYED_ROW_ERRORS) {
-    lines.push(
-      $t('csv_sync_and_more_errors', {
-        count: totalErrorCount - MAX_DISPLAYED_ROW_ERRORS,
-      }),
-    );
-  }
-  return lines.join('\n');
+  const lines = formatRowErrorLines(
+    payload?.meta?.row_errors,
+    payload?.meta?.row_errors_count,
+    $t,
+  );
+  return lines.length === 0 ? undefined : lines.join('\n');
 };
 
 const onFilesUploaded = async (filePaths: string[]) => {

--- a/frontend/src/composables/useUploadCard.ts
+++ b/frontend/src/composables/useUploadCard.ts
@@ -5,8 +5,10 @@ import {
 } from 'src/stores/backofficeDataManagement';
 import type {
   ImportRow,
+  JobRowError,
   SyncJobResponse,
 } from 'src/stores/backofficeDataManagement';
+import { formatRowErrorLines } from 'src/utils/rowErrors';
 
 export function useUploadCard() {
   const { t } = useI18n();
@@ -131,14 +133,23 @@ export function useUploadCard() {
     message: string;
     error?: string;
     stats?: Record<string, unknown>;
+    rowErrors: string[];
   } {
-    if (!job) return { message: '' };
+    if (!job) return { message: '', rowErrors: [] };
 
     const meta = job.meta as Record<string, unknown> | undefined;
+    const stats = meta?.stats as
+      { row_errors?: JobRowError[]; row_errors_count?: number } | undefined;
+
     return {
       message: job.status_message || '',
       error: meta?.error as string | undefined,
       stats: meta?.stats as Record<string, unknown> | undefined,
+      rowErrors: formatRowErrorLines(
+        stats?.row_errors,
+        stats?.row_errors_count,
+        t,
+      ),
     };
   }
 

--- a/frontend/src/utils/rowErrors.ts
+++ b/frontend/src/utils/rowErrors.ts
@@ -1,0 +1,70 @@
+import type { JobRowError } from 'src/stores/backofficeDataManagement';
+import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
+
+/**
+ * Cap on how many individual row-error lines a CSV upload result renders.
+ * Beyond this, a single "... and N more error(s)" summary line is appended
+ * instead of an ever-growing list.
+ */
+export const MAX_DISPLAYED_ROW_ERRORS = 5;
+
+/**
+ * Translate function shape expected from `useI18n()`'s `t` — kept minimal
+ * so this stays a plain (non-Vue) utility and is trivial to unit test.
+ */
+type Translate = (key: string, params?: Record<string, unknown>) => string;
+
+/**
+ * Format a CSV/data-ingestion job's per-row validation errors into
+ * human-readable lines ("Row 3: co2_factor: Input should be a valid
+ * number (got 'abc')"), capped at {@link MAX_DISPLAYED_ROW_ERRORS} with a
+ * trailing "... and N more error(s)" summary when there are more.
+ *
+ * Shared between `ModuleTable.vue` (which reads `payload.meta.row_errors`
+ * off the live SSE job stream) and `useUploadCard.ts` (which reads
+ * `job.meta.stats.row_errors` off the persisted job record) so both CSV
+ * upload surfaces render the same reasons instead of one of them dumping
+ * the raw backend payload.
+ *
+ * @param rowErrors - Row-level errors, e.g. `payload.meta.row_errors`.
+ * @param rowErrorsCount - Total error count (may exceed `rowErrors.length`
+ *   when the backend caps how many row errors it records); falls back to
+ *   `rowErrors.length` when not provided.
+ * @param t - Translate function (`useI18n()`'s `t`).
+ * @returns Formatted lines, or an empty array when there are no row errors.
+ */
+export function formatRowErrorLines(
+  rowErrors: JobRowError[] | undefined,
+  rowErrorsCount: number | undefined,
+  t: Translate,
+): string[] {
+  const errors = rowErrors ?? [];
+  if (errors.length === 0) return [];
+
+  const totalErrorCount = rowErrorsCount ?? errors.length;
+  const lines = errors.slice(0, MAX_DISPLAYED_ROW_ERRORS).map((e) => {
+    let reason = e.reason;
+
+    // Special handling for headcount duplicate institutional ID error to
+    // provide a more user-friendly message.
+    if (reason === 'DUPLICATE_INSTITUTIONAL_ID') {
+      reason = t('headcount-member-error-duplicate-uid', {
+        label:
+          typeof INSTITUTIONAL_ID_LABEL !== 'undefined'
+            ? INSTITUTIONAL_ID_LABEL
+            : '',
+      });
+    }
+    return t('csv_sync_row_error', { row: e.row, reason });
+  });
+
+  if (totalErrorCount > MAX_DISPLAYED_ROW_ERRORS) {
+    lines.push(
+      t('csv_sync_and_more_errors', {
+        count: totalErrorCount - MAX_DISPLAYED_ROW_ERRORS,
+      }),
+    );
+  }
+
+  return lines;
+}


### PR DESCRIPTION
Part of #659.

Implementation plan: `docs/src/implementation-plans/659-upload-csv-error-messages.md`

_Branch scaffold only — plan not yet implemented._
