### PR TITLE
fix/1782 chart color scales wrong

### DIFF
--- a/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
+++ b/frontend/src/components/charts/results/CarbonFootPrintPerPersonChart.vue
@@ -156,7 +156,7 @@ const additionalSeriesData = computed(() => {
       stack: 'total',
       encode: encodeFor('category', 'food'),
       itemStyle: {
-        color: colors.value.mint.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.food,
       },
       label: {
         show: false,
@@ -168,7 +168,7 @@ const additionalSeriesData = computed(() => {
       stack: 'total',
       encode: encodeFor('category', 'waste'),
       itemStyle: {
-        color: colors.value.periwinkle.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.waste,
       },
       label: {
         show: false,
@@ -265,7 +265,7 @@ const seriesArray = computed(() => {
       stack: 'total',
       encode: encodeFor('category', 'professional_travel'),
       itemStyle: {
-        color: colors.value.babyBlue.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.professional_travel,
       },
       label: {
         show: false,
@@ -277,7 +277,7 @@ const seriesArray = computed(() => {
       stack: 'total',
       encode: encodeFor('category', 'purchases'),
       itemStyle: {
-        color: colors.value.lightGreen.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.purchases,
       },
       label: {
         show: false,
@@ -289,7 +289,7 @@ const seriesArray = computed(() => {
       stack: 'total',
       encode: encodeFor('category', 'research_facilities'),
       itemStyle: {
-        color: colors.value.paleYellowGreen.darker,
+        color: CHART_CATEGORY_COLOR_SCHEMES.value.research_facilities,
       },
       label: {
         show: false,

--- a/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
+++ b/frontend/src/components/charts/results/ItFocusBreakdownChart.vue
@@ -24,7 +24,6 @@ import { useEchartsTooltip } from 'src/components/charts/results/useEchartsToolt
 import {
   buildChartDecal,
   CHART_CATEGORY_COLOR_SCHEMES,
-  colors,
 } from 'src/constant/charts';
 import { IT_FOCUS_CATEGORY_TO_MODULE } from 'src/constant/itFocus';
 import { useColorblindStore } from 'src/stores/colorblind';
@@ -141,8 +140,8 @@ const IT_FOCUS_CATEGORY_ORDER = [
 ] as const;
 
 const categoryColor = computed(() => ({
-  equipment_it: colors.value.plum.dark,
-  purchases_it: colors.value.lightGreen.dark,
+  equipment_it: CHART_CATEGORY_COLOR_SCHEMES.value.equipment,
+  purchases_it: CHART_CATEGORY_COLOR_SCHEMES.value.purchases,
   external_cloud_and_ai:
     CHART_CATEGORY_COLOR_SCHEMES.value.external_cloud_and_ai,
   research_facilities_it:

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -45,6 +45,7 @@ use([
 import type { EmissionBreakdownResponse } from 'src/stores/modules';
 import type { TooltipRow } from 'src/types/chartTooltip';
 import { formatTonnesForChart } from 'src/utils/number';
+import { stackShade } from 'src/utils/chart-shades';
 import { usePrintMode } from 'src/composables/print/usePrintMode';
 import { downloadEchartAsPng } from 'src/utils/chartDownload';
 
@@ -1067,13 +1068,7 @@ const chartOption = computed((): EChartsOption => {
         stack: 'total',
         animation: true,
         encode: { x: 'category', y: `equip_rank${i + 1}` },
-        itemStyle: {
-          color: getSubcategoryColor(
-            'equipment',
-            item.key,
-            colors.value.plum.default,
-          ),
-        },
+        itemStyle: { color: stackShade(colors.value.plum, i) },
         label: { show: false },
       }));
     })(),
@@ -1095,13 +1090,7 @@ const chartOption = computed((): EChartsOption => {
         stack: 'total',
         animation: true,
         encode: { x: 'category', y: `purch_rank${i + 1}` },
-        itemStyle: {
-          color: getSubcategoryColor(
-            'purchases',
-            item.key,
-            colors.value.lightGreen.default,
-          ),
-        },
+        itemStyle: { color: stackShade(colors.value.lightGreen, i) },
         label: { show: false },
       }));
       const restSeries = {

--- a/frontend/src/constant/charts.ts
+++ b/frontend/src/constant/charts.ts
@@ -473,8 +473,8 @@ export const CHART_SUBCATEGORY_COLOR_SCHEMES = computed(
     },
     research_facilities: {
       facilities: colors.value.paleYellowGreen.darker,
-      it_facilities: colors.value.paleYellowGreen.default,
-      animal: colors.value.paleYellowGreen.dark,
+      it_facilities: colors.value.paleYellowGreen.dark,
+      animal: colors.value.paleYellowGreen.default,
     },
     purchases: (() => {
       const keys = [

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -845,7 +845,7 @@ const getUncertainty = (
             <q-toggle
               v-model="viewUncertainties"
               :label="$t('results_view_uncertainties')"
-              color="accent"
+              color="info"
               keep-color
               size="lg"
               class="text-weight-medium"

--- a/frontend/src/utils/chart-shades.ts
+++ b/frontend/src/utils/chart-shades.ts
@@ -1,0 +1,20 @@
+export const STACK_SHADE_ORDER = [
+  'darker',
+  'dark',
+  'default',
+  'light',
+  'lighter',
+] as const;
+
+export type StackShadeName = (typeof STACK_SHADE_ORDER)[number];
+
+export type ShadeScale = Record<StackShadeName, string>;
+
+/**
+ * Shade for the i-th segment counted from the bottom of a stacked bar:
+ * index 0 (bottom) is darkest, lightening upward. Index clamps to [0, 4].
+ */
+export function stackShade(scale: ShadeScale, index: number): string {
+  const clamped = Math.min(Math.max(index, 0), STACK_SHADE_ORDER.length - 1);
+  return scale[STACK_SHADE_ORDER[clamped]];
+}

--- a/frontend/tests/unit/chart-shades.spec.ts
+++ b/frontend/tests/unit/chart-shades.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression test for the chart color-scale bug — in the main Results stacked
+ * bar chart, some bars rendered a darker shade above a lighter one.
+ *
+ * ECharts stacks series sharing ``stack: 'total'`` in series-array order
+ * (first series = bottom segment). ``stackShade`` (``utils/chart-shades.ts``)
+ * pins the shade to the segment's position: index 0 (bottom) is darkest,
+ * lightening upward. ``ModuleCarbonFootprintChart.vue`` uses it for the
+ * value-ranked equipment/purchases stacks, so the largest subcategory is
+ * always the darkest bottom segment regardless of which subcategory ranks
+ * first. This test pins the darkest-bottom invariant and the index→shade
+ * contract.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import {
+  STACK_SHADE_ORDER,
+  stackShade,
+  type ShadeScale,
+} from '../../src/utils/chart-shades';
+
+// paleYellowGreen default-mode scale from ``constant/charts.ts``
+const scale: ShadeScale = {
+  darker: '#ABCF84',
+  dark: '#C0DEA0',
+  default: '#D5EBBE',
+  light: '#E5F2D4',
+  lighter: '#F0F8EA',
+};
+
+function luminance(hex: string): number {
+  const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+test('shades lighten monotonically from the bottom of the stack upward', () => {
+  for (let i = 1; i < STACK_SHADE_ORDER.length; i++) {
+    expect(luminance(stackShade(scale, i))).toBeGreaterThan(
+      luminance(stackShade(scale, i - 1)),
+    );
+  }
+});
+
+test('index maps to the shade at the same position in STACK_SHADE_ORDER', () => {
+  STACK_SHADE_ORDER.forEach((name, i) => {
+    expect(stackShade(scale, i)).toBe(scale[name]);
+  });
+});
+
+test('out-of-range indices clamp to the darkest and lightest shades', () => {
+  expect(stackShade(scale, -1)).toBe(scale.darker);
+  expect(stackShade(scale, STACK_SHADE_ORDER.length)).toBe(scale.lighter);
+  expect(stackShade(scale, 99)).toBe(scale.lighter);
+});


### PR DESCRIPTION
## What does this change?
Fixes incorrect chart color scales in the Results stacked bar charts, where segments sometimes rendered a darker shade above a lighter one instead of lightening monotonically from bottom to top:

- Adds a new `stackShade(scale, index)` utility (`utils/chart-shades.ts`) that maps a stack segment's position to a fixed shade order (`darker → dark → default → light → lighter`, clamped to the array bounds), with unit tests pinning the darkest-bottom invariant and the index→shade mapping.
- `ModuleCarbonFootprintChart.vue`: the value-ranked equipment/purchases stacked series now use `stackShade` instead of `getSubcategoryColor(...)` with a single fixed color, so segment shade follows stack position instead of subcategory identity.
- `CarbonFootPrintPerPersonChart.vue`: food/waste/professional_travel/purchases/research_facilities series now pull their color from `CHART_CATEGORY_COLOR_SCHEMES` instead of ad-hoc `colors.value.<name>.darker` references that didn't match the shared category palette.
- `ItFocusBreakdownChart.vue`: `equipment_it`/`purchases_it` colors switched from hardcoded `colors.value.plum.dark` / `colors.value.lightGreen.dark` to `CHART_CATEGORY_COLOR_SCHEMES`, for consistency with the rest of the chart's categories.
- `constant/charts.ts`: fixes a swapped `research_facilities` subcategory color mapping (`it_facilities` and `animal` had their `default`/`dark` shades reversed).
- `ResultsPage.vue`: the "view uncertainties" toggle color changed from `accent` to `info` (for consistency with the corrected palette).

## Why is this needed?
The stacked bar charts in the Results page were showing an inconsistent/incorrect color progression within stacks (per the branch name, "chart color scales wrong"), which is misleading when scanning a stack from largest to smallest segment. Centralizing shade selection in `stackShade` and routing more series through the shared `CHART_CATEGORY_COLOR_SCHEMES` fixes the inconsistency and removes several hardcoded, easily-drifting color references (including a genuine swapped-color bug in `research_facilities`).

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1782 

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.