### PR TITLE
refactor(1713): explicit ROLE_PROVIDER_TYPE/UNIT_PROVIDER_TYPE config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -106,17 +106,24 @@ TABLEAU_MAX_FIELDS=50
 
 
 ## -------------------------------------------------------------
-# ROLE PROVIDERS Configuration PLUGIN)
+# ROLE / UNIT PROVIDER Configuration
 ## -------------------------------------------------------------
-# Could be 'default' or 'accred' or 'test' (for testing/development)
-PROVIDER_PLUGIN=default
-## If 'accred' is chosen, additional settings are required:
-# ACCRED_API_URL=https://accred.example.com/api
+# ROLE_PROVIDER_TYPE selects where app roles come from: 'jwt' (parse from
+# JWT claims), 'accred' (EPFL Accred API), or 'test' (for testing/dev).
+# UNIT_PROVIDER_TYPE selects where institutional units come from:
+# 'database' (local DB), 'accred' (EPFL Accred API), or 'test'.
+# Both are required — no default, invalid/missing values fail at startup.
+ROLE_PROVIDER_TYPE=jwt
+UNIT_PROVIDER_TYPE=database
+## ACCRED_* config is the shared Accred API integration used by both
+## providers above — required whenever either ROLE_PROVIDER_TYPE or
+## UNIT_PROVIDER_TYPE is 'accred':
+# ACCRED_API_BASE_URL=https://accred.example.com/api
 # ACCRED_API_KEY=your-accred-api-key
 # ACCRED_API_USERNAME=your-accred-username
 ## we want to check the health of Accred API, and that it returns one of our expected authorizations
 ## could be health endpoint or direct authorizations check (it is here to check if we're autenticated and authorized)
-# ACCRED_API_HEALTH_URL=https://accred.example.com/api/authorizations?type=right&authid=co2.superadmin
+# ACCRED_AUTHORIZATION_HEALTHCHECK_URL=https://accred.example.com/api/authorizations?type=right&authid=co2.superadmin
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,12 +1,27 @@
 """Application configuration using Pydantic settings."""
 
+from enum import Enum
 from functools import lru_cache
 from typing import Optional
 
-from pydantic import Field, computed_field, field_validator
+from pydantic import Field, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from app.models.user import UserProvider
+
+class RoleProviderType(str, Enum):
+    """Backend implementation selection for where app roles come from."""
+
+    JWT = "jwt"
+    ACCRED = "accred"
+    TEST = "test"
+
+
+class UnitProviderType(str, Enum):
+    """Backend implementation selection for where institutional units come from."""
+
+    DATABASE = "database"
+    ACCRED = "accred"
+    TEST = "test"
 
 
 class Settings(BaseSettings):
@@ -163,41 +178,27 @@ class Settings(BaseSettings):
     TABLEAU_REST_MIN_API_VERSION: str = "2.4"
     TABLEAU_MAX_FIELDS: int = 50
 
-    # Role Provider Plugin Configuration
-    PROVIDER_PLUGIN: UserProvider = Field(
-        default=UserProvider.DEFAULT,
+    # Role/Unit provider selection — where do app roles / institutional units
+    # come from. No default: invalid or missing config fails at startup
+    # rather than silently picking a provider.
+    ROLE_PROVIDER_TYPE: RoleProviderType = Field(
         description=(
-            "Role provider plugin to use for fetching user roles. "
-            "Options:"
-            "   'default' (parse from JWT claims)"
-            "   'accred' (EPFL Accred API)."
-            "   'test' (for testing/development)."
-            "The 'default' provider expects roles in JWT claims as flat strings like "
-            "'co2.user.std@unit:12345'. The 'accred' provider calls the EPFL Accred API"
-            "to fetch authorizations and maps them to roles based on accredunitid."
+            "Where app roles come from: 'jwt' (parse from JWT claims), "
+            "'accred' (EPFL Accred API), or 'test' (for testing/development)."
+        ),
+    )
+    UNIT_PROVIDER_TYPE: UnitProviderType = Field(
+        description=(
+            "Where institutional units come from: 'database' (local DB), "
+            "'accred' (EPFL Accred API), or 'test' (for testing/development)."
         ),
     )
 
-    @field_validator("PROVIDER_PLUGIN", mode="before")
-    @classmethod
-    def provider_plugin_coerce(cls, v):
-        if isinstance(v, UserProvider):
-            return v
-        if isinstance(v, int):
-            return UserProvider(v)
-        if isinstance(v, str):
-            try:
-                return UserProvider[v.upper()]
-            except KeyError:
-                # Try by value
-                for member in UserProvider:
-                    if member.name == v.upper() or str(member.value) == v:
-                        return member
-                raise ValueError(f"Invalid provider: {v}")
-        raise ValueError(f"Invalid provider: {v}")
-
-    # EPFL Accred API Configuration (for 'accred' role provider)
-    ACCRED_API_URL: Optional[str] = Field(
+    # EPFL Accred API Configuration — required whenever ROLE_PROVIDER_TYPE
+    # and/or UNIT_PROVIDER_TYPE is 'accred' (see validate_accred_config).
+    # Shared by both RoleProvider and UnitProvider — Accred is one API
+    # serving both concerns, so the config is not role- or unit-specific.
+    ACCRED_API_BASE_URL: Optional[str] = Field(
         default=None,
         description="EPFL Accred API base URL (e.g., https://api.epfl.ch/v1/accreds)",
     )
@@ -209,10 +210,36 @@ class Settings(BaseSettings):
         default=None,
         description="EPFL Accred API key/password for Basic Auth",
     )
-    ACCRED_API_HEALTH_URL: Optional[str] = Field(
+    ACCRED_AUTHORIZATION_HEALTHCHECK_URL: Optional[str] = Field(
         default=None,
-        description="EPFL Accred API health check URL",
+        description=(
+            "Accred authorization-readiness check URL for /ready — confirms "
+            "backend credentials can reach Accred and read the expected "
+            "authorization data. Not a generic API health URL."
+        ),
     )
+
+    @model_validator(mode="after")
+    def validate_accred_config(self) -> "Settings":
+        """Require Accred credentials whenever a provider selects Accred.
+
+        No fallback: missing config fails Settings construction at startup.
+        """
+        uses_accred = (
+            self.ROLE_PROVIDER_TYPE == RoleProviderType.ACCRED
+            or self.UNIT_PROVIDER_TYPE == UnitProviderType.ACCRED
+        )
+        if not uses_accred:
+            return self
+
+        missing = [
+            name
+            for name in ("ACCRED_API_BASE_URL", "ACCRED_API_USERNAME", "ACCRED_API_KEY")
+            if getattr(self, name) is None
+        ]
+        if missing:
+            raise ValueError("Missing required Accred config: " + ", ".join(missing))
+        return self
 
     # OAuth/OIDC Configuration (supports Keycloak, Entra ID, or other OIDC providers)
     OAUTH_CLIENT_ID: Optional[str] = Field(
@@ -450,4 +477,8 @@ class Settings(BaseSettings):
 @lru_cache()
 def get_settings() -> Settings:
     """Get cached settings instance."""
-    return Settings()
+    # ROLE_PROVIDER_TYPE/UNIT_PROVIDER_TYPE have no default (intentional —
+    # missing config must fail startup) so mypy sees them as required
+    # constructor args; pydantic-settings actually sources them from the
+    # environment/.env file at runtime.
+    return Settings()  # type: ignore[call-arg]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.api.router import api_router
-from app.core.config import get_settings
+from app.core.config import RoleProviderType, UnitProviderType, get_settings
 from app.core.exception_handlers import permission_denied_handler
 from app.core.exceptions import (
     InsufficientScopeError,
@@ -328,15 +328,21 @@ async def ready():
         db_status = "error"
         details["db_error"] = str(e)
 
-    # Role provider health check
+    # Role/unit provider health check — runs whenever either provider is
+    # configured to use Accred, since ACCRED_AUTHORIZATION_HEALTHCHECK_URL
+    # covers the shared Accred integration, not one provider specifically.
     role_provider_status = "skipped"
-    if (settings.PROVIDER_PLUGIN == "accred") and settings.ACCRED_API_HEALTH_URL:
+    uses_accred = (
+        settings.ROLE_PROVIDER_TYPE == RoleProviderType.ACCRED
+        or settings.UNIT_PROVIDER_TYPE == UnitProviderType.ACCRED
+    )
+    if uses_accred and settings.ACCRED_AUTHORIZATION_HEALTHCHECK_URL:
         try:
             import httpx
 
             async with httpx.AsyncClient(timeout=2) as client:
                 resp = await client.get(
-                    settings.ACCRED_API_HEALTH_URL,
+                    settings.ACCRED_AUTHORIZATION_HEALTHCHECK_URL,
                     auth=(settings.ACCRED_API_USERNAME, settings.ACCRED_API_KEY),
                 )
                 if resp.status_code == 200:

--- a/backend/app/providers/role_provider.py
+++ b/backend/app/providers/role_provider.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 import httpx
 
-from app.core.config import get_settings
+from app.core.config import RoleProviderType, get_settings
 from app.core.logging import get_logger
 from app.models.user import (
     AffiliationScope,
@@ -108,8 +108,8 @@ class RoleProvider(ABC):
         pass
 
 
-class DefaultRoleProvider(RoleProvider):
-    """Default role provider that extracts roles from JWT claims.
+class JwtClaimsRoleProvider(RoleProvider):
+    """Role provider that extracts roles from JWT claims.
 
     Expects roles in flat string format from JWT claims:
     - "calco2.user.standard@unit:12345" →
@@ -123,7 +123,7 @@ class DefaultRoleProvider(RoleProvider):
     type: UserProvider = UserProvider.DEFAULT
 
     async def get_user_by_user_id(self, user_id: str) -> Dict[str, Any]:
-        """Not implemented for DefaultRoleProvider."""
+        """Not implemented for JwtClaimsRoleProvider."""
         # You can return an empty dict or raise an error
         return {}
 
@@ -245,7 +245,7 @@ class DefaultRoleProvider(RoleProvider):
         return parsed_roles
 
     async def get_roles_by_user_id(self, user_id: str) -> List[Role]:
-        """Not implemented for DefaultRoleProvider.
+        """Not implemented for JwtClaimsRoleProvider.
 
         Args:
             user_id: User ID of the user
@@ -253,7 +253,7 @@ class DefaultRoleProvider(RoleProvider):
             Empty list as this provider does not support fetching by user ID
         """
         logger.warning(
-            "get_roles_by_user_id not implemented for DefaultRoleProvider",
+            "get_roles_by_user_id not implemented for JwtClaimsRoleProvider",
             extra={"user_id": user_id},
         )
         return []
@@ -349,16 +349,14 @@ class AccredRoleProvider(RoleProvider):
     type: UserProvider = UserProvider.ACCRED
 
     def __init__(self):
-        """Initialize the Accred provider with API credentials."""
-        self.api_url = settings.ACCRED_API_URL
+        """Initialize the Accred provider with API credentials.
+
+        Credential completeness is enforced at startup by Settings'
+        validate_accred_config — this constructor does not re-check it.
+        """
+        self.api_url = settings.ACCRED_API_BASE_URL
         self.api_username = settings.ACCRED_API_USERNAME
         self.api_key = settings.ACCRED_API_KEY
-
-        if not all([self.api_url, self.api_username, self.api_key]):
-            logger.warning(
-                "Accred API credentials not fully configured. "
-                "Set ACCRED_API_URL, ACCRED_API_USERNAME, and ACCRED_API_KEY."
-            )
 
     def get_user_id(self, userinfo: Dict[str, Any]) -> str:
         """Get institutional ID for a user.
@@ -644,14 +642,21 @@ class AccredRoleProvider(RoleProvider):
             raise
 
 
-def get_role_provider(provider_type: UserProvider | None = None) -> RoleProvider:
+def get_role_provider(
+    provider_type: RoleProviderType | UserProvider | None = None,
+) -> RoleProvider:
     """Factory function to get the configured role provider.
 
-    Returns the appropriate role provider based on the
-    PROVIDER_PLUGIN setting.
+    Returns the appropriate role provider based on the ROLE_PROVIDER_TYPE
+    setting, unless overridden by ``provider_type``. Callers that need to
+    re-resolve roles from an entity's original source (e.g. background sync
+    reading a persisted ``User.provider``/``DataIngestionJob.provider``)
+    pass that persisted ``UserProvider`` value directly as the override.
 
     Args:
-        provider_type: Optional provider type override
+        provider_type: Optional provider type override — either a
+            ``RoleProviderType`` (config selection) or a ``UserProvider``
+            (persisted source metadata).
 
     Returns:
         RoleProvider instance
@@ -660,18 +665,20 @@ def get_role_provider(provider_type: UserProvider | None = None) -> RoleProvider
         ValueError: If an unknown provider type is configured
     """
     if provider_type is None:
-        provider_type = settings.PROVIDER_PLUGIN
+        provider_type = settings.ROLE_PROVIDER_TYPE
 
-    if provider_type == UserProvider.DEFAULT:
-        logger.info("Using DefaultRoleProvider (JWT claims)")
-        return DefaultRoleProvider()
-    elif provider_type == UserProvider.ACCRED:
-        logger.info("Using AccredRoleProvider (EPFL Accred API)")
-        return AccredRoleProvider()
-    elif provider_type == UserProvider.TEST:
-        logger.info("Using TestRoleProvider (for testing)")
-        return TestRoleProvider()
-    raise ValueError(f"Unknown role provider type: {provider_type!r}")
+    match provider_type:
+        case RoleProviderType.JWT | UserProvider.DEFAULT:
+            logger.info("Using JwtClaimsRoleProvider (JWT claims)")
+            return JwtClaimsRoleProvider()
+        case RoleProviderType.ACCRED | UserProvider.ACCRED:
+            logger.info("Using AccredRoleProvider (EPFL Accred API)")
+            return AccredRoleProvider()
+        case RoleProviderType.TEST | UserProvider.TEST:
+            logger.info("Using TestRoleProvider (for testing)")
+            return TestRoleProvider()
+        case _:
+            raise ValueError(f"Unknown role provider type: {provider_type!r}")
 
 
 class RoleProviderNetworkError(Exception):

--- a/backend/app/providers/unit_provider.py
+++ b/backend/app/providers/unit_provider.py
@@ -5,7 +5,7 @@ import httpx
 from sqlmodel import Session, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.config import get_settings
+from app.core.config import UnitProviderType, get_settings
 from app.core.logging import get_logger
 from app.models.unit import Unit
 from app.models.user import RoleName, UserProvider
@@ -68,9 +68,9 @@ class UnitProvider(ABC):
         return units[0] if units else None
 
 
-class DefaultUnitProvider(UnitProvider):
+class DatabaseUnitProvider(UnitProvider):
     type: UserProvider = UserProvider.DEFAULT
-    """Default unit provider that reads from the database."""
+    """Unit provider that reads from the database."""
 
     def __init__(self, db_session: Session | AsyncSession):
         self.db_session = db_session
@@ -98,16 +98,14 @@ class AccredUnitProvider(UnitProvider):
     """
 
     def __init__(self):
-        """Initialize the Accred provider with API credentials."""
-        self.api_url = settings.ACCRED_API_URL
+        """Initialize the Accred provider with API credentials.
+
+        Credential completeness is enforced at startup by Settings'
+        validate_accred_config — this constructor does not re-check it.
+        """
+        self.api_url = settings.ACCRED_API_BASE_URL
         self.api_username = settings.ACCRED_API_USERNAME
         self.api_key = settings.ACCRED_API_KEY
-
-        if not all([self.api_url, self.api_username, self.api_key]):
-            logger.warning(
-                "Accred API credentials not fully configured. "
-                "Set ACCRED_API_URL, ACCRED_API_USERNAME, and ACCRED_API_KEY."
-            )
 
     async def fetch_all_units(self) -> tuple[list[dict], list[dict]]:
         if not all([self.api_url, self.api_username, self.api_key]):
@@ -340,37 +338,46 @@ class TestUnitProvider(UnitProvider):
 
 
 def get_unit_provider(
-    provider_type: UserProvider | None = None,
+    provider_type: UnitProviderType | UserProvider | None = None,
     db_session: Session | AsyncSession | None = None,
 ) -> UnitProvider:
     """Factory function to get the configured unit provider.
 
+    Returns the appropriate unit provider based on the UNIT_PROVIDER_TYPE
+    setting, unless overridden by ``provider_type``. Callers that need to
+    re-resolve units from an entity's original source (e.g. background sync
+    reading a persisted ``DataIngestionJob.provider``) pass that persisted
+    ``UserProvider`` value directly as the override.
+
     Args:
-        provider_type: Optional provider type override
-        db_session: Database session for DefaultUnitProvider
+        provider_type: Optional provider type override — either a
+            ``UnitProviderType`` (config selection) or a ``UserProvider``
+            (persisted source metadata).
+        db_session: Database session for DatabaseUnitProvider
 
     Returns:
         UnitProvider instance
     """
     if provider_type is None:
-        provider_type = settings.PROVIDER_PLUGIN
+        provider_type = settings.UNIT_PROVIDER_TYPE
 
-    if provider_type == UserProvider.DEFAULT:
-        logger.info("Using DefaultUnitProvider (Database)")
-        if not db_session:
-            raise ValueError("DefaultUnitProvider requires a database session")
-        return DefaultUnitProvider(db_session)
-    elif provider_type == UserProvider.ACCRED:
-        logger.info("Using AccredUnitProvider (EPFL Accred API)")
-        return AccredUnitProvider()
-    elif provider_type == UserProvider.TEST:
-        logger.info("Using TestUnitProvider (for testing)")
-        return TestUnitProvider()
-    else:
-        logger.error(
-            "Unknown unit provider type, falling back to default",
-            extra={"provider_type": provider_type},
-        )
-        if not db_session:
-            raise ValueError("DefaultUnitProvider requires a database session")
-        return DefaultUnitProvider(db_session)
+    match provider_type:
+        case UnitProviderType.DATABASE | UserProvider.DEFAULT:
+            logger.info("Using DatabaseUnitProvider (Database)")
+            if not db_session:
+                raise ValueError("DatabaseUnitProvider requires a database session")
+            return DatabaseUnitProvider(db_session)
+        case UnitProviderType.ACCRED | UserProvider.ACCRED:
+            logger.info("Using AccredUnitProvider (EPFL Accred API)")
+            return AccredUnitProvider()
+        case UnitProviderType.TEST | UserProvider.TEST:
+            logger.info("Using TestUnitProvider (for testing)")
+            return TestUnitProvider()
+        case _:
+            logger.error(
+                "Unknown unit provider type, falling back to database",
+                extra={"provider_type": provider_type},
+            )
+            if not db_session:
+                raise ValueError("DatabaseUnitProvider requires a database session")
+            return DatabaseUnitProvider(db_session)

--- a/backend/app/tasks/unit_sync_tasks.py
+++ b/backend/app/tasks/unit_sync_tasks.py
@@ -93,7 +93,7 @@ async def unit_sync_handler(
     if job.provider == UserProvider.DEFAULT:
         raise ValueError(
             f"unit_sync job {job.id}: UserProvider.DEFAULT has no unit "
-            f"source; check PROVIDER_PLUGIN and current_user.provider"
+            f"source; check UNIT_PROVIDER_TYPE and current_user.provider"
         )
 
     # #1236 — TWO advisory locks for unit_sync, both transaction-scoped

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,6 +57,8 @@ env = [
     "FRONTEND_URL=http://test-frontend",
     "DEBUG=False",
     "ELASTICSEARCH_INDEX=opdo-test",
+    "ROLE_PROVIDER_TYPE=test",
+    "UNIT_PROVIDER_TYPE=test",
 
 ]
 

--- a/backend/tests/integration/providers/test_role_provider_config.py
+++ b/backend/tests/integration/providers/test_role_provider_config.py
@@ -2,7 +2,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from app.models.user import Role, RoleName, UserProvider
+from app.core.config import RoleProviderType
+from app.models.user import Role, RoleName
 from app.providers.role_provider import get_role_provider
 
 # ============================================================================
@@ -14,10 +15,10 @@ class TestRoleProviderIntegration:
     """Integration tests for role provider system."""
 
     @pytest.mark.asyncio
-    async def test_default_provider_full_workflow(self):
-        """Test complete workflow with DefaultRoleProvider."""
+    async def test_jwt_provider_full_workflow(self):
+        """Test complete workflow with JwtClaimsRoleProvider."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.PROVIDER_PLUGIN = UserProvider.DEFAULT
+            mock_settings.ROLE_PROVIDER_TYPE = RoleProviderType.JWT
 
             provider = get_role_provider()
             userinfo = {
@@ -38,8 +39,8 @@ class TestRoleProviderIntegration:
     async def test_accred_provider_full_workflow(self):
         """Test complete workflow with AccredRoleProvider."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.PROVIDER_PLUGIN = UserProvider.ACCRED
-            mock_settings.ACCRED_API_URL = "https://api-test.epfl.ch"
+            mock_settings.ROLE_PROVIDER_TYPE = RoleProviderType.ACCRED
+            mock_settings.ACCRED_API_BASE_URL = "https://api-test.epfl.ch"
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
 

--- a/backend/tests/integration/test_main.py
+++ b/backend/tests/integration/test_main.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import app.main as main
+from app.core.config import RoleProviderType, UnitProviderType
 
 client = TestClient(main.app)
 
@@ -41,7 +42,8 @@ async def test_ready_db_ok(monkeypatch):
             return None
 
     monkeypatch.setattr("app.db.get_db_session", AsyncMock(return_value=DummySession()))
-    monkeypatch.setattr(main.settings, "PROVIDER_PLUGIN", "other")
+    monkeypatch.setattr(main.settings, "ROLE_PROVIDER_TYPE", RoleProviderType.JWT)
+    monkeypatch.setattr(main.settings, "UNIT_PROVIDER_TYPE", UnitProviderType.DATABASE)
     resp = await main.ready()
     assert resp.status_code == 200
     assert resp.body
@@ -55,7 +57,8 @@ async def test_ready_db_error(monkeypatch):
         raise Exception("db fail")
 
     monkeypatch.setattr("app.db.get_db_session", raise_exc)
-    monkeypatch.setattr(main.settings, "PROVIDER_PLUGIN", "other")
+    monkeypatch.setattr(main.settings, "ROLE_PROVIDER_TYPE", RoleProviderType.JWT)
+    monkeypatch.setattr(main.settings, "UNIT_PROVIDER_TYPE", UnitProviderType.DATABASE)
     resp = await main.ready()
     assert resp.status_code == 503
     assert b"unhealthy" in resp.body
@@ -63,16 +66,17 @@ async def test_ready_db_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ready_role_provider_skipped(monkeypatch):
-    # PROVIDER_PLUGIN != "accred"
+    # neither ROLE_PROVIDER_TYPE nor UNIT_PROVIDER_TYPE is "accred"
     monkeypatch.setattr("app.db.get_db_session", AsyncMock())
-    monkeypatch.setattr(main.settings, "PROVIDER_PLUGIN", "other")
+    monkeypatch.setattr(main.settings, "ROLE_PROVIDER_TYPE", RoleProviderType.JWT)
+    monkeypatch.setattr(main.settings, "UNIT_PROVIDER_TYPE", UnitProviderType.DATABASE)
     resp = await main.ready()
     assert b"skipped" in resp.body
 
 
 @pytest.mark.asyncio
 async def test_ready_role_provider_ok(monkeypatch):
-    # PROVIDER_PLUGIN == "accred" and health returns 200
+    # ROLE_PROVIDER_TYPE == "accred" and health returns 200
     class DummySession:
         async def __aenter__(self):
             return self
@@ -84,8 +88,11 @@ async def test_ready_role_provider_ok(monkeypatch):
             return None
 
     monkeypatch.setattr("app.db.get_db_session", AsyncMock(return_value=DummySession()))
-    monkeypatch.setattr(main.settings, "PROVIDER_PLUGIN", "accred")
-    monkeypatch.setattr(main.settings, "ACCRED_API_HEALTH_URL", "http://fake")
+    monkeypatch.setattr(main.settings, "ROLE_PROVIDER_TYPE", RoleProviderType.ACCRED)
+    monkeypatch.setattr(main.settings, "UNIT_PROVIDER_TYPE", UnitProviderType.DATABASE)
+    monkeypatch.setattr(
+        main.settings, "ACCRED_AUTHORIZATION_HEALTHCHECK_URL", "http://fake"
+    )
     monkeypatch.setattr(main.settings, "ACCRED_API_USERNAME", "u")
     monkeypatch.setattr(main.settings, "ACCRED_API_KEY", "k")
 
@@ -101,7 +108,7 @@ async def test_ready_role_provider_ok(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ready_role_provider_error(monkeypatch):
-    # PROVIDER_PLUGIN == "accred" and health raises error
+    # ROLE_PROVIDER_TYPE == "accred" and health raises error
     class DummySession:
         async def __aenter__(self):
             return self
@@ -113,8 +120,11 @@ async def test_ready_role_provider_error(monkeypatch):
             return None
 
     monkeypatch.setattr("app.db.get_db_session", AsyncMock(return_value=DummySession()))
-    monkeypatch.setattr(main.settings, "PROVIDER_PLUGIN", "accred")
-    monkeypatch.setattr(main.settings, "ACCRED_API_HEALTH_URL", "http://fake")
+    monkeypatch.setattr(main.settings, "ROLE_PROVIDER_TYPE", RoleProviderType.ACCRED)
+    monkeypatch.setattr(main.settings, "UNIT_PROVIDER_TYPE", UnitProviderType.DATABASE)
+    monkeypatch.setattr(
+        main.settings, "ACCRED_AUTHORIZATION_HEALTHCHECK_URL", "http://fake"
+    )
     monkeypatch.setattr(main.settings, "ACCRED_API_USERNAME", "u")
     monkeypatch.setattr(main.settings, "ACCRED_API_KEY", "k")
 

--- a/backend/tests/unit/core/test_config_provider_types.py
+++ b/backend/tests/unit/core/test_config_provider_types.py
@@ -1,0 +1,90 @@
+"""Regression tests for Settings' role/unit provider type config (#1713).
+
+ROLE_PROVIDER_TYPE and UNIT_PROVIDER_TYPE replace the old, overloaded
+PROVIDER_PLUGIN env var. Both are required with no default — missing or
+invalid config must fail Settings construction at startup, not silently
+fall back. Selecting 'accred' on either requires all three
+ACCRED_API_* vars (see Settings.validate_accred_config).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import RoleProviderType, Settings, UnitProviderType
+
+
+def test_missing_role_provider_type_fails_startup(monkeypatch):
+    monkeypatch.delenv("ROLE_PROVIDER_TYPE", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(UNIT_PROVIDER_TYPE=UnitProviderType.TEST)
+
+
+def test_missing_unit_provider_type_fails_startup(monkeypatch):
+    monkeypatch.delenv("UNIT_PROVIDER_TYPE", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(ROLE_PROVIDER_TYPE=RoleProviderType.JWT)
+
+
+def test_invalid_role_provider_type_fails_startup():
+    with pytest.raises(ValidationError):
+        Settings(ROLE_PROVIDER_TYPE="bogus", UNIT_PROVIDER_TYPE=UnitProviderType.TEST)
+
+
+def test_invalid_unit_provider_type_fails_startup():
+    with pytest.raises(ValidationError):
+        Settings(ROLE_PROVIDER_TYPE=RoleProviderType.JWT, UNIT_PROVIDER_TYPE="bogus")
+
+
+def test_jwt_and_database_do_not_require_accred_config():
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.JWT,
+        UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
+    )
+    assert settings.ACCRED_API_BASE_URL is None
+
+
+def test_test_provider_types_do_not_require_accred_config():
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.TEST,
+        UNIT_PROVIDER_TYPE=UnitProviderType.TEST,
+    )
+    assert settings.ACCRED_API_BASE_URL is None
+
+
+def test_accred_role_provider_requires_all_three_accred_vars():
+    with pytest.raises(ValidationError, match="Missing required Accred config"):
+        Settings(
+            ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
+            UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
+        )
+
+
+def test_accred_unit_provider_requires_all_three_accred_vars():
+    with pytest.raises(ValidationError, match="Missing required Accred config"):
+        Settings(
+            ROLE_PROVIDER_TYPE=RoleProviderType.JWT,
+            UNIT_PROVIDER_TYPE=UnitProviderType.ACCRED,
+        )
+
+
+def test_accred_error_lists_missing_vars_only():
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
+            UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
+            ACCRED_API_USERNAME="user",
+        )
+    message = str(exc_info.value)
+    assert "ACCRED_API_BASE_URL" in message
+    assert "ACCRED_API_KEY" in message
+
+
+def test_accred_provider_succeeds_with_all_three_vars():
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
+        UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
+        ACCRED_API_BASE_URL="https://accred.example.com",
+        ACCRED_API_USERNAME="user",
+        ACCRED_API_KEY="key",
+    )
+    assert settings.ACCRED_API_BASE_URL == "https://accred.example.com"

--- a/backend/tests/unit/providers/test_role_provider.py
+++ b/backend/tests/unit/providers/test_role_provider.py
@@ -1,6 +1,6 @@
 """Unit and integration tests for role provider plugin system.
 
-Tests cover both DefaultRoleProvider and AccredRoleProvider with 100% coverage.
+Tests cover both JwtClaimsRoleProvider and AccredRoleProvider with 100% coverage.
 """
 
 from typing import Any, Dict
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
+from app.core.config import RoleProviderType
 from app.models.user import (
     AffiliationScope,
     GlobalScope,
@@ -20,7 +21,8 @@ from app.models.user import (
 )
 from app.providers.role_provider import (
     AccredRoleProvider,
-    DefaultRoleProvider,
+    JwtClaimsRoleProvider,
+    TestRoleProvider,
     get_role_provider,
 )
 
@@ -33,10 +35,10 @@ from app.providers.role_provider import (
 def mock_settings():
     """Fixture providing mock settings."""
     settings = Mock()
-    settings.ACCRED_API_URL = "https://api.epfl.ch"
+    settings.ACCRED_API_BASE_URL = "https://api.epfl.ch"
     settings.ACCRED_API_USERNAME = "test_user"
     settings.ACCRED_API_KEY = "test_key"
-    settings.PROVIDER_PLUGIN = "default"
+    settings.ROLE_PROVIDER_TYPE = RoleProviderType.JWT
     return settings
 
 
@@ -67,17 +69,17 @@ def sample_user_id() -> int:
 
 
 # ============================================================================
-# DefaultRoleProvider Tests
+# JwtClaimsRoleProvider Tests
 # ============================================================================
 
 
-class TestDefaultRoleProvider:
-    """Test suite for DefaultRoleProvider."""
+class TestJwtClaimsRoleProvider:
+    """Test suite for JwtClaimsRoleProvider."""
 
     @pytest.mark.asyncio
     async def test_parse_roles_with_unit_scope(self, sample_userinfo, sample_user_id):
         """Test parsing roles with unit scope."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(sample_userinfo)
 
         assert len(roles) == 3
@@ -96,7 +98,7 @@ class TestDefaultRoleProvider:
             "email": "admin@epfl.ch",
             "roles": [f"{RoleName.CO2_SUPERADMIN.value}@global"],
         }
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert len(roles) == 1
@@ -106,7 +108,7 @@ class TestDefaultRoleProvider:
     async def test_parse_roles_no_roles_in_jwt(self):
         """Test handling of missing roles in JWT."""
         userinfo = {"email": "user@epfl.ch"}
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert roles == []
@@ -115,7 +117,7 @@ class TestDefaultRoleProvider:
     async def test_parse_roles_empty_roles_list(self):
         """Test handling of empty roles list."""
         userinfo = {"email": "user@epfl.ch", "roles": []}
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert roles == []
@@ -130,7 +132,7 @@ class TestDefaultRoleProvider:
                 f"{RoleName.CO2_USER_STD.value}@unit:12345",
             ],
         }
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert len(roles) == 1
@@ -148,7 +150,7 @@ class TestDefaultRoleProvider:
                 f"{RoleName.CO2_USER_STD.value}@unit:12345",
             ],
         }
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert len(roles) == 1
@@ -166,7 +168,7 @@ class TestDefaultRoleProvider:
                 f"{RoleName.CO2_USER_STD.value}@unit:12345",
             ],
         }
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert len(roles) == 1
@@ -181,7 +183,7 @@ class TestDefaultRoleProvider:
             "email": "user@epfl.ch",
             "roles": [f" {RoleName.CO2_USER_STD.value} @ unit : 12345 "],
         }
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert len(roles) == 1
@@ -200,7 +202,7 @@ class TestDefaultRoleProvider:
                 f"{RoleName.CO2_USER_STD.value}@unit:11111",
             ],
         }
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles(userinfo)
 
         assert len(roles) == 3
@@ -223,7 +225,7 @@ class TestAccredRoleProvider:
     def accred_provider(self):
         """Fixture providing an AccredRoleProvider instance."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = "https://api.epfl.ch"
+            mock_settings.ACCRED_API_BASE_URL = "https://api.epfl.ch"
             mock_settings.ACCRED_API_USERNAME = "test_user"
             mock_settings.ACCRED_API_KEY = "test_key"
             provider = AccredRoleProvider()
@@ -542,7 +544,7 @@ class TestAccredRoleProvider:
     def test_accred_missing_credentials(self):
         """Test AccredRoleProvider initialization with missing credentials."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = None
+            mock_settings.ACCRED_API_BASE_URL = None
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
 
@@ -553,7 +555,7 @@ class TestAccredRoleProvider:
     async def test_accred_missing_credentials_get_roles(self):
         """Test get_roles returns empty list when credentials are missing."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = None
+            mock_settings.ACCRED_API_BASE_URL = None
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
 
@@ -571,20 +573,20 @@ class TestAccredRoleProvider:
 class TestGetRoleProvider:
     """Test suite for get_role_provider factory function."""
 
-    def test_get_default_role_provider(self):
-        """Test that DefaultRoleProvider is returned for 'default' type."""
+    def test_get_jwt_role_provider(self):
+        """Test that JwtClaimsRoleProvider is returned for 'jwt' type."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.PROVIDER_PLUGIN = UserProvider.DEFAULT
+            mock_settings.ROLE_PROVIDER_TYPE = RoleProviderType.JWT
 
             provider = get_role_provider()
 
-            assert isinstance(provider, DefaultRoleProvider)
+            assert isinstance(provider, JwtClaimsRoleProvider)
 
     def test_get_accred_role_provider(self):
         """Test that AccredRoleProvider is returned for 'accred' type."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.PROVIDER_PLUGIN = UserProvider.ACCRED
-            mock_settings.ACCRED_API_URL = "https://api.epfl.ch"
+            mock_settings.ROLE_PROVIDER_TYPE = RoleProviderType.ACCRED
+            mock_settings.ACCRED_API_BASE_URL = "https://api.epfl.ch"
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
 
@@ -592,20 +594,50 @@ class TestGetRoleProvider:
 
             assert isinstance(provider, AccredRoleProvider)
 
-    def test_get_unknown_role_provider_raises(self):
-        """Pins F9: unknown PROVIDER_PLUGIN raises ValueError instead of
-        silently degrading to DefaultRoleProvider."""
+    def test_get_test_role_provider(self):
+        """Test that TestRoleProvider is returned for 'test' type."""
         with patch("app.providers.role_provider.settings") as mock_settings:
-            mock_settings.PROVIDER_PLUGIN = "unknown"
+            mock_settings.ROLE_PROVIDER_TYPE = RoleProviderType.TEST
+
+            provider = get_role_provider()
+
+            assert isinstance(provider, TestRoleProvider)
+
+    def test_get_role_provider_override_accepts_persisted_user_provider(self):
+        """The override param also accepts a persisted ``UserProvider``
+        value (e.g. ``User.provider``), used by background sync to
+        re-resolve roles from an entity's original source regardless of
+        the current ROLE_PROVIDER_TYPE setting."""
+        provider = get_role_provider(UserProvider.ACCRED)
+        assert isinstance(provider, AccredRoleProvider)
+
+    def test_get_unknown_role_provider_raises(self):
+        """Pins F9: unknown ROLE_PROVIDER_TYPE raises ValueError instead of
+        silently degrading to JwtClaimsRoleProvider."""
+        with patch("app.providers.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_TYPE = "unknown"
 
             with pytest.raises(ValueError, match="Unknown role provider type"):
                 get_role_provider()
 
+    def test_factory_no_longer_reads_provider_plugin(self):
+        """Regression: the factory must read ROLE_PROVIDER_TYPE, not the
+        removed PROVIDER_PLUGIN setting."""
+        with patch("app.providers.role_provider.settings") as mock_settings:
+            mock_settings.ROLE_PROVIDER_TYPE = RoleProviderType.JWT
+            # A stray PROVIDER_PLUGIN would only be read by legacy code; the
+            # factory must ignore it and dispatch off ROLE_PROVIDER_TYPE.
+            mock_settings.PROVIDER_PLUGIN = RoleProviderType.ACCRED
 
-class TestDefaultRoleProviderClaimCombinations:
+            provider = get_role_provider()
+
+            assert isinstance(provider, JwtClaimsRoleProvider)
+
+
+class TestJwtClaimsRoleProviderClaimCombinations:
     """Tests for issue #458 success criterion 'incorrect role/claim combinations'.
 
-    Pin the behaviour of DefaultRoleProvider when the IdP returns
+    Pin the behaviour of JwtClaimsRoleProvider when the IdP returns
     malformed or unexpected role claims. F11 and F12 are now fixed —
     these tests assert the hardened behaviour.
     """
@@ -615,7 +647,7 @@ class TestDefaultRoleProviderClaimCombinations:
         """Pins F11 fix: a role whose name is not in the RoleName enum is
         skipped (with a warning), so one malformed entry from the IdP does
         not DoS the entire login."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         good_role = f"{RoleName.CO2_USER_STD.value}@unit:12345"
         userinfo = {
             "sub": "x",
@@ -629,7 +661,7 @@ class TestDefaultRoleProviderClaimCombinations:
     async def test_empty_role_name_is_skipped_not_raised(self):
         """Pins F11 fix: an empty role name (e.g. `@unit:12345`) is also a
         ValueError from RoleName(""); must be skipped with a warning."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles({"sub": "x", "roles": ["@unit:12345"]})
         assert roles == []
 
@@ -638,7 +670,7 @@ class TestDefaultRoleProviderClaimCombinations:
         """Pins F12 fix: roles with an unknown scope type
         (e.g. `co2.user.standard@bogus:value`) emit a warning before being
         dropped. Silent drops mask IdP/config drift."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         with caplog.at_level("WARNING"):
             roles = await provider.get_roles(
                 {
@@ -657,14 +689,14 @@ class TestDefaultRoleProviderClaimCombinations:
         """If the IdP returns a non-list `roles` claim (e.g. a string), the
         provider must not crash. Current behaviour: returns []. Pin so we
         notice if iteration semantics change."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles({"sub": "x", "roles": "not_a_list"})
         assert roles == []
 
     @pytest.mark.asyncio
     async def test_missing_roles_claim_returns_empty(self):
         """If the IdP omits the `roles` claim entirely, return []."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         roles = await provider.get_roles({"sub": "x"})
         assert roles == []
 
@@ -672,7 +704,7 @@ class TestDefaultRoleProviderClaimCombinations:
     async def test_role_with_non_string_entry_is_skipped(self):
         """A role entry that isn't a string (e.g. a dict from a misconfigured
         IdP) must be skipped, not crash the whole resolution."""
-        provider = DefaultRoleProvider()
+        provider = JwtClaimsRoleProvider()
         good_role = f"{RoleName.CO2_USER_STD.value}@unit:12345"
         roles = await provider.get_roles(
             {"sub": "x", "roles": [{"not": "a string"}, 42, good_role]}

--- a/backend/tests/unit/providers/test_unit_provider.py
+++ b/backend/tests/unit/providers/test_unit_provider.py
@@ -5,10 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from app.core.config import UnitProviderType
 from app.models.user import UserProvider
 from app.providers.unit_provider import (
     AccredUnitProvider,
-    DefaultUnitProvider,
+    DatabaseUnitProvider,
     TestUnitProvider,
     get_unit_provider,
 )
@@ -20,7 +21,7 @@ from app.providers.unit_provider import (
 class TestAccredMapApiUnit:
     def _make_provider(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = "https://api.example.com"
+            mock_settings.ACCRED_API_BASE_URL = "https://api.example.com"
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
             return AccredUnitProvider()
@@ -117,7 +118,7 @@ class TestAccredMapApiUnit:
 class TestAccredGetUnits:
     def _make_provider(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = "https://api.example.com"
+            mock_settings.ACCRED_API_BASE_URL = "https://api.example.com"
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
             return AccredUnitProvider()
@@ -173,7 +174,7 @@ class TestAccredGetUnits:
     @pytest.mark.asyncio
     async def test_get_units_not_configured(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = ""
+            mock_settings.ACCRED_API_BASE_URL = ""
             mock_settings.ACCRED_API_USERNAME = ""
             mock_settings.ACCRED_API_KEY = ""
             provider = AccredUnitProvider()
@@ -207,7 +208,7 @@ class TestAccredFetchAllUnits:
     @pytest.mark.asyncio
     async def test_fetch_all_units_not_configured(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = ""
+            mock_settings.ACCRED_API_BASE_URL = ""
             mock_settings.ACCRED_API_USERNAME = ""
             mock_settings.ACCRED_API_KEY = ""
             provider = AccredUnitProvider()
@@ -218,7 +219,7 @@ class TestAccredFetchAllUnits:
     @pytest.mark.asyncio
     async def test_fetch_all_units_single_page(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = "https://api.example.com"
+            mock_settings.ACCRED_API_BASE_URL = "https://api.example.com"
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
             provider = AccredUnitProvider()
@@ -254,7 +255,7 @@ class TestAccredFetchAllUnits:
     @pytest.mark.asyncio
     async def test_fetch_all_units_deduplicates_users(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.ACCRED_API_URL = "https://api.example.com"
+            mock_settings.ACCRED_API_BASE_URL = "https://api.example.com"
             mock_settings.ACCRED_API_USERNAME = "user"
             mock_settings.ACCRED_API_KEY = "key"
             provider = AccredUnitProvider()
@@ -283,15 +284,15 @@ class TestAccredFetchAllUnits:
 
 
 # ---------------------------------------------------------------------------
-# DefaultUnitProvider.get_units (with real async db)
+# DatabaseUnitProvider.get_units (with real async db)
 # ---------------------------------------------------------------------------
-class TestDefaultUnitProvider:
+class TestDatabaseUnitProvider:
     @pytest.mark.asyncio
     async def test_get_all_units(self, db_session, make_unit):
         await make_unit(db_session, name="Unit A")
         await make_unit(db_session, name="Unit B")
 
-        provider = DefaultUnitProvider(db_session)
+        provider = DatabaseUnitProvider(db_session)
         units = await provider.get_units()
         assert len(units) == 2
 
@@ -300,14 +301,14 @@ class TestDefaultUnitProvider:
         u1 = await make_unit(db_session, name="Unit A")
         await make_unit(db_session, name="Unit B")
 
-        provider = DefaultUnitProvider(db_session)
+        provider = DatabaseUnitProvider(db_session)
         units = await provider.get_units(unit_ids=[u1.id])
         assert len(units) == 1
         assert units[0].name == "Unit A"
 
     @pytest.mark.asyncio
     async def test_get_units_empty_db(self, db_session):
-        provider = DefaultUnitProvider(db_session)
+        provider = DatabaseUnitProvider(db_session)
         units = await provider.get_units()
         assert units == []
 
@@ -382,34 +383,66 @@ class TestGetUnitById:
 # get_unit_provider factory
 # ---------------------------------------------------------------------------
 class TestGetUnitProvider:
-    def test_default_requires_session(self):
+    def test_database_requires_session_via_override(self):
+        """Override param also accepts a persisted UserProvider value (e.g.
+        DataIngestionJob.provider), used by background sync to re-resolve
+        units from an entity's original source."""
         with pytest.raises(ValueError, match="requires a database session"):
             get_unit_provider(UserProvider.DEFAULT, db_session=None)
 
-    def test_default_with_session(self):
+    def test_database_with_session_via_override(self):
         mock_db = MagicMock()
         provider = get_unit_provider(UserProvider.DEFAULT, db_session=mock_db)
-        assert isinstance(provider, DefaultUnitProvider)
+        assert isinstance(provider, DatabaseUnitProvider)
 
-    def test_accred(self):
+    def test_accred_via_override(self):
         provider = get_unit_provider(UserProvider.ACCRED)
         assert isinstance(provider, AccredUnitProvider)
 
-    def test_test_provider(self):
+    def test_test_provider_via_override(self):
         provider = get_unit_provider(UserProvider.TEST)
         assert isinstance(provider, TestUnitProvider)
 
-    def test_unknown_falls_back_to_default(self):
+    def test_unknown_falls_back_to_database(self):
         mock_db = MagicMock()
         provider = get_unit_provider(999, db_session=mock_db)
-        assert isinstance(provider, DefaultUnitProvider)
+        assert isinstance(provider, DatabaseUnitProvider)
 
     def test_unknown_without_session_raises(self):
         with pytest.raises(ValueError):
             get_unit_provider(999, db_session=None)
 
-    def test_none_uses_settings(self):
+    def test_none_uses_settings_database(self):
         with patch("app.providers.unit_provider.settings") as mock_settings:
-            mock_settings.PROVIDER_PLUGIN = UserProvider.TEST
+            mock_settings.UNIT_PROVIDER_TYPE = UnitProviderType.DATABASE
+            mock_db = MagicMock()
+            provider = get_unit_provider(None, db_session=mock_db)
+            assert isinstance(provider, DatabaseUnitProvider)
+
+    def test_none_uses_settings_accred(self):
+        with patch("app.providers.unit_provider.settings") as mock_settings:
+            mock_settings.UNIT_PROVIDER_TYPE = UnitProviderType.ACCRED
+            mock_settings.ACCRED_API_BASE_URL = "https://api.example.com"
+            mock_settings.ACCRED_API_USERNAME = "user"
+            mock_settings.ACCRED_API_KEY = "key"
             provider = get_unit_provider(None)
+            assert isinstance(provider, AccredUnitProvider)
+
+    def test_none_uses_settings_test(self):
+        with patch("app.providers.unit_provider.settings") as mock_settings:
+            mock_settings.UNIT_PROVIDER_TYPE = UnitProviderType.TEST
+            provider = get_unit_provider(None)
+            assert isinstance(provider, TestUnitProvider)
+
+    def test_factory_no_longer_reads_provider_plugin(self):
+        """Regression: the factory must read UNIT_PROVIDER_TYPE, not the
+        removed PROVIDER_PLUGIN setting."""
+        with patch("app.providers.unit_provider.settings") as mock_settings:
+            mock_settings.UNIT_PROVIDER_TYPE = UnitProviderType.TEST
+            # A stray PROVIDER_PLUGIN would only be read by legacy code; the
+            # factory must ignore it and dispatch off UNIT_PROVIDER_TYPE.
+            mock_settings.PROVIDER_PLUGIN = UnitProviderType.ACCRED
+
+            provider = get_unit_provider(None)
+
             assert isinstance(provider, TestUnitProvider)

--- a/docs/src/architecture/03-subsystem-map.md
+++ b/docs/src/architecture/03-subsystem-map.md
@@ -108,7 +108,7 @@ by the app Helm chart.
 
 - **API routers** (`/api/v1/*`) — REST surface; HTTP-only auth cookies.
 - **Auth** — Authlib OIDC handshake with Entra ID; mints and validates JWT cookies in-process (no separate auth service). See [Auth Flow](./04-auth-flow.md).
-- **Roles & permissions** — from JWT claims, or the EPFL Accred API when `PROVIDER_PLUGIN=accred`.
+- **Roles & permissions** — from JWT claims, or the EPFL Accred API when `ROLE_PROVIDER_TYPE=accred`.
 - **Data ingestion** — pluggable providers; the professional-travel provider reads flights from Tableau VizQL.
 - **Exchange rates** — pulls FX rates from the ECB API (8-hour in-memory cache).
 - **Files** — `enacit4r-files` abstraction; writes to EPFL S3 when configured, otherwise the local filesystem.

--- a/docs/src/architecture/04-auth-flow.md
+++ b/docs/src/architecture/04-auth-flow.md
@@ -111,16 +111,16 @@ Validation path in `backend/app/core/security.py`:
 
 `backend/app/providers/role_provider.py` defines three providers:
 
-- **`DefaultRoleProvider`** — reads roles from JWT claims. Used in
+- **`JwtClaimsRoleProvider`** — reads roles from JWT claims. Used in
   development and synthetic-data flows.
 - **`AccredRoleProvider`** — fetches from the EPFL Accred API. Production.
 - **`TestRoleProvider`** — synthetic roles for `/auth/login-test`
   (DEBUG-only route).
 
-Selection is driven by `settings.PROVIDER_PLUGIN` through the factory
+Selection is driven by `settings.ROLE_PROVIDER_TYPE` through the factory
 `get_role_provider(provider_type)`. F9 hardened the factory: an unknown
-`PROVIDER_PLUGIN` value now raises `ValueError` instead of silently
-falling back to `DefaultRoleProvider`. F11/F12 hardened claim parsing:
+provider type now raises `ValueError` instead of silently
+falling back to `JwtClaimsRoleProvider`. F11/F12 hardened claim parsing:
 malformed `RoleName` entries and unknown scope types are skipped with a
 warning rather than aborting the login.
 
@@ -161,8 +161,8 @@ truth: the implementation plan
 | F8      | `backend/tests/integration/v1/test_auth_security.py` | `test_me_rejects_legacy_user_id_only_token`, `test_refresh_rejects_legacy_user_id_only_token`                                                |
 | F9      | `backend/tests/unit/providers/test_role_provider.py` | `test_get_unknown_role_provider_raises` (in `TestGetRoleProvider`)                                                                           |
 | F10     | `backend/tests/integration/v1/test_auth_security.py` | `test_jwt_expired_rejected`                                                                                                                  |
-| F11     | `backend/tests/unit/providers/test_role_provider.py` | `test_unknown_role_name_is_skipped_not_raised`, `test_empty_role_name_is_skipped_not_raised` (in `TestDefaultRoleProviderClaimCombinations`) |
-| F12     | `backend/tests/unit/providers/test_role_provider.py` | `test_unknown_scope_type_warns_when_skipped` (in `TestDefaultRoleProviderClaimCombinations`)                                                 |
+| F11     | `backend/tests/unit/providers/test_role_provider.py` | `test_unknown_role_name_is_skipped_not_raised`, `test_empty_role_name_is_skipped_not_raised` (in `TestJwtClaimsRoleProviderClaimCombinations`) |
+| F12     | `backend/tests/unit/providers/test_role_provider.py` | `test_unknown_scope_type_warns_when_skipped` (in `TestJwtClaimsRoleProviderClaimCombinations`)                                                 |
 
 Additional pinning tests:
 
@@ -170,7 +170,7 @@ Additional pinning tests:
 - `test_e2e_callback_session_refresh_logout_happy_path` — end-to-end happy path.
 - `test_secure_cookie_is_dropped_over_http_breaking_followup_calls` —
   F2 regression guard; demonstrates the cookie-drop symptom.
-- `TestDefaultRoleProviderClaimCombinations::*` — claim-combination
+- `TestJwtClaimsRoleProviderClaimCombinations::*` — claim-combination
   matrix for the role provider.
 - `backend/tests/unit/core/test_security_gates.py::*` — permission gate unit
   tests covering `is_permitted` / `check_permission` / `require_permission`.

--- a/docs/src/implementation-plans/1713-role-unit-provider-env-rename.md
+++ b/docs/src/implementation-plans/1713-role-unit-provider-env-rename.md
@@ -1,0 +1,156 @@
+---
+status: proposed
+issue: 1713
+last_updated: 2026-07-07
+title: "Backend provider configuration naming cleanup"
+summary: "Split the overloaded PROVIDER_PLUGIN/ACCRED_API_URL env contract into explicit ROLE_PROVIDER_TYPE / UNIT_PROVIDER_TYPE / ACCRED_* config, renaming DefaultRoleProvider/DefaultUnitProvider and decoupling provider-selection enums from the persisted UserProvider metadata enum."
+---
+
+# Backend provider configuration naming cleanup
+
+## Problem
+
+`PROVIDER_PLUGIN` is one generic env var driving two unrelated backend
+concerns: `RoleProvider` (source of app roles/authorizations) and
+`UnitProvider` (source of institutional units). `default` doesn't mean the
+same thing in both: `DefaultRoleProvider` = roles from JWT/OIDC claims;
+`DefaultUnitProvider` = units from the local database — same string, opposite
+semantics. `UserProvider` is also overloaded: used both for provider
+_selection_ config and as persisted _source metadata_ on `User`/`Unit`
+models. These are different concepts and must not share an enum.
+
+Goal: backend config should separately and explicitly answer — where do
+roles come from? where do units come from? how does the backend talk to
+Accred? what provider/source metadata is persisted on users/units? No
+`default` naming anywhere; invalid/missing config fails hard at startup, no
+fallback.
+
+Non-goal: frontend runtime config (frontend already has `injectEnv.js`); no
+new `/runtime-config` endpoint.
+
+## Design
+
+### Env contract
+
+Remove: `PROVIDER_PLUGIN`, `ACCRED_API_URL`.
+
+Add:
+
+- `ROLE_PROVIDER_TYPE` (`jwt|accred|test`)
+- `UNIT_PROVIDER_TYPE` (`database|accred|test`)
+- `ACCRED_API_BASE_URL`
+- `ACCRED_API_USERNAME`
+- `ACCRED_API_KEY`
+- `ACCRED_AUTHORIZATION_HEALTHCHECK_URL`
+
+### Naming rules
+
+- `*_PROVIDER_TYPE` = backend implementation selection.
+- `ACCRED_*` = backend machine-to-machine Accred integration config.
+- Provider/source metadata on models = persisted origin of user/unit data.
+- Do **not** rename `ACCRED_API_BASE_URL` to `ROLE_PROVIDER_API_URL` — Accred
+  is used by both RoleProvider and UnitProvider, so the API URL belongs to
+  the Accred integration, not to role resolution specifically.
+- `UserProvider` is not reused for config selection. It may remain as
+  persisted/source metadata (`User.provider = accred|test|oidc/jwt`,
+  `Unit.provider = accred|database|test`), but selection config and
+  persisted metadata must never be the same enum.
+
+### Config types
+
+```py
+class RoleProviderType(str, Enum):
+    JWT = "jwt"; ACCRED = "accred"; TEST = "test"
+
+class UnitProviderType(str, Enum):
+    DATABASE = "database"; ACCRED = "accred"; TEST = "test"
+```
+
+### Settings + validator
+
+```py
+class Settings(BaseSettings):
+    ROLE_PROVIDER_TYPE: RoleProviderType
+    UNIT_PROVIDER_TYPE: UnitProviderType
+    ACCRED_API_BASE_URL: AnyHttpUrl | None = None
+    ACCRED_API_USERNAME: str | None = None
+    ACCRED_API_KEY: str | None = None
+    ACCRED_AUTHORIZATION_HEALTHCHECK_URL: AnyHttpUrl | None = None
+
+    @model_validator(mode="after")
+    def validate_accred_config(self):
+        uses_accred = (
+            self.ROLE_PROVIDER_TYPE == RoleProviderType.ACCRED
+            or self.UNIT_PROVIDER_TYPE == UnitProviderType.ACCRED
+        )
+        if uses_accred:
+            missing = [
+                n for n in ("ACCRED_API_BASE_URL", "ACCRED_API_USERNAME", "ACCRED_API_KEY")
+                if getattr(self, n) is None
+            ]
+            if missing:
+                raise ValueError("Missing required Accred config: " + ", ".join(missing))
+        return self
+```
+
+No fallback, no compatibility layer, no deprecated env support — missing or
+invalid config fails at startup.
+
+### Factories
+
+- `get_role_provider()` reads `settings.ROLE_PROVIDER_TYPE` (was
+  `PROVIDER_PLUGIN`), match/case -> `JwtClaimsRoleProvider` (renamed from
+  `DefaultRoleProvider`), `AccredRoleProvider`, `TestRoleProvider`.
+- `get_unit_provider()` reads `settings.UNIT_PROVIDER_TYPE` (was
+  `PROVIDER_PLUGIN`), match/case -> `DatabaseUnitProvider` (renamed from
+  `DefaultUnitProvider`), `AccredUnitProvider`, `TestUnitProvider`.
+
+### Accred providers
+
+Both `AccredRoleProvider` and `AccredUnitProvider` switch to
+`settings.ACCRED_API_BASE_URL` / `ACCRED_API_USERNAME` / `ACCRED_API_KEY`,
+dropping `settings.ACCRED_API_URL`. Constructors assume already-validated
+config — no constructor-level "credentials not fully configured" warnings;
+invalid config is a startup `Settings` error, not a runtime provider
+warning.
+
+### Healthcheck
+
+`ACCRED_AUTHORIZATION_HEALTHCHECK_URL` is specifically an
+authorization-readiness check (backend credentials can reach Accred and
+read expected authorization data) — not a generic API health URL.
+
+### Breaking changes
+
+`PROVIDER_PLUGIN` and `ACCRED_API_URL` are removed outright. No deprecated
+fallback, no migration compatibility. Deployment manifests must be updated
+in the same PR.
+
+## Steps
+
+- [ ] Add `RoleProviderType`/`UnitProviderType` enums and rewrite `Settings`
+      (`ROLE_PROVIDER_TYPE`, `UNIT_PROVIDER_TYPE`, `ACCRED_API_BASE_URL`,
+      `ACCRED_API_USERNAME`, `ACCRED_API_KEY`,
+      `ACCRED_AUTHORIZATION_HEALTHCHECK_URL`) with the `validate_accred_config`
+      model validator, in `backend/app/core/config.py`
+- [ ] Rename `DefaultRoleProvider` -> `JwtClaimsRoleProvider`; rewire
+      `get_role_provider()` to dispatch on `settings.ROLE_PROVIDER_TYPE` in
+      `backend/app/providers/role_provider.py`
+- [ ] Rename `DefaultUnitProvider` -> `DatabaseUnitProvider`; rewire
+      `get_unit_provider()` to dispatch on `settings.UNIT_PROVIDER_TYPE` in
+      `backend/app/providers/unit_provider.py`
+- [ ] Update `AccredRoleProvider`/`AccredUnitProvider` to read
+      `ACCRED_API_BASE_URL`/`ACCRED_API_USERNAME`/`ACCRED_API_KEY`; drop
+      `ACCRED_API_URL` and the constructor-level config warning
+- [ ] Update deployment manifests to the new env var names (remove
+      `PROVIDER_PLUGIN`, `ACCRED_API_URL`; add `ROLE_PROVIDER_TYPE`,
+      `UNIT_PROVIDER_TYPE`, `ACCRED_API_BASE_URL`, `ACCRED_API_USERNAME`,
+      `ACCRED_API_KEY`, `ACCRED_AUTHORIZATION_HEALTHCHECK_URL`)
+- [ ] Config tests: missing/invalid `ROLE_PROVIDER_TYPE`/`UNIT_PROVIDER_TYPE`
+      fail startup; Accred selection requires the 3 `ACCRED_*` vars; jwt/database
+      selection doesn't require them
+- [ ] Factory tests: each provider type returns the right class for both
+      `get_role_provider()` and `get_unit_provider()`
+- [ ] Regression tests: factories no longer read `PROVIDER_PLUGIN`; Accred
+      providers no longer read `ACCRED_API_URL`
+- [ ] Update backend `.env.example` with the new vars and a short config note

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -15,9 +15,10 @@ APP_SENTRY_DSN=
 APP_ENVIRONMENT=development
 
 # Public display label + portal URL shown in the calculator's access popover
-# (role delegation). Free text — NOT the backend PROVIDER_PLUGIN (jwt/accred/
-# test). No code default: empty / unset → the popover CTA link is hidden. Set
-# per-env in the ops repo to rebrand for another institution.
+# (role delegation). Free text — NOT the backend ROLE_PROVIDER_TYPE/
+# UNIT_PROVIDER_TYPE (jwt|accred|test / database|accred|test). No code
+# default: empty / unset → the popover CTA link is hidden. Set per-env in the
+# ops repo to rebrand for another institution.
 APP_ACCESS_MANAGEMENT_PROVIDER_NAME=xxx
 APP_ACCESS_MANAGEMENT_PROVIDER_URL=xxx
 APP_EQUIPMENT_POWER_FEEDBACK_EMAIL=xxx

--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -117,11 +117,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "co2-calculator.backendSecretName" . }}
                   key: {{ .Values.backend.existingSecret.keys.accredApiUsernameKey | default "ACCRED_API_USERNAME" }}
-            - name: ACCRED_API_URL
+            - name: ACCRED_API_BASE_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "co2-calculator.backendSecretName" . }}
-                  key: {{ .Values.backend.existingSecret.keys.accredApiUrlKey | default "ACCRED_API_URL" }}
+                  key: {{ .Values.backend.existingSecret.keys.accredApiBaseUrlKey | default "ACCRED_API_BASE_URL" }}
             - name: FILES_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -37,11 +37,12 @@ backend:
     ALGORITHM: "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: "480"
     REFRESH_TOKEN_EXPIRE_HOURS: "24"
-    PROVIDER_PLUGIN: "default" # Could be 'default' or 'accred' or 'test'
+    ROLE_PROVIDER_TYPE: "jwt" # Could be 'jwt', 'accred', or 'test'
+    UNIT_PROVIDER_TYPE: "database" # Could be 'database', 'accred', or 'test'
     OAUTH_SCOPE: "openid profile email"
     OAUTH_COOKIE_PATH: "/"
     FRONTEND_URL: "http://localhost:3000" # Change to frontend URL in production
-    ACCRED_API_HEALTH_URL: "https://url-you-want-to-check"
+    ACCRED_AUTHORIZATION_HEALTHCHECK_URL: "https://url-you-want-to-check"
     # Background job safety poller (orphan-job recovery)
     RUN_BACKGROUND_POLLER: "true"
     POLLER_INTERVAL_SECONDS: "2" # Seconds between poller sweeps
@@ -142,7 +143,7 @@ backend:
       oauthTenantIdKey: OAUTH_TENANT_ID # Key in the existing secret for OAuth tenant ID
       accredApiKeyKey: ACCRED_API_KEY # Key in the existing secret for Accred API key
       accredApiUsernameKey: ACCRED_API_USERNAME # Key in the existing secret for Accred API username
-      accredApiUrlKey: ACCRED_API_URL # Key in the existing secret for Accred API URL
+      accredApiBaseUrlKey: ACCRED_API_BASE_URL # Key in the existing secret for Accred API base URL
       filesEncryptionKeyKey: FILES_ENCRYPTION_KEY # Key in the existing secret for files encryption key
       filesEncryptionSaltKey: FILES_ENCRYPTION_SALT # Key in the existing secret for files encryption salt
       filesMaxSizeMbKey: FILES_MAX_SIZE_MB # Key in the existing secret for maximum file size (MB)
@@ -226,7 +227,8 @@ frontend:
     # in the ops repo (e.g. "stage", "production").
     APP_ENVIRONMENT: "production"
     # Public label + portal URL shown in the calculator's access popover (role
-    # delegation). Free text — NOT the backend PROVIDER_PLUGIN role provider.
+    # delegation). Free text — NOT the backend ROLE_PROVIDER_TYPE/
+    # UNIT_PROVIDER_TYPE provider selection.
     # Example placeholders only; real per-env values are set in the ops repo.
     # No code default: if unset the popover CTA/label is hidden.
     APP_ACCESS_MANAGEMENT_PROVIDER_NAME: "ACCRED"


### PR DESCRIPTION
Part of #1713.

Implementation plan: `docs/src/implementation-plans/1713-role-unit-provider-env-rename.md`

_Branch scaffold only — plan not yet implemented. Breaking change: deployment manifests need updating in the same PR as the code change._
