### PR TITLE
fix/translations corrections

### DIFF
--- a/frontend/src/components/molecules/data-management/UploadCard.vue
+++ b/frontend/src/components/molecules/data-management/UploadCard.vue
@@ -356,7 +356,7 @@ function handleAbort() {
               {{ $t('data_management_rows_imported') }}
             </span>
             <span v-if="jobInfo.timestamp">
-              {{ jobInfo.rowsProcessed !== undefined ? '•' : '' }}
+              {{ jobInfo.rowsProcessed !== undefined ? '·' : '' }}
               {{ jobInfo.timestamp.toLocaleDateString() }}
             </span>
           </div>

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -229,8 +229,7 @@ async function uploadSelectedFile(file: File) {
       (payload?: JobUpdatePayload) => {
         const result = payload?.result;
         const rowsProcessed = payload?.meta?.rows_processed as
-          | number
-          | undefined;
+          number | undefined;
 
         let color: string;
         let message: string;

--- a/frontend/src/components/molecules/data-management/UploadCardReferences.vue
+++ b/frontend/src/components/molecules/data-management/UploadCardReferences.vue
@@ -229,7 +229,8 @@ async function uploadSelectedFile(file: File) {
       (payload?: JobUpdatePayload) => {
         const result = payload?.result;
         const rowsProcessed = payload?.meta?.rows_processed as
-          number | undefined;
+          | number
+          | undefined;
 
         let color: string;
         let message: string;
@@ -413,7 +414,7 @@ function isErrorOrWarning(): boolean {
             {{ getJobInfo().rowsProcessed }}
             {{ $t('data_management_rows_imported') }}
             <span v-if="getJobInfo().timestamp">
-              • {{ getJobInfo().timestamp.toLocaleDateString() }}
+              · {{ getJobInfo().timestamp.toLocaleDateString() }}
             </span>
           </div>
         </div>

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -26,26 +26,23 @@
     <template v-else>
       <template v-if="!isPrintMode">
         <div class="flex w-full items-center justify-between q-mx-lg">
-          <div class="text-body1 text-weight-medium q-ml-sm q-mb-md text-black">
-            {{ carbonFootprintTitle }}
-          </div>
           <div
-            v-if="showControls"
-            class="flex items-center no-wrap q-gutter-xs"
+            class="flex items-center no-wrap q-ml-sm q-mb-md text-body1 text-weight-medium text-black"
           >
+            {{ carbonFootprintTitle }}
             <q-btn
-              v-if="emissionTypeInfoKey && moduleChartView === 'type'"
+              v-if="emissionTypeInfoKey"
               flat
               round
               dense
               icon="info_outline"
               size="sm"
-              class="text-grey-7"
+              class="text-grey-7 q-ml-xs"
               :aria-label="t('emission-type-breakdown-info-aria')"
             >
               <q-tooltip
-                anchor="bottom right"
-                self="top right"
+                anchor="bottom left"
+                self="top left"
                 :offset="[0, 8]"
                 max-width="320px"
                 class="text-body2"
@@ -53,6 +50,11 @@
                 {{ t(emissionTypeInfoKey) }}
               </q-tooltip>
             </q-btn>
+          </div>
+          <div
+            v-if="showControls"
+            class="flex items-center no-wrap q-gutter-xs"
+          >
             <div class="chart-view-toggle">
               <q-btn
                 unelevated
@@ -258,9 +260,12 @@ watch(
   },
 );
 
-const emissionTypeInfoKey = computed(() =>
-  getEmissionTypeBreakdownInfoKey(props.type),
-);
+const emissionTypeInfoKey = computed(() => {
+  const key = getEmissionTypeBreakdownInfoKey(props.type);
+  // Honor the tooltips.ts convention: empty copy hides the icon.
+  if (!key || !te(key) || !t(key)) return null;
+  return key;
+});
 
 const carbonFootprintTitle = computed(() => {
   const moduleKey = `carbon_footprint_title_${props.type}`;

--- a/frontend/src/components/organisms/module/ModuleTitle.vue
+++ b/frontend/src/components/organisms/module/ModuleTitle.vue
@@ -17,10 +17,20 @@
           </p>
           <p
             v-if="hasDescriptionSubtext"
-            class="text-caption text-grey-5 q-mb-none q-mt-xs"
+            class="subtext text-caption text-grey-5 q-mb-none q-mt-xs q-mb-lg"
           >
             {{ $t(`${type}-title-subtext`) }}
           </p>
+          <a
+            v-if="documentationLink"
+            :href="documentationLink"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="doc-link text-caption text-grey-6 q-mt-sm"
+          >
+            <q-icon :name="outlinedArticle" size="16px" class="q-mr-xs" />
+            {{ documentationTitle }}
+          </a>
         </div>
         <q-icon
           v-if="tooltipText"
@@ -41,7 +51,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { outlinedInfo } from '@quasar/extras/material-icons-outlined';
+import {
+  outlinedArticle,
+  outlinedInfo,
+} from '@quasar/extras/material-icons-outlined';
 import { Module } from 'src/constant/modules';
 import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 
@@ -57,8 +70,19 @@ const props = withDefaults(
   },
 );
 
-const { t } = useI18n();
+const { t, te } = useI18n();
 const tooltipText = computed(() => t(`module-${props.type}-title`));
+
+// Per-module documentation link: label + URL live in each module's i18n file.
+// Rendered only when the module defines a non-empty link.
+const documentationLink = computed(() => {
+  const key = `${props.type}-documentation-link`;
+  return te(key) ? t(key) : '';
+});
+const documentationTitle = computed(() => {
+  const key = `${props.type}-documentation-title`;
+  return te(key) && t(key) ? t(key) : t('documentation');
+});
 </script>
 
 <style scoped lang="scss">
@@ -79,5 +103,22 @@ const tooltipText = computed(() => t(`module-${props.type}-title`));
   display: flex;
   align-items: center;
   gap: tokens.$spacing-md;
+}
+
+// Preserve authored line breaks / blank lines so bullet lists in the
+// subtext render as intended instead of collapsing into one run-on line.
+.subtext {
+  white-space: pre-line;
+}
+
+.doc-link {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 </style>

--- a/frontend/src/constant/emissionTypeBreakdownInfo.ts
+++ b/frontend/src/constant/emissionTypeBreakdownInfo.ts
@@ -5,9 +5,13 @@ import { MODULES } from 'src/constant/modules';
 export const EMISSION_TYPE_BREAKDOWN_INFO_KEYS: Partial<
   Record<Module, string>
 > = {
-  [MODULES.Equipment]: 'module-equipment-charts',
+  [MODULES.Headcount]: 'module-headcount-charts',
+  [MODULES.ProcessEmissions]: 'module-process-emissions-charts',
   [MODULES.Buildings]: 'module-buildings-charts',
+  [MODULES.Equipment]: 'module-equipment-charts',
   [MODULES.ExternalCloudAndAI]: 'module-external-cloud-and-ai-charts',
+  [MODULES.ProfessionalTravel]: 'module-professional-travel-charts',
+  [MODULES.Purchase]: 'module-purchase-charts',
   [MODULES.ResearchFacilities]: 'module-research-facilities-charts',
 };
 

--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -135,10 +135,11 @@ const planeCabinClassField: ModuleField = {
   sortable: true,
   ratio: '1/1',
   editableInline: true,
+  optionLabelsAreKeys: true,
   options: [
-    { value: 'first', label: 'First' },
-    { value: 'business', label: 'Business' },
-    { value: 'economy', label: 'Economy' },
+    { value: 'first', label: 'charts-first-class-subcategory' },
+    { value: 'business', label: 'charts-business-class-subcategory' },
+    { value: 'economy', label: 'charts-eco-class-subcategory' },
   ],
 };
 

--- a/frontend/src/i18n/buildings.ts
+++ b/frontend/src/i18n/buildings.ts
@@ -10,8 +10,16 @@ export default {
     fr: 'Local | Locaux',
   },
   [`${MODULES.Buildings}-description`]: {
-    en: 'This module estimates the carbon footprint related to energy combustion sources (if your unit uses a non-centralized energy source) as well as to other building functions (heating, air conditioning, ventilation, and lighting). For more information: [buildings](https://epfl-enac.github.io/co2-calculator-user-doc/building/)',
-    fr: "Ce module permet d'estimer l'empreinte carbone liée aux émissions de combustion d'énergie (au cas où votre unité utilise une source d'énergie non-centralisée) ainsi que celles liées au bâtiment (chauffage, climatisation, ventilation et éclairage). Pour plus d'information : [bâtiments](https://epfl-enac.github.io/co2-calculator-user-doc/fr/building/)",
+    en: 'This module estimates the carbon footprint related to energy combustion sources (if your unit uses a non-centralized energy source) as well as to other building functions (heating, air conditioning, ventilation, and lighting).',
+    fr: "Ce module permet d'estimer l'empreinte carbone liée aux émissions de combustion d'énergie (au cas où votre unité utilise une source d'énergie non-centralisée) ainsi que celles liées au bâtiment (chauffage, climatisation, ventilation et éclairage).",
+  },
+  [`${MODULES.Buildings}-documentation-title`]: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
+  [`${MODULES.Buildings}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/building/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/building/',
   },
   [`${MODULES.Buildings}-title-subtext`]: {
     en: 'Enter the data required to estimate the carbon footprint related to the use of the buildings.',

--- a/frontend/src/i18n/buildings.ts
+++ b/frontend/src/i18n/buildings.ts
@@ -135,10 +135,6 @@ export default {
     en: 'Add',
     fr: 'Ajouter ',
   },
-  [`${MODULES.Buildings}.combustion-form-title`]: {
-    en: 'Add a heating type',
-    fr: 'Ajouter un type de chauffage',
-  },
 
   // Combustion fields
   [`${MODULES.Buildings}.inputs.name`]: {

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -503,10 +503,6 @@ export default {
     en: 'Equipment usage carbon footprint',
     fr: "Empreinte carbone liée à l'utilisation des équipements",
   },
-  carbon_footprint_tooltip_equipment: {
-    en: 'The emissions considered here are those related to the energy required to operate the equipment (scientific, IT, etc.).',
-    fr: "Les émissions considérées ici sont celles liées à l'énergie nécessaire à l'utilisation des équipements (scientifiques, informatiques, etc.).",
-  },
   carbon_footprint_title_purchase: {
     en: 'Purchases carbon footprint',
     fr: 'Empreinte carbone des achats',

--- a/frontend/src/i18n/equipment.ts
+++ b/frontend/src/i18n/equipment.ts
@@ -23,9 +23,7 @@ Please fill in the following columns:
 
 - Active use and standby use: Please enter the number of hours each piece of equipment is used per week. It is recommended to make a conservative estimate (not underestimated) to minimize the time required for this task.
 
-If your equipement active or standby power is different from the one used by default, please contact the administrator.
-
-For more information: [equipment](https://epfl-enac.github.io/co2-calculator-user-doc/equipment/)`,
+If your equipement active or standby power is different from the one used by default, please contact the administrator.`,
     fr: `Ce module permet d'estimer la consommation électrique de vos équipements scientifiques, IT et autres. La liste de équipements vient de l'inventaire effectué par votre unité pour la faculté.
 
 Veuillez remplir les colonnes suivantes:
@@ -34,9 +32,15 @@ Veuillez remplir les colonnes suivantes:
 
 - Usage actif et usage standby: veuillez mettre à jour les heures d'utilisation de chaque équipement par semaine. Il est recommandé de faire une estimation conservatrice (qui n'est pas sous-estimée) pour limiter le temps dédié à cette tâche.
 
-Si la puissance moyenne active ou standby de votre équipement est différente de celle utilisée par défaut, merci de contacter l'administrateur.
-
-Pour plus d'information : [équipments](https://epfl-enac.github.io/co2-calculator-user-doc/fr/equipment/)`,
+Si la puissance moyenne active ou standby de votre équipement est différente de celle utilisée par défaut, merci de contacter l'administrateur.`,
+  },
+  [`${MODULES.Equipment}-documentation-title`]: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
+  [`${MODULES.Equipment}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/equipment/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/equipment/',
   },
   [`${MODULES.Equipment}-charts-title`]: {
     en: 'Charts',

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -26,11 +26,6 @@ export default {
     fr: "Ajoutez une utilisation de service d'IA externe",
   },
 
-  // CHARTS external-cloud-and-ai.charts-title
-  [`${MODULES.ExternalCloudAndAI}-charts-title`]: {
-    en: 'External cloud emissions CHARTS',
-    fr: 'Émissions du cloud externe CHARTS',
-  },
   // external-cloud-and-ai.cloud_services_table_title
   [`${MODULES.ExternalCloudAndAI}.cloud_services_table_title`]: {
     en: 'External cloud service ({count}) | External cloud services ({count})',

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -10,8 +10,16 @@ export default {
     fr: "Saisissez vos données relatives à l'utilisation de clouds externes pour estimer leur empreinte carbone.",
   },
   [`${MODULES.ExternalCloudAndAI}-title-subtext`]: {
-    en: 'This module calculates the carbon footprint associated with the use of external cloud services and AI. Some cells may or may not be editable depending on the type of service selected. For external cloud services, it is necessary to enter the provider name, used type of service (compute or storage), spending and associated currency. For AI services, it is necessary to enter the provider name, type of use (text, code or image generation), number of users and frequency of use. For more information: [external clouds & IA](https://epfl-enac.github.io/co2-calculator-user-doc/building/)',
-    fr: "Ce module calcule l'empreinte carbone liée à l'utilisation de services de clouds externes et d'intelligence artificielle. Certaines cellules seront ou non éditables en fonction du type de service sélectionné. Pour les services de clouds externes, il est nécessaire de saisir le nom du fournisseur, le type de service utilisé (calcul ou stockage), le montant dépensé et la devise associée. Pour les services d'IAs, il faut fournir le nom du fournisseur, le type d'utilisation (génération de texte, de code ou d'image), le nombre d'utilisateurs et la fréquence d'utilisation. Pour plus d'information : [clouds externes et IA](https://epfl-enac.github.io/co2-calculator-user-doc/fr/external-cloud/)",
+    en: 'This module calculates the carbon footprint associated with the use of external cloud services and AI. Some cells may or may not be editable depending on the type of service selected. For external cloud services, it is necessary to enter the provider name, used type of service (compute or storage), spending and associated currency. For AI services, it is necessary to enter the provider name, type of use (text, code or image generation), number of users and frequency of use.',
+    fr: "Ce module calcule l'empreinte carbone liée à l'utilisation de services de clouds externes et d'intelligence artificielle. Certaines cellules seront ou non éditables en fonction du type de service sélectionné. Pour les services de clouds externes, il est nécessaire de saisir le nom du fournisseur, le type de service utilisé (calcul ou stockage), le montant dépensé et la devise associée. Pour les services d'IAs, il faut fournir le nom du fournisseur, le type d'utilisation (génération de texte, de code ou d'image), le nombre d'utilisateurs et la fréquence d'utilisation.",
+  },
+  [`${MODULES.ExternalCloudAndAI}-documentation-title`]: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
+  [`${MODULES.ExternalCloudAndAI}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/external-cloud/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/external-cloud/',
   },
   // external-cloud-and-ai-external_clouds-form-title
   // Add an external cloud usage / Ajouter une utilisation de cloud externe

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -20,7 +20,7 @@ export default {
   },
   [`${MODULES.Headcount}-student`]: {
     en: 'Student| Students',
-    fr: 'Étudiant•e| Étudiant•e•s',
+    fr: 'Étudiant·e| Étudiant·e·s',
   },
   [`${MODULES.Headcount}-member-table-title`]: {
     en: 'Member ({count})| Members ({count})',
@@ -28,7 +28,7 @@ export default {
   },
   [`${MODULES.Headcount}-student-table-title`]: {
     en: 'Students',
-    fr: 'Étudiant•es',
+    fr: 'Étudiant·es',
   },
 
   [`${MODULES.Headcount}-student-table-title-info-label`]: {
@@ -58,7 +58,7 @@ export default {
 
   [`${MODULES.Headcount}-student-form-add-button`]: {
     en: 'Add Student FTE',
-    fr: 'Ajouter un EPT étudiant•e',
+    fr: 'Ajouter un EPT étudiant·e',
   },
   // module member
 
@@ -81,21 +81,15 @@ export default {
   // module_mylab_student_form_field_fte_label
   [`${MODULES.Headcount}-student_form_field_fte_label`]: {
     en: 'Total Student FTE',
-    fr: 'EPT étudiant•es total',
+    fr: 'EPT étudiant·es total',
   },
   [`${MODULES.Headcount}-student-form-title`]: {
     en: 'Add Student FTE',
-    fr: 'Ajouter un EPT étudiant•e',
+    fr: 'Ajouter un EPT étudiant·e',
   },
-
-  [`${MODULES.Headcount}-student-form-subtitle`]: {
-    en: 'Enter the aggregated student FTE for your unit over the year.',
-    fr: 'Entrez de manière agrégée les EPT des étudiant·es qui ont travaillé dans votre unité sur l’année.',
-  },
-
   [`${MODULES.Headcount}-student-form-title-info-label`]: {
     en: 'fte student tooltip',
-    fr: 'info-bulle étudiant•e EPT',
+    fr: 'info-bulle étudiant·e EPT',
   },
   'headcount-member-function-required': {
     en: 'Function is required',
@@ -104,41 +98,5 @@ export default {
   'headcount-member-error-duplicate-uid': {
     en: "This user's {label} already exists.",
     fr: 'Le {label} de cet utilisateur•rice existe déjà.',
-  },
-  headcount_student: {
-    en: 'Student',
-    fr: 'Étudiant•e',
-  },
-  headcount_professor: {
-    en: 'Professor',
-    fr: 'Professeur•e',
-  },
-  headcount_scientific_collaborator: {
-    en: 'Scientific Collaborator',
-    fr: 'Collaborateur•rice scientifique',
-  },
-  headcount_postdoctoral_researcher: {
-    en: 'Postdoctoral Researcher',
-    fr: 'Chercheur•e postdoctoral•e',
-  },
-  headcount_postdoctoral_assistant: {
-    en: 'Postdoctoral Assistant',
-    fr: 'Assistant•e postdoctoral•e',
-  },
-  headcount_doctoral_assistant: {
-    en: 'Doctoral Assistant',
-    fr: 'Assistant•e doctorant•e',
-  },
-  headcount_trainee: {
-    en: 'Trainee',
-    fr: 'Stagiaire',
-  },
-  headcount_technical_administrative_staff: {
-    en: 'Technical/Administrative Staff',
-    fr: 'Personnel technique/administratif',
-  },
-  headcount_other: {
-    en: 'Other',
-    fr: 'Autre',
   },
 } as const;

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -11,8 +11,16 @@ export default {
     fr: 'Vérifiez les membres de l’unité et leurs équivalents plein-temps (EPT)',
   },
   [`${MODULES.Headcount}-title-subtext`]: {
-    en: `This module automatically displays the names, functions, SCIPERs, and FTE values of your unit’s members as of the reference year. For student contributions, please manually add their total accumulated FTE over the year. The total number of FTEs is used to generate the indicators for the additional categories (Food, Commuting, and Waste), as well as the total carbon footprint per FTE for your unit. For more information: User Guide [headcount](https://epfl-enac.github.io/co2-calculator-user-doc/headcount/) and [additional categories ](https://epfl-enac.github.io/co2-calculator-user-doc/additional-categories/)`,
-    fr: `Ce module affiche automatiquement les noms, fonctions, SCIPERs et valeurs EPT des membres de votre unité pour l'année de référence. Pour les contributions des étudiant·e·s, veuillez ajouter manuellement leur EPT total sur l'ensemble de l'année. Le nombre total d'EPT est utilisé pour générer les indicateurs des catégories additionnelles (Alimentation, Pendularité et Déchets), ainsi que l'empreinte carbone totale par EPT pour votre unité. Pour plus d'information : Documentation utilisation [personnel](https://epfl-enac.github.io/co2-calculator-user-doc/fr/headcount/), et [catégories additionnelles](https://epfl-enac.github.io/co2-calculator-user-doc/fr/additional-categories/)`,
+    en: `This module automatically displays the names, functions, SCIPERs, and FTE values of your unit’s members as of the reference year. For student contributions, please manually add their total accumulated FTE over the year. The total number of FTEs is used to generate the indicators for the additional categories (Food, Commuting, and Waste), as well as the total carbon footprint per FTE for your unit.`,
+    fr: `Ce module affiche automatiquement les noms, fonctions, SCIPERs et valeurs EPT des membres de votre unité pour l'année de référence. Pour les contributions des étudiant·e·s, veuillez ajouter manuellement leur EPT total sur l'ensemble de l'année. Le nombre total d'EPT est utilisé pour générer les indicateurs des catégories additionnelles (Alimentation, Pendularité et Déchets), ainsi que l'empreinte carbone totale par EPT pour votre unité.`,
+  },
+  [`${MODULES.Headcount}-documentation-title`]: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
+  [`${MODULES.Headcount}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/headcount/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/headcount/',
   },
   [`${MODULES.Headcount}-member`]: {
     en: 'Member| Members',

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -18,8 +18,16 @@ export default {
     fr: 'Entrez les sources d’émissions de procédé de gaz utilisés dans ou issues de réactions chimiques ou physiques dans le laboratoire.',
   },
   [`${MODULES.ProcessEmissions}-title-subtext`]: {
-    en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module. For more information: [processes](https://epfl-enac.github.io/co2-calculator-user-doc/processes/)',
-    fr: "Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif. Pour plus d'information : [procédés](https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/)",
+    en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module.',
+    fr: 'Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif.',
+  },
+  [`${MODULES.ProcessEmissions}-documentation-title`]: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
+  [`${MODULES.ProcessEmissions}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/processes/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/',
   },
   [`${MODULES.ProcessEmissions}-process_emissions-form-title`]: {
     en: 'Add an emitted gas',

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -114,8 +114,16 @@ export default {
     fr: 'Consultez et renseignez les voyages professionnels de votre unité.',
   },
   [`${MODULES.ProfessionalTravel}-title-subtext`]: {
-    en: "This module allows you to estimate and visualize the impact of your (or your unit's) travel by train and plane. Data relating to your air travel is provided to us by the EPFL Travel Agency, and the associated carbon footprint is calculated taking into account several factors such as distance, class booked, flight altitude, number of people on the plane, airline, etc. If you have traveled outside of the agency, please enter the departure city and arrival city in the tab below. The calculation methodology will then be different and will take into account the distance and type of flight (very short-haul, short-haul, medium-haul, or long-haul). For more information: [professional travel](https://epfl-enac.github.io/co2-calculator-user-doc/professional-travel/)",
-    fr: "Ce module permet d'estimer et de visualiser l'impact de vos voyages (ou de votre unité) en train et en avion. Les données relatives à vos voyages en avion nous sont communiquées par l’Agence de voyages EPFL et l’empreinte carbone associée est calculée en considérant plusieurs facteurs tels que la distance, la classe réservée, la hauteur de vol, le nombre de personne dans l’avion, la compagnie aérienne, etc. Si vous avez effectué un voyage hors agence, merci de saisir dans l’onglet ci-dessous, la ville de départ et la ville d’arrivée. La méthodologie de calcul sera alors différente et considérera la distance et le type de vol (très court-courrier, court-courrier, moyen-courrier ou long-courrier). Pour plus d'information : [voyages professionnels](https://epfl-enac.github.io/co2-calculator-user-doc/fr/professional-travel/)",
+    en: "This module allows you to estimate and visualize the impact of your (or your unit's) travel by train and plane. Data relating to your air travel is provided to us by the EPFL Travel Agency, and the associated carbon footprint is calculated taking into account several factors such as distance, class booked, flight altitude, number of people on the plane, airline, etc. If you have traveled outside of the agency, please enter the departure city and arrival city in the tab below. The calculation methodology will then be different and will take into account the distance and type of flight (very short-haul, short-haul, medium-haul, or long-haul).",
+    fr: "Ce module permet d'estimer et de visualiser l'impact de vos voyages (ou de votre unité) en train et en avion. Les données relatives à vos voyages en avion nous sont communiquées par l’Agence de voyages EPFL et l’empreinte carbone associée est calculée en considérant plusieurs facteurs tels que la distance, la classe réservée, la hauteur de vol, le nombre de personne dans l’avion, la compagnie aérienne, etc. Si vous avez effectué un voyage hors agence, merci de saisir dans l’onglet ci-dessous, la ville de départ et la ville d’arrivée. La méthodologie de calcul sera alors différente et considérera la distance et le type de vol (très court-courrier, court-courrier, moyen-courrier ou long-courrier).",
+  },
+  [`${MODULES.ProfessionalTravel}-documentation-title`]: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
+  [`${MODULES.ProfessionalTravel}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/professional-travel/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/professional-travel/',
   },
   [`${MODULES.ProfessionalTravel}-results-total-travel-carbon-footprint`]: {
     en: 'Total travel carbon footprint',

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -59,14 +59,6 @@ export default {
     en: 'Add a train trip',
     fr: 'Ajoutez un trajet en train',
   },
-  [`${MODULES.ProfessionalTravel}-train-location-local-language-tooltip`]: {
-    en: 'Enter the city or station name in the local language.',
-    fr: 'Saisir la ville ou la gare dans la langue locale.',
-  },
-  [`${MODULES.ProfessionalTravel}-form-tooltip`]: {
-    en: 'Please enter the details of your trip by train of flight in Switzerland or abroad. Every leg of the journey needs to be entered a new trip (e.g. Lausanne to New York would be 1. a train from Lausanne to Geneva Airport, then 2. a flight from Geneva Airport to Paris-Charles de Gaulle and 3. A flight from Paris-Charles de Gaulle to John F. Kennedy International Airport). The return can be selected by checking the box provided for this purpose. The station name must be entered in the station’s local language. ',
-    fr: 'Veuillez saisir les détails de votre voyage en train ou en avion, en Suisse ou à l’étranger. Chaque étape du trajet doit être saisie comme un nouveau voyage (par ex. : Lausanne–New York correspondrait à 1. un trajet en train de Lausanne à l’aéroport de Genève, puis 2. un vol de l’aéroport de Genève à Paris–Charles-de-Gaulle et 3. un vol de Paris–Charles-de-Gaulle à l’aéroport international John-F.-Kennedy). Le retour peut être sélectionné en cochant la case prévue à cet effet. Le nom de la station doit être saisi dans la langue locale de celle-ci.',
-  },
   [`${MODULES.ProfessionalTravel}-other-form-title`]: {
     en: 'Add a trip',
     fr: 'Ajoutez un voyage',
@@ -129,44 +121,11 @@ export default {
     en: 'Total travel carbon footprint',
     fr: 'Empreinte carbone totale déplacements',
   },
-  [`${MODULES.ProfessionalTravel}-results-total-travel-carbon-footprint-tooltip`]:
-    {
-      en: 'Total carbon footprint from all professional travel including flights, trains, and commuting',
-      fr: 'Empreinte carbone totale de tous les déplacements professionnels incluant les vols, trains et trajets domicile-travail',
-    },
   [`${MODULES.ProfessionalTravel}-results-total-travel-carbon-footprint-comparison`]:
     {
       en: 'is equivalent to ~{km} km driven with car',
       fr: 'équivaut à ~{km} km parcourus en voiture',
     },
-  [`${MODULES.ProfessionalTravel}-results-travel-per-fte`]: {
-    en: 'Travel per FTE',
-    fr: 'Déplacements par EPT',
-  },
-  [`${MODULES.ProfessionalTravel}-results-travel-per-fte-unit`]: {
-    en: 'per FTE',
-    fr: 'par EPT',
-  },
-  [`${MODULES.ProfessionalTravel}-results-travel-per-fte-tooltip`]: {
-    en: 'Average travel carbon footprint per full-time equivalent employee',
-    fr: 'Empreinte carbone moyenne des déplacements par équivalent temps plein',
-  },
-  [`${MODULES.ProfessionalTravel}-results-travel-per-fte-comparison`]: {
-    en: 'at EPFL in average professional travel represents {percentage}.',
-    fr: "à l'EPFL en moyenne, les déplacements professionnels représentent {percentage}.",
-  },
-  [`${MODULES.ProfessionalTravel}-results-year-to-year-evolution`]: {
-    en: 'Year-to-year evolution',
-    fr: "Évolution d'année en année",
-  },
-  [`${MODULES.ProfessionalTravel}-results-year-to-year-evolution-tooltip`]: {
-    en: 'Change in travel carbon footprint compared to the previous year',
-    fr: "Évolution de l'empreinte carbone des déplacements par rapport à l'année précédente",
-  },
-  [`${MODULES.ProfessionalTravel}-results-year-to-year-evolution-comparison`]: {
-    en: 'Equivalent to {trips} trips a full year.',
-    fr: 'Équivalent à {trips} voyages pendant une année complète.',
-  },
   // Class keys
   class_1: {
     en: '1st class',

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -249,10 +249,6 @@ export default {
     en: 'Show additional estimated categories',
     fr: 'Afficher les catégories supplémentaires',
   },
-  unit_carbon_footprint_scope_tooltip_aria: {
-    en: 'Definitions of GHG scopes 1, 2 and 3 in this chart',
-    fr: 'Définitions des scopes 1, 2 et 3 des GES dans ce graphique',
-  },
   unit_carbon_footprint_scope_prefix: {
     en: '{scope} {n}:',
     fr: '{scope} {n} :',
@@ -620,8 +616,8 @@ export default {
     fr: 'Affaires',
   },
   'charts-eco-class-subcategory': {
-    en: 'Eco',
-    fr: 'Éco',
+    en: 'Economy',
+    fr: 'Économique',
   },
   'charts-clouds-subcategory': {
     en: 'External clouds',
@@ -1096,14 +1092,6 @@ export default {
   'it-focus-waffle-caption': {
     en: 'Each square = 0.1% of the total carbon footprint of the unit',
     fr: "Chaque carré = 0.1% de l'empreinte carbone totale de l'unité",
-  },
-  results_filter_pill_research_facilities_tooltip: {
-    en: 'These emissions are calculated based on research facilities data.',
-    fr: 'Ces émissions sont calculées à partir des données propres aux infrastructure de recherche.',
-  },
-  results_filter_pill_additional_data_tooltip: {
-    en: "These emissions are calculated based on EPFL's general assumptions.",
-    fr: "Ces émissions sont calculées à partir des hypothèses générales de l'EPFL.",
   },
   results_filter_panel_title: {
     en: 'Display filters',

--- a/frontend/src/i18n/tooltips.ts
+++ b/frontend/src/i18n/tooltips.ts
@@ -482,18 +482,39 @@ export default {
   // Each module results section contains a breakdown chart. A (ℹ) icon can
   // appear next to the chart title to give users context about what is
   // included in — or excluded from — the visualisation.
+  // Leave en/fr empty ("") to hide the icon for that module's chart.
+  //
+  // Module order in the app:
+  //   Headcount → Process Emissions → Buildings → Equipment →
+  //   External Cloud & AI → Professional Travel → Purchases → Research Facilities
 
-  'module-equipment-charts': {
-    en: 'The emissions considered here are those related to the energy required to operate the equipment (scientific, IT, etc.).',
-    fr: "Les émissions considérées ici sont celles liées à l'énergie nécessaire à l'utilisation des équipements (scientifiques, informatiques, etc.).",
+  'module-headcount-charts': {
+    en: "The emissions shown here are calculated on the basis of the unit's headcount (FTE) and contribute to Scope 3 of the carbon footprint.",
+    fr: "Les émissions présentées ici sont calculées sur la base de l'effectif de l'unité (EPT) et contribuent au Scope 3 de l'empreinte carbone.",
+  },
+  'module-process-emissions-charts': {
+    en: 'The emissions considered here are the direct process emissions of the unit, broken down by greenhouse gas. They contribute to Scope 1 of the carbon footprint.',
+    fr: "Les émissions considérées ici sont les émissions de procédés directes de l'unité, réparties par gaz à effet de serre. Elles contribuent au Scope 1 de l'empreinte carbone.",
   },
   'module-buildings-charts': {
     en: 'The emissions considered here are those related to the energy used for heating, lighting, ventilation, and cooling in buildings.',
     fr: "Les émissions considérées ici sont celles liées à l'énergie nécessaire pour le chauffage, l'éclairage, la ventilation et le froid dans les bâtiments.",
   },
+  'module-equipment-charts': {
+    en: 'The emissions considered here are those related to the energy required to operate the equipment (scientific, IT, etc.).',
+    fr: "Les émissions considérées ici sont celles liées à l'énergie nécessaire à l'utilisation des équipements (scientifiques, informatiques, etc.).",
+  },
   'module-external-cloud-and-ai-charts': {
     en: 'The results are aggregated by service type: external clouds and AI.',
     fr: 'Les résultats sont aggrégés par type de service: clouds externes et IA.',
+  },
+  'module-professional-travel-charts': {
+    en: "The emissions considered here are those related to the unit's professional travel, broken down by mode of transport (plane and train).",
+    fr: "Les émissions considérées ici sont celles liées aux voyages professionnels de l'unité, réparties par mode de transport (avion et train).",
+  },
+  'module-purchase-charts': {
+    en: "The emissions considered here are those related to the unit's purchases, broken down by purchase category.",
+    fr: "Les émissions considérées ici sont celles liées aux achats de l'unité, réparties par catégorie d'achat.",
   },
   'module-research-facilities-charts': {
     en: 'If these research activities were performed independently by the unit, the emissions coming from them would be higher. Using shared research facilities helps to reduce overall EPFL emissions.',


### PR DESCRIPTION
## What does this change?

- **Documentation links** — extracts the inline Markdown links from every module's description text into dedicated `{module}-documentation-link` and `{module}-documentation-title` i18n keys, and renders them as a proper `<a>` element in `ModuleTitle.vue` with an article icon.
- **Chart info tooltips** — adds `EMISSION_TYPE_BREAKDOWN_INFO_KEYS` entries and tooltip copy for Headcount, Process Emissions, Professional Travel, and Purchases; moves the info icon to sit beside the chart title (not inside the controls group); hides it when the translation key resolves to an empty string.
- **Middle dot** — replaces the bullet `•` with the typographic middle dot `·` in French gender-inclusive labels (`Étudiant·e`, `étudiant·es`, etc.) and in the upload card date separator.
- **Cabin class labels** — switches the plane cabin-class field from hard-coded strings (`'First'`, `'Business'`, `'Economy'`) to i18n keys; corrects "Eco" → "Economy" / "Éco" → "Économique".
- **Dead keys removed** — prunes unused translation keys across `headcount.ts`, `professional_travel.ts`, `results.ts`, `common.ts`, and `external_cloud.ts` that referenced removed UI elements.
- **`pre-line` subtext** — adds `white-space: pre-line` to the module subtext so authored line breaks render as intended.

## Why is this needed?

Documentation links were embedded as raw Markdown inside plain text strings, which rendered inconsistently and mixed content with presentation. Several translation keys were either unused or duplicated, cabin class labels were not localised, and the typographic bullet was inconsistent with EPFL's gender-inclusive writing convention.

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues
- Related to #

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.