### PR TITLE
feat: add Simulator Plan UI, routes and model fields (#1804)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: verify
+description: Launch and drive the CO2 calculator full stack (FastAPI + Quasar) locally to verify a change end-to-end with a test login.
+---
+
+# Verify the CO2 calculator locally
+
+## Launch
+
+```bash
+# DB must be up (docker postgres). Migrations:
+cd backend && make db-migrate
+
+# Backend (background):
+cd backend && uv run uvicorn app.main:app --host 127.0.0.1 --port 8000
+
+# Frontend dev server (background, :9000; proxies /api/* -> :8000/* stripping /api):
+cd frontend && npm run dev
+```
+
+OpenAPI is at `http://127.0.0.1:8000/openapi.json` (NOT /v1/openapi.json); routes are mounted under `/v1`.
+
+## Auth (debug builds only)
+
+`GET /v1/auth/login-test?role=<role>` sets auth cookies (302). Roles:
+`calco2.user.standard` (own-scope), `calco2.user.principal` (unit-scope),
+`calco2.backoffice.admin` (global — passes `require_unit_access` for ANY unit).
+
+- curl: `curl -c cookies.txt ".../v1/auth/login-test?role=calco2.backoffice.admin"` then `-b cookies.txt`.
+- Browser/Playwright: navigate to `http://localhost:9000/api/v1/auth/login-test?role=...` (cookies land on localhost:9000 via the proxy), then goto `/` — guards resolve the default workspace.
+
+## Test-user workspace prerequisites (gotchas)
+
+Test roles are scoped to fixture unit institutional_ids 13032–13035 which are
+NOT in the dev DB, and `make seed-data` fails because the fixture
+`institutional_code`s collide with real units. What works:
+
+1. Insert one TEST-provider unit with `institutional_id='13032'` and a free
+   code (e.g. '99932'), copying other fields from `TEST_UNITS` in
+   `backend/app/providers/test_fixtures.py`.
+2. Insert `YearConfiguration(year=2026, provider=UserProvider.TEST, is_started=True)`
+   — `configured_years` in `/v1/session` filters by the user's provider.
+3. Create the Calculator report or `GET /v1/workspace/{unit}/{year}/home` 404s
+   and the frontend loops: `POST /v1/carbon-reports/ {"year":2026,"unit_id":<id>}`.
+
+Then login-test principal lands on `/en/<id>-enac-it4r-test/2026/home`.
+
+## Driving the GUI
+
+Playwright is a frontend devDependency; scripts must run from `frontend/`
+(module resolution). Don't use `waitForLoadState('networkidle')` — the dev
+server's HMR socket keeps it from firing; use `waitForURL`/`domcontentloaded`.
+
+## Cleanup
+
+Delete any data created on REAL units (low ids are real dev data). The
+TEST-provider unit/year rows are provider-isolated and invisible to real users.

--- a/backend/alembic/versions/2026_07_14_1623-f9d210343448_project_planner_simulator_plans.py
+++ b/backend/alembic/versions/2026_07_14_1623-f9d210343448_project_planner_simulator_plans.py
@@ -1,0 +1,90 @@
+# codeql[py/unused-global-variable]
+"""project planner simulator plans
+
+Adds creator tracking to carbon_projects and relaxes the one-project-per-
+(unit, type) constraint so a unit can hold multiple Simulator_Plan projects
+(each plan is one project row identified by its name).
+
+Note: the downgrade cannot recreate uq_carbon_projects_unit_type if a unit
+already has more than one Simulator_Plan project.
+
+Revision ID: f9d210343448
+Revises: 89c3079e388d
+Create Date: 2026-07-14 16:23:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f9d210343448"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "89c3079e388d"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "carbon_projects",
+        sa.Column("created_by", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "carbon_projects",
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_carbon_projects_created_by_users",
+        "carbon_projects",
+        "users",
+        ["created_by"],
+        ["id"],
+    )
+    op.drop_constraint(
+        "uq_carbon_projects_unit_type", "carbon_projects", type_="unique"
+    )
+    # One project per (unit, type) still holds for Calculator and
+    # Simulator_Explore; Simulator_Plan allows many projects per unit.
+    op.create_index(
+        "uq_carbon_projects_unit_type_nonplan",
+        "carbon_projects",
+        ["unit_id", "carbon_report_type"],
+        unique=True,
+        postgresql_where=sa.text("carbon_report_type != 'Simulator_Plan'"),
+    )
+    # Plan names are URL identifiers: unique per unit among plan projects.
+    op.create_index(
+        "uq_carbon_projects_unit_plan_name",
+        "carbon_projects",
+        ["unit_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("carbon_report_type = 'Simulator_Plan'"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("uq_carbon_projects_unit_plan_name", table_name="carbon_projects")
+    op.drop_index("uq_carbon_projects_unit_type_nonplan", table_name="carbon_projects")
+    op.create_unique_constraint(
+        "uq_carbon_projects_unit_type",
+        "carbon_projects",
+        ["unit_id", "carbon_report_type"],
+    )
+    op.drop_constraint(
+        "fk_carbon_projects_created_by_users", "carbon_projects", type_="foreignkey"
+    )
+    op.drop_column("carbon_projects", "created_at")
+    op.drop_column("carbon_projects", "created_by")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -16,6 +16,7 @@ from app.api.v1 import (
     factors,
     files,
     locations,
+    simulator_plan,
     taxonomies,
     unit_results,
     units,
@@ -51,6 +52,9 @@ api_router.include_router(factors.router, prefix="/factors", tags=["factors"])
 api_router.include_router(taxonomies.router, prefix="/taxonomies", tags=["taxonomies"])
 api_router.include_router(
     carbon_report.router, prefix="/carbon-reports", tags=["carbon-reports"]
+)
+api_router.include_router(
+    simulator_plan.router, prefix="/project-plans", tags=["project-plans"]
 )
 api_router.include_router(locations.router, prefix="/locations", tags=["locations"])
 api_router.include_router(files.router, prefix="/files", tags=["files"])

--- a/backend/app/api/v1/simulator_plan.py
+++ b/backend/app/api/v1/simulator_plan.py
@@ -1,0 +1,144 @@
+"""Simulator plan (project planner) API endpoints."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.deps import get_current_user, get_db
+from app.core.logging import get_logger
+from app.core.policy import require_unit_access
+from app.models.unit import Unit
+from app.models.user import User
+from app.schemas.simulator_plan import (
+    SimulatorPlanCreate,
+    SimulatorPlanRead,
+    SimulatorPlanUpdate,
+)
+from app.services.simulator_plan_service import SimulatorPlanService
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+async def _require_plan_unit_access(
+    db: AsyncSession, current_user: User, plan_id: int
+) -> SimulatorPlanService:
+    """Load the plan's unit and enforce access; 404 if the plan is missing."""
+    service = SimulatorPlanService(db)
+    plan = await service.repo.get_plan(plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    unit = await db.get(Unit, plan.unit_id)
+    require_unit_access(current_user, unit)
+    return service
+
+
+@router.get("/unit/{unit_id}/", response_model=List[SimulatorPlanRead])
+async def list_simulator_plans(
+    unit_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List all simulator plans for a unit, newest first."""
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
+    service = SimulatorPlanService(db)
+    return await service.list_plans(unit_id)
+
+
+@router.post(
+    "/unit/{unit_id}/",
+    response_model=SimulatorPlanRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_simulator_plan(
+    unit_id: int,
+    plan: Optional[SimulatorPlanCreate] = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Create a simulator plan; without a name, the next default is assigned."""
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
+    service = SimulatorPlanService(db)
+    try:
+        result = await service.create_plan(
+            unit_id=unit_id,
+            user=current_user,
+            name=plan.name if plan else None,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    await db.commit()
+    return result
+
+
+@router.get("/unit/{unit_id}/by-name/{name}", response_model=SimulatorPlanRead)
+async def get_simulator_plan_by_name(
+    unit_id: int,
+    name: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get a simulator plan of a unit by its name."""
+    unit = await db.get(Unit, unit_id)
+    require_unit_access(current_user, unit)
+    service = SimulatorPlanService(db)
+    result = await service.get_plan_by_name(unit_id, name)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    return result
+
+
+@router.patch("/{plan_id}", response_model=SimulatorPlanRead)
+async def rename_simulator_plan(
+    plan_id: int,
+    plan: SimulatorPlanUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Rename a simulator plan."""
+    service = await _require_plan_unit_access(db, current_user, plan_id)
+    try:
+        result = await service.rename_plan(plan_id, plan.name)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if result is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    await db.commit()
+    return result
+
+
+@router.post(
+    "/{plan_id}/duplicate",
+    response_model=SimulatorPlanRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def duplicate_simulator_plan(
+    plan_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Duplicate a simulator plan under the next free `<name>-N` name."""
+    service = await _require_plan_unit_access(db, current_user, plan_id)
+    result = await service.duplicate_plan(plan_id, current_user)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    await db.commit()
+    return result
+
+
+@router.delete("/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_simulator_plan(
+    plan_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete a simulator plan (and any carbon reports attached to it)."""
+    service = await _require_plan_unit_access(db, current_user, plan_id)
+    deleted = await service.delete_plan(plan_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/models/carbon_project.py
+++ b/backend/app/models/carbon_project.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy import Column, DateTime
 from sqlalchemy import Enum as SAEnum
 from sqlmodel import Field, SQLModel
 
@@ -32,16 +33,27 @@ class CarbonProjectBase(SQLModel):
     end_year: Optional[int] = Field(default=None, nullable=True, index=True)
     name: Optional[str] = Field(default=None, nullable=True, index=True)
     is_viewable_by_unit_members: bool = Field(default=False, nullable=False)
+    created_by: Optional[int] = Field(
+        default=None,
+        foreign_key="users.id",
+        nullable=True,
+        description="User who created the project (set for Simulator Plan projects)",
+    )
+    created_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+        description="Creation timestamp (set for Simulator Plan projects)",
+    )
 
 
 class CarbonProject(CarbonProjectBase, table=True):
+    # Uniqueness is enforced by two partial indexes managed in the migration
+    # (Postgres-only; the SQLite unit-test schema is intentionally
+    # unconstrained):
+    # - uq_carbon_projects_unit_type_nonplan: one project per (unit_id,
+    #   carbon_report_type) for Calculator / Simulator_Explore
+    # - uq_carbon_projects_unit_plan_name: unique (unit_id, name) among
+    #   Simulator_Plan projects (the name is a URL identifier)
     __tablename__ = "carbon_projects"
-    __table_args__ = (
-        UniqueConstraint(
-            "unit_id",
-            "carbon_report_type",
-            name="uq_carbon_projects_unit_type",
-        ),
-    )
 
     id: Optional[int] = Field(default=None, primary_key=True, index=True)

--- a/backend/app/repositories/carbon_project_repo.py
+++ b/backend/app/repositories/carbon_project_repo.py
@@ -1,0 +1,97 @@
+"""Carbon project repository for simulator plan database operations."""
+
+from typing import Optional
+
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReport, CarbonReportType
+from app.models.user import User
+
+logger = get_logger(__name__)
+
+
+class CarbonProjectRepository:
+    """Repository for CarbonProject database operations (Simulator Plan)."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    def _plan_with_creator_stmt(self):
+        """Base SELECT of plan projects joined with the creator display name."""
+        return (
+            select(CarbonProject, col(User.display_name))
+            .outerjoin(User, col(CarbonProject.created_by) == col(User.id))
+            .where(CarbonProject.carbon_report_type == CarbonReportType.SIMULATOR_PLAN)
+        )
+
+    async def list_plans_by_unit(
+        self, unit_id: int
+    ) -> list[tuple[CarbonProject, Optional[str]]]:
+        """List plan projects for a unit with creator names, newest first.
+
+        Ordered by id (creation order); created_at is nullable so ordering
+        on it would need NULL handling.
+        """
+        statement = (
+            self._plan_with_creator_stmt()
+            .where(CarbonProject.unit_id == unit_id)
+            .order_by(col(CarbonProject.id).desc())
+        )
+        result = await self.session.execute(statement)
+        return [(project, display_name) for project, display_name in result.all()]
+
+    async def get_plan(self, plan_id: int) -> Optional[CarbonProject]:
+        """Get a plan project by ID (non-plan projects are not returned)."""
+        statement = select(CarbonProject).where(
+            CarbonProject.id == plan_id,
+            CarbonProject.carbon_report_type == CarbonReportType.SIMULATOR_PLAN,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    async def get_plan_by_name(
+        self, unit_id: int, name: str
+    ) -> Optional[tuple[CarbonProject, Optional[str]]]:
+        """Get a plan project by unit and name, with the creator name."""
+        statement = self._plan_with_creator_stmt().where(
+            CarbonProject.unit_id == unit_id,
+            CarbonProject.name == name,
+        )
+        result = await self.session.execute(statement)
+        row = result.first()
+        if row is None:
+            return None
+        project, display_name = row
+        return project, display_name
+
+    async def list_plan_names(self, unit_id: int) -> set[str]:
+        """Return the names of all plan projects for a unit."""
+        statement = select(col(CarbonProject.name)).where(
+            CarbonProject.unit_id == unit_id,
+            CarbonProject.carbon_report_type == CarbonReportType.SIMULATOR_PLAN,
+        )
+        result = await self.session.execute(statement)
+        return {name for name in result.scalars().all() if name is not None}
+
+    async def list_report_ids_for_project(self, project_id: int) -> list[int]:
+        """Return the IDs of carbon reports belonging to a project."""
+        statement = select(col(CarbonReport.id)).where(
+            CarbonReport.carbon_project_id == project_id
+        )
+        result = await self.session.execute(statement)
+        return [report_id for report_id in result.scalars().all()]
+
+    async def create(self, project: CarbonProject) -> CarbonProject:
+        """Persist and flush a new carbon project."""
+        self.session.add(project)
+        await self.session.flush()
+        await self.session.refresh(project)
+        return project
+
+    async def delete(self, project: CarbonProject) -> None:
+        """Delete a carbon project."""
+        await self.session.delete(project)
+        await self.session.flush()

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -1,0 +1,58 @@
+"""Simulator plan schemas for API request/response validation."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+def _validate_plan_name(value: str) -> str:
+    """Strip and validate a plan name (it is a single URL path segment)."""
+    value = value.strip()
+    if not value:
+        raise ValueError("Plan name cannot be empty")
+    if "/" in value:
+        raise ValueError("Plan name cannot contain '/'")
+    return value
+
+
+class SimulatorPlanCreate(BaseModel):
+    """Schema for creating a simulator plan.
+
+    ``name`` is optional: when omitted, the service assigns the next
+    available default name (new-project, new-project-2, ...).
+    """
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        return _validate_plan_name(value)
+
+
+class SimulatorPlanUpdate(BaseModel):
+    """Schema for renaming a simulator plan."""
+
+    name: str = Field(min_length=1, max_length=100)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return _validate_plan_name(value)
+
+
+class SimulatorPlanRead(BaseModel):
+    """Schema for reading a simulator plan."""
+
+    id: int
+    unit_id: int
+    name: str
+    created_by: Optional[int] = None
+    created_at: Optional[datetime] = None
+    creator_name: Optional[str] = None
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -166,6 +166,11 @@ class CarbonReportService:
         """Return the existing CarbonProject for a unit+type, or None.
 
         Idempotent: never creates or mutates any data.
+
+        Must not be called with SIMULATOR_PLAN: a unit can have many plan
+        projects, so ``scalar_one_or_none`` would raise MultipleResultsFound.
+        Use :class:`app.services.simulator_plan_service.SimulatorPlanService`
+        for plans.
         """
         stmt = select(CarbonProject).where(
             CarbonProject.unit_id == unit_id,

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -1,0 +1,182 @@
+"""Simulator plan service for business logic.
+
+A "plan" (project planner project) is a ``CarbonProject`` row with
+``carbon_report_type = SIMULATOR_PLAN``; its ``name`` is the URL identifier
+shown in the project planner routes.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReportType
+from app.models.user import User
+from app.repositories.carbon_project_repo import CarbonProjectRepository
+from app.schemas.simulator_plan import SimulatorPlanRead
+from app.services.carbon_report_service import CarbonReportService
+
+logger = get_logger(__name__)
+
+DEFAULT_PLAN_NAME = "new-project"
+
+
+def _next_available_name(base: str, existing: set[str]) -> str:
+    """Return ``base`` if free, else the first free ``base-2``, ``base-3``, ..."""
+    if base not in existing:
+        return base
+    return _next_suffixed_name(base, existing)
+
+
+def _next_suffixed_name(base: str, existing: set[str]) -> str:
+    """Return the first free ``base-2``, ``base-3``, ... (never bare ``base``)."""
+    counter = 2
+    while f"{base}-{counter}" in existing:
+        counter += 1
+    return f"{base}-{counter}"
+
+
+def _to_read(project: CarbonProject, creator_name: Optional[str]) -> SimulatorPlanRead:
+    return SimulatorPlanRead(
+        id=project.id,  # type: ignore[arg-type]
+        unit_id=project.unit_id,
+        name=project.name or "",
+        created_by=project.created_by,
+        created_at=project.created_at,
+        creator_name=creator_name,
+    )
+
+
+class SimulatorPlanService:
+    """Service for simulator plan (project planner) business logic.
+
+    Flushes within the session; committing is the caller's (route's)
+    responsibility, matching :class:`CarbonReportService`.
+    """
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.repo = CarbonProjectRepository(session)
+        self.report_service = CarbonReportService(session)
+
+    async def list_plans(self, unit_id: int) -> list[SimulatorPlanRead]:
+        """List all plans for a unit, newest first."""
+        rows = await self.repo.list_plans_by_unit(unit_id)
+        return [_to_read(project, creator_name) for project, creator_name in rows]
+
+    async def get_plan_by_name(
+        self, unit_id: int, name: str
+    ) -> Optional[SimulatorPlanRead]:
+        """Get a plan by unit and name, or None."""
+        row = await self.repo.get_plan_by_name(unit_id, name)
+        if row is None:
+            return None
+        project, creator_name = row
+        return _to_read(project, creator_name)
+
+    async def create_plan(
+        self, *, unit_id: int, user: User, name: Optional[str] = None
+    ) -> SimulatorPlanRead:
+        """Create a plan for a unit, owned by ``user``.
+
+        Without an explicit ``name``, assigns the next available default name
+        (new-project, new-project-2, ...). An explicit name that collides with
+        an existing plan of the unit raises ``ValueError``.
+        """
+        existing_names = await self.repo.list_plan_names(unit_id)
+        if name is None:
+            name = _next_available_name(DEFAULT_PLAN_NAME, existing_names)
+        elif name in existing_names:
+            raise ValueError(f"A plan named '{name}' already exists for this unit")
+        project = CarbonProject(
+            unit_id=unit_id,
+            carbon_report_type=CarbonReportType.SIMULATOR_PLAN,
+            name=name,
+            created_by=user.id,
+            created_at=datetime.now(timezone.utc),
+        )
+        project = await self._flush_guarded(self.repo.create(project))
+        return _to_read(project, user.display_name)
+
+    async def rename_plan(
+        self, plan_id: int, new_name: str
+    ) -> Optional[SimulatorPlanRead]:
+        """Rename a plan; returns None if the plan does not exist.
+
+        Renaming to the current name is a no-op; a collision with another
+        plan of the same unit raises ``ValueError``.
+        """
+        project = await self.repo.get_plan(plan_id)
+        if project is None:
+            return None
+        if new_name != project.name:
+            existing_names = await self.repo.list_plan_names(project.unit_id)
+            if new_name in existing_names:
+                raise ValueError(
+                    f"A plan named '{new_name}' already exists for this unit"
+                )
+            project.name = new_name
+            project = await self._flush_guarded(self.repo.create(project))
+        return await self._read_with_creator(project)
+
+    async def duplicate_plan(
+        self, plan_id: int, user: User
+    ) -> Optional[SimulatorPlanRead]:
+        """Duplicate a plan as ``<name>-2`` (then ``-3``, ...); None if missing.
+
+        Only the project row is copied for now; plan contents (carbon reports)
+        will need copying once the planner page stores data.
+        """
+        source = await self.repo.get_plan(plan_id)
+        if source is None:
+            return None
+        existing_names = await self.repo.list_plan_names(source.unit_id)
+        new_name = _next_suffixed_name(source.name or "", existing_names)
+        copy = CarbonProject(
+            unit_id=source.unit_id,
+            carbon_report_type=CarbonReportType.SIMULATOR_PLAN,
+            start_year=source.start_year,
+            end_year=source.end_year,
+            name=new_name,
+            is_viewable_by_unit_members=source.is_viewable_by_unit_members,
+            created_by=user.id,
+            created_at=datetime.now(timezone.utc),
+        )
+        copy = await self._flush_guarded(self.repo.create(copy))
+        return _to_read(copy, user.display_name)
+
+    async def delete_plan(self, plan_id: int) -> bool:
+        """Delete a plan and any carbon reports attached to it.
+
+        ``carbon_reports.carbon_project_id`` has no ON DELETE cascade, so
+        dependent reports (and their modules) are deleted explicitly first.
+        """
+        project = await self.repo.get_plan(plan_id)
+        if project is None:
+            return False
+        report_ids = await self.repo.list_report_ids_for_project(plan_id)
+        for report_id in report_ids:
+            await self.report_service.delete(report_id)
+        await self.repo.delete(project)
+        return True
+
+    async def _read_with_creator(self, project: CarbonProject) -> SimulatorPlanRead:
+        """Build a Read DTO resolving the creator display name via the join."""
+        row = await self.repo.get_plan_by_name(project.unit_id, project.name or "")
+        if row is None:
+            return _to_read(project, None)
+        refreshed, creator_name = row
+        return _to_read(refreshed, creator_name)
+
+    @staticmethod
+    async def _flush_guarded(awaitable) -> CarbonProject:
+        """Await a repo write, mapping unique-index races to ValueError."""
+        try:
+            return await awaitable
+        except IntegrityError as exc:
+            raise ValueError(
+                "A plan with this name already exists for this unit"
+            ) from exc

--- a/backend/tests/unit/services/test_simulator_plan_service.py
+++ b/backend/tests/unit/services/test_simulator_plan_service.py
@@ -1,0 +1,217 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession as SAAsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from app.models.user import User
+from app.schemas.carbon_report import CarbonReportCreate
+from app.services.carbon_report_service import CarbonReportService
+from app.services.simulator_plan_service import (
+    SimulatorPlanService,
+    _next_available_name,
+)
+
+DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest_asyncio.fixture
+async def async_session():
+    engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)  # Ensure a clean slate
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async_session = sessionmaker(engine, class_=SAAsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def user(async_session):
+    db_user = User(
+        institutional_id="100001",
+        email="ada@example.com",
+        display_name="Ada Lovelace",
+    )
+    async_session.add(db_user)
+    await async_session.flush()
+    return db_user
+
+
+# ── _next_available_name (pure function) ──────────────────────────────────────
+
+
+def test_next_available_name_returns_base_when_free():
+    assert _next_available_name("new-project", set()) == "new-project"
+
+
+def test_next_available_name_appends_suffixes():
+    assert _next_available_name("new-project", {"new-project"}) == "new-project-2"
+    assert (
+        _next_available_name("new-project", {"new-project", "new-project-2"})
+        == "new-project-3"
+    )
+
+
+def test_next_available_name_fills_gaps():
+    assert (
+        _next_available_name("new-project", {"new-project", "new-project-3"})
+        == "new-project-2"
+    )
+
+
+# ── create_plan ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_plan_default_name_sequence(async_session, user):
+    service = SimulatorPlanService(async_session)
+    first = await service.create_plan(unit_id=1, user=user)
+    second = await service.create_plan(unit_id=1, user=user)
+
+    assert first.name == "new-project"
+    assert second.name == "new-project-2"
+    assert first.unit_id == 1
+    assert first.created_by == user.id
+    assert first.created_at is not None
+    assert first.creator_name == "Ada Lovelace"
+
+
+@pytest.mark.asyncio
+async def test_create_plan_default_names_are_per_unit(async_session, user):
+    service = SimulatorPlanService(async_session)
+    first = await service.create_plan(unit_id=1, user=user)
+    other_unit = await service.create_plan(unit_id=2, user=user)
+
+    assert first.name == "new-project"
+    assert other_unit.name == "new-project"
+
+
+@pytest.mark.asyncio
+async def test_create_plan_explicit_name_collision_raises(async_session, user):
+    service = SimulatorPlanService(async_session)
+    await service.create_plan(unit_id=1, user=user, name="my-plan")
+    with pytest.raises(ValueError):
+        await service.create_plan(unit_id=1, user=user, name="my-plan")
+
+
+# ── get_plan_by_name / list_plans ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_plan_by_name(async_session, user):
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="my-plan")
+    fetched = await service.get_plan_by_name(1, "my-plan")
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.creator_name == "Ada Lovelace"
+    assert await service.get_plan_by_name(1, "unknown") is None
+    assert await service.get_plan_by_name(2, "my-plan") is None
+
+
+@pytest.mark.asyncio
+async def test_list_plans_scoped_to_unit(async_session, user):
+    service = SimulatorPlanService(async_session)
+    await service.create_plan(unit_id=1, user=user, name="a")
+    await service.create_plan(unit_id=1, user=user, name="b")
+    await service.create_plan(unit_id=2, user=user, name="c")
+
+    plans = await service.list_plans(1)
+    assert {p.name for p in plans} == {"a", "b"}
+
+
+# ── rename_plan ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_plan(async_session, user):
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="old-name")
+    renamed = await service.rename_plan(created.id, "new-name")
+
+    assert renamed is not None
+    assert renamed.name == "new-name"
+    assert renamed.creator_name == "Ada Lovelace"
+    assert await service.get_plan_by_name(1, "old-name") is None
+    assert await service.get_plan_by_name(1, "new-name") is not None
+
+
+@pytest.mark.asyncio
+async def test_rename_plan_same_name_is_noop(async_session, user):
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="same")
+    renamed = await service.rename_plan(created.id, "same")
+    assert renamed is not None
+    assert renamed.name == "same"
+
+
+@pytest.mark.asyncio
+async def test_rename_plan_collision_raises(async_session, user):
+    service = SimulatorPlanService(async_session)
+    await service.create_plan(unit_id=1, user=user, name="taken")
+    created = await service.create_plan(unit_id=1, user=user, name="mine")
+    with pytest.raises(ValueError):
+        await service.rename_plan(created.id, "taken")
+
+
+@pytest.mark.asyncio
+async def test_rename_plan_missing_returns_none(async_session, user):
+    service = SimulatorPlanService(async_session)
+    assert await service.rename_plan(9999, "whatever") is None
+
+
+# ── duplicate_plan ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_plan_suffix_chain(async_session, user):
+    service = SimulatorPlanService(async_session)
+    original = await service.create_plan(unit_id=1, user=user, name="foo")
+
+    first_copy = await service.duplicate_plan(original.id, user)
+    second_copy = await service.duplicate_plan(original.id, user)
+
+    assert first_copy is not None and first_copy.name == "foo-2"
+    assert second_copy is not None and second_copy.name == "foo-3"
+    assert first_copy.created_by == user.id
+    assert first_copy.creator_name == "Ada Lovelace"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_plan_missing_returns_none(async_session, user):
+    service = SimulatorPlanService(async_session)
+    assert await service.duplicate_plan(9999, user) is None
+
+
+# ── delete_plan ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_plan(async_session, user):
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="doomed")
+
+    assert await service.delete_plan(created.id) is True
+    assert await service.get_plan_by_name(1, "doomed") is None
+    assert await service.delete_plan(created.id) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_plan_cascades_attached_reports(async_session, user):
+    """A plan with carbon reports attached deletes them (and their modules)."""
+    plan_service = SimulatorPlanService(async_session)
+    report_service = CarbonReportService(async_session)
+
+    plan = await plan_service.create_plan(unit_id=1, user=user, name="with-report")
+    report = await report_service.create(
+        CarbonReportCreate(year=2026, unit_id=1, carbon_project_id=plan.id)
+    )
+
+    assert await plan_service.delete_plan(plan.id) is True
+    assert await report_service.get(report.id) is None
+    modules = await report_service.module_service.list_modules(report.id)
+    assert len(modules) == 0

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -35,6 +35,8 @@ erDiagram
   }
   carbon_projects {
     VARCHAR carbon_report_type
+    DATETIME created_at
+    INTEGER created_by FK
     INTEGER end_year "indexed"
     INTEGER id PK
     BOOLEAN is_viewable_by_unit_members
@@ -236,6 +238,7 @@ erDiagram
   units ||--}o carbon_projects : "unit_id"
   units ||--}o carbon_reports : "unit_id"
   units ||--}o unit_users : "unit_id"
+  users ||--}o carbon_projects : "created_by"
   users ||--}o unit_users : "user_id"
 ```
 

--- a/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
+++ b/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
@@ -1,9 +1,34 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import type { QTableColumn } from 'quasar';
 import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
 
-const { t } = useI18n();
+import {
+  useSimulatorPlansStore,
+  type SimulatorPlan,
+} from 'src/stores/simulatorPlans';
+import { useWorkspaceStore } from 'src/stores/workspace';
+import { parseUtcDate } from 'src/utils/date';
+
+const { t, locale } = useI18n();
+const route = useRoute();
+const router = useRouter();
+const workspaceStore = useWorkspaceStore();
+const plansStore = useSimulatorPlansStore();
+
+// workspaceGuard ensures selectedUnit is always set before the home page
+// renders (same invariant as SimulationExplorePage).
+const unitId = computed(() => workspaceStore.selectedUnit!.id);
+
+const creating = ref(false);
+const confirmDelete = ref(false);
+const planToDelete = ref<SimulatorPlan | null>(null);
+
+function formatPlanDate(dateString: string | null): string {
+  if (!dateString) return '';
+  return parseUtcDate(dateString).toLocaleDateString(locale.value);
+}
 
 const planColumns = computed<QTableColumn[]>(() => [
   {
@@ -16,23 +41,23 @@ const planColumns = computed<QTableColumn[]>(() => [
   {
     name: 'date',
     label: t('planner_table_date'),
-    field: 'date',
+    field: 'created_at',
     align: 'left',
     sortable: true,
+    format: (val) => formatPlanDate(val as string | null),
   },
   {
     name: 'creator',
     label: t('planner_table_creator'),
-    field: 'creator',
+    field: 'creator_name',
     align: 'left',
     sortable: true,
   },
   {
     name: 'tco2eq',
     label: t('tco2eq'),
-    field: 'tco2eq',
+    field: () => '',
     align: 'right',
-    sortable: true,
   },
   {
     name: 'action',
@@ -42,33 +67,50 @@ const planColumns = computed<QTableColumn[]>(() => [
   },
 ]);
 
-// PLACEHOLDER: TO BE DELETED WHEN PLAN ROWS ARE POPULATED
-const planRows = [
-  {
-    name: 'Scientific Grant H',
-    date: '21-03-2026',
-    creator: 'Charlie Weil',
-    tco2eq: "2'543",
-  },
-  {
-    name: 'Big Buying year',
-    date: '15-04-2026',
-    creator: 'Benjamin Botros',
-    tco2eq: "3'301",
-  },
-  {
-    name: 'Unit reorganisation',
-    date: '04-05-2026',
-    creator: 'Pierre Guilbart',
-    tco2eq: "1'201",
-  },
-  {
-    name: 'Change of leadership 2027',
-    date: '04-06-2026',
-    creator: 'Andrina Beuggert',
-    tco2eq: "5'500",
-  },
-];
+async function refresh() {
+  await plansStore.fetchPlans(unitId.value);
+}
+
+async function onStartProject() {
+  if (creating.value) return;
+  creating.value = true;
+  try {
+    const plan = await plansStore.createPlan(unitId.value);
+    await router.push({
+      name: 'project-planner',
+      params: { ...route.params, name: plan.name },
+    });
+  } finally {
+    creating.value = false;
+  }
+}
+
+async function onDuplicate(row: SimulatorPlan) {
+  await plansStore.duplicatePlan(row.id);
+  await refresh();
+}
+
+function onEdit(row: SimulatorPlan) {
+  void router.push({
+    name: 'project-planner',
+    params: { ...route.params, name: row.name },
+  });
+}
+
+function onAskDelete(row: SimulatorPlan) {
+  planToDelete.value = row;
+  confirmDelete.value = true;
+}
+
+async function onConfirmDelete() {
+  if (!planToDelete.value) return;
+  await plansStore.deletePlan(planToDelete.value.id);
+  confirmDelete.value = false;
+  planToDelete.value = null;
+  await refresh();
+}
+
+onMounted(refresh);
 </script>
 
 <template>
@@ -81,7 +123,7 @@ const planRows = [
             {{ $t('co2_project_planner_title') }}
           </h2>
           <q-badge color="info" class="text-weight-bold planner-count">
-            {{ planRows.length }}
+            {{ plansStore.plans.length }}
           </q-badge>
         </div>
         <q-btn
@@ -92,7 +134,8 @@ const planRows = [
           no-caps
           size="md"
           class="text-weight-medium"
-          :to="{ name: 'project-planner' }"
+          :loading="creating"
+          @click="onStartProject"
         />
       </div>
 
@@ -105,8 +148,9 @@ const planRows = [
         dense
         class="co2-table"
         :columns="planColumns"
-        :rows="planRows"
-        row-key="name"
+        :rows="plansStore.plans"
+        :loading="plansStore.loading"
+        row-key="id"
         hide-pagination
         :rows-per-page-options="[0]"
         :no-data-label="$t('common_no_items')"
@@ -147,6 +191,7 @@ const planRows = [
                     square
                     size="xs"
                     class="square-button"
+                    @click="onDuplicate(props.row)"
                   />
                   <q-btn
                     icon="o_edit"
@@ -159,6 +204,7 @@ const planRows = [
                     square
                     size="xs"
                     class="square-button"
+                    @click="onEdit(props.row)"
                   />
                   <q-btn
                     icon="o_delete"
@@ -171,16 +217,78 @@ const planRows = [
                     square
                     size="xs"
                     class="square-button"
+                    @click="onAskDelete(props.row)"
                   />
                 </div>
               </template>
-              <template v-else>{{ props.row[col.field] }}</template>
+              <template v-else>{{ col.value }}</template>
             </q-td>
           </q-tr>
         </template>
       </q-table>
     </div>
   </section>
+
+  <q-dialog v-model="confirmDelete" class="modal modal--md" persistent>
+    <q-card class="column">
+      <q-card-section class="flex justify-between items-center">
+        <div class="text-h4 text-weight-medium">
+          {{
+            $t('common_delete_dialog_title', {
+              item: planToDelete?.name ?? '',
+            })
+          }}
+        </div>
+        <q-btn
+          v-close-popup
+          flat
+          size="md"
+          icon="o_close"
+          color="grey-6"
+          class="text-weight-medium"
+        />
+      </q-card-section>
+      <q-separator />
+      <!-- q-form so Enter submits the dialog (autofocus on the submit button
+           gives the native form an Enter target — there are no text inputs). -->
+      <q-form @submit.prevent="onConfirmDelete">
+        <q-card-section class="q-py-lg q-px-md">
+          <span class="text-body1">
+            {{
+              $t('common_delete_dialog_description', {
+                item: planToDelete?.name ?? '',
+              })
+            }}
+          </span>
+        </q-card-section>
+        <q-separator />
+        <q-card-actions class="q-py-lg q-px-md row q-gutter-sm">
+          <q-btn
+            type="button"
+            color="grey-4"
+            text-color="primary"
+            :label="$t('common_cancel')"
+            unelevated
+            no-caps
+            outline
+            size="md"
+            class="text-weight-medium col"
+            @click="confirmDelete = false"
+          />
+          <q-btn
+            type="submit"
+            autofocus
+            color="info"
+            :label="$t('common_delete')"
+            unelevated
+            no-caps
+            size="md"
+            class="text-weight-medium col"
+          />
+        </q-card-actions>
+      </q-form>
+    </q-card>
+  </q-dialog>
 </template>
 
 <style scoped lang="scss">

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -95,4 +95,28 @@ export default {
     en: 'Simulation carbon footprint {year}',
     fr: 'Empreinte carbone de la simulation {year}',
   },
+  project_planner_page_title: {
+    en: 'Project planner',
+    fr: 'Planificateur de projet',
+  },
+  project_planner_page_intro: {
+    en: 'Plan the carbon footprint of an upcoming project. Give your project a name; its content will appear here.',
+    fr: "Planifiez l'empreinte carbone d'un projet à venir. Donnez un nom à votre projet ; son contenu apparaîtra ici.",
+  },
+  project_planner_name_label: {
+    en: 'Project name',
+    fr: 'Nom du projet',
+  },
+  project_planner_name_save: {
+    en: 'Save',
+    fr: 'Enregistrer',
+  },
+  project_planner_not_found: {
+    en: 'This project does not exist or has been deleted.',
+    fr: "Ce projet n'existe pas ou a été supprimé.",
+  },
+  project_planner_back_home: {
+    en: 'Back to home',
+    fr: "Retour à l'accueil",
+  },
 };

--- a/frontend/src/pages/app/AddSimulationPage.vue
+++ b/frontend/src/pages/app/AddSimulationPage.vue
@@ -1,7 +1,0 @@
-<template>
-  <q-page>
-    <h1 class="text-h1">Add Simulation</h1>
-  </q-page>
-</template>
-
-<script setup lang="ts"></script>

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -1,0 +1,125 @@
+<template>
+  <q-page class="page-grid">
+    <q-card v-if="notFound" flat class="container">
+      <q-icon
+        name="o_calendar_month"
+        color="info"
+        size="32px"
+        class="q-mb-md"
+      />
+      <h1 class="text-h2 q-mb-md">{{ $t('project_planner_page_title') }}</h1>
+      <p class="text-body1 q-mb-md">
+        {{ $t('project_planner_not_found') }}
+      </p>
+      <q-btn
+        unelevated
+        no-caps
+        color="info"
+        :label="$t('project_planner_back_home')"
+        class="text-weight-medium"
+        :to="{ name: 'home' }"
+      />
+    </q-card>
+
+    <template v-else-if="plan">
+      <q-card flat class="container">
+        <q-icon
+          name="o_calendar_month"
+          color="info"
+          size="32px"
+          class="q-mb-md"
+        />
+        <h1 class="text-h2 q-mb-md">{{ $t('project_planner_page_title') }}</h1>
+        <p class="text-body1 q-mb-none">
+          {{ $t('project_planner_page_intro') }}
+        </p>
+      </q-card>
+
+      <q-card flat bordered class="q-pa-lg">
+        <div class="row items-end q-gutter-md">
+          <q-input
+            v-model="nameInput"
+            :label="$t('project_planner_name_label')"
+            outlined
+            dense
+            class="col"
+            @keyup.enter="saveName"
+          />
+          <q-btn
+            unelevated
+            no-caps
+            color="info"
+            :label="$t('project_planner_name_save')"
+            :disable="!canSave"
+            :loading="saving"
+            size="md"
+            class="text-weight-medium"
+            @click="saveName"
+          />
+        </div>
+      </q-card>
+    </template>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import {
+  useSimulatorPlansStore,
+  type SimulatorPlan,
+} from 'src/stores/simulatorPlans';
+import { useWorkspaceStore } from 'src/stores/workspace';
+
+const route = useRoute();
+const router = useRouter();
+const workspaceStore = useWorkspaceStore();
+const plansStore = useSimulatorPlansStore();
+
+// workspaceGuard ensures selectedUnit is always set before this route renders
+// (same invariant as SimulationExplorePage).
+const unitId = computed(() => workspaceStore.selectedUnit!.id);
+
+const plan = ref<SimulatorPlan | null>(null);
+const notFound = ref(false);
+const nameInput = ref('');
+const saving = ref(false);
+
+const canSave = computed(() => {
+  const trimmed = nameInput.value.trim();
+  return trimmed.length > 0 && trimmed !== plan.value?.name;
+});
+
+async function saveName() {
+  if (!plan.value || !canSave.value || saving.value) return;
+  saving.value = true;
+  try {
+    const updated = await plansStore.renamePlan(
+      plan.value.id,
+      nameInput.value.trim(),
+    );
+    plan.value = updated;
+    nameInput.value = updated.name;
+    // Param-only replace keeps this component instance mounted.
+    await router.replace({
+      name: 'project-planner',
+      params: { ...route.params, name: updated.name },
+    });
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(async () => {
+  try {
+    plan.value = await plansStore.getPlanByName(
+      unitId.value,
+      String(route.params.name),
+    );
+    nameInput.value = plan.value.name;
+  } catch {
+    notFound.value = true;
+  }
+});
+</script>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -209,13 +209,13 @@ const routes: RouteRecordRaw[] = [
               },
               {
                 // Reached from the "Start a project" button on the unified
-                // home page (CO2ProjectPlanner).
-                path: 'simulation/add',
+                // home page (CO2ProjectPlanner); :name is the plan name.
+                path: `simulation/project-planner/:name(${SIMULATION_ID_PATTERN})`,
                 name: 'project-planner',
-                component: () => import('pages/app/AddSimulationPage.vue'),
+                component: () => import('pages/app/ProjectPlannerPage.vue'),
                 meta: {
                   requiresAuth: true,
-                  note: 'Project Planner - Add a new project simulation',
+                  note: 'Project Planner - plan a project simulation',
                   breadcrumb: true,
                 },
               },
@@ -229,16 +229,7 @@ const routes: RouteRecordRaw[] = [
                   breadcrumb: true,
                 },
               },
-              {
-                path: `simulation/plan/:plan(${SIMULATION_ID_PATTERN})`,
-                name: 'simulation-plan',
-                component: () => import('pages/app/SimulationPlanPage.vue'),
-                meta: {
-                  requiresAuth: true,
-                  note: 'Simulation - Plan a simulation',
-                  breadcrumb: true,
-                },
-              },
+
               {
                 path: 'documentation',
                 name: 'documentation',

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -1,0 +1,83 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+import { api } from 'src/api/http';
+
+/**
+ * Hand-typed DTO mirroring backend/app/schemas/simulator_plan.py; re-run
+ * `cd frontend && make gen-api-types` against an up-to-date backend to
+ * replace with generated `paths['/project-plans/...']` types.
+ */
+export interface SimulatorPlan {
+  id: number;
+  unit_id: number;
+  name: string;
+  created_by: number | null;
+  created_at: string | null;
+  creator_name: string | null;
+}
+
+export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
+  const plans = ref<SimulatorPlan[]>([]);
+  const loading = ref(false);
+
+  async function fetchPlans(unitId: number): Promise<void> {
+    loading.value = true;
+    try {
+      plans.value = await api
+        .get(`project-plans/unit/${unitId}/`)
+        .json<SimulatorPlan[]>();
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function createPlan(
+    unitId: number,
+    name?: string,
+  ): Promise<SimulatorPlan> {
+    return api
+      .post(`project-plans/unit/${unitId}/`, {
+        json: { name: name ?? null },
+      })
+      .json<SimulatorPlan>();
+  }
+
+  async function getPlanByName(
+    unitId: number,
+    name: string,
+  ): Promise<SimulatorPlan> {
+    return api
+      .get(`project-plans/unit/${unitId}/by-name/${encodeURIComponent(name)}`, {
+        skipErrorCodes: [404],
+      })
+      .json<SimulatorPlan>();
+  }
+
+  async function renamePlan(
+    planId: number,
+    name: string,
+  ): Promise<SimulatorPlan> {
+    return api
+      .patch(`project-plans/${planId}`, { json: { name } })
+      .json<SimulatorPlan>();
+  }
+
+  async function duplicatePlan(planId: number): Promise<SimulatorPlan> {
+    return api.post(`project-plans/${planId}/duplicate`).json<SimulatorPlan>();
+  }
+
+  async function deletePlan(planId: number): Promise<void> {
+    await api.delete(`project-plans/${planId}`);
+  }
+
+  return {
+    plans,
+    loading,
+    fetchPlans,
+    createPlan,
+    getPlanByName,
+    renamePlan,
+    duplicatePlan,
+    deletePlan,
+  };
+});


### PR DESCRIPTION
## What does this change?
Implements the backend and frontend for the "Project Planner" feature (simulator plans), replacing a static placeholder table and a stub route with a real CRUD flow:

- **Backend**: new `CarbonProject`-based "Simulator Plan" concept — a `carbon_projects` row with `carbon_report_type = SIMULATOR_PLAN`, uniquely identified per unit by its `name` (used as a URL segment). Adds:
  - `created_by` / `created_at` columns on `carbon_projects` plus an Alembic migration that relaxes the old `uq_carbon_projects_unit_type` unique constraint into two partial unique indexes (one project per unit+type for Calculator/Simulator_Explore, many allowed for Simulator_Plan, unique by unit+name).
  - New `CarbonProjectRepository`, `SimulatorPlanService`, and Pydantic schemas (`SimulatorPlanCreate`/`Update`/`Read`).
  - New `/v1/project-plans/...` API router: list plans for a unit, create (auto-assigns `new-project`, `new-project-2`, ... if no name given), get by name, rename, duplicate (`<name>-N`), and delete (cascades to attached carbon reports/modules).
  - New unit test suite for `SimulatorPlanService` covering naming, collisions, rename/duplicate/delete, and cascade deletion.
  - New `.claude/skills/verify/SKILL.md` documenting how to run the full stack locally with a test login for end-to-end verification.
  - ERD docs updated for the new columns/relationship.
- **Frontend**:
  - `CO2ProjectPlanner.vue` (home page project list) now fetches real plans via a new `simulatorPlans` Pinia store instead of rendering hardcoded placeholder rows, and wires up create/duplicate/edit/delete actions (with a delete confirmation dialog).
  - New `ProjectPlannerPage.vue` replaces the old `AddSimulationPage.vue` stub, showing a plan (found by unit + name) with an editable, save-able project name.
  - Router: the `project-planner` route now takes a `:name` param (`simulation/project-planner/:name`) instead of the old static `simulation/add` path; the separate `simulation-plan` route/`SimulationPlanPage.vue` is removed.
  - New i18n keys for the project planner page (title, intro, name label/save, not-found, back-home).

Also included (likely unrelated engine/toolchain drift, not part of this feature):
- `package.json` / lockfile: reverts the Node engine requirement from `>=v26.5.0 <27` back to `>=v24.15.0 <25`.

## Why is this needed?
The project planner section of the home page and its "Start a project" button were previously backed entirely by placeholder/static data and a stub page (`AddSimulationPage.vue`), with no way to actually create, rename, duplicate, or delete a project plan. This change gives project planner projects a real backend model and API, and wires the frontend up to it end-to-end so units can manage their simulator plans.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1804

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.