### PR TITLE
test(1403b): backend common-module-behavior integration tests

### DIFF
--- a/backend/tests/integration/backoffice/test_incomplete_flag.py
+++ b/backend/tests/integration/backoffice/test_incomplete_flag.py
@@ -297,9 +297,15 @@ def test_every_module_reports_complete_once_all_mandatory_uploads_present(
     signal the Configurator reads to enable "Ouvrir l'année pour les
     utilisateurs" (the absence case is covered in slice (a))."""
     _, factory = db_fully_uploaded_year
-    app.dependency_overrides[deps_module.get_current_user] = lambda: type(
-        "U", (), {"id": 1, "provider": UserProvider.DEFAULT, "institutional_id": "1"}
-    )()
+
+    def override_get_current_user():
+        return type(
+            "U",
+            (),
+            {"id": 1, "provider": UserProvider.DEFAULT, "institutional_id": "1"},
+        )()
+
+    app.dependency_overrides[deps_module.get_current_user] = override_get_current_user
 
     async def override_get_db():
         async with factory() as session:

--- a/backend/tests/integration/backoffice/test_incomplete_flag.py
+++ b/backend/tests/integration/backoffice/test_incomplete_flag.py
@@ -1,0 +1,325 @@
+"""Tests for the "Incomplete" tag computation (issue #1403 checklist item):
+
+    "Incomplete" tag persists at sub-module/module level until required
+    files (factors, references where applicable) are uploaded, and clears
+    once upload is complete.
+
+The logic lives in ``app.api.v1.year_configuration._annotate_module_incomplete``
+(+ ``_submodule_incomplete_reasons``). Per the plan, these are exercised
+directly with varied ``YearConfiguration.config`` module fixtures (missing
+factor, missing reference, fully complete, disabled) rather than a slow
+multi-step upload simulation — the function is pure (mutates the dict it's
+given, no I/O), so no DB is needed for that part.
+
+The final test drives the real ``GET /year-configuration/{year}`` endpoint
+with every mandatory upload seeded, to pin the "ready to open" *presence*
+case (slice (a) of #1403 covers the *absence* case on a fresh year).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+from app.api.v1.year_configuration import _annotate_module_incomplete
+from app.core.submodule_mandatoriness import (
+    MODULES_REQUIRING_COMMON_FACTOR,
+    SUBMODULE_MANDATORINESS,
+)
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
+from app.models.user import UserProvider
+from app.models.year_configuration import YearConfiguration
+from app.services.year_config_service import generate_default_year_config
+
+# ---------------------------------------------------------------------------
+# Pure unit-style tests against ``_annotate_module_incomplete``
+# ---------------------------------------------------------------------------
+
+_HEADCOUNT = int(ModuleTypeEnum.headcount)
+# DataEntryTypeEnum.member — mandatory_factor=True, mandatory_reference=False
+_MEMBER = 1
+_EQUIPMENT = int(ModuleTypeEnum.equipment)
+# DataEntryTypeEnum.scientific — noFactors, covered by common factor
+_SCIENTIFIC = 10
+_TRAVEL = int(ModuleTypeEnum.professional_travel)
+# DataEntryTypeEnum.train — mandatory_factor=True, mandatory_reference=True
+_TRAIN = 21
+
+
+def test_submodule_missing_factor_flags_incomplete():
+    """A module submodule requiring a factor with no ``latest_factor_job``
+    is incomplete, and the reason is surfaced."""
+    module_val = {
+        "enabled": True,
+        "submodules": {str(_MEMBER): {"enabled": True, "latest_factor_job": None}},
+    }
+    _annotate_module_incomplete(module_val, _HEADCOUNT)
+
+    sub = module_val["submodules"][str(_MEMBER)]
+    assert sub["incomplete"] is True
+    assert sub["incomplete_reasons"] == ["missing_factor"]
+    assert module_val["incomplete"] is True
+
+
+def test_submodule_missing_reference_flags_incomplete():
+    """Train requires both factor and reference; factor present, reference
+    missing → still incomplete, reason pinpoints the reference."""
+    module_val = {
+        "enabled": True,
+        "submodules": {
+            str(_TRAIN): {
+                "enabled": True,
+                "latest_factor_job": {"job_id": 1},
+                "latest_reference_job": None,
+            }
+        },
+    }
+    _annotate_module_incomplete(module_val, _TRAVEL)
+
+    sub = module_val["submodules"][str(_TRAIN)]
+    assert sub["incomplete"] is True
+    assert sub["incomplete_reasons"] == ["missing_reference"]
+    assert module_val["incomplete"] is True
+
+
+def test_fully_complete_submodule_clears_incomplete():
+    """Every mandatory upload present → incomplete clears at both levels."""
+    module_val = {
+        "enabled": True,
+        "submodules": {
+            str(_TRAIN): {
+                "enabled": True,
+                "latest_factor_job": {"job_id": 1},
+                "latest_reference_job": {"job_id": 2},
+            }
+        },
+    }
+    _annotate_module_incomplete(module_val, _TRAVEL)
+
+    sub = module_val["submodules"][str(_TRAIN)]
+    assert sub["incomplete"] is False
+    assert sub["incomplete_reasons"] == []
+    assert module_val["incomplete"] is False
+
+
+def test_disabled_module_forces_incomplete_false_despite_missing_uploads():
+    """A disabled module is never "incomplete" — matches the legacy
+    frontend gate (nothing to upload for a module nobody sees)."""
+    module_val = {
+        "enabled": False,
+        "submodules": {str(_MEMBER): {"enabled": True, "latest_factor_job": None}},
+    }
+    _annotate_module_incomplete(module_val, _HEADCOUNT)
+
+    assert module_val["incomplete"] is False
+
+
+def test_disabled_submodule_does_not_drive_module_incomplete():
+    """An incomplete submodule that is itself disabled must not roll up
+    into the module-level flag — only *enabled* submodules count."""
+    module_val = {
+        "enabled": True,
+        "submodules": {
+            str(_MEMBER): {"enabled": False, "latest_factor_job": None},
+        },
+    }
+    _annotate_module_incomplete(module_val, _HEADCOUNT)
+
+    # The submodule itself still reports incomplete (it IS missing its
+    # factor) — only the module-level rollup ignores it.
+    assert module_val["submodules"][str(_MEMBER)]["incomplete"] is True
+    assert module_val["incomplete"] is False
+
+
+def test_common_factor_module_needs_module_level_factor_job():
+    """Equipment is in ``MODULES_REQUIRING_COMMON_FACTOR``: even with every
+    submodule individually satisfied (they're all noFactors), the module
+    stays incomplete until the module-level common factor upload lands."""
+    assert _EQUIPMENT in MODULES_REQUIRING_COMMON_FACTOR
+    module_val = {
+        "enabled": True,
+        "latest_common_factor_job": None,
+        "submodules": {
+            str(_SCIENTIFIC): {"enabled": True, "latest_factor_job": None},
+        },
+    }
+    _annotate_module_incomplete(module_val, _EQUIPMENT)
+
+    # The submodule itself has no mandatory factor (noFactors) — not
+    # individually incomplete.
+    assert module_val["submodules"][str(_SCIENTIFIC)]["incomplete"] is False
+    # But the module rolls up incomplete via the missing common factor.
+    assert module_val["incomplete"] is True
+
+
+def test_common_factor_present_clears_module_incomplete():
+    """Same shape as above, but the common factor job is now present —
+    the module clears."""
+    module_val = {
+        "enabled": True,
+        "latest_common_factor_job": {"job_id": 9},
+        "submodules": {
+            str(_SCIENTIFIC): {"enabled": True, "latest_factor_job": None},
+        },
+    }
+    _annotate_module_incomplete(module_val, _EQUIPMENT)
+
+    assert module_val["incomplete"] is False
+
+
+def test_common_factor_satisfies_submodule_missing_own_factor():
+    """A submodule with ``mandatory_factor=True`` is satisfied by the
+    module's common-factor job even without its own — matches the legacy
+    frontend fallback rule (``_submodule_incomplete_reasons`` docstring)."""
+    # additional_purchases (67) is the one purchase submodule with its own
+    # mandatory_factor=True; the module (purchase=5) is also in
+    # MODULES_REQUIRING_COMMON_FACTOR.
+    purchase = int(ModuleTypeEnum.purchase)
+    assert SUBMODULE_MANDATORINESS[(purchase, 67)].mandatory_factor is True
+    assert purchase in MODULES_REQUIRING_COMMON_FACTOR
+
+    module_val = {
+        "enabled": True,
+        "latest_common_factor_job": {"job_id": 9},
+        "submodules": {"67": {"enabled": True, "latest_factor_job": None}},
+    }
+    _annotate_module_incomplete(module_val, purchase)
+
+    assert module_val["submodules"]["67"]["incomplete"] is False
+    assert module_val["incomplete"] is False
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level "ready to open" — presence case (every module complete)
+# ---------------------------------------------------------------------------
+
+YEAR = 2025
+URL = f"/api/v1/year-configuration/{YEAR}"
+
+
+def _seed_jobs_for_full_completion() -> list[DataIngestionJob]:
+    """One finished factor/reference job per mandatory (module, det) pair,
+    plus a module-level common-factor job for every module in
+    ``MODULES_REQUIRING_COMMON_FACTOR`` — enough to satisfy every
+    ``incomplete`` rule across the whole default config."""
+    jobs: list[DataIngestionJob] = []
+
+    def _job(module_type_id, data_entry_type_id, target_type) -> DataIngestionJob:
+        return DataIngestionJob(
+            entity_type=EntityType.MODULE_PER_YEAR,
+            module_type_id=module_type_id,
+            data_entry_type_id=data_entry_type_id,
+            year=YEAR,
+            target_type=target_type,
+            ingestion_method=IngestionMethod.csv,
+            provider=UserProvider.DEFAULT,
+            state=IngestionState.FINISHED,
+            result=IngestionResult.SUCCESS,
+            is_current=True,
+        )
+
+    for module_type, dets in MODULE_TYPE_TO_DATA_ENTRY_TYPES.items():
+        for det in dets:
+            rules = SUBMODULE_MANDATORINESS.get((int(module_type), int(det)))
+            if rules is None:
+                continue
+            if rules.mandatory_factor:
+                jobs.append(_job(int(module_type), int(det), TargetType.FACTORS))
+            if rules.mandatory_reference:
+                jobs.append(_job(int(module_type), int(det), TargetType.REFERENCE_DATA))
+
+    for module_type_id in MODULES_REQUIRING_COMMON_FACTOR:
+        jobs.append(_job(module_type_id, None, TargetType.FACTORS))
+
+    return jobs
+
+
+@pytest_asyncio.fixture
+async def db_fully_uploaded_year():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        session.add(
+            YearConfiguration(
+                year=YEAR,
+                provider=UserProvider.DEFAULT,
+                is_started=False,
+                configuration_completed=datetime.now(timezone.utc),
+                config=generate_default_year_config(),
+            )
+        )
+        session.add_all(_seed_jobs_for_full_completion())
+        await session.commit()
+        yield session, async_session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_every_module_reports_complete_once_all_mandatory_uploads_present(
+    client, monkeypatch, db_fully_uploaded_year
+):
+    """Presence case: once every mandatory factor/reference (submodule and
+    common) is uploaded, the year-configuration response marks every
+    module — and every submodule — ``incomplete=False``. This is the
+    signal the Configurator reads to enable "Ouvrir l'année pour les
+    utilisateurs" (the absence case is covered in slice (a))."""
+    _, factory = db_fully_uploaded_year
+    app.dependency_overrides[deps_module.get_current_user] = lambda: type(
+        "U", (), {"id": 1, "provider": UserProvider.DEFAULT, "institutional_id": "1"}
+    )()
+
+    async def override_get_db():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+
+    response = client.get(URL)
+    assert response.status_code == 200, response.text
+    modules = response.json()["config"]["modules"]
+
+    incomplete_modules = {
+        m: val["incomplete"] for m, val in modules.items() if val["incomplete"]
+    }
+    assert incomplete_modules == {}, (
+        f"expected every module complete, still incomplete: {incomplete_modules}"
+    )
+    for module_key, module_val in modules.items():
+        for sub_key, sub_val in module_val["submodules"].items():
+            assert sub_val["incomplete"] is False, (
+                f"module {module_key} submodule {sub_key} still incomplete: "
+                f"{sub_val['incomplete_reasons']}"
+            )

--- a/backend/tests/integration/backoffice/test_module_activation.py
+++ b/backend/tests/integration/backoffice/test_module_activation.py
@@ -1,0 +1,275 @@
+"""Integration tests for module/sub-module activation behavior (issue #1403,
+checklist item "Common module behavior").
+
+Covers, at the ``YearConfiguration`` API layer (backend source of truth for
+the backoffice Configurator):
+
+- Deactivating one module must not alter unrelated modules' upload state.
+- Re-activating a module preserves previously uploaded data (no data loss
+  on toggle) — uploads live in ``DataIngestionJob`` rows, keyed
+  independently of the module's ``enabled`` flag, so toggling ``enabled``
+  must never touch them.
+- Sub-module activation/deactivation persists in ``YearConfiguration.config``.
+
+Issue #1433 (sibling PR) reports that deactivating Headcount in the
+Configurator visually hides Equipment/Process Emissions/Purchases data.
+Its own investigation plan (``1433-headcount-deactivation-deletes-other-
+modules-data.md``) ruled out ``_deep_merge`` / the year-configuration
+response as the mechanism via code review, but left it unconfirmed pending
+a regression test. ``test_deactivating_headcount_does_not_alter_sibling_
+modules`` below IS that regression test, scoped to this test suite's layer
+(the year-configuration response the Configurator screen renders from). If
+this test ever starts failing, the cascade lives in the layer #1403(b)
+covers and should be fixed here (not xfail'd) — the plan's suspected
+culprits (report-stats/stat-bucket computation, or a frontend gate) are
+outside this file's scope and remain #1433's to chase down.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.module_type import ModuleTypeEnum
+from app.models.user import UserProvider
+from app.models.year_configuration import YearConfiguration
+from app.services.year_config_service import generate_default_year_config
+
+URL = "/api/v1/year-configuration/2025"
+YEAR = 2025
+
+
+def _finished_job(
+    *, module_type_id: int, data_entry_type_id: int, target_type: TargetType
+) -> DataIngestionJob:
+    """A FINISHED+SUCCESS upload job — what a "data already uploaded"
+    submodule looks like in the ``latest_*_job`` enrichment."""
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        module_type_id=module_type_id,
+        data_entry_type_id=data_entry_type_id,
+        year=YEAR,
+        target_type=target_type,
+        ingestion_method=IngestionMethod.csv,
+        provider=UserProvider.DEFAULT,
+        state=IngestionState.FINISHED,
+        result=IngestionResult.SUCCESS,
+        is_current=True,
+    )
+
+
+@pytest_asyncio.fixture
+async def db_with_multi_module_uploads():
+    """Seed one YearConfiguration + DATA_ENTRIES jobs for Headcount
+    (member), Equipment (scientific), Purchase (scientific_equipment) and
+    Process Emissions — one representative submodule per module — so the
+    year-configuration response has real "data uploaded" state to compare
+    across a Headcount enable/disable toggle."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", echo=False, future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        session.add(
+            YearConfiguration(
+                year=YEAR,
+                provider=UserProvider.DEFAULT,
+                is_started=False,
+                configuration_completed=datetime.now(timezone.utc),
+                config=generate_default_year_config(),
+            )
+        )
+        session.add_all(
+            [
+                _finished_job(
+                    module_type_id=int(ModuleTypeEnum.headcount),
+                    data_entry_type_id=1,  # member
+                    target_type=TargetType.DATA_ENTRIES,
+                ),
+                _finished_job(
+                    module_type_id=int(ModuleTypeEnum.equipment),
+                    data_entry_type_id=10,  # scientific
+                    target_type=TargetType.DATA_ENTRIES,
+                ),
+                _finished_job(
+                    module_type_id=int(ModuleTypeEnum.purchase),
+                    data_entry_type_id=60,  # scientific_equipment
+                    target_type=TargetType.DATA_ENTRIES,
+                ),
+                _finished_job(
+                    module_type_id=int(ModuleTypeEnum.process_emissions),
+                    data_entry_type_id=50,  # process_emissions
+                    target_type=TargetType.DATA_ENTRIES,
+                ),
+            ]
+        )
+        await session.commit()
+        yield session, async_session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def _admin_user() -> MagicMock:
+    u = MagicMock()
+    u.id = 1
+    u.email = "backoffice-admin@example.com"
+    u.institutional_id = "99999"
+    u.provider = UserProvider.DEFAULT
+    return u
+
+
+def _wire(monkeypatch, db_factory) -> None:
+    app.dependency_overrides[deps_module.get_current_user] = _admin_user
+
+    async def override_get_db():
+        async with db_factory() as session:
+            yield session
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+
+    async def fake_is_permitted(user, path, action="view"):
+        return path == "backoffice.configuration" and action in ("view", "edit")
+
+    monkeypatch.setattr("app.api.v1.year_configuration.is_permitted", fake_is_permitted)
+
+    # ``audit_document_one_current_idx`` is declared with
+    # ``postgresql_where=...`` only — a Postgres-only partial-unique index.
+    # SQLite's generic ``Index()`` DDL ignores the dialect-specific WHERE
+    # clause and creates a fully unique index on (entity_id, entity_type)
+    # instead, so a second PATCH to the same year (needed to exercise
+    # disable-then-re-enable) trips a UNIQUE constraint that production
+    # Postgres never would. Audit trail persistence isn't what these tests
+    # cover — stub it out rather than fight the sqlite/pg DDL divergence.
+    async def fake_create_audit_entry(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.api.v1.year_configuration.create_audit_entry", fake_create_audit_entry
+    )
+
+
+def _module_snapshot(config: dict, module_type_id: int) -> dict:
+    """Extract the comparable, job-derived fields for one module (drop
+    ``enabled``/``incomplete`` — those are expected to change; the point is
+    the *upload* fields must not)."""
+    module = config["modules"][str(module_type_id)]
+    return {
+        sub_key: {
+            "latest_data_job": sub_val.get("latest_data_job"),
+            "latest_factor_job": sub_val.get("latest_factor_job"),
+            "latest_reference_job": sub_val.get("latest_reference_job"),
+        }
+        for sub_key, sub_val in module["submodules"].items()
+    }
+
+
+def test_deactivating_headcount_does_not_alter_sibling_modules(
+    client, monkeypatch, db_with_multi_module_uploads
+):
+    """#1433 regression pin: disabling Headcount must leave Equipment,
+    Purchase and Process Emissions' uploaded-data state byte-for-byte
+    unchanged in the year-configuration response — the same response the
+    Configurator screen renders module cards from."""
+    _, factory = db_with_multi_module_uploads
+    _wire(monkeypatch, factory)
+
+    before = client.get(URL).json()["config"]
+    before_snapshots = {
+        m: _module_snapshot(before, m)
+        for m in (
+            int(ModuleTypeEnum.equipment),
+            int(ModuleTypeEnum.purchase),
+            int(ModuleTypeEnum.process_emissions),
+        )
+    }
+
+    patch = client.patch(URL, json={"config": {"modules": {"1": {"enabled": False}}}})
+    assert patch.status_code == 200, patch.text
+    assert patch.json()["config"]["modules"]["1"]["enabled"] is False
+
+    after = client.get(URL).json()["config"]
+    for module_type_id, snapshot in before_snapshots.items():
+        assert _module_snapshot(after, module_type_id) == snapshot, (
+            f"module {module_type_id}'s upload state changed after "
+            "disabling Headcount — #1433 cascade reproduced at the "
+            "year-configuration layer"
+        )
+
+
+def test_reactivating_module_preserves_previously_uploaded_data(
+    client, monkeypatch, db_with_multi_module_uploads
+):
+    """Disable then re-enable Headcount: its own member submodule's
+    ``latest_data_job`` must still be there — the toggle only flips a bool
+    in ``config``, it never touches the ``DataIngestionJob`` rows."""
+    _, factory = db_with_multi_module_uploads
+    _wire(monkeypatch, factory)
+
+    before = client.get(URL).json()["config"]
+    headcount_before = _module_snapshot(before, int(ModuleTypeEnum.headcount))
+    assert headcount_before["1"]["latest_data_job"] is not None  # sanity
+
+    client.patch(URL, json={"config": {"modules": {"1": {"enabled": False}}}})
+    reenabled = client.patch(
+        URL, json={"config": {"modules": {"1": {"enabled": True}}}}
+    )
+    assert reenabled.status_code == 200, reenabled.text
+    assert reenabled.json()["config"]["modules"]["1"]["enabled"] is True
+
+    after = client.get(URL).json()["config"]
+    assert _module_snapshot(after, int(ModuleTypeEnum.headcount)) == headcount_before
+
+
+def test_submodule_activation_persists_in_config(
+    client, monkeypatch, db_with_multi_module_uploads
+):
+    """Toggling a sub-module's ``enabled`` flag persists in
+    ``YearConfiguration.config`` and survives a re-fetch."""
+    _, factory = db_with_multi_module_uploads
+    _wire(monkeypatch, factory)
+
+    patch = client.patch(
+        URL,
+        json={"config": {"modules": {"4": {"submodules": {"10": {"enabled": False}}}}}},
+    )
+    assert patch.status_code == 200, patch.text
+    assert (
+        patch.json()["config"]["modules"]["4"]["submodules"]["10"]["enabled"] is False
+    )
+
+    refetched = client.get(URL).json()["config"]
+    assert refetched["modules"]["4"]["submodules"]["10"]["enabled"] is False
+    # Sibling submodule untouched by the sub-module-scoped patch.
+    assert refetched["modules"]["4"]["submodules"]["11"]["enabled"] is True

--- a/backend/tests/integration/services/data_ingestion/test_backoffice_factor_upload_green_box_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_backoffice_factor_upload_green_box_pg.py
@@ -1,0 +1,258 @@
+"""Integration tests for the backoffice factor-upload pipeline (issue
+#1403 checklist, slice (b) — backend common-module-behavior):
+
+- Uploading a factor file leads to a job with no error status (the
+  Configurator's "green box" condition) — driven at the API level
+  (``POST /files/temp-upload`` + ``POST /sync/dispatch``), not the UI.
+- The validation pipeline correctly *dispatches* a bad row to a recorded
+  row-error without aborting the whole batch (spot-check of one concrete,
+  already-implemented field-level rule — not a re-test of every DTO;
+  field-level validation itself is covered by
+  ``tests/unit/services/data_ingestion/csv_providers/``).
+
+Both tests drive the real ``ModulePerYearFactorCSVProvider`` against the
+committed CI-safe fixture ``tests/fixtures/csv/purchases_common_factors_
+smoke.csv`` (module-level "common factor" upload for Purchase, module_type
+5). This lives under ``services/data_ingestion/`` (not the new
+``backoffice/`` package) and requires real Postgres — ``FactorRepository.
+upsert_factors`` issues a Postgres-only ``ON CONFLICT ... (classification::
+text)`` upsert that SQLite cannot parse, so every existing test that
+exercises real factor upsert already lives here as a ``_pg`` suite; this
+mirrors that established placement rather than fighting it.
+
+Setup mirrors ``test_plan_310b_factor_reupload_endpoint_pg.py``: real HTTP
+dispatch, ``SessionLocal`` monkeypatched so the background job runs
+against the test Postgres, and the ``+psycopg`` driver (not ``+asyncpg``)
+for the app-facing engine — asyncpg is strict about tz-aware datetimes on
+a tz-naive column in ``audit_documents.changed_at`` (a latent, unrelated
+model bug production's psycopg driver silently coerces around; out of
+scope here, see that file's comment for the full story).
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.api.deps as deps_module
+from app.main import app
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.module_type import ModuleTypeEnum
+from app.models.user import UserProvider
+from app.models.year_configuration import YearConfiguration
+from app.services.year_config_service import generate_default_year_config
+
+from .conftest import csv_fixture_path
+
+YEAR = 2025
+POLL_TIMEOUT_SECONDS = 15.0
+POLL_INTERVAL_SECONDS = 0.1
+
+
+@pytest_asyncio.fixture
+async def pg_app(pg_dsn, monkeypatch, tmp_path):
+    """Wire the FastAPI app to the test Postgres + bypass auth + redirect
+    file storage to ``tmp_path``. See module docstring for the
+    ``+psycopg`` driver rationale."""
+    psycopg_dsn = pg_dsn.replace("+asyncpg", "+psycopg")
+    engine = create_async_engine(psycopg_dsn, future=True)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with factory() as session:
+            yield session
+
+    fake_user = MagicMock()
+    fake_user.id = 1
+    fake_user.email = "backoffice-admin@example.com"
+    fake_user.display_name = "Backoffice Admin"
+    fake_user.institutional_id = "99999"
+    fake_user.provider = UserProvider.DEFAULT
+    # ``/files/temp-upload`` gates on this directly (not the mockable
+    # ``is_permitted`` OPA call).
+    fake_user.calculate_permissions.return_value = {
+        "backoffice.configuration": ["view", "edit"]
+    }
+
+    app.dependency_overrides[deps_module.get_db] = override_get_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: fake_user
+
+    async def always_allowed(*_args, **_kwargs) -> bool:
+        return True
+
+    monkeypatch.setattr("app.api.v1.data_sync.is_permitted", always_allowed)
+
+    monkeypatch.setattr(
+        "app.core.config.get_settings.cache_clear", lambda: None, raising=False
+    )
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "FILES_STORAGE_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "FILES_ENCRYPTION_KEY", "")
+    monkeypatch.setattr(settings, "FILES_ENCRYPTION_SALT", "")
+
+    # Plan 310-C: every job_type funnels through app.tasks.runner, which
+    # opens its own sessions via the bare ``SessionLocal`` name imported
+    # at module load — rebind where it's used, not where it's defined.
+    monkeypatch.setattr("app.tasks.runner.SessionLocal", factory)
+    monkeypatch.setattr("app.tasks.emission_recalculation_tasks.SessionLocal", factory)
+
+    async with factory() as session:
+        session.add(
+            YearConfiguration(
+                year=YEAR,
+                provider=UserProvider.DEFAULT,
+                is_started=False,
+                configuration_completed=datetime.now(timezone.utc),
+                config=generate_default_year_config(),
+            )
+        )
+        await session.commit()
+
+    yield {"factory": factory, "dsn": psycopg_dsn}
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+async def _wait_for_job(
+    factory, job_id: int, *, timeout: float = POLL_TIMEOUT_SECONDS
+) -> DataIngestionJob:
+    import asyncio
+    import time
+
+    deadline = time.monotonic() + timeout
+    last_state = None
+    while time.monotonic() < deadline:
+        async with factory() as s:
+            row = (
+                await s.execute(
+                    select(DataIngestionJob).where(col(DataIngestionJob.id) == job_id)
+                )
+            ).scalar_one()
+            last_state = row.state
+            if row.state == IngestionState.FINISHED:
+                return row
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError(
+        f"Job {job_id} did not reach FINISHED within {timeout}s "
+        f"(last state seen: {last_state})"
+    )
+
+
+async def _upload_and_dispatch(
+    client, *, csv_bytes: bytes, filename: str, tmp_path: Path
+) -> int:
+    """Write the CSV straight into the (patched) storage root and dispatch.
+
+    Mirrors ``test_plan_310b_factor_reupload_endpoint_pg.py``: the real
+    ``/files/temp-upload`` endpoint holds a MODULE-LEVEL ``files_store``
+    singleton built at import time (``app/api/v1/files.py``), so
+    patching ``settings.FILES_STORAGE_PATH`` after import never reaches
+    it — only the factor provider's lazily-constructed ``files_store``
+    (built per-request from live settings) sees the patched path. Writing
+    the file directly sidesteps that singleton mismatch; ``/sync/dispatch``
+    is still the real API surface under test.
+    """
+    folder = tmp_path / "tmp" / "green_box"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / filename).write_bytes(csv_bytes)
+    file_path = f"tmp/green_box/{filename}"
+
+    dispatch = await client.post(
+        "/v1/sync/dispatch",
+        json={
+            "ingestion_method": IngestionMethod.csv.value,
+            "target_type": TargetType.FACTORS.value,
+            "year": YEAR,
+            "file_path": file_path,
+            "config": {"module_type_id": ModuleTypeEnum.purchase.value},
+        },
+    )
+    assert dispatch.status_code == 200, dispatch.text
+    body = dispatch.json()
+    assert body["state"] == IngestionState.NOT_STARTED.value, (
+        "dispatch itself must not report an error state"
+    )
+    return body["job_id"]
+
+
+@pytest.mark.asyncio
+async def test_factor_csv_upload_dispatches_and_finishes_without_error(
+    pg_app, tmp_path
+):
+    """Green-box condition: a valid factor CSV, uploaded and dispatched
+    through the real API, runs through the real ``ModulePerYearFactorCSV
+    Provider`` and reaches FINISHED with a non-ERROR result."""
+    factory = pg_app["factory"]
+    csv_path: Path = csv_fixture_path("purchases_common", "factors")
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        job_id = await _upload_and_dispatch(
+            client,
+            csv_bytes=csv_path.read_bytes(),
+            filename="purchases_common_factors_smoke.csv",
+            tmp_path=tmp_path,
+        )
+
+    job = await _wait_for_job(factory, job_id)
+
+    assert job.job_type == "factor_ingest"
+    assert job.target_type == TargetType.FACTORS
+    assert job.result == IngestionResult.SUCCESS, job.status_message
+
+
+@pytest.mark.asyncio
+async def test_factor_csv_upload_flags_invalid_category_without_aborting_batch(
+    pg_app, tmp_path
+):
+    """Spot-check of one concrete, already-implemented validation rule:
+    ``purchase_category`` must match a ``DataEntryTypeEnum`` member name
+    exactly (``_resolve_data_entry_type`` in ``base_factor_csv_provider.
+    py``). One bad row alongside good ones must be recorded as a row
+    error and skipped — not silently accepted, and not fatal to the rest
+    of the batch — pinning that the pipeline *dispatches* validation
+    failures correctly rather than either ignoring or over-rejecting them."""
+    factory = pg_app["factory"]
+    csv_path: Path = csv_fixture_path("purchases_common", "factors")
+    lines = csv_path.read_text().splitlines()
+    header, valid_rows = lines[0], lines[1:]
+    bad_row = "eur,not_a_real_category,99999999,Bogus,ZZ,0.5"
+    csv_bytes = "\n".join([header, *valid_rows, bad_row]).encode()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        job_id = await _upload_and_dispatch(
+            client,
+            csv_bytes=csv_bytes,
+            filename="purchases_common_factors_with_bad_row.csv",
+            tmp_path=tmp_path,
+        )
+
+    job = await _wait_for_job(factory, job_id)
+
+    # Partial success: the good rows still upserted, so the pipeline
+    # downgrades to WARNING rather than failing the whole file.
+    assert job.result == IngestionResult.WARNING, job.status_message
+    stats = (job.meta or {}).get("stats", {})
+    assert stats.get("row_errors_count") == 1
+    row_errors = stats.get("row_errors", [])
+    assert any("not_a_real_category" in e.get("reason", "") for e in row_errors), (
+        row_errors
+    )


### PR DESCRIPTION
Part of #1403 (slice b/4 — see docs/src/implementation-plans/1403-backoffice-integration-tests-master.md).

## Covers

- **Module deactivation/reactivation**: deactivating Headcount does not alter Equipment/Purchase/Process Emissions' upload state in the year-configuration response; re-enabling a module preserves its own previously-uploaded data (uploads live in `DataIngestionJob` rows, independent of the `enabled` flag). `backend/tests/integration/backoffice/test_module_activation.py`
- **Sub-module activation** persists correctly in `YearConfiguration.config` and doesn't leak to sibling sub-modules. Same file.
- **"Incomplete" tag computation**: unit-style tests directly against `_annotate_module_incomplete` / `_submodule_incomplete_reasons` (`app/api/v1/year_configuration.py`) with varied config fixtures — missing factor, missing reference, fully complete, disabled module, disabled submodule, common-factor module-level requirement and its per-submodule fallback. Plus one endpoint-level test seeding every mandatory upload across every module/submodule and asserting `GET /year-configuration/{year}` reports every module `incomplete=False` (the "ready to open" presence case — slice (a) covers the absence case). `backend/tests/integration/backoffice/test_incomplete_flag.py`
- **Factor upload green box**: a valid factor CSV, dispatched through the real `/sync/dispatch` API, runs through the real `ModulePerYearFactorCSVProvider` against real Postgres and reaches `FINISHED` + `SUCCESS`. **Data validation pipeline dispatch spot-check**: one bad row (invalid `purchase_category`) alongside good ones is recorded as a row error and skipped without aborting the batch (result downgrades to `WARNING`), pinning that the pipeline routes validation failures correctly rather than ignoring or over-rejecting. `backend/tests/integration/services/data_ingestion/test_backoffice_factor_upload_green_box_pg.py` (lives under `services/data_ingestion/`, not the new `backoffice/` package, because `FactorRepository.upsert_factors` issues a Postgres-only `ON CONFLICT` upsert SQLite can't parse — matches where every other test touching real factor upsert already lives).

## #1433 note

Issue #1433 (sibling PR, separately tracked) reports that deactivating Headcount in the Configurator visually hides Equipment/Process Emissions/Purchases data. I wrote the regression test its own investigation plan called for (`test_deactivating_headcount_does_not_alter_sibling_modules`) — it asserts sibling modules' upload state is byte-for-byte unchanged after disabling Headcount. **It passes, not xfail'd**: no cascade reproduces at the year-configuration layer (matching #1433's own code-review conclusion that `_deep_merge` isn't the culprit). If a cascade exists, it lives elsewhere (report-stats/stat-bucket computation or a frontend gate, per #1433's plan) — outside this slice's scope and #1433's to chase down.

## Test plan

- [x] `uv run pytest backend/tests/integration/backoffice/ backend/tests/integration/services/data_ingestion/test_backoffice_factor_upload_green_box_pg.py` — 14 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy` on the new files — no issues