### PR TITLE
test(1403a): backend access + year-initialization integration tests

### DIFF
--- a/backend/tests/integration/v1/test_permission_scope_e2e.py
+++ b/backend/tests/integration/v1/test_permission_scope_e2e.py
@@ -43,6 +43,7 @@ from app.models.user import (
     Role,
     RoleName,
     UnitScope,
+    UserProvider,
     calculate_user_permissions,
 )
 
@@ -538,4 +539,96 @@ class TestActivePipelinesPerYearGate:
         user = _user("11111", [_std(UNIT_IID)])
         _wire_active_pipelines(monkeypatch, user)
         r = client.get(ACTIVE_PIPELINES_URL)
+        assert r.status_code == 403, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /api/v1/year-configuration/{year} (#1403 slice a) — the
+# ``Calco2.backoffice.admin`` gate for the BackOffice Configuration tab.
+#
+# ``create_year_configuration`` guards on ``backoffice.configuration.edit``,
+# which ``calculate_user_permissions`` grants ONLY to CO2_SUPERADMIN
+# ("calco2.backoffice.admin"). CO2_BACKOFFICE_METIER (even affiliation-
+# scoped, which unlocks reporting/users/documentation/ui_texts) never gets
+# it — configuration is Super Admin only (#862). No mocking of
+# ``is_permitted`` here: the real role → permission → OPA-style policy
+# chain runs, same as the rest of this file.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+YEAR_CONFIG_CREATE_URL = "/api/v1/year-configuration/2025"
+
+
+@pytest_asyncio.fixture
+async def empty_db():
+    """In-memory SQLite with all tables created, no seeded rows."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _wire_year_config(monkeypatch, user, factory) -> None:
+    """Wire the real user + a real DB; stub only the background dispatch.
+
+    ``fire_and_forget`` would otherwise spawn the actual unit-sync job
+    runner — irrelevant to an access-control test and slow/flaky in-process.
+    """
+    user.provider = UserProvider.DEFAULT
+    app.dependency_overrides[deps_module.get_current_user] = lambda: user
+
+    async def override_get_db():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+
+    def fake_fire_and_forget(coro, *, name=None):
+        coro.close()
+        return None
+
+    monkeypatch.setattr(
+        "app.api.v1.year_configuration.fire_and_forget", fake_fire_and_forget
+    )
+
+
+class TestYearConfigurationAdminOnlyGate:
+    """Only Calco2.backoffice.admin (CO2_SUPERADMIN) may create a year
+    configuration; every other role is denied via the same
+    ``backoffice.configuration.edit`` gate."""
+
+    def test_superadmin_creates_year_configuration(self, client, monkeypatch, empty_db):
+        user = _user("11111", [_superadmin()])
+        _wire_year_config(monkeypatch, user, empty_db)
+        r = client.post(YEAR_CONFIG_CREATE_URL)
+        assert r.status_code == 201, r.text
+
+    def test_backoffice_metier_denied(self, client, monkeypatch, empty_db):
+        """Affiliation-scoped metier holds reporting/users/documentation/
+        ui_texts but NOT configuration — Super Admin only (#862)."""
+        user = _user("11111", [_backoffice_scoped(ENAC_CF)])
+        _wire_year_config(monkeypatch, user, empty_db)
+        r = client.post(YEAR_CONFIG_CREATE_URL)
+        assert r.status_code == 403, r.text
+
+    def test_principal_denied(self, client, monkeypatch, empty_db):
+        user = _user("11111", [_principal(UNIT_IID)])
+        _wire_year_config(monkeypatch, user, empty_db)
+        r = client.post(YEAR_CONFIG_CREATE_URL)
+        assert r.status_code == 403, r.text
+
+    def test_std_denied(self, client, monkeypatch, empty_db):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire_year_config(monkeypatch, user, empty_db)
+        r = client.post(YEAR_CONFIG_CREATE_URL)
+        assert r.status_code == 403, r.text
+
+    def test_no_roles_denied(self, client, monkeypatch, empty_db):
+        user = _user("11111", roles=[])
+        _wire_year_config(monkeypatch, user, empty_db)
+        r = client.post(YEAR_CONFIG_CREATE_URL)
         assert r.status_code == 403, r.text

--- a/backend/tests/integration/v1/test_year_configuration_init.py
+++ b/backend/tests/integration/v1/test_year_configuration_init.py
@@ -1,0 +1,171 @@
+"""Integration tests for ``POST /api/v1/year-configuration/{year}`` (#1403
+slice a — year initialization checklist items).
+
+Access control for this route is covered by
+``test_permission_scope_e2e.py::TestYearConfigurationAdminOnlyGate`` (real
+permission chain); this file uses a mocked ``is_permitted`` (matching
+``test_year_configuration_list.py``'s convention) since it only needs an
+admin/non-admin toggle to reach the create logic.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+from app.main import app
+from app.models.data_ingestion import DataIngestionJob
+from app.models.user import UserProvider
+
+CREATE_URL = "/api/v1/year-configuration/{year}"
+
+
+@pytest_asyncio.fixture
+async def db_factory():
+    """In-memory SQLite with all tables created, no seeded rows."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def _user() -> MagicMock:
+    u = MagicMock()
+    u.id = 1
+    u.email = "test@example.com"
+    u.institutional_id = "11111"
+    u.provider = UserProvider.DEFAULT
+    return u
+
+
+def _wire(monkeypatch, factory, *, is_admin: bool) -> None:
+    """Real DB, mocked ``is_permitted`` (admin toggle), no-op background
+    dispatch — the job ROW is the assertion target, not the sync handler's
+    actual Accred call (out of scope: slow integration, per #1403's design
+    doc)."""
+    app.dependency_overrides[deps_module.get_current_user] = lambda: _user()
+
+    async def override_get_db():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+
+    async def fake_is_permitted(user, path, action="view"):
+        if path == "backoffice.configuration" and action == "edit":
+            return is_admin
+        return False
+
+    monkeypatch.setattr("app.api.v1.year_configuration.is_permitted", fake_is_permitted)
+
+    def fake_fire_and_forget(coro, *, name=None):
+        coro.close()
+        return None
+
+    monkeypatch.setattr(
+        "app.api.v1.year_configuration.fire_and_forget", fake_fire_and_forget
+    )
+
+
+# ---------------------------------------------------------------------------
+# Year bounds — #1204 (PR #1737) adds "2025 <= year <= current_year" but
+# hasn't merged into dev yet. These pin the INTENDED behavior and stay
+# skipped (not deleted) until #1204 lands, per #1403's "no silent pass" rule.
+# ---------------------------------------------------------------------------
+
+
+_SKIP_1204 = "blocked on #1204 merging (PR #1737 not yet merged into dev)"
+
+
+class TestYearBoundsValidation:
+    @pytest.mark.skip(reason=_SKIP_1204)
+    def test_year_below_2025_rejected(self, client, monkeypatch, db_factory):
+        _wire(monkeypatch, db_factory, is_admin=True)
+        r = client.post(CREATE_URL.format(year=2024))
+        assert r.status_code in (400, 422), r.text
+
+    @pytest.mark.skip(reason=_SKIP_1204)
+    def test_year_above_current_year_rejected(self, client, monkeypatch, db_factory):
+        _wire(monkeypatch, db_factory, is_admin=True)
+        future_year = datetime.utcnow().year + 1
+        r = client.post(CREATE_URL.format(year=future_year))
+        assert r.status_code in (400, 422), r.text
+
+
+# ---------------------------------------------------------------------------
+# Issue #867 — creating a year auto-enqueues a unit_sync DataIngestionJob
+# tied to a freshly-minted pipeline_id, so the frontend can subscribe to
+# the Accred sync via SSE immediately.
+# ---------------------------------------------------------------------------
+
+
+class TestCreateYearConfigurationEnqueuesUnitSync:
+    @pytest.mark.asyncio
+    async def test_creates_persisted_unit_sync_job(
+        self, client, monkeypatch, db_factory
+    ):
+        _wire(monkeypatch, db_factory, is_admin=True)
+
+        r = client.post(CREATE_URL.format(year=2025))
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["pipeline_id"]
+
+        async with db_factory() as session:
+            stmt = select(DataIngestionJob).where(
+                col(DataIngestionJob.year) == 2025,
+                col(DataIngestionJob.job_type) == "unit_sync",
+            )
+            jobs = (await session.exec(stmt)).all()
+        assert len(jobs) == 1
+        assert str(jobs[0].pipeline_id) == body["pipeline_id"]
+
+    def test_non_admin_cannot_create(self, client, monkeypatch, db_factory):
+        _wire(monkeypatch, db_factory, is_admin=False)
+        r = client.post(CREATE_URL.format(year=2025))
+        assert r.status_code == 403, r.text
+
+
+# ---------------------------------------------------------------------------
+# Checklist: "All modules show Incomplete on the config homepage before
+# any data is uploaded" — asserted at the actual endpoint response, the
+# real config homepage read (unit-level coverage of the same computation
+# lives in test_year_configuration_incomplete_flag.py).
+# ---------------------------------------------------------------------------
+
+
+class TestFreshYearShowsAllModulesIncomplete:
+    def test_all_modules_incomplete_in_create_response(
+        self, client, monkeypatch, db_factory
+    ):
+        _wire(monkeypatch, db_factory, is_admin=True)
+
+        r = client.post(CREATE_URL.format(year=2025))
+        assert r.status_code == 201, r.text
+        modules = r.json()["config"]["modules"]
+        assert modules  # sanity: default config actually has modules
+        for module_key, module_val in modules.items():
+            assert module_val["incomplete"] is True, module_key

--- a/backend/tests/unit/v1/test_year_configuration_incomplete_flag.py
+++ b/backend/tests/unit/v1/test_year_configuration_incomplete_flag.py
@@ -10,6 +10,11 @@ issue-#1215 regression invariant.
 """
 
 from app.api.v1.year_configuration import _enrich_config_with_incomplete_flags
+from app.core.submodule_mandatoriness import (
+    MODULES_REQUIRING_COMMON_FACTOR,
+    get_submodule_mandatoriness,
+)
+from app.services.year_config_service import generate_default_year_config
 
 
 def _sub(latest_factor_job=None, latest_reference_job=None, **extra) -> dict:
@@ -300,3 +305,58 @@ class TestEdgeCases:
         config: dict = {"modules": {}}
         _enrich_config_with_incomplete_flags(config)
         assert config == {"modules": {}}
+
+
+# ---------------------------------------------------------------------------
+# #1403 slice a — the real ``generate_default_year_config()`` shape (all 8
+# modules, no jobs), not the synthetic 2-submodule fixtures above.
+# ---------------------------------------------------------------------------
+
+
+def _satisfy_all_mandatory(config: dict) -> None:
+    """Mutate a freshly-generated config so every mandatory factor/
+    reference is 'present' — the shape ``_enrich_config_with_jobs`` would
+    produce once every required upload has landed."""
+    for module_key, module_val in config["modules"].items():
+        module_id = int(module_key)
+        for sub_key, sub_val in module_val["submodules"].items():
+            rules = get_submodule_mandatoriness(module_id, int(sub_key))
+            if rules.mandatory_factor:
+                sub_val["latest_factor_job"] = {"result": 0}
+            if rules.mandatory_reference:
+                sub_val["latest_reference_job"] = {"result": 0}
+        if module_id in MODULES_REQUIRING_COMMON_FACTOR:
+            module_val["latest_common_factor_job"] = {"result": 0}
+
+
+class TestFreshDefaultYearConfiguration:
+    """Checklist: "All modules show Incomplete on the config homepage
+    with no data uploaded." A freshly generated config (no jobs at all)
+    must mark every real module ``incomplete=True`` — this is exactly the
+    shape ``create_year_configuration`` enriches before returning (#867)."""
+
+    def test_every_module_incomplete_with_no_jobs(self):
+        config = generate_default_year_config()
+        _enrich_config_with_incomplete_flags(config)
+        assert config["modules"]  # sanity: default config has real modules
+        for module_key, module_val in config["modules"].items():
+            assert module_val["incomplete"] is True, module_key
+
+
+class TestOpenYearForUsersGate:
+    """Backend half of the frontend's ``anyModuleIncomplete`` computed
+    (``yearConfig.ts``): ``any(module.incomplete for module in
+    config.modules)``. Blocks "Ouvrir l'année pour les utilisateurs" while
+    any module lacks its mandatory uploads; clears only once every module
+    has them."""
+
+    def test_blocks_while_any_module_incomplete(self):
+        config = generate_default_year_config()
+        _enrich_config_with_incomplete_flags(config)
+        assert any(m["incomplete"] for m in config["modules"].values()) is True
+
+    def test_clears_once_every_module_satisfied(self):
+        config = generate_default_year_config()
+        _satisfy_all_mandatory(config)
+        _enrich_config_with_incomplete_flags(config)
+        assert any(m["incomplete"] for m in config["modules"].values()) is False


### PR DESCRIPTION
Part of #1403 (slice a/4 — see docs/src/implementation-plans/1403-backoffice-integration-tests-master.md).

## Covered

**Access**
- `backend/tests/integration/v1/test_permission_scope_e2e.py` (extended, `TestYearConfigurationAdminOnlyGate`): only `Calco2.backoffice.admin` (`CO2_SUPERADMIN`) reaches `POST /api/v1/year-configuration/{year}`. `CO2_BACKOFFICE_METIER` (affiliation-scoped, which unlocks reporting/users/documentation/ui_texts), a principal, a std user, and a no-role user are all denied via the real permission chain (no mocked `is_permitted`).

**Year initialization**
- `backend/tests/integration/v1/test_year_configuration_init.py` (new):
  - Creating a year auto-enqueues its `unit_sync` `DataIngestionJob` (#867) — asserts the persisted job row + `pipeline_id`, not the actual Accred sync flow.
  - The create-endpoint response marks every module `incomplete=True` on a fresh year (no uploads yet).
- `backend/tests/unit/v1/test_year_configuration_incomplete_flag.py` (extended): `_annotate_module_incomplete` over the real `generate_default_year_config()` shape — every one of the 8 real modules is `incomplete=True` with no jobs, and the "Ouvrir l'année pour les utilisateurs" gate (backend half of the frontend's `anyModuleIncomplete`) blocks while any module is incomplete and clears once every module's mandatory factor/reference/common-factor uploads are satisfied.

## Skipped / out of scope

- **Year bounds (2025 ≤ year ≤ current_year)**: #1204 (PR #1737) implements this but isn't merged into `dev` yet. `TestYearBoundsValidation` in `test_year_configuration_init.py` pins the intended behavior as `pytest.mark.skip(reason="blocked on #1204 merging …")` rather than reimplementing the fix here — un-skip once #1204 lands.
- Frontend confirmation-message rendering for the Accred sync and the frontend `anyModuleIncomplete`/gate button rendering are UI-only — that's slice c's job, not backend.

## Test plan

- [x] `uv run pytest tests/integration/v1/test_year_configuration_init.py tests/integration/v1/test_permission_scope_e2e.py tests/unit/v1/test_year_configuration_incomplete_flag.py` → 56 passed, 2 skipped