### PR TITLE
feat/385 feat merge carbon reports

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -409,6 +409,7 @@ async def get_top_class_breakdown(
     year: int,
     module_id: str,
     carbon_project_type: int = Query(default=0, ge=0, le=2),
+    combine_unit_ids: List[int] = Query(default_factory=list),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> List:
@@ -417,6 +418,9 @@ async def get_top_class_breakdown(
     Returns a list per subcategory, each containing the top 3 items (by
     emission) and a "rest" bucket. Works for any module configured in
     ``_MODULE_TOP_CLASS_GROUP_FIELD``.
+
+    ``combine_unit_ids`` re-ranks the classes over the union of those units'
+    entries plus ``unit_id``'s, for the Results page's combined-units view.
     """
     report_type = _resolve_carbon_report_type(carbon_project_type)
     await check_module_permission_for_unit(
@@ -437,13 +441,46 @@ async def get_top_class_breakdown(
             detail=f"Top-class breakdown not supported for module '{module_id}'",
         )
 
-    carbon_report_module_id = await get_carbon_report_id(
-        unit_id=unit_id,
-        year=year,
-        module_type_id=module_type,
-        db=db,
-        report_type=report_type,
-    )
+    carbon_report_module_ids = [
+        await get_carbon_report_id(
+            unit_id=unit_id,
+            year=year,
+            module_type_id=module_type,
+            db=db,
+            report_type=report_type,
+        )
+    ]
+    # A combined unit the caller cannot view, or that has no report this year,
+    # drops out of the aggregate. Raising here would surface as a 403 and the
+    # frontend turns any 403 into a hard redirect to /unauthorized.
+    for combine_unit_id in dict.fromkeys(combine_unit_ids):
+        if combine_unit_id == unit_id:
+            continue
+        try:
+            await check_module_permission_for_unit(
+                current_user=current_user,
+                module_id=module_id,
+                action="view",
+                db=db,
+                unit_id=combine_unit_id,
+            )
+            carbon_report_module_ids.append(
+                await get_carbon_report_id(
+                    unit_id=combine_unit_id,
+                    year=year,
+                    module_type_id=module_type,
+                    db=db,
+                    report_type=report_type,
+                )
+            )
+        except HTTPException:
+            logger.info(
+                "Skipping combined unit in top-class breakdown",
+                extra={
+                    "unit_id": sanitize(combine_unit_id),
+                    "module_id": sanitize(module_id),
+                },
+            )
 
     data_entry_types = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(module_type, [])
 
@@ -460,7 +497,7 @@ async def get_top_class_breakdown(
     for field, dets in field_groups.items():
         stats.extend(
             await svc.get_top_class_breakdown(
-                carbon_report_module_id=carbon_report_module_id,
+                carbon_report_module_ids=carbon_report_module_ids,
                 data_entry_types=dets,
                 group_by_field=field,
                 report_year=int(year),

--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -27,6 +27,7 @@ from app.repositories.carbon_report_repo import CarbonReportRepository
 from app.schemas.carbon_report import CarbonReportModuleRead
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.data_entry_service import DataEntryService
+from app.services.unit_service import UnitService
 from app.services.unit_totals_service import UnitTotalsService
 from app.utils.report_computations import (
     compute_results_summary,
@@ -194,6 +195,137 @@ async def get_multi_year_breakdown(
         years.append({"year": year, **build_year_comparison(stats)})
 
     return {"years": years}
+
+
+async def _authorize_and_resolve_reports(
+    db: AsyncSession,
+    current_user: User,
+    unit_ids: list[int],
+    year: int,
+) -> list[CarbonReport]:
+    """Resolve the CALCULATOR report of each requested unit, for one year.
+
+    Every unit must be one the caller may see, per the same allow-list the
+    workspace switcher is built from. A unit outside it yields 404 rather than
+    403: the frontend turns any 403 into a hard redirect to /unauthorized, so a
+    forged id must look like "not found", not trip that redirect.
+
+    Units with no report for ``year`` are skipped, so the aggregate simply
+    covers the units that do have one.
+    """
+    if not unit_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one unit_id is required",
+        )
+
+    allowed_unit_ids = {
+        unit["id"] for unit in await UnitService(db).get_user_units(current_user)
+    }
+    unknown = [unit_id for unit_id in unit_ids if unit_id not in allowed_unit_ids]
+    if unknown:
+        logger.info(
+            "Merged stats requested for inaccessible units",
+            extra={"unit_ids": sanitize(unknown), "user_id": sanitize(current_user.id)},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unit(s) not found: {', '.join(str(u) for u in unknown)}",
+        )
+
+    report_repo = CarbonReportRepository(db)
+    reports: list[CarbonReport] = []
+    for unit_id in dict.fromkeys(unit_ids):
+        report = await report_repo.get_by_unit_and_year(unit_id=unit_id, year=year)
+        if report is not None:
+            reports.append(report)
+    return reports
+
+
+@router.get("/merged/report-stats", response_model=dict)
+async def get_merged_report_stats(
+    unit_ids: list[int] = Query(default_factory=list),
+    year: int = Query(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Sum several units' persisted report stats into one payload.
+
+    Same shape as ``/{carbon_report_id}/report-stats``, so the frontend derives
+    its charts from it unchanged. ``merge_report_stats`` drops per-unit
+    top-class detail on purpose, so the IT section's is re-ranked across all
+    the reports here rather than unioned.
+    """
+    reports = await _authorize_and_resolve_reports(db, current_user, unit_ids, year)
+    if not reports:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No carbon report found for year {year}",
+        )
+
+    merged = merge_report_stats([dict(report.stats or {}) for report in reports])
+
+    report_ids = [report.id for report in reports if report.id is not None]
+    merged["it"]["top_class_detail"] = await CarbonReportModuleService(
+        db
+    ).build_merged_it_top_classes(report_ids, report_year=year)
+
+    validated_total = 0.0
+    for report_id in report_ids:
+        validated = await build_validated_totals(db, report_id)
+        validated_total += validated["total_tonnes_co2eq"]
+    merged["total_tonnes_validated_co2eq"] = validated_total
+
+    return merged
+
+
+@router.get("/merged/results-summary", response_model=dict)
+async def get_merged_results_summary(
+    unit_ids: list[int] = Query(default_factory=list),
+    year: int = Query(...),
+    exclude_modules: list[int] = Query(default_factory=list),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Results summary over several units, summed per module.
+
+    Each unit contributes its own validated module totals and its own
+    previous-year comparison basis, so the year-over-year figure stays
+    meaningful for a combined perimeter.
+    """
+    reports = await _authorize_and_resolve_reports(db, current_user, unit_ids, year)
+    if not reports:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No carbon report found for year {year}",
+        )
+
+    service = UnitTotalsService(db)
+    current_emissions: dict[str, float] = {}
+    current_fte: dict[str, float] = {}
+    prev_emissions: dict[str, float] = {}
+    for report in reports:
+        if report.id is None:
+            continue
+        raw = await service.get_results_summary(report.id)
+        for target, source in (
+            (current_emissions, raw["current_emissions"]),
+            (current_fte, raw["current_fte"]),
+            (prev_emissions, raw["prev_emissions"]),
+        ):
+            for module_type_id, value in source.items():
+                target[module_type_id] = target.get(module_type_id, 0.0) + (
+                    value or 0.0
+                )
+
+    return compute_results_summary(
+        current_emissions,
+        current_fte,
+        prev_emissions,
+        get_settings().CO2_PER_KM_KG,
+        str(ModuleTypeEnum.headcount.value),
+        exclude_module_type_ids=set(exclude_modules),
+    )
 
 
 @router.get("/{carbon_report_id}/report-stats", response_model=dict)

--- a/backend/app/providers/test_fixtures.py
+++ b/backend/app/providers/test_fixtures.py
@@ -82,11 +82,34 @@ def get_test_role_by_user_id(user_id: str) -> RoleName | None:
 
 _PRINCIPAL_ID = TEST_USERS[RoleName.CO2_USER_PRINCIPAL]["institutional_id"]
 
-# A coherent ENAC subtree: lvl2 anchor -> lvl3 -> lvl4. Each unit's own
-# institutional_code is the last token of its (self-inclusive) root->leaf
-# path_institutional_code, mirroring real ACCRED data
+# A coherent ENAC subtree: lvl2 anchor -> lvl3 -> four sibling lvl4 labs. Each
+# unit's own institutional_code is the last token of its (self-inclusive)
+# root->leaf path_institutional_code, mirroring real ACCRED data
 # (" ".join(ancestors + [self])). EPFL root (code 10582 / cf 13029) is an
 # ancestor token only; it is not a stored unit.
+#
+# Only level-4 units surface as workspaces (see UnitService.get_user_units),
+# so the four leaves below are what a login-test user picks between.
+_LVL4_PATH_CODE = "10582 12635 11435"
+_LVL4_PATH_IID = "13029 13030 13031"
+_LVL4_PATH_NAME = "EPFL ENAC-TEST ENAC-SG-TEST"
+
+
+def _test_leaf(institutional_code: str, institutional_id: str, name: str) -> Unit:
+    """Build a level-4 TEST lab hanging off ENAC-SG-TEST."""
+    return Unit(
+        provider=UserProvider.TEST,
+        institutional_code=institutional_code,
+        institutional_id=institutional_id,
+        name=name,
+        level=4,
+        principal_user_institutional_id=_PRINCIPAL_ID,
+        path_institutional_code=f"{_LVL4_PATH_CODE} {institutional_code}",
+        path_institutional_id=f"{_LVL4_PATH_IID} {institutional_id}",
+        path_name=f"{_LVL4_PATH_NAME} {name}",
+    )
+
+
 TEST_UNITS: List[Unit] = [
     Unit(
         provider=UserProvider.TEST,
@@ -110,23 +133,19 @@ TEST_UNITS: List[Unit] = [
         path_institutional_id="13029 13030 13031",
         path_name="EPFL ENAC-TEST ENAC-SG-TEST",
     ),
-    Unit(
-        provider=UserProvider.TEST,
-        institutional_code="14270",
-        institutional_id="13032",
-        name="ENAC-IT4R-TEST",
-        level=4,
-        principal_user_institutional_id=_PRINCIPAL_ID,
-        path_institutional_code="10582 12635 11435 14270",
-        path_institutional_id="13029 13030 13031 13032",
-        path_name="EPFL ENAC-TEST ENAC-SG-TEST ENAC-IT4R-TEST",
-    ),
+    _test_leaf("14270", "13032", "ENAC-IT4R-TEST"),
+    _test_leaf("14271", "13033", "ENAC-LAB1-TEST"),
+    _test_leaf("14272", "13034", "ENAC-LAB2-TEST"),
+    _test_leaf("14273", "13035", "ENAC-LAB3-TEST"),
 ]
 
 # Quick lookup helpers
 TEST_UNIT_IDS = [u.institutional_id for u in TEST_UNITS if u.institutional_id]
-# Primary (leaf) test unit id as a non-optional str for unit/own scope construction.
-_TEST_UNIT_IID: str = TEST_UNITS[-1].institutional_id or ""
+# Leaf (level-4) test unit ids — the selectable workspaces. Unit/own scopes are
+# built over all of them so a login-test user lands with four units to pick from.
+TEST_LEAF_UNIT_IIDS: List[str] = [
+    u.institutional_id for u in TEST_UNITS if u.level == 4 and u.institutional_id
+]
 
 
 # -- Test Roles ---------------------------------------------------------------
@@ -136,14 +155,16 @@ TEST_ROLES: Dict[RoleName, List[Role]] = {
     RoleName.CO2_USER_STD: [
         Role(
             role=RoleName.CO2_USER_STD,
-            on=OwnScope(institutional_id=_TEST_UNIT_IID),
-        ),
+            on=OwnScope(institutional_id=unit_iid),
+        )
+        for unit_iid in TEST_LEAF_UNIT_IIDS
     ],
     RoleName.CO2_USER_PRINCIPAL: [
         Role(
             role=RoleName.CO2_USER_PRINCIPAL,
-            on=UnitScope(institutional_id=_TEST_UNIT_IID),
-        ),
+            on=UnitScope(institutional_id=unit_iid),
+        )
+        for unit_iid in TEST_LEAF_UNIT_IIDS
     ],
     RoleName.CO2_BACKOFFICE_METIER: [
         Role(

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -617,7 +617,7 @@ class DataEntryEmissionRepository:
 
     async def get_top_class_breakdown(
         self,
-        carbon_report_module_id: int,
+        carbon_report_module_ids: List[int],
         data_entry_types: List[DataEntryTypeEnum],
         group_by_field: str,
         top_n: int = 3,
@@ -631,8 +631,12 @@ class DataEntryEmissionRepository:
         subcategory (data_entry_type) by the specified JSON data field, returning
         the top N items plus a "rest" bucket.
 
+        Passing several module ids yields a single cross-unit ranking: the
+        grouping keys are (data_entry_type, class), so rows from every module
+        collapse into the same class before the top-N cut is applied.
+
         Args:
-            carbon_report_module_id: The carbon report module to query.
+            carbon_report_module_ids: The carbon report modules to query.
             data_entry_types: Which data entry types to include.
             group_by_field: The DataEntry.data JSON field to group by
                 (e.g. ``"equipment_class"`` or
@@ -642,6 +646,8 @@ class DataEntryEmissionRepository:
                 display label instead of ``group_by_field`` values.
             report_year: Carbon report year.
         """
+        if not carbon_report_module_ids:
+            return []
         det_name_map = {det.value: det.name for det in data_entry_types}
         category_expr = col(DataEntry.data_entry_type_id)
         class_expr = DataEntry.data[group_by_field].as_string()
@@ -674,7 +680,7 @@ class DataEntryEmissionRepository:
             select(*ranked_columns)
             .join(DataEntry, col(DataEntryEmission.data_entry_id) == col(DataEntry.id))
             .where(
-                DataEntry.carbon_report_module_id == carbon_report_module_id,
+                col(DataEntry.carbon_report_module_id).in_(carbon_report_module_ids),
                 col(DataEntry.data_entry_type_id).in_(
                     [det.value for det in data_entry_types]
                 ),

--- a/backend/app/seed/random_generator/seed_carbon_reports.py
+++ b/backend/app/seed/random_generator/seed_carbon_reports.py
@@ -101,8 +101,10 @@ async def insert_carbon_projects(conn):
 async def insert_carbon_reports(conn, unit_to_project):
     print(f"Creating carbon reports for {len(unit_to_project)} units...")
 
+    # `overall_status` is NOT NULL and its default lives on the SQLModel field,
+    # not on the column — a raw INSERT must supply it.
     records = [
-        (year, unit_id, project_id)
+        (year, unit_id, project_id, ModuleStatus.NOT_STARTED.value)
         for unit_id, project_id in unit_to_project.items()
         for year in YEARS
     ]
@@ -111,15 +113,16 @@ async def insert_carbon_reports(conn, unit_to_project):
         CREATE TEMP TABLE tmp_carbon_reports (
             year INTEGER,
             unit_id INTEGER,
-            carbon_project_id INTEGER
+            carbon_project_id INTEGER,
+            overall_status INTEGER
         ) ON COMMIT DROP
     """)
 
     await conn.copy_records_to_table("tmp_carbon_reports", records=records)
 
     inserted = await conn.fetch("""
-        INSERT INTO carbon_reports (year, unit_id, carbon_project_id)
-        SELECT year, unit_id, carbon_project_id
+        INSERT INTO carbon_reports (year, unit_id, carbon_project_id, overall_status)
+        SELECT year, unit_id, carbon_project_id, overall_status
         FROM tmp_carbon_reports
         ON CONFLICT (carbon_project_id, year) DO NOTHING
         RETURNING id

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -27,6 +27,11 @@ from app.modules.buildings.schemas import (
     EnergyCombustionHandlerCreate,
 )
 from app.modules.emissions import EmissionType
+from app.modules.emissions.registry import (
+    DATA_ENTRY_TO_EMISSION_TYPES,
+    emission_type_scope,
+)
+from app.modules.emissions.taxonomy import get_subtree_leaves
 from app.modules.equipment.schemas import EquipmentHandlerCreate
 from app.modules.external_cloud_and_ai.schemas import (
     REQUESTS_FREQUENCY_OPTIONS,
@@ -489,14 +494,52 @@ def generate_data_entries_for_module(module_id, module_type_id):
     return rows
 
 
+# The app resolves these data entry types' emission types at compute time from
+# the factor rows (``_RUNTIME_RESOLVERS``), which the seeder deliberately skips.
+# Seeding needs *some* valid leaf under the right taxonomy root, otherwise the
+# emission falls outside the module's stat buckets and recompute yields zero.
+_SEED_EMISSION_ROOTS: dict[DataEntryTypeEnum, EmissionType] = {
+    DataEntryTypeEnum.building: EmissionType.buildings__rooms,
+    DataEntryTypeEnum.energy_combustion: EmissionType.buildings__combustion,
+    DataEntryTypeEnum.plane: EmissionType.professional_travel__plane,
+    DataEntryTypeEnum.train: EmissionType.professional_travel__train,
+    DataEntryTypeEnum.external_clouds: EmissionType.external__clouds,
+    DataEntryTypeEnum.process_emissions: EmissionType.process_emissions,
+    DataEntryTypeEnum.research_facilities: EmissionType.research_facilities,
+    DataEntryTypeEnum.mice_and_fish_animal_facilities: EmissionType.research_facilities,
+    DataEntryTypeEnum.purchases_centralized: EmissionType.purchases,
+}
+
+
+def seed_emission_candidates(
+    data_entry_type: DataEntryTypeEnum,
+) -> list[EmissionType]:
+    """Emission types a seeded entry of this data entry type may carry.
+
+    Every data entry type of every module must resolve to at least one leaf, or
+    that module seeds entries with no emissions and recomputes to an empty
+    chart. ``tests/unit/seed/test_seed_data_entries.py`` pins that.
+    """
+    static = DATA_ENTRY_TO_EMISSION_TYPES.get(data_entry_type)
+    if static:
+        return list(static)
+    root = _SEED_EMISSION_ROOTS.get(data_entry_type)
+    if root is None:
+        return []
+    return [EmissionType(leaf_id) for leaf_id in get_subtree_leaves(root)]
+
+
 def generate_emissions_for_entry(entry_id, data_entry_type_id):
     rows = []
     now = datetime.now(timezone.utc)
 
     # simple placeholder logic for speed — no factor lookup; primary_factor_id
     # stays NULL. Fields mirror ``DataEntryEmissionBase``.
-    emission_type = random.choice(list(EmissionType))  # nosec B311
-    scope = emission_type.scope.value if emission_type.scope is not None else None
+    candidates = seed_emission_candidates(DataEntryTypeEnum(data_entry_type_id))
+    if not candidates:
+        return rows
+    emission_type = random.choice(candidates)  # nosec B311
+    scope = emission_type_scope(emission_type)
 
     rows.append(
         (

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -530,12 +530,58 @@ class CarbonReportModuleService:
         stats_key, data_entry_types, group_by_field = spec
         emission_repo = DataEntryEmissionRepository(self.session)
         rows = await emission_repo.get_top_class_breakdown(
-            carbon_report_module_id=module.id,
+            carbon_report_module_ids=[module.id],
             data_entry_types=data_entry_types,
             group_by_field=group_by_field,
             report_year=report_year,
         )
         return {"it_top_classes": {stats_key: rows}}
+
+    async def build_merged_it_top_classes(
+        self, carbon_report_ids: List[int], report_year: int | None = None
+    ) -> dict[str, list]:
+        """Rank IT top classes across several reports as one aggregate.
+
+        The per-report ``it_top_classes`` persisted in module stats cannot be
+        unioned — a union of per-unit top-3 lists is not a top-3. This re-ranks
+        from the underlying data entries of every report at once.
+        """
+        if not carbon_report_ids:
+            return {}
+
+        rows = (
+            await self.session.execute(
+                select(
+                    col(CarbonReportModule.id),
+                    col(CarbonReportModule.module_type_id),
+                ).where(
+                    col(CarbonReportModule.carbon_report_id).in_(carbon_report_ids),
+                    col(CarbonReportModule.module_type_id).in_(
+                        [m.value for m in _IT_TOP_CLASS_SPECS]
+                    ),
+                )
+            )
+        ).all()
+
+        module_ids_by_type: dict[ModuleTypeEnum, list[int]] = {}
+        for module_id, module_type_id in rows:
+            module_ids_by_type.setdefault(ModuleTypeEnum(module_type_id), []).append(
+                module_id
+            )
+
+        emission_repo = DataEntryEmissionRepository(self.session)
+        top_classes: dict[str, list] = {}
+        for module_type, module_ids in module_ids_by_type.items():
+            stats_key, data_entry_types, group_by_field = _IT_TOP_CLASS_SPECS[
+                module_type
+            ]
+            top_classes[stats_key] = await emission_repo.get_top_class_breakdown(
+                carbon_report_module_ids=module_ids,
+                data_entry_types=data_entry_types,
+                group_by_field=group_by_field,
+                report_year=report_year,
+            )
+        return top_classes
 
     async def delete_all_modules_for_report(self, carbon_report_id: int) -> int:
         """Delete all modules for a carbon report. Returns count deleted."""

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -839,7 +839,7 @@ class DataEntryEmissionService:
 
     async def get_top_class_breakdown(
         self,
-        carbon_report_module_id: int,
+        carbon_report_module_ids: list[int],
         data_entry_types: list[DataEntryTypeEnum],
         group_by_field: str,
         top_n: int = 3,
@@ -850,9 +850,10 @@ class DataEntryEmissionService:
         """Get emissions aggregated by subcategory and a grouping field.
 
         Generic method that returns top N items per subcategory plus a "rest" bucket.
+        Several module ids are ranked together as one cross-unit aggregate.
         """
         return await self.repo.get_top_class_breakdown(
-            carbon_report_module_id=carbon_report_module_id,
+            carbon_report_module_ids=carbon_report_module_ids,
             data_entry_types=data_entry_types,
             group_by_field=group_by_field,
             top_n=top_n,

--- a/backend/app/utils/report_computations.py
+++ b/backend/app/utils/report_computations.py
@@ -4,6 +4,8 @@ Extracted from carbon_report_module_stats routes so they can be unit tested
 without DB or HTTP dependencies.
 """
 
+from collections.abc import Mapping
+
 
 def compute_validated_totals(
     emission_stats: dict[str, float],
@@ -42,9 +44,9 @@ def compute_validated_totals(
 
 
 def compute_results_summary(
-    current_emissions: dict[str, float | None],
-    current_fte: dict[str, float | None],
-    prev_emissions: dict[str, float],
+    current_emissions: Mapping[str, float | None],
+    current_fte: Mapping[str, float | None],
+    prev_emissions: Mapping[str, float],
     co2_per_km_kg: float,
     headcount_key: str,
     exclude_module_type_ids: set[int] | frozenset[int] = frozenset(),

--- a/backend/app/utils/report_stats.py
+++ b/backend/app/utils/report_stats.py
@@ -109,6 +109,16 @@ def build_year_comparison(stats: dict) -> dict:
     }
 
 
+# Bucket detail lists persisted alongside the numeric aggregates, mapped to the
+# field naming each row. They are plain per-key kg sums (no top-N), so summing
+# them across reports is exact: e.g. the same building in two units collapses
+# into one row, as it should.
+_BUCKET_DETAIL_NAME_FIELDS = {
+    "by_building": "building_name",
+    "by_category": "category",
+}
+
+
 def _merge_bucket_into(target: dict, bucket: dict) -> None:
     target["total_kg"] += bucket.get("total_kg", 0.0) or 0.0
     for et_id_str, kg in (bucket.get("by_emission_type") or {}).items():
@@ -119,10 +129,38 @@ def _merge_bucket_into(target: dict, bucket: dict) -> None:
         target["by_additional_value"][et_id_str] = target["by_additional_value"].get(
             et_id_str, 0.0
         ) + float(add_val)
+    for detail_key, name_field in _BUCKET_DETAIL_NAME_FIELDS.items():
+        rows = bucket.get(detail_key)
+        if not rows:
+            continue
+        accumulator = target.setdefault(detail_key, {})
+        for row in rows:
+            name = row.get(name_field)
+            if name is None:
+                continue
+            accumulator[name] = accumulator.get(name, 0.0) + (
+                row.get("kg_co2eq") or 0.0
+            )
+
+
+def _finalize_bucket_details(bucket: dict) -> None:
+    """Turn the name→kg accumulators back into the persisted row shape."""
+    for detail_key, name_field in _BUCKET_DETAIL_NAME_FIELDS.items():
+        accumulator = bucket.get(detail_key)
+        if not isinstance(accumulator, dict):
+            continue
+        bucket[detail_key] = [
+            {name_field: name, "kg_co2eq": kg, "tonnes_co2eq": kg / 1000.0}
+            for name, kg in sorted(accumulator.items())
+            if kg > 0
+        ]
 
 
 def merge_report_stats(stats_list: list[dict]) -> dict:
     """Merge several reports' stats into one aggregate of the same shape.
+
+    Bucket detail lists (embodied energy by building / by category) are summed
+    per key, so charts fed from them keep working on a combined perimeter.
 
     Per-unit top-class detail is dropped: a union of per-unit top-3 lists is
     not a meaningful aggregate.
@@ -154,6 +192,7 @@ def merge_report_stats(stats_list: list[dict]) -> dict:
             _merge_bucket_into(merged_bucket, bucket)
         if merged_bucket is None:
             continue
+        _finalize_bucket_details(merged_bucket)
         buckets[key] = merged_bucket
         for et_id_str, kg in merged_bucket["by_emission_type"].items():
             by_emission_type[et_id_str] = by_emission_type.get(et_id_str, 0.0) + kg

--- a/backend/tests/integration/v1/test_merged_report_stats.py
+++ b/backend/tests/integration/v1/test_merged_report_stats.py
@@ -1,0 +1,237 @@
+"""Integration tests for the combined-units Results endpoints (#385).
+
+The Results page sums several units' carbon reports into one view. These tests
+pin the three properties that make that safe:
+
+* the merged payloads equal the arithmetic sum of the single-unit ones;
+* the IT top-class detail is re-ranked across units rather than dropped
+  (``merge_report_stats`` deliberately discards it, so the endpoint has to put
+  it back);
+* a unit the caller cannot reach yields 404, never 403 — the frontend turns any
+  403 into a hard redirect to /unauthorized.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.deps as deps_module
+from app.core.constants import ModuleStatus
+from app.main import app
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_entry_emission import EmissionType
+from app.models.module_type import ModuleTypeEnum
+from app.models.user import RoleName
+
+EQUIPMENT = ModuleTypeEnum.equipment.value
+EMISSION_ID = str(EmissionType.food.value)
+
+
+def report_stats(total_kg: float, fte: float) -> dict:
+    """A persisted carbon_report.stats payload with one populated bucket."""
+    return {
+        "buckets": {
+            "equipment": {
+                "scope": 2,
+                "additional": False,
+                "total_kg": total_kg,
+                "by_emission_type": {EMISSION_ID: total_kg},
+                "by_additional_value": {},
+            }
+        },
+        "validated_buckets": ["equipment"],
+        "total": total_kg,
+        "validated_total": total_kg,
+        "total_fte": fte,
+        "by_emission_type": {EMISSION_ID: total_kg},
+        "by_additional_value": {},
+        "entry_count": 1,
+    }
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def policy_allow(monkeypatch):
+    async def _mock(*args, **kwargs):
+        return {"allow": True, "filters": {}}
+
+    monkeypatch.setattr("app.services.unit_service.query_policy", _mock)
+
+
+@pytest.fixture
+async def workspace(
+    db_session,
+    make_unit,
+    make_user,
+    make_unit_user,
+    make_carbon_report,
+    make_carbon_report_module,
+    make_data_entry,
+    make_data_entry_emission,
+):
+    """Two reachable level-4 units with equipment data, and one unreachable."""
+    user = await make_user(db_session)
+    units = {}
+    reports = {}
+
+    async def _seed_unit(name: str, total_kg: float, fte: float, reachable: bool):
+        unit = await make_unit(db_session, level=4, name=name)
+        if reachable:
+            await make_unit_user(
+                db_session,
+                unit_id=unit.id,
+                user_id=user.id,
+                role=RoleName.CO2_USER_PRINCIPAL,
+            )
+        report = await make_carbon_report(
+            db_session, unit_id=unit.id, year=2026, stats=report_stats(total_kg, fte)
+        )
+        module = await make_carbon_report_module(
+            db_session,
+            carbon_report_id=report.id,
+            module_type_id=EQUIPMENT,
+            status=ModuleStatus.VALIDATED,
+            stats={"total": total_kg},
+        )
+        entry = await make_data_entry(
+            db_session,
+            carbon_report_module_id=module.id,
+            data_entry_type_id=DataEntryTypeEnum.it.value,
+            data={"equipment_class": "Server"},
+        )
+        await make_data_entry_emission(
+            db_session, data_entry_id=entry.id, kg_co2eq=total_kg
+        )
+        units[name] = unit
+        reports[name] = report
+
+    await _seed_unit("Lab-A", 1000.0, 10.0, reachable=True)
+    await _seed_unit("Lab-B", 3000.0, 5.0, reachable=True)
+    await _seed_unit("Lab-Forbidden", 9999.0, 1.0, reachable=False)
+    await db_session.commit()
+
+    async def _override_db():
+        yield db_session
+
+    app.dependency_overrides[deps_module.get_db] = _override_db
+    app.dependency_overrides[deps_module.get_current_user] = lambda: user
+    return {"user": user, "units": units, "reports": reports}
+
+
+async def test_merged_report_stats_sums_units(client, workspace, policy_allow):
+    unit_ids = [workspace["units"]["Lab-A"].id, workspace["units"]["Lab-B"].id]
+
+    response = client.get(
+        "/api/v1/modules-stats/merged/report-stats",
+        params={"unit_ids": unit_ids, "year": 2026},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["total"] == 4000.0
+    assert payload["total_fte"] == 15.0
+    assert payload["buckets"]["equipment"]["total_kg"] == 4000.0
+    assert payload["scope2"] == 4000.0
+    # Validated headline is summed across the reports, not taken from one.
+    assert payload["total_tonnes_validated_co2eq"] == pytest.approx(4.0)
+
+
+async def test_merged_report_stats_reranks_it_top_classes(
+    client, workspace, policy_allow
+):
+    """merge_report_stats drops top_class_detail; the endpoint must restore it."""
+    unit_ids = [workspace["units"]["Lab-A"].id, workspace["units"]["Lab-B"].id]
+
+    response = client.get(
+        "/api/v1/modules-stats/merged/report-stats",
+        params={"unit_ids": unit_ids, "year": 2026},
+    )
+
+    assert response.status_code == 200, response.text
+    top_class_detail = response.json()["it"]["top_class_detail"]
+    assert top_class_detail, "IT top-class detail must survive the merge"
+
+    equipment_rows = top_class_detail["equipment_it"]
+    # Both units contribute the same class, so it ranks once at their sum.
+    server_values = [
+        child["value"]
+        for row in equipment_rows
+        for child in row["children"]
+        if child["name"] == "Server"
+    ]
+    assert server_values == [pytest.approx(4000.0)]
+
+
+async def test_merged_results_summary_equals_sum_of_singles(
+    client, workspace, policy_allow
+):
+    unit_ids = [workspace["units"]["Lab-A"].id, workspace["units"]["Lab-B"].id]
+
+    merged = client.get(
+        "/api/v1/modules-stats/merged/results-summary",
+        params={"unit_ids": unit_ids, "year": 2026},
+    )
+    assert merged.status_code == 200, merged.text
+
+    singles = [
+        client.get(
+            f"/api/v1/modules-stats/{workspace['reports'][name].id}/results-summary"
+        ).json()
+        for name in ("Lab-A", "Lab-B")
+    ]
+
+    merged_total = merged.json()["unit_totals"]["total_tonnes_co2eq"]
+    assert merged_total == pytest.approx(
+        sum(single["unit_totals"]["total_tonnes_co2eq"] for single in singles)
+    )
+
+
+async def test_unreachable_unit_yields_404_not_403(client, workspace, policy_allow):
+    """A 403 here would hard-redirect the SPA to /unauthorized."""
+    unit_ids = [
+        workspace["units"]["Lab-A"].id,
+        workspace["units"]["Lab-Forbidden"].id,
+    ]
+
+    response = client.get(
+        "/api/v1/modules-stats/merged/report-stats",
+        params={"unit_ids": unit_ids, "year": 2026},
+    )
+
+    assert response.status_code == 404
+
+
+async def test_merged_route_wins_over_carbon_report_id_route(
+    client, workspace, policy_allow
+):
+    """`/merged/report-stats` must not be parsed as carbon_report_id="merged"."""
+    response = client.get(
+        "/api/v1/modules-stats/merged/report-stats",
+        params={"unit_ids": [workspace["units"]["Lab-A"].id], "year": 2026},
+    )
+
+    assert response.status_code != 422
+    assert response.status_code == 200
+
+
+async def test_units_without_a_report_for_the_year_are_skipped(
+    client, workspace, policy_allow
+):
+    unit_ids = [workspace["units"]["Lab-A"].id, workspace["units"]["Lab-B"].id]
+
+    response = client.get(
+        "/api/v1/modules-stats/merged/report-stats",
+        params={"unit_ids": unit_ids, "year": 2023},
+    )
+
+    assert response.status_code == 404

--- a/backend/tests/unit/seed/test_seed_emission_candidates.py
+++ b/backend/tests/unit/seed/test_seed_emission_candidates.py
@@ -1,0 +1,55 @@
+"""Every seeded data entry must be able to carry an emission.
+
+A data entry type with no candidate emission type seeds entries that recompute
+to a zero bucket total, so the module's charts come up empty in dev with no
+error anywhere. This pins the mapping against drift in either the taxonomy or
+``MODULE_TYPE_TO_DATA_ENTRY_TYPES``.
+"""
+
+import pytest
+
+from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
+from app.modules.emissions.registry import MODULE_STAT_BUCKETS
+from app.seed.random_generator.seed_data_entries import seed_emission_candidates
+
+_ALL_DATA_ENTRY_TYPES = [
+    (module_type, data_entry_type)
+    for module_type, data_entry_types in MODULE_TYPE_TO_DATA_ENTRY_TYPES.items()
+    for data_entry_type in data_entry_types
+]
+
+
+@pytest.mark.parametrize(
+    ("module_type", "data_entry_type"),
+    _ALL_DATA_ENTRY_TYPES,
+    ids=[f"{ModuleTypeEnum(m).name}-{d.name}" for m, d in _ALL_DATA_ENTRY_TYPES],
+)
+def test_every_data_entry_type_can_seed_an_emission(module_type, data_entry_type):
+    assert seed_emission_candidates(data_entry_type), (
+        f"{data_entry_type.name} has no seedable emission type; entries of this "
+        f"type would seed with zero emissions and "
+        f"{ModuleTypeEnum(module_type).name} would recompute to an empty chart"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_type", "data_entry_type"),
+    _ALL_DATA_ENTRY_TYPES,
+    ids=[f"{ModuleTypeEnum(m).name}-{d.name}" for m, d in _ALL_DATA_ENTRY_TYPES],
+)
+def test_seeded_emissions_land_in_their_module_buckets(module_type, data_entry_type):
+    """An emission outside the module's buckets is silently dropped by recompute."""
+    bucket_node_ids = {
+        node.value
+        for bucket_nodes in MODULE_STAT_BUCKETS[ModuleTypeEnum(module_type)]
+        for node in bucket_nodes.nodes
+    }
+    outside = [
+        emission_type.name
+        for emission_type in seed_emission_candidates(data_entry_type)
+        if emission_type.value not in bucket_node_ids
+    ]
+    assert not outside, (
+        f"{data_entry_type.name} may seed {outside}, which fall outside "
+        f"{ModuleTypeEnum(module_type).name}'s stat buckets"
+    )

--- a/backend/tests/unit/utils/test_report_stats.py
+++ b/backend/tests/unit/utils/test_report_stats.py
@@ -204,3 +204,62 @@ def test_year_comparison_empty_stats():
     assert entry["modules"] == {}
     assert entry["scopes"] == {"1": 0.0, "2": 0.0, "3": 0.0}
     assert entry["total_tonnes_co2eq"] == 0.0
+
+
+def _embodied_report(by_building: list[dict], by_category: list[dict]) -> dict:
+    """A minimal report whose embodied bucket carries the detail lists."""
+    return {
+        "buckets": {
+            "embodied_energy": {
+                "scope": 3,
+                "additional": True,
+                "total_kg": sum(row["kg_co2eq"] for row in by_category),
+                "by_emission_type": {},
+                "by_additional_value": {},
+                "by_building": by_building,
+                "by_category": by_category,
+            }
+        },
+        "validated_buckets": ["embodied_energy"],
+        "total": sum(row["kg_co2eq"] for row in by_category),
+        "validated_total": 0.0,
+        "total_fte": 0.0,
+        "entry_count": 0,
+    }
+
+
+def test_merge_report_stats_sums_embodied_energy_detail():
+    """Without this the combined Results view shows a total but an empty chart."""
+    first = _embodied_report(
+        by_building=[{"building_name": "GC", "kg_co2eq": 1000.0, "tonnes_co2eq": 1.0}],
+        by_category=[
+            {"category": "concrete", "kg_co2eq": 600.0, "tonnes_co2eq": 0.6},
+            {"category": "steel", "kg_co2eq": 400.0, "tonnes_co2eq": 0.4},
+        ],
+    )
+    second = _embodied_report(
+        by_building=[
+            # Same building in another unit collapses into one row.
+            {"building_name": "GC", "kg_co2eq": 500.0, "tonnes_co2eq": 0.5},
+            {"building_name": "BC", "kg_co2eq": 250.0, "tonnes_co2eq": 0.25},
+        ],
+        by_category=[{"category": "steel", "kg_co2eq": 750.0, "tonnes_co2eq": 0.75}],
+    )
+
+    bucket = merge_report_stats([first, second])["buckets"]["embodied_energy"]
+
+    assert bucket["by_building"] == [
+        {"building_name": "BC", "kg_co2eq": 250.0, "tonnes_co2eq": 0.25},
+        {"building_name": "GC", "kg_co2eq": 1500.0, "tonnes_co2eq": 1.5},
+    ]
+    assert bucket["by_category"] == [
+        {"category": "concrete", "kg_co2eq": 600.0, "tonnes_co2eq": 0.6},
+        {"category": "steel", "kg_co2eq": 1150.0, "tonnes_co2eq": 1.15},
+    ]
+
+
+def test_merge_report_stats_omits_absent_bucket_detail():
+    """Buckets that never carried detail lists must not grow empty ones."""
+    merged = merge_report_stats([_build_report_stats(_modules())])
+    assert "by_building" not in merged["buckets"]["equipment"]
+    assert "by_category" not in merged["buckets"]["equipment"]

--- a/frontend/src/api/modules.ts
+++ b/frontend/src/api/modules.ts
@@ -109,3 +109,29 @@ export async function getResultsSummary(
   const query = searchParams.toString();
   return api.get(query ? `${path}?${query}` : path).json<ResultsSummary>();
 }
+
+/**
+ * Fetch the results summary summed over several units for one year.
+ *
+ * @param unitIds - Units to combine, including the one currently viewed
+ * @param year - Report year
+ * @param excludeModules - Optional list of module_type_ids to exclude from totals
+ * @returns Combined totals and per-module breakdowns, same shape as the single-unit call
+ */
+export async function getMergedResultsSummary(
+  unitIds: number[],
+  year: number,
+  excludeModules: number[] = [],
+): Promise<ResultsSummary> {
+  const searchParams = new URLSearchParams();
+  searchParams.append('year', String(year));
+  for (const id of unitIds) {
+    searchParams.append('unit_ids', String(id));
+  }
+  for (const id of excludeModules) {
+    searchParams.append('exclude_modules', String(id));
+  }
+  return api
+    .get(`modules-stats/merged/results-summary?${searchParams.toString()}`)
+    .json<ResultsSummary>();
+}

--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -176,7 +176,7 @@ import HeadCountBarChart from 'src/components/molecules/HeadCountBarChart.vue';
 import TripsMap from 'src/components/molecules/TripsMap.vue';
 import GenericEmissionTreeMapChart from 'src/components/charts/GenericEmissionTreeMapChart.vue';
 import EmissionTypeBreakdownChart from 'src/components/charts/results/EmissionTypeBreakdownChart.vue';
-import { useModuleStore } from 'src/stores/modules';
+import { useModuleStore, type MergedUnitsContext } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useAuthStore } from 'src/stores/auth';
 import { PermissionAction } from 'src/utils/permission';
@@ -202,10 +202,20 @@ const props = withDefaults(
     forcedView?: 'breakdown' | 'type';
     showControls?: boolean;
     printMode?: boolean;
+    /** Extra units whose entries are ranked together with the current unit's. */
+    combineUnitIds?: number[];
+    /**
+     * Module type ids the parent has filtered out. Must match what the parent
+     * passed to `getEmissionBreakdown`, or the refetch below misses the shared
+     * cache and overwrites the parent's breakdown with an unfiltered one.
+     */
+    excludeModules?: number[];
   }>(),
   {
     showControls: true,
     forcedView: 'breakdown',
+    combineUnitIds: () => [],
+    excludeModules: () => [],
   },
 );
 
@@ -316,6 +326,17 @@ const supportsTopClassBreakdown = computed(() =>
   TOP_CLASS_MODULES.includes(props.type),
 );
 
+/**
+ * Mirrors the Results page's combined-units context. Without it the breakdown
+ * refetch below would overwrite the combined data with this unit's alone.
+ */
+const mergedUnitsContext = computed<MergedUnitsContext | null>(() => {
+  const unitId = workspaceStore.selectedUnit?.id;
+  const year = workspaceStore.selectedYear;
+  if (!props.combineUnitIds.length || !unitId || !year) return null;
+  return { unitIds: [unitId, ...props.combineUnitIds], year };
+});
+
 function fetchTopClassBreakdownIfNeeded() {
   const unitId = workspaceStore.selectedUnit?.id;
   const year = workspaceStore.selectedYear;
@@ -324,7 +345,12 @@ function fetchTopClassBreakdownIfNeeded() {
     return;
   }
   if (unitId && year && supportsTopClassBreakdown.value) {
-    void moduleStore.getTopClassBreakdown(unitId, String(year), props.type);
+    void moduleStore.getTopClassBreakdown(
+      unitId,
+      String(year),
+      props.type,
+      props.combineUnitIds,
+    );
   }
 }
 
@@ -359,10 +385,19 @@ function fetchTripsMapIfNeeded() {
 }
 
 watch(
-  () => workspaceStore.selectedCarbonReport?.id,
-  (carbonReportId) => {
+  () => [
+    workspaceStore.selectedCarbonReport?.id,
+    props.combineUnitIds.join(','),
+    props.excludeModules.join(','),
+  ],
+  () => {
+    const carbonReportId = workspaceStore.selectedCarbonReport?.id;
     if (carbonReportId) {
-      void moduleStore.getEmissionBreakdown(carbonReportId);
+      void moduleStore.getEmissionBreakdown(
+        carbonReportId,
+        props.excludeModules,
+        mergedUnitsContext.value,
+      );
       fetchTopClassBreakdownIfNeeded();
       fetchTripsMapIfNeeded();
     }

--- a/frontend/src/components/organisms/print/ResultsPrintModulePage.vue
+++ b/frontend/src/components/organisms/print/ResultsPrintModulePage.vue
@@ -16,9 +16,14 @@ interface Props {
   hasCo2PerKmKg: boolean;
   co2PerKmKg: number;
   currentYear: number;
+  combineUnitIds?: number[];
+  excludeModules?: number[];
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  combineUnitIds: () => [],
+  excludeModules: () => [],
+});
 
 const { t, te } = useI18n();
 
@@ -152,6 +157,8 @@ function getTotalModuleCarbonFootprintTitle(): string {
           :type="module"
           forced-view="type"
           :show-controls="false"
+          :combine-unit-ids="props.combineUnitIds"
+          :exclude-modules="props.excludeModules"
         />
       </q-card>
 
@@ -163,6 +170,8 @@ function getTotalModuleCarbonFootprintTitle(): string {
           :type="module"
           forced-view="breakdown"
           :show-controls="false"
+          :combine-unit-ids="props.combineUnitIds"
+          :exclude-modules="props.excludeModules"
         />
       </q-card>
     </div>

--- a/frontend/src/composables/print/useResultsPrintData.ts
+++ b/frontend/src/composables/print/useResultsPrintData.ts
@@ -3,13 +3,18 @@ import { useRoute } from 'vue-router';
 
 import {
   getResultsSummary,
+  getMergedResultsSummary,
   type ResultsSummary,
   type ModuleResult,
 } from 'src/api/modules';
 import { MODULES, MODULES_LIST, type Module } from 'src/constant/modules';
 import { IT_FOCUS_SOURCE_MODULES } from 'src/constant/itFocus';
 import { getModuleTypeId, MODULE_STATES } from 'src/constant/moduleStates';
-import { useModuleStore, useTimelineStore } from 'src/stores/modules';
+import {
+  useModuleStore,
+  useTimelineStore,
+  type MergedUnitsContext,
+} from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 
 export function useResultsPrintData() {
@@ -45,6 +50,28 @@ export function useResultsPrintData() {
       if (id !== undefined) ids.push(id);
     }
     return ids;
+  });
+
+  /** Combined units carried over from the Results page's `?combineUnits=`. */
+  const combinedUnitIds = computed(() => {
+    const raw = route.query.combineUnits;
+    const value = Array.isArray(raw) ? raw.join(',') : raw;
+    if (!value) return [];
+    const currentUnitId = workspaceStore.selectedUnit?.id;
+    const reachable = new Set(workspaceStore.units.map((unit) => unit.id));
+    return value
+      .split(',')
+      .map((id) => Number(id))
+      .filter((id) => id !== currentUnitId && reachable.has(id));
+  });
+
+  const mergedContext = computed<MergedUnitsContext | null>(() => {
+    const currentUnitId = workspaceStore.selectedUnit?.id;
+    if (!combinedUnitIds.value.length || !currentUnitId) return null;
+    return {
+      unitIds: [currentUnitId, ...combinedUnitIds.value],
+      year: currentYear.value,
+    };
   });
 
   const co2PerKmKg = computed(() => resultsSummary.value?.co2_per_km_kg ?? 0);
@@ -209,12 +236,16 @@ export function useResultsPrintData() {
   }
 
   async function fetchAllData(carbonReportId: number) {
+    const merged = mergedContext.value;
     try {
       resultsSummaryLoading.value = true;
-      resultsSummary.value = await getResultsSummary(
-        carbonReportId,
-        excludedModules.value,
-      );
+      resultsSummary.value = merged
+        ? await getMergedResultsSummary(
+            merged.unitIds,
+            merged.year,
+            excludedModules.value,
+          )
+        : await getResultsSummary(carbonReportId, excludedModules.value);
     } catch {
       resultsSummary.value = null;
     } finally {
@@ -224,14 +255,21 @@ export function useResultsPrintData() {
     await moduleStore.getEmissionBreakdown(
       carbonReportId,
       excludedModules.value,
+      merged,
     );
-    await moduleStore.getItBreakdown(carbonReportId, excludedModules.value);
+    await moduleStore.getItBreakdown(
+      carbonReportId,
+      excludedModules.value,
+      merged,
+    );
   }
 
   return {
     resultsSummary,
     resultsSummaryLoading,
     currentYear,
+    combinedUnitIds,
+    excludedModules,
     viewAdditionalData,
     co2PerKmKg,
     hasCo2PerKmKg,

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -144,16 +144,30 @@ export default {
     fr: 'kg CO₂-eq',
   },
   results_title: {
-    en: 'Results',
-    fr: 'Résultats',
+    en: 'Annual carbon footprint',
+    fr: 'Empreinte carbone annuelle',
+  },
+  // Subtitle under the Results heading: which units are summed, and for which year.
+  results_perimeter_subtitle: {
+    en: '{unit} · {year}',
+    fr: '{unit} · {year}',
   },
   results_print_title: {
     en: 'Total results',
     fr: 'Résultats totaux',
   },
+  // Still the subtitle of the printed report, which keeps its own header.
   results_subtitle: {
     en: 'Annual carbon footprint {year}',
     fr: 'Empreinte carbone annuelle {year}',
+  },
+  results_combine_units_label: {
+    en: 'Add a Unit',
+    fr: 'Ajouter une unité',
+  },
+  results_combine_units_counter: {
+    en: '{unit} + {count} units',
+    fr: '{unit} + {count} unités',
   },
   results_total_unit_carbon_footprint: {
     en: 'Unit carbon footprint',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -16,12 +16,17 @@ import BigNumber from 'src/components/molecules/BigNumber.vue';
 import { getModuleIconColors } from 'src/composables/useModuleIconColors';
 import {
   getResultsSummary,
+  getMergedResultsSummary,
   type ResultsSummary,
   type ModuleResult,
 } from 'src/api/modules';
 
 import { useWorkspaceStore } from 'src/stores/workspace';
-import { useTimelineStore, useModuleStore } from 'src/stores/modules';
+import {
+  useTimelineStore,
+  useModuleStore,
+  type MergedUnitsContext,
+} from 'src/stores/modules';
 import { useResultsFiltersStore } from 'src/stores/resultsFilters';
 import { storeToRefs } from 'pinia';
 import { IT_FOCUS_SOURCE_MODULES } from 'src/constant/itFocus';
@@ -157,16 +162,63 @@ const excludedModules = computed(() => {
   return ids;
 });
 
+const currentUnitId = computed(() => workspaceStore.selectedUnit?.id ?? null);
+
+/** Units offered for combining: everything the user can reach except this one. */
+const combineUnitOptions = computed(() =>
+  workspaceStore.units
+    .filter((unit) => unit.id !== currentUnitId.value)
+    .map((unit) => ({ label: unit.name, value: unit.id })),
+);
+
+const combinedUnitIds = ref<number[]>([]);
+
+/** Ignore ids the user cannot reach, so a hand-edited URL degrades quietly. */
+function readCombineUnitsQuery(): number[] {
+  const raw = route.query.combineUnits;
+  const value = Array.isArray(raw) ? raw.join(',') : raw;
+  if (!value) return [];
+  const selectable = new Set(combineUnitOptions.value.map((o) => o.value));
+  return value
+    .split(',')
+    .map((id) => Number(id))
+    .filter((id) => selectable.has(id));
+}
+
+function unitNameById(unitId: number): string {
+  return workspaceStore.units.find((unit) => unit.id === unitId)?.name ?? '';
+}
+
+function toggleCombinedUnit(unitId: number) {
+  combinedUnitIds.value = combinedUnitIds.value.includes(unitId)
+    ? combinedUnitIds.value.filter((id) => id !== unitId)
+    : [...combinedUnitIds.value, unitId];
+}
+
+/** Null in single-unit mode; the fetches then take their existing per-report path. */
+const mergedContext = computed<MergedUnitsContext | null>(() => {
+  if (!combinedUnitIds.value.length || currentUnitId.value === null)
+    return null;
+  return {
+    unitIds: [currentUnitId.value, ...combinedUnitIds.value],
+    year: currentYear.value,
+  };
+});
+
 async function fetchResultsSummary() {
+  const merged = mergedContext.value;
   const carbonReportId = workspaceStore.selectedCarbonReport?.id;
-  if (!carbonReportId) return;
+  if (!merged && !carbonReportId) return;
 
   try {
     resultsSummaryLoading.value = true;
-    resultsSummary.value = await getResultsSummary(
-      carbonReportId,
-      excludedModules.value,
-    );
+    resultsSummary.value = merged
+      ? await getMergedResultsSummary(
+          merged.unitIds,
+          merged.year,
+          excludedModules.value,
+        )
+      : await getResultsSummary(Number(carbonReportId), excludedModules.value);
   } catch {
     resultsSummary.value = null;
   } finally {
@@ -177,13 +229,21 @@ async function fetchResultsSummary() {
 async function fetchEmissionBreakdown() {
   const carbonReportId = workspaceStore.selectedCarbonReport?.id;
   if (!carbonReportId) return;
-  await moduleStore.getEmissionBreakdown(carbonReportId, excludedModules.value);
+  await moduleStore.getEmissionBreakdown(
+    carbonReportId,
+    excludedModules.value,
+    mergedContext.value,
+  );
 }
 
 async function fetchItBreakdown() {
   const carbonReportId = workspaceStore.selectedCarbonReport?.id;
   if (!carbonReportId) return;
-  await moduleStore.getItBreakdown(carbonReportId, excludedModules.value);
+  await moduleStore.getItBreakdown(
+    carbonReportId,
+    excludedModules.value,
+    mergedContext.value,
+  );
 }
 
 /** Schedule a callback after the next paint frame, then wait for idle. */
@@ -200,6 +260,7 @@ function afterPaint(cb: () => void) {
 }
 
 onMounted(async () => {
+  combinedUnitIds.value = readCombineUnitsQuery();
   await fetchResultsSummary();
 
   // Phase 1: after first paint, mount charts + start data fetches.
@@ -216,12 +277,32 @@ onMounted(async () => {
   });
 });
 
-// Watch for year/unit changes
+// A combine set is only meaningful against the unit and year it was picked for.
+watch(
+  () => [currentUnitId.value, currentYear.value],
+  () => {
+    combinedUnitIds.value = [];
+  },
+);
+
+// Keep the selection in the URL so it survives a reload and rides along to the
+// PDF export. Params are untouched, so `workspaceGuard` skips its reload.
+watch(combinedUnitIds, (ids) => {
+  void router.replace({
+    query: {
+      ...route.query,
+      combineUnits: ids.length ? ids.join(',') : undefined,
+    },
+  });
+});
+
+// Watch for year/unit/combine changes
 watch(
   () => [
     workspaceStore.selectedCarbonReport?.id,
     currentYear.value,
     hideResearchFacilities.value,
+    combinedUnitIds.value.join(','),
   ],
   async () => {
     moduleStore.invalidateEmissionBreakdown();
@@ -264,6 +345,38 @@ const getModuleResult = (module: string): ModuleResult | undefined => {
 const isModuleAvailable = (module: string): boolean =>
   isModuleFullyAvailable(module as Module, Boolean(getModuleResult(module)));
 const { t, te } = useI18n();
+
+const combinedUnitNames = computed(() =>
+  combinedUnitIds.value
+    .map((id) => workspaceStore.units.find((unit) => unit.id === id)?.name)
+    .filter((name): name is string => Boolean(name)),
+);
+
+/** Up to two units in the perimeter are named; beyond that a counter is used. */
+const titleUnitLabel = computed(() => {
+  const currentName = workspaceStore.selectedUnit?.name ?? '';
+  const names = combinedUnitNames.value;
+  if (!names.length) return currentName;
+  if (names.length === 1) return `${currentName} + ${names[0]}`;
+  return t('results_combine_units_counter', {
+    unit: currentName,
+    count: names.length,
+  });
+});
+
+/**
+ * The perimeter moves to a subtitle rather than sitting inside the heading:
+ * "footprint - UNIT + 3 units, 2026" stacked a dash, a plus and a comma on one
+ * line. This also matches the title/subtitle pairing used by the cards below.
+ */
+const resultsTitleLead = computed(() => t('results_title'));
+
+const resultsSubtitle = computed(() =>
+  t('results_perimeter_subtitle', {
+    unit: titleUnitLabel.value,
+    year: currentYear.value,
+  }),
+);
 
 function getTotalModuleCarbonFootprintTitle(module: Module): string {
   const specificKey = `results_total_module_carbon_footprint_${module}`;
@@ -425,6 +538,9 @@ const downloadPDF = () => {
     query: {
       hideResearchFacilities: hideResearchFacilities.value ? '1' : '0',
       hideAdditionalData: hideAdditionalData.value ? '1' : '0',
+      ...(combinedUnitIds.value.length
+        ? { combineUnits: combinedUnitIds.value.join(',') }
+        : {}),
     },
   });
   window.open(resolved.href, '_blank');
@@ -451,13 +567,71 @@ const getUncertainty = (
     <div class="page-grid">
       <q-card flat bordered class="q-pa-xl">
         <div class="flex justify-between items-center">
-          <div>
+          <div class="results-header__identity">
             <h2 class="text-h2 text-weight-medium">
-              {{ $t('results_title') }}
+              {{ resultsTitleLead }}
             </h2>
-            <span class="text-body1 text-secondary">{{
-              $t('results_subtitle', { year: currentYear })
-            }}</span>
+            <span class="text-body1 text-secondary">{{ resultsSubtitle }}</span>
+            <div
+              v-if="combineUnitOptions.length"
+              class="results-header__combine"
+            >
+              <!-- Each toggle rewrites the `combineUnits` query param, and
+                   Quasar dismisses menus on navigation — keep it open so
+                   several units can be ticked in one go. -->
+              <q-btn-dropdown
+                :label="$t('results_combine_units_label')"
+                color="info"
+                outline
+                no-caps
+                dense
+                no-route-dismiss
+                class="results-header__combine-btn"
+              >
+                <q-list dense>
+                  <q-item
+                    v-for="option in combineUnitOptions"
+                    :key="option.value"
+                    v-ripple
+                    clickable
+                    @click="toggleCombinedUnit(option.value)"
+                  >
+                    <q-item-section side>
+                      <!-- Display only: the enclosing q-item owns the toggle,
+                           so a click on the box must not toggle a second time. -->
+                      <q-checkbox
+                        :model-value="combinedUnitIds.includes(option.value)"
+                        color="info"
+                        dense
+                        tabindex="-1"
+                        class="results-header__combine-check"
+                      />
+                    </q-item-section>
+                    <q-item-section>
+                      <q-item-label>{{ option.label }}</q-item-label>
+                    </q-item-section>
+                  </q-item>
+                </q-list>
+              </q-btn-dropdown>
+
+              <q-chip
+                v-if="workspaceStore.selectedUnit"
+                color="info"
+                text-color="white"
+                class="results-header__combine-chip"
+                :label="workspaceStore.selectedUnit.name"
+              />
+              <q-chip
+                v-for="unitId in combinedUnitIds"
+                :key="unitId"
+                color="info"
+                text-color="white"
+                removable
+                class="results-header__combine-chip results-header__combine-chip--removable"
+                :label="unitNameById(unitId)"
+                @remove="toggleCombinedUnit(unitId)"
+              />
+            </div>
           </div>
 
           <div class="flex column justify-between">
@@ -740,7 +914,11 @@ const getUncertainty = (
                     <template v-if="getModuleResult(module)">
                       <!-- Per-module treemap -->
                       <template v-if="isModuleValidated(module)">
-                        <ModuleCharts :type="module" />
+                        <ModuleCharts
+                          :type="module"
+                          :combine-unit-ids="combinedUnitIds"
+                          :exclude-modules="excludedModules"
+                        />
                       </template>
                       <div class="module-stats-row">
                         <BigNumber
@@ -894,6 +1072,67 @@ const getUncertainty = (
 <style scoped lang="scss">
 .page-grid {
   gap: 2.5rem;
+}
+
+.results-header__identity {
+  min-width: 0;
+}
+
+// Dropdown button, then one badge per unit in the combined perimeter. Wraps
+// rather than pushing the header actions off on narrow viewports.
+.results-header__combine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.75rem;
+}
+
+// The row owns the toggle; the box is a display affordance, so it must not
+// swallow the click (which would toggle twice and appear to do nothing).
+.results-header__combine-check {
+  pointer-events: none;
+}
+
+// The button and the badges are one control strip: same type scale, same
+// vertical rhythm, so the dashed "add" affordance reads as a peer of the chips.
+// Only the horizontal padding differs — chips carry a remove icon that needs
+// breathing room from the label without widening the badge.
+$combine-font-size: 0.75rem;
+$combine-padding-y: 0.3125rem;
+$combine-padding-x: 0.75rem;
+$combine-chip-padding-x: 1.125rem;
+
+.results-header__combine-btn {
+  border-radius: 1.25rem;
+  font-weight: 400;
+  font-size: $combine-font-size;
+  padding: $combine-padding-y $combine-padding-x;
+
+  // Quasar draws the outline on a ::before pseudo-element, not on the button.
+  &::before {
+    border-style: dashed;
+    border-radius: inherit;
+  }
+}
+
+.results-header__combine-chip {
+  font-size: $combine-font-size;
+  padding: $combine-padding-y $combine-chip-padding-x;
+  height: auto;
+  margin: 0;
+}
+
+// The remove icon is its own visual terminator, so it needs less room to the
+// chip's edge than a bare label does — otherwise it reads as floating inside.
+.results-header__combine-chip--removable {
+  padding-right: 0.625rem;
+
+  :deep(.q-chip__icon--remove) {
+    margin-left: 0.5rem;
+    margin-right: 0;
+    font-size: 1.1em;
+  }
 }
 
 // Deactivated / no-EDIT-permission / no-stats-yet — same muted treatment

--- a/frontend/src/pages/app/ResultsPrintPage.vue
+++ b/frontend/src/pages/app/ResultsPrintPage.vue
@@ -16,6 +16,8 @@ const {
   resultsSummary,
   resultsSummaryLoading,
   currentYear,
+  combinedUnitIds,
+  excludedModules,
   viewAdditionalData,
   co2PerKmKg,
   hasCo2PerKmKg,
@@ -256,6 +258,8 @@ onMounted(async () => {
         :has-co2-per-km-kg="hasCo2PerKmKg"
         :co2-per-km-kg="co2PerKmKg"
         :current-year="currentYear"
+        :combine-unit-ids="combinedUnitIds"
+        :exclude-modules="excludedModules"
       />
 
       <ReportPage

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -41,6 +41,15 @@ export interface ValidatedTotalsResponse {
   total_fte: number;
 }
 
+/**
+ * The units whose carbon reports are summed on the Results page, and the year
+ * they are summed for. `unitIds` includes the unit currently being viewed.
+ */
+export interface MergedUnitsContext {
+  unitIds: number[];
+  year: number;
+}
+
 export interface EmbodiedEnergyCategoryEntry {
   category: string;
   kg_co2eq: number;
@@ -968,12 +977,19 @@ export const useModuleStore = defineStore('modules', () => {
     unit: number,
     year: string,
     moduleId: string,
+    combineUnitIds: number[] = [],
   ) {
     state.loadingTopClassBreakdown = true;
     state.errorTopClassBreakdown = null;
     state.topClassBreakdown = [];
     try {
-      const path = `modules/${encodeURIComponent(unit)}/${encodeURIComponent(year)}/${encodeURIComponent(moduleId)}/top-class-breakdown`;
+      const basePath = `modules/${encodeURIComponent(unit)}/${encodeURIComponent(year)}/${encodeURIComponent(moduleId)}/top-class-breakdown`;
+      const searchParams = new URLSearchParams();
+      for (const id of combineUnitIds) {
+        searchParams.append('combine_unit_ids', String(id));
+      }
+      const query = searchParams.toString();
+      const path = query ? `${basePath}?${query}` : basePath;
       const data = await api.get(path).json<Array<Record<string, unknown>>>();
       state.topClassBreakdown = data;
     } catch (err: unknown) {
@@ -1015,11 +1031,34 @@ export const useModuleStore = defineStore('modules', () => {
   const emissionBreakdownInFlightToken = ref(0);
   let emissionBreakdownInFlight: Promise<void> | null = null;
 
+  /**
+   * In combined mode the same carbonReportId maps to different data depending
+   * on which units are summed, so the unit set has to be part of the key.
+   */
   function makeBreakdownCacheKey(
     carbonReportId: number,
     excludeModules: number[],
+    merged: MergedUnitsContext | null = null,
   ): string {
-    return `${carbonReportId}::${[...excludeModules].sort((a, b) => a - b).join(',')}`;
+    const base = `${carbonReportId}::${[...excludeModules].sort((a, b) => a - b).join(',')}`;
+    if (!merged) return base;
+    const units = [...merged.unitIds].sort((a, b) => a - b).join(',');
+    return `${base}::m=${units}@${merged.year}`;
+  }
+
+  function reportStatsPath(
+    carbonReportId: number,
+    merged: MergedUnitsContext | null,
+  ): string {
+    if (!merged) {
+      return `modules-stats/${encodeURIComponent(carbonReportId)}/report-stats`;
+    }
+    const searchParams = new URLSearchParams();
+    searchParams.append('year', String(merged.year));
+    for (const id of merged.unitIds) {
+      searchParams.append('unit_ids', String(id));
+    }
+    return `modules-stats/merged/report-stats?${searchParams.toString()}`;
   }
 
   function invalidateEmissionBreakdown() {
@@ -1058,8 +1097,13 @@ export const useModuleStore = defineStore('modules', () => {
   async function getEmissionBreakdown(
     carbonReportId: number,
     excludeModules: number[] = [],
+    merged: MergedUnitsContext | null = null,
   ) {
-    const cacheKey = makeBreakdownCacheKey(carbonReportId, excludeModules);
+    const cacheKey = makeBreakdownCacheKey(
+      carbonReportId,
+      excludeModules,
+      merged,
+    );
     if (emissionBreakdownCacheKey.value === cacheKey) return;
     if (
       emissionBreakdownInFlight &&
@@ -1080,8 +1124,9 @@ export const useModuleStore = defineStore('modules', () => {
         emissionBreakdownInFlightCacheKey.value === cacheKey;
 
       try {
-        const path = `modules-stats/${encodeURIComponent(carbonReportId)}/report-stats`;
-        const stats = await api.get(path).json<ReportStats>();
+        const stats = await api
+          .get(reportStatsPath(carbonReportId, merged))
+          .json<ReportStats>();
         if (!isLatestRequest()) {
           return;
         }
@@ -1155,12 +1200,14 @@ export const useModuleStore = defineStore('modules', () => {
   async function getItBreakdown(
     carbonReportId: number,
     excludeModules: number[] = [],
+    merged: MergedUnitsContext | null = null,
   ) {
     state.loadingItBreakdown = true;
     state.errorItBreakdown = null;
     try {
-      const path = `modules-stats/${encodeURIComponent(carbonReportId)}/report-stats`;
-      const stats = await api.get(path).json<ReportStats>();
+      const stats = await api
+        .get(reportStatsPath(carbonReportId, merged))
+        .json<ReportStats>();
       state.itBreakdown = toItBreakdown(stats, excludeModules);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## What does this change?

Adds a **combined-units view** to the Results page. Users can now tick one or more sibling units from a dropdown; the page sums their carbon reports into a single set of charts and totals, re-ranks IT top classes across the union, and carries the selection into the PDF export.

Backend additions:
- `GET /modules-stats/merged/report-stats` — sums persisted `CarbonReport.stats` across several units, re-inserts IT top-class detail ranked over the union.
- `GET /modules-stats/merged/results-summary` — sums each unit's validated module totals and previous-year comparison basis.
- `combine_unit_ids` query param on `get_top_class_breakdown` — re-ranks IT classes over the union of units rather than a single unit's module.

Supporting changes:
- `merge_report_stats` now sums `by_building` / `by_category` bucket detail lists so embodied-energy charts remain populated in combined mode.
- Test fixtures expanded from one level-4 unit to four sibling labs; seed script fixed to supply `overall_status` and correctly scope emission types to their data entry types.
- "No assigned unit" landing flow refactored: back-office config users are forwarded directly to the data-management page; everyone else reaches `/unauthorized` tagged `reason=no-unit`.
- Quasar pinned back to 2.20.2.
- "Compare years" checkbox removed.

## Why is this needed?

EPFL units that share infrastructure (labs under the same section) need to see their combined carbon footprint without manually adding numbers. The existing single-report endpoints couldn't support this because a union of per-unit top-3 lists is not a meaningful aggregate — the merge has to re-rank from raw data.

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #385

---
See [[Development Workflow](https://claude.ai/docs/src/architecture/workflow-guide.md)](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.