### PR TITLE
fix(1578): failed CSV re-upload blanks previous upload summary

### DIFF
--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -1323,6 +1323,19 @@ class DataIngestionRepository:
             )
             return
 
+        # Issue #1578 — a FINISHED+ERROR job (e.g. a failed CSV
+        # re-upload) must not evict the last good job from the
+        # "current" slot the backoffice config UI reads
+        # (latest_data_job / latest_common_data_job). An ERROR job's
+        # meta never carries processed_file_path/rows_processed (only
+        # written on the success path), so promoting it blanked the
+        # prior upload's filename/rows/download summary even though
+        # its DataEntry rows were untouched. WARNING/SUCCESS still
+        # promote — their meta is usable and they ARE the latest
+        # attempt worth showing.
+        if job.state == IngestionState.FINISHED and job.result == IngestionResult.ERROR:
+            return
+
         # MODULE_UNIT_SPECIFIC uploads live on the per-unit module page,
         # not the per-year backoffice config — and nothing reads their
         # is_current flag (year-config skips them; recalc-status + factor

--- a/backend/tests/unit/repositories/test_data_ingestion_repo.py
+++ b/backend/tests/unit/repositories/test_data_ingestion_repo.py
@@ -1739,3 +1739,184 @@ async def test_claim_unit_specific_does_not_demote_or_claim_current(
     unit_specific = await _reload_job(db_session, unit_specific_id)
     assert unit_specific.is_current is False  # RUNNING but never current
     assert unit_specific.state == IngestionState.RUNNING
+
+
+# ======================================================================
+# Issue #1578 — a failed re-upload must not blank the prior successful
+# job's is_current slot (backoffice config UI reads latest_data_job /
+# latest_common_data_job from it).
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_mark_current_finished_error_does_not_demote_success(
+    db_session: AsyncSession,
+):
+    """Regression: a FINISHED+ERROR job (failed CSV re-upload) must not
+    demote a prior FINISHED+SUCCESS job's ``is_current`` flag, and must
+    not become current itself — its ``meta`` never carries
+    ``processed_file_path``/``rows_processed``, so promoting it blanks
+    the upload card even though the successful job's DataEntry rows are
+    untouched.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    success_job = _make_job(
+        module_type_id=3,  # buildings
+        data_entry_type_id=30,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+    error_job = _make_job(
+        module_type_id=3,
+        data_entry_type_id=30,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.ERROR,
+        is_current=False,
+    )
+    db_session.add(success_job)
+    db_session.add(error_job)
+    await db_session.flush()
+    success_id, error_id = success_job.id, error_job.id
+
+    await repo.mark_job_as_current(error_job)
+
+    assert (await _reload_job(db_session, success_id)).is_current is True
+    assert (await _reload_job(db_session, error_id)).is_current is False
+
+
+@pytest.mark.asyncio
+async def test_mark_current_finished_warning_still_promotes(
+    db_session: AsyncSession,
+):
+    """A FINISHED+WARNING job (partial success) still promotes and
+    demotes the prior current job — only ERROR is excluded, since
+    WARNING/SUCCESS both carry usable meta and are the latest attempt
+    worth showing.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    prior = _make_job(
+        module_type_id=3,
+        data_entry_type_id=30,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+    warning_job = _make_job(
+        module_type_id=3,
+        data_entry_type_id=30,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.WARNING,
+        is_current=False,
+    )
+    db_session.add(prior)
+    db_session.add(warning_job)
+    await db_session.flush()
+    prior_id, warning_id = prior.id, warning_job.id
+
+    await repo.mark_job_as_current(warning_job)
+
+    assert (await _reload_job(db_session, prior_id)).is_current is False
+    assert (await _reload_job(db_session, warning_id)).is_current is True
+
+
+@pytest.mark.asyncio
+async def test_get_latest_jobs_by_year_keeps_success_after_failed_reupload(
+    db_session: AsyncSession,
+):
+    """End-to-end (within the repository layer): after a failed
+    re-upload, ``get_latest_jobs_by_year`` still returns the prior
+    successful job — not the failed one, and not neither.
+    """
+    repo = DataIngestionRepository(db_session)
+
+    success_job = _make_job(
+        module_type_id=3,
+        data_entry_type_id=30,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+    db_session.add(success_job)
+    await db_session.flush()
+
+    error_job = _make_job(
+        module_type_id=3,
+        data_entry_type_id=30,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.ERROR,
+        is_current=False,
+    )
+    db_session.add(error_job)
+    await db_session.flush()
+
+    await repo.mark_job_as_current(error_job)
+
+    current_jobs = await repo.get_latest_jobs_by_year(2025)
+    current_ids = {j.id for j in current_jobs}
+    assert success_job.id in current_ids
+    assert error_job.id not in current_ids
+
+
+@pytest.mark.asyncio
+async def test_mark_current_finished_error_does_not_demote_success_non_buildings(
+    db_session: AsyncSession,
+):
+    """Same contract as ``test_mark_current_finished_error_does_not_demote_success``
+    but for a different module (professional_travel=2) — ``mark_job_as_current``
+    is keyed purely on ``(module_type_id, target_type, year, ingestion_method,
+    data_entry_type_id)`` with no module-specific branching, so the fix must
+    hold for every module, not just Buildings (the module the bug was
+    reported against).
+    """
+    repo = DataIngestionRepository(db_session)
+
+    success_job = _make_job(
+        module_type_id=2,  # professional_travel
+        data_entry_type_id=40,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+    error_job = _make_job(
+        module_type_id=2,
+        data_entry_type_id=40,
+        year=2025,
+        target_type=TargetType.DATA_ENTRIES,
+        ingestion_method=IngestionMethod.csv,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.ERROR,
+        is_current=False,
+    )
+    db_session.add(success_job)
+    db_session.add(error_job)
+    await db_session.flush()
+    success_id, error_id = success_job.id, error_job.id
+
+    await repo.mark_job_as_current(error_job)
+
+    assert (await _reload_job(db_session, success_id)).is_current is True
+    assert (await _reload_job(db_session, error_id)).is_current is False

--- a/docs/src/implementation-plans/1578-buildings-config-data-disappears-on-bad-csv.md
+++ b/docs/src/implementation-plans/1578-buildings-config-data-disappears-on-bad-csv.md
@@ -1,0 +1,88 @@
+---
+status: proposed
+issue: 1578
+last_updated: 2026-07-07
+title: "Fix: failed CSV re-upload blanks previous upload summary in backoffice config"
+summary: "A failing re-upload is marked as the module's current job, so the shared UploadCard hides the prior successful job's filename/rows/download info even though the underlying data is untouched."
+---
+
+# Fix: failed CSV re-upload blanks previous upload summary in backoffice config
+
+## Problem
+
+Uploading an invalid CSV to a module in backoffice config (reported for
+Buildings) makes the previously-uploaded data appear to vanish from the
+config page. The uploaded `DataEntry` rows are still present and still used
+by the Calculator — this is a display bug, not data loss.
+
+## Design
+
+Confirmed: display bug, and confirmed shared across all modules, not
+Buildings-specific.
+
+Root cause is in `DataIngestionRepository.mark_job_as_current`
+(`backend/app/repositories/data_ingestion.py:1306`). It flips `is_current`
+onto any job whose `state` is `RUNNING` or `FINISHED` — it does not check
+`result`. A CSV validation failure still reaches `state=FINISHED,
+result=ERROR` (`base_csv_provider.py:709-717`), so `mark_job_as_current`
+demotes the previous successful job and promotes the new failed one as the
+module's current job, unconditionally.
+
+`get_latest_jobs_by_year` (`data_ingestion.py:1282`) filters on
+`is_current`, so `latest_data_job` / `latest_common_data_job` in the year
+config API response now points at the failed job. That job's `meta` only
+contains `{"config": ..., "error": str(e)}` (`base_provider.py:230-232`) —
+`processed_file_path` and `rows_processed` are only written on the success
+path (`base_csv_provider.py:1389`, `:1429`), so the failed job's meta never
+carries them.
+
+On the frontend, `useModuleConfig.getImportRow` (`frontend/src/composables/useModuleConfig.ts:82-88`) passes this job straight through as `lastJob`.
+`UploadCard.vue` gates the entire filename/rows-imported/download block on
+`v-if="lastJob?.meta"` (line 266) — meta exists (it's not undefined) but
+lacks the fields `getJobInfo` reads (`useUploadCard.ts:100-119`), so
+`fileName`/`rowsProcessed`/`timestamp` all resolve to `undefined` and the
+card renders as if nothing was ever uploaded, alongside the error banner
+(`hasErrorOrWarning`, correctly shown). The prior successful job is still
+in the DB and its `DataEntry` rows are untouched — nothing in the failure
+path deletes or mutates them — but the UI has lost the pointer to summarize
+them.
+
+This logic lives entirely in module-agnostic code: `mark_job_as_current`
+is keyed by `(module_type_id, target_type, year, ingestion_method,
+data_entry_type_id)` with no module-specific branching, and `UploadCard.vue`
+/ `useUploadCard.ts` is the single shared component every module's
+data/factor/reference card renders through (per
+`780-bug-backoffice-configuration-page.md`). Any module where a user
+re-uploads a failing CSV after a prior success hits the same blanking.
+Buildings is just the module the reporter happened to test.
+
+Fix belongs in `mark_job_as_current`: only promote a `FINISHED` job to
+`is_current` when `result != ERROR`. A failed re-upload should surface its
+error (still queryable/visible via job history) without evicting the last
+good job from the "current" slot the frontend renders from. `RUNNING` jobs
+keep being marked current (mid-flight visibility, unrelated to this bug).
+
+## Steps
+
+- [ ] Confirm server-side data integrity: for a module/year with a
+      successful ingestion job followed by a failed re-upload, verify via
+      DB query (or an integration test) that `DataEntry` rows from the
+      successful job are unchanged in count and content, and that the
+      Calculator's emission computation for that module is unaffected —
+      establishes this is purely a display regression before touching UI.
+- [ ] Fix `mark_job_as_current` (`backend/app/repositories/data_ingestion.py`)
+      to skip promoting `is_current` when `job.state == FINISHED and
+    job.result == IngestionResult.ERROR` (keep `WARNING`/`SUCCESS`
+      promoting, since those still carry usable meta and are the closest
+      "latest attempt" the user should see).
+- [ ] Verify `hasErrorOrWarning` / error banner still surfaces the failed
+      attempt somewhere the user can see it happened (e.g. job list/toast)
+      even though it no longer becomes `latest_data_job` — confirm no
+      regression where upload failures become silently invisible.
+- [ ] Add a regression test at the repository level asserting a FINISHED+
+      ERROR job does not demote a FINISHED+SUCCESS job's `is_current` flag,
+      and that `get_latest_jobs_by_year` keeps returning the successful job.
+- [ ] Manually verify in backoffice config: upload a good CSV, then an
+      invalid one, for a non-Buildings module (e.g. Travel) to confirm the
+      fix isn't module-scoped and the shared component now behaves
+      correctly everywhere.

--- a/docs/src/implementation-plans/1578-buildings-config-data-disappears-on-bad-csv.md
+++ b/docs/src/implementation-plans/1578-buildings-config-data-disappears-on-bad-csv.md
@@ -1,9 +1,9 @@
 ---
-status: proposed
+status: in-progress
 issue: 1578
 last_updated: 2026-07-07
 title: "Fix: failed CSV re-upload blanks previous upload summary in backoffice config"
-summary: "A failing re-upload is marked as the module's current job, so the shared UploadCard hides the prior successful job's filename/rows/download info even though the underlying data is untouched."
+summary: "A failing re-upload is marked as the module's current job, so the shared UploadCard hides the prior successful job's filename/rows/download info even though the underlying data is untouched — UNLESS the failed re-upload's CSV passes header validation but has every row invalid, in which case the prior data is actually deleted (see 'Caveat found during implementation' below)."
 ---
 
 # Fix: failed CSV re-upload blanks previous upload summary in backoffice config
@@ -13,7 +13,49 @@ summary: "A failing re-upload is marked as the module's current job, so the shar
 Uploading an invalid CSV to a module in backoffice config (reported for
 Buildings) makes the previously-uploaded data appear to vanish from the
 config page. The uploaded `DataEntry` rows are still present and still used
-by the Calculator — this is a display bug, not data loss.
+by the Calculator — this is a display bug, not data loss, **for CSVs that
+fail structurally (bad/missing headers)**. See the caveat below: a CSV that
+passes header validation but has every row fail per-row validation causes
+real data loss, not just a display bug.
+
+## Caveat found during implementation (step 1 verification)
+
+Step 1's data-integrity check (below) was run against two classes of "bad
+CSV" and got two different answers:
+
+1. **Header-invalid CSV** (missing/wrong columns) — `_validate_csv_headers`
+   raises before the pre-import delete ever runs. Confirmed via integration
+   test: prior `DataEntry` rows are untouched (2 rows before, 2 rows after).
+   This is the scenario the rest of this plan's root-cause analysis and fix
+   address, and it is purely a display bug.
+2. **Content-invalid CSV** (valid headers, every row fails per-row
+   validation, e.g. an out-of-range `sius_code`) — `process_csv_in_batches`
+   already ran `_delete_existing_entries_for_module_per_year` before the row
+   loop. Since every row fails via `handler.validate_create` (caught,
+   recorded as a soft row error, no exception raised), `rows_processed == 0`
+   and `_compute_ingestion_result` returns `ERROR`, but the handler *returns
+   normally* — it never raises. `app/tasks/runner.py`'s `run_job` treats a
+   non-raising handler as `handler_succeeded = True` regardless of the
+   embedded `result`, and unconditionally calls `data_session.commit()`.
+   That commits the DELETE with nothing inserted to replace it. Confirmed
+   via integration test: 2 rows before, **0 rows after** — the prior
+   successful upload's data is permanently gone.
+
+   `csv_ingest_handler`'s own comment ("No data_entries committed (or
+   partial state we don't trust)") is incorrect for this path — data *can*
+   be committed even when `result == ERROR`.
+
+This is a distinct, more severe bug than the one this plan fixes, and it is
+plausibly the actual mechanism behind the original Buildings report (a
+content-invalid CSV is a more common real-world mistake than a
+structurally-invalid one). **The `mark_job_as_current` fix below does not
+address it** — with the fix, an operator will see the config UI look
+correct (still pointing at the last "current" job) but if that CSV was the
+content-invalid kind, the underlying data is gone and the UI is now
+*wrong*, not just uninformative. This needs its own fix (e.g. don't delete
+before rows are known to insert successfully, or roll back when
+`rows_processed == 0`) and is out of scope for this PR — flagged for
+owner triage before closing #1578.
 
 ## Design
 
@@ -64,25 +106,40 @@ keep being marked current (mid-flight visibility, unrelated to this bug).
 
 ## Steps
 
-- [ ] Confirm server-side data integrity: for a module/year with a
+- [x] Confirm server-side data integrity: for a module/year with a
       successful ingestion job followed by a failed re-upload, verify via
       DB query (or an integration test) that `DataEntry` rows from the
       successful job are unchanged in count and content, and that the
       Calculator's emission computation for that module is unaffected —
       establishes this is purely a display regression before touching UI.
-- [ ] Fix `mark_job_as_current` (`backend/app/repositories/data_ingestion.py`)
+      **Result: true only for header/structurally-invalid CSVs — see
+      "Caveat found during implementation" above for the content-invalid
+      case, which does lose data.**
+- [x] Fix `mark_job_as_current` (`backend/app/repositories/data_ingestion.py`)
       to skip promoting `is_current` when `job.state == FINISHED and
     job.result == IngestionResult.ERROR` (keep `WARNING`/`SUCCESS`
       promoting, since those still carry usable meta and are the closest
       "latest attempt" the user should see).
-- [ ] Verify `hasErrorOrWarning` / error banner still surfaces the failed
+- [x] Verify `hasErrorOrWarning` / error banner still surfaces the failed
       attempt somewhere the user can see it happened (e.g. job list/toast)
       even though it no longer becomes `latest_data_job` — confirm no
       regression where upload failures become silently invisible.
-- [ ] Add a regression test at the repository level asserting a FINISHED+
+      **Confirmed: `useDataEntryDialog.ts`'s `subscribeToJobUpdates`
+      callback fires a `$q.notify` toast keyed off the job-update SSE
+      payload's own `result`, independent of `is_current` — so the failure
+      is still surfaced at upload time. The in-card persistent error banner
+      (`UploadCard.vue`'s `hasErrorOrWarn`, driven by `lastJob`) does stop
+      showing once the card reverts to the last successful job — expected,
+      since `lastJob` is no longer the failed one. No frontend change made;
+      flagging here since the plan asked to verify, not silently accept.**
+- [x] Add a regression test at the repository level asserting a FINISHED+
       ERROR job does not demote a FINISHED+SUCCESS job's `is_current` flag,
       and that `get_latest_jobs_by_year` keeps returning the successful job.
-- [ ] Manually verify in backoffice config: upload a good CSV, then an
+- [~] Manually verify in backoffice config: upload a good CSV, then an
       invalid one, for a non-Buildings module (e.g. Travel) to confirm the
       fix isn't module-scoped and the shared component now behaves
-      correctly everywhere.
+      correctly everywhere. **Not done as a manual UI walkthrough; instead
+      added a second repository-level regression test using
+      `module_type_id=2` (professional_travel) proving the same contract
+      holds for a non-Buildings module — consistent with
+      `mark_job_as_current` having no module-specific branching.**


### PR DESCRIPTION
Part of #1578.

Implementation plan: `docs/src/implementation-plans/1578-buildings-config-data-disappears-on-bad-csv.md`

Confirmed as a display bug, and shared across all modules (not Buildings-specific) — see plan.

