### PR TITLE
feat 1416: update calculator update i18n entries 

### DIFF
--- a/frontend/src/i18n/calculator_update.ts
+++ b/frontend/src/i18n/calculator_update.ts
@@ -24,40 +24,43 @@ export default {
     fr: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
   },
   // --- Calculator Update list (unified home page) ---
+  // Listed newest first: the home page sorts entries by their index.
   calculator_update_1_title: {
-    en: 'Update of Ecoinvent factors',
-    fr: 'Mise à jour des facteurs Ecoinvent',
+    en: 'Purchases emission factors',
+    fr: 'Facteurs d’émission des achats',
   },
   calculator_update_1_date: {
-    en: '17 march 2026',
-    fr: '17 mars 2026',
+    en: '24 June 2026',
+    fr: '24 juin 2026',
   },
   calculator_update_1_body: {
-    en: 'The purchases factors have been updated on Monday 12 July because tita titata',
-    fr: 'Les facteurs des achats ont été mis à jour le lundi 12 juillet parce que tita titata',
+    en: 'A new version of the emission factors dataset, published by Labo1point5 in June 2026, has been integrated into the tool.',
+    fr: 'Une nouvelle version du jeu de facteurs d’émission, publiée par Labo1point5 en juin 2026, a été intégrée à l’outil.',
   },
   calculator_update_2_title: {
-    en: 'New Research Facility at EPFL',
-    fr: 'Nouvelle infrastructure de recherche à l’EPFL',
+    en: 'Buildings data',
+    fr: 'Données des bâtiments',
   },
   calculator_update_2_date: {
-    en: '13 march 2026',
-    fr: '13 mars 2026',
+    en: '18 June 2026',
+    fr: '18 juin 2026',
   },
   calculator_update_2_body: {
-    en: 'New platform IT4R has huge impact Co2 and has been added to module Research Facilities and boycotting toblerone for inclusivity reasons',
-    fr: 'La nouvelle plateforme IT4R a un fort impact Co2 et a été ajoutée au module Infrastructures de recherche et boycotte le toblerone pour des raisons d’inclusivité',
+    en: 'Following updates to the EPFL rooms dataset and discussions with infrastructure managers, the room-to-unit assignment has been revised, to account for shared spaces.',
+    fr: 'À la suite de la mise à jour du jeu de données des locaux de l’EPFL et des discussions avec les gestionnaires d’infrastructures, l’attribution des locaux aux unités a été révisée afin de tenir compte des espaces partagés.',
   },
+  // Empty slot: left blank so a third update can be filled in from the
+  // documentation editing back-office. Blank entries are not rendered.
   calculator_update_3_title: {
-    en: 'Software update',
-    fr: 'Mise à jour logicielle',
+    en: '',
+    fr: '',
   },
   calculator_update_3_date: {
-    en: '13 march 2026',
-    fr: '13 mars 2026',
+    en: '',
+    fr: '',
   },
   calculator_update_3_body: {
-    en: 'If you experience bugs, do Logout and Login again, our amazing software team has solved it all youp!',
-    fr: 'Si vous rencontrez des bugs, déconnectez-vous et reconnectez-vous, notre superbe équipe logicielle a tout résolu youp !',
+    en: '',
+    fr: '',
   },
 };


### PR DESCRIPTION
## What does this change?

Replaces placeholder ("fake news") content in `calculator_update.ts` with the two real updates that should appear on the home page: the new Labo1point5 purchases emission factors dataset (June 2026) and the revised EPFL buildings/room-to-unit assignment (June 2026). The third slot is cleared to blank so it can be filled via the back-office without a code change.

## Why is this needed?

The home page calculator update list was populated with lorem ipsum and dummy text during development. This replaces it with accurate, publication-ready copy in both English and French.

## Type of change

Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist

- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues

- Related to #1416

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.