### PR TITLE
fix: eliminate blank pages in report print output

### DIFF
--- a/frontend/src/components/organisms/ReportPage.vue
+++ b/frontend/src/components/organisms/ReportPage.vue
@@ -79,8 +79,19 @@ withDefaults(defineProps<Props>(), {
 @media print {
   .page {
     margin: 0;
+    // The sheet is defined by @page (A4). Forcing the element to an exact
+    // 297mm height overflows onto a blank sheet due to sub-pixel rounding,
+    // so let content flow naturally in print and rely on the page breaks.
+    height: auto;
+    min-height: 0;
     page-break-after: always;
     break-after: page;
+  }
+
+  // Don't force a break after the final page — it emits a trailing blank sheet.
+  .page:last-child {
+    page-break-after: auto;
+    break-after: auto;
   }
 }
 </style>

--- a/frontend/src/layouts/PrintLayout.vue
+++ b/frontend/src/layouts/PrintLayout.vue
@@ -26,6 +26,18 @@ body {
   body {
     background: white !important;
   }
+
+  /* Quasar sizes QLayout to 100vh and adds inline offset padding to
+     QPageContainer for the (now hidden) header/footer. Left as-is, that
+     overflows the content onto a trailing blank sheet. */
+  .q-layout,
+  .q-page-container {
+    min-height: 0 !important;
+  }
+
+  .q-page-container {
+    padding: 0 !important;
+  }
 }
 </style>
 


### PR DESCRIPTION
## What does this change?
Eliminates blank/trailing pages in the report print (PDF export) output by
fixing print CSS in two components:

- **`ReportPage.vue`**: stops forcing the `.page` element to a fixed 297mm
  height (which overflowed onto a blank sheet via sub-pixel rounding) by
  setting `height: auto` and `min-height: 0`, letting content flow naturally
  and relying on page breaks. Also removes the forced `page-break-after` on the
  final `.page` (`:last-child`), which was emitting a trailing blank sheet.
- **`PrintLayout.vue`**: zeroes out Quasar's `QLayout` / `QPageContainer`
  min-height (sized to 100vh) and removes the `QPageContainer` offset padding
  added for the now-hidden header/footer, both of which were pushing content
  onto a trailing blank sheet.

## Why is this needed?
The report print/PDF export was emitting extra blank pages. Forced element
heights and Quasar's default layout sizing/offset padding overflowed the
content region, producing a blank sheet after each page (and a trailing one at
the end). Letting content flow naturally and suppressing the final page break
yields clean, blank-page-free PDF output.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1208

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.