### PR TITLE
fix(reporting): added look-up of units by multiple parent_unit_type_label

### DIFF
--- a/backend/app/api/v1/backoffice_reporting.py
+++ b/backend/app/api/v1/backoffice_reporting.py
@@ -78,7 +78,7 @@ async def list_units(
     level: int | None = None,
     parent_id: str | None = None,
     unit_type_labels: Annotated[list[str] | None, Query()] = None,
-    parent_unit_type_label: str | None = None,
+    parent_unit_type_label: Annotated[list[str] | None, Query()] = None,
     name: Optional[str] = Query(
         None, description="Filter by unit name (partial match)"
     ),
@@ -117,7 +117,7 @@ async def list_units(
         query = query.join(
             parent_alias,
             col(Unit.parent_institutional_code) == parent_alias.institutional_code,
-        ).where(parent_alias.unit_type_label == parent_unit_type_label)
+        ).where(col(parent_alias.unit_type_label).in_(parent_unit_type_label))
 
     # 4. Affiliation scoping (#459)
     if not is_global:


### PR DESCRIPTION
## What does this change?

Additional criteria in list units entry point, to search for units by any parent unit labels.

<img width="405" height="327" alt="image" src="https://github.com/user-attachments/assets/a2a52e35-0276-48ac-b58a-41b01bc9a735" />


## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #
- Related to #

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
