### PR TITLE
feat(740): copy factors from previous year

### DIFF
--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -69,12 +69,17 @@ class IngestionMethod(int, Enum):
     :vartype manual: Literal[2]
     :var computed: Recompute factor values from existing emission data
     :vartype computed: Literal[3]
+    :var copy_previous_year: Clone factor rows from a source year (default
+        ``year - 1``, overridable via ``filters.source_year``) into the
+        target year — see ``FactorCopyProvider`` (#740).
+    :vartype copy_previous_year: Literal[4]
     """
 
     api = 0
     csv = 1
     manual = 2
     computed = 3
+    copy_previous_year = 4
 
 
 class TargetType(int, Enum):

--- a/backend/app/services/data_ingestion/factor_copy_provider.py
+++ b/backend/app/services/data_ingestion/factor_copy_provider.py
@@ -1,0 +1,193 @@
+"""Provider that clones a data-entry-type's factors from a prior year.
+
+Most factor tables (emission factor CSVs, unit costs, classifications) do
+not change year over year — only a handful of rows get revised.  Rather
+than forcing a full CSV/API/computed re-sync for every
+``(module_type_id, data_entry_type_id)`` pair on every newly-opened year,
+this provider copies the existing ``Factor`` rows for a source year
+(default ``year - 1``, overridable via ``filters.source_year``) into the
+target year.
+
+Runs through the same ingestion-job pipeline as every other factor
+provider (SSE progress, ``latest_factor_job`` enrichment, pipeline
+observability) — see ``backend/app/services/data_ingestion/factor_update_provider.py``
+for the sibling "computed" shape this mirrors.
+"""
+
+from typing import Any, Dict, List
+
+from app.core.logging import get_logger
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import (
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.factor import Factor
+from app.repositories.factor_repo import FactorRepository
+from app.services.data_ingestion.base_provider import DataIngestionProvider
+from app.services.factor_service import FactorService
+
+logger = get_logger(__name__)
+
+
+class FactorCopyProvider(DataIngestionProvider):
+    """Clones ``Factor`` rows from a source year into the target year.
+
+    Selects every factor for ``(data_entry_type_id, source_year)`` and
+    writes a clone (``id=None``, ``year=target_year``) via
+    ``FactorRepository.upsert_factors``.  That repository method's
+    identity key — ``(data_entry_type_id, year, emission_type_id,
+    classification::text)`` — excludes ``id``, so re-running this
+    provider (a retry, or a deliberate re-copy) updates the existing
+    target-year rows in place instead of duplicating them.
+
+    No-ops cleanly (zero rows, ``SUCCESS`` result) when the source year
+    has no factors for this data-entry type — nothing to copy is not an
+    error.
+    """
+
+    @property
+    def provider_name(self) -> IngestionMethod:
+        """Return the ingestion method identifier."""
+        return IngestionMethod.copy_previous_year
+
+    @property
+    def target_type(self) -> TargetType:
+        """Return the target type for this provider."""
+        return TargetType.FACTORS
+
+    @property
+    def entity_type(self) -> EntityType:
+        """Return the entity type for this provider."""
+        return EntityType.MODULE_PER_YEAR
+
+    async def validate_connection(self) -> bool:
+        """Always valid — no external connection required."""
+        return True
+
+    async def fetch_data(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Not used; ingest is overridden directly."""
+        return []
+
+    async def transform_data(
+        self, raw_data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Not used; ingest is overridden directly."""
+        return raw_data
+
+    async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Not used; ingest is overridden directly."""
+        return {"inserted": 0, "skipped": 0, "errors": 0}
+
+    def _resolve_source_year(
+        self, target_year: int, filters: Dict[str, Any] | None
+    ) -> int:
+        """Resolve the source year: ``filters.source_year`` or ``year - 1``."""
+        source_year_raw = (filters or {}).get("source_year")
+        if source_year_raw is None:
+            return target_year - 1
+        return int(source_year_raw)
+
+    async def ingest(
+        self,
+        filters: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        """Copy factors for ``(data_entry_type_id, source_year)`` into ``year``.
+
+        Args:
+            filters: Optional dict; ``source_year`` overrides the default
+                     ``year - 1`` source.
+
+        Returns:
+            Dict with ``state``, ``status_message``, and ``data`` (stats dict).
+        """
+        await self._update_job(
+            status_message="processing",
+            state=IngestionState.RUNNING,
+            result=None,
+            extra_metadata={"message": "Starting factor copy..."},
+        )
+
+        data_entry_type_id_raw = self.config.get("data_entry_type_id")
+        year_raw = self.config.get("year")
+
+        if data_entry_type_id_raw is None:
+            raise ValueError("data_entry_type_id is required for factor copy")
+        if year_raw is None:
+            raise ValueError("year is required for factor copy")
+        if self.job_id is None:
+            raise ValueError("job_id is required for factor copy")
+
+        target_year = int(year_raw)
+        data_entry_type = DataEntryTypeEnum(int(data_entry_type_id_raw))
+        source_year = self._resolve_source_year(target_year, filters)
+
+        factor_service = FactorService(self.data_session)
+        source_factors = await factor_service.list_by_data_entry_type(
+            data_entry_type_id=data_entry_type,
+            year=source_year,
+        )
+
+        stats: Dict[str, Any] = {
+            "source_year": source_year,
+            "target_year": target_year,
+            "rows_found": len(source_factors),
+            "rows_copied": 0,
+        }
+
+        if not source_factors:
+            status_msg = (
+                f"No factors found for {data_entry_type.name} in "
+                f"{source_year}; nothing to copy"
+            )
+            await self._update_job(
+                status_message=status_msg,
+                state=IngestionState.FINISHED,
+                result=IngestionResult.SUCCESS,
+                extra_metadata={"message": status_msg, "stats": stats},
+            )
+            return {
+                "state": IngestionState.FINISHED,
+                "status_message": status_msg,
+                "data": {"result": IngestionResult.SUCCESS, "stats": stats},
+            }
+
+        cloned: List[Factor] = [
+            Factor(
+                emission_type_id=factor.emission_type_id,
+                data_entry_type_id=factor.data_entry_type_id,
+                classification=factor.classification,
+                values=factor.values,
+                year=target_year,
+            )
+            for factor in source_factors
+        ]
+
+        factor_repo = FactorRepository(self.data_session)
+        affected = await factor_repo.upsert_factors(cloned, current_job_id=self.job_id)
+        # asyncpg can return rowcount=-1 for executemany ON CONFLICT
+        # statements where it can't tally the result reliably — fall back
+        # to the input size (mirrors ``BaseFactorCSVProvider._upsert_batch``).
+        stats["rows_copied"] = affected if affected >= 0 else len(cloned)
+
+        await self.data_session.flush()
+
+        status_msg = (
+            f"Copied {stats['rows_copied']} factor(s) from {source_year} "
+            f"to {target_year}"
+        )
+        await self._update_job(
+            status_message=status_msg,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            extra_metadata={"message": status_msg, "stats": stats},
+        )
+
+        return {
+            "state": IngestionState.FINISHED,
+            "status_message": status_msg,
+            "data": {"result": IngestionResult.SUCCESS, "stats": stats},
+        }

--- a/backend/app/services/data_ingestion/provider_factory.py
+++ b/backend/app/services/data_ingestion/provider_factory.py
@@ -23,6 +23,7 @@ from app.services.data_ingestion.csv_providers import (
     ModuleUnitSpecificCSVProvider,
     ReferenceDataCSVProvider,
 )
+from app.services.data_ingestion.factor_copy_provider import FactorCopyProvider
 
 
 class ProviderFactory:
@@ -63,6 +64,20 @@ class ProviderFactory:
                 TargetType.FACTORS,
                 EntityType.MODULE_PER_YEAR,
             ): ModulePerYearFactorCSVProvider
+            for module_type in ModuleTypeEnum
+        },
+        # MODULE_PER_YEAR factor copy-from-previous-year providers (#740) —
+        # same registration shape as the factor CSV providers above, since
+        # the copy is keyed by (module_type, data_entry_type) exactly like
+        # a CSV re-upload, just sourced from last year's rows instead of a
+        # file.
+        **{
+            (
+                module_type,
+                IngestionMethod.copy_previous_year,
+                TargetType.FACTORS,
+                EntityType.MODULE_PER_YEAR,
+            ): FactorCopyProvider
             for module_type in ModuleTypeEnum
         },
         ## MODULE_PER_YEAR REDUCTION OBJECTIVES

--- a/backend/tests/unit/services/data_ingestion/test_factor_copy_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_factor_copy_provider.py
@@ -1,0 +1,228 @@
+"""Tests for FactorCopyProvider (#740)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import IngestionResult, IngestionState
+from app.models.factor import Factor
+from app.services.data_ingestion.factor_copy_provider import FactorCopyProvider
+
+
+def _make_provider(
+    *,
+    data_entry_type_id: int = DataEntryTypeEnum.member.value,
+    year: int = 2025,
+    job_id: int | None = 99,
+) -> FactorCopyProvider:
+    provider = FactorCopyProvider(
+        config={"data_entry_type_id": data_entry_type_id, "year": year},
+        data_session=MagicMock(),
+    )
+    provider.job_id = job_id
+    provider.data_session.flush = AsyncMock()
+    return provider
+
+
+def _make_factor(
+    emission_type_id: int = 5,
+    classification: dict | None = None,
+    values: dict | None = None,
+    year: int = 2024,
+    factor_id: int = 1,
+) -> Factor:
+    return Factor(
+        id=factor_id,
+        emission_type_id=emission_type_id,
+        data_entry_type_id=DataEntryTypeEnum.member.value,
+        classification=classification or {"kind": "member"},
+        values=values or {"factor": 1.23},
+        year=year,
+    )
+
+
+@pytest.mark.asyncio
+async def test_copies_rows_into_target_year_with_defaulted_source_year():
+    """No ``filters.source_year`` → source defaults to ``year - 1``; rows
+    are cloned with ``id=None`` and ``year=target_year``."""
+    provider = _make_provider(year=2025)
+    source_factors = [
+        _make_factor(factor_id=1, values={"a": 1}),
+        _make_factor(factor_id=2, values={"a": 2}),
+    ]
+
+    with (
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorService"
+        ) as MockFactorService,
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorRepository"
+        ) as MockFactorRepo,
+    ):
+        MockFactorService.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=source_factors
+        )
+        MockFactorRepo.return_value.upsert_factors = AsyncMock(return_value=2)
+
+        result = await provider.ingest(filters=None)
+
+        # Source lookup used the defaulted year (2025 - 1 = 2024).
+        MockFactorService.return_value.list_by_data_entry_type.assert_awaited_once_with(
+            data_entry_type_id=DataEntryTypeEnum.member,
+            year=2024,
+        )
+
+        upsert_call = MockFactorRepo.return_value.upsert_factors.await_args
+        cloned = upsert_call.args[0]
+        assert upsert_call.kwargs["current_job_id"] == 99
+        assert len(cloned) == 2
+        for clone, source in zip(cloned, source_factors):
+            assert clone.id is None
+            assert clone.year == 2025
+            assert clone.emission_type_id == source.emission_type_id
+            assert clone.classification == source.classification
+            assert clone.values == source.values
+
+    assert result["state"] == IngestionState.FINISHED
+    assert result["data"]["result"] == IngestionResult.SUCCESS
+    assert result["data"]["stats"]["rows_found"] == 2
+    assert result["data"]["stats"]["rows_copied"] == 2
+    assert result["data"]["stats"]["source_year"] == 2024
+    assert result["data"]["stats"]["target_year"] == 2025
+
+
+@pytest.mark.asyncio
+async def test_source_year_override_from_filters():
+    """``filters.source_year`` overrides the ``year - 1`` default."""
+    provider = _make_provider(year=2025)
+    source_factors = [_make_factor(year=2020)]
+
+    with (
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorService"
+        ) as MockFactorService,
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorRepository"
+        ) as MockFactorRepo,
+    ):
+        MockFactorService.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=source_factors
+        )
+        MockFactorRepo.return_value.upsert_factors = AsyncMock(return_value=1)
+
+        result = await provider.ingest(filters={"source_year": 2020})
+
+        MockFactorService.return_value.list_by_data_entry_type.assert_awaited_once_with(
+            data_entry_type_id=DataEntryTypeEnum.member,
+            year=2020,
+        )
+        cloned = MockFactorRepo.return_value.upsert_factors.await_args.args[0]
+        assert cloned[0].year == 2025  # target year, not the source year
+
+    assert result["data"]["stats"]["source_year"] == 2020
+    assert result["data"]["stats"]["target_year"] == 2025
+
+
+@pytest.mark.asyncio
+async def test_noops_cleanly_when_source_year_has_no_factors():
+    """Source year with zero rows → SUCCESS no-op, no upsert call."""
+    provider = _make_provider(year=2025)
+
+    with (
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorService"
+        ) as MockFactorService,
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorRepository"
+        ) as MockFactorRepo,
+    ):
+        MockFactorService.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=[]
+        )
+        MockFactorRepo.return_value.upsert_factors = AsyncMock()
+
+        result = await provider.ingest(filters=None)
+
+        MockFactorRepo.return_value.upsert_factors.assert_not_called()
+
+    assert result["state"] == IngestionState.FINISHED
+    assert result["data"]["result"] == IngestionResult.SUCCESS
+    assert result["data"]["stats"]["rows_found"] == 0
+    assert result["data"]["stats"]["rows_copied"] == 0
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_retry_produces_equivalent_clones():
+    """Running the same copy twice (simulating a retry) builds the same
+    id-less clone payload both times — safe to re-run because
+    ``upsert_factors``'s identity key excludes ``id`` and matches on
+    (data_entry_type_id, year, emission_type_id, classification)."""
+    source_factors = [_make_factor(factor_id=1, values={"a": 1})]
+
+    calls: list[list[Factor]] = []
+
+    async def _capture_upsert(factors, current_job_id):
+        calls.append(factors)
+        return len(factors)
+
+    with (
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorService"
+        ) as MockFactorService,
+        patch(
+            "app.services.data_ingestion.factor_copy_provider.FactorRepository"
+        ) as MockFactorRepo,
+    ):
+        MockFactorService.return_value.list_by_data_entry_type = AsyncMock(
+            return_value=source_factors
+        )
+        MockFactorRepo.return_value.upsert_factors = AsyncMock(
+            side_effect=_capture_upsert
+        )
+
+        provider1 = _make_provider(year=2025)
+        await provider1.ingest(filters=None)
+        provider2 = _make_provider(year=2025)
+        await provider2.ingest(filters=None)
+
+    assert len(calls) == 2
+    first, second = calls
+    assert len(first) == len(second) == 1
+    assert first[0].id is None and second[0].id is None
+    assert first[0].year == second[0].year == 2025
+    assert first[0].classification == second[0].classification
+    assert first[0].values == second[0].values
+    assert first[0].emission_type_id == second[0].emission_type_id
+
+
+@pytest.mark.asyncio
+async def test_missing_data_entry_type_id_raises():
+    provider = FactorCopyProvider(config={"year": 2025}, data_session=MagicMock())
+    provider.job_id = 1
+    with pytest.raises(ValueError, match="data_entry_type_id is required"):
+        await provider.ingest(filters=None)
+
+
+@pytest.mark.asyncio
+async def test_missing_year_raises():
+    provider = FactorCopyProvider(
+        config={"data_entry_type_id": DataEntryTypeEnum.member.value},
+        data_session=MagicMock(),
+    )
+    provider.job_id = 1
+    with pytest.raises(ValueError, match="year is required"):
+        await provider.ingest(filters=None)
+
+
+@pytest.mark.asyncio
+async def test_missing_job_id_raises():
+    provider = FactorCopyProvider(
+        config={
+            "data_entry_type_id": DataEntryTypeEnum.member.value,
+            "year": 2025,
+        },
+        data_session=MagicMock(),
+    )
+    with pytest.raises(ValueError, match="job_id is required"):
+        await provider.ingest(filters=None)

--- a/backend/tests/unit/v1/test_sync_module_factors_copy.py
+++ b/backend/tests/unit/v1/test_sync_module_factors_copy.py
@@ -1,0 +1,128 @@
+"""Unit test for POST /v1/sync/factors/{module}/{det} accepting the
+``copy_previous_year`` ingestion method (#740).
+
+Calls the endpoint function directly (not through TestClient/ASGI) with
+mocked collaborators — ``ProviderFactory.create_provider``,
+``_stamp_job_type_and_meta``, ``fire_and_forget``/``run_job``, and the
+request-context extractors — so this stays a fast unit test rather than
+requiring a real Postgres (see the ``_pg`` integration suite for the
+full-stack round trip of other sync endpoints).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.v1 import data_sync
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import IngestionMethod, TargetType
+from app.models.module_type import ModuleTypeEnum
+
+
+@pytest.mark.asyncio
+async def test_sync_module_factors_accepts_copy_previous_year_with_source_year_filter():
+    """``ingestion_method=copy_previous_year`` + ``filters.source_year``
+    is accepted, dispatched to ``ProviderFactory.create_provider`` with the
+    new method, and the filter is threaded into the job's stamped meta —
+    the same ``meta["filters"]`` slot ``factor_ingest_handler`` reads at
+    run time to call ``provider.ingest(filters)``.
+    """
+    sync_request = data_sync.SyncRequest(
+        ingestion_method=IngestionMethod.copy_previous_year,
+        target_type=TargetType.FACTORS,
+        year=2025,
+        filters={"source_year": 2020},
+    )
+
+    mock_provider = MagicMock()
+    mock_provider.validate_connection = AsyncMock(return_value=True)
+    mock_provider.create_job = AsyncMock(return_value=42)
+    type(mock_provider).__name__ = "FactorCopyProvider"
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    with (
+        patch.object(
+            data_sync.ProviderFactory,
+            "create_provider",
+            AsyncMock(return_value=mock_provider),
+        ) as mock_create_provider,
+        patch.object(data_sync, "_stamp_job_type_and_meta", AsyncMock()) as mock_stamp,
+        patch.object(data_sync, "run_job", MagicMock(return_value="job-coro")),
+        patch.object(data_sync, "fire_and_forget", MagicMock()),
+        patch.object(data_sync, "extract_ip_address", return_value="127.0.0.1"),
+        patch.object(data_sync, "extract_route_payload", AsyncMock(return_value=None)),
+    ):
+        response = await data_sync.sync_module_factors(
+            module_type_id=ModuleTypeEnum.headcount,
+            data_entry_type_id=DataEntryTypeEnum.member,
+            syncRequest=sync_request,
+            request=MagicMock(),
+            background_tasks=MagicMock(),
+            db=db,
+            current_user=MagicMock(),
+        )
+
+    assert response["job_id"] == 42
+
+    # Provider selection was dispatched with the new ingestion method,
+    # scoped to the requested module/data-entry type.
+    _, create_kwargs = mock_create_provider.call_args
+    assert create_kwargs["ingestion_method"] == IngestionMethod.copy_previous_year
+    assert create_kwargs["target_type"] == TargetType.FACTORS
+    assert (
+        create_kwargs["config"]["data_entry_type_id"] == DataEntryTypeEnum.member.value
+    )
+    assert create_kwargs["config"]["module_type_id"] == ModuleTypeEnum.headcount
+
+    # filters.source_year is threaded through to the job's stamped meta.
+    _, stamp_kwargs = mock_stamp.call_args
+    assert stamp_kwargs["extra_meta"] == {"filters": {"source_year": 2020}}
+    assert stamp_kwargs["job_type"] == "factor_ingest"
+
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_module_factors_copy_previous_year_defaults_filters_to_empty_dict():
+    """No ``filters`` on the request → stamped meta gets ``{}``, which the
+    provider interprets as "use ``year - 1``" (see FactorCopyProvider)."""
+    sync_request = data_sync.SyncRequest(
+        ingestion_method=IngestionMethod.copy_previous_year,
+        target_type=TargetType.FACTORS,
+        year=2025,
+    )
+
+    mock_provider = MagicMock()
+    mock_provider.validate_connection = AsyncMock(return_value=True)
+    mock_provider.create_job = AsyncMock(return_value=7)
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    with (
+        patch.object(
+            data_sync.ProviderFactory,
+            "create_provider",
+            AsyncMock(return_value=mock_provider),
+        ),
+        patch.object(data_sync, "_stamp_job_type_and_meta", AsyncMock()) as mock_stamp,
+        patch.object(data_sync, "run_job", MagicMock(return_value="job-coro")),
+        patch.object(data_sync, "fire_and_forget", MagicMock()),
+        patch.object(data_sync, "extract_ip_address", return_value="127.0.0.1"),
+        patch.object(data_sync, "extract_route_payload", AsyncMock(return_value=None)),
+    ):
+        response = await data_sync.sync_module_factors(
+            module_type_id=ModuleTypeEnum.headcount,
+            data_entry_type_id=DataEntryTypeEnum.member,
+            syncRequest=sync_request,
+            request=MagicMock(),
+            background_tasks=MagicMock(),
+            db=db,
+            current_user=MagicMock(),
+        )
+
+    assert response["job_id"] == 7
+    _, stamp_kwargs = mock_stamp.call_args
+    assert stamp_kwargs["extra_meta"] == {"filters": {}}

--- a/docs/src/implementation-plans/740-backoffice-copy-factors-from-last-year.md
+++ b/docs/src/implementation-plans/740-backoffice-copy-factors-from-last-year.md
@@ -1,9 +1,9 @@
 ---
-status: proposed
+status: delivered
 issue: 740
-last_updated: 2026-07-07
+last_updated: 2026-07-09
 title: "Backoffice: Copy factors from previous year"
-summary: "Add a backoffice action to duplicate a prior year's factor rows into a newly opened year, bulk or per-row, instead of forcing a full CSV re-upload."
+summary: "Add a backoffice action to duplicate a prior year's factor rows into a newly opened year, bulk or per-submodule, instead of forcing a full CSV re-upload."
 ---
 
 # Backoffice: Copy factors from previous year
@@ -97,12 +97,39 @@ is deferred to a follow-up if operators ask for it after using bulk copy.
 
 ## Steps
 
-- [ ] Add `IngestionMethod.copy_previous_year` to `backend/app/models/data_ingestion.py`
-- [ ] Implement `FactorCopyProvider` (source-year lookup, clone-with-new-year, `upsert_factors`)
-- [ ] Register provider in `ProviderFactory.PROVIDERS` for `(copy_previous_year, TargetType.FACTORS)`
-- [ ] Unit test: `FactorCopyProvider` copies rows, is idempotent on retry, no-ops when source year is empty
-- [ ] Unit test: `sync_module_factors` endpoint accepts `ingestion_method=copy_previous_year` with `filters.source_year` override
-- [ ] Frontend: `initiateFactorCopyFromPreviousYear` in `backofficeDataManagement.ts`
-- [ ] Frontend: per-submodule "Copy from {year-1}" button in `DataManagementPage.vue`, gated on prior-year success via `getPreviousYearSuccessfulJobs`
-- [ ] Frontend: page-level "Copy all factors from {year-1}" bulk action looping per-submodule calls
-- [ ] Manual verification: open a new year, bulk-copy from prior year, confirm submodules flip from "incomplete" to populated without CSV re-upload
+- [x] Add `IngestionMethod.copy_previous_year` to `backend/app/models/data_ingestion.py`
+- [x] Implement `FactorCopyProvider` (source-year lookup, clone-with-new-year, `upsert_factors`)
+- [x] Register provider in `ProviderFactory.PROVIDERS` for `(copy_previous_year, TargetType.FACTORS)`
+- [x] Unit test: `FactorCopyProvider` copies rows, is idempotent on retry, no-ops when source year is empty
+- [x] Unit test: `sync_module_factors` endpoint accepts `ingestion_method=copy_previous_year` with `filters.source_year` override
+- [x] Frontend: `initiateFactorCopyFromPreviousYear` in `backofficeDataManagement.ts`
+- [x] Frontend: per-submodule "Copy from {year-1}" button (in `UploadCardFactors.vue` / `SubmoduleItem.vue`, consumed from `DataManagementPage.vue`'s module tree), gated on prior-year success via `getPreviousYearSuccessfulJobs`
+- [x] Frontend: page-level "Copy all factors from {year-1}" bulk action in `DataManagementPage.vue` looping per-submodule calls, skipping pairs with no source-year factors
+- [x] Manual/logical verification: reasoned through the end-to-end flow (see "Verification" note below) — no live app available in this environment to click through.
+
+### Implementation notes (2026-07-09)
+
+- The per-submodule "Copy from {year-1}" button lives on the existing
+  `UploadCardFactors` card (next to "Compute Missing Factors"), wired
+  through `SubmoduleItem.vue` → `useSubmoduleConfig.ts`, not directly in
+  `DataManagementPage.vue` (that file only hosts the page-level bulk
+  button) — the per-submodule UI composition already lived one level
+  down from the page component before this change (mirrors how
+  "Compute Missing Factors" is wired), so the new button follows the
+  same layering rather than moving existing structure.
+- A confirmation dialog (`CopyFactorsDialog.vue`, modeled on the
+  existing `ComputedFactorDialog.vue`) gates both the per-submodule and
+  bulk actions, since copying overwrites already-entered current-year
+  factor rows for the affected data-entry type(s).
+- Pre-existing, unrelated mechanism found during implementation: a
+  file-replay "copy from previous year" flow already exists for
+  individual data-entry-type dialogs (`useDataEntryDialog.ts` +
+  `config.source_job_id` + `_resolve_source_job_to_file_path` in
+  `data_sync.py`), which re-uploads the prior year's *processed CSV
+  file* through the normal CSV provider. It is orthogonal to this
+  plan's DB-level `FactorCopyProvider`: it depends on the source year's
+  processed file still existing in file storage and only replays
+  CSV-sourced factors, whereas `FactorCopyProvider` clones the `Factor`
+  rows directly from the database and also covers factors that were
+  never CSV-uploaded (e.g. seeded or computed). Both mechanisms now
+  coexist; no changes were made to the file-replay path.

--- a/docs/src/implementation-plans/740-backoffice-copy-factors-from-last-year.md
+++ b/docs/src/implementation-plans/740-backoffice-copy-factors-from-last-year.md
@@ -1,0 +1,108 @@
+---
+status: proposed
+issue: 740
+last_updated: 2026-07-07
+title: "Backoffice: Copy factors from previous year"
+summary: "Add a backoffice action to duplicate a prior year's factor rows into a newly opened year, bulk or per-row, instead of forcing a full CSV re-upload."
+---
+
+# Backoffice: Copy factors from previous year
+
+## Problem
+
+Factors (`factors` table) are year-scoped (`Factor.year`, indexed, unique per
+`(data_entry_type_id, year, emission_type_id, classification)`). The only way
+to populate factors for a newly-opened year today is a CSV/API/computed sync
+per `(module_type_id, data_entry_type_id)` via
+`POST /v1/sync/factors/{module_type_id}/{data_entry_type_id}`
+(`backend/app/api/v1/data_sync.py:998`), routed through
+`ProviderFactory.PROVIDERS`/`COMPUTED_FACTOR_PROVIDERS`
+(`backend/app/services/data_ingestion/provider_factory.py`) keyed on
+`(IngestionMethod, TargetType)` or
+`(module, data_entry_type, IngestionMethod, TargetType, EntityType)`.
+
+Most factor tables (emission factor CSVs, unit costs, classifications) do not
+change year over year — only a handful of rows get revised. Operators
+currently must re-upload the full CSV for every module/data-entry-type
+combination for every new year, even when 95%+ of rows are identical to the
+prior year. `year_configuration` creation
+(`create_year_configuration`, `backend/app/api/v1/year_configuration.py:608`)
+already auto-enqueues a `unit_sync` job but does nothing for factors — every
+submodule starts "incomplete" (`_enrich_config_with_incomplete_flags`) until
+manually synced.
+
+`getPreviousYearSuccessfulJobs` (`frontend/src/stores/backofficeDataManagement.ts:572`)
+already reads the prior year's finished jobs for prerequisite checks, so the
+frontend already has the previous-year job list in scope where a "copy"
+action would be offered — no new lookup needed there.
+
+No copy/duplicate/clone mechanism exists today (`grep` for
+`copy|duplicate|clone` across `factor_service.py`, `factor_repo.py`,
+`factors.py`, `backoffice.py` — the only "copy" hit is
+`FactorRepository._upsert_via_copy`, a Postgres `COPY`-based upsert
+implementation detail, unrelated).
+
+## Design
+
+Reuse the existing ingestion-job pipeline rather than inventing a parallel
+synchronous copy path — this keeps SSE progress, `latest_factor_job`
+enrichment, and the pipeline-observability UI (issue #857) working unchanged
+for the new action.
+
+**Backend**
+
+1. Add `IngestionMethod.copy_previous_year` (int enum,
+   `backend/app/models/data_ingestion.py`) alongside `api/csv/manual/computed`.
+2. New provider `FactorCopyProvider`
+   (`backend/app/services/data_ingestion/factor_copy_provider.py`, mirrors
+   `factor_update_provider.py`'s shape): given `module_type_id`,
+   `data_entry_type_id`, target `year`, reads `source_year` from
+   `syncRequest.filters` (default `year - 1`), selects all `Factor` rows for
+   `(data_entry_type_id, source_year)` scoped to the module's emission
+   type(s) via `FactorService.list_by_data_entry_type`, clones each row with
+   `year=target_year` and `id=None`, and writes them via the existing
+   `FactorRepository.upsert_factors` (identity key already excludes `id`, so
+   re-running is idempotent and safe to retry).
+3. Register `(IngestionMethod.copy_previous_year, TargetType.FACTORS)` in
+   `ProviderFactory.PROVIDERS` — no new endpoint needed, the existing
+   `POST /v1/sync/factors/{module_type_id}/{data_entry_type_id}` already
+   accepts `ingestion_method` + `filters` in `SyncRequest` and dispatches
+   through `ProviderFactory.create_provider`.
+4. Bulk "copy all" for a year: a thin loop endpoint
+   `POST /v1/sync/factors/copy-previous-year/{year}` (or a frontend-side
+   loop over configured `(module_type_id, data_entry_type_id)` pairs calling
+   the per-module endpoint — prefer the frontend loop, it reuses
+   `initiateSync`'s existing per-submodule pipeline tracking instead of
+   inventing a second bulk-job abstraction). Skip pairs with zero source-year
+   rows (nothing to copy) rather than erroring.
+5. No migration needed — `Factor.year` and its indexes already exist.
+
+**Frontend**
+
+6. `backofficeDataManagement.ts`: add `initiateFactorCopyFromPreviousYear(moduleTypeId, dataEntryTypeId, year)`,
+   mirrors `initiateComputedFactorSync` (`:602`) but posts
+   `ingestion_method: IngestionMethod.COPY_PREVIOUS_YEAR`. Gate visibility
+   per-submodule on `getPreviousYearSuccessfulJobs(year - 1, moduleTypeId, TargetType.FACTORS)`
+   returning non-empty (nothing to copy from an unsynced prior year).
+7. `DataManagementPage.vue`: add a "Copy from {year-1}" action next to each
+   submodule's existing CSV-upload control, plus one page-level "Copy all
+   factors from {year-1}" bulk button that loops the per-submodule call.
+   Existing job-card/pipeline UI (issue #857) covers progress display with
+   no changes.
+
+Individual-row copy (copying a single factor entry rather than a whole
+module/data-entry-type table) is out of scope for v1 — the issue's primary
+ask ("open 2024 ... to have a previous year") is the bulk case; per-row copy
+is deferred to a follow-up if operators ask for it after using bulk copy.
+
+## Steps
+
+- [ ] Add `IngestionMethod.copy_previous_year` to `backend/app/models/data_ingestion.py`
+- [ ] Implement `FactorCopyProvider` (source-year lookup, clone-with-new-year, `upsert_factors`)
+- [ ] Register provider in `ProviderFactory.PROVIDERS` for `(copy_previous_year, TargetType.FACTORS)`
+- [ ] Unit test: `FactorCopyProvider` copies rows, is idempotent on retry, no-ops when source year is empty
+- [ ] Unit test: `sync_module_factors` endpoint accepts `ingestion_method=copy_previous_year` with `filters.source_year` override
+- [ ] Frontend: `initiateFactorCopyFromPreviousYear` in `backofficeDataManagement.ts`
+- [ ] Frontend: per-submodule "Copy from {year-1}" button in `DataManagementPage.vue`, gated on prior-year success via `getPreviousYearSuccessfulJobs`
+- [ ] Frontend: page-level "Copy all factors from {year-1}" bulk action looping per-submodule calls
+- [ ] Manual verification: open a new year, bulk-copy from prior year, confirm submodules flip from "incomplete" to populated without CSV re-upload

--- a/frontend/src/components/molecules/data-management/CopyFactorsDialog.vue
+++ b/frontend/src/components/molecules/data-management/CopyFactorsDialog.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+interface Props {
+  modelValue: boolean;
+  year: number;
+  /** Override the default single-submodule confirmation message — used
+   * by the page-level "Copy all factors" bulk action (#740). */
+  messageKey?: string;
+}
+
+withDefaults(defineProps<Props>(), {
+  messageKey: 'data_management_copy_factors_confirm_message',
+});
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'confirm'): void;
+  (e: 'cancel'): void;
+}>();
+
+const { t: $t } = useI18n();
+
+function handleClose() {
+  emit('cancel');
+  emit('update:modelValue', false);
+}
+
+function handleConfirm() {
+  emit('confirm');
+  emit('update:modelValue', false);
+}
+</script>
+
+<template>
+  <q-dialog
+    :model-value="modelValue"
+    persistent
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <q-card style="min-width: 420px">
+      <q-card-section class="row items-center q-pb-none">
+        <q-icon name="content_copy" color="accent" size="sm" class="q-mr-sm" />
+        <div class="text-h6">
+          {{ $t('data_management_copy_factors_confirm_title', { year }) }}
+        </div>
+        <q-space />
+        <q-btn
+          flat
+          size="md"
+          icon="o_close"
+          color="grey-6"
+          @click="handleClose"
+        />
+      </q-card-section>
+      <q-separator />
+      <q-card-section class="text-body2">
+        {{ $t(messageKey, { year }) }}
+      </q-card-section>
+      <q-card-actions class="q-px-md q-pb-md">
+        <q-btn flat :label="$t('common_cancel')" @click="handleClose" />
+        <q-btn
+          color="accent"
+          unelevated
+          :label="$t('common_confirm')"
+          @click="handleConfirm"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<style scoped></style>

--- a/frontend/src/components/molecules/data-management/SubmoduleItem.vue
+++ b/frontend/src/components/molecules/data-management/SubmoduleItem.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-import { ref, inject, computed, type ComputedRef, type Ref } from 'vue';
+import {
+  ref,
+  inject,
+  computed,
+  watch,
+  onMounted,
+  type ComputedRef,
+  type Ref,
+} from 'vue';
 import { useSubmoduleConfig } from 'src/composables/useSubmoduleConfig';
 import { useRecalculation } from 'src/composables/useRecalculation';
 import {
@@ -14,6 +22,7 @@ import UploadCardData from 'src/components/molecules/data-management/UploadCardD
 import UploadCardFactors from 'src/components/molecules/data-management/UploadCardFactors.vue';
 import UploadCardReferences from 'src/components/molecules/data-management/UploadCardReferences.vue';
 import ComputedFactorDialog from 'src/components/molecules/data-management/ComputedFactorDialog.vue';
+import CopyFactorsDialog from 'src/components/molecules/data-management/CopyFactorsDialog.vue';
 
 interface Props {
   submodule: SubmoduleConfig;
@@ -39,6 +48,11 @@ const {
   computedFactorRunning,
   anyComputedFactorRunning,
   confirmComputedFactorSync,
+  copyFactorsRunning,
+  anyCopyFactorsRunning,
+  loadCopyFactorsAvailability,
+  canCopyFactorsFromPreviousYear,
+  confirmCopyFactorsFromPreviousYear,
 } = useSubmoduleConfig();
 
 const { getRecalcStatus } = useRecalculation();
@@ -82,6 +96,30 @@ function openComputedFactorConfirm() {
 async function handleComputedFactorConfirm() {
   await confirmComputedFactorSync(props.submodule, handleJobCompleted);
 }
+
+// #740 — "Copy from {year - 1}" per-submodule factor copy. Availability
+// (does the prior year have factors to copy?) is loaded once on mount
+// and whenever the selected year changes.
+const showCopyFactorsConfirm = ref(false);
+
+function openCopyFactorsConfirm() {
+  showCopyFactorsConfirm.value = true;
+}
+
+async function handleCopyFactorsConfirm() {
+  await confirmCopyFactorsFromPreviousYear(props.submodule, handleJobCompleted);
+}
+
+onMounted(() => {
+  void loadCopyFactorsAvailability(props.submodule);
+});
+
+watch(
+  () => yearConfigStore.selectedYear,
+  () => {
+    void loadCopyFactorsAvailability(props.submodule);
+  },
+);
 
 async function handleReferenceCompleted() {
   await handleJobCompleted();
@@ -274,6 +312,10 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         :module="submodule.key"
         :computed-factor-running="computedFactorRunning[submodule.key]"
         :any-computed-factor-running="anyComputedFactorRunning"
+        :can-copy-from-previous-year="canCopyFactorsFromPreviousYear(submodule)"
+        :copy-factors-running="copyFactorsRunning[submodule.key]"
+        :any-copy-factors-running="anyCopyFactorsRunning"
+        :previous-year="yearConfigStore.selectedYear - 1"
         :pipeline-progress="pipelineProgress"
         :on-download="
           (e, y) => {
@@ -283,6 +325,7 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
         @upload="(row) => openDataEntryDialog(row, TargetType.FACTORS)"
         @recalculate="() => triggerTypeRecalculation(submodule)"
         @compute-factors="openComputedFactorConfirm"
+        @copy-from-previous-year="openCopyFactorsConfirm"
         @abort="handleAbortPipeline"
       />
       <UploadCardReferences
@@ -313,6 +356,12 @@ const isSubmoduleDisabled = (sub: SubmoduleConfig): boolean =>
       v-model="showComputedFactorConfirm"
       @confirm="handleComputedFactorConfirm"
       @cancel="showComputedFactorConfirm = false"
+    />
+    <CopyFactorsDialog
+      v-model="showCopyFactorsConfirm"
+      :year="yearConfigStore.selectedYear - 1"
+      @confirm="handleCopyFactorsConfirm"
+      @cancel="showCopyFactorsConfirm = false"
     />
   </q-expansion-item>
 </template>

--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -35,6 +35,11 @@ interface Props {
   hasComputedFactorButton?: boolean;
   computedFactorRunning?: boolean;
   isComputedFactorDisabled?: boolean;
+  /** #740 — "Copy from {year}" button (per-submodule factor copy). */
+  hasCopyFactorsButton?: boolean;
+  copyFactorsLabel?: string;
+  copyFactorsRunning?: boolean;
+  isCopyFactorsDisabled?: boolean;
   row?: ImportRow;
 }
 
@@ -54,6 +59,10 @@ const props = withDefaults(defineProps<Props>(), {
   hasComputedFactorButton: false,
   computedFactorRunning: false,
   isComputedFactorDisabled: false,
+  hasCopyFactorsButton: false,
+  copyFactorsLabel: undefined,
+  copyFactorsRunning: false,
+  isCopyFactorsDisabled: false,
   row: undefined,
 });
 
@@ -62,6 +71,7 @@ const emit = defineEmits<{
   (e: 'download', row: ImportRow, targetType: TargetType): void;
   (e: 'recalculate', item: ImportRow): void;
   (e: 'compute-factors', item: ImportRow): void;
+  (e: 'copy-factors', item: ImportRow): void;
   // Stops the whole pipeline this card is bound to (replaces the
   // legacy per-job ``cancel`` — see backofficeDataManagement.abortPipeline
   // for the why).  Parent resolves the pipeline_id via inject.
@@ -214,6 +224,12 @@ function handleComputeFactors() {
   }
 }
 
+function handleCopyFactors() {
+  if (props.row) {
+    emit('copy-factors', props.row);
+  }
+}
+
 function handleAbort() {
   emit('abort');
 }
@@ -270,6 +286,22 @@ function handleAbort() {
             class="text-weight-medium"
             :disable="isDisabled || isComputedFactorDisabled"
             @click="handleComputeFactors"
+          />
+        </template>
+
+        <!-- #740 — Copy factors from previous year -->
+        <template v-if="hasCopyFactorsButton">
+          <q-spinner-rings v-if="copyFactorsRunning" color="grey" />
+          <q-btn
+            v-else
+            color="accent"
+            outline
+            icon="content_copy"
+            size="sm"
+            :label="copyFactorsLabel"
+            class="text-weight-medium"
+            :disable="isDisabled || isCopyFactorsDisabled"
+            @click="handleCopyFactors"
           />
         </template>
       </div>

--- a/frontend/src/components/molecules/data-management/UploadCardFactors.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardFactors.vue
@@ -17,6 +17,12 @@ interface Props {
   isDisabled?: boolean;
   computedFactorRunning?: boolean;
   anyComputedFactorRunning?: boolean;
+  /** #740 — whether the previous year has factors available to copy. */
+  canCopyFromPreviousYear?: boolean;
+  copyFactorsRunning?: boolean;
+  anyCopyFactorsRunning?: boolean;
+  /** #740 — source year shown in the "Copy from {year}" button label. */
+  previousYear?: number;
   /** Issue #1219 — module-scoped pipeline progress (null when idle). */
   pipelineProgress?: PipelineProgress | null;
   onDownload?: (row: ImportRow, targetType: TargetType) => void;
@@ -27,6 +33,10 @@ const props = withDefaults(defineProps<Props>(), {
   isDisabled: false,
   computedFactorRunning: false,
   anyComputedFactorRunning: false,
+  canCopyFromPreviousYear: false,
+  copyFactorsRunning: false,
+  anyCopyFactorsRunning: false,
+  previousYear: undefined,
   pipelineProgress: null,
   onDownload: undefined,
 });
@@ -35,6 +45,7 @@ const emit = defineEmits<{
   (e: 'upload', row: ImportRow, targetType: TargetType): void;
   (e: 'recalculate', item: ImportRow): void;
   (e: 'compute-factors', item: ImportRow): void;
+  (e: 'copy-from-previous-year', item: ImportRow): void;
   (e: 'abort'): void;
 }>();
 
@@ -81,6 +92,10 @@ function handleRecalculate(item: ImportRow) {
 function handleComputeFactors(item: ImportRow) {
   emit('compute-factors', item);
 }
+
+function handleCopyFromPreviousYear(item: ImportRow) {
+  emit('copy-from-previous-year', item);
+}
 </script>
 
 <template>
@@ -100,10 +115,17 @@ function handleComputeFactors(item: ImportRow) {
     :has-computed-factor-button="hasComputedFactor"
     :computed-factor-running="computedFactorRunning"
     :is-computed-factor-disabled="props.anyComputedFactorRunning"
+    :has-copy-factors-button="canCopyFromPreviousYear"
+    :copy-factors-label="
+      $t('data_management_copy_from_year', { year: previousYear })
+    "
+    :copy-factors-running="copyFactorsRunning"
+    :is-copy-factors-disabled="props.anyCopyFactorsRunning"
     @upload="handleUpload"
     @download="handleDownload"
     @recalculate="handleRecalculate"
     @compute-factors="handleComputeFactors"
+    @copy-factors="handleCopyFromPreviousYear"
     @abort="emit('abort')"
   />
 </template>

--- a/frontend/src/composables/useSubmoduleConfig.ts
+++ b/frontend/src/composables/useSubmoduleConfig.ts
@@ -350,6 +350,114 @@ export function useSubmoduleConfig() {
     }
   }
 
+  // #740 — "Copy from {year - 1}" per-submodule factor copy.
+  //
+  // Availability is cached per submodule key rather than re-fetched on
+  // every render: ``getPreviousYearSuccessfulJobs`` hits
+  // ``sync/jobs/year/{year}/latest`` and filters client-side, so we
+  // only want to pay for it once per submodule per year.
+  const copyFactorsAvailability = ref<Record<string, boolean>>({});
+  const copyFactorsRunning = ref<Record<string, boolean>>({});
+  const anyCopyFactorsRunning = computed(() =>
+    Object.values(copyFactorsRunning.value).some(Boolean),
+  );
+
+  async function loadCopyFactorsAvailability(
+    sub: SubmoduleConfig,
+  ): Promise<void> {
+    if (sub.dataEntryTypeId === undefined) return;
+    try {
+      const jobs = await backofficeDataManagement.getPreviousYearSuccessfulJobs(
+        yearConfigStore.selectedYear - 1,
+        sub.moduleTypeId,
+        TargetType.FACTORS,
+      );
+      copyFactorsAvailability.value[sub.key] = jobs.some(
+        (job) => job.data_entry_type_id === sub.dataEntryTypeId,
+      );
+    } catch {
+      copyFactorsAvailability.value[sub.key] = false;
+    }
+  }
+
+  function canCopyFactorsFromPreviousYear(sub: SubmoduleConfig): boolean {
+    return !!copyFactorsAvailability.value[sub.key];
+  }
+
+  async function confirmCopyFactorsFromPreviousYear(
+    sub: SubmoduleConfig,
+    onCompleted: () => Promise<void>,
+  ): Promise<void> {
+    if (sub.dataEntryTypeId === undefined) return;
+    copyFactorsRunning.value[sub.key] = true;
+    try {
+      const jobId =
+        await backofficeDataManagement.initiateFactorCopyFromPreviousYear(
+          sub.moduleTypeId,
+          sub.dataEntryTypeId,
+          yearConfigStore.selectedYear,
+        );
+      backofficeDataManagement.subscribeToJobUpdates(
+        jobId,
+        (payload?: JobUpdatePayload) => {
+          const result = payload?.result;
+          if (result === IngestionResult.WARNING) {
+            Notify.create({
+              type: 'warning',
+              message: $t('data_management_copy_factors_warning'),
+              caption: payload?.status_message ?? '',
+              position: 'top',
+              timeout: 5000,
+            });
+          } else if (result === IngestionResult.SUCCESS) {
+            Notify.create({
+              type: 'positive',
+              message: $t('data_management_copy_factors_success'),
+              position: 'top',
+              timeout: 5000,
+            });
+          } else {
+            Notify.create({
+              type: 'negative',
+              message: $t('data_management_copy_factors_error'),
+              caption: payload?.status_message ?? '',
+              position: 'top',
+              timeout: 5000,
+            });
+          }
+          copyFactorsRunning.value[sub.key] = false;
+          void onCompleted();
+        },
+        (payload?: JobUpdatePayload) => {
+          Notify.create({
+            type: 'negative',
+            message: $t('data_management_copy_factors_error'),
+            caption: payload?.status_message ?? '',
+            position: 'top',
+            timeout: 5000,
+          });
+          copyFactorsRunning.value[sub.key] = false;
+          void onCompleted();
+        },
+        () => {
+          copyFactorsRunning.value[sub.key] = false;
+        },
+        () => {
+          void onCompleted();
+        },
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '';
+      Notify.create({
+        type: 'negative',
+        message: $t('data_management_copy_factors_error'),
+        caption: msg,
+        position: 'top',
+      });
+      copyFactorsRunning.value[sub.key] = false;
+    }
+  }
+
   return {
     isSubmoduleEnabled,
     isSubmoduleIncomplete,
@@ -366,5 +474,10 @@ export function useSubmoduleConfig() {
     computedFactorRunning,
     anyComputedFactorRunning,
     confirmComputedFactorSync,
+    copyFactorsRunning,
+    anyCopyFactorsRunning,
+    loadCopyFactorsAvailability,
+    canCopyFactorsFromPreviousYear,
+    confirmCopyFactorsFromPreviousYear,
   };
 }

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -617,6 +617,46 @@ export default {
     en: 'View details in Pipeline Operations',
     fr: 'Voir les détails dans Pipeline Operations',
   },
+  data_management_copy_factors_confirm_title: {
+    en: 'Copy factors from {year}',
+    fr: 'Copier les facteurs depuis {year}',
+  },
+  data_management_copy_factors_confirm_message: {
+    en: 'This will copy factor rows from {year} into the current year. Existing rows for the current year will be updated to match. Do you want to proceed?',
+    fr: "Ceci copiera les facteurs de l'année {year} vers l'année en cours. Les facteurs existants pour l'année en cours seront mis à jour en conséquence. Souhaitez-vous continuer ?",
+  },
+  data_management_copy_factors_success: {
+    en: 'Factors copied successfully',
+    fr: 'Facteurs copiés avec succès',
+  },
+  data_management_copy_factors_warning: {
+    en: 'Factors copied with warnings',
+    fr: 'Facteurs copiés avec avertissements',
+  },
+  data_management_copy_factors_error: {
+    en: 'Failed to copy factors from previous year',
+    fr: "Échec de la copie des facteurs de l'année précédente",
+  },
+  data_management_copy_all_factors: {
+    en: 'Copy all factors from {year}',
+    fr: 'Copier tous les facteurs depuis {year}',
+  },
+  data_management_copy_all_factors_confirm_message: {
+    en: 'This will copy factor rows from {year} into every submodule of the current year that has no factors yet copied from it. Submodules without factors for {year} are skipped. Do you want to proceed?',
+    fr: "Ceci copiera les facteurs de l'année {year} dans tous les sous-modules de l'année en cours n'ayant pas encore de facteurs copiés depuis celle-ci. Les sous-modules sans facteurs pour {year} sont ignorés. Souhaitez-vous continuer ?",
+  },
+  data_management_copy_all_factors_success: {
+    en: 'Copied factors for {count} submodule(s)',
+    fr: 'Facteurs copiés pour {count} sous-module(s)',
+  },
+  data_management_copy_all_factors_none: {
+    en: 'No submodules have factors available to copy from {year}',
+    fr: "Aucun sous-module n'a de facteurs disponibles à copier depuis {year}",
+  },
+  data_management_copy_all_factors_error: {
+    en: 'Some submodules failed to copy factors',
+    fr: 'Certains sous-modules ont échoué à copier les facteurs',
+  },
   data_management_recalculation_needed: {
     en: 'Recalculation Needed',
     fr: 'Recalcul nécessaire',

--- a/frontend/src/pages/back-office/DataManagementPage.vue
+++ b/frontend/src/pages/back-office/DataManagementPage.vue
@@ -9,14 +9,17 @@ import { MODULES_LIST } from 'src/constant/modules';
 import ModuleConfig from 'src/components/organisms/data-management/ModuleConfig.vue';
 import ReductionObjectivesSection from 'src/components/organisms/data-management/ReductionObjectivesSection.vue';
 import DataEntryDialog from 'src/components/organisms/data-management/DataEntryDialog.vue';
+import CopyFactorsDialog from 'src/components/molecules/data-management/CopyFactorsDialog.vue';
 
 import {
   TargetType,
+  useBackofficeDataManagement,
   type ImportRow,
 } from 'src/stores/backofficeDataManagement';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { usePipelineStateStore } from 'src/stores/pipelineState';
 import { usePipelineStream } from 'src/composables/usePipelineStream';
+import { MODULE_SUBMODULES } from 'src/constant/backoffice-module-config';
 import { Notify, Loading } from 'quasar';
 import { useI18n } from 'vue-i18n';
 
@@ -264,6 +267,95 @@ provide('openDataEntryDialog', openDataEntryDialog);
 async function handleDialogCompleted() {
   await yearConfigStore.fetchConfig(selectedYear.value);
 }
+
+// #740 — "Copy all factors from {year - 1}" bulk action: loops the same
+// per-submodule /sync/factors call the individual "Copy from {year - 1}"
+// buttons use (see useSubmoduleConfig.confirmCopyFactorsFromPreviousYear),
+// one per configured (module_type_id, data_entry_type_id) pair, instead
+// of adding a separate backend bulk endpoint — this reuses each job's
+// existing per-submodule pipeline tracking (SSE, pipeline_id) rather than
+// inventing a second bulk-job abstraction. Pairs whose previous year has
+// no successful FACTORS job (nothing to copy) are skipped rather than
+// erroring.
+const backofficeDataManagement = useBackofficeDataManagement();
+const showBulkCopyFactorsConfirm = ref(false);
+const bulkCopyFactorsRunning = ref(false);
+
+const allFactorSubmodules = computed(() =>
+  Object.values(MODULE_SUBMODULES)
+    .flat()
+    .filter((sub) => sub.dataEntryTypeId !== undefined),
+);
+
+function openBulkCopyFactorsConfirm() {
+  showBulkCopyFactorsConfirm.value = true;
+}
+
+async function handleBulkCopyFactorsConfirm() {
+  bulkCopyFactorsRunning.value = true;
+  const sourceYear = selectedYear.value - 1;
+  let copied = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  try {
+    for (const sub of allFactorSubmodules.value) {
+      if (sub.dataEntryTypeId === undefined) continue;
+      try {
+        const previousJobs =
+          await backofficeDataManagement.getPreviousYearSuccessfulJobs(
+            sourceYear,
+            sub.moduleTypeId,
+            TargetType.FACTORS,
+          );
+        const hasSourceFactors = previousJobs.some(
+          (job) => job.data_entry_type_id === sub.dataEntryTypeId,
+        );
+        if (!hasSourceFactors) {
+          skipped += 1;
+          continue;
+        }
+        await backofficeDataManagement.initiateFactorCopyFromPreviousYear(
+          sub.moduleTypeId,
+          sub.dataEntryTypeId,
+          selectedYear.value,
+        );
+        copied += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+
+    if (copied === 0 && failed === 0) {
+      Notify.create({
+        type: 'info',
+        message: $t('data_management_copy_all_factors_none', {
+          year: sourceYear,
+        }),
+        position: 'top',
+      });
+    } else if (failed > 0) {
+      Notify.create({
+        type: 'warning',
+        message: $t('data_management_copy_all_factors_error'),
+        caption: `${copied} ${$t('data_management_copy_all_factors_success', { count: copied })}, ${failed} failed, ${skipped} skipped`,
+        position: 'top',
+      });
+    } else {
+      Notify.create({
+        type: 'positive',
+        message: $t('data_management_copy_all_factors_success', {
+          count: copied,
+        }),
+        position: 'top',
+      });
+    }
+
+    await fetchYearConfig();
+  } finally {
+    bulkCopyFactorsRunning.value = false;
+  }
+}
 </script>
 
 <template>
@@ -417,6 +509,20 @@ async function handleDialogCompleted() {
 
       <q-btn
         v-if="yearConfigStore.config && !yearSyncInFlight"
+        icon="content_copy"
+        color="accent"
+        outline
+        :label="
+          $t('data_management_copy_all_factors', { year: selectedYear - 1 })
+        "
+        class="text-weight-medium q-mt-md q-mr-sm"
+        :loading="bulkCopyFactorsRunning"
+        data-testid="copy-all-factors-btn"
+        @click="openBulkCopyFactorsConfirm"
+      />
+
+      <q-btn
+        v-if="yearConfigStore.config && !yearSyncInFlight"
         icon="calendar_month"
         color="accent"
         :label="$t('open_year_for_users')"
@@ -445,6 +551,14 @@ async function handleDialogCompleted() {
       :target-type="dialogTargetType ?? TargetType.DATA_ENTRIES"
       @completed="handleDialogCompleted"
       @progressing="handleDialogCompleted"
+    />
+
+    <copy-factors-dialog
+      v-model="showBulkCopyFactorsConfirm"
+      :year="selectedYear - 1"
+      message-key="data_management_copy_all_factors_confirm_message"
+      @confirm="handleBulkCopyFactorsConfirm"
+      @cancel="showBulkCopyFactorsConfirm = false"
     />
   </q-page>
 </template>

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -98,6 +98,10 @@ export enum IngestionMethod {
   CSV = 1,
   MANUAL = 2,
   COMPUTED = 3,
+  // Clones factors from a source year (default year - 1, overridable via
+  // filters.source_year) into the target year — see backend
+  // ``app.models.data_ingestion.IngestionMethod.copy_previous_year`` (#740).
+  COPY_PREVIOUS_YEAR = 4,
 }
 // institutional_footprint
 // population_projections
@@ -655,6 +659,65 @@ provider_type
     }
 
     /**
+     * Trigger a "copy factors from previous year" job for a given
+     * module / data-entry type (#740).  Uses the same /sync/factors
+     * endpoint as ``initiateComputedFactorSync``, but with
+     * ``ingestion_method=COPY_PREVIOUS_YEAR``.
+     *
+     * ``sourceYear`` overrides the backend default of ``year - 1``
+     * (e.g. to skip a year with known-bad data); omit to use the default.
+     *
+     * Returns the created job_id.
+     */
+    async function initiateFactorCopyFromPreviousYear(
+      moduleTypeId: number,
+      dataEntryTypeId: number,
+      year: number,
+      sourceYear?: number,
+    ): Promise<number> {
+      if (loading.value) throw new Error('Another operation is in progress');
+
+      loading.value = true;
+      error.value = null;
+
+      try {
+        const response = (await api
+          .post(`sync/factors/${moduleTypeId}/${dataEntryTypeId}`, {
+            json: {
+              ingestion_method: IngestionMethod.COPY_PREVIOUS_YEAR,
+              target_type: TargetType.FACTORS,
+              year,
+              filters:
+                sourceYear !== undefined ? { source_year: sourceYear } : {},
+            },
+          })
+          .json()) as { job_id: number; pipeline_id?: string };
+
+        // Issue #1219 — see initiateSync: seed the pipeline_id now so
+        // the card subscribes from dispatch, not from the post-finish
+        // active-pipelines poll.
+        if (response.pipeline_id) {
+          usePipelineStateStore().setPipelineId(
+            moduleTypeId,
+            year,
+            response.pipeline_id,
+          );
+        }
+
+        return response.job_id;
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          error.value = err.message ?? 'Failed to initiate factor copy';
+        } else {
+          error.value = 'Failed to initiate factor copy';
+        }
+        throw err;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    /**
      * Trigger emission recalculation for a single data entry type.
      * Returns the created job_id.
      */
@@ -800,6 +863,7 @@ provider_type
       getPreviousYearSuccessfulJobs,
       initiateSync,
       initiateComputedFactorSync,
+      initiateFactorCopyFromPreviousYear,
       initiateEmissionRecalculation,
       initiateModuleEmissionRecalculation,
       subscribeToJobUpdates,

--- a/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
+++ b/frontend/tests/integration/pipeline-diagnostic-tooltip.spec.ts
@@ -107,10 +107,11 @@ test.describe('data-management — pipeline observability + a11y (Unit 11)', () 
   let activePipelines: ActivePipelinesController;
   const year = defaultSelectedYear();
 
-  test.beforeEach(async ({ page, context }) => {
-    // Clipboard API is gated behind permissions in chromium — tests
-    // that read ``navigator.clipboard.readText`` need both grants.
-    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  test.beforeEach(async ({ page }) => {
+    // No clipboard permission grants needed: the copy test asserts off
+    // the deterministic ``window.__clipboard`` mirror installed by
+    // ``installPlaywrightTestShims`` — the real system clipboard is
+    // never read or written (headless CI can't do either reliably).
     ({ activePipelines } = await setupDataManagementMocks(page, year));
   });
 
@@ -178,13 +179,21 @@ test.describe('data-management — pipeline observability + a11y (Unit 11)', () 
     await waitForSsePipe(page, PIPELINE_UUID);
     await badge.hover();
 
-    // The copy button is the only ``content_copy`` icon in the
-    // tooltip.  Quasar's tooltip portal sets ``no-pointer-events`` on
-    // the wrapper, so even ``click({ force: true })`` lands on the
-    // overlay and the underlying Vue ``@click`` handler never fires.
-    // Dispatch a synthetic ``click`` event straight at the button
-    // element instead — the same event Vue listens for.
-    const copyButton = page
+    // Scope the lookup to the open diagnostic tooltip (the portal
+    // containing the ``Pipeline:`` label): the data-management page
+    // itself also renders ``content_copy`` buttons (#740 "copy
+    // factors" feature), so a page-wide ``.first()`` would grab the
+    // wrong button.  Quasar's tooltip portal sets
+    // ``no-pointer-events`` on the wrapper, so even
+    // ``click({ force: true })`` lands on the overlay and the
+    // underlying Vue ``@click`` handler never fires.  Dispatch a
+    // synthetic ``click`` event straight at the button element
+    // instead — the same event Vue listens for.
+    const diagnosticTooltip = page
+      .locator('.q-tooltip')
+      .filter({ hasText: PIPELINE_LABEL });
+    await expect(diagnosticTooltip).toBeVisible();
+    const copyButton = diagnosticTooltip
       .locator('button')
       .filter({ has: page.locator('.q-icon').getByText('content_copy') })
       .first();

--- a/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
+++ b/frontend/tests/integration/setup/pipeline-tooltip-mocks.ts
@@ -164,37 +164,27 @@ export async function installPlaywrightTestShims(page: Page): Promise<void> {
       Native;
 
     // 3. Clipboard mirror.
-    //    Headless chromium accepts the ``clipboard-write`` permission
-    //    grant but the resulting write doesn't always flow back through
-    //    ``navigator.clipboard.readText()`` reliably across the
-    //    Playwright transport.  Hijack
-    //    ``Clipboard.prototype.writeText`` (the prototype is shared
-    //    by every ``navigator.clipboard`` instance) and mirror the
-    //    value into ``window.__clipboard`` so the spec asserts off
-    //    the deterministic mirror instead of fighting transport
-    //    quirks.  Quasar's ``copyToClipboard`` also has an
-    //    ``execCommand`` fallback when ``navigator.clipboard`` is
-    //    undefined; we leave clipboard defined so the prototype
-    //    patch is what runs.
+    //    The real clipboard is not reliably writable/readable in
+    //    headless CI (permission + focus quirks), so don't touch it at
+    //    all: replace ``Clipboard.prototype.writeText`` (the prototype
+    //    is shared by every ``navigator.clipboard`` instance) with a
+    //    recorder that mirrors the value into ``window.__clipboard``
+    //    and resolves immediately.  The spec asserts off the
+    //    deterministic mirror — this still exercises the component's
+    //    real behaviour (it must call ``writeText`` with the right
+    //    value).  Quasar's ``copyToClipboard`` only falls back to
+    //    ``execCommand`` when ``navigator.clipboard`` is undefined; we
+    //    leave clipboard defined so the prototype patch is what runs.
     type ClipMirror = { value: string };
     const mirror: ClipMirror = { value: '' };
     (window as Window & { __clipboard?: ClipMirror }).__clipboard = mirror;
-    if (
-      typeof Clipboard !== 'undefined' &&
-      Clipboard.prototype &&
-      typeof Clipboard.prototype.writeText === 'function'
-    ) {
-      const original = Clipboard.prototype.writeText;
+    if (typeof Clipboard !== 'undefined' && Clipboard.prototype) {
       Clipboard.prototype.writeText = function (
         this: Clipboard,
         text: string,
       ): Promise<void> {
         mirror.value = text;
-        try {
-          return original.call(this, text);
-        } catch {
-          return Promise.resolve();
-        }
+        return Promise.resolve();
       };
     }
   });


### PR DESCRIPTION
Part of #740.

Implementation plan: `docs/src/implementation-plans/740-backoffice-copy-factors-from-last-year.md`

## Summary

- Backend: `IngestionMethod.copy_previous_year` + `FactorCopyProvider`
  clones `Factor` rows from a source year (default `year - 1`,
  overridable via `filters.source_year`) into the target year, writing
  through the existing idempotent `FactorRepository.upsert_factors`.
  Registered in `ProviderFactory` — runs through the existing
  `POST /v1/sync/factors/{module_type_id}/{data_entry_type_id}` endpoint
  and job pipeline (SSE, pipeline observability), no new endpoint.
- Frontend: `initiateFactorCopyFromPreviousYear` in
  `backofficeDataManagement.ts`, a per-submodule "Copy from {year-1}"
  button (gated on `getPreviousYearSuccessfulJobs`) next to the existing
  factor upload/compute controls, and a page-level "Copy all factors
  from {year-1}" bulk action looping the per-submodule call across
  configured (module, data-entry type) pairs.
- Individual-row copy is out of scope for this PR (per the plan).

## Test plan

- [x] Backend unit tests: `FactorCopyProvider` (copy, idempotent retry,
      no-op on empty source year) and the `sync_module_factors` endpoint
      accepting `ingestion_method=copy_previous_year` +
      `filters.source_year` — 9 new tests, all passing.
- [x] Full backend unit suite (1759 tests) passes, no regressions.
- [x] Frontend type-check (`make type-check`), ESLint, and Prettier pass
      on touched files.
- [ ] Manual click-through in a running app (not available in this
      environment) — reasoned through the flow instead; see the plan
      doc's "Implementation notes" section.