### PR TITLE
feat: add scope label to print pages and ReportPage (#462)

### DIFF
--- a/frontend/src/components/organisms/ReportPage.vue
+++ b/frontend/src/components/organisms/ReportPage.vue
@@ -1,11 +1,12 @@
 <template>
   <section class="page" :class="{ 'page--first': isFirst }">
-    <header v-if="title || pageNumber != null" class="page__header">
+    <header v-if="title || scope || pageNumber != null" class="page__header">
       <div class="page__title">
         <q-img src="/epfl-logo.svg" :alt="$t('logo_alt')" width="75px" />
         <span class="q-ml-md text-h5 text-weight-medium">{{
           $t('calculator_title')
         }}</span>
+        <span v-if="scope" class="page__scope">{{ scope }}</span>
       </div>
       <div class="page__number">
         <span v-if="pageNumber != null">{{ pageNumber }}</span>
@@ -21,12 +22,15 @@
 <script setup lang="ts">
 interface Props {
   title?: string;
+  /** What the report covers, e.g. "SCI-STI-AB · 2025". Shown on every sheet. */
+  scope?: string;
   pageNumber?: number;
   isFirst?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
   title: undefined,
+  scope: undefined,
   pageNumber: undefined,
   isFirst: false,
 });
@@ -60,6 +64,13 @@ withDefaults(defineProps<Props>(), {
 .page__title {
   font-weight: 600;
   font-size: 14px;
+}
+
+.page__scope {
+  margin-left: 12px;
+  font-weight: 400;
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 .page__number {

--- a/frontend/src/components/organisms/print/ResultsPrintModulePage.vue
+++ b/frontend/src/components/organisms/print/ResultsPrintModulePage.vue
@@ -18,11 +18,13 @@ interface Props {
   currentYear: number;
   combineUnitIds?: number[];
   excludeModules?: number[];
+  scope?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   combineUnitIds: () => [],
   excludeModules: () => [],
+  scope: undefined,
 });
 
 const { t, te } = useI18n();
@@ -56,7 +58,7 @@ function getTotalModuleCarbonFootprintTitle(): string {
 </script>
 
 <template>
-  <ReportPage :title="$t(module)" :page-number="pageNumber">
+  <ReportPage :title="$t(module)" :scope="scope" :page-number="pageNumber">
     <h2 class="text-h5 q-mt-none report-h2">
       {{ $t(module) }}
     </h2>

--- a/frontend/src/composables/print/useBackofficePrintBase.ts
+++ b/frontend/src/composables/print/useBackofficePrintBase.ts
@@ -1,22 +1,21 @@
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { useBackofficeStore } from 'src/stores/backoffice';
 import type { UnitFilters } from 'src/stores/backoffice';
-import { MODULES } from 'src/constant/modules';
+import { buildBackofficeScopeLabel } from 'src/utils/unitPerimeterLabel';
+import { MODULES, MODULES_LIST } from 'src/constant/modules';
 import { MODULE_TO_CATEGORIES } from 'src/constant/charts';
 
-const BREAKDOWN_MODULES = [
-  MODULES.ProcessEmissions,
-  MODULES.Buildings,
-  MODULES.Equipment,
-  MODULES.ExternalCloudAndAI,
-  MODULES.Purchase,
-  MODULES.ResearchFacilities,
-  MODULES.ProfessionalTravel,
-] as const;
+// Same order as the calculator (MODULES_LIST from timelineItems); headcount has
+// no emission breakdown.
+const BREAKDOWN_MODULES = MODULES_LIST.filter(
+  (mod) => mod !== MODULES.Headcount,
+);
 
 export function useBackofficePrintBase() {
   const route = useRoute();
+  const { t } = useI18n();
   const backofficeStore = useBackofficeStore();
 
   const filters = computed<UnitFilters>(() => {
@@ -40,6 +39,20 @@ export function useBackofficePrintBase() {
     () => units.value?.validated_units_count ?? 0,
   );
   const tableTotal = computed(() => units.value?.total_units_count ?? 0);
+
+  const perimeterLabel = computed(() =>
+    buildBackofficeScopeLabel(units.value?.data ?? [], t),
+  );
+
+  /** Header line naming what this export covers: "SCI-STI-AB · 2025". */
+  const scopeLabel = computed(() => {
+    const years = (filters.value.years ?? []).join(', ');
+    if (!years) return perimeterLabel.value;
+    return t('results_perimeter_subtitle', {
+      unit: perimeterLabel.value,
+      year: years,
+    });
+  });
 
   const availableModules = computed(() => {
     if (!reportingEmissionBreakdown.value) return [];
@@ -75,6 +88,8 @@ export function useBackofficePrintBase() {
     reportingItBreakdown,
     validatedCount,
     tableTotal,
+    perimeterLabel,
+    scopeLabel,
     availableModules,
     fetchData,
   };

--- a/frontend/src/composables/print/useResultsPrintData.ts
+++ b/frontend/src/composables/print/useResultsPrintData.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 import {
@@ -16,9 +17,11 @@ import {
   type MergedUnitsContext,
 } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
+import { buildUnitPerimeterLabel } from 'src/utils/unitPerimeterLabel';
 
 export function useResultsPrintData() {
   const route = useRoute();
+  const { t } = useI18n();
   const workspaceStore = useWorkspaceStore();
   const timelineStore = useTimelineStore();
   const moduleStore = useModuleStore();
@@ -73,6 +76,29 @@ export function useResultsPrintData() {
       year: currentYear.value,
     };
   });
+
+  const combinedUnitNames = computed(() =>
+    combinedUnitIds.value
+      .map((id) => workspaceStore.units.find((unit) => unit.id === id)?.name)
+      .filter((name): name is string => Boolean(name)),
+  );
+
+  /** Same perimeter label as the on-screen Results page. */
+  const perimeterLabel = computed(() =>
+    buildUnitPerimeterLabel(
+      workspaceStore.selectedUnit?.name ?? '',
+      combinedUnitNames.value,
+      t,
+    ),
+  );
+
+  /** Header line naming what this export covers: "SCI-STI-AB · 2025". */
+  const scopeLabel = computed(() =>
+    t('results_perimeter_subtitle', {
+      unit: perimeterLabel.value,
+      year: currentYear.value,
+    }),
+  );
 
   const co2PerKmKg = computed(() => resultsSummary.value?.co2_per_km_kg ?? 0);
   const hasCo2PerKmKg = computed(() => co2PerKmKg.value > 0);
@@ -269,6 +295,8 @@ export function useResultsPrintData() {
     resultsSummaryLoading,
     currentYear,
     combinedUnitIds,
+    perimeterLabel,
+    scopeLabel,
     excludedModules,
     viewAdditionalData,
     co2PerKmKg,

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -1,4 +1,9 @@
 export default {
+  // Perimeter of a printed export that spans several affiliations.
+  print_scope_units_count: {
+    en: '{count} units',
+    fr: '{count} unités',
+  },
   backoffice_reporting_print_combined_title: {
     en: 'Combined Report',
     fr: 'Rapport combiné',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -38,6 +38,7 @@ import ReductionObjectiveChart from 'src/components/charts/results/ReductionObje
 import { useRoute, useRouter } from 'vue-router';
 import { nOrDash } from 'src/utils/number';
 import { resolveLanguage } from 'src/utils/language';
+import { buildUnitPerimeterLabel } from 'src/utils/unitPerimeterLabel';
 
 const yearConfigStore = useYearConfigStore();
 
@@ -352,17 +353,13 @@ const combinedUnitNames = computed(() =>
     .filter((name): name is string => Boolean(name)),
 );
 
-/** Up to two units in the perimeter are named; beyond that a counter is used. */
-const titleUnitLabel = computed(() => {
-  const currentName = workspaceStore.selectedUnit?.name ?? '';
-  const names = combinedUnitNames.value;
-  if (!names.length) return currentName;
-  if (names.length === 1) return `${currentName} + ${names[0]}`;
-  return t('results_combine_units_counter', {
-    unit: currentName,
-    count: names.length,
-  });
-});
+const titleUnitLabel = computed(() =>
+  buildUnitPerimeterLabel(
+    workspaceStore.selectedUnit?.name ?? '',
+    combinedUnitNames.value,
+    t,
+  ),
+);
 
 /**
  * The perimeter moves to a subtitle rather than sitting inside the heading:

--- a/frontend/src/pages/app/ResultsPrintPage.vue
+++ b/frontend/src/pages/app/ResultsPrintPage.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { nOrDash } from 'src/utils/number';
+import { toPrintDocumentTitle } from 'src/utils/unitPerimeterLabel';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
 import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonFootPrintPerPersonChart.vue';
@@ -17,6 +18,7 @@ const {
   resultsSummaryLoading,
   currentYear,
   combinedUnitIds,
+  scopeLabel,
   excludedModules,
   viewAdditionalData,
   co2PerKmKg,
@@ -125,6 +127,12 @@ onMounted(async () => {
 
   await loadModulesConfig();
   await fetchAllData(carbonReportId);
+
+  // Chrome seeds the "Save as PDF" filename from the document title.
+  document.title = toPrintDocumentTitle(
+    scopeLabel.value,
+    t('results_print_title'),
+  );
 });
 </script>
 
@@ -148,6 +156,7 @@ onMounted(async () => {
     >
       <ReportPage
         :title="$t('results_print_title')"
+        :scope="scopeLabel"
         :page-number="1"
         :is-first="true"
       >
@@ -155,7 +164,7 @@ onMounted(async () => {
           {{ $t('results_print_title') }}
         </h2>
         <div class="text-body2 text-secondary report-subtitle">
-          {{ $t('results_subtitle', { year: currentYear }) }}
+          {{ scopeLabel }}
         </div>
 
         <div class="grid-3-col q-mt-lg">
@@ -260,11 +269,13 @@ onMounted(async () => {
         :current-year="currentYear"
         :combine-unit-ids="combinedUnitIds"
         :exclude-modules="excludedModules"
+        :scope="scopeLabel"
       />
 
       <ReportPage
         v-if="showItFocusSection"
         :title="$t('it-focus-title')"
+        :scope="scopeLabel"
         :page-number="itPageNumber"
       >
         <h2 class="text-h5 q-mt-none">
@@ -290,6 +301,7 @@ onMounted(async () => {
           additionalChartsValidated
         "
         :title="$t('results_additional_title')"
+        :scope="scopeLabel"
         :page-number="additionalPageNumber"
       >
         <h2 class="text-h5 q-mt-none">

--- a/frontend/src/pages/back-office/BackofficeResultsPrintPage.vue
+++ b/frontend/src/pages/back-office/BackofficeResultsPrintPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
@@ -8,10 +9,12 @@ import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonF
 import EmissionBreakdownChart from 'src/components/charts/EmissionBreakdownChart.vue';
 import ItFocusBreakdownChart from 'src/components/charts/results/ItFocusBreakdownChart.vue';
 import { useBackofficeResultsPrintData } from 'src/composables/print/useBackofficeResultsPrintData';
+import { toPrintDocumentTitle } from 'src/utils/unitPerimeterLabel';
+
+const { t } = useI18n();
 
 const {
   loading,
-  years,
   reportingEmissionBreakdown,
   validatedCount,
   tableTotal,
@@ -22,6 +25,7 @@ const {
   headcountValidated,
   availableModules,
   reportingItBreakdown,
+  scopeLabel,
   fetchData,
 } = useBackofficeResultsPrintData();
 
@@ -29,14 +33,17 @@ const hasData = computed(
   () => !loading.value && reportingEmissionBreakdown.value != null,
 );
 
-const yearsLabel = computed(() => years.value.join(', '));
-
 function printReport() {
   window.print();
 }
 
 onMounted(async () => {
   await fetchData();
+  // Chrome seeds the "Save as PDF" filename from the document title.
+  document.title = toPrintDocumentTitle(
+    scopeLabel.value,
+    t('backoffice_reporting_print_results_title'),
+  );
 });
 </script>
 
@@ -62,14 +69,15 @@ onMounted(async () => {
       <!-- Page 1: Title, scope, big numbers -->
       <ReportPage
         :title="$t('backoffice_reporting_print_results_title')"
+        :scope="scopeLabel"
         :page-number="1"
         :is-first="true"
       >
         <h2 class="text-h5 q-mt-none">
           {{ $t('backoffice_reporting_print_results_title') }}
         </h2>
-        <div v-if="yearsLabel" class="text-body2 text-secondary q-mb-lg">
-          {{ yearsLabel }}
+        <div v-if="scopeLabel" class="text-body2 text-secondary q-mb-lg">
+          {{ scopeLabel }}
         </div>
 
         <div class="q-mt-md">
@@ -128,7 +136,7 @@ onMounted(async () => {
         </section>
       </ReportPage>
 
-      <ReportPage>
+      <ReportPage :scope="scopeLabel">
         <section v-if="reportingItBreakdown" class="q-mt-md">
           <ItFocusBreakdownChart
             :data="reportingItBreakdown"

--- a/frontend/src/pages/back-office/ReportingPrintPage.vue
+++ b/frontend/src/pages/back-office/ReportingPrintPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
 import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
 import ReportingStatCards from 'src/components/organisms/backoffice/reporting/ReportingStatCards.vue';
@@ -10,6 +11,9 @@ import EmissionBreakdownChart from 'src/components/charts/EmissionBreakdownChart
 import ItFocusBreakdownChart from 'src/components/charts/results/ItFocusBreakdownChart.vue';
 import { useBackofficeReportingPrintData } from 'src/composables/print/useBackofficeReportingPrintData';
 import { MODULE_STATES } from 'src/constant/moduleStates';
+import { toPrintDocumentTitle } from 'src/utils/unitPerimeterLabel';
+
+const { t } = useI18n();
 
 const {
   loading,
@@ -22,6 +26,7 @@ const {
   totalModules,
   availableModules,
   reportingItBreakdown,
+  scopeLabel,
   fetchData,
 } = useBackofficeReportingPrintData();
 
@@ -34,6 +39,11 @@ function printReport() {
 
 onMounted(async () => {
   await fetchData();
+  // Chrome seeds the "Save as PDF" filename from the document title.
+  document.title = toPrintDocumentTitle(
+    scopeLabel.value,
+    t('backoffice_reporting_print_combined_title'),
+  );
 });
 </script>
 
@@ -59,12 +69,14 @@ onMounted(async () => {
       <!-- Page 1: Title, completion rate, usage stats + aggregate charts -->
       <ReportPage
         :title="$t('backoffice_reporting_print_combined_title')"
+        :scope="scopeLabel"
         :page-number="1"
         :is-first="true"
       >
         <h2 class="text-h5 q-mt-none">
           {{ $t('backoffice_reporting_print_combined_title') }}
         </h2>
+        <div class="text-body2 text-secondary">{{ scopeLabel }}</div>
 
         <div class="q-mt-md">
           <CompletionRateBar
@@ -109,7 +121,7 @@ onMounted(async () => {
         </section>
       </ReportPage>
 
-      <ReportPage>
+      <ReportPage :scope="scopeLabel">
         <section v-if="reportingItBreakdown" class="q-mt-md">
           <ItFocusBreakdownChart
             :data="reportingItBreakdown"
@@ -125,6 +137,7 @@ onMounted(async () => {
         v-for="(mod, i) in availableModules"
         :key="mod"
         :title="$t('backoffice_reporting_print_combined_title')"
+        :scope="scopeLabel"
         :page-number="2 + i"
       >
         <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>

--- a/frontend/src/utils/unitPerimeterLabel.ts
+++ b/frontend/src/utils/unitPerimeterLabel.ts
@@ -1,0 +1,48 @@
+/**
+ * Labels the perimeter of a report — which unit(s) it covers.
+ *
+ * Kept free of any i18n import (`t` is injected) so it stays usable from unit
+ * specs: importing the i18n boot from a util pulls in `import.meta.glob` and
+ * the spec silently collects no tests.
+ */
+export type TranslateFn = (
+  key: string,
+  named?: Record<string, unknown>,
+) => string;
+
+/** Up to two units in the perimeter are named; beyond that a counter is used. */
+export function buildUnitPerimeterLabel(
+  currentName: string,
+  combinedNames: string[],
+  t: TranslateFn,
+): string {
+  if (!combinedNames.length) return currentName;
+  if (combinedNames.length === 1) return `${currentName} + ${combinedNames[0]}`;
+  return t('results_combine_units_counter', {
+    unit: currentName,
+    count: combinedNames.length,
+  });
+}
+
+/**
+ * The perimeter of a backoffice export, which spans whatever the reporting
+ * filters matched: a single unit, one whole affiliation, or a mixed bag.
+ */
+export function buildBackofficeScopeLabel(
+  rows: Array<{ unit_name: string; affiliation: string }>,
+  t: TranslateFn,
+): string {
+  if (rows.length === 1) return rows[0]?.unit_name ?? '';
+  const affiliations = new Set(rows.map((row) => row.affiliation));
+  if (affiliations.size === 1) {
+    const [only] = [...affiliations];
+    if (only) return only;
+  }
+  return t('print_scope_units_count', { count: rows.length });
+}
+
+/** Filename-safe version of a scope label, for `document.title`. */
+export function toPrintDocumentTitle(scope: string, prefix: string): string {
+  const slug = scope.replace(/[^\p{L}\p{N}]+/gu, '-').replace(/^-|-$/g, '');
+  return slug ? `${prefix}_${slug}` : prefix;
+}

--- a/frontend/tests/unit/unit-perimeter-label.spec.ts
+++ b/frontend/tests/unit/unit-perimeter-label.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * The printed reports (#462) must name the unit/affiliation they cover, so a
+ * saved PDF stays identifiable once it leaves the browser. These helpers build
+ * that label for both flows: the user Results export (one unit, possibly with
+ * combined units) and the backoffice export (a filter that can span many).
+ */
+
+import { test, expect } from '@playwright/test';
+
+import {
+  buildUnitPerimeterLabel,
+  buildBackofficeScopeLabel,
+  toPrintDocumentTitle,
+} from '../../src/utils/unitPerimeterLabel';
+
+/** Stub translator: renders `{named}` placeholders so keys stay assertable. */
+const t = (key: string, named?: Record<string, unknown>) =>
+  key.replace(/\{(\w+)\}/g, (_, name: string) => String(named?.[name] ?? ''));
+
+const tCounter = (key: string, named?: Record<string, unknown>) => {
+  if (key === 'results_combine_units_counter')
+    return t('{unit} + {count} units', named);
+  if (key === 'print_scope_units_count') return t('{count} units', named);
+  return key;
+};
+
+test('names the single unit when nothing is combined', () => {
+  expect(buildUnitPerimeterLabel('SCI-STI-AB', [], tCounter)).toBe(
+    'SCI-STI-AB',
+  );
+});
+
+test('names both units when exactly one is combined', () => {
+  expect(buildUnitPerimeterLabel('SCI-STI-AB', ['ENAC-IIE'], tCounter)).toBe(
+    'SCI-STI-AB + ENAC-IIE',
+  );
+});
+
+test('counts the others beyond two units', () => {
+  expect(buildUnitPerimeterLabel('SCI-STI-AB', ['A', 'B', 'C'], tCounter)).toBe(
+    'SCI-STI-AB + 3 units',
+  );
+});
+
+test('backoffice scope names the unit when a single row is exported', () => {
+  const rows = [{ unit_name: 'SCI-STI-AB', affiliation: 'STI' }];
+  expect(buildBackofficeScopeLabel(rows, tCounter)).toBe('SCI-STI-AB');
+});
+
+test('backoffice scope names the affiliation when all rows share one', () => {
+  const rows = [
+    { unit_name: 'SCI-STI-AB', affiliation: 'STI' },
+    { unit_name: 'SCI-STI-CD', affiliation: 'STI' },
+  ];
+  expect(buildBackofficeScopeLabel(rows, tCounter)).toBe('STI');
+});
+
+test('backoffice scope falls back to a count across affiliations', () => {
+  const rows = [
+    { unit_name: 'SCI-STI-AB', affiliation: 'STI' },
+    { unit_name: 'ENAC-IIE-XY', affiliation: 'ENAC' },
+  ];
+  expect(buildBackofficeScopeLabel(rows, tCounter)).toBe('2 units');
+});
+
+test('document title is filename-safe and keeps the scope', () => {
+  expect(toPrintDocumentTitle('SCI-STI-AB · 2025', 'Total results')).toBe(
+    'Total results_SCI-STI-AB-2025',
+  );
+});
+
+test('document title falls back to the prefix without a scope', () => {
+  expect(toPrintDocumentTitle('', 'Total results')).toBe('Total results');
+});


### PR DESCRIPTION
## What does this change?
Adds a "scope" label (e.g. `SCI-STI-AB · 2025`) to printed/PDF reports, shown in the header of every printed page and used to seed a filename-safe `document.title` so Chrome's "Save as PDF" produces an identifiable filename. Specifically:

- `ReportPage.vue` gains a new `scope` prop, rendered next to the title in the page header.
- `ResultsPrintModulePage.vue`, `ResultsPrintPage.vue`, `BackofficeResultsPrintPage.vue`, and `ReportingPrintPage.vue` now pass a computed `scopeLabel` into `ReportPage` on every printed page, and set `document.title` via a new `toPrintDocumentTitle` helper on mount.
- New `frontend/src/utils/unitPerimeterLabel.ts` module (with unit tests) centralizes the perimeter-labeling logic: `buildUnitPerimeterLabel` (single-unit vs. combined-units results reports), `buildBackofficeScopeLabel` (single unit vs. shared affiliation vs. mixed backoffice export), and `toPrintDocumentTitle` (slugifies the scope for use in a filename).
- `ResultsPage.vue`'s existing inline `titleUnitLabel` logic is refactored to reuse `buildUnitPerimeterLabel` instead of duplicating it.
- `EmissionBreakdownChart.vue` and `useBackofficePrintBase.ts` both replace their hardcoded `TREEMAP_MODULES`/`BREAKDOWN_MODULES` arrays with a filter over the canonical `MODULES_LIST`.
- New i18n key `print_scope_units_count` (en/fr) for the "N units" fallback label.

Also included, seemingly unrelated to the PDF-scope feature (likely picked up from a rebase/merge with `dev`):
- `.github/workflows/deploy.yml`: pins the reusable deploy workflow back to `v3.0.7` (from `v3.1.0`) and removes the `skip_vulnerability_scan: false` input, replacing it with a new `scan-built-images` job that installs a version-pinned `trivy` and scans the freshly built images post-deploy (fails only on fixable HIGH/CRITICAL findings).
- `.github/workflows/image-vulnerability-scan.yml`: replaces the call to the shared reusable registry-scan workflow with a fully inlined scan job (trivy + crane, tag discovery, per-tag issue creation, truncating oversized reports to fit GitHub's issue body limit).

## Why is this needed?
Printed/exported reports (results and backoffice reporting) previously had no on-page or filename indication of which unit(s)/affiliation/year they covered, making saved PDFs hard to identify once outside the browser. This adds a consistent, reusable scope label across all print/export flows and threads it into the saved PDF's filename. The `MODULES_LIST`-based refactor removes duplicated, hand-maintained module-ordering arrays that had to be kept in sync with the backend.

The workflow changes appear to move vulnerability scanning off the shared reusable `epfl-enac-build-push-deploy-action` workflow and back to an inlined/custom implementation, and add a post-deploy scan step — likely for more control over scan behavior and issue formatting, independent of this PR's main feature.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [x] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #462

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.