### PR TITLE
fix(tests): isolate config provider-type tests from local .env

### DIFF
--- a/backend/tests/unit/core/test_config_provider_types.py
+++ b/backend/tests/unit/core/test_config_provider_types.py
@@ -16,6 +16,14 @@ from app.core.config import RoleProviderType, Settings, UnitProviderType
 from app.main import assert_accred_settings
 
 
+@pytest.fixture(autouse=True)
+def _no_local_dotenv(monkeypatch, tmp_path):
+    # Settings(env_file=".env") reads the real backend/.env when cwd points
+    # at it, so a developer's local Accred config can silently satisfy
+    # fields these tests expect to be missing. Run from an empty dir instead.
+    monkeypatch.chdir(tmp_path)
+
+
 def test_missing_role_provider_type_fails_startup(monkeypatch):
     monkeypatch.delenv("ROLE_PROVIDER_TYPE", raising=False)
     with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary
- `test_config_provider_types.py` failed locally (not in CI) whenever `backend/.env` had `ROLE_PROVIDER_TYPE`/`UNIT_PROVIDER_TYPE`/`ACCRED_API_*` populated, e.g. for local Accred testing.
- Root cause: `Settings(env_file=".env")` reads the real `backend/.env` on every construction regardless of `monkeypatch.delenv`, so a locally-configured `.env` silently fills in fields the tests assert are missing.
- Fix: autouse fixture `chdir`s to a `tmp_path` for this test file so no `.env` is found, restoring the tests' intended isolation. Unrelated to the Node 26 / Python 3.14 dependency bump.

## Test plan
- [x] `uv run pytest tests/unit/core/test_config_provider_types.py -q` passes from `backend/` with the real `.env` present (previously 8/11 failed there)
- [x] `uv run pytest tests/unit -q` — full unit suite passes (1861 passed)
- [x] `ruff check` / `mypy` clean on the changed file