### PR TITLE
fix: make canUserAccessModule workspace-scoped (view AND edit)

### DIFF
--- a/frontend/src/components/organisms/module/ModuleNavigation.vue
+++ b/frontend/src/components/organisms/module/ModuleNavigation.vue
@@ -29,6 +29,9 @@ const currentIndex = computed(() => {
 });
 
 const isLastModule = computed(() => {
+  // `indexOf` returns -1 when the list is empty, which would otherwise equal
+  // `length - 1` and render the results link on a module with no neighbours.
+  if (currentIndex.value === -1) return false;
   return currentIndex.value === visibleModulesList.value.length - 1;
 });
 

--- a/frontend/src/router/guards/permissionGuard.ts
+++ b/frontend/src/router/guards/permissionGuard.ts
@@ -8,8 +8,11 @@ import type { Module } from 'src/constant/modules';
 /**
  * Single permission guard for route `beforeEnter`.
  *
- * - Module routes (`meta.moduleEdit`) require workspace-scoped view AND edit on
- *   the route's `:module` param (data entry needs edit breadth).
+ * - Module routes (`meta.moduleEdit`) are gated by `canUserAccessModule` on the
+ *   route's `:module` param: workspace-scoped view AND edit (data entry needs
+ *   edit breadth). The sidebar, the prev/next arrows and the home "start"
+ *   button filter on that same predicate, so a rendered affordance can never
+ *   land the user on `/unauthorized` (#1382).
  * - Back-office routes declare `meta.requiredPermission` (+ optional
  *   `meta.requiredAction`, default view), checked any-scope so affiliation- and
  *   unit-suffixed keys match. `meta.requiredPermission` is the single source of
@@ -26,10 +29,7 @@ export function permissionGuard(
 
   if (to.meta.moduleEdit) {
     const module = to.params.module as Module;
-    if (
-      !authStore.hasUserModulePermission(module, PermissionAction.VIEW) ||
-      !authStore.hasUserModulePermission(module, PermissionAction.EDIT)
-    ) {
+    if (!authStore.canUserAccessModule(module)) {
       return { name: 'unauthorized' };
     }
     return true;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -12,9 +12,10 @@ import { computed } from 'vue';
 import {
   PermissionAction,
   MODULE_STATUS_PERMISSION,
-  hasPermission,
   hasAnyScopePermission,
+  hasWorkspacePermission,
   hasBackOfficeAreaPermission,
+  canAccessModule,
   getModulePermissionPath,
   type FlatUserPermissions,
 } from 'src/utils/permission';
@@ -169,27 +170,17 @@ export const useAuthStore = defineStore('auth', () => {
     action: PermissionAction = PermissionAction.VIEW,
   ): boolean {
     if (!user.value || !user.value.permissions) return false;
-    // Check for global permission first (without workspace context)
-    const globallyPermitted = hasPermission(
+    // A global (bare) key wins; otherwise the lookup carries workspace context
+    // and matches either the unit-scoped key (principal) or the own-scoped key
+    // (standard user, ``modules.X/<unit>/own``). Unit-level-only controls (e.g.
+    // the validate button) use a dedicated permission key (``module.status``),
+    // not scope inference.
+    return hasWorkspacePermission(
       user.value.permissions,
       path,
+      workspaceStore.selectedUnit?.institutional_id,
       action,
     );
-    if (globallyPermitted) return true;
-    // append workspace context to permission path if available. A unit-context
-    // lookup matches either the unit-scoped key (principal) or the own-scoped
-    // key (standard user, ``modules.X/<unit>/own``) — mirrors the backend
-    // ``has_permission``. Unit-level-only controls (e.g. the validate button)
-    // use a dedicated permission key (``module.status``), not scope inference.
-    const institutionalId = workspaceStore.selectedUnit?.institutional_id;
-    if (institutionalId) {
-      const unitPath = `${path}/${institutionalId}`;
-      return (
-        hasPermission(user.value.permissions, unitPath, action) ||
-        hasPermission(user.value.permissions, `${unitPath}/own`, action)
-      );
-    }
-    return false;
   }
 
   /**
@@ -220,12 +211,20 @@ export const useAuthStore = defineStore('auth', () => {
     return hasUserPermission(MODULE_STATUS_PERMISSION, PermissionAction.EDIT);
   }
 
+  /**
+   * Whether the current user may open `module`'s page in the selected unit.
+   *
+   * `permissionGuard` enforces this on navigation and the nav surfaces
+   * (sidebar, prev/next arrows, home "start" button) filter on it, so no
+   * affordance can lead to `/unauthorized` (#1382). Deliberately
+   * workspace-scoped: a grant held in another unit must not make a module
+   * appear here.
+   */
   function canUserAccessModule(module: Module): boolean {
-    const path = getModulePermissionPath(module);
-    if (!path) return true; // Unprotected module, accessible to all users
-    return (
-      hasUserAnyScopePermission(path, PermissionAction.VIEW) ||
-      hasUserAnyScopePermission(path, PermissionAction.EDIT)
+    return canAccessModule(
+      user.value?.permissions,
+      module,
+      workspaceStore.selectedUnit?.institutional_id,
     );
   }
 

--- a/frontend/src/utils/permission.ts
+++ b/frontend/src/utils/permission.ts
@@ -159,6 +159,64 @@ export function hasAnyScopePermission(
 }
 
 /**
+ * Check if the user has `action` on `path` within the SELECTED workspace unit.
+ *
+ * Resolution order, mirroring the backend's `has_permission`:
+ *   1. the bare key (`modules.headcount`) — a global grant,
+ *   2. the unit-scoped key (`modules.headcount/<unit>`) — principal,
+ *   3. the own-scoped key (`modules.headcount/<unit>/own`) — standard user.
+ *
+ * Unlike `hasAnyScopePermission`, a grant held in a DIFFERENT unit never
+ * matches. Use this for anything that reads or writes unit data.
+ */
+export function hasWorkspacePermission(
+  permissions: FlatUserPermissions | null | undefined,
+  path: string,
+  institutionalId: string | undefined,
+  action: PermissionAction = PermissionAction.VIEW,
+): boolean {
+  if (hasPermission(permissions, path, action)) return true;
+  if (!institutionalId) return false;
+  const unitPath = `${path}/${institutionalId}`;
+  return (
+    hasPermission(permissions, unitPath, action) ||
+    hasPermission(permissions, `${unitPath}/own`, action)
+  );
+}
+
+/**
+ * Whether the user may open `module`'s page in the selected unit.
+ *
+ * This is the single definition of module reachability: `permissionGuard`
+ * enforces it on navigation, and the nav surfaces (sidebar, prev/next arrows,
+ * home "start" button) filter on it, so an affordance can never lead to
+ * `/unauthorized` (#1382). Module pages are data-entry pages, hence view AND
+ * edit. Modules with no permission path are unreachable, not public.
+ */
+export function canAccessModule(
+  permissions: FlatUserPermissions | null | undefined,
+  module: Module,
+  institutionalId: string | undefined,
+): boolean {
+  const path = getModulePermissionPath(module);
+  if (!path) return false;
+  return (
+    hasWorkspacePermission(
+      permissions,
+      path,
+      institutionalId,
+      PermissionAction.VIEW,
+    ) &&
+    hasWorkspacePermission(
+      permissions,
+      path,
+      institutionalId,
+      PermissionAction.EDIT,
+    )
+  );
+}
+
+/**
  * Check if the user holds ANY back-office area permission granting `action`.
  *
  * The back-office area is the `backoffice.*` page family (reporting, users,

--- a/frontend/tests/unit/module-access-permission.spec.ts
+++ b/frontend/tests/unit/module-access-permission.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression test for #1382 — a standard user lands on "403 Unauthorized
+ * Access" by clicking the home "start" button, or the prev/next module arrows
+ * at the bottom of a module page (Equipment from External Cloud & AI, Purchase
+ * from Professional travel).
+ *
+ * Root cause: the nav surfaces filtered on ``canUserAccessModule``, which used
+ * ``hasAnyScopePermission`` — it matches a grant held in ANY unit and accepts
+ * view OR edit. ``permissionGuard`` meanwhile required workspace-scoped view
+ * AND edit. A user who is standard (own-scoped) in the selected unit but holds
+ * a grant on, say, Equipment in some other unit therefore saw the Equipment
+ * arrow, and the guard bounced them to ``/unauthorized`` on click.
+ *
+ * The fix makes ``canAccessModule`` the single predicate behind both the guard
+ * and the nav surfaces. These tests pin it against the backend's actual grants
+ * (``calculate_user_permissions`` in ``backend/app/models/user.py``): a
+ * standard user receives only ``modules.professional_travel/<unit>/own`` and
+ * ``modules.external_cloud_and_ai/<unit>/own``.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { MODULES } from '../../src/constant/modules';
+import {
+  canAccessModule,
+  type FlatUserPermissions,
+} from '../../src/utils/permission';
+
+const UNIT = '0184';
+const OTHER_UNIT = '9999';
+
+/** What `CO2_USER_STD` actually receives for `UNIT`. */
+const STANDARD_USER = {
+  [`modules.professional_travel/${UNIT}/own`]: ['view', 'edit'],
+  [`modules.external_cloud_and_ai/${UNIT}/own`]: ['view', 'edit'],
+} as unknown as FlatUserPermissions;
+
+/** What `CO2_USER_PRINCIPAL` receives for `UNIT`. */
+const PRINCIPAL_USER = {
+  [`modules.headcount/${UNIT}`]: ['view', 'edit', 'sync'],
+  [`modules.equipment/${UNIT}`]: ['view', 'edit', 'sync'],
+  [`modules.professional_travel/${UNIT}`]: ['view', 'edit', 'sync'],
+  [`modules.external_cloud_and_ai/${UNIT}`]: ['view', 'edit', 'sync'],
+  [`module.status/${UNIT}`]: ['edit'],
+} as unknown as FlatUserPermissions;
+
+test('standard user reaches exactly the two own-scoped modules', () => {
+  expect(canAccessModule(STANDARD_USER, MODULES.ExternalCloudAndAI, UNIT)).toBe(
+    true,
+  );
+  expect(canAccessModule(STANDARD_USER, MODULES.ProfessionalTravel, UNIT)).toBe(
+    true,
+  );
+});
+
+test('standard user cannot reach the modules the arrows used to point at', () => {
+  // Equipment sits just before External Cloud & AI in `MODULES_ORDER`, and
+  // Purchase just after Professional travel — the two arrows from the issue.
+  expect(canAccessModule(STANDARD_USER, MODULES.Equipment, UNIT)).toBe(false);
+  expect(canAccessModule(STANDARD_USER, MODULES.Purchase, UNIT)).toBe(false);
+  // Headcount is first in `MODULES_ORDER`: where the "start" button pointed.
+  expect(canAccessModule(STANDARD_USER, MODULES.Headcount, UNIT)).toBe(false);
+});
+
+test('a grant in another unit does not unlock the module in this one', () => {
+  // The assertion the old `hasAnyScopePermission` implementation failed.
+  const crossUnit = {
+    ...STANDARD_USER,
+    [`modules.equipment/${OTHER_UNIT}`]: ['view', 'edit', 'sync'],
+  } as unknown as FlatUserPermissions;
+
+  expect(canAccessModule(crossUnit, MODULES.Equipment, UNIT)).toBe(false);
+  expect(canAccessModule(crossUnit, MODULES.Equipment, OTHER_UNIT)).toBe(true);
+});
+
+test('principal reaches every module granted on the selected unit', () => {
+  expect(canAccessModule(PRINCIPAL_USER, MODULES.Headcount, UNIT)).toBe(true);
+  expect(canAccessModule(PRINCIPAL_USER, MODULES.Equipment, UNIT)).toBe(true);
+  expect(
+    canAccessModule(PRINCIPAL_USER, MODULES.ProfessionalTravel, UNIT),
+  ).toBe(true);
+  // Not granted at all — no `modules.purchase` key in this fixture.
+  expect(canAccessModule(PRINCIPAL_USER, MODULES.Purchase, UNIT)).toBe(false);
+});
+
+test('view without edit is not enough — module pages are data entry', () => {
+  const viewOnly = {
+    [`modules.equipment/${UNIT}`]: ['view'],
+  } as unknown as FlatUserPermissions;
+  expect(canAccessModule(viewOnly, MODULES.Equipment, UNIT)).toBe(false);
+});
+
+test('a global (bare) grant reaches the module in any unit', () => {
+  const global = {
+    'modules.equipment': ['view', 'edit'],
+  } as unknown as FlatUserPermissions;
+  expect(canAccessModule(global, MODULES.Equipment, UNIT)).toBe(true);
+  expect(canAccessModule(global, MODULES.Equipment, undefined)).toBe(true);
+});
+
+test('no selected unit means no unit-scoped access', () => {
+  expect(
+    canAccessModule(STANDARD_USER, MODULES.ProfessionalTravel, undefined),
+  ).toBe(false);
+});
+
+test('modules with no permission path are unreachable, not public', () => {
+  // `Commuting` maps to `null` in `getModulePermissionPath`; the guard denies
+  // it, so the nav must not offer it either.
+  expect(canAccessModule(PRINCIPAL_USER, MODULES.Commuting, UNIT)).toBe(false);
+});
+
+test('null/undefined permissions deny everything', () => {
+  expect(canAccessModule(null, MODULES.ProfessionalTravel, UNIT)).toBe(false);
+  expect(canAccessModule(undefined, MODULES.ProfessionalTravel, UNIT)).toBe(
+    false,
+  );
+});


### PR DESCRIPTION
## What does this change?

Introduces `canAccessModule` as a single, workspace-scoped predicate that both `permissionGuard` and all nav surfaces (sidebar, prev/next arrows, home "start" button) use to decide whether a module is reachable. Also adds `hasWorkspacePermission` to `permission.ts`, consolidating the unit-scoped resolution logic that was previously duplicated inline in `auth.ts`.

A secondary fix guards `isLastModule` in `ModuleNavigation.vue` against the case where `indexOf` returns `-1` on an empty list (which would otherwise equal `length - 1` and render the results link when no neighbours exist).

## Why is this needed?

Standard users were landing on `403 Unauthorized Access` when clicking the home "start" button or the prev/next arrows between modules (e.g. Equipment ← External Cloud & AI, Purchase ← Professional travel).

Root cause: `canUserAccessModule` filtered nav affordances using `hasAnyScopePermission`, which matched a grant in **any** unit and accepted view **or** edit. `permissionGuard` meanwhile required workspace-scoped view **and** edit. A user with an own-scoped grant on External Cloud & AI in the selected unit, but a unit-scoped grant on Equipment in a different unit, would see the Equipment arrow rendered — and be bounced to `/unauthorized` on click.

## Type of change

Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues
- Related to #1382

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.