### PR TITLE
feat/1783 backoffice reporting order

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -321,8 +321,7 @@ async def list_backoffice_units(
     return PaginatedUnitReportingData(
         data=unit_reporting_data,
         pagination=PaginationMeta(**result),
-        emission_breakdown=result.get("emission_breakdown"),
-        it_breakdown=result.get("it_breakdown"),
+        stats=result.get("stats"),
         validated_units_count=result.get("validated_units_count", 0),
         in_progress_units_count=result.get("in_progress_units_count", 0),
         not_started_units_count=result.get("not_started_units_count", 0),

--- a/backend/app/schemas/backoffice.py
+++ b/backend/app/schemas/backoffice.py
@@ -68,8 +68,9 @@ class PaginatedUnitReportingData(BaseModel):
 
     data: List[UnitReportingData]
     pagination: PaginationMeta
-    emission_breakdown: Optional[Dict[str, Any]] = None
-    it_breakdown: Optional[Dict[str, Any]] = None
+    # Merged per-report stats across the filtered units. The frontend reshapes
+    # this into the emission/IT breakdown rows the reporting charts consume.
+    stats: Optional[Dict[str, Any]] = None
     validated_units_count: int = 0
     in_progress_units_count: int = 0
     not_started_units_count: int = 0

--- a/frontend/src/components/charts/EmissionBreakdownChart.vue
+++ b/frontend/src/components/charts/EmissionBreakdownChart.vue
@@ -12,7 +12,7 @@ import {
   CHART_SUBCATEGORY_COLOR_SCHEMES,
 } from 'src/constant/charts';
 import { getEmissionTypeBreakdownInfoKey } from 'src/constant/emissionTypeBreakdownInfo';
-import { MODULES } from 'src/constant/modules';
+import { MODULES, MODULES_LIST } from 'src/constant/modules';
 import {
   CATEGORY_CHART_KEYS,
   type EmissionTreemapCategory,
@@ -36,17 +36,9 @@ const props = defineProps<{
 const { t } = useI18n();
 const isPrintMode = usePrintMode();
 
-// Modules that can appear as tabs (exclude headcount — no treemap chart)
-// Same left-to-right order as the bar chart (mirrors backend MODULE_BREAKDOWN_ORDER)
-const TREEMAP_MODULES = [
-  MODULES.ProcessEmissions,
-  MODULES.Buildings,
-  MODULES.Equipment,
-  MODULES.ExternalCloudAndAI,
-  MODULES.Purchase,
-  MODULES.ResearchFacilities,
-  MODULES.ProfessionalTravel,
-] as const;
+// Modules that can appear as tabs, in the canonical app order
+// (MODULES_LIST from timelineItems); headcount has no treemap chart.
+const TREEMAP_MODULES = MODULES_LIST.filter((mod) => mod !== MODULES.Headcount);
 
 /** Modules that actually have non-zero data in the current breakdown */
 const availableModules = computed(() => {

--- a/frontend/src/pages/back-office/ReportingPage.vue
+++ b/frontend/src/pages/back-office/ReportingPage.vue
@@ -55,7 +55,8 @@ async function toggleSelectAll(shouldSelectAll: boolean) {
   await fetchUnits();
 }
 
-const selectedYears = ref<string[]>(['2026']); // Default to latest year
+// Populated by ReportingYear, which defaults to the latest configured year.
+const selectedYears = ref<string[]>([]);
 
 // Track selected hierarchy filters from ReportingFilters
 const selectedPathAffiliation = ref<number[]>([]);


### PR DESCRIPTION
## What does this change?
Reworks how emission/IT breakdown data is passed from backend to frontend and fixes module ordering in the backoffice reporting charts:

- **Backend**: `PaginatedUnitReportingData` replaces the separate `emission_breakdown` and `it_breakdown` fields with a single merged `stats` field, and `list_backoffice_units` now returns `result.get("stats")` instead of the two separate breakdowns. The frontend is expected to reshape `stats` into the breakdown rows the reporting charts consume.
- **Frontend (`EmissionBreakdownChart.vue`)**: `TREEMAP_MODULES` (the tabs shown in the emission breakdown treemap) is now derived from the canonical `MODULES_LIST` (filtering out `Headcount`, which has no treemap chart) instead of a manually hardcoded, separately-ordered array.
- **Frontend (`ReportingPage.vue`)**: `selectedYears` no longer defaults to a hardcoded `['2026']`; it now starts empty and is populated by the `ReportingYear` component, which defaults to the latest configured year.

## Why is this needed?
The treemap's module tab order was maintained by hand in a comment-documented array that had to be kept in sync with the backend's `MODULE_BREAKDOWN_ORDER` and the bar chart — a source of drift/bugs (matching the branch name "reporting-order"). Deriving the order from `MODULES_LIST` removes that duplication. Hardcoding `'2026'` as the default reporting year would also silently become stale/incorrect as new years are configured; deferring to `ReportingYear`'s own default keeps it correct going forward. The backend `stats` consolidation simplifies the API surface by merging what were two separate breakdown fields into one.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1783

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.