### PR TITLE
fix(1564): allow same headcount member with multiple roles

### DIFF
--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -253,28 +253,32 @@ class DataEntryRepository:
         self,
         carbon_report_module_id: int,
         data_entry_type_id: int,
-        field: str,
-        value: str,
+        fields: dict[str, str],
         exclude_id: Optional[int] = None,
     ) -> bool:
-        """Check whether a JSON data field value is unique within a submodule.
+        """Check whether a set of JSON data field values is unique within a submodule.
 
         Args:
             carbon_report_module_id: The module to scope the check to.
             data_entry_type_id: The submodule type.
-            field: The JSON key inside ``DataEntry.data`` to check.
-            value: The value that must be unique.
+            fields: JSON keys inside ``DataEntry.data`` mapped to the values that
+                must be unique together (ANDed). A single-entry dict reproduces
+                the previous single-field check.
             exclude_id: Optional entry ID to exclude (for PATCH uniqueness checks).
 
         Returns:
-            True if the value is unique (no conflicting row found), False otherwise.
+            True if the combination is unique (no conflicting row found), False
+            otherwise.
         """
         statement = (
             select(DataEntry)
             .where(
                 col(DataEntry.carbon_report_module_id) == carbon_report_module_id,
                 col(DataEntry.data_entry_type_id) == data_entry_type_id,
-                DataEntry.data[field].as_string() == value,
+                *[
+                    DataEntry.data[key].as_string() == val
+                    for key, val in fields.items()
+                ],
             )
             .limit(1)
         )
@@ -532,6 +536,7 @@ class DataEntryRepository:
         is_plane_entry = data_entry_type_id == DataEntryTypeEnum.plane.value
         OriginLocation: Any = None
         DestLocation: Any = None
+        traveler_name_subq: Any = None
         is_buildings_entry = data_entry_type_id in (DataEntryTypeEnum.building.value,)
         is_headcount_entry = data_entry_type_id in (
             DataEntryTypeEnum.member.value,
@@ -681,7 +686,33 @@ class DataEntryRepository:
 
             entities = [DataEntry, emission_agg.c.total_kg_co2eq, Factor]
             if is_travel_entry:
-                entities.extend([MemberEntry, DataEntryEmission])
+                # A person can hold multiple headcount roles (sius_code) in the
+                # same unit, so a plain JOIN on (uid, module) can match >1
+                # MemberEntry row and fan out/duplicate every travel row for
+                # that person. traveler_name is identical across roles, so pick
+                # one match deterministically via a correlated scalar subquery
+                # (same pattern as list_units's latest_stats_subq; LATERAL
+                # JOIN is avoided — unsupported on SQLite, used in unit tests).
+                # Tie-break on lowest id: always present, unlike sius_code
+                # which can be null on legacy rows.
+                traveler_name_subq = (
+                    select(MemberEntry.data["name"].as_string())
+                    .where(
+                        MemberEntry.data["user_institutional_id"].as_string()
+                        == DataEntry.data["user_institutional_id"].as_string(),
+                        col(MemberEntry.carbon_report_module_id)
+                        == col(DataEntry.carbon_report_module_id),
+                        col(MemberEntry.data_entry_type_id)
+                        == DataEntryTypeEnum.member.value,
+                    )
+                    .order_by(asc(col(MemberEntry.id)))
+                    .limit(1)
+                    .correlate(DataEntry)
+                    .scalar_subquery()
+                )
+                entities.extend(
+                    [traveler_name_subq.label("traveler_name"), DataEntryEmission]
+                )
                 if is_train_entry or is_plane_entry:
                     OriginLocation = aliased(Location)
                     DestLocation = aliased(Location)
@@ -708,21 +739,6 @@ class DataEntryRepository:
 
             if is_travel_entry:
                 statement = statement.join(
-                    MemberEntry,
-                    (
-                        MemberEntry.data["user_institutional_id"].as_string()
-                        == DataEntry.data["user_institutional_id"].as_string()
-                    )
-                    & (
-                        col(MemberEntry.carbon_report_module_id)
-                        == col(DataEntry.carbon_report_module_id)
-                    )
-                    & (
-                        col(MemberEntry.data_entry_type_id)
-                        == DataEntryTypeEnum.member.value
-                    ),
-                    isouter=True,
-                ).join(
                     DataEntryEmission,
                     col(DataEntryEmission.data_entry_id) == DataEntry.id,
                     isouter=True,
@@ -808,6 +824,12 @@ class DataEntryRepository:
                 DataEntryEmission.additional_value,
                 DataEntry.data["distance_km"].as_float(),
             )
+            # The class-level sort_map's "traveler_name" references MemberEntry
+            # directly, which relied on the (now-removed) plain JOIN. Point it at
+            # the same correlated subquery used for enrichment above, or sorting
+            # by traveler_name would silently reintroduce an unjoined MemberEntry
+            # reference (implicit cross join).
+            sort_map["traveler_name"] = traveler_name_subq
         if (is_train_entry or is_plane_entry) and OriginLocation is not None:
             sort_map["origin_name"] = OriginLocation.name
             sort_map["destination_name"] = DestLocation.name
@@ -857,9 +879,7 @@ class DataEntryRepository:
         for row in rows:
             # Pre-bind conditionally-unpacked variables so static type checkers
             # see them as definitely-bound (T | None) on every branch path.
-            # MemberEntry is a SQLAlchemy alias of DataEntry, so the runtime
-            # type is DataEntry.
-            member_entry: DataEntry | None = None
+            traveler_name: str | None = None
             _emission: DataEntryEmission | None = None
             building_room: BuildingRoom | None = None
             _origin_loc: Location | None = None
@@ -871,9 +891,9 @@ class DataEntryRepository:
             # 2. Unpack only the remaining tail fields
             if is_travel_entry:
                 if is_train_entry or is_plane_entry:
-                    member_entry, _emission, _origin_loc, _dest_loc = row[3:]
+                    traveler_name, _emission, _origin_loc, _dest_loc = row[3:]
                 else:
-                    member_entry, _emission = row[3:]
+                    traveler_name, _emission = row[3:]
             elif is_buildings_entry:
                 building_room = row[3]
 
@@ -881,9 +901,11 @@ class DataEntryRepository:
             # accidental mutation (here or downstream) cannot be flushed back to
             # the DB. This method only reads scalar columns and the JSON `data`
             # field after unpack — no lazy relationships — so expunge is safe.
+            # traveler_name is a plain scalar (from a subquery), not an ORM row,
+            # so it needs no detaching.
             self._detach(data_entry, primary_factor)
             if is_travel_entry:
-                self._detach(member_entry, _emission, _origin_loc, _dest_loc)
+                self._detach(_emission, _origin_loc, _dest_loc)
             elif is_buildings_entry:
                 self._detach(building_room)
 
@@ -910,8 +932,8 @@ class DataEntryRepository:
                     if _emission is not None and _emission.additional_value is not None
                     else enriched_data.get("distance_km")
                 )
-                if member_entry is not None:
-                    enriched_data["traveler_name"] = member_entry.data.get("name")
+                if traveler_name is not None:
+                    enriched_data["traveler_name"] = traveler_name
                 if distance_km is not None:
                     enriched_data["distance_km"] = distance_km
                 if is_train_entry or is_plane_entry:

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -63,15 +63,22 @@ class DataEntryService:
             data_entry_type_id=data_entry_type_id,
         )
 
-    async def check_institutional_id_unique(
-        self, carbon_report_module_id: int, uid: str, exclude_id: Optional[int] = None
+    async def check_member_role_unique(
+        self,
+        carbon_report_module_id: int,
+        uid: str,
+        sius_code: str,
+        exclude_id: Optional[int] = None,
     ) -> bool:
-        """Check whether user_institutional_id is unique in member submodule."""
+        """Check whether (user_institutional_id, sius_code) is unique.
+
+        A person can legitimately hold multiple roles (``sius_code``) in the
+        same unit, so the uniqueness key is the role, not just the person.
+        """
         return await self.repo.check_json_field_unique(
             carbon_report_module_id=carbon_report_module_id,
             data_entry_type_id=DataEntryTypeEnum.member.value,
-            field="user_institutional_id",
-            value=uid,
+            fields={"user_institutional_id": uid, "sius_code": sius_code},
             exclude_id=exclude_id,
         )
 
@@ -114,8 +121,7 @@ class DataEntryService:
         return await self.repo.check_json_field_unique(
             carbon_report_module_id=carbon_report_module_id,
             data_entry_type_id=data_entry_type_id,
-            field=field,
-            value=value,
+            fields={field: value},
             exclude_id=exclude_id,
         )
 

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -933,8 +933,10 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             # Parallel list of kg_co2eq overrides aligned with `batch` by index.
             # Carried out-of-band so kg_co2eq never lands in DataEntry.data.
             batch_kg_co2eq_overrides: List[float | None] = []
-            # Track seen user_institutional_ids per module to catch intra-CSV duplicates
-            seen_institutional_ids: Dict[int, set] = {}
+            # Track seen (user_institutional_id, sius_code) pairs per module to
+            # catch intra-CSV duplicates. A person can legitimately hold two
+            # roles (different sius_code) in the same unit.
+            seen_institutional_ids: Dict[int, set[tuple[str, str]]] = {}
             csv_reader = csv.DictReader(
                 io.StringIO(setup_result["csv_text"], newline="")
             )
@@ -993,7 +995,8 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 if data_entry is None:
                     raise ValueError("Data entry is None without error message")
 
-                # Check institutional ID uniqueness for member entries
+                # Check (user_institutional_id, sius_code) role uniqueness for
+                # member entries.
                 # TODO: refactor, should not be done in base_csv_provider but elsewhere
                 # process or task or sql
                 if (
@@ -1002,17 +1005,20 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                     and data_entry.data.get("user_institutional_id")
                 ):
                     uid = str(data_entry.data["user_institutional_id"])
+                    sius_code = str(data_entry.data["sius_code"])
                     module_id = data_entry.carbon_report_module_id
                     module_seen = seen_institutional_ids.setdefault(module_id, set())
-                    if uid in module_seen:
+                    role_key = (uid, sius_code)
+                    if role_key in module_seen:
                         error_msg = "DUPLICATE_INSTITUTIONAL_ID"
                         self._record_row_error(
                             stats, row_idx, error_msg, max_row_errors
                         )
                         continue
-                    is_unique = await data_entry_service.check_institutional_id_unique(
+                    is_unique = await data_entry_service.check_member_role_unique(
                         carbon_report_module_id=module_id,
                         uid=uid,
+                        sius_code=sius_code,
                     )
                     if not is_unique:
                         error_msg = "DUPLICATE_INSTITUTIONAL_ID"
@@ -1020,7 +1026,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                             stats, row_idx, error_msg, max_row_errors
                         )
                         continue
-                    module_seen.add(uid)
+                    module_seen.add(role_key)
 
                 # Row processed successfully
                 batch.append(data_entry)

--- a/backend/app/workflows/carbon_report_module.py
+++ b/backend/app/workflows/carbon_report_module.py
@@ -108,12 +108,6 @@ class CarbonReportModuleWorkflow:
         except IntegrityError as e:
             await self.session.rollback()
 
-            if "data_entries_unique_member_uid_per_module_idx" in str(e.orig):
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail="This user institutional id already exists in this module.",
-                )
-
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Database integrity error.",

--- a/backend/app/workflows/carbon_report_module.py
+++ b/backend/app/workflows/carbon_report_module.py
@@ -69,12 +69,13 @@ class CarbonReportModuleWorkflow:
             data_entry_type == DataEntryTypeEnum.member
             and validated_data.model_dump().get("user_institutional_id")
         ):
-            uid = validated_data.model_dump()["user_institutional_id"]
-            is_unique = await DataEntryService(
-                self.session
-            ).check_institutional_id_unique(
+            member_data = validated_data.model_dump()
+            uid = member_data["user_institutional_id"]
+            sius_code = member_data["sius_code"]
+            is_unique = await DataEntryService(self.session).check_member_role_unique(
                 carbon_report_module_id=carbon_report_module.id,
                 uid=uid,
+                sius_code=sius_code,
             )
             if not is_unique:
                 raise HTTPException(

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -9,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportModule, CarbonReportType
 from app.models.data_entry import DataEntry, DataEntryStatusEnum, DataEntryTypeEnum
-from app.models.data_entry_emission import EmissionType
+from app.models.data_entry_emission import DataEntryEmission, EmissionType
 from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
 from app.repositories.data_entry_repo import DEFAULT_FILTER_MAP, DataEntryRepository
@@ -1416,6 +1416,104 @@ async def test_get_submodule_data_duplicate_factor_rows_resolve_deterministicall
     assert len(response.items) == 1
     item = response.items[0]
     assert item.active_power_w == 42.0, "lowest factor id must win deterministically"
+
+
+# ======================================================================
+# Regression #1564 Part 2: travel<->headcount join must not fan out for a
+# member holding multiple roles (sius_code) in the same unit.
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_submodule_data_travel_not_duplicated_for_multi_role_member(
+    db_session: AsyncSession,
+):
+    """A person can now legitimately have two headcount rows in the same
+    unit (different sius_code, issue #1564 Part 1). The MemberEntry join
+    used to fetch the traveler's display name must pick exactly one of
+    those rows deterministically — not fan out and duplicate the travel
+    entry once per matching role."""
+    repo = DataEntryRepository(db_session)
+
+    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
+    db_session.add(report)
+    await db_session.flush()
+
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status="in_progress",
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    # Two headcount roles for the same person, same unit/module.
+    db_session.add_all(
+        [
+            DataEntry(
+                carbon_report_module_id=module.id,
+                data_entry_type_id=DataEntryTypeEnum.member,
+                data={
+                    "name": "X X",
+                    "user_institutional_id": "123456",
+                    "sius_code": "53",
+                },
+            ),
+            DataEntry(
+                carbon_report_module_id=module.id,
+                data_entry_type_id=DataEntryTypeEnum.member,
+                data={
+                    "name": "X X",
+                    "user_institutional_id": "123456",
+                    "sius_code": "54",
+                },
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    travel_entry = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data={
+            "origin_iata": "GVA",
+            "destination_iata": "ZRH",
+            "cabin_class": "economy",
+            "user_institutional_id": "123456",
+            "number_of_trips": 1,
+        },
+    )
+    db_session.add(travel_entry)
+    await db_session.flush()
+    assert travel_entry.id is not None
+    db_session.add(
+        DataEntryEmission(
+            data_entry_id=travel_entry.id,
+            emission_type_id=EmissionType.professional_travel__plane.value,
+            kg_co2eq=100.0,
+        )
+    )
+    await db_session.flush()
+
+    response = await repo.get_submodule_data(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.plane.value,
+        limit=10,
+        offset=0,
+        sort_by="id",
+        sort_order="asc",
+    )
+
+    assert len(response.items) == 1, (
+        "a multi-role member's travel entry must appear exactly once, not "
+        "once per matching headcount role"
+    )
+    assert response.summary.total_items == 1
+    total_kg_co2eq = sum(item.kg_co2eq or 0 for item in response.items)
+    assert total_kg_co2eq == pytest.approx(100.0), (
+        "kg_co2eq must not be double-counted by the join fan-out"
+    )
 
 
 # ======================================================================

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -4,10 +4,13 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
-from app.models.data_entry import DataEntrySourceEnum, DataEntryTypeEnum
+from app.models.carbon_report import CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntrySourceEnum, DataEntryTypeEnum
 from app.models.data_ingestion import EntityType, IngestionResult
+from app.models.module_type import ModuleTypeEnum
 from app.models.user import UserProvider
 from app.services.data_ingestion.base_csv_provider import (
     REUPLOAD_HINT,
@@ -248,6 +251,107 @@ async def test_process_csv_with_blank_rows_does_not_raise_value_error():
 
     # 5. Assertions: check execution runs without completely failing out
     assert result is not None
+
+
+# ======================================================================
+# Issue #1564 — member (uid, sius_code) composite uniqueness in the row loop
+# ======================================================================
+
+
+def _drive_member_csv(
+    db_session: AsyncSession, module_id: int, rows_data: list[dict]
+) -> "ConcreteCSVProvider":
+    """Build a provider that feeds ``rows_data`` through the real row loop.
+
+    ``_process_row`` is stubbed to skip CSV parsing/validation (out of scope
+    here) but returns a real ``member`` DataEntry per row, so the composite
+    (user_institutional_id, sius_code) uniqueness check in
+    ``process_csv_in_batches`` — the code under test — runs for real against
+    ``db_session``. ``_process_batch`` is stubbed to skip factor/emission
+    computation, which is irrelevant to the uniqueness check.
+    """
+    config = {
+        "file_path": "tmp/test.csv",
+        "carbon_report_module_id": module_id,
+        "year": 2025,
+    }
+    provider = ConcreteCSVProvider(config, data_session=db_session)
+
+    mock_files_store = MagicMock()
+    mock_files_store.move_file = AsyncMock(return_value="processing/test.csv")
+    mock_files_store.file_exists = AsyncMock(return_value=True)
+    csv_content = ("\n".join(["header"] + ["row"] * len(rows_data))).encode()
+    mock_files_store.get_file = AsyncMock(return_value=(csv_content, "text/csv"))
+    provider._files_store = mock_files_store
+
+    async def mock_setup():
+        return {
+            "handlers": [],
+            "factors_map": {},
+            "expected_columns": {"header"},
+            "required_columns": set(),
+        }
+
+    provider._setup_handlers_and_factors = mock_setup
+
+    async def fake_process_row(row, row_idx, setup_result, stats, max_row_errors, _map):
+        entry = DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.member.value,
+            carbon_report_module_id=module_id,
+            data=dict(rows_data[row_idx - 1]),
+        )
+        return entry, None, None, None
+
+    provider._process_row = fake_process_row
+    provider._process_batch = AsyncMock(return_value=len(rows_data))
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_csv_batch_accepts_same_member_different_sius_code(
+    db_session: AsyncSession,
+):
+    """Same unit + user_institutional_id, different sius_code (multi-role
+    member) — both rows must be ingested, no DUPLICATE_INSTITUTIONAL_ID."""
+    module = CarbonReportModule(
+        carbon_report_id=1, module_type_id=ModuleTypeEnum.headcount.value, status=0
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    rows_data = [
+        {"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
+        {"name": "X X", "user_institutional_id": "123456", "sius_code": "54"},
+    ]
+    provider = _drive_member_csv(db_session, module.id, rows_data)
+
+    result = await provider.process_csv_in_batches()
+
+    assert result["stats"]["row_errors_count"] == 0
+    assert result["stats"]["rows_processed"] == 2
+
+
+@pytest.mark.asyncio
+async def test_csv_batch_rejects_true_duplicate_member_role(db_session: AsyncSession):
+    """Same unit + user_institutional_id + sius_code (true duplicate) — the
+    second row is rejected with DUPLICATE_INSTITUTIONAL_ID."""
+    module = CarbonReportModule(
+        carbon_report_id=1, module_type_id=ModuleTypeEnum.headcount.value, status=0
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    rows_data = [
+        {"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
+        {"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
+    ]
+    provider = _drive_member_csv(db_session, module.id, rows_data)
+
+    result = await provider.process_csv_in_batches()
+
+    assert result["stats"]["row_errors_count"] == 1
+    assert result["stats"]["row_errors"][0]["reason"] == "DUPLICATE_INSTITUTIONAL_ID"
+    assert result["stats"]["rows_processed"] == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/workflows/test_carbon_report_module_create.py
+++ b/backend/tests/unit/workflows/test_carbon_report_module_create.py
@@ -1,0 +1,142 @@
+"""Regression tests for CarbonReportModuleWorkflow.create — issue #1564.
+
+A member can legitimately hold two roles (different ``sius_code``) in the
+same unit. The uniqueness check on manual (API) create must key on
+``(user_institutional_id, sius_code)``, not ``user_institutional_id`` alone.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.user import UserProvider
+from app.schemas.data_entry import DataEntryResponse
+from app.schemas.user import UserRead
+from app.workflows.carbon_report_module import CarbonReportModuleWorkflow
+
+_CURRENT_USER = UserRead(
+    id=5,
+    display_name="Test User",
+    email="test.user@example.org",
+    provider=UserProvider.TEST,
+    institutional_id="352707",
+)
+
+
+def _member_item_data(sius_code: str) -> dict:
+    return {
+        "name": "X X",
+        "user_institutional_id": "123456",
+        "sius_code": sius_code,
+        "fte": 0.5,
+    }
+
+
+def _make_workflow_deps():
+    """Build the mocked DataEntryService/EmissionService/ModuleService trio
+    shared by both tests, mirroring the pattern in
+    test_carbon_report_module_update.py."""
+    session = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+
+    data_entry_service = MagicMock()
+    data_entry_service.create = AsyncMock(
+        return_value=DataEntryResponse(
+            id=1,
+            data_entry_type_id=DataEntryTypeEnum.member.value,
+            carbon_report_module_id=42,
+            data=_member_item_data("54"),
+        )
+    )
+
+    emission_service = MagicMock()
+    emission_service.upsert_by_data_entry = AsyncMock()
+    module_service = MagicMock()
+    module_service.recompute_stats = AsyncMock()
+
+    return session, data_entry_service, emission_service, module_service
+
+
+@pytest.mark.asyncio
+async def test_create_second_role_for_existing_member_is_accepted():
+    """A second role (different sius_code) for an already-registered SCIPER
+    in the same unit must succeed (201), not be rejected as a duplicate."""
+    session, data_entry_service, emission_service, module_service = (
+        _make_workflow_deps()
+    )
+    data_entry_service.check_member_role_unique = AsyncMock(return_value=True)
+    workflow = CarbonReportModuleWorkflow(session)
+
+    with (
+        patch(
+            "app.workflows.carbon_report_module.DataEntryService",
+            return_value=data_entry_service,
+        ),
+        patch(
+            "app.workflows.carbon_report_module.DataEntryEmissionService",
+            return_value=emission_service,
+        ),
+        patch(
+            "app.workflows.carbon_report_module.CarbonReportModuleService",
+            return_value=module_service,
+        ),
+    ):
+        response = await workflow.create(
+            carbon_report_module=MagicMock(id=42, module_type_id=1),
+            data_entry_type_id=DataEntryTypeEnum.member.value,
+            item_data=_member_item_data("54"),
+            current_user=_CURRENT_USER,
+            request_context={},
+            background_tasks=MagicMock(),
+        )
+
+    assert response.id == 1
+    data_entry_service.check_member_role_unique.assert_awaited_once()
+    call_kwargs = data_entry_service.check_member_role_unique.call_args.kwargs
+    assert call_kwargs["uid"] == "123456"
+    assert call_kwargs["sius_code"] == "54"
+    data_entry_service.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_role_for_existing_member_is_rejected():
+    """The same (user_institutional_id, sius_code) pair must still be
+    rejected with 422 DUPLICATE_INSTITUTIONAL_ID."""
+    session, data_entry_service, emission_service, module_service = (
+        _make_workflow_deps()
+    )
+    data_entry_service.check_member_role_unique = AsyncMock(return_value=False)
+    workflow = CarbonReportModuleWorkflow(session)
+
+    with (
+        patch(
+            "app.workflows.carbon_report_module.DataEntryService",
+            return_value=data_entry_service,
+        ),
+        patch(
+            "app.workflows.carbon_report_module.DataEntryEmissionService",
+            return_value=emission_service,
+        ),
+        patch(
+            "app.workflows.carbon_report_module.CarbonReportModuleService",
+            return_value=module_service,
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await workflow.create(
+                carbon_report_module=MagicMock(id=42, module_type_id=1),
+                data_entry_type_id=DataEntryTypeEnum.member.value,
+                item_data=_member_item_data("53"),
+                current_user=_CURRENT_USER,
+                request_context={},
+                background_tasks=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "DUPLICATE_INSTITUTIONAL_ID"
+    data_entry_service.create.assert_not_awaited()

--- a/docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md
+++ b/docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md
@@ -1,7 +1,7 @@
 ---
-status: proposed
+status: delivered
 issue: 1564
-last_updated: 2026-07-07
+last_updated: 2026-07-08
 title: "Headcount: Allow the Same Member With Multiple Roles in One Unit"
 summary: "Headcount uniqueness is keyed on user_institutional_id alone, so a member with two SIUS roles in the same unit gets their second CSV row silently dropped; fixing that exposes a real duplicate-row risk in the Professional Travel <-> Headcount join that must be fixed in the same PR."
 ---
@@ -85,15 +85,15 @@ Recommendation: (B), on the same reasoning `1661-sql-factor-resolution.md` used 
 
 ## Steps
 
-- [ ] Extend `DataEntryRepository.check_json_field_unique` (`data_entry_repo.py:252`) to accept a `fields: dict[str, str]` composite predicate (backward-compatible: single-entry dict == today's behavior), or add a sibling method — reuse the existing `DataEntry.data[k].as_string()` pattern.
-- [ ] Update `DataEntryService.check_institutional_id_unique` (`data_entry_service.py:66`) to require `sius_code` and check the composite `(user_institutional_id, sius_code)` key; rename to reflect the new semantics.
-- [ ] Update `backend/app/workflows/carbon_report_module.py:68-83` to pass `sius_code` into the renamed check.
-- [ ] Update `backend/app/services/data_ingestion/base_csv_provider.py:982-1009`: key `seen_institutional_ids` by `(uid, sius_code)` tuple; pass `sius_code` into the DB check.
-- [ ] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id`, different `sius_code` -> both rows ingested, `stats["errors"]` empty for those rows.
-- [ ] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id` + same `sius_code` (true duplicate) -> second row still rejected with `DUPLICATE_INSTITUTIONAL_ID`.
-- [ ] Regression test: manual API create of a second role for an existing member (same unit, same SCIPER, different `sius_code`) -> 201, not 422.
-- [ ] Update `docs/src/implementation-plans/518-headcount-uniqueness-validation.md` status/scope note to point at this plan (the "uniqueness is per `carbon_report_module_id`" line needs a "...and per `sius_code`" amendment) per the "keep implementation plans aligned" convention.
-- [ ] **Decision needed before this step**: option (A) or (B) above for the Professional Travel join. Once decided:
-  - [ ] (B, recommended) Replace the plain `MemberEntry` join in `data_entry_repo.py:706-722` with a `LEFT JOIN LATERAL ... LIMIT 1` (or correlated-subquery equivalent, matching `1661-sql-factor-resolution.md`'s pattern) keyed on `(user_institutional_id, carbon_report_module_id)`, deterministic tie-break (e.g. lowest `sius_code` or lowest `id`) when a person has multiple roles.
-  - [ ] (A, alternative) Add role capture to travel create/update DTOs + frontend traveler picker, extend the join predicate to include it, and resolve the retroactive-migration question for existing travel rows.
-- [ ] Regression test pinning the travel-join fix: seed a same-unit two-role member with at least one travel entry, assert the travel list returns exactly one row for that entry (not two) and `kg_co2eq` sums aren't doubled — this is the test that would have caught this bug, must ship in the same PR as the composite-uniqueness change, not as a follow-up.
+- [x] Extend `DataEntryRepository.check_json_field_unique` (`data_entry_repo.py:252`) to accept a `fields: dict[str, str]` composite predicate (backward-compatible: single-entry dict == today's behavior), or add a sibling method — reuse the existing `DataEntry.data[k].as_string()` pattern.
+- [x] Update `DataEntryService.check_institutional_id_unique` (`data_entry_service.py:66`) to require `sius_code` and check the composite `(user_institutional_id, sius_code)` key; rename to reflect the new semantics. *(Shipped as `check_member_role_unique`.)*
+- [x] Update `backend/app/workflows/carbon_report_module.py:68-83` to pass `sius_code` into the renamed check.
+- [x] Update `backend/app/services/data_ingestion/base_csv_provider.py:982-1009`: key `seen_institutional_ids` by `(uid, sius_code)` tuple; pass `sius_code` into the DB check.
+- [x] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id`, different `sius_code` -> both rows ingested, `stats["errors"]` empty for those rows.
+- [x] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id` + same `sius_code` (true duplicate) -> second row still rejected with `DUPLICATE_INSTITUTIONAL_ID`.
+- [x] Regression test: manual API create of a second role for an existing member (same unit, same SCIPER, different `sius_code`) -> 201, not 422.
+- [x] Update `docs/src/implementation-plans/518-headcount-uniqueness-validation.md` status/scope note to point at this plan (the "uniqueness is per `carbon_report_module_id`" line needs a "...and per `sius_code`" amendment) per the "keep implementation plans aligned" convention.
+- [x] **Decision needed before this step**: option (A) or (B) above for the Professional Travel join. Once decided:
+  - [x] (B, shipped) Replaced the plain `MemberEntry` join in `data_entry_repo.py` with a correlated scalar subquery (not `LEFT JOIN LATERAL` — unsupported on SQLite, used in unit tests) selecting `traveler_name`, keyed on `(user_institutional_id, carbon_report_module_id, data_entry_type_id=member)`, tie-broken on lowest `MemberEntry.id` (always present and monotonic, unlike `sius_code` which can be null on legacy rows). The class-level `sort_map["traveler_name"]` (in `professional_travel/schemas.py`) referenced the now-removed `MemberEntry` join directly; the repo overrides it locally with the same subquery so sorting by traveler name doesn't reintroduce an unjoined `MemberEntry` reference.
+  - [ ] (A, alternative) Not implemented — out of scope per the owner's decision.
+- [x] Regression test pinning the travel-join fix: seed a same-unit two-role member with at least one travel entry, assert the travel list returns exactly one row for that entry (not two) and `kg_co2eq` sums aren't doubled. Verified this test fails on the pre-fix join (temporarily reverted, re-ran, confirmed 2 duplicated rows) and passes post-fix.

--- a/docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md
+++ b/docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md
@@ -1,0 +1,43 @@
+---
+status: proposed
+issue: 1564
+last_updated: 2026-07-07
+title: "Headcount: Allow the Same Member With Multiple Roles in One Unit"
+summary: "Headcount uniqueness is keyed on user_institutional_id alone, so a member with two SIUS roles in the same unit gets their second CSV row silently dropped."
+---
+
+# Headcount: Allow the Same Member With Multiple Roles in One Unit
+
+## Problem
+
+`docs/src/implementation-plans/518-headcount-uniqueness-validation.md` (delivered) scoped headcount uniqueness to "same SCIPER within the same `carbon_report_module_id`" (unit + year) and shipped it keyed on `user_institutional_id` alone. That design didn't account for `sius_code` (the member's function/role, one of `HeadcountItemResponse.SIUS_CODE_VALUES` in `backend/app/modules/headcount/schemas.py:29`) — a real person can legitimately hold two roles in the same unit and appear as two headcount rows: same `unit_institutional_id` + `user_institutional_id`, different `sius_code`/`fte`.
+
+The single-field check landed in two places, both routing through the same shared primitive, `DataEntryRepository.check_json_field_unique` (`backend/app/repositories/data_entry_repo.py:252-284`), via `DataEntryService.check_institutional_id_unique` (`backend/app/services/data_entry_service.py:66-76`, hardcoded `field="user_institutional_id"`):
+
+1. **Manual create (API)** — `backend/app/workflows/carbon_report_module.py:68-83`. A second role for the same SCIPER raises `HTTPException(422, "DUPLICATE_INSTITUTIONAL_ID")`.
+2. **Bulk/backoffice CSV ingestion** — `backend/app/services/data_ingestion/base_csv_provider.py:982-1009`. This is the path the issue actually hits: rows are processed in order, an in-batch `seen_institutional_ids: dict[module_id, set[uid]]` is checked first (line 992-998), then the DB check (line 999-1002). Either hit records `stats["errors"]` with `"DUPLICATE_INSTITUTIONAL_ID"` and `continue`s — the second role's row is silently skipped, matching the issue report exactly ("the second time the same user_institutional_id appears the row is ignored").
+
+Both enforcement points treat `user_institutional_id` as the whole uniqueness key; neither considers `sius_code`.
+
+## Design
+
+Fix once, at the shared primitive, not in each caller:
+
+- **`DataEntryService.check_institutional_id_unique`** (`data_entry_service.py:66-76`): extend to take the composite key. Simplest shape: add a required `sius_code: str` param and have it call `repo.check_json_field_unique` twice-filtered — or, cleaner, extend `DataEntryRepository.check_json_field_unique` to accept a `fields: dict[str, str]` (multiple `DataEntry.data[k].as_string() == v` predicates ANDed) instead of a single `field`/`value` pair, matching the existing JSON-query pattern already used in `filter_map`/`sort_map`. Rename the wrapper to `check_member_role_unique` (or similar) to reflect the new key; update its two call sites.
+- **`backend/app/workflows/carbon_report_module.py:68-83`**: pass `sius_code` from `validated_data` alongside `uid` into the renamed check.
+- **`backend/app/services/data_ingestion/base_csv_provider.py:982-1009`**: change `seen_institutional_ids` from `dict[int, set[str]]` (uid) to `dict[int, set[tuple[str, str]]]` (uid, sius_code), and pass `sius_code` into the DB-level check call. `HeadCountCreate.sius_code` (`backend/app/modules/headcount/schemas.py:46`) is a required field on member rows, so it's always present by the time this check runs.
+- **Advisory `GET .../check-unique` endpoint** (`backend/app/api/v1/carbon_report_module.py:750-812`, backed by `DataEntryService.check_json_field_unique`): currently single-field only, generic (not headcount-specific). Grep of `frontend/src` found no live caller (only present in generated `frontend/src/types/api/openapi.d.ts`) — it's currently dead frontend-side. Leave the generic single-field signature as-is (it's not the headcount-specific path); do not wire a composite variant into it unless a future member-form pre-submit check is actually built.
+- **Downstream aggregation**: `aggregate_by="sius_code"` (`backend/app/api/v1/carbon_report_module.py:299`, FTE-per-function stats) already groups by function and sums `fte` per `DataEntry` row — one row per role is the correct unit of aggregation there, so multiple rows per person need no change. Checked `DataEntryRepository` for any `SELECT DISTINCT` / dedup on `user_institutional_id` in stats/count paths (`data_entry_repo.py`) — none found, so no existing KPI silently double-counts or under-counts people today. Note only: any future "distinct headcount" (people, not roles) metric must `DISTINCT` on `user_institutional_id`, not just count rows.
+
+No DB schema change needed — `DataEntry.data` is JSON, the uniqueness key is enforced at the application layer only (same as #518), so this is a pure application-level composite-key fix.
+
+## Steps
+
+- [ ] Extend `DataEntryRepository.check_json_field_unique` (`data_entry_repo.py:252`) to accept a `fields: dict[str, str]` composite predicate (backward-compatible: single-entry dict == today's behavior), or add a sibling method — reuse the existing `DataEntry.data[k].as_string()` pattern.
+- [ ] Update `DataEntryService.check_institutional_id_unique` (`data_entry_service.py:66`) to require `sius_code` and check the composite `(user_institutional_id, sius_code)` key; rename to reflect the new semantics.
+- [ ] Update `backend/app/workflows/carbon_report_module.py:68-83` to pass `sius_code` into the renamed check.
+- [ ] Update `backend/app/services/data_ingestion/base_csv_provider.py:982-1009`: key `seen_institutional_ids` by `(uid, sius_code)` tuple; pass `sius_code` into the DB check.
+- [ ] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id`, different `sius_code` -> both rows ingested, `stats["errors"]` empty for those rows.
+- [ ] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id` + same `sius_code` (true duplicate) -> second row still rejected with `DUPLICATE_INSTITUTIONAL_ID`.
+- [ ] Regression test: manual API create of a second role for an existing member (same unit, same SCIPER, different `sius_code`) -> 201, not 422.
+- [ ] Update `docs/src/implementation-plans/518-headcount-uniqueness-validation.md` status/scope note to point at this plan (the "uniqueness is per `carbon_report_module_id`" line needs a "...and per `sius_code`" amendment) per the "keep implementation plans aligned" convention.

--- a/docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md
+++ b/docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md
@@ -3,7 +3,7 @@ status: proposed
 issue: 1564
 last_updated: 2026-07-07
 title: "Headcount: Allow the Same Member With Multiple Roles in One Unit"
-summary: "Headcount uniqueness is keyed on user_institutional_id alone, so a member with two SIUS roles in the same unit gets their second CSV row silently dropped."
+summary: "Headcount uniqueness is keyed on user_institutional_id alone, so a member with two SIUS roles in the same unit gets their second CSV row silently dropped; fixing that exposes a real duplicate-row risk in the Professional Travel <-> Headcount join that must be fixed in the same PR."
 ---
 
 # Headcount: Allow the Same Member With Multiple Roles in One Unit
@@ -19,6 +19,28 @@ The single-field check landed in two places, both routing through the same share
 
 Both enforcement points treat `user_institutional_id` as the whole uniqueness key; neither considers `sius_code`.
 
+**Confirmed by the reporter (2026-07-07), with real data shape:**
+
+Same-unit, two roles — the case this issue is about, currently broken (second row dropped):
+
+```
+unit_institutional_id  name     sius_code  user_institutional_id  fte
+1234                   XXX XXX  53         123456                 0.75
+1234                   XXX XXX  54         123456                 0.25
+```
+
+Both rows must be accepted and shown in the headcount module, each contributing its own FTE to the SIUS-code chart independently.
+
+Cross-unit, same role — a _different_ shape, already working correctly today (uniqueness is scoped per `carbon_report_module_id`, i.e. per unit+year, so two different units never collide):
+
+```
+unit_institutional_id  name     sius_code  user_institutional_id  fte
+1234                   XXX XXX  53         123456                 0.75
+5678                   XXX XXX  53         123456                 0.25
+```
+
+This second shape is **not** part of this bug and needs no uniqueness-key change — it's confirmation that the existing per-unit scoping already does the right thing. It matters below only because it's the same "one SCIPER, multiple headcount rows" precondition that the Professional Travel join has to tolerate — and, cross-unit, it already does (a travel entry only ever joins against its own unit's headcount roster, so a same-SCIPER row in a _different_ unit is never a join candidate). The genuinely new risk is same-unit, multi-role, which today can't exist in the data at all (rejected at ingestion) and will start existing the moment this fix ships.
+
 ## Design
 
 Fix once, at the shared primitive, not in each caller:
@@ -31,6 +53,36 @@ Fix once, at the shared primitive, not in each caller:
 
 No DB schema change needed — `DataEntry.data` is JSON, the uniqueness key is enforced at the application layer only (same as #518), so this is a pure application-level composite-key fix.
 
+## Downstream impact: Professional Travel join must be fixed in the same PR
+
+This is not optional follow-up work — shipping the composite-uniqueness fix alone, without this, introduces a live correctness bug in every unit that has a genuine multi-role member with travel data.
+
+**The bug.** `DataEntryRepository`'s travel list/enrichment query (`backend/app/repositories/data_entry_repo.py:706-722`) joins every Professional Travel `DataEntry` to a headcount `MemberEntry` (an aliased `DataEntry`) purely to read the traveler's display name:
+
+```python
+statement = statement.join(
+    MemberEntry,
+    (
+        MemberEntry.data["user_institutional_id"].as_string()
+        == DataEntry.data["user_institutional_id"].as_string()
+    )
+    & (col(MemberEntry.carbon_report_module_id) == col(DataEntry.carbon_report_module_id))
+    & (col(MemberEntry.data_entry_type_id) == DataEntryTypeEnum.member.value),
+    isouter=True,
+)
+```
+
+This assumes **exactly one** headcount row per `(user_institutional_id, carbon_report_module_id)` — true today only because the ingestion-side uniqueness check (the bug this plan fixes) has been silently enforcing it as a side effect. The moment a unit has a real two-role member (the confirmed same-unit case above), this join matches **two** `MemberEntry` rows for that SCIPER, and every one of that person's travel `DataEntry` rows gets duplicated in the result set — once per matching role. `traveler_name` itself won't visibly differ (the `name` field is identical on both role rows), so the duplication is invisible in that column, but list pagination and any `kg_co2eq` sum/rollup computed from these joined rows will double-count that person's trips. Confirmed there is no `LIMIT`/`DISTINCT`/dedup anywhere in this query path that would catch it — `count_stmt` (used for pagination totals) deliberately excludes the `MemberEntry` join already (`count_factor_joins` doesn't include it), which means **count and returned rows can already disagree in row count** once fan-out happens, on top of the double-counted emissions.
+
+`professional_travel/schemas.py` confirms travel entries capture only `user_institutional_id` today — no `sius_code`/role field (there's a commented-out `traveler_id`/`traveler_name` pair suggesting an FK-based approach was considered and shelved). So travel currently has no way to say _which_ of a person's roles a given trip belongs to, even if we wanted it to.
+
+**Two ways to fix it — need a decision before implementation, not a default:**
+
+- **(A) Make travel role-aware.** Capture `sius_code` (or a direct FK to the specific headcount `DataEntry.id`) on the traveler selection in the frontend dropdown, store it on the travel entry, and extend the join predicate to match on it too — restores a 1:1 join. Correct if a trip is conceptually attributable to a specific role/function. Bigger surface: frontend traveler-picker UX (must show and let the user pick among a person's roles when they have more than one), a new field on travel create/update DTOs, a data migration question for existing travel rows (which role do they retroactively belong to — unanswerable from existing data, would need to default to "unknown"/first-match).
+- **(B) Make the join deterministic instead of role-aware.** A trip belongs to the _person_, not a role — `traveler_name` is decorative lookup data, identical across that person's role rows anyway. Replace the plain `JOIN` with a `LEFT JOIN LATERAL ... LIMIT 1` (or the correlated-subquery equivalent already shipped in `docs/src/implementation-plans/1661-sql-factor-resolution.md` for the exact same "pick one deterministically instead of fanning out" problem) so multi-role members never produce duplicate travel rows, full stop. Smaller, self-contained, no frontend/DTO change, no migration question — but permanently forecloses ever attributing a specific trip to a specific role.
+
+Recommendation: (B), on the same reasoning `1661-sql-factor-resolution.md` used — same codebase, same shape of problem, already-proven pattern, and nothing in the #1564 issue or the reporter's examples asks for role-specific trip attribution. Flagging as an open decision rather than assuming, since it's a product call, not just an implementation detail.
+
 ## Steps
 
 - [ ] Extend `DataEntryRepository.check_json_field_unique` (`data_entry_repo.py:252`) to accept a `fields: dict[str, str]` composite predicate (backward-compatible: single-entry dict == today's behavior), or add a sibling method — reuse the existing `DataEntry.data[k].as_string()` pattern.
@@ -41,3 +93,7 @@ No DB schema change needed — `DataEntry.data` is JSON, the uniqueness key is e
 - [ ] Regression test: CSV batch with two rows, same `unit_institutional_id` + `user_institutional_id` + same `sius_code` (true duplicate) -> second row still rejected with `DUPLICATE_INSTITUTIONAL_ID`.
 - [ ] Regression test: manual API create of a second role for an existing member (same unit, same SCIPER, different `sius_code`) -> 201, not 422.
 - [ ] Update `docs/src/implementation-plans/518-headcount-uniqueness-validation.md` status/scope note to point at this plan (the "uniqueness is per `carbon_report_module_id`" line needs a "...and per `sius_code`" amendment) per the "keep implementation plans aligned" convention.
+- [ ] **Decision needed before this step**: option (A) or (B) above for the Professional Travel join. Once decided:
+  - [ ] (B, recommended) Replace the plain `MemberEntry` join in `data_entry_repo.py:706-722` with a `LEFT JOIN LATERAL ... LIMIT 1` (or correlated-subquery equivalent, matching `1661-sql-factor-resolution.md`'s pattern) keyed on `(user_institutional_id, carbon_report_module_id)`, deterministic tie-break (e.g. lowest `sius_code` or lowest `id`) when a person has multiple roles.
+  - [ ] (A, alternative) Add role capture to travel create/update DTOs + frontend traveler picker, extend the join predicate to include it, and resolve the retroactive-migration question for existing travel rows.
+- [ ] Regression test pinning the travel-join fix: seed a same-unit two-role member with at least one travel entry, assert the travel list returns exactly one row for that entry (not two) and `kg_co2eq` sums aren't doubled — this is the test that would have caught this bug, must ship in the same PR as the composite-uniqueness change, not as a follow-up.

--- a/docs/src/implementation-plans/518-headcount-uniqueness-validation.md
+++ b/docs/src/implementation-plans/518-headcount-uniqueness-validation.md
@@ -18,6 +18,8 @@ Two issues exist:
 
 Scope: uniqueness is **per `carbon_report_module_id`** (same unit + year). The same SCIPER across different units/years is allowed (by design).
 
+> **Amended by [#1564](1564-headcount-duplicate-member-multiple-roles.md):** uniqueness is per `carbon_report_module_id` **and per `sius_code`** — a member can legitimately hold two roles (different `sius_code`) in the same unit, so the key is `(user_institutional_id, sius_code)`, not `user_institutional_id` alone. See that plan for the composite-key fix and the downstream Professional Travel join fix it required.
+
 ---
 
 ## Part 1 — Backend: Uniqueness Validation on Create
@@ -118,6 +120,8 @@ Two issues exist:
 2. **Generic label**: the field shows "Institutional ID" but EPFL calls it "SCIPER". The label should be institution-configurable by a dev.
 
 Scope: uniqueness is **per `carbon_report_module_id`** (same unit + year). The same SCIPER across different units/years is allowed (by design).
+
+> **Amended by [#1564](1564-headcount-duplicate-member-multiple-roles.md):** uniqueness is per `carbon_report_module_id` **and per `sius_code`** — a member can legitimately hold two roles (different `sius_code`) in the same unit, so the key is `(user_institutional_id, sius_code)`, not `user_institutional_id` alone. See that plan for the composite-key fix and the downstream Professional Travel join fix it required.
 
 ---
 


### PR DESCRIPTION
Part of #1564.

Implementation plan: `docs/src/implementation-plans/1564-headcount-duplicate-member-multiple-roles.md`

Amends the uniqueness rule shipped in #518 (`docs/src/implementation-plans/518-headcount-uniqueness-validation.md`) to a composite `(user_institutional_id, sius_code)` key.

_Branch scaffold only — plan not yet implemented._
