### PR TITLE
feat 1567: remove first cabin class for plane travel

### DIFF
--- a/backend/app/modules/emissions/taxonomy.py
+++ b/backend/app/modules/emissions/taxonomy.py
@@ -70,7 +70,6 @@ class EmissionType(int, Enum):
     professional_travel__train__class_1 = 50101
     professional_travel__train__class_2 = 50102
     professional_travel__plane = 50200
-    professional_travel__plane__first = 50201
     professional_travel__plane__business = 50202
     professional_travel__plane__eco = 50203
 

--- a/backend/app/modules/professional_travel/emissions.py
+++ b/backend/app/modules/professional_travel/emissions.py
@@ -10,7 +10,6 @@ STAT_BUCKETS: tuple[StatBucket, ...] = (
 )
 
 _PLANE_CABIN_MAP: dict[str, EmissionType] = {
-    "first": EmissionType.professional_travel__plane__first,
     "business": EmissionType.professional_travel__plane__business,
     "economy": EmissionType.professional_travel__plane__eco,
 }

--- a/backend/app/modules/professional_travel/schemas.py
+++ b/backend/app/modules/professional_travel/schemas.py
@@ -90,7 +90,7 @@ class PlaneCabinClassValidationMixin:
     @field_validator("cabin_class", mode="after")
     @classmethod
     def validate_cabin_class(cls, v: Optional[str]) -> Optional[str]:
-        valid_classes = ["first", "business", "economy"]
+        valid_classes = ["business", "economy"]
         if v is not None and v.lower() not in valid_classes:
             raise ValueError(
                 f"Invalid cabin class '{v}', must be one of {valid_classes}"
@@ -662,7 +662,6 @@ class _TravelPlaneBaseValidationMixin:
         valid_cabin_classes = [
             "economy",
             "business",
-            "first",
         ]
         if not v:
             raise ValueError("Cabin class is required")

--- a/backend/app/seed/random_generator/seed_data_entries.py
+++ b/backend/app/seed/random_generator/seed_data_entries.py
@@ -229,7 +229,7 @@ def build_plane_travel() -> dict:
         "user_institutional_id": _user_institutional_id(),
         "origin_iata": fake.lexify(text="???").upper(),
         "destination_iata": fake.lexify(text="???").upper(),
-        "cabin_class": random.choice(["economy", "business", "first"]),  # nosec B311
+        "cabin_class": random.choice(["economy", "business"]),  # nosec B311
         "departure_date": date.today().isoformat(),
         "number_of_trips": random.randint(1, 10),  # nosec B311
         "note": maybe(fake.sentence(nb_words=6)),

--- a/backend/app/seed/random_generator/seed_factors.py
+++ b/backend/app/seed/random_generator/seed_factors.py
@@ -104,7 +104,6 @@ async def create_factors(session: AsyncSession):
     cabin_classes_type = [
         EmissionType.professional_travel__plane__eco,
         EmissionType.professional_travel__plane__business,
-        EmissionType.professional_travel__plane__first,
     ]
     distance_bands = [
         ("Short-haul", 0, 1000),

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -248,13 +248,12 @@ class ProfessionalTravelApiProvider(BaseTableauApiProvider):
         return datetime.strptime(date_str, "%Y%m%d")
 
     def _normalize_class(self, class_str: str) -> str:
-        # Canonical cabin_class vocabulary ("economy"/"business"/"first") —
+        # Canonical cabin_class vocabulary ("economy"/"business") —
         # the value resolve_emission_types and factor classification key on.
         # Must NOT emit "eco": the resolver rejects it (the old wrong value),
         # so economy flights would resolve to no emission type.
         mapping = {
             "AIR ECONOMY CLASS": "economy",
             "AIR BUSINESS CLASS": "business",
-            "AIR FIRST CLASS": "first",
         }
         return mapping.get(class_str, "economy")

--- a/backend/tests/integration/modules/plane/test_persistence_invariant.py
+++ b/backend/tests/integration/modules/plane/test_persistence_invariant.py
@@ -85,12 +85,12 @@ async def test_listing_plane_with_emissions_does_not_pollute_data(
     db_session.add(factor)
     await db_session.flush()
 
-    # The exact shape the user reported in the bug write-up: GVA→ZRH first
+    # The exact shape the user reported in the bug write-up: GVA→ZRH business
     # class, no precomputed kg_co2eq.
     original_data = {
         "origin_iata": "GVA",
         "destination_iata": "ZRH",
-        "cabin_class": "first",
+        "cabin_class": "business",
         "user_institutional_id": "150322",
         "number_of_trips": 1,
         "departure_date": "2025/01/09",

--- a/backend/tests/integration/modules/professional_travel/test_traveler_dropdown_integration.py
+++ b/backend/tests/integration/modules/professional_travel/test_traveler_dropdown_integration.py
@@ -218,7 +218,7 @@ def test_plane_create_dto_accepts_user_institutional_id_from_dropdown():
 
 
 def test_plane_create_dto_rejects_invalid_cabin_class():
-    """Cabin class must be one of economy / business / first."""
+    """Cabin class must be one of economy / business."""
     with pytest.raises(ValidationError):
         ProfessionalTravelPlaneHandlerCreate(
             data_entry_type_id=DataEntryTypeEnum.plane.value,

--- a/backend/tests/unit/repositories/test_data_entry_repo.py
+++ b/backend/tests/unit/repositories/test_data_entry_repo.py
@@ -1014,7 +1014,7 @@ async def test_get_submodule_data_does_not_persist_computed_fields(
     original_data = {
         "origin_iata": "GVA",
         "destination_iata": "ZRH",
-        "cabin_class": "first",
+        "cabin_class": "business",
         "user_institutional_id": "150322",
         "number_of_trips": 1,
         "primary_factor_id": None,

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -942,7 +942,7 @@ async def test_process_row_extracts_kg_co2eq_out_of_band():
             data={
                 "origin_iata": "GVA",
                 "destination_iata": "ZRH",
-                "cabin_class": "first",
+                "cabin_class": "business",
             }
         )
 
@@ -972,7 +972,7 @@ async def test_process_row_extracts_kg_co2eq_out_of_band():
     row = {
         "origin_iata": "GVA",
         "destination_iata": "ZRH",
-        "cabin_class": "first",
+        "cabin_class": "business",
         "user_institutional_id": "150322",
         "number_of_trips": "1",
         "kg_co2eq": "152.685",

--- a/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_professional_travel_api_provider.py
@@ -152,12 +152,9 @@ class TestNormalizeClass:
         p = _make_provider()
         assert p._normalize_class("AIR BUSINESS CLASS") == "business"
 
-    def test_first(self):
-        p = _make_provider()
-        assert p._normalize_class("AIR FIRST CLASS") == "first"
-
     def test_unknown_defaults_to_economy(self):
         p = _make_provider()
+        assert p._normalize_class("AIR FIRST CLASS") == "economy"
         assert p._normalize_class("SOMETHING ELSE") == "economy"
         assert p._normalize_class("") == "economy"
 

--- a/backend/tests/unit/utils/test_plane_cabin_class.py
+++ b/backend/tests/unit/utils/test_plane_cabin_class.py
@@ -18,8 +18,6 @@ from app.modules.professional_travel.emissions import resolve_plane
         ("ECONOMY", EmissionType.professional_travel__plane__eco),
         ("business", EmissionType.professional_travel__plane__business),
         ("Business", EmissionType.professional_travel__plane__business),
-        ("first", EmissionType.professional_travel__plane__first),
-        ("First", EmissionType.professional_travel__plane__first),
     ],
 )
 def test_resolve_plane_maps_class_to_emission_type(
@@ -35,6 +33,7 @@ def test_resolve_plane_maps_class_to_emission_type(
     "data",
     [
         {"cabin_class": "eco"},  # old wrong frontend value — must NOT match
+        {"cabin_class": "first"},  # removed cabin class (#1567) — must NOT match
         {"cabin_class": "premium"},
         {"cabin_class": ""},
         {},  # missing key

--- a/backend/tests/unit/utils/test_plane_calculation.py
+++ b/backend/tests/unit/utils/test_plane_calculation.py
@@ -20,10 +20,8 @@ from app.services.data_entry_emission_service import DataEntryEmissionService
 _EF = {
     ("short_to_medium_haul", "economy"): 0.2906,
     ("short_to_medium_haul", "business"): 0.4471,
-    ("short_to_medium_haul", "first"): 0.2906,
     ("medium_to_long_haul", "economy"): 0.1902,
     ("medium_to_long_haul", "business"): 0.3930,
-    ("medium_to_long_haul", "first"): 0.6056,
 }
 _RFI = 1.35
 
@@ -45,7 +43,7 @@ def _comp() -> EmissionComputation:
 
 
 # ---------------------------------------------------------------------------
-# 1. Formula correctness for all 6 factor combinations
+# 1. Formula correctness for all 4 factor combinations
 # ---------------------------------------------------------------------------
 
 
@@ -54,10 +52,8 @@ def _comp() -> EmissionComputation:
     [
         ("short_to_medium_haul", "economy", 506.0),  # GVA → CDG (haversine+95)
         ("short_to_medium_haul", "business", 506.0),
-        ("short_to_medium_haul", "first", 506.0),
         ("medium_to_long_haul", "economy", 5926.0),  # CDG → JFK
         ("medium_to_long_haul", "business", 5926.0),
-        ("medium_to_long_haul", "first", 5926.0),
     ],
 )
 def test_apply_formula_matches_spec(
@@ -78,31 +74,22 @@ def test_apply_formula_matches_spec(
 
 
 # ---------------------------------------------------------------------------
-# 2. Short-haul first == short-haul economy (same EF per spec)
+# 2. Short-haul economy formula at the reference distance
 # ---------------------------------------------------------------------------
 
 
-def test_short_haul_first_equals_short_haul_economy() -> None:
+def test_short_haul_economy_formula() -> None:
     distance_km = 500.0
+    ef = _EF[("short_to_medium_haul", "economy")]
     eco = _svc()._apply_formula(
         ctx={"distance_km": distance_km},
         factor_values={
-            "ef_kg_co2eq_per_km": _EF[("short_to_medium_haul", "economy")],
+            "ef_kg_co2eq_per_km": ef,
             "rfi_adjustment": _RFI,
         },
         comp=_comp(),
     )
-    first = _svc()._apply_formula(
-        ctx={"distance_km": distance_km},
-        factor_values={
-            "ef_kg_co2eq_per_km": _EF[("short_to_medium_haul", "first")],
-            "rfi_adjustment": _RFI,
-        },
-        comp=_comp(),
-    )
-    assert eco == pytest.approx(first, rel=1e-9), (
-        "Short-haul first class must use the same EF as economy per issue #863 spec"
-    )
+    assert eco == pytest.approx(distance_km * ef * _RFI, rel=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -135,11 +122,11 @@ def test_business_emits_more_than_economy(category: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 4. Long-haul first is the highest emitter per km
+# 4. Long-haul business is the highest emitter per km
 # ---------------------------------------------------------------------------
 
 
-def test_long_haul_first_highest_emitter() -> None:
+def test_long_haul_business_highest_emitter() -> None:
     distance_km = 6000.0
     results = {
         cls: _svc()._apply_formula(
@@ -150,9 +137,9 @@ def test_long_haul_first_highest_emitter() -> None:
             },
             comp=_comp(),
         )
-        for cls in ("economy", "business", "first")
+        for cls in ("economy", "business")
     }
-    assert results["first"] > results["business"] > results["economy"], (
+    assert results["business"] > results["economy"], (
         f"Long-haul ranking wrong: {results}"
     )
 
@@ -209,7 +196,7 @@ def test_resolve_computations_passes_cabin_class_as_subkind() -> None:
     )
 
 
-@pytest.mark.parametrize("cabin_class", ["economy", "business", "first"])
+@pytest.mark.parametrize("cabin_class", ["economy", "business"])
 def test_resolve_computations_all_classes(cabin_class: str) -> None:
     handler = ProfessionalTravelPlaneModuleHandler()
 
@@ -219,6 +206,6 @@ def test_resolve_computations_all_classes(cabin_class: str) -> None:
 
     ctx = {"haul_category": "medium_to_long_haul", "distance_km": 5926.0}
     computations = handler.resolve_computations(
-        _FakeEntry(), EmissionType.professional_travel__plane__first, ctx
+        _FakeEntry(), EmissionType.professional_travel__plane__business, ctx
     )
     assert computations[0].factor_query.subkind == cabin_class

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -87,7 +87,6 @@ const LABEL_KEY_MAP: Record<string, string> = {
   // professional travel ZZ items
   class_1: 'charts-class-1-subcategory',
   class_2: 'charts-class-2-subcategory',
-  first: 'charts-first-class-subcategory',
   business: 'charts-business-class-subcategory',
   eco: 'charts-eco-class-subcategory',
 };

--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -137,7 +137,6 @@ const planeCabinClassField: ModuleField = {
   editableInline: true,
   optionLabelsAreKeys: true,
   options: [
-    { value: 'first', label: 'charts-first-class-subcategory' },
     { value: 'business', label: 'charts-business-class-subcategory' },
     { value: 'economy', label: 'charts-eco-class-subcategory' },
   ],

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -607,10 +607,6 @@ export default {
     en: '2nd class',
     fr: '2ème classe',
   },
-  'charts-first-class-subcategory': {
-    en: 'First',
-    fr: 'Première',
-  },
   'charts-business-class-subcategory': {
     en: 'Business',
     fr: 'Affaires',

--- a/frontend/src/types/emission-taxonomy.gen.ts
+++ b/frontend/src/types/emission-taxonomy.gen.ts
@@ -36,7 +36,6 @@ export const EMISSION_TYPE_NAMES: Record<number, string> = {
   50101: 'professional_travel__train__class_1',
   50102: 'professional_travel__train__class_2',
   50200: 'professional_travel__plane',
-  50201: 'professional_travel__plane__first',
   50202: 'professional_travel__plane__business',
   50203: 'professional_travel__plane__eco',
   60000: 'buildings',


### PR DESCRIPTION
## What does this change?
Removes "first class" as a valid plane cabin class throughout the app, leaving only "business" and "economy":

- **Backend**: removes `professional_travel__plane__first` (emission type `50201`) from the `EmissionType` enum and its taxonomy entry; removes `"first"` from the cabin-class validation lists in `ProfessionalTravelPlaneHandlerCreate` schemas and the `_PLANE_CABIN_MAP` used to resolve emission types; removes the `"first"` factor from seed factor generation and random seed data generation; removes the `"AIR FIRST CLASS"` mapping in the Tableau professional-travel API provider's `_normalize_class` (now falls through to the "unknown → economy" default).
- **Backend tests**: updates/removes tests referencing `"first"` cabin class across persistence, ingestion, dropdown, and calculation test suites; adds an explicit regression test asserting `{"cabin_class": "first"}` no longer resolves to an emission type; removes the now-inapplicable "short-haul first == economy" and "long-haul first is highest emitter" formula tests (previously covering 6 factor combinations, now 4).
- **Frontend**: removes the `first` option from the plane cabin class field config (`professional-travel.ts`), removes the `50201`/`professional_travel__plane__first` entry from the generated emission-taxonomy types, removes the `first`/`charts-first-class-subcategory` label mapping from the emission treemap chart, and removes the `charts-first-class-subcategory` i18n string (en/fr).

## Why is this needed?
"First class" is being retired as a selectable/reportable cabin class for professional travel — likely because it's rarely/never used at EPFL and adds unnecessary complexity to cabin-class options, emission-factor seeding, and data ingestion mapping. This change fully removes it from the data model, validation, seeding, ingestion normalization, UI options, and charts so no new "first class" entries can be created and existing code paths no longer reference it.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

## Related issues
- Related to #1567

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.