### PR TITLE
fix(1559): idempotent tmp->processing file move on job retry

### DIFF
--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -1097,13 +1097,8 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         if not tmp_path:
             raise ValueError("Missing file_path in config")
         _validate_file_path(tmp_path)  # Extra safety check
-        filename = tmp_path.split("/")[-1]
-        processing_path = f"processing/{self.job_id}/{filename}"
-
-        logger.info(f"Moving file from {tmp_path} to {processing_path}")
-        move_result = await self.files_store.move_file(tmp_path, processing_path)
-        if not move_result:
-            raise Exception(f"Failed to move file from {tmp_path} to {processing_path}")
+        processing_path = await self._move_to_processing(tmp_path)
+        filename = processing_path.split("/")[-1]
 
         # Download and decode CSV content
         logger.info(f"Downloading CSV from {processing_path}")
@@ -1377,18 +1372,9 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
 
         # Move file from processing/ to processed/
         processing_path = setup_result["processing_path"]
-        filename = setup_result["filename"]
-        processed_path = f"processed/{self.job_id}/{filename}"
-        logger.info(f"Moving file from {processing_path} to {processed_path}")
-        move_result = await self.files_store.move_file(processing_path, processed_path)
-        metadata_update = {}
-        if not move_result:
-            logger.warning(
-                f"Failed to move file from {processing_path} to {processed_path}"
-            )
-            metadata_update["processed_file_path"] = processing_path
-        else:
-            metadata_update = {"processed_file_path": processed_path}
+        metadata_update = {
+            "processed_file_path": await self._move_to_processed(processing_path)
+        }
 
         # Flush all changes
         await self.data_session.flush()

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -258,13 +258,8 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
         if not tmp_path:
             raise ValueError("Missing file_path in config")
         _validate_file_path(tmp_path)
-        filename = tmp_path.split("/")[-1]
-        processing_path = f"processing/{self.job_id}/{filename}"
-
-        logger.info(f"Moving file from {tmp_path} to {processing_path}")
-        move_result = await self.files_store.move_file(tmp_path, processing_path)
-        if not move_result:
-            raise ValueError("Failed to move file to processing path")
+        processing_path = await self._move_to_processing(tmp_path)
+        filename = processing_path.split("/")[-1]
 
         logger.info(f"Downloading CSV from {processing_path}")
         file_content, mime_type = await self.files_store.get_file(processing_path)
@@ -546,18 +541,9 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
             stats["factors_deleted"] = await self._delete_stale_factors(factor_repo)
 
         processing_path = setup_result["processing_path"]
-        filename = setup_result["filename"]
-        processed_path = f"processed/{self.job_id}/{filename}"
-        logger.info(f"Moving file from {processing_path} to {processed_path}")
-        move_result = await self.files_store.move_file(processing_path, processed_path)
-        metadata_update: Dict[str, Any] = {}
-        if not move_result:
-            logger.warning(
-                f"Failed to move file from {processing_path} to {processed_path}"
-            )
-            metadata_update["processed_file_path"] = processing_path
-        else:
-            metadata_update = {"processed_file_path": processed_path}
+        metadata_update: Dict[str, Any] = {
+            "processed_file_path": await self._move_to_processed(processing_path)
+        }
 
         await self.data_session.flush()
 

--- a/backend/app/services/data_ingestion/base_provider.py
+++ b/backend/app/services/data_ingestion/base_provider.py
@@ -48,6 +48,66 @@ class DataIngestionProvider(ABC):
     async def set_job_id(self, job_id: int):
         self.job_id = job_id
 
+    @property
+    def files_store(self) -> Any:
+        """File storage backend for the move helpers below.
+
+        Not abstract: only the CSV-provider subclasses that call
+        ``_move_to_processing``/``_move_to_processed`` override this (each
+        lazily constructs its own); API-based providers never touch file
+        storage and have no reason to implement it.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not provide a files_store"
+        )
+
+    async def _move_to_processing(self, tmp_path: str) -> str:
+        """Move an uploaded file from ``tmp/`` to ``processing/<job_id>/``.
+
+        Idempotent: if a prior attempt already produced the destination
+        (job crashed/restarted after the move but before FINISHED, then
+        ``sweep_stuck_running_jobs`` reset it to NOT_STARTED for retry),
+        skip the move instead of failing on a tmp source the first
+        attempt already consumed (#1559). A destination that's still
+        missing means the move genuinely needs to happen; any failure
+        there still raises.
+        """
+        filename = tmp_path.split("/")[-1]
+        processing_path = f"processing/{self.job_id}/{filename}"
+        if await self.files_store.file_exists(processing_path):
+            logger.info(
+                f"File already at {processing_path} (prior attempt); "
+                "skipping move"
+            )
+            return processing_path
+        logger.info(f"Moving file from {tmp_path} to {processing_path}")
+        if not await self.files_store.move_file(tmp_path, processing_path):
+            raise Exception(f"Failed to move file from {tmp_path} to {processing_path}")
+        return processing_path
+
+    async def _move_to_processed(self, processing_path: str) -> str:
+        """Move an ingested file from ``processing/`` to ``processed/<job_id>/``.
+
+        Idempotent like ``_move_to_processing``. Unlike that move, a
+        failure here is non-fatal — the data is already committed, only
+        archival bookkeeping is at stake — so it logs and returns the
+        un-moved ``processing_path`` instead of raising.
+        """
+        filename = processing_path.split("/")[-1]
+        processed_path = f"processed/{self.job_id}/{filename}"
+        if await self.files_store.file_exists(processed_path):
+            logger.info(
+                f"File already at {processed_path} (prior attempt); skipping move"
+            )
+            return processed_path
+        logger.info(f"Moving file from {processing_path} to {processed_path}")
+        if not await self.files_store.move_file(processing_path, processed_path):
+            logger.warning(
+                f"Failed to move file from {processing_path} to {processed_path}"
+            )
+            return processing_path
+        return processed_path
+
     @abstractmethod
     async def validate_connection(self) -> bool:
         pass

--- a/backend/app/services/data_ingestion/base_provider.py
+++ b/backend/app/services/data_ingestion/base_provider.py
@@ -76,8 +76,7 @@ class DataIngestionProvider(ABC):
         processing_path = f"processing/{self.job_id}/{filename}"
         if await self.files_store.file_exists(processing_path):
             logger.info(
-                f"File already at {processing_path} (prior attempt); "
-                "skipping move"
+                f"File already at {processing_path} (prior attempt); skipping move"
             )
             return processing_path
         logger.info(f"Moving file from {tmp_path} to {processing_path}")

--- a/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_reduction_objective_csv_provider.py
@@ -263,15 +263,8 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
         if not tmp_path:
             raise ValueError("Missing file_path in config")
         _validate_file_path(tmp_path)
-        filename = tmp_path.split("/")[-1]
-        processing_path = f"processing/{self.job_id}/{filename}"
-
-        logger.info(f"Moving file from {tmp_path} to {processing_path}")
-        move_result = await self.files_store.move_file(tmp_path, processing_path)
-        if not move_result:
-            raise ValueError(
-                f"Failed to move file from {tmp_path} to {processing_path}"
-            )
+        processing_path = await self._move_to_processing(tmp_path)
+        filename = processing_path.split("/")[-1]
 
         # Download & decode
         logger.info(f"Downloading CSV from {processing_path}")
@@ -442,14 +435,7 @@ class BaseReductionObjectiveCSVProvider(DataIngestionProvider, ABC):
     ) -> Dict[str, Any]:
         """Move file to processed/, update job to FINISHED."""
         processing_path = setup["processing_path"]
-        processed_path = setup["processed_path"]
-
-        logger.info(f"Moving file from {processing_path} to {processed_path}")
-        move_result = await self.files_store.move_file(processing_path, processed_path)
-        if not move_result:
-            logger.warning(
-                f"Failed to move file from {processing_path} to {processed_path}"
-            )
+        await self._move_to_processed(processing_path)
 
         await self.data_session.flush()
 

--- a/backend/app/services/data_ingestion/csv_providers/reference_data.py
+++ b/backend/app/services/data_ingestion/csv_providers/reference_data.py
@@ -167,7 +167,7 @@ class ReferenceDataCSVProvider(DataIngestionProvider):
                     "reference type (expected plane=20, train=21, building=30)"
                 )
 
-            processed_path = await self._move_to_processed(processing_path, filename)
+            processed_path = await self._move_to_processed(processing_path)
 
             result = (
                 IngestionResult.SUCCESS
@@ -224,34 +224,12 @@ class ReferenceDataCSVProvider(DataIngestionProvider):
         if not self.source_file_path:
             raise ValueError("Missing file_path in config")
         _validate_file_path(self.source_file_path)
-        filename = self.source_file_path.split("/")[-1]
-        processing_path = f"processing/{self.job_id}/{filename}"
-        logger.info(f"Moving file from {self.source_file_path} to {processing_path}")
-        move_result = await self.files_store.move_file(
-            self.source_file_path, processing_path
-        )
-        if not move_result:
-            raise ValueError("Failed to move file to processing path")
+        processing_path = await self._move_to_processing(self.source_file_path)
+        filename = processing_path.split("/")[-1]
 
         file_content, _ = await self.files_store.get_file(processing_path)
         csv_text = file_content.decode("utf-8")
         return csv_text, processing_path, filename
-
-    async def _move_to_processed(self, processing_path: str, filename: str) -> str:
-        """On success only — promote ``processing/<job>/<file>`` to ``processed/``.
-
-        Kept off the failure path so an admin downloading "the last CSV"
-        always reads a file that was actually ingested.
-        """
-        processed_path = f"processed/{self.job_id}/{filename}"
-        moved = await self.files_store.move_file(processing_path, processed_path)
-        if not moved:
-            logger.warning(
-                f"Failed to move {processing_path} to {processed_path} — "
-                "keeping in processing/"
-            )
-            return processing_path
-        return processed_path
 
     @staticmethod
     def _validate_headers(

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -1074,6 +1074,50 @@ async def test_recompute_module_stats_skips_when_pure_async():
 
 
 # ======================================================================
+# Setup / Idempotent Move Tests (#1559)
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_setup_and_validate_skips_move_when_already_in_processing():
+    """Regression #1559: a retry after a prior successful tmp->processing
+    move (job crashed/restarted before FINISHED, sweep_stuck_running_jobs
+    reset it to NOT_STARTED) must succeed by reading the file that is
+    already at processing/<job_id>/, not fail with "Failed to move file"
+    just because the tmp/ source is gone.
+    """
+    config = {"file_path": "tmp/test.csv", "job_id": 7, "carbon_report_module_id": 99}
+    provider = ConcreteCSVProvider(config, data_session=MagicMock())
+    # Short-circuit the DB lookup at the top of _setup_and_validate.
+    provider.job = SimpleNamespace(id=7)
+
+    async def mock_setup():
+        return {
+            "handlers": [],
+            "factors_map": {},
+            "expected_columns": {"col1"},
+            "required_columns": set(),
+        }
+
+    provider._setup_handlers_and_factors = mock_setup
+
+    mock_files_store = MagicMock()
+    # Destination already present (prior attempt); tmp/ source is gone —
+    # move_file would fail if called, proving the retry never touches it.
+    mock_files_store.file_exists = AsyncMock(return_value=True)
+    mock_files_store.move_file = AsyncMock(
+        side_effect=AssertionError("move_file must not be called on retry")
+    )
+    mock_files_store.get_file = AsyncMock(return_value=(b"col1\nval1\n", "text/csv"))
+    provider._files_store = mock_files_store
+
+    result = await provider._setup_and_validate()
+
+    mock_files_store.move_file.assert_not_awaited()
+    assert result["processing_path"] == "processing/7/test.csv"
+
+
+# ======================================================================
 # Finalization Tests
 # ======================================================================
 
@@ -1087,6 +1131,7 @@ async def test_finalize_and_commit_moves_file_and_updates_job():
     provider = ConcreteCSVProvider(config, data_session=MagicMock())
 
     provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
     provider._files_store.move_file = AsyncMock(return_value=True)
     provider.data_session.flush = AsyncMock()
     provider._update_job = AsyncMock()

--- a/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_factor_csv_provider.py
@@ -328,6 +328,7 @@ async def test_finalize_and_commit_move_file_failure():
         data_session=MagicMock(),
     )
     provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
     provider._files_store.move_file = AsyncMock(return_value=False)
     provider.data_session.flush = AsyncMock()
 

--- a/backend/tests/unit/services/data_ingestion/test_base_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_provider.py
@@ -1,0 +1,152 @@
+"""Unit tests for the shared move helpers on ``DataIngestionProvider``.
+
+Regression coverage for #1559: the tmp->processing move used to be a
+one-shot consume with no "already done" branch. When a job crashed/
+restarted after the move but before FINISHED, ``sweep_stuck_running_jobs``
+reset it to NOT_STARTED and the retry re-attempted the move on a tmp
+source the first attempt had already consumed, raising a misleading
+"Failed to move file" error even though the data was safe in
+``processing/<job_id>/``.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.data_ingestion.base_provider import DataIngestionProvider
+
+
+class ConcreteProvider(DataIngestionProvider):
+    """Minimal concrete subclass — only exists to exercise the base class's
+    move helpers, which are the thing under test here."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._files_store: Any = None
+
+    @property
+    def files_store(self) -> Any:
+        return self._files_store
+
+    async def validate_connection(self) -> bool:
+        return True
+
+    async def fetch_data(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return []
+
+    async def transform_data(
+        self, raw_data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        return raw_data
+
+    async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {"inserted": 0, "skipped": 0, "errors": 0}
+
+
+def _make_provider(job_id: int = 7) -> ConcreteProvider:
+    provider = ConcreteProvider({"job_id": job_id}, data_session=MagicMock())
+    provider.job_id = job_id
+    return provider
+
+
+# ======================================================================
+# _move_to_processing
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_move_to_processing_skips_when_destination_already_exists():
+    """Retry after a prior successful move: destination present, tmp/
+    source already consumed. Must skip the move, not fail."""
+    provider = _make_provider()
+    provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=True)
+    provider._files_store.move_file = AsyncMock(
+        side_effect=AssertionError(
+            "move_file must not be called when destination exists"
+        )
+    )
+
+    result = await provider._move_to_processing("tmp/abc/data.csv")
+
+    assert result == "processing/7/data.csv"
+    provider._files_store.move_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_move_to_processing_moves_when_destination_missing():
+    provider = _make_provider()
+    provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
+    provider._files_store.move_file = AsyncMock(return_value=True)
+
+    result = await provider._move_to_processing("tmp/abc/data.csv")
+
+    assert result == "processing/7/data.csv"
+    provider._files_store.move_file.assert_awaited_once_with(
+        "tmp/abc/data.csv", "processing/7/data.csv"
+    )
+
+
+@pytest.mark.asyncio
+async def test_move_to_processing_raises_on_genuine_move_failure():
+    """A real move failure (permissions, disk, or a genuinely missing
+    source) with no destination present is still fatal — the idempotency
+    check must not swallow every failure, only the already-done case."""
+    provider = _make_provider()
+    provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
+    provider._files_store.move_file = AsyncMock(return_value=False)
+
+    with pytest.raises(Exception, match="Failed to move file"):
+        await provider._move_to_processing("tmp/abc/data.csv")
+
+
+# ======================================================================
+# _move_to_processed
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_move_to_processed_skips_when_destination_already_exists():
+    provider = _make_provider()
+    provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=True)
+    provider._files_store.move_file = AsyncMock(
+        side_effect=AssertionError(
+            "move_file must not be called when destination exists"
+        )
+    )
+
+    result = await provider._move_to_processed("processing/7/data.csv")
+
+    assert result == "processed/7/data.csv"
+    provider._files_store.move_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_move_to_processed_moves_when_destination_missing():
+    provider = _make_provider()
+    provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
+    provider._files_store.move_file = AsyncMock(return_value=True)
+
+    result = await provider._move_to_processed("processing/7/data.csv")
+
+    assert result == "processed/7/data.csv"
+
+
+@pytest.mark.asyncio
+async def test_move_to_processed_failure_is_non_fatal():
+    """Unlike tmp->processing, a processing->processed failure must not
+    raise — the ingested data is already committed; only archival
+    bookkeeping is at stake. Falls back to the un-moved path."""
+    provider = _make_provider()
+    provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
+    provider._files_store.move_file = AsyncMock(return_value=False)
+
+    result = await provider._move_to_processed("processing/7/data.csv")
+
+    assert result == "processing/7/data.csv"

--- a/backend/tests/unit/services/data_ingestion/test_module_per_year_factor_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_module_per_year_factor_csv_provider.py
@@ -100,6 +100,7 @@ async def test_finalize_and_commit_routes_batch_through_upsert(monkeypatch):
         data_session=mock_data_session,
     )
     provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
     provider._files_store.move_file = AsyncMock(return_value=True)
 
     mock_factor_repo = MagicMock()
@@ -165,6 +166,7 @@ def _sweep_provider() -> ModulePerYearFactorCSVProvider:
         data_session=data_session,
     )
     provider._files_store = MagicMock()
+    provider._files_store.file_exists = AsyncMock(return_value=False)
     provider._files_store.move_file = AsyncMock(return_value=True)
     return provider
 

--- a/docs/src/implementation-plans/1559-ingestion-idempotent-tmp-to-processing-move.md
+++ b/docs/src/implementation-plans/1559-ingestion-idempotent-tmp-to-processing-move.md
@@ -1,0 +1,73 @@
+---
+status: proposed
+issue: 1559
+last_updated: 2026-07-07
+title: "Idempotent tmp->processing (and processing->processed) file moves on job retry"
+summary: "Skip the move if the destination already exists so a retried ingestion job doesn't fail on a file a prior attempt already consumed."
+---
+
+# Idempotent tmp->processing (and processing->processed) file moves on job retry
+
+## Problem
+
+**Symptom.** After a backend restart, CSV ingestion intermittently fails with:
+`Processing failed: Failed to move file from tmp/<ts>/headcount_data.csv to processing/<job_id>/headcount_data.csv`
+
+**Root cause: the `tmp -> processing` move is not idempotent on retry.**
+
+1. The move consumes the source. `BaseCSVProvider._setup_and_validate` (`backend/app/services/data_ingestion/base_csv_provider.py:1113-1116`, confirmed still current) calls `files_store.move_file(tmp_path, processing_path)` (a `shutil.move`) and raises if it returns falsy.
+2. `move_file` returns `False` only when the source is missing. In `enacit4r_files/services/local.py:308`, a missing source raises `FileNotFoundError` internally, caught and converted to `return False`. So the error means _the tmp source is already gone_, not a permissions/disk problem.
+3. A retry finds the source already consumed — the first attempt already `shutil.move`d it into `processing/<job_id>/`. The move is a one-shot consume with no "already done" branch.
+4. A restart triggers the retry. `sweep_stuck_running_jobs` (`backend/app/repositories/data_ingestion.py:1135`) resets stale `RUNNING` jobs to `NOT_STARTED` so `claim_job` re-dispatches them. Its own docstring flags a no-heartbeat duplicate-run hazard (a long job past `STALE_JOB_TIMEOUT_MINUTES`, or a crash after the move). So: restart after the move → job re-queued → `_setup_and_validate` runs again → move fails on the already-moved file.
+
+This explains "sometimes": it only fails when the crash/restart lands _after_ the move but before the job is marked FINISHED. Data is never lost — it sits safely in `processing/<job_id>/`; the retry just refuses to recognize it.
+
+**Affected code (same pattern duplicated across all four `DataIngestionProvider` subclasses):**
+
+| Move            | File                                       | Line (verified 2026-07-07) |
+| --------------- | ------------------------------------------ | -------------------------- |
+| tmp->processing | `base_csv_provider.py`                     | 1113-1116                  |
+| tmp->processing | `base_factor_csv_provider.py`              | 260-265                    |
+| tmp->processing | `base_reduction_objective_csv_provider.py` | 261-270                    |
+| tmp->processing | `csv_providers/reference_data.py`          | 228-230                    |
+
+The later `processing -> processed` moves share the same retry hazard:
+
+- `base_csv_provider.py:1378` (issue cited 1452; drifted, still present)
+- `base_factor_csv_provider.py:552`
+- `base_reduction_objective_csv_provider.py:448`
+- `csv_providers/reference_data.py:247`
+
+`DataIngestionProvider` (shared ABC, `backend/app/services/data_ingestion/base_provider.py:24`) is the natural home for a centralized helper. `files_store.file_exists` exists on the same service as `move_file` (`enacit4r_files/services/local.py:253`), so the idempotency check needs no new dependency.
+
+## Design
+
+Make each move idempotent: if the destination already exists, a prior attempt already did the move — skip it instead of failing.
+
+```python
+filename = tmp_path.split("/")[-1]
+processing_path = f"processing/{self.job_id}/{filename}"
+if await self.files_store.file_exists(processing_path):
+    logger.info(f"File already at {processing_path} (prior attempt); skipping move")
+else:
+    if not await self.files_store.move_file(tmp_path, processing_path):
+        raise Exception(f"Failed to move file from {tmp_path} to {processing_path}")
+```
+
+Centralize as two helpers on `DataIngestionProvider` (`base_provider.py`) rather than patching four call sites independently (DRY, and it forecloses a fifth copy of the bug landing in a future provider):
+
+- `_move_to_processing(tmp_path: str) -> str` — tmp->processing, returns `processing_path`.
+- `_move_to_processed(processing_path: str) -> str` — processing->processed, returns `processed_path`.
+
+Both check destination existence before calling `move_file`, log-and-skip when already present, and raise only when the move is actually attempted and fails. Call sites (all four providers, both move points each) replace their inline `move_file` + raise blocks with a call to the shared helper.
+
+## Steps
+
+- [ ] Add `_move_to_processing(tmp_path) -> str` and `_move_to_processed(processing_path) -> str` to `DataIngestionProvider` in `backend/app/services/data_ingestion/base_provider.py`, each guarded by a `file_exists` check on the destination before calling `move_file`.
+- [ ] Replace the inline tmp->processing move in `base_csv_provider.py:1113-1116` with `self._move_to_processing(tmp_path)`.
+- [ ] Replace the inline tmp->processing move in `base_factor_csv_provider.py:260-265` with the same helper call.
+- [ ] Replace the inline tmp->processing move in `base_reduction_objective_csv_provider.py:261-270` with the same helper call.
+- [ ] Replace the inline tmp->processing move in `csv_providers/reference_data.py:228-230` with the same helper call.
+- [ ] Replace the four processing->processed moves (`base_csv_provider.py:1378`, `base_factor_csv_provider.py:552`, `base_reduction_objective_csv_provider.py:448`, `csv_providers/reference_data.py:247`) with `self._move_to_processed(processing_path)`.
+- [ ] Add a regression test: place the file in `processing/<job_id>/` (simulating a prior attempt) with no source in `tmp/`, run the provider's setup, and assert it succeeds (reads from `processing/`) instead of raising "Failed to move file". Cover at least one provider directly and rely on the shared helper for the rest.
+- [ ] Out of scope: the deeper `STALE_JOB_TIMEOUT_MINUTES` / no-heartbeat duplicate-run issue (Plan 310C per the `sweep_stuck_running_jobs` docstring) is the underlying trigger for duplicate runs. The idempotent move fixes this symptom directly without touching the job runner; leave 310C as a separate, later plan.


### PR DESCRIPTION
Part of #1559.

Implementation plan: `docs/src/implementation-plans/1559-ingestion-idempotent-tmp-to-processing-move.md`