### PR TITLE
fix: enforce Accred config at app boot, not Settings construction

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,7 +4,7 @@ from enum import Enum
 from functools import lru_cache
 from typing import Optional
 
-from pydantic import Field, computed_field, model_validator
+from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -254,7 +254,9 @@ class Settings(BaseSettings):
     )
 
     # EPFL Accred API Configuration — required whenever ROLE_PROVIDER_TYPE
-    # and/or UNIT_PROVIDER_TYPE is 'accred' (see validate_accred_config).
+    # and/or UNIT_PROVIDER_TYPE is 'accred', enforced at app boot by
+    # assert_accred_settings (app/main.py), NOT here: Settings is also
+    # built by non-app contexts (alembic migrations) that never call Accred.
     # Shared by both RoleProvider and UnitProvider — Accred is one API
     # serving both concerns, so the config is not role- or unit-specific.
     ACCRED_API_BASE_URL: Optional[str] = Field(
@@ -277,28 +279,6 @@ class Settings(BaseSettings):
             "authorization data. Not a generic API health URL."
         ),
     )
-
-    @model_validator(mode="after")
-    def validate_accred_config(self) -> "Settings":
-        """Require Accred credentials whenever a provider selects Accred.
-
-        No fallback: missing config fails Settings construction at startup.
-        """
-        uses_accred = (
-            self.ROLE_PROVIDER_TYPE == RoleProviderType.ACCRED
-            or self.UNIT_PROVIDER_TYPE == UnitProviderType.ACCRED
-        )
-        if not uses_accred:
-            return self
-
-        missing = [
-            name
-            for name in ("ACCRED_API_BASE_URL", "ACCRED_API_USERNAME", "ACCRED_API_KEY")
-            if getattr(self, name) is None
-        ]
-        if missing:
-            raise ValueError("Missing required Accred config: " + ", ".join(missing))
-        return self
 
     # OAuth/OIDC Configuration (supports Keycloak, Entra ID, or other OIDC providers)
     OAUTH_CLIENT_ID: Optional[str] = Field(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,10 +42,33 @@ def assert_security_settings(settings) -> None:
         raise RuntimeError(f"Missing required security settings: {missing}")
 
 
+def assert_accred_settings(settings) -> None:
+    """Require Accred credentials at boot whenever a provider selects Accred.
+
+    Enforced here rather than in Settings construction so non-app contexts
+    that build Settings but never call Accred (alembic migrations) don't
+    need the credentials.
+    """
+    uses_accred = (
+        settings.ROLE_PROVIDER_TYPE == RoleProviderType.ACCRED
+        or settings.UNIT_PROVIDER_TYPE == UnitProviderType.ACCRED
+    )
+    if not uses_accred:
+        return
+    missing = [
+        name
+        for name in ("ACCRED_API_BASE_URL", "ACCRED_API_USERNAME", "ACCRED_API_KEY")
+        if getattr(settings, name) is None
+    ]
+    if missing:
+        raise RuntimeError("Missing required Accred config: " + ", ".join(missing))
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Run on application startup."""
     assert_security_settings(settings)
+    assert_accred_settings(settings)
 
     logger.info(
         "Starting application",

--- a/backend/app/providers/role_provider.py
+++ b/backend/app/providers/role_provider.py
@@ -351,8 +351,9 @@ class AccredRoleProvider(RoleProvider):
     def __init__(self):
         """Initialize the Accred provider with API credentials.
 
-        Credential completeness is enforced at startup by Settings'
-        validate_accred_config — this constructor does not re-check it.
+        Credential completeness is enforced at app boot by
+        assert_accred_settings (app/main.py) — this constructor does not
+        re-check it.
         """
         self.api_url = settings.ACCRED_API_BASE_URL
         self.api_username = settings.ACCRED_API_USERNAME

--- a/backend/app/providers/unit_provider.py
+++ b/backend/app/providers/unit_provider.py
@@ -100,8 +100,9 @@ class AccredUnitProvider(UnitProvider):
     def __init__(self):
         """Initialize the Accred provider with API credentials.
 
-        Credential completeness is enforced at startup by Settings'
-        validate_accred_config — this constructor does not re-check it.
+        Credential completeness is enforced at app boot by
+        assert_accred_settings (app/main.py) — this constructor does not
+        re-check it.
         """
         self.api_url = settings.ACCRED_API_BASE_URL
         self.api_username = settings.ACCRED_API_USERNAME

--- a/backend/tests/unit/core/test_config_provider_types.py
+++ b/backend/tests/unit/core/test_config_provider_types.py
@@ -3,14 +3,17 @@
 ROLE_PROVIDER_TYPE and UNIT_PROVIDER_TYPE replace the old, overloaded
 PROVIDER_PLUGIN env var. Both are required with no default — missing or
 invalid config must fail Settings construction at startup, not silently
-fall back. Selecting 'accred' on either requires all three
-ACCRED_API_* vars (see Settings.validate_accred_config).
+fall back. Selecting 'accred' on either requires all three ACCRED_API_*
+vars at app boot (assert_accred_settings in app/main.py) — but NOT at
+Settings construction, so non-app contexts like alembic migrations can
+build Settings without Accred credentials.
 """
 
 import pytest
 from pydantic import ValidationError
 
 from app.core.config import RoleProviderType, Settings, UnitProviderType
+from app.main import assert_accred_settings
 
 
 def test_missing_role_provider_type_fails_startup(monkeypatch):
@@ -51,32 +54,46 @@ def test_test_provider_types_do_not_require_accred_config():
     assert settings.ACCRED_API_BASE_URL is None
 
 
-def test_accred_role_provider_requires_all_three_accred_vars():
-    with pytest.raises(ValidationError, match="Missing required Accred config"):
-        Settings(
-            ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
-            UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
-        )
+def test_accred_settings_construct_without_creds_for_non_app_contexts():
+    # Regression: alembic migrations build Settings with the app's env
+    # (provider type 'accred') but must not need Accred credentials.
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
+        UNIT_PROVIDER_TYPE=UnitProviderType.ACCRED,
+    )
+    assert settings.ACCRED_API_BASE_URL is None
 
 
-def test_accred_unit_provider_requires_all_three_accred_vars():
-    with pytest.raises(ValidationError, match="Missing required Accred config"):
-        Settings(
-            ROLE_PROVIDER_TYPE=RoleProviderType.JWT,
-            UNIT_PROVIDER_TYPE=UnitProviderType.ACCRED,
-        )
+def test_accred_role_provider_requires_all_three_accred_vars_at_boot():
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
+        UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
+    )
+    with pytest.raises(RuntimeError, match="Missing required Accred config"):
+        assert_accred_settings(settings)
 
 
-def test_accred_error_lists_missing_vars_only():
-    with pytest.raises(ValidationError) as exc_info:
-        Settings(
-            ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
-            UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
-            ACCRED_API_USERNAME="user",
-        )
+def test_accred_unit_provider_requires_all_three_accred_vars_at_boot():
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.JWT,
+        UNIT_PROVIDER_TYPE=UnitProviderType.ACCRED,
+    )
+    with pytest.raises(RuntimeError, match="Missing required Accred config"):
+        assert_accred_settings(settings)
+
+
+def test_accred_boot_error_lists_missing_vars_only():
+    settings = Settings(
+        ROLE_PROVIDER_TYPE=RoleProviderType.ACCRED,
+        UNIT_PROVIDER_TYPE=UnitProviderType.DATABASE,
+        ACCRED_API_USERNAME="user",
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        assert_accred_settings(settings)
     message = str(exc_info.value)
     assert "ACCRED_API_BASE_URL" in message
     assert "ACCRED_API_KEY" in message
+    assert "ACCRED_API_USERNAME" not in message
 
 
 def test_accred_provider_succeeds_with_all_three_vars():
@@ -87,4 +104,5 @@ def test_accred_provider_succeeds_with_all_three_vars():
         ACCRED_API_USERNAME="user",
         ACCRED_API_KEY="key",
     )
+    assert_accred_settings(settings)
     assert settings.ACCRED_API_BASE_URL == "https://accred.example.com"


### PR DESCRIPTION
## Problem

The dev deployment's migration Job crashed before running any migration:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
  Value error, Missing required Accred config: ACCRED_API_BASE_URL, ACCRED_API_USERNAME, ACCRED_API_KEY
```

`Settings.validate_accred_config` ran on every `Settings()` construction. Alembic's `env.py` builds `Settings` just to read `DB_URL`, so the migration container — which gets `ROLE_PROVIDER_TYPE=accred` from `backend.env` but (correctly) no Accred credentials — inherited an app-level requirement it can never use. The `SECRET_KEY`/OAuth entries already in `migration-job.yaml` are older band-aids for this same pattern.

## Fix

Move the check to `assert_accred_settings()` in `main.py`'s lifespan, next to the existing `assert_security_settings()`:

- **App**: same fail-closed guarantee — missing Accred creds with an accred provider still abort boot (providers are built lazily per-request, so the constructor can't be the enforcement point).
- **Migrations** (and any non-app context): `Settings` constructs with just its env; no Accred creds needed. No helm chart change required.

## Tests

- Regression: `Settings` with accred providers and no creds now constructs (the migration scenario).
- The three Accred-requirement tests moved from `ValidationError` at construction to `RuntimeError` from the boot check.

Verified with the migration container's exact env: `import app.models` + `get_settings()` succeed, boot check still raises.