### PR TITLE
fix: use injected APP_ENVIRONMENT to expose login-test or not (#1644)

### DIFF
--- a/frontend/src/router/routeNames.ts
+++ b/frontend/src/router/routeNames.ts
@@ -9,10 +9,17 @@
  * Anything in this file MUST stay free of Vite-specific imports and
  * runtime side effects.
  */
+import { runtimeConfig } from 'src/config/runtime';
+
+export const isDevEnvironment =
+  runtimeConfig.environment === 'development' ||
+  runtimeConfig.environment === 'dev';
 
 export const LOGIN_ROUTE_NAME = 'login';
 export const LOGIN_TEST_ROUTE_NAME = 'login-test';
-export const LOGIN_ROUTES = [LOGIN_ROUTE_NAME, LOGIN_TEST_ROUTE_NAME];
+export const LOGIN_ROUTES = isDevEnvironment
+  ? [LOGIN_ROUTE_NAME, LOGIN_TEST_ROUTE_NAME]
+  : [LOGIN_ROUTE_NAME];
 export const HOME_ROUTE_NAME = 'home';
 export const WORKSPACE_ROUTE_NAME = 'workspace-dashboard';
 export const UNAUTHORIZED_ROUTE_NAME = 'unauthorized';

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -6,6 +6,7 @@ import redirectToDefaultRoute from './guards/redirectToDefaultRoute';
 import { permissionGuard } from './guards/permissionGuard';
 import { moduleEnabledGuard } from './guards/moduleEnabledGuard';
 import { PermissionAction } from 'src/stores/auth';
+import { isDevEnvironment } from './routeNames';
 
 // Route parameter validation patterns
 const LANGUAGE_PATTERN = 'en|fr';
@@ -153,15 +154,19 @@ const routes: RouteRecordRaw[] = [
               breadcrumb: false,
             },
           },
-          {
-            path: 'login-test',
-            name: LOGIN_TEST_ROUTE_NAME,
-            component: () => import('pages/app/LoginTestPage.vue'),
-            meta: {
-              note: 'Test User authentication - Login page',
-              breadcrumb: false,
-            },
-          },
+          ...(isDevEnvironment
+            ? [
+                {
+                  path: 'login-test',
+                  name: LOGIN_TEST_ROUTE_NAME,
+                  component: () => import('pages/app/LoginTestPage.vue'),
+                  meta: {
+                    note: 'Test User authentication - Login page',
+                    breadcrumb: false,
+                  },
+                },
+              ]
+            : []),
           {
             path: `:unit(${UNIT_PATTERN})/:year(${YEAR_PATTERN})`,
             name: WORKSPACE_ROUTE_NAME,


### PR DESCRIPTION
## What does this change?

* Do not expose login-test when not necessary

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Closes #1644 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
