### PR TITLE
Fix/1416 start button permissions bug

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -224,8 +224,8 @@ export const useAuthStore = defineStore('auth', () => {
     const path = getModulePermissionPath(module);
     if (!path) return true; // Unprotected module, accessible to all users
     return (
-      hasUserAnyScopePermission(path, PermissionAction.VIEW) ||
-      hasUserAnyScopePermission(path, PermissionAction.EDIT)
+      hasUserPermission(path, PermissionAction.VIEW) ||
+      hasUserPermission(path, PermissionAction.EDIT)
     );
   }
 


### PR DESCRIPTION

## What does this change?

The fix  now checks module permissions with the workspace-scoped hasUserPermission() instead of the any-scope hasUserAnyScopePermission():  when deciding whether to show/link a module, the frontend now asks "can this user access this module in the currently selected unit?" instead of "can this user access this module in any unit they belong to?".

This corrects the Start/Continue buttons on the home page, the module sidebar, and the module prev/next navigation — all three go through canUserAccessModule().

## Why is this needed?

A user who is principal in unit A and standard user in unit B got a 403 → /unauthorized redirect when clicking Start on unit B's home page.

Cause: permissions are flat keys that carry the unit in them (modules.headcount/<unitA>, modules.professional_travel/<unitB>/own, …). The any-scope check matched the user's unit A keys while unit B was selected, so the Start button targeted a module (e.g. headcount) the user may not view in unit B. The backend correctly refused (check_module_permission_for_unit), and the global 403 handler in api/http.ts kicked the user to /unauthorized.

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #1416 

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
