### PR TITLE
feat(planner): auto-prefill modules on reference-year set

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -56,7 +56,6 @@ from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.carbon_report_service import CarbonReportService
 from app.services.data_entry_emission_service import DataEntryEmissionService
 from app.services.data_entry_service import DataEntryService
-from app.services.simulator_plan_service import SimulatorPlanService
 from app.utils.request_context import extract_ip_address, extract_route_payload
 from app.workflows.carbon_report_module import CarbonReportModuleWorkflow
 from app.workflows.embodied_energy import EmbodiedEnergyWorkflow
@@ -742,51 +741,6 @@ async def get_submodule(
     )
 
     return submodule_data
-
-
-@router.post(
-    "/{carbon_report_id}/modules/{module_id}/prefill",
-    response_model=CarbonReportModuleRead,
-)
-async def prefill_module_from_reference(
-    carbon_report_id: int,
-    module_id: str,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Snapshot-copy the reference-year entries into a plan module (type 2).
-
-    Wipes previous snapshot rows and re-copies the reference-year
-    Calculator entries at ``percentage_of_reference_year = 100``; user-added
-    rows survive. Only meaningful for Simulator Plan reports — reports
-    without a reference year are rejected.
-    """
-    report, module = await resolve_report_module(
-        carbon_report_id, module_id, db, current_user, action="edit"
-    )
-    await check_module_permission_for_unit(
-        current_user=current_user,
-        module_id=module_id,
-        action="edit",
-        db=db,
-        unit_id=report.unit_id,
-    )
-    service = SimulatorPlanService(db)
-    try:
-        copied = await service.prefill_module_from_reference(
-            report, module.module_type_id
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
-    await db.commit()
-    logger.info(
-        f"Prefilled module {sanitize(module_id)} of report "
-        f"{sanitize(carbon_report_id)} with {sanitize(copied)} snapshot entries"
-    )
-    refreshed = await CarbonReportModuleService(db).get_module(
-        carbon_report_id, module.module_type_id
-    )
-    return refreshed if refreshed is not None else module
 
 
 @router.get(

--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -36,6 +36,17 @@ ALL_MODULE_TYPE_IDS = [mt for mt in ModuleTypeEnum]
 TOTAL_MODULE_TYPES = len(ModuleTypeEnum)
 DEFAULT_COMPLETION_PROGRESS = f"0/{TOTAL_MODULE_TYPES}"
 
+# Simulator Plan "prefilled" (type-2) modules: snapshot-copied from the
+# reference year. Mirrors the frontend planner-module-config
+# ``behavior === 'prefilled'`` set.
+PLANNER_PREFILLED_MODULE_TYPES: set[ModuleTypeEnum] = {
+    ModuleTypeEnum.process_emissions,
+    ModuleTypeEnum.buildings,
+    ModuleTypeEnum.equipment,
+    ModuleTypeEnum.research_facilities,
+    ModuleTypeEnum.external_cloud_and_ai,
+}
+
 
 # corresponding data_entry_type enum for each module type
 

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -333,25 +333,6 @@ class DataEntryRepository:
         result = await self.session.execute(statement)
         return list(result.scalars().all())
 
-    async def list_module_ids_with_source(
-        self, carbon_report_id: int, source: int
-    ) -> list[int]:
-        """Module ids of a report that hold entries from the given source."""
-        statement = (
-            select(col(DataEntry.carbon_report_module_id))
-            .join(
-                CarbonReportModule,
-                col(DataEntry.carbon_report_module_id) == col(CarbonReportModule.id),
-            )
-            .where(
-                col(CarbonReportModule.carbon_report_id) == carbon_report_id,
-                col(DataEntry.source) == source,
-            )
-            .distinct()
-        )
-        result = await self.session.execute(statement)
-        return [module_id for module_id in result.scalars().all()]
-
     async def list_by_data_entry_type_and_year(
         self,
         data_entry_type_id: DataEntryTypeEnum,

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -15,7 +15,11 @@ from app.core.logging import get_logger
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportType
 from app.models.data_entry import DataEntry, DataEntrySourceEnum
-from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
+from app.models.module_type import (
+    MODULE_TYPE_TO_DATA_ENTRY_TYPES,
+    PLANNER_PREFILLED_MODULE_TYPES,
+    ModuleTypeEnum,
+)
 from app.models.user import User
 from app.repositories.carbon_project_repo import CarbonProjectRepository
 from app.repositories.data_entry_repo import DataEntryRepository
@@ -212,32 +216,36 @@ class SimulatorPlanService:
             report.reference_year = reference_year
             self.session.add(report)
             await self.session.flush()
-            await self._resnapshot_prefilled_modules(report)
+            await self._prefill_reference_modules(report)
             await self._recalculate_report_emissions(report)
         return await self._year_read(report)
 
-    async def _resnapshot_prefilled_modules(self, report: CarbonReport) -> None:
-        """Re-copy snapshot entries of already-prefilled modules.
+    async def _prefill_reference_modules(self, report: CarbonReport) -> None:
+        """Auto-prefill every prefilled-behavior module from the reference year.
 
-        Called on reference-year change: modules holding PLANNER_SNAPSHOT
-        entries get wiped and re-copied from the new baseline; user-added
-        rows are untouched (their emissions are recomputed separately).
+        Runs on reference-year set/change (there is no manual prefill trigger):
+        each prefilled module gets its PLANNER_SNAPSHOT rows wiped and re-copied
+        at 100% from the reference year's Calculator data; user-added rows
+        survive. No-op when the reference year has no Calculator report for the
+        unit — there is simply nothing to copy.
         """
         if report.id is None:
             raise ValueError("report must be persisted before use")
-        entry_repo = DataEntryRepository(self.session)
-        module_ids = await entry_repo.list_module_ids_with_source(
-            report.id, DataEntrySourceEnum.PLANNER_SNAPSHOT.value
+        if report.reference_year is None:
+            return
+        ref_report = await self.repo.get_calculator_report(
+            report.unit_id, report.reference_year
         )
-        if not module_ids:
+        if ref_report is None:
             return
         modules = await self.report_service.module_service.list_modules(report.id)
-        modules_by_id = {m.id: m for m in modules}
-        for module_id in module_ids:
-            module = modules_by_id.get(module_id)
-            if module is None:
-                continue
-            await self.prefill_module_from_reference(report, module.module_type_id)
+        prefilled_ids = sorted(
+            m.module_type_id
+            for m in modules
+            if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
+        )
+        for module_type_id in prefilled_ids:
+            await self.prefill_module_from_reference(report, module_type_id)
 
     async def _year_read(self, report: CarbonReport) -> SimulatorPlanYearRead:
         """Build the per-year DTO (report + its modules)."""

--- a/backend/tests/unit/services/test_simulator_plan_service.py
+++ b/backend/tests/unit/services/test_simulator_plan_service.py
@@ -322,6 +322,65 @@ async def test_set_reference_year_missing_year_returns_none(async_session, user)
     assert await service.set_reference_year(created.id, 2031, 2024) is None
 
 
+@pytest.mark.asyncio
+async def test_set_reference_year_auto_prefills_prefilled_modules(async_session, user):
+    """Setting the reference year auto-prefills prefilled modules; others stay empty.
+
+    There is no manual prefill trigger anymore — set_reference_year is the only
+    entry point, and it must snapshot every prefilled-behavior module.
+    """
+    service = SimulatorPlanService(async_session)
+    ref_report, _, _ = await _calculator_report_with_process_entries(
+        service, async_session
+    )
+    # A non-prefilled module (purchase) with a reference entry that must NOT copy.
+    modules = await service.report_service.module_service.list_modules(ref_report.id)
+    purchase_module = next(
+        m for m in modules if m.module_type_id == int(ModuleTypeEnum.purchase)
+    )
+    async_session.add(
+        DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.scientific_equipment.value,
+            carbon_report_module_id=purchase_module.id,
+            data={"amount": 10.0},
+        )
+    )
+    await async_session.flush()
+
+    plan = await service.create_plan(unit_id=1, user=user, name="proj")
+    # No manual prefill call: the reference-year set is the only trigger.
+    report = await _plan_year_report(service, plan.id, reference_year=2024)
+
+    module_service = service.report_service.module_service
+    entry_repo = DataEntryRepository(async_session)
+
+    process_module = await module_service.get_module(
+        report.id, int(ModuleTypeEnum.process_emissions)
+    )
+    process_rows = await entry_repo.list_by_module(process_module.id)
+    assert len(process_rows) == 2
+    assert all(
+        r.source == DataEntrySourceEnum.PLANNER_SNAPSHOT.value for r in process_rows
+    )
+
+    plan_purchase = await module_service.get_module(
+        report.id, int(ModuleTypeEnum.purchase)
+    )
+    assert await entry_repo.list_by_module(plan_purchase.id) == []
+
+
+@pytest.mark.asyncio
+async def test_set_reference_year_without_calc_report_is_noop(async_session, user):
+    """A reference year with no Calculator report still sets, prefilling nothing."""
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="proj")
+    await service.update_plan(
+        created.id, SimulatorPlanUpdate(start_year=2027, end_year=2027)
+    )
+    result = await service.set_reference_year(created.id, 2027, 2024)
+    assert result is not None and result.reference_year == 2024
+
+
 # ── prefill_module_from_reference (snapshot copy) ─────────────────────────────
 
 

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -53,22 +53,6 @@
               </q-item-section>
               <q-item-section side @click.stop>
                 <div class="row items-center no-wrap q-gutter-sm">
-                  <q-btn
-                    v-if="entry.config.behavior === 'prefilled'"
-                    unelevated
-                    no-caps
-                    dense
-                    size="sm"
-                    color="negative"
-                    :label="$t('planner_module_prefill_button')"
-                    :disable="!yearData.reference_year || !entry.module"
-                    :loading="prefillingModule === entry.config.module"
-                    @click="onPrefill(entry.config.module)"
-                  >
-                    <q-tooltip v-if="!yearData.reference_year">
-                      {{ $t('planner_reference_year_hint') }}
-                    </q-tooltip>
-                  </q-btn>
                   <q-checkbox
                     :model-value="entry.module?.is_active ?? true"
                     :label="$t('planner_module_active_label')"
@@ -161,7 +145,6 @@ const plansStore = useSimulatorPlansStore();
 
 const yearOpen = ref(true);
 const settingReferenceYear = ref(false);
-const prefillingModule = ref<Module | null>(null);
 const togglingModuleId = ref<number | null>(null);
 
 const moduleEntries = computed<ModuleEntry[]>(() =>
@@ -199,6 +182,13 @@ async function onReferenceYearChange(referenceYear: number) {
       props.yearData.year,
       referenceYear,
     );
+    // Setting the reference year auto-prefills every prefilled module; refresh
+    // the open module so its snapshot rows appear without a manual reload.
+    const expanded = props.expandedKey?.startsWith(`${props.yearData.year}-`);
+    const module = props.expandedKey?.split('-').slice(1).join('-') as
+      | Module
+      | undefined;
+    if (expanded && module) await refreshExpandedModule(module);
   } catch {
     $q.notify({ type: 'negative', message: t('planner_reference_year_error') });
   } finally {
@@ -217,21 +207,6 @@ async function onToggleActive(entry: ModuleEntry, active: boolean) {
     );
   } finally {
     togglingModuleId.value = null;
-  }
-}
-
-async function onPrefill(module: Module) {
-  prefillingModule.value = module;
-  try {
-    await plansStore.prefillModule(props.yearData.id, module);
-    if (props.expandedKey === expansionKey(module)) {
-      await refreshExpandedModule(module);
-    }
-    $q.notify({ type: 'positive', message: t('planner_prefill_done') });
-  } catch {
-    $q.notify({ type: 'negative', message: t('planner_prefill_error') });
-  } finally {
-    prefillingModule.value = null;
   }
 }
 </script>

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -211,18 +211,6 @@ export default {
     en: 'Prefilled from reference year',
     fr: "Prérempli depuis l'année de référence",
   },
-  planner_module_prefill_button: {
-    en: 'Prefill',
-    fr: 'Préremplir',
-  },
-  planner_prefill_done: {
-    en: 'Module prefilled from the reference year',
-    fr: "Module prérempli depuis l'année de référence",
-  },
-  planner_prefill_error: {
-    en: 'Prefill failed — check that the reference year has Calculator data',
-    fr: "Échec du préremplissage — vérifiez que l'année de référence contient des données du Calculateur",
-  },
   planner_purchase_totals_table_title: {
     en: 'CHF total per purchase submodule',
     fr: "Total CHF par sous-module d'achats",

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -156,24 +156,6 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     );
   }
 
-  /**
-   * Snapshot-prefill a type-2 module from the plan-year's reference year
-   * (wipes previous snapshot rows, keeps user-added rows). Returns the
-   * refreshed module.
-   */
-  async function prefillModule(
-    carbonReportId: number,
-    moduleType: string,
-  ): Promise<SimulatorPlanModule> {
-    const updated = await api
-      .post(
-        `carbon-reports/${carbonReportId}/modules/${encodeURIComponent(moduleType)}/prefill`,
-      )
-      .json<SimulatorPlanModule>();
-    replaceModuleInYear(carbonReportId, updated);
-    return updated;
-  }
-
   /** Toggle a module's Active checkbox on one plan-year report. */
   async function setModuleActive(
     carbonReportId: number,
@@ -210,7 +192,6 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     renamePlan,
     fetchPlanYears,
     setReferenceYear,
-    prefillModule,
     setModuleActive,
     duplicatePlan,
     deletePlan,


### PR DESCRIPTION
## What

Removes the manual per-module **Prefill** button from the Simulator Plan (Project Planner) and makes prefill automatic.

## Trigger chosen (and why)

The task asks to "automatically prefill at carbon_report creation", but prefill **hard-requires a reference year**, and plan-year reports are created in `_sync_year_reports` **without** one — the reference year is picked later, per year. So creation-time prefill is impossible.

The only moment prefill *can* run is when the reference year is set. So **setting/changing the reference year is now the sole prefill trigger.** Previously `_resnapshot_prefilled_modules` only re-copied modules that were *already* snapshotted (by the manual button); it now prefills **every** prefilled-behavior module:

- Process Emissions, Buildings, Equipments, Research Facilities, External Clouds & AI

copied at 100% from the reference year's Calculator data, exactly as the manual path did. The `%`-slider / `percentage_of_reference_year` behavior is unchanged.

Setting a reference year for which the unit has **no Calculator report** is a no-op (nothing to copy) rather than an error, so a reference year can always be set.

## Changes

**Backend**
- `module_type.py`: new `PLANNER_PREFILLED_MODULE_TYPES` set (mirrors the frontend `behavior === 'prefilled'` config).
- `simulator_plan_service.py`: `_resnapshot_prefilled_modules` → `_prefill_reference_modules`, prefilling all prefilled-behavior modules on reference-year set.
- Removed the now-dead `POST /carbon-reports/{id}/modules/{module_id}/prefill` route and the unused `list_module_ids_with_source` repo method (no backward-compat requirement).

**Frontend**
- Removed the Prefill `q-btn`, `prefillingModule`, `onPrefill`, the `prefillModule` store action, and the unused i18n keys (`planner_module_prefill_button`, `planner_prefill_done`, `planner_prefill_error`).
- After a reference-year change, the open module is refreshed so snapshot rows appear without a reload.
- Kept the reference-kg column + `%` slider and the "Prefilled from reference year" badge key.

## Tests / gates

- Backend `ruff` ✅, `ty` ✅, `pytest tests/unit/services/test_simulator_plan_service.py` → 29 passed ✅ (new: `test_set_reference_year_auto_prefills_prefilled_modules` proves prefill happens with no manual call and non-prefilled modules stay empty; `test_set_reference_year_without_calc_report_is_noop`).
- Frontend `make type-check` (vue-tsc) ✅, `eslint` ✅.