### PR TITLE
fix: headcount ingest/aggregation stage incident — cross-source replace, stuck-job recovery, ops visibility (#1564)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -216,7 +216,7 @@ FORMULA_VERSION_SHA256_SHORT=12ac4b6fde65760a5c84f7ab56a518cde056c09c
 # Max NOT_STARTED jobs dispatched per sweep (>= 1)
 # POLLER_BATCH_LIMIT=100
 # Minutes before a RUNNING job is considered stale and auto-recovered
-# STALE_JOB_TIMEOUT_MINUTES=60
+# STALE_JOB_TIMEOUT_MINUTES=5
 
 # -----------------------------------------------------------------------------
 # Bulk Ingest Performance

--- a/backend/alembic/versions/2026_07_17_1215-7bfda0d45f14_add_created_at_to_data_ingestion_jobs.py
+++ b/backend/alembic/versions/2026_07_17_1215-7bfda0d45f14_add_created_at_to_data_ingestion_jobs.py
@@ -1,0 +1,48 @@
+# codeql[py/unused-global-variable]
+"""add created_at to data_ingestion_jobs
+
+Revision ID: 7bfda0d45f14
+Revises: 3f1c7a94be2e
+Create Date: 2026-07-17 12:15:49.510720
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7bfda0d45f14"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "3f1c7a94be2e"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # False-positive drop_index on uq_active_datasource_per_module pruned
+    # (partial unique index lives outside SQLModel metadata).
+    op.add_column(
+        "data_ingestion_jobs",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("data_ingestion_jobs", "created_at")

--- a/backend/alembic/versions/2026_07_17_1511-8eeff0a9fa26_backfill_data_entries_year_and_unit_id_.py
+++ b/backend/alembic/versions/2026_07_17_1511-8eeff0a9fa26_backfill_data_entries_year_and_unit_id_.py
@@ -1,0 +1,58 @@
+# codeql[py/unused-global-variable]
+"""backfill data_entries year and unit_id from carbon reports
+
+Revision ID: 8eeff0a9fa26
+Revises: 7bfda0d45f14
+Create Date: 2026-07-17 15:11:57.728216
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8eeff0a9fa26"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "7bfda0d45f14"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Backfill denormalized scope columns on API-synced data entries.
+
+    API providers built DataEntry rows without ``year``/``unit_id``
+    (stage incident 2026-07-17), so the per-year cross-source replace
+    DELETE — which keys on ``data_entries.year`` — never matched them
+    and re-uploads mass-collided on DUPLICATE_INSTITUTIONAL_ID. Derive
+    both from the entry's carbon report. (False-positive drop_index on
+    uq_active_datasource_per_module pruned — partial unique index lives
+    outside SQLModel metadata.)
+    """
+    op.execute(
+        sa.text(
+            """
+            UPDATE data_entries de
+            SET year = cr.year,
+                unit_id = cr.unit_id
+            FROM carbon_report_modules crm
+            JOIN carbon_reports cr ON cr.id = crm.carbon_report_id
+            WHERE de.carbon_report_module_id = crm.id
+              AND (de.year IS NULL OR de.unit_id IS NULL)
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """No-op: the backfill only fills NULLs with derivable values."""

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -585,6 +585,24 @@ def _resolve_enum_name(
     )
 
 
+def _job_is_stale(job: DataIngestionJob, cutoff: datetime) -> bool:
+    """RUNNING with a lock heartbeat older than the stale window.
+
+    Mirrors ``sweep_stuck_running_jobs``'s predicate so the console badge
+    and the auto-recovery sweep agree on what "stuck" means.
+    """
+    if job.state != IngestionState.RUNNING:
+        return False
+    if job.locked_at is None:
+        return True
+    locked_at = job.locked_at
+    # SQLite test DBs return tz-naive datetimes for tz-aware columns
+    # (same quirk handled in ``recover_job``); Postgres is always aware.
+    if locked_at.tzinfo is None:
+        locked_at = locked_at.replace(tzinfo=timezone.utc)
+    return locked_at < cutoff
+
+
 class PipelineJobListEntry(BaseModel):
     """One job inside a pipeline, as shown in the ops-console DAG (#1234).
 
@@ -611,9 +629,20 @@ class PipelineJobListEntry(BaseModel):
     # the table shows names, not integers, with no frontend drift).
     data_entry_type_label: Optional[str] = None
     year: Optional[int] = None
+    # created_at → started_at is queue wait (chain/lock/poller latency);
+    # started_at → finished_at is execution. The console shows both so a
+    # sub-second aggregation that waited 20s behind its recalc sibling
+    # doesn't read as "<1s total".
+    created_at: Optional[datetime] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
     attempts: Optional[int] = None
+    # Derived server-side (backend owns the staleness rule): RUNNING with a
+    # lock heartbeat older than STALE_JOB_TIMEOUT_MINUTES — the owning pod
+    # died mid-job. The console renders a badge + the manual Recover button
+    # (POST /jobs/{id}/recover only accepts stale rows, so gating the button
+    # on this flag mirrors the endpoint's own 409 rule).
+    is_stale: bool = False
     meta: dict = {}
 
     @field_serializer("state")
@@ -1559,6 +1588,9 @@ async def list_pipelines(
                 crm_ids.add(crm)
     inst_by_crm = await _institutional_ids_for_crms(db, list(crm_ids))
 
+    stale_cutoff = datetime.now(timezone.utc) - timedelta(
+        minutes=get_settings().STALE_JOB_TIMEOUT_MINUTES
+    )
     items: list[PipelineListItem] = []
     for group in groups:
         jobs = group["jobs"]
@@ -1619,9 +1651,11 @@ async def list_pipelines(
                         data_entry_type_id=j.data_entry_type_id,
                         data_entry_type_label=_det_label(j.data_entry_type_id),
                         year=j.year,
+                        created_at=j.created_at,
                         started_at=j.started_at,
                         finished_at=j.finished_at,
                         attempts=j.attempts,
+                        is_stale=_job_is_stale(j, stale_cutoff),
                         meta=_project_pipeline_meta(
                             j.meta,
                             include_factor_errors=j.target_type == TargetType.FACTORS,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -637,6 +637,11 @@ class PipelineJobListEntry(BaseModel):
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
     attempts: Optional[int] = None
+    # Pod that claimed this job (``locked_by``). With a shared DB, a local
+    # dev process and cluster pods compete for the same NOT_STARTED rows —
+    # showing the owner makes mixed-ownership chains diagnosable at a
+    # glance (the local+dev-DB scenario, 2026-07-17).
+    worker: Optional[str] = None
     # Derived server-side (backend owns the staleness rule): RUNNING with a
     # lock heartbeat older than STALE_JOB_TIMEOUT_MINUTES — the owning pod
     # died mid-job. The console renders a badge + the manual Recover button
@@ -1655,6 +1660,7 @@ async def list_pipelines(
                         started_at=j.started_at,
                         finished_at=j.finished_at,
                         attempts=j.attempts,
+                        worker=j.locked_by,
                         is_stale=_job_is_stale(j, stale_cutoff),
                         meta=_project_pipeline_meta(
                             j.meta,

--- a/backend/app/api/v1/data_sync.py
+++ b/backend/app/api/v1/data_sync.py
@@ -42,13 +42,19 @@ from app.models.pod import Pod
 from app.models.unit import Unit
 from app.models.user import User
 from app.models.year_configuration import YearConfiguration
-from app.repositories.data_ingestion import DataIngestionRepository, WhyStaleLiteral
+from app.repositories.data_ingestion import (
+    DataIngestionRepository,
+    WhyStaleLiteral,
+    is_job_stale,
+    stale_job_cutoff,
+)
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 from app.services.data_ingestion.provider_factory import ProviderFactory
 from app.services.pipeline_progress import PhaseLabel, compute_pipeline_progress
 from app.tasks._background import fire_and_forget
 from app.tasks.runner import run_job
 from app.tasks.unit_sync_tasks import SyncUnitRequest
+from app.utils.datetime_utc import as_utc
 from app.utils.request_context import extract_ip_address, extract_route_payload
 from app.utils.scoping import (
     can_view_module_flow,
@@ -583,24 +589,6 @@ def _resolve_enum_name(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         detail=f"Invalid {field} '{value}'. Expected one of: {valid}",
     )
-
-
-def _job_is_stale(job: DataIngestionJob, cutoff: datetime) -> bool:
-    """RUNNING with a lock heartbeat older than the stale window.
-
-    Mirrors ``sweep_stuck_running_jobs``'s predicate so the console badge
-    and the auto-recovery sweep agree on what "stuck" means.
-    """
-    if job.state != IngestionState.RUNNING:
-        return False
-    if job.locked_at is None:
-        return True
-    locked_at = job.locked_at
-    # SQLite test DBs return tz-naive datetimes for tz-aware columns
-    # (same quirk handled in ``recover_job``); Postgres is always aware.
-    if locked_at.tzinfo is None:
-        locked_at = locked_at.replace(tzinfo=timezone.utc)
-    return locked_at < cutoff
 
 
 class PipelineJobListEntry(BaseModel):
@@ -1225,7 +1213,7 @@ async def list_workers(
     # of an in-Python filter so a schema-drift dev DB (``pods``
     # column still ``TIMESTAMP`` without TZ from before the model
     # moved to ``DateTime(timezone=True)``) doesn't explode the
-    # comparison — see ``_as_utc`` below.  Production never serves
+    # comparison — see ``as_utc``.  Production never serves
     # naive rows; this is purely defensive for long-lived dev DBs.
     pods_all = (
         (await db.execute(select(Pod).order_by(col(Pod.last_heartbeat_at).desc())))
@@ -1233,21 +1221,7 @@ async def list_workers(
         .all()
     )
 
-    def _as_utc(dt: datetime) -> datetime:
-        """Coerce tz-naive datetimes to UTC.
-
-        Defends against the schema-drift case where ``pods`` was
-        created with plain ``TIMESTAMP`` (no TZ) before the model
-        moved to ``DateTime(timezone=True)`` — ``SQLModel.metadata.
-        create_all`` doesn't ALTER existing tables, so a long-lived
-        dev DB still serves naive values.  Treating naive rows as
-        UTC matches what the heartbeat writer was always producing
-        (``datetime.now(timezone.utc)``) and keeps the subtraction
-        below from blowing up.
-        """
-        return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
-
-    pods = [p for p in pods_all if _as_utc(p.last_heartbeat_at) >= cutoff]
+    pods = [p for p in pods_all if as_utc(p.last_heartbeat_at) >= cutoff]
     if not pods:
         return []
 
@@ -1275,10 +1249,10 @@ async def list_workers(
             pod_id=p.pod_id,
             git_sha=p.git_sha,
             app_version=p.app_version,
-            started_at=_as_utc(p.started_at),
-            last_heartbeat_at=_as_utc(p.last_heartbeat_at),
+            started_at=as_utc(p.started_at),
+            last_heartbeat_at=as_utc(p.last_heartbeat_at),
             heartbeat_age_seconds=int(
-                (now - _as_utc(p.last_heartbeat_at)).total_seconds()
+                (now - as_utc(p.last_heartbeat_at)).total_seconds()
             ),
             claimed_job_count=claimed_by_pod.get(p.pod_id, 0),
         )
@@ -1593,9 +1567,7 @@ async def list_pipelines(
                 crm_ids.add(crm)
     inst_by_crm = await _institutional_ids_for_crms(db, list(crm_ids))
 
-    stale_cutoff = datetime.now(timezone.utc) - timedelta(
-        minutes=get_settings().STALE_JOB_TIMEOUT_MINUTES
-    )
+    stale_cutoff = stale_job_cutoff(get_settings().STALE_JOB_TIMEOUT_MINUTES)
     items: list[PipelineListItem] = []
     for group in groups:
         jobs = group["jobs"]
@@ -1661,7 +1633,7 @@ async def list_pipelines(
                         finished_at=j.finished_at,
                         attempts=j.attempts,
                         worker=j.locked_by,
-                        is_stale=_job_is_stale(j, stale_cutoff),
+                        is_stale=is_job_stale(j, stale_cutoff),
                         meta=_project_pipeline_meta(
                             j.meta,
                             include_factor_errors=j.target_type == TargetType.FACTORS,
@@ -2121,8 +2093,9 @@ async def recover_job(
     Recover a job stuck in RUNNING after a pod crash.
 
     Resets the job to NOT_STARTED and clears the lock. Only allowed
-    when ``locked_at`` is older than ``STALE_JOB_TIMEOUT_MINUTES`` (default 30 min).
-
+    when ``locked_at`` is older than ``STALE_JOB_TIMEOUT_MINUTES`` —
+    the same window the auto-recovery sweep and the console's stale
+    badge use, so the button only appears when this call will succeed.
     """
     settings = get_settings()
     repo = DataIngestionRepository(db)

--- a/backend/app/api/v1/workspace_home.py
+++ b/backend/app/api/v1/workspace_home.py
@@ -41,6 +41,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.api.v1.carbon_report_module_stats import build_validated_totals
+from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.policy import require_unit_access
 from app.models.carbon_report import CarbonReportModule
@@ -51,6 +52,7 @@ from app.services.carbon_report_service import CarbonReportService
 
 logger = get_logger(__name__)
 router = APIRouter()
+settings = get_settings()
 
 
 class HomeYearConfiguration(BaseModel):
@@ -69,6 +71,10 @@ class HomeYearConfiguration(BaseModel):
 
     year: int
     config: Dict[str, Any]
+    # The frontend's yearConfig store hard-errors on any year-config payload
+    # missing this bound (#1204 follow-up), and the workspace guard feeds this
+    # slim shape straight into it — so the aggregate must carry it too.
+    min_configurable_year: int
 
 
 async def build_home_year_configuration(
@@ -91,7 +97,11 @@ async def build_home_year_configuration(
     if not result:
         return None
 
-    return HomeYearConfiguration(year=result.year, config=result.config)
+    return HomeYearConfiguration(
+        year=result.year,
+        config=result.config,
+        min_configurable_year=settings.MIN_CONFIGURABLE_YEAR,
+    )
 
 
 class WorkspaceHomeResponse(BaseModel):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -400,17 +400,20 @@ class Settings(BaseSettings):
 
     # Background job safety (Plan 310A + auto-recovery sweep, PR #998)
     STALE_JOB_TIMEOUT_MINUTES: int = Field(
-        default=60,
+        default=5,
         description=(
             "Minutes before a RUNNING job is considered stale.  Doubles as "
             "the auto-recovery sweep's threshold: jobs whose ``locked_at`` "
             "is older than this are reset to NOT_STARTED (or marked "
-            "FINISHED+ERROR if attempts >= max_attempts).  Until the worker "
-            "heartbeats ``locked_at`` (planned in 310C), set this *above* "
-            "the longest plausible job runtime — otherwise the sweep will "
-            "preempt a still-working pod and trigger duplicate processing.  "
-            "60 min gives ample headroom for current ingest/recalc loads; "
-            "raise if a specific job type is expected to run longer."
+            "FINISHED+ERROR if attempts >= max_attempts).  The 310-C runner "
+            "heartbeats ``locked_at`` every quarter of this window, so the "
+            "value bounds *crash recovery latency*, not job runtime — a "
+            "healthy long-running job is never falsely recovered.  Keep it "
+            "high enough that transient DB outages shorter than the window "
+            "don't make a live runner self-abort (see ``_heartbeat_loop``); "
+            "5 min = 75s heartbeats and ~5-6 min worst-case recovery after "
+            "a pod dies mid-job (stage incident 2026-07-17: the old 60 min "
+            "default left a killed aggregation invisible for an hour)."
         ),
     )
     # #1723 — bounds every run_job dispatch path (poller sweep, chain_job

--- a/backend/app/models/data_entry.py
+++ b/backend/app/models/data_entry.py
@@ -66,6 +66,18 @@ class DataEntrySourceEnum(int, Enum):
     EXTERNAL_INTEGRATION = 5  # Third-party integration or import
 
 
+# Machine-owned bulk per-year sources. A per-year ingest (CSV upload or API
+# sync) is a complete yearly export, so it replaces ALL of these — a CSV
+# upload after an API sync (or vice versa) must not collide with the other
+# mechanism's rows. Manual entries (USER_MANUAL) and unit-specific uploads
+# (*_UNIT_SPECIFIC) are operator-owned and always preserved.
+BULK_PER_YEAR_SOURCES: tuple[DataEntrySourceEnum, ...] = (
+    DataEntrySourceEnum.CSV_MODULE_PER_YEAR,
+    DataEntrySourceEnum.API_MODULE_PER_YEAR,
+    DataEntrySourceEnum.EXTERNAL_INTEGRATION,
+)
+
+
 ## Will be renamed to data_entries later
 class DataEntryBase(SQLModel):
     """Base module model with shared fields."""

--- a/backend/app/models/data_ingestion.py
+++ b/backend/app/models/data_ingestion.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 from uuid import UUID
@@ -266,6 +266,18 @@ class DataIngestionJob(DataIngestionJobBase, table=True):
     )
 
     # Observability (Plan 310C)
+    created_at: Optional[datetime] = Field(
+        # Python-side stamp (repo convention) so the ORM never sends an
+        # explicit NULL past the server_default; the server_default remains
+        # for the migration backfill of pre-existing rows.
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(SADateTime(timezone=True), server_default=text("now()")),
+        description=(
+            "Timestamp the job row was created.  created_at → started_at is "
+            "queue wait (chain/lock/poller latency); started_at → finished_at "
+            "is execution — the ops console shows both."
+        ),
+    )
     started_at: Optional[datetime] = Field(
         default=None,
         sa_column=Column(SADateTime(timezone=True)),

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -259,6 +259,14 @@ class DataEntryRepository:
         ``check_member_role_unique`` SELECT at stage latencies turned an
         8.5k-row parse into ~10 minutes (14 rows/s, 2026-07-17), the same
         N+1 shape the COPY batching already removed on the write side.
+
+        Snapshot semantics: concurrent bulk writers are serialized by the
+        per-(module_type, year) advisory lock at dispatch, but that lock is
+        transaction-scoped and drops at each batch commit, so a writer
+        committing mid-file is invisible to an already-taken snapshot. The
+        airtight guard is the DB-enforced partial unique index deferred in
+        the 1564 incident plan; until then this is no weaker than the old
+        per-row check-then-COPY, just a wider read-to-write window.
         """
         if not carbon_report_module_ids:
             return set()

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -249,6 +249,34 @@ class DataEntryRepository:
         await self.session.flush()
         return bool(deleted)
 
+    async def get_member_role_keys(
+        self, carbon_report_module_ids: list[int]
+    ) -> set[tuple[int, str, str]]:
+        """Bulk-fetch existing member (module, uid, sius_code) role keys.
+
+        Seeds the CSV ingest's in-memory duplicate set in ONE query so the
+        row loop never round-trips per row — the per-row
+        ``check_member_role_unique`` SELECT at stage latencies turned an
+        8.5k-row parse into ~10 minutes (14 rows/s, 2026-07-17), the same
+        N+1 shape the COPY batching already removed on the write side.
+        """
+        if not carbon_report_module_ids:
+            return set()
+        stmt = select(
+            col(DataEntry.carbon_report_module_id),
+            DataEntry.data["user_institutional_id"].as_string(),
+            DataEntry.data["sius_code"].as_string(),
+        ).where(
+            col(DataEntry.carbon_report_module_id).in_(carbon_report_module_ids),
+            col(DataEntry.data_entry_type_id) == DataEntryTypeEnum.member.value,
+        )
+        rows = (await self.session.execute(stmt)).all()
+        return {
+            (module_id, uid, sius)
+            for module_id, uid, sius in rows
+            if uid is not None and sius is not None
+        }
+
     async def check_json_field_unique(
         self,
         carbon_report_module_id: int,

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -190,22 +190,23 @@ class DataEntryRepository:
         self,
         year: int,
         data_entry_type_ids: list[int],
-        source: int,  # DataEntrySourceEnum value
+        sources: list[int],  # DataEntrySourceEnum values
     ) -> int:
         """Full-year replace delete for MODULE_PER_YEAR ingest.
 
-        Per-year CSVs are complete exports: a new upload replaces ALL
-        prior rows of that (year, type, source) regardless of unit, so
-        the delete keys on the denormalized ``data_entries.year`` column
-        — no module-tree resolution, one indexed statement.  Returns
-        the number of rows deleted.
+        Per-year feeds (CSV or API) are complete exports: a new ingest
+        replaces ALL prior rows of that (year, type) across the given
+        sources regardless of unit, so the delete keys on the
+        denormalized ``data_entries.year`` column — no module-tree
+        resolution, one indexed statement.  Returns the number of rows
+        deleted.
         """
-        if not data_entry_type_ids:
+        if not data_entry_type_ids or not sources:
             return 0
         statement = delete(DataEntry).where(
             col(DataEntry.year) == year,
             col(DataEntry.data_entry_type_id).in_(data_entry_type_ids),
-            col(DataEntry.source) == source,
+            col(DataEntry.source).in_(sources),
         )
         result = await self.session.execute(statement)
         await self.session.flush()

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -1155,19 +1155,12 @@ class DataIngestionRepository:
 
         Returns ``(recovered_count, abandoned_count)``.
 
-        ⚠️ **No heartbeat (yet)**: ``locked_at`` is set ONCE by
-        ``claim_job`` and never refreshed during execution, so any
-        legitimately long-running job whose runtime exceeds
-        ``stale_timeout_minutes`` will be falsely classified as stale.
-        That triggers duplicate processing — the sweep recovers the row,
-        another pod claims and re-runs it, while the original pod is
-        still working toward its commit.  Mitigation today: set
-        ``STALE_JOB_TIMEOUT_MINUTES`` *above* the longest plausible job
-        runtime (default 60 min, raise if needed).  Plan 310C wires a
-        per-job heartbeat into the generic ``run_job`` runner; until
-        then, this method shares the same long-running-job hazard as the
-        manual ``recover_job`` path — the sweep just exercises it more
-        often.
+        ``locked_at`` is refreshed by the 310-C runner's per-job
+        heartbeat (``_heartbeat_loop``, every quarter of the stale
+        window), so a healthy long-running job never trips this sweep —
+        the timeout bounds *crash recovery latency* only.  Staleness
+        here means the owning pod stopped heartbeating: crashed, was
+        evicted, or was SIGTERMed mid-job (stage incident 2026-07-17).
         """
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=stale_timeout_minutes)
         stale_filter = and_(

--- a/backend/app/repositories/data_ingestion.py
+++ b/backend/app/repositories/data_ingestion.py
@@ -21,8 +21,43 @@ from app.models.data_ingestion import (
     TargetType,
 )
 from app.models.user import UserProvider
+from app.utils.datetime_utc import as_utc
 
 logger = get_logger(__name__)
+
+
+def stale_job_cutoff(stale_timeout_minutes: int) -> datetime:
+    """The instant before which an unrefreshed lock heartbeat counts as stale."""
+    return datetime.now(timezone.utc) - timedelta(minutes=stale_timeout_minutes)
+
+
+def stale_running_clause(cutoff: datetime):
+    """SQL predicate for a stuck job: RUNNING with a heartbeat older than cutoff.
+
+    Single source of truth for "stuck" — the auto-recovery sweep, the manual
+    ``recover_job`` gate, and the ops-console stale badge (``is_job_stale``)
+    all derive from here so they can never disagree on when Recover works.
+    """
+    return and_(
+        col(DataIngestionJob.state) == IngestionState.RUNNING,
+        or_(
+            col(DataIngestionJob.locked_at).is_(None),
+            col(DataIngestionJob.locked_at) < cutoff,
+        ),
+    )
+
+
+def is_job_stale(job: DataIngestionJob, cutoff: datetime) -> bool:
+    """Python twin of ``stale_running_clause`` for already-loaded rows.
+
+    Used by the ops-console listing to derive the stale badge without a
+    second query. ``test_stale_predicate_parity`` locks the two together.
+    """
+    if job.state != IngestionState.RUNNING:
+        return False
+    if job.locked_at is None:
+        return True
+    return as_utc(job.locked_at) < cutoff
 
 
 class _ClaimUnavailable(Exception):
@@ -1162,14 +1197,7 @@ class DataIngestionRepository:
         here means the owning pod stopped heartbeating: crashed, was
         evicted, or was SIGTERMed mid-job (stage incident 2026-07-17).
         """
-        cutoff = datetime.now(timezone.utc) - timedelta(minutes=stale_timeout_minutes)
-        stale_filter = and_(
-            col(DataIngestionJob.state) == IngestionState.RUNNING,
-            or_(
-                col(DataIngestionJob.locked_at).is_(None),
-                col(DataIngestionJob.locked_at) < cutoff,
-            ),
-        )
+        stale_filter = stale_running_clause(stale_job_cutoff(stale_timeout_minutes))
 
         # Bucket 1: still has retries left → unlock and let claim_job pick
         # it up next cycle.  Preserve ``attempts`` so claim_job's
@@ -1226,16 +1254,11 @@ class DataIngestionRepository:
         Atomic UPDATE — safe under concurrent claim/recover.  Only succeeds
         when locked_at is older than ``stale_timeout_minutes`` (or NULL).
         """
-        cutoff = datetime.now(timezone.utc) - timedelta(minutes=stale_timeout_minutes)
         result = await self.session.execute(
             update(DataIngestionJob)
             .where(
                 col(DataIngestionJob.id) == job_id,
-                col(DataIngestionJob.state) == IngestionState.RUNNING,
-                or_(
-                    col(DataIngestionJob.locked_at).is_(None),
-                    col(DataIngestionJob.locked_at) < cutoff,
-                ),
+                stale_running_clause(stale_job_cutoff(stale_timeout_minutes)),
             )
             .values(
                 state=IngestionState.NOT_STARTED,

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -10,6 +10,7 @@ from sqlite3 import IntegrityError
 from typing import Any, Dict, List, Optional
 
 from fastapi import BackgroundTasks
+from fastapi.encoders import jsonable_encoder
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -206,6 +207,14 @@ class AuditDocumentService:
         Returns:
             The newly created AuditDocument
         """
+        # JSON-safety at the boundary, not in N callers: the snapshot and
+        # payload land in JSON columns serialized by the plain json.dumps
+        # in app.db (no default=) — a datetime/UUID/Decimal from any caller
+        # would 500 the flush (stage incident 2026-07-17, job created_at).
+        data_snapshot = jsonable_encoder(data_snapshot)
+        if route_payload is not None:
+            route_payload = jsonable_encoder(route_payload)
+
         # Get current version to compute diff and hash chain
         current = await self.get_current_version(entity_type, entity_id)
 

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -5,11 +5,13 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import BackgroundTasks
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.models.audit import AuditChangeTypeEnum
+from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import DataEntry, DataEntryTypeEnum
 
 # from app.repositories.headcount_repo import HeadCountRepository
@@ -109,6 +111,50 @@ class DataEntryService:
             exclude_id=exclude_id,
         )
 
+    async def fill_denormalized_scope(self, data_entries: list[DataEntry]) -> None:
+        """Stamp denormalized ``year``/``unit_id`` from each entry's carbon report.
+
+        Central guarantee, not per-provider convention: the per-year
+        cross-source replace DELETE keys on ``data_entries.year`` and the
+        factor join keys on it too, so a NULL-year row silently escapes
+        both (stage incident 2026-07-17: API-synced rows without the stamp
+        survived every replace). One query per call over the distinct
+        module ids still missing a value; already-stamped entries cost
+        nothing. Unknown module ids are left for the FK to reject loudly.
+        """
+        module_ids = {
+            e.carbon_report_module_id
+            for e in data_entries
+            if (e.year is None or e.unit_id is None)
+            and e.carbon_report_module_id is not None
+        }
+        if not module_ids:
+            return
+        stmt = (
+            select(
+                col(CarbonReportModule.id),
+                col(CarbonReport.year),
+                col(CarbonReport.unit_id),
+            )
+            .join(
+                CarbonReport,
+                col(CarbonReport.id) == col(CarbonReportModule.carbon_report_id),
+            )
+            .where(col(CarbonReportModule.id).in_(module_ids))
+        )
+        scope = {
+            module_id: (year, unit_id)
+            for module_id, year, unit_id in (await self.session.execute(stmt)).all()
+        }
+        for entry in data_entries:
+            resolved = scope.get(entry.carbon_report_module_id)
+            if resolved is None:
+                continue
+            if entry.year is None:
+                entry.year = resolved[0]
+            if entry.unit_id is None:
+                entry.unit_id = resolved[1]
+
     async def create(
         self,
         carbon_report_module_id: int,
@@ -137,6 +183,7 @@ class DataEntryService:
         if created_by_id is not None:
             entry.created_by_id = created_by_id
 
+        await self.fill_denormalized_scope([entry])
         created_entry = await self.repo.create(entry)
 
         # 3. replace by flush; commit should happen in 'orchestrator' or 'route'
@@ -208,6 +255,7 @@ class DataEntryService:
                 if created_by_id is not None:
                     entry.created_by_id = created_by_id
 
+        await self.fill_denormalized_scope(data_entries)
         db_objs = await self.repo.bulk_create(data_entries)
         await self.session.flush()  # Ensure data_entry IDs are populated
 
@@ -281,6 +329,7 @@ class DataEntryService:
                 entry.source = source
             if created_by_id is not None:
                 entry.created_by_id = created_by_id
+        await self.fill_denormalized_scope(data_entries)
         count = await self.repo.bulk_copy(data_entries)
         logger.info(f"COPY-inserted {count} data entries (job {sanitize(job_id)})")
         return count

--- a/backend/app/services/data_ingestion/api_providers/base_tableau_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/base_tableau_api_provider.py
@@ -97,27 +97,6 @@ class BaseTableauApiProvider(DataIngestionProvider):
     INGEST_NOUN: str = "data"
     MISSING_UNIT_REASON: str = "Missing unit (Centre financier)"
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        # module_id → unit_id, filled by _resolve_carbon_report_modules;
-        # stamps the denormalized DataEntry.unit_id at entry build time.
-        self._module_to_unit_id: dict[int, int] = {}
-
-    @property
-    def _ingest_year(self) -> int:
-        """Denormalized ``DataEntry.year`` for the entries this ingest builds.
-
-        The per-year cross-source replace DELETE keys on
-        ``data_entries.year``, so API rows must carry it exactly like CSV
-        rows do (stage incident 2026-07-17: NULL-year API rows survived
-        every replace and mass-collided re-uploads on
-        DUPLICATE_INSTITUTIONAL_ID).
-        """
-        year = self.config.get("year")
-        if year is None:
-            raise ValueError(f"year is required for {self.INGEST_NOUN} data import")
-        return int(year)
-
     @staticmethod
     def _strip_unit_prefix(unit_id: str | None) -> str | None:
         """Strip a single leading letter from unit IDs like 'F0828'."""
@@ -545,7 +524,6 @@ class BaseTableauApiProvider(DataIngestionProvider):
         year = self.config.get("year")
         if not year:
             raise ValueError(f"year is required for {self.INGEST_NOUN} data import")
-        self._module_to_unit_id = {}
 
         module_type_id = self.module_type_id
         if not module_type_id and self.job and self.job.module_type_id:
@@ -643,7 +621,6 @@ class BaseTableauApiProvider(DataIngestionProvider):
 
             # Map institutional_id to carbon_report_module_id
             code_to_module_map[unit_institutional_id] = carbon_report_module.id
-            self._module_to_unit_id[carbon_report_module.id] = unit_id
 
         logger.info(
             f"Resolved carbon_report_module_ids for {len(code_to_module_map)} units"

--- a/backend/app/services/data_ingestion/api_providers/base_tableau_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/base_tableau_api_provider.py
@@ -97,6 +97,27 @@ class BaseTableauApiProvider(DataIngestionProvider):
     INGEST_NOUN: str = "data"
     MISSING_UNIT_REASON: str = "Missing unit (Centre financier)"
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # module_id → unit_id, filled by _resolve_carbon_report_modules;
+        # stamps the denormalized DataEntry.unit_id at entry build time.
+        self._module_to_unit_id: dict[int, int] = {}
+
+    @property
+    def _ingest_year(self) -> int:
+        """Denormalized ``DataEntry.year`` for the entries this ingest builds.
+
+        The per-year cross-source replace DELETE keys on
+        ``data_entries.year``, so API rows must carry it exactly like CSV
+        rows do (stage incident 2026-07-17: NULL-year API rows survived
+        every replace and mass-collided re-uploads on
+        DUPLICATE_INSTITUTIONAL_ID).
+        """
+        year = self.config.get("year")
+        if year is None:
+            raise ValueError(f"year is required for {self.INGEST_NOUN} data import")
+        return int(year)
+
     @staticmethod
     def _strip_unit_prefix(unit_id: str | None) -> str | None:
         """Strip a single leading letter from unit IDs like 'F0828'."""
@@ -524,6 +545,7 @@ class BaseTableauApiProvider(DataIngestionProvider):
         year = self.config.get("year")
         if not year:
             raise ValueError(f"year is required for {self.INGEST_NOUN} data import")
+        self._module_to_unit_id = {}
 
         module_type_id = self.module_type_id
         if not module_type_id and self.job and self.job.module_type_id:
@@ -621,6 +643,7 @@ class BaseTableauApiProvider(DataIngestionProvider):
 
             # Map institutional_id to carbon_report_module_id
             code_to_module_map[unit_institutional_id] = carbon_report_module.id
+            self._module_to_unit_id[carbon_report_module.id] = unit_id
 
         logger.info(
             f"Resolved carbon_report_module_ids for {len(code_to_module_map)} units"

--- a/backend/app/services/data_ingestion/api_providers/base_tableau_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/base_tableau_api_provider.py
@@ -26,7 +26,7 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.url_safety import validate_external_url
 from app.models.connector import ConnectorConnection, ConnectorType
-from app.models.data_entry import DataEntrySourceEnum, DataEntryTypeEnum
+from app.models.data_entry import BULK_PER_YEAR_SOURCES, DataEntryTypeEnum
 from app.models.data_ingestion import IngestionResult, IngestionState
 from app.models.module_type import ModuleTypeEnum
 from app.repositories.unit_repo import UnitRepository
@@ -785,13 +785,14 @@ class BaseTableauApiProvider(DataIngestionProvider):
         raise ValueError(error_msg)
 
     async def _delete_existing_api_entries(self) -> int:
-        """Replace this provider's prior API import for the target year.
+        """Replace prior bulk per-year ingests for the target year.
 
-        API feeds are complete yearly exports. Delete only rows created by an
-        external integration for this provider's data-entry type, preserving
-        manual entries and CSV uploads. This is called only after at least one
-        valid replacement row has survived transformation and module
-        resolution.
+        API feeds are complete yearly exports. Delete every machine-owned
+        bulk source (prior API syncs AND per-year CSV uploads — see
+        ``BULK_PER_YEAR_SOURCES``) for this provider's data-entry type,
+        preserving manual entries and unit-specific uploads. This is called
+        only after at least one valid replacement row has survived
+        transformation and module resolution.
         """
         year = self.config.get("year")
         if year is None:
@@ -801,10 +802,10 @@ class BaseTableauApiProvider(DataIngestionProvider):
         deleted_rows = await service.repo.bulk_delete_by_source_year(
             year=int(year),
             data_entry_type_ids=[self.DATA_ENTRY_TYPE.value],
-            source=DataEntrySourceEnum.EXTERNAL_INTEGRATION.value,
+            sources=[s.value for s in BULK_PER_YEAR_SOURCES],
         )
         logger.info(
-            "Deleted %s data entries from the previous %s API import "
+            "Deleted %s data entries from the previous %s bulk ingest "
             "(year=%s, data_entry_type_id=%s)",
             deleted_rows,
             self.INGEST_NOUN,

--- a/backend/app/services/data_ingestion/api_providers/headcount_members_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/headcount_members_api_provider.py
@@ -124,10 +124,6 @@ class HeadcountMembersApiProvider(BaseTableauApiProvider):
                 "fte": record["fte"],
                 "note": record.get("note"),
             },
-            # Denormalized scope columns, mirroring the CSV path — the
-            # per-year cross-source replace DELETE keys on ``year``.
-            year=self._ingest_year,
-            unit_id=self._module_to_unit_id.get(carbon_report_module_id),
         )
 
     async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/backend/app/services/data_ingestion/api_providers/headcount_members_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/headcount_members_api_provider.py
@@ -124,6 +124,10 @@ class HeadcountMembersApiProvider(BaseTableauApiProvider):
                 "fte": record["fte"],
                 "note": record.get("note"),
             },
+            # Denormalized scope columns, mirroring the CSV path — the
+            # per-year cross-source replace DELETE keys on ``year``.
+            year=self._ingest_year,
+            unit_id=self._module_to_unit_id.get(carbon_report_module_id),
         )
 
     async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -204,14 +204,12 @@ class ProfessionalTravelApiProvider(BaseTableauApiProvider):
             if override is not None:
                 data_payload[KG_CO2EQ_OVERRIDE_KEY] = override
 
+            # year/unit_id are stamped centrally by
+            # DataEntryService.fill_denormalized_scope in bulk_create.
             entry = DataEntry(
                 carbon_report_module_id=carbon_report_module_id,
                 data_entry_type_id=DataEntryTypeEnum.plane.value,
                 data=data_payload,
-                # Denormalized scope columns, mirroring the CSV path — the
-                # per-year cross-source replace DELETE keys on ``year``.
-                year=self._ingest_year,
-                unit_id=self._module_to_unit_id.get(carbon_report_module_id),
             )
             entries.append(entry)
             kg_co2eq_overrides.append(override)

--- a/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/professional_travel_api_provider.py
@@ -208,6 +208,10 @@ class ProfessionalTravelApiProvider(BaseTableauApiProvider):
                 carbon_report_module_id=carbon_report_module_id,
                 data_entry_type_id=DataEntryTypeEnum.plane.value,
                 data=data_payload,
+                # Denormalized scope columns, mirroring the CSV path — the
+                # per-year cross-source replace DELETE keys on ``year``.
+                year=self._ingest_year,
+                unit_id=self._module_to_unit_id.get(carbon_report_module_id),
             )
             entries.append(entry)
             kg_co2eq_overrides.append(override)

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -808,6 +808,22 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             f"(year={self.year}, {len(valid_entry_types)} types, full replace)"
         )
 
+    def _ingests_member_entries(self) -> bool:
+        """Whether this ingest can produce ``member`` entries (headcount).
+
+        Gates the member-role duplicate-set prefetch so non-headcount
+        uploads never pay the extra query.
+        """
+        module_type_ref = self.module_type_id
+        if module_type_ref is None and self.job is not None:
+            module_type_ref = self.job.module_type_id
+        if module_type_ref is None:
+            return False
+        entry_types = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(
+            ModuleTypeEnum(module_type_ref), []
+        )
+        return DataEntryTypeEnum.member in entry_types
+
     def _enter_phase(self, phase: str) -> None:
         """Mark the start of a pipeline phase (resets the rate/ETA baseline)."""
         self._phase = phase
@@ -958,9 +974,25 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             # Carried out-of-band so kg_co2eq never lands in DataEntry.data.
             batch_kg_co2eq_overrides: List[float | None] = []
             # Track seen (user_institutional_id, sius_code) pairs per module to
-            # catch intra-CSV duplicates. A person can legitimately hold two
-            # roles (different sius_code) in the same unit.
+            # catch duplicates. A person can legitimately hold two roles
+            # (different sius_code) in the same unit. Seeded with the DB's
+            # surviving member rows (post-delete: manual/unit-specific ones)
+            # in ONE bulk query — a per-row uniqueness SELECT at stage
+            # latencies turned an 8.5k-row parse into ~10 min (2026-07-17).
             seen_institutional_ids: Dict[int, set[tuple[str, str]]] = {}
+            if self._ingests_member_entries():
+                member_module_ids: list[int] = (
+                    list(unit_to_module_map.values())
+                    if unit_to_module_map
+                    else [self.carbon_report_module_id]
+                    if self.carbon_report_module_id
+                    else []
+                )
+                existing_keys = await data_entry_service.repo.get_member_role_keys(
+                    member_module_ids
+                )
+                for mod_id, uid, sius in existing_keys:
+                    seen_institutional_ids.setdefault(mod_id, set()).add((uid, sius))
             csv_reader = csv.DictReader(
                 io.StringIO(setup_result["csv_text"], newline="")
             )
@@ -1023,9 +1055,8 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                     raise ValueError("Data entry is None without error message")
 
                 # Check (user_institutional_id, sius_code) role uniqueness for
-                # member entries.
-                # TODO: refactor, should not be done in base_csv_provider but elsewhere
-                # process or task or sql
+                # member entries — pure set lookup: intra-CSV dupes and
+                # pre-existing DB rows are both in the seeded set above.
                 if (
                     data_entry.data_entry_type_id == DataEntryTypeEnum.member
                     and data_entry.data
@@ -1037,17 +1068,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                     module_seen = seen_institutional_ids.setdefault(module_id, set())
                     role_key = (uid, sius_code)
                     if role_key in module_seen:
-                        error_msg = "DUPLICATE_INSTITUTIONAL_ID"
-                        self._record_row_error(
-                            stats, row_idx, error_msg, max_row_errors
-                        )
-                        continue
-                    is_unique = await data_entry_service.check_member_role_unique(
-                        carbon_report_module_id=module_id,
-                        uid=uid,
-                        sius_code=sius_code,
-                    )
-                    if not is_unique:
                         error_msg = "DUPLICATE_INSTITUTIONAL_ID"
                         self._record_row_error(
                             stats, row_idx, error_msg, max_row_errors

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -48,6 +48,7 @@ from app.services.data_entry_service import DataEntryService
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 from app.services.unit_service import UnitService
 from app.services.user_service import UserService
+from app.utils.progress import format_progress
 
 logger = get_logger(__name__)
 
@@ -218,9 +219,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         self._missing_unit_codes: set[str] = set()
         # Track which missing units we've already warned about (deduplication)
         self._missing_units_logged: set[str] = set()
-        # module_id → unit_id, filled by _resolve_carbon_report_modules;
-        # used to stamp the denormalized DataEntry.unit_id at row build.
-        self._module_to_unit_id: Dict[int, int] = {}
         # Cache for carbon_report_module_id -> year mapping (avoid per-row DB queries)
         self._year_cache: Dict[int, int] = {}
         # Progress reporting: current phase label + throttle/rate bookkeeping.
@@ -613,7 +611,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             if institutional_id is None:
                 continue
             full_map[institutional_id] = module_id
-            self._module_to_unit_id[module_id] = unit_db_id
         logger.info(
             f"Bulk-resolved {len(full_map)} existing "
             f"carbon_report_modules for year={self.year}, "
@@ -709,7 +706,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                         f"module_type_id={module_type_id}"
                     )
                 code_to_module_map[unit_institutional_id] = carbon_report_module.id
-                self._module_to_unit_id[carbon_report_module.id] = unit_id
 
         logger.info(
             f"Resolved carbon_report_module_ids: "
@@ -808,22 +804,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             f"(year={self.year}, {len(valid_entry_types)} types, full replace)"
         )
 
-    def _ingests_member_entries(self) -> bool:
-        """Whether this ingest can produce ``member`` entries (headcount).
-
-        Gates the member-role duplicate-set prefetch so non-headcount
-        uploads never pay the extra query.
-        """
-        module_type_ref = self.module_type_id
-        if module_type_ref is None and self.job is not None:
-            module_type_ref = self.job.module_type_id
-        if module_type_ref is None:
-            return False
-        entry_types = MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(
-            ModuleTypeEnum(module_type_ref), []
-        )
-        return DataEntryTypeEnum.member in entry_types
-
     def _enter_phase(self, phase: str) -> None:
         """Mark the start of a pipeline phase (resets the rate/ETA baseline)."""
         self._phase = phase
@@ -868,17 +848,6 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             parse_elapsed - row_t,
         )
 
-    @staticmethod
-    def _format_progress(
-        phase: str, processed: int | None, total: int | None, elapsed: float
-    ) -> str:
-        """Human-readable progress line with throughput + rough ETA."""
-        if not processed or not total:
-            return phase
-        rate = processed / max(elapsed, 1e-3)
-        eta = (total - processed) / rate if rate > 0 else 0.0
-        return f"{phase}: {processed}/{total} rows ({rate:.0f}/s, ~{eta:.0f}s left)"
-
     async def _report(
         self,
         phase: str,
@@ -898,9 +867,7 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             return
         self._last_report_at = now
 
-        msg = self._format_progress(
-            phase, processed, total, now - self._phase_started_at
-        )
+        msg = format_progress(phase, processed, total, now - self._phase_started_at)
         meta: Dict[str, Any] = dict(stats) if stats else {}
         meta["progress"] = {"phase": phase, "processed": processed, "total": total}
         logger.info(msg)
@@ -980,19 +947,20 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             # in ONE bulk query — a per-row uniqueness SELECT at stage
             # latencies turned an 8.5k-row parse into ~10 min (2026-07-17).
             seen_institutional_ids: Dict[int, set[tuple[str, str]]] = {}
-            if self._ingests_member_entries():
-                member_module_ids: list[int] = (
-                    list(unit_to_module_map.values())
-                    if unit_to_module_map
-                    else [self.carbon_report_module_id]
-                    if self.carbon_report_module_id
-                    else []
-                )
-                existing_keys = await data_entry_service.repo.get_member_role_keys(
-                    member_module_ids
-                )
-                for mod_id, uid, sius in existing_keys:
-                    seen_institutional_ids.setdefault(mod_id, set()).add((uid, sius))
+            # Unconditional on purpose: the query is one indexed round trip
+            # that returns nothing for non-member modules, and gating it on
+            # a resolvable module_type_id would silently skip DB-level
+            # dedup for member uploads that omit it (raw-API dispatch).
+            member_module_ids: list[int] = []
+            if unit_to_module_map:
+                member_module_ids = list(unit_to_module_map.values())
+            elif self.carbon_report_module_id:
+                member_module_ids = [self.carbon_report_module_id]
+            existing_keys = await data_entry_service.repo.get_member_role_keys(
+                member_module_ids
+            )
+            for mod_id, uid, sius in existing_keys:
+                seen_institutional_ids.setdefault(mod_id, set()).add((uid, sius))
             csv_reader = csv.DictReader(
                 io.StringIO(setup_result["csv_text"], newline="")
             )
@@ -1373,14 +1341,13 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
             if kg_co2eq_override is not None:
                 data[KG_CO2EQ_OVERRIDE_KEY] = kg_co2eq_override
 
+            # Denormalized scope columns (year/unit_id) are stamped
+            # centrally by DataEntryService.fill_denormalized_scope on
+            # every write path — no per-provider stamping to forget.
             data_entry = DataEntry(
                 data_entry_type_id=data_entry_type,
                 carbon_report_module_id=carbon_report_module_id,
                 data=data,
-                # Denormalized scope columns — back the per-year
-                # full-replace delete without module resolution.
-                year=self.year,
-                unit_id=self._module_to_unit_id.get(carbon_report_module_id),
             )
 
             return data_entry, None, None, kg_co2eq_override

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -15,6 +15,7 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.models.carbon_report import CarbonReport, CarbonReportModule
 from app.models.data_entry import (
+    BULK_PER_YEAR_SOURCES,
     DataEntry,
     DataEntrySourceEnum,
     DataEntryTypeEnum,
@@ -757,11 +758,14 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         data_entry_service: DataEntryService,
     ) -> None:
         """
-        Delete existing entries from previous CSV_MODULE_PER_YEAR uploads.
+        Delete existing entries from previous bulk per-year ingests.
 
-        This ensures that MODULE_PER_YEAR uploads replace only the data
-        that was uploaded through the same mechanism, preserving manual
-        entries and unit-specific uploads.
+        A per-year upload is a complete yearly export, so it replaces every
+        machine-owned bulk source (prior CSV uploads AND API syncs — see
+        ``BULK_PER_YEAR_SOURCES``), preserving manual entries and
+        unit-specific uploads. Without the cross-source delete, uploading a
+        CSV after an API sync mass-skips rows as DUPLICATE_INSTITUTIONAL_ID
+        against the surviving API copies.
 
         Note: MODULE_UNIT_SPECIFIC uses append-only strategy (no deletion).
 
@@ -790,17 +794,17 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
 
         # Full-year replace: per-year CSVs are complete exports, so ONE
         # indexed DELETE on the denormalized ``data_entries.year`` column
-        # replaces every prior row of (year, types, source) — no module
+        # replaces every prior row of (year, types, bulk sources) — no module
         # resolution, no audit trail (the bulk path skips audit on insert
         # too; the job row is the operator-facing record).
         deleted_rows = await data_entry_service.repo.bulk_delete_by_source_year(
             year=self.year,
             data_entry_type_ids=[t.value for t in valid_entry_types],
-            source=DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value,
+            sources=[s.value for s in BULK_PER_YEAR_SOURCES],
         )
 
         logger.info(
-            f"Deleted {deleted_rows} data entries from previous CSV uploads "
+            f"Deleted {deleted_rows} data entries from previous bulk ingests "
             f"(year={self.year}, {len(valid_entry_types)} types, full replace)"
         )
 

--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -965,15 +965,18 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
                 io.StringIO(setup_result["csv_text"], newline="")
             )
 
+            last_yield = time.perf_counter()
             for row_idx, row in enumerate(csv_reader, start=1):
                 # Row processing is mostly CPU (parse/validate, cached
                 # lookups) — with 50k-row COPY batches nothing else
                 # would run on the event loop for the whole file.
-                # Yield every 100 rows so /healthz & /ready stay under the
-                # liveness/readiness probe timeout even on a CPU-tight pod;
-                # a 1000-row stretch could exceed 2s and trigger a restart.
-                if row_idx % 100 == 0:
+                # Yield on wall time so /healthz & /ready stay under the
+                # k8s probe timeout (2s on stage) regardless of per-row
+                # cost — a fixed row count stretches with a slow DB.
+                if time.perf_counter() - last_yield > 0.05:
                     await asyncio.sleep(0)
+                    last_yield = time.perf_counter()
+                if row_idx % 100 == 0:
                     # Throttled internally to PROGRESS_REPORT_INTERVAL_S, so the
                     # long parse/validate phase shows live throughput + ETA
                     # instead of going silent for tens of seconds.

--- a/backend/app/services/data_ingestion/base_provider.py
+++ b/backend/app/services/data_ingestion/base_provider.py
@@ -199,7 +199,10 @@ class DataIngestionProvider(ABC):
         await audit_service.create_version(
             entity_type="DataIngestionJob",
             entity_id=self.job_id,
-            data_snapshot=job.model_dump(),
+            # mode="json" so datetime columns (created_at is stamped at
+            # insert) serialize to ISO strings — the audit row stores the
+            # snapshot in a JSON column with the stdlib encoder.
+            data_snapshot=job.model_dump(mode="json"),
             change_type=AuditChangeTypeEnum.CREATE,
             changed_by=changed_by,
             change_reason=f"Data ingestion job created via {ingestion_method.value}",

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -12,6 +12,7 @@ preemption check, and the FINISHED-state write — these handlers
 only contain the work itself.
 """
 
+import time
 from typing import Optional
 from uuid import UUID
 
@@ -340,13 +341,21 @@ async def emission_recalc_handler(
 
     job_id = job.id
 
+    progress_started = time.monotonic()
+
     async def _progress(done: int, total: int) -> None:
         # Committed on job_session immediately so SSE subscribers see
         # live progress while the workflow keeps computing on
         # data_session (the two sessions are independent by design).
+        elapsed = max(time.monotonic() - progress_started, 1e-3)
+        rate = done / elapsed
+        eta = (total - done) / rate if rate > 0 else 0.0
         await job_repo.update_ingestion_job(
             job_id=job_id,
-            status_message=f"Recalculating emissions... {done}/{total}",
+            status_message=(
+                f"Recalculating emissions: {done}/{total} entries "
+                f"({rate:.0f}/s, ~{eta:.0f}s left)"
+            ),
             metadata={},
         )
         await job_session.commit()

--- a/backend/app/tasks/emission_recalculation_tasks.py
+++ b/backend/app/tasks/emission_recalculation_tasks.py
@@ -35,6 +35,7 @@ from app.repositories.data_ingestion import DataIngestionRepository
 from app.tasks._chain import AGGREGATION_DEDUP, chain_job
 from app.tasks._locks import acquire_factor_recalc_lock
 from app.tasks.registry import register
+from app.utils.progress import format_progress
 from app.workflows.emission_recalculation import EmissionRecalculationWorkflow
 
 logger = get_logger(__name__)
@@ -347,14 +348,14 @@ async def emission_recalc_handler(
         # Committed on job_session immediately so SSE subscribers see
         # live progress while the workflow keeps computing on
         # data_session (the two sessions are independent by design).
-        elapsed = max(time.monotonic() - progress_started, 1e-3)
-        rate = done / elapsed
-        eta = (total - done) / rate if rate > 0 else 0.0
         await job_repo.update_ingestion_job(
             job_id=job_id,
-            status_message=(
-                f"Recalculating emissions: {done}/{total} entries "
-                f"({rate:.0f}/s, ~{eta:.0f}s left)"
+            status_message=format_progress(
+                "Recalculating emissions",
+                done,
+                total,
+                time.monotonic() - progress_started,
+                unit="entries",
             ),
             metadata={},
         )

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -429,8 +429,14 @@ async def _heartbeat_loop(job_id: int, abort_event: asyncio.Event) -> None:
                     logger.warning(
                         f"_heartbeat_loop: lost lock on job {job_id} "
                         "(preempted or state moved out of RUNNING) — "
-                        "stopping heartbeat"
+                        "aborting handler"
                     )
+                    # Arm the abort, don't just stop heartbeating: the
+                    # row is owned elsewhere now, and letting the handler
+                    # run to completion commits its data_session writes
+                    # and chains children BEFORE the finish CAS can drop
+                    # them — duplicate work the new owner also performs.
+                    abort_event.set()
                     return
             consecutive_failures = 0
         except asyncio.CancelledError:

--- a/backend/app/tasks/runner.py
+++ b/backend/app/tasks/runner.py
@@ -393,7 +393,7 @@ async def _heartbeat_loop(job_id: int, abort_event: asyncio.Event) -> None:
     """Refresh ``locked_at`` on the active job until cancelled.
 
     Wake every ``STALE_JOB_TIMEOUT_MINUTES / 4`` (default: every
-    15 min for a 60 min timeout) and call ``repo.heartbeat``.  If
+    75s for a 5 min timeout) and call ``repo.heartbeat``.  If
     the heartbeat returns 0 rows updated, our lock has been preempted
     — exit the loop so the runner's preemption check can take over
     on its next pass.

--- a/backend/app/utils/datetime_utc.py
+++ b/backend/app/utils/datetime_utc.py
@@ -1,0 +1,15 @@
+"""Timezone-aware datetime helpers shared across API and repository layers."""
+
+from datetime import datetime, timezone
+
+
+def as_utc(dt: datetime) -> datetime:
+    """Coerce a tz-naive datetime to UTC.
+
+    Defends against stores that return naive values for tz-aware columns:
+    SQLite test DBs always do, and long-lived dev DBs created before a
+    column moved to ``DateTime(timezone=True)`` still serve naive rows
+    (``create_all`` doesn't ALTER existing tables). Writers in this
+    codebase always produce UTC, so treating naive as UTC is exact.
+    """
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)

--- a/backend/app/utils/progress.py
+++ b/backend/app/utils/progress.py
@@ -1,0 +1,20 @@
+"""Shared progress-line formatting for long-running jobs.
+
+One format for every job status line (CSV ingest, emission recalc, …) so
+the ops console reads consistently and rate/ETA math lives in one place.
+"""
+
+
+def format_progress(
+    phase: str,
+    processed: int | None,
+    total: int | None,
+    elapsed: float,
+    unit: str = "rows",
+) -> str:
+    """Human-readable progress line with throughput + rough ETA."""
+    if not processed or not total:
+        return phase
+    rate = processed / max(elapsed, 1e-3)
+    eta = (total - processed) / rate if rate > 0 else 0.0
+    return f"{phase}: {processed}/{total} {unit} ({rate:.0f}/s, ~{eta:.0f}s left)"

--- a/backend/app/workflows/emission_recalculation.py
+++ b/backend/app/workflows/emission_recalculation.py
@@ -20,9 +20,19 @@ from app.services.factor_resolver import FactorResolver
 
 logger = get_logger(__name__)
 
-# Emit a progress log line (and invoke the caller's progress callback)
-# every N computed entries.
+# Flush the batched emission writes every N computed entries (write-batching
+# concern only — progress reporting is time-based, below).
 PROGRESS_INTERVAL = 5000
+
+# Yield the event loop whenever this much wall time passed in pure-CPU
+# per-entry compute. Stage incident 2026-07-17: the previous every-1000-entries
+# yield left multi-second stretches where /healthz couldn't get a slot, k8s
+# liveness (2s timeout, 3×20s) killed the pod exactly 60s into the recalc.
+YIELD_INTERVAL_S = 0.05
+
+# Emit a progress log line + job status update this often (mirrors
+# ingestion's PROGRESS_REPORT_INTERVAL_S).
+PROGRESS_REPORT_INTERVAL_S = 2.0
 
 
 class EmissionRecalculationWorkflow:
@@ -127,6 +137,8 @@ class EmissionRecalculationWorkflow:
         total_written = 0
         total_replaced = 0
         slice_started = time.perf_counter()
+        last_yield = slice_started
+        last_report = slice_started
         # Per-segment wall time for a recalc profile line (diagnostic, the
         # analog of ingestion's row-loop profile): localises where per-entry
         # time goes so a slow slice is measured, not guessed.
@@ -199,10 +211,13 @@ class EmissionRecalculationWorkflow:
 
             processed = recalculated + errors
             # With cached factors/year, per-entry compute can be pure
-            # CPU — yield regularly so the event loop (API, SSE,
-            # heartbeats) never starves during a 50k-entry slice.
-            if processed % 1000 == 0:
+            # CPU — yield on wall time, not entry count, so the event
+            # loop (API, /healthz probes, SSE, heartbeats) never starves
+            # regardless of per-entry cost.
+            now = time.perf_counter()
+            if now - last_yield > YIELD_INTERVAL_S:
                 await asyncio.sleep(0)
+                last_yield = time.perf_counter()
             if processed % PROGRESS_INTERVAL == 0:
                 # Flush this chunk's writes (one DELETE + one COPY) so
                 # neither the emission buffer nor a single statement
@@ -215,6 +230,8 @@ class EmissionRecalculationWorkflow:
                 total_replaced += len(processed_entry_ids)
                 processed_entry_ids = []
                 prepared_emissions = []
+            if now - last_report > PROGRESS_REPORT_INTERVAL_S:
+                last_report = time.perf_counter()
                 logger.info(
                     f"Recalc {data_entry_type_id.name}/{year}: "
                     f"{processed}/{len(entries)} entries computed "
@@ -228,6 +245,11 @@ class EmissionRecalculationWorkflow:
             processed_entry_ids, prepared_emissions
         )
         total_replaced += len(processed_entry_ids)
+        # Terminal progress update — with time-based reporting a short
+        # slice may never cross the report interval, and the operator
+        # should always see N/N before the runner's own finish message.
+        if progress_callback is not None:
+            await progress_callback(recalculated + errors, len(entries))
         slice_elapsed = time.perf_counter() - slice_started
         logger.info(
             f"Recalc {data_entry_type_id.name}/{year}: replaced emissions for "

--- a/backend/tests/integration/data_ingestion/test_csv_validation.py
+++ b/backend/tests/integration/data_ingestion/test_csv_validation.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.models.data_entry import DataEntrySourceEnum
+from app.models.data_entry import BULK_PER_YEAR_SOURCES, DataEntrySourceEnum
 from app.services.data_ingestion.csv_providers.module_per_year import (
     ModulePerYearCSVProvider,
 )
@@ -106,13 +106,13 @@ class TestModulePerYearBehavior:
             mock_data_entry_service,
         )
 
-        # Verify the single set-based delete targets CSV_MODULE_PER_YEAR
-        # for the job's year — human (USER_MANUAL) and unit-specific
-        # sources are untouched by construction of the source filter.
+        # Verify the single set-based delete targets every machine-owned
+        # bulk source for the job's year — human (USER_MANUAL) and
+        # unit-specific sources are untouched by construction of the filter.
         calls = mock_data_entry_service.repo.bulk_delete_by_source_year.call_args_list
         assert len(calls) == 1
         kwargs = calls[0].kwargs
-        assert kwargs["source"] == DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value
+        assert kwargs["sources"] == [s.value for s in BULK_PER_YEAR_SOURCES]
         assert kwargs["year"] == 2025
 
 
@@ -149,10 +149,10 @@ class TestHumanDataProtection:
 
     @pytest.mark.asyncio
     async def test_delete_method_uses_correct_source_filter(self):
-        """Verify deletion only targets CSV_MODULE_PER_YEAR entries.
+        """Verify deletion only targets machine-owned bulk per-year sources.
 
         This test verifies the filtering logic that protects human entries:
-        - Only entries with source=CSV_MODULE_PER_YEAR are deleted
+        - Entries with bulk sources (CSV per-year, API sync) ARE deleted
         - Entries with source=USER_MANUAL are NOT deleted
         - Entries with source=CSV_MODULE_UNIT_SPECIFIC are NOT deleted
         """
@@ -196,14 +196,16 @@ class TestHumanDataProtection:
             mock_data_entry_service,
         )
 
-        # Verify the call uses the CSV_MODULE_PER_YEAR source filter —
-        # this is what protects human entries (USER_MANUAL source) and
-        # unit-specific uploads (CSV_MODULE_UNIT_SPECIFIC source).
+        # Verify the call uses the bulk-source filter — this is what
+        # protects human entries (USER_MANUAL source) and unit-specific
+        # uploads (CSV_MODULE_UNIT_SPECIFIC source) while replacing prior
+        # CSV uploads AND API syncs (cross-source replace).
         calls = mock_data_entry_service.repo.bulk_delete_by_source_year.call_args_list
         assert len(calls) == 1, "Expected exactly one set-based deletion call"
         kwargs = calls[0].kwargs
-        assert kwargs["source"] == DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value, (
-            f"Expected CSV_MODULE_PER_YEAR source, got {kwargs['source']}"
+        assert kwargs["sources"] == [s.value for s in BULK_PER_YEAR_SOURCES]
+        assert DataEntrySourceEnum.EXTERNAL_INTEGRATION.value in kwargs["sources"]
+        assert DataEntrySourceEnum.USER_MANUAL.value not in kwargs["sources"]
+        assert (
+            DataEntrySourceEnum.CSV_MODULE_UNIT_SPECIFIC.value not in kwargs["sources"]
         )
-        assert kwargs["source"] != DataEntrySourceEnum.USER_MANUAL.value
-        assert kwargs["source"] != DataEntrySourceEnum.CSV_MODULE_UNIT_SPECIFIC.value

--- a/backend/tests/integration/services/data_ingestion/test_bulk_copy_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_bulk_copy_pg.py
@@ -121,9 +121,12 @@ async def test_year_delete_replaces_only_matching_source_and_year(
     psycopg_session, make_unit, make_carbon_report, make_carbon_report_module
 ):
     """Full-year replace contract: ``bulk_delete_by_source_year`` removes
-    rows matching (year, type, source) via the denormalized ``year``
-    column, leaving other sources and other years untouched."""
-    from app.models.data_entry import DataEntrySourceEnum
+    rows matching (year, type) across ALL machine-owned bulk sources —
+    CSV per-year AND API sync (stage incident 2026-07-17: surviving API
+    rows mass-skipped a CSV re-upload as DUPLICATE_INSTITUTIONAL_ID) —
+    via the denormalized ``year`` column, leaving manual entries and
+    other years untouched."""
+    from app.models.data_entry import BULK_PER_YEAR_SOURCES, DataEntrySourceEnum
 
     module = await _seed_module(
         psycopg_session, make_unit, make_carbon_report, make_carbon_report_module
@@ -143,6 +146,7 @@ async def test_year_delete_replaces_only_matching_source_and_year(
     await repo.bulk_copy(
         [
             _entry(2026, DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value),
+            _entry(2026, DataEntrySourceEnum.EXTERNAL_INTEGRATION.value),
             _entry(2026, DataEntrySourceEnum.USER_MANUAL.value),
             _entry(2025, DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value),
         ]
@@ -152,12 +156,12 @@ async def test_year_delete_replaces_only_matching_source_and_year(
     deleted = await repo.bulk_delete_by_source_year(
         year=2026,
         data_entry_type_ids=[DataEntryTypeEnum.member.value],
-        source=DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value,
+        sources=[s.value for s in BULK_PER_YEAR_SOURCES],
     )
     await psycopg_session.commit()
     psycopg_session.expire_all()
 
-    assert deleted == 1
+    assert deleted == 2
     rows = (
         (
             await psycopg_session.execute(

--- a/backend/tests/unit/models/test_data_ingestion_job_audit_snapshot.py
+++ b/backend/tests/unit/models/test_data_ingestion_job_audit_snapshot.py
@@ -1,0 +1,38 @@
+"""Regression: the create_job audit snapshot must be stdlib-JSON-safe.
+
+``create_job`` stores ``job.model_dump(mode="json")`` in the audit
+document's JSON column, which is serialized by the plain ``json.dumps``
+configured in ``app.db``. When ``created_at`` gained an insert-time
+default (2026-07-17), a python-mode ``model_dump()`` started carrying a
+real ``datetime`` and every ``POST /v1/sync/dispatch`` 500'd on the
+audit INSERT.
+"""
+
+import json
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionState,
+    TargetType,
+)
+
+
+def test_fresh_job_snapshot_is_json_serializable():
+    job = DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR,
+        ingestion_method=IngestionMethod.csv,
+        target_type=TargetType.DATA_ENTRIES,
+        state=IngestionState.NOT_STARTED,
+        status_message="Job created",
+        meta={},
+    )
+
+    # created_at is stamped at construction — the exact condition that
+    # broke the python-mode dump.
+    assert job.created_at is not None
+
+    snapshot = job.model_dump(mode="json")
+    json.dumps(snapshot, ensure_ascii=False)
+    assert isinstance(snapshot["created_at"], str)

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -19,6 +19,7 @@ from app.models.data_entry import (
 from app.models.data_ingestion import EntityType, IngestionResult
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import UserProvider
+from app.repositories.data_entry_repo import DataEntryRepository
 from app.services.data_ingestion.base_csv_provider import (
     REUPLOAD_HINT,
     BaseCSVProvider,
@@ -207,7 +208,7 @@ async def test_validate_csv_headers_empty_file():
 
 
 @pytest.mark.asyncio
-async def test_process_csv_with_blank_rows_does_not_raise_value_error():
+async def test_process_csv_with_blank_rows_does_not_raise_value_error(monkeypatch):
     """Regression test: Verifies that intermittent and trailing structural
     blank rows (like ',,') are skipped by the loop guard and do not cause
     the batch processor to raise a 'Data entry is None without error message'
@@ -222,6 +223,11 @@ async def test_process_csv_with_blank_rows_does_not_raise_value_error():
     # Mock out the batch-saving step completely to avoid database repository
     # dependencies
     provider._process_batch = AsyncMock(return_value=2)
+    # The unconditional duplicate-set prefetch hits the repo; the mocked
+    # session can't answer SQL, so stub it to an empty seed.
+    monkeypatch.setattr(
+        DataEntryRepository, "get_member_role_keys", AsyncMock(return_value=set())
+    )
 
     # 2. Mock the async files_store layer
     mock_files_store = MagicMock()
@@ -287,10 +293,12 @@ def _drive_member_csv(
     ``db_session``. ``_process_batch`` is stubbed to skip factor/emission
     computation, which is irrelevant to the uniqueness check.
     """
+    # Deliberately NO module_type_id: the duplicate-set seeding must be
+    # unconditional — a raw-API dispatch can omit it, and gating the seed
+    # on it silently dropped DB-level dedup (code-review finding).
     config = {
         "file_path": "tmp/test.csv",
         "carbon_report_module_id": module_id,
-        "module_type_id": ModuleTypeEnum.headcount.value,
         "year": 2025,
     }
     provider = ConcreteCSVProvider(config, data_session=db_session)

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -290,6 +290,7 @@ def _drive_member_csv(
     config = {
         "file_path": "tmp/test.csv",
         "carbon_report_module_id": module_id,
+        "module_type_id": ModuleTypeEnum.headcount.value,
         "year": 2025,
     }
     provider = ConcreteCSVProvider(config, data_session=db_session)
@@ -361,6 +362,40 @@ async def test_csv_batch_rejects_true_duplicate_member_role(db_session: AsyncSes
     rows_data = [
         {"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
         {"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
+    ]
+    provider = _drive_member_csv(db_session, module.id, rows_data)
+
+    result = await provider.process_csv_in_batches()
+
+    assert result["stats"]["row_errors_count"] == 1
+    assert result["stats"]["row_errors"][0]["reason"] == "DUPLICATE_INSTITUTIONAL_ID"
+    assert result["stats"]["rows_processed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_csv_batch_rejects_role_already_persisted(db_session: AsyncSession):
+    """A (user_institutional_id, sius_code) already in the DB for the module
+    (e.g. a manual entry surviving the bulk replace) rejects the CSV row via
+    the pre-seeded set — ONE bulk prefetch instead of a per-row SELECT
+    (stage 2026-07-17: the per-row check ran at 14 rows/s)."""
+    module = CarbonReportModule(
+        carbon_report_id=1, module_type_id=ModuleTypeEnum.headcount.value, status=0
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    db_session.add(
+        DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.member.value,
+            carbon_report_module_id=module.id,
+            data={"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
+        )
+    )
+    await db_session.flush()
+
+    rows_data = [
+        {"name": "X X", "user_institutional_id": "123456", "sius_code": "53"},
+        {"name": "X X", "user_institutional_id": "123456", "sius_code": "54"},
     ]
     provider = _drive_member_csv(db_session, module.id, rows_data)
 

--- a/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_csv_provider.py
@@ -10,7 +10,12 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
 from app.models.carbon_report import CarbonReportModule
-from app.models.data_entry import DataEntry, DataEntrySourceEnum, DataEntryTypeEnum
+from app.models.data_entry import (
+    BULK_PER_YEAR_SOURCES,
+    DataEntry,
+    DataEntrySourceEnum,
+    DataEntryTypeEnum,
+)
 from app.models.data_ingestion import EntityType, IngestionResult
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import UserProvider
@@ -1780,7 +1785,15 @@ async def test_delete_scoped_to_specific_data_entry_type():
     assert call_kwargs["data_entry_type_ids"] == [
         DataEntryTypeEnum.research_facilities.value
     ]
-    assert call_kwargs["source"] == DataEntrySourceEnum.CSV_MODULE_PER_YEAR.value
+    # Cross-source replace: a per-year CSV upload also replaces prior API
+    # syncs — otherwise their surviving rows mass-skip the upload as
+    # DUPLICATE_INSTITUTIONAL_ID (stage incident, 2026-07-17).
+    assert call_kwargs["sources"] == [s.value for s in BULK_PER_YEAR_SOURCES]
+    assert DataEntrySourceEnum.EXTERNAL_INTEGRATION.value in call_kwargs["sources"]
+    assert DataEntrySourceEnum.USER_MANUAL.value not in call_kwargs["sources"]
+    assert (
+        DataEntrySourceEnum.CSV_MODULE_UNIT_SPECIFIC.value not in call_kwargs["sources"]
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/services/data_ingestion/test_base_tableau_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_base_tableau_provider.py
@@ -24,7 +24,7 @@ from app.models.connector import (
     ConnectorDatasource,
     ConnectorType,
 )
-from app.models.data_entry import DataEntrySourceEnum, DataEntryTypeEnum
+from app.models.data_entry import BULK_PER_YEAR_SOURCES, DataEntryTypeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.services.data_ingestion.api_providers.base_tableau_api_provider import (
     BaseTableauApiProvider,
@@ -205,8 +205,10 @@ async def test_delete_existing_api_entries_replaces_same_year_and_type(session):
         deleted = await provider._delete_existing_api_entries()
 
     assert deleted == 7
+    # Cross-source replace: an API sync also replaces prior per-year CSV
+    # uploads, so the two bulk mechanisms never collide on duplicates.
     delete.assert_awaited_once_with(
         year=2024,
         data_entry_type_ids=[DataEntryTypeEnum.plane.value],
-        source=DataEntrySourceEnum.EXTERNAL_INTEGRATION.value,
+        sources=[s.value for s in BULK_PER_YEAR_SOURCES],
     )

--- a/backend/tests/unit/services/data_ingestion/test_headcount_members_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_headcount_members_api_provider.py
@@ -257,6 +257,37 @@ class TestIngest:
 
 
 # ---------------------------------------------------------------------------
+# Denormalized scope columns (stage incident 2026-07-17)
+# ---------------------------------------------------------------------------
+
+
+class TestDenormalizedScopeColumns:
+    def test_build_data_entry_stamps_year_and_unit_id(self):
+        """Regression: API entries carried year=NULL, so the per-year
+        cross-source replace DELETE (keyed on ``data_entries.year``)
+        never matched them and CSV re-uploads mass-collided on
+        DUPLICATE_INSTITUTIONAL_ID."""
+        provider = _make_provider()  # config carries year=2025
+        # Normally populated by _resolve_carbon_report_modules before
+        # any entry is built (see the ingest flow in the tableau base).
+        provider._module_to_unit_id = {77: 42}
+
+        entry = provider._build_data_entry(
+            {
+                "name": "Role Std",
+                "sius_code": "51",
+                "user_institutional_id": "123456",
+                "fte": 0.5,
+                "note": None,
+            },
+            carbon_report_module_id=77,
+        )
+
+        assert entry.year == 2025
+        assert entry.unit_id == 42
+
+
+# ---------------------------------------------------------------------------
 # Factory registration
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/services/data_ingestion/test_headcount_members_api_provider.py
+++ b/backend/tests/unit/services/data_ingestion/test_headcount_members_api_provider.py
@@ -257,37 +257,6 @@ class TestIngest:
 
 
 # ---------------------------------------------------------------------------
-# Denormalized scope columns (stage incident 2026-07-17)
-# ---------------------------------------------------------------------------
-
-
-class TestDenormalizedScopeColumns:
-    def test_build_data_entry_stamps_year_and_unit_id(self):
-        """Regression: API entries carried year=NULL, so the per-year
-        cross-source replace DELETE (keyed on ``data_entries.year``)
-        never matched them and CSV re-uploads mass-collided on
-        DUPLICATE_INSTITUTIONAL_ID."""
-        provider = _make_provider()  # config carries year=2025
-        # Normally populated by _resolve_carbon_report_modules before
-        # any entry is built (see the ingest flow in the tableau base).
-        provider._module_to_unit_id = {77: 42}
-
-        entry = provider._build_data_entry(
-            {
-                "name": "Role Std",
-                "sius_code": "51",
-                "user_institutional_id": "123456",
-                "fte": 0.5,
-                "note": None,
-            },
-            carbon_report_module_id=77,
-        )
-
-        assert entry.year == 2025
-        assert entry.unit_id == 42
-
-
-# ---------------------------------------------------------------------------
 # Factory registration
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/services/test_audit_snapshot_json_safety.py
+++ b/backend/tests/unit/services/test_audit_snapshot_json_safety.py
@@ -1,0 +1,41 @@
+"""Regression: ``create_version`` normalizes snapshots at the boundary.
+
+The audit snapshot lands in a JSON column serialized by the plain
+``json.dumps`` configured in ``app.db`` (no ``default=``), so a datetime
+(or UUID/Decimal) in any caller's snapshot 500'd the flush — first hit by
+the job ``created_at`` on ``POST /v1/sync/dispatch`` (2026-07-17). The
+encoder now runs once inside ``create_version`` so the invariant no
+longer lives in N call sites.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.audit import AuditChangeTypeEnum
+from app.services.audit_service import AuditDocumentService
+
+
+@pytest.mark.asyncio
+async def test_create_version_accepts_datetime_carrying_snapshot(
+    db_session: AsyncSession,
+):
+    doc = await AuditDocumentService(db_session).create_version(
+        entity_type="DataIngestionJob",
+        entity_id=1,
+        data_snapshot={
+            "created_at": datetime.now(timezone.utc),
+            "pipeline_id": uuid4(),
+            "state": 2,
+        },
+        change_type=AuditChangeTypeEnum.CREATE,
+        changed_by=1,
+        handler_id="test",
+    )
+    # The flush inside create_version serializes the JSON column — reaching
+    # here without TypeError is the regression guard; the stored snapshot
+    # must be JSON-native.
+    assert isinstance(doc.data_snapshot["created_at"], str)
+    assert isinstance(doc.data_snapshot["pipeline_id"], str)

--- a/backend/tests/unit/services/test_fill_denormalized_scope.py
+++ b/backend/tests/unit/services/test_fill_denormalized_scope.py
@@ -1,0 +1,83 @@
+"""Regression tests for central denormalized-scope stamping.
+
+Stage incident 2026-07-17: API providers built DataEntry rows without
+``year``/``unit_id``, so the per-year cross-source replace DELETE (keyed
+on ``data_entries.year``) never matched them and CSV re-uploads
+mass-collided on DUPLICATE_INSTITUTIONAL_ID. The stamp now lives in ONE
+place — ``DataEntryService.fill_denormalized_scope``, called by every
+write path (create / bulk_create / bulk_copy) — so no provider can
+forget it.
+"""
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryTypeEnum
+from app.models.module_type import ModuleTypeEnum
+from app.services.data_entry_service import DataEntryService
+
+
+async def _seed_module(db_session: AsyncSession) -> CarbonReportModule:
+    report = CarbonReport(unit_id=42, year=2025, carbon_project_id=1)
+    db_session.add(report)
+    await db_session.flush()
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.headcount.value,
+        status=0,
+    )
+    db_session.add(module)
+    await db_session.flush()
+    return module
+
+
+@pytest.mark.asyncio
+async def test_fill_stamps_year_and_unit_id_from_carbon_report(
+    db_session: AsyncSession,
+):
+    module = await _seed_module(db_session)
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.member.value,
+        carbon_report_module_id=module.id,
+        data={"user_institutional_id": "123456", "sius_code": "51"},
+    )
+
+    await DataEntryService(db_session).fill_denormalized_scope([entry])
+
+    assert entry.year == 2025
+    assert entry.unit_id == 42
+
+
+@pytest.mark.asyncio
+async def test_fill_never_overwrites_existing_values(db_session: AsyncSession):
+    module = await _seed_module(db_session)
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.member.value,
+        carbon_report_module_id=module.id,
+        data={},
+        year=2024,
+        unit_id=7,
+    )
+
+    await DataEntryService(db_session).fill_denormalized_scope([entry])
+
+    assert entry.year == 2024
+    assert entry.unit_id == 7
+
+
+@pytest.mark.asyncio
+async def test_fill_is_a_noop_when_all_entries_are_stamped(
+    db_session: AsyncSession,
+):
+    # No query fired for fully-stamped batches — assert via no module rows
+    # needed: an unknown module id with values set is left untouched.
+    entry = DataEntry(
+        data_entry_type_id=DataEntryTypeEnum.member.value,
+        carbon_report_module_id=999999,
+        data={},
+        year=2025,
+        unit_id=1,
+    )
+    await DataEntryService(db_session).fill_denormalized_scope([entry])
+    assert entry.year == 2025

--- a/backend/tests/unit/tasks/test_runner_heartbeat_abort.py
+++ b/backend/tests/unit/tasks/test_runner_heartbeat_abort.py
@@ -132,6 +132,40 @@ async def test_heartbeat_loop_sets_abort_event_after_threshold_failures(
 
 
 @pytest.mark.asyncio
+async def test_heartbeat_loop_arms_abort_on_lost_lock(monkeypatch):
+    """A heartbeat returning 0 rows (lock preempted / state left RUNNING)
+    must ARM the abort, not just stop heartbeating — otherwise the handler
+    runs to completion and its pre-CAS data commits + chained children
+    duplicate the new owner's work (code-review finding, 2026-07-17)."""
+    settings_mock = MagicMock()
+    settings_mock.STALE_JOB_TIMEOUT_MINUTES = 1
+    monkeypatch.setattr(runner_mod, "get_settings", lambda: settings_mock)
+
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_secs: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(runner_mod.asyncio, "sleep", _fast_sleep)
+
+    preempted_repo = MagicMock()
+    preempted_repo.heartbeat = AsyncMock(return_value=0)
+    monkeypatch.setattr(
+        runner_mod, "DataIngestionRepository", lambda _s: preempted_repo
+    )
+    monkeypatch.setattr(runner_mod, "SessionLocal", _mock_session_ctx)
+
+    abort_event = asyncio.Event()
+    await asyncio.wait_for(
+        runner_mod._heartbeat_loop(job_id=42, abort_event=abort_event),
+        timeout=5.0,
+    )
+
+    assert abort_event.is_set(), "lost lock must arm the abort_event"
+    assert preempted_repo.heartbeat.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_loop_resets_counter_on_success(monkeypatch):
     """A successful heartbeat between failures resets the counter,
     so the loop tolerates intermittent DB blips below the threshold."""
@@ -156,7 +190,7 @@ async def test_heartbeat_loop_resets_counter_on_success(monkeypatch):
         1,  # success — resets counter
         RuntimeError("blip 4"),
         RuntimeError("blip 5"),
-        0,  # preemption (updated == 0) — clean exit, NOT abort
+        0,  # preemption (updated == 0) — exits AND arms the abort
     ]
     repo_mock = MagicMock()
     repo_mock.heartbeat = AsyncMock(side_effect=side_effects)
@@ -169,10 +203,13 @@ async def test_heartbeat_loop_resets_counter_on_success(monkeypatch):
         timeout=5.0,
     )
 
-    # The counter reset means we never reach the threshold even though
-    # there were five failure exceptions in total.
-    assert not abort_event.is_set()
+    # The counter reset means the failure threshold was never reached even
+    # though there were five failure exceptions in total — proven by the
+    # loop surviving to the 7th call. The final 0-update (lost lock) then
+    # arms the abort so the runner cancels the handler instead of letting
+    # it finish work another pod now owns.
     assert repo_mock.heartbeat.await_count == 7
+    assert abort_event.is_set()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/v1/test_pipeline_job_staleness.py
+++ b/backend/tests/unit/v1/test_pipeline_job_staleness.py
@@ -1,15 +1,23 @@
-"""Unit tests for the ops-console ``is_stale`` derivation.
+"""Unit tests for the shared job-staleness predicate.
 
-``_job_is_stale`` gates the console's stale badge + manual Recover button;
-it must mirror ``sweep_stuck_running_jobs``'s predicate (RUNNING with a
-lock heartbeat older than the stale window) so the UI and the auto-recovery
-sweep agree on what "stuck" means.
+``is_job_stale`` gates the console's stale badge + manual Recover button;
+``stale_running_clause`` is the SQL side used by the auto-recovery sweep
+and the ``recover_job`` gate. Both derive from one module so the UI and
+recovery machinery can never disagree on what "stuck" means — the parity
+test at the bottom locks the two implementations together.
 """
 
 from datetime import datetime, timedelta, timezone
 
-from app.api.v1.data_sync import _job_is_stale
-from app.models.data_ingestion import DataIngestionJob, EntityType, IngestionState
+import pytest
+from sqlmodel import select
+
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionState,
+)
+from app.repositories.data_ingestion import is_job_stale, stale_running_clause
 
 CUTOFF = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
 
@@ -22,24 +30,54 @@ def _job(state: IngestionState, locked_at: datetime | None) -> DataIngestionJob:
 
 def test_running_with_stale_heartbeat_is_stale():
     job = _job(IngestionState.RUNNING, CUTOFF - timedelta(minutes=1))
-    assert _job_is_stale(job, CUTOFF) is True
+    assert is_job_stale(job, CUTOFF) is True
 
 
 def test_running_with_fresh_heartbeat_is_not_stale():
     job = _job(IngestionState.RUNNING, CUTOFF + timedelta(minutes=1))
-    assert _job_is_stale(job, CUTOFF) is False
+    assert is_job_stale(job, CUTOFF) is False
 
 
 def test_running_without_lock_is_stale():
-    assert _job_is_stale(_job(IngestionState.RUNNING, None), CUTOFF) is True
+    assert is_job_stale(_job(IngestionState.RUNNING, None), CUTOFF) is True
 
 
 def test_finished_is_never_stale():
     job = _job(IngestionState.FINISHED, CUTOFF - timedelta(hours=2))
-    assert _job_is_stale(job, CUTOFF) is False
+    assert is_job_stale(job, CUTOFF) is False
 
 
 def test_naive_locked_at_is_treated_as_utc():
     # SQLite test DBs return tz-naive datetimes for tz-aware columns.
     naive = (CUTOFF - timedelta(minutes=1)).replace(tzinfo=None)
-    assert _job_is_stale(_job(IngestionState.RUNNING, naive), CUTOFF) is True
+    assert is_job_stale(_job(IngestionState.RUNNING, naive), CUTOFF) is True
+
+
+@pytest.mark.asyncio
+async def test_stale_predicate_parity(db_session):
+    """The SQL clause and the Python twin classify the same rows the same
+    way — a change to one without the other fails here."""
+    jobs = [
+        _job(IngestionState.RUNNING, CUTOFF - timedelta(minutes=1)),  # stale
+        _job(IngestionState.RUNNING, CUTOFF + timedelta(minutes=1)),  # fresh
+        _job(IngestionState.RUNNING, None),  # stale (no lock)
+        _job(IngestionState.FINISHED, CUTOFF - timedelta(hours=2)),  # terminal
+        _job(IngestionState.NOT_STARTED, None),  # never stale
+    ]
+    for job in jobs:
+        db_session.add(job)
+    await db_session.flush()
+
+    sql_ids = set(
+        (
+            await db_session.execute(
+                select(DataIngestionJob.id).where(stale_running_clause(CUTOFF))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    python_ids = {j.id for j in jobs if is_job_stale(j, CUTOFF)}
+
+    assert sql_ids == python_ids
+    assert len(python_ids) == 2

--- a/backend/tests/unit/v1/test_pipeline_job_staleness.py
+++ b/backend/tests/unit/v1/test_pipeline_job_staleness.py
@@ -1,0 +1,45 @@
+"""Unit tests for the ops-console ``is_stale`` derivation.
+
+``_job_is_stale`` gates the console's stale badge + manual Recover button;
+it must mirror ``sweep_stuck_running_jobs``'s predicate (RUNNING with a
+lock heartbeat older than the stale window) so the UI and the auto-recovery
+sweep agree on what "stuck" means.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.api.v1.data_sync import _job_is_stale
+from app.models.data_ingestion import DataIngestionJob, EntityType, IngestionState
+
+CUTOFF = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+
+
+def _job(state: IngestionState, locked_at: datetime | None) -> DataIngestionJob:
+    return DataIngestionJob(
+        entity_type=EntityType.MODULE_PER_YEAR, state=state, locked_at=locked_at
+    )
+
+
+def test_running_with_stale_heartbeat_is_stale():
+    job = _job(IngestionState.RUNNING, CUTOFF - timedelta(minutes=1))
+    assert _job_is_stale(job, CUTOFF) is True
+
+
+def test_running_with_fresh_heartbeat_is_not_stale():
+    job = _job(IngestionState.RUNNING, CUTOFF + timedelta(minutes=1))
+    assert _job_is_stale(job, CUTOFF) is False
+
+
+def test_running_without_lock_is_stale():
+    assert _job_is_stale(_job(IngestionState.RUNNING, None), CUTOFF) is True
+
+
+def test_finished_is_never_stale():
+    job = _job(IngestionState.FINISHED, CUTOFF - timedelta(hours=2))
+    assert _job_is_stale(job, CUTOFF) is False
+
+
+def test_naive_locked_at_is_treated_as_utc():
+    # SQLite test DBs return tz-naive datetimes for tz-aware columns.
+    naive = (CUTOFF - timedelta(minutes=1)).replace(tzinfo=None)
+    assert _job_is_stale(_job(IngestionState.RUNNING, naive), CUTOFF) is True

--- a/backend/tests/unit/v1/test_workspace_home.py
+++ b/backend/tests/unit/v1/test_workspace_home.py
@@ -102,3 +102,19 @@ async def test_stats_always_present_with_validated_total(monkeypatch):
     # Per-module states ride alongside (no separate list_modules call).
     assert result.module_states == [{"module_type_id": 1, "status": 2}]
     wh_module.build_validated_totals.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_home_year_config_carries_min_configurable_year():
+    # Regression: the workspace guard fans this slim payload into the frontend
+    # yearConfig store, which hard-errors on any year-config response missing
+    # ``min_configurable_year`` (#1204 follow-up).
+    db = MagicMock()
+    result = MagicMock()
+    result.first.return_value = SimpleNamespace(year=2025, config={"modules": {}})
+    db.exec = AsyncMock(return_value=result)
+
+    config = await wh_module.build_home_year_configuration(db, 2025, MagicMock())
+
+    assert config is not None
+    assert config.min_configurable_year == wh_module.settings.MIN_CONFIGURABLE_YEAR

--- a/backend/tests/unit/workflows/test_emission_recalculation.py
+++ b/backend/tests/unit/workflows/test_emission_recalculation.py
@@ -385,13 +385,14 @@ async def test_recalculate_reports_affected_module_ids_for_chain():
 
 
 @pytest.mark.asyncio
-async def test_recalculate_reports_progress_at_interval(monkeypatch):
-    """Every PROGRESS_INTERVAL computed entries, the workflow logs and
-    invokes the caller's progress callback (the handlers stamp it onto
-    the job row so SSE/UI can track long recalcs)."""
+async def test_recalculate_reports_progress_time_based(monkeypatch):
+    """Progress reporting is wall-time-throttled (stage incident
+    2026-07-17: the old every-5000-entries gate gave an 8488-entry slice
+    a single update). With the throttle forced open, every entry reports,
+    plus the terminal N/N update after the loop."""
     import app.workflows.emission_recalculation as wf_mod
 
-    monkeypatch.setattr(wf_mod, "PROGRESS_INTERVAL", 1)
+    monkeypatch.setattr(wf_mod, "PROGRESS_REPORT_INTERVAL_S", -1.0)
     mock_session = MagicMock()
     svc = EmissionRecalculationWorkflow(mock_session)
 
@@ -430,7 +431,53 @@ async def test_recalculate_reports_progress_at_interval(monkeypatch):
             DataEntryTypeEnum.plane, 2025, progress_callback=_progress
         )
 
-    assert progress_calls == [(1, 2), (2, 2)]
+    assert progress_calls == [(1, 2), (2, 2), (2, 2)]
+
+
+@pytest.mark.asyncio
+async def test_recalculate_always_reports_terminal_progress():
+    """A slice too fast to cross the report interval still gets the
+    terminal N/N update — the operator never sees a job finish while the
+    status line reads an intermediate count."""
+    mock_session = MagicMock()
+    svc = EmissionRecalculationWorkflow(mock_session)
+
+    entries = [_make_mock_entry(1, 10), _make_mock_entry(2, 10)]
+    progress_calls: list[tuple[int, int]] = []
+
+    async def _progress(done: int, total: int) -> None:
+        progress_calls.append((done, total))
+
+    with (
+        patch(
+            "app.workflows.emission_recalculation.DataEntryRepository"
+        ) as mock_repo_cls,
+        patch(
+            "app.workflows.emission_recalculation.FactorResolver"
+        ) as mock_resolver_cls,
+        patch(
+            "app.workflows.emission_recalculation.DataEntryEmissionService"
+        ) as mock_emission_cls,
+        patch("app.workflows.emission_recalculation.DataEntryResponse"),
+        patch(
+            "app.workflows.emission_recalculation.BaseModuleHandler"
+        ) as mock_handler_cls,
+    ):
+        mock_handler_cls.get_by_type.return_value = _make_mock_handler()
+        mock_repo_cls.return_value.list_by_data_entry_type_and_year = AsyncMock(
+            return_value=entries
+        )
+        _patch_resolver_empty(mock_resolver_cls)
+        mock_emission_cls.return_value.prepare_create = AsyncMock(return_value=[])
+        mock_emission_cls.return_value.bulk_replace_for_entries = AsyncMock(
+            return_value=0
+        )
+
+        await svc.recalculate_for_data_entry_type(
+            DataEntryTypeEnum.plane, 2025, progress_callback=_progress
+        )
+
+    assert progress_calls == [(2, 2)]
 
 
 # ======================================================================

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -112,6 +112,7 @@ erDiagram
   }
   data_ingestion_jobs {
     INTEGER attempts
+    DATETIME created_at
     INTEGER data_entry_type_id "indexed"
     INTEGER entity_id
     VARCHAR entity_type

--- a/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
+++ b/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
@@ -1,0 +1,71 @@
+---
+status: delivered
+issue: 1564
+last_updated: 2026-07-17
+title: "Stage incident follow-ups: cross-source bulk replace + stuck-job recovery"
+summary: "Headcount CSV upload after an API sync mass-skipped 8465 rows as DUPLICATE_INSTITUTIONAL_ID (bulk sources didn't replace each other), and a pod SIGTERM mid-recalc left the aggregation invisible for the 60-min stale window. Delivers cross-source full replace, 5-min heartbeat-based stale recovery, queue-time visibility, and a manual Recover button."
+---
+
+# Stage incident follow-ups (2026-07-17)
+
+## Incident
+
+Testing #1564 on stage: a headcount CSV upload after an API sync inserted
+20 of 8485 rows (8465 skipped `DUPLICATE_INSTITUTIONAL_ID`), then the
+chained `emission_recalc` was killed 60s in by a pod SIGTERM and sat
+`RUNNING` with no recovery in sight.
+
+Three root causes, one per section below.
+
+## 1. Cross-source bulk replace
+
+The per-year replace delete was scoped to `source=CSV_MODULE_PER_YEAR`
+only, while the `(user_institutional_id, sius_code)` uniqueness check has
+no source filter — so API-synced rows (`EXTERNAL_INTEGRATION`) survived
+the delete and collided with every CSV row.
+
+**Decision (maintainer):** a bulk per-year ingest (CSV _or_ API) is a
+complete yearly export and replaces all machine-owned bulk sources.
+
+- `BULK_PER_YEAR_SOURCES` (`models/data_entry.py`): CSV per-year, API
+  per-year, external integration. Manual + unit-specific always preserved.
+- `bulk_delete_by_source_year` takes `sources: list[int]`; both callers
+  (`base_csv_provider`, `base_tableau_api_provider`) pass the constant.
+- Tests: unit (both providers) + pg integration seed an API row and prove
+  it's replaced.
+
+Note: the test file itself carried 760 intra-file `(uid, sius_code)`
+duplicate rows — those still skip by design; whether the key needs a third
+component is an open data question, not covered here.
+
+## 2. Stuck-job recovery latency
+
+The pod was SIGTERMed mid-job (readiness "connection refused" was a
+_consequence_ — the likely cause is node-pressure eviction: 128Mi request
+vs 512Mi limit; confirm via the pod's `lastState.terminated`). Nothing
+marks a cancelled job, so the row stayed `RUNNING` until the stale sweep —
+whose window was 60 min, a default from before the 310-C per-job heartbeat
+existed.
+
+- `STALE_JOB_TIMEOUT_MINUTES` 60 → **5** (config default, helm,
+  .env.example): heartbeats every 75s, dead-pod recovery ≤ ~6 min. The
+  window bounds _crash-recovery latency_, not job runtime — stale
+  docstrings claiming otherwise rewritten (`sweep_stuck_running_jobs`,
+  `_heartbeat_loop`).
+- Not 2 min: the same window is the live runner's self-abort threshold on
+  heartbeat failures; 5 min tolerates transient DB outages.
+
+**Deferred (needs plan + both maintainers):** shutdown handler in
+`run_job` releasing claimed jobs on CancelledError (near-instant recovery
+after graceful kills); dedicated worker Deployment so long jobs stop
+sharing lifecycle with HTTP pods; memory request raised toward real usage.
+
+## 3. Operator visibility
+
+- Jobs table gains `created_at` (migration `7bfda0d45f14`); the ops
+  console shows `queued Xs` (created→started) next to the run duration —
+  a sub-second aggregation that waited 20s no longer reads as "<1s total".
+- `PipelineJobListEntry.is_stale` derived server-side (same predicate as
+  the sweep); the console renders a stale badge + **Recover** button
+  wiring the pre-existing `POST /jobs/{id}/recover`. Deliberately _not_ a
+  new persisted job state — staleness is derived, not stored.

--- a/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
+++ b/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
@@ -34,6 +34,17 @@ complete yearly export and replaces all machine-owned bulk sources.
 - Tests: unit (both providers) + pg integration seed an API row and prove
   it's replaced.
 
+**Follow-up (same incident, second layer):** the replace DELETE keys on
+the denormalized `data_entries.year`, but the API providers built their
+entries **without** `year`/`unit_id` — so the cross-source delete matched
+zero API rows and re-uploads still mass-collided. Both API providers now
+stamp the scope columns (module→unit map built during resolution;
+`_ingest_year` property fails loudly without a configured year), and
+migration `8eeff0a9fa26` backfills existing NULL rows from each entry's
+carbon report. The data card also treats an API sync as existing data
+(re-upload label + same ERROR/WARNING/SUCCESS color mapping as CSV, with
+CSV precedence — a WARNING sync previously rendered as red "Add Data").
+
 Note: the test file itself carried 760 intra-file `(uid, sius_code)`
 duplicate rows — those still skip by design; whether the key needs a third
 component is an open data question, not covered here.

--- a/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
+++ b/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
@@ -37,11 +37,12 @@ complete yearly export and replaces all machine-owned bulk sources.
 **Follow-up (same incident, second layer):** the replace DELETE keys on
 the denormalized `data_entries.year`, but the API providers built their
 entries **without** `year`/`unit_id` — so the cross-source delete matched
-zero API rows and re-uploads still mass-collided. Both API providers now
-stamp the scope columns (module→unit map built during resolution;
-`_ingest_year` property fails loudly without a configured year), and
-migration `8eeff0a9fa26` backfills existing NULL rows from each entry's
-carbon report. The data card also treats an API sync as existing data
+zero API rows and re-uploads still mass-collided. The stamp now lives
+centrally in `DataEntryService.fill_denormalized_scope` (called by
+create / bulk_create / bulk_copy — post-review altitude fix, replacing
+the initial per-provider stamping), so no write path can omit it; manual
+entries are stamped too. Migration `8eeff0a9fa26` backfills existing
+NULL rows from each entry's carbon report. The data card also treats an API sync as existing data
 (re-upload label + same ERROR/WARNING/SUCCESS color mapping as CSV, with
 CSV precedence — a WARNING sync previously rendered as red "Add Data").
 

--- a/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
+++ b/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
@@ -45,6 +45,25 @@ carbon report. The data card also treats an API sync as existing data
 (re-upload label + same ERROR/WARNING/SUCCESS color mapping as CSV, with
 CSV precedence — a WARNING sync previously rendered as red "Add Data").
 
+**Follow-up (performance):** the row loop ran ONE uniqueness SELECT per
+row — at stage latencies an 8.5k-row parse dropped to 14 rows/s (~10
+min), the same N+1 shape COPY batching had already removed on the write
+side. The in-memory duplicate set is now seeded with all existing
+`(module, uid, sius_code)` member tuples in one bulk query
+(`get_member_role_keys`), gated to headcount ingests; the per-row check
+is a set lookup. The manual-entry path keeps its single-row
+`check_member_role_unique`.
+
+**Deferred (schema change on validated data — proposal for the lead):**
+DB-enforced member-role uniqueness as defense-in-depth: a partial unique
+index on `(carbon_report_module_id, data->>'user_institutional_id',
+data->>'sius_code') WHERE data_entry_type_id = <member>`, with the bulk
+path COPYing into a staging table and `INSERT … ON CONFLICT DO NOTHING`.
+Only variant airtight under concurrent writers; today the per-year
+advisory locks already serialize bulk ingests, so this is belt-and-braces.
+Costs: staging-table refactor of the COPY path and loss of per-row
+"Row N: DUPLICATE" reporting.
+
 Note: the test file itself carried 760 intra-file `(uid, sius_code)`
 duplicate rows — those still skip by design; whether the key needs a third
 component is an open data question, not covered here.

--- a/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
+++ b/docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md
@@ -40,12 +40,25 @@ component is an open data question, not covered here.
 
 ## 2. Stuck-job recovery latency
 
-The pod was SIGTERMed mid-job (readiness "connection refused" was a
-_consequence_ — the likely cause is node-pressure eviction: 128Mi request
-vs 512Mi limit; confirm via the pod's `lastState.terminated`). Nothing
-marks a cancelled job, so the row stayed `RUNNING` until the stale sweep —
-whose window was 60 min, a default from before the 310-C per-job heartbeat
-existed.
+The pod was SIGTERMed mid-job. **Root cause confirmed by probe-latency
+measurement on stage:** the recalc loop yielded the event loop only every
+1000 entries, so `/healthz` (a no-op endpoint) couldn't get a slot within
+the kubelet's 2s probe timeout during pure-CPU stretches — three straight
+liveness failures at 20s period killed the pod exactly 60s after
+`Recalc member/2025` started. (Memory was fine: 798Mi of 1000Mi.
+Readiness "connection refused" events were the restart gap, not the
+cause.) Nothing marks a cancelled job, so the row stayed `RUNNING` until
+the stale sweep — whose window was 60 min, a default from before the
+310-C per-job heartbeat existed.
+
+**Fix (event-loop starvation):** both CPU loops now yield on wall time
+(~50ms) instead of entry count — recalc (`emission_recalculation.py`,
+was every 1000 entries) and CSV row loop (`base_csv_provider.py`, was
+every 100 rows). Recalc progress reporting also went time-based (every
+2s, was every 5000 entries) with a terminal N/N update, and the job
+status line carries rate + ETA. **Ops action (cluster config, not this
+repo):** stage's probe overrides set `timeoutSeconds: 2` — raise to 5
+(the chart default) for liveness and readiness.
 
 - `STALE_JOB_TIMEOUT_MINUTES` 60 → **5** (config default, helm,
   .env.example): heartbeats every 75s, dead-pod recovery ≤ ~6 min. The

--- a/frontend/scripts/openapi.snapshot.json
+++ b/frontend/scripts/openapi.snapshot.json
@@ -8833,6 +8833,19 @@
             "title": "Locked At",
             "description": "Timestamp of the most recent successful claim"
           },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "Timestamp the job row was created.  created_at \u2192 started_at is queue wait (chain/lock/poller latency); started_at \u2192 finished_at is execution \u2014 the ops console shows both."
+          },
           "started_at": {
             "anyOf": [
               {
@@ -9760,6 +9773,18 @@
             ],
             "title": "Year"
           },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
           "started_at": {
             "anyOf": [
               {
@@ -9794,6 +9819,11 @@
               }
             ],
             "title": "Attempts"
+          },
+          "is_stale": {
+            "type": "boolean",
+            "title": "Is Stale",
+            "default": false
           },
           "meta": {
             "additionalProperties": true,

--- a/frontend/scripts/openapi.snapshot.json
+++ b/frontend/scripts/openapi.snapshot.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "CO2 Calculator API",
+    "title": "CO2 Calculator API - LOCAL",
     "description": "\n    CO2 Calculator API with permission-based authorization using Open Policy Agent.\n\n    ## Features\n\n    * **JWT Authentication** - Secure token-based authentication\n    * **Permission-Based Authorization** - Fine-grained access control with\n      calculated permissions\n    * **OPA Policies** - Policy-based resource filtering and access control\n    * **Multi-tenancy** - Support for multiple EPFL units with scope-based\n      data filtering\n    * **RESTful API** - Clean and consistent API design\n\n    ## Permission-Based Authorization\n\n    The API uses a permission-based authorization model where:\n\n    - **Roles are assigned** to users (e.g., principal, backoffice metier, super admin)\n    - **Permissions are calculated** dynamically from roles at authentication\n    - **Access control** is enforced at the route level using permissions\n    - **Data filtering** is applied based on user scope (global, unit, own)\n\n    ### Permission Structure\n\n    Permissions follow a hierarchical dot-notation structure:\n\n    * **backoffice.*** - One permission per backoffice page\n        * `backoffice.reporting` (view, export) - Reporting (affiliation-scoped)\n        * `backoffice.users` (view, edit, export) - User management\n        * `backoffice.documentation` / `backoffice.ui_texts` (view, edit)\n        * `backoffice.configuration` / `backoffice.pipeline_operations`\n          (view, edit) - super admin only\n        * `backoffice.logs` (view) - super admin only\n\n    * **modules.*** - CO2 calculation modules (unit-scoped `\u2026/<unit>`, or\n      own-scoped `\u2026/<unit>/own` for standard users)\n        * `modules.headcount`, `modules.professional_travel`, `modules.equipment`,\n          \u2026 (view, edit, sync)\n\n    ### Permission Actions\n\n    Each permission supports different actions:\n    - **view** - Read access to resources\n    - **edit** - Create, update, and delete operations\n    - **export** - Data export capabilities\n\n    ### How Permissions Work\n\n    1. User authenticates via `/api/v1/auth/login` and receives JWT token\n    2. JWT token contains user information and assigned roles\n    3. On each request, permissions are calculated from roles\n    4. Routes use `require_permission(\"path.resource\", \"action\")` decorator\n    5. If permission denied, returns 403 with specific error message\n    6. Data queries are filtered by user scope (global/unit/own)\n\n    ### Example Permission Check\n\n    ```python\n    @router.get(\"/headcounts\")\n    async def get_headcounts(\n        user: User = Depends(require_permission(\"modules.headcount\", \"view\"))\n    ):\n        # Only users with modules.headcount.view permission can access\n        # Data is filtered by scope: global, unit, or own\n    ```\n\n    ## Authorization Model with OPA\n\n    The API uses OPA (Open Policy Agent) patterns for authorization decisions:\n\n    1. **Route-level permission checks** - Enforced via `require_permission()`\n       decorator\n    2. **Service-level data filtering** - Applied via `get_data_filters()`\n       based on scope\n    3. **Resource-level access control** - Checked via `check_resource_access()`\n       for individual resources\n\n    ### Scope-Based Data Filtering\n\n    Data access is automatically filtered based on user scope:\n\n    * **Global scope** (super admin) - See all data\n    * **Unit scope** (principals) - See data for their assigned units\n    * **Own scope** (standard users) - See only their own data\n\n    ## Assigned Roles\n\n    Users are assigned one or more of these roles. Permissions are calculated\n    from role assignments:\n\n    * **calco2.user.std** - Basic user with own-scope access\n    * **calco2.user.principal** - Unit-level manager with unit-scope access\n    * **calco2.backoffice.metier** - Backoffice administrator with reporting and\n      data access\n    * **calco2.backoffice.admin** - Super administrator with full system and backoffice\n    See permission documentation for detailed role-to-permission mapping.\n\n    ## 403 Error Responses\n\n    When a user lacks required permissions, the API returns a 403 Forbidden response:\n\n    ```json\n    {\n        \"detail\": \"Permission denied: modules.headcount.edit required\"\n    }\n    ```\n\n    ### Common Causes\n\n    * **Missing permission** - User's roles don't grant the required permission\n    * **Insufficient scope** - User has permission but wrong scope\n      (e.g., different unit)\n    * **Resource restrictions** - Business rules prevent access\n      (e.g., API trips are read-only)\n\n    ### Requesting Access\n\n    To gain additional permissions:\n    1. Contact your unit principal or backoffice administrator\n    2. Request the specific permission needed (shown in error message)\n    3. Administrator can assign appropriate role via\n       `/api/v1/backoffice/users` endpoints\n\n    ",
     "version": "0.1.0"
   },
@@ -46,13 +46,55 @@
         }
       }
     },
+    "/v1/auth/login-test": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login Test",
+        "description": "Test login endpoint for development.\n\nRegistered on the router only when ``settings.DEBUG`` is true (see\nbottom of this module). In a production build the route does not\nexist \u2014 clients see 404 rather than 403, and the handler code is\nunreachable.",
+        "operationId": "login_test_v1_auth_login_test_get",
+        "parameters": [
+          {
+            "name": "role",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "co2.user.std",
+              "title": "Role"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/session": {
       "get": {
         "tags": [
           "session"
         ],
         "summary": "Get Session",
-        "description": "Return the current session's user (whoami).\n\nRequires a valid ``auth_token`` cookie. Resolves user by stable\nidentity (institutional_id, provider) from JWT. Uses cached DB\nroles \u2014 does not sync from the role provider synchronously.",
+        "description": "Return the current session bootstrap payload (whoami + workspace context).\n\nRequires a valid ``auth_token`` cookie. Resolves user by stable\nidentity (institutional_id, provider) from JWT. Uses cached DB\nroles \u2014 does not sync from the role provider synchronously.\n\nBeyond the user, the response bundles the units the caller can access and\nthe globally-configured years, so the frontend hydrates its whole auth/\nworkspace context in a single request instead of three.",
         "operationId": "get_session_v1_session_get",
         "parameters": [
           {
@@ -78,7 +120,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserRead"
+                  "$ref": "#/components/schemas/SessionRead"
                 }
               }
             }
@@ -1616,7 +1658,10 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 {
                   "type": "null"
@@ -1888,7 +1933,7 @@
           "modules"
         ],
         "summary": "Get Top Class Breakdown",
-        "description": "Get emissions aggregated by subcategory with top 3 items per subcategory.\n\nReturns a list per subcategory, each containing the top 3 items (by\nemission) and a \"rest\" bucket. Works for any module configured in\n``_MODULE_TOP_CLASS_GROUP_FIELD``.",
+        "description": "Get emissions aggregated by subcategory with top 3 items per subcategory.\n\nReturns a list per subcategory, each containing the top 3 items (by\nemission) and a \"rest\" bucket. Works for any module configured in\n``_MODULE_TOP_CLASS_GROUP_FIELD``.\n\n``combine_unit_ids`` re-ranks the classes over the union of those units'\nentries plus ``unit_id``'s, for the Results page's combined-units view.",
         "operationId": "get_top_class_breakdown_v1_modules__unit_id___year___module_id__top_class_breakdown_get",
         "parameters": [
           {
@@ -1928,6 +1973,18 @@
               "minimum": 0,
               "default": 0,
               "title": "Carbon Project Type"
+            }
+          },
+          {
+            "name": "combine_unit_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "title": "Combine Unit Ids"
             }
           },
           {
@@ -2897,60 +2954,6 @@
         }
       }
     },
-    "/v1/modules-stats/{carbon_report_id}/validated-totals": {
-      "get": {
-        "tags": [
-          "modules-stats"
-        ],
-        "summary": "Get Validated Totals",
-        "description": "Get validated totals for a carbon report.\n\nAggregates emissions (kg \u2192 tonnes CO2eq) and FTE across all validated\nmodules in the given carbon report. Both are keyed by module_type_id so\nheadcount appears with total_fte while other modules show total_tonnes_co2eq.\n\nReturns:\n    {\n        \"modules\": {1: 25.5, 2: 15.0, 4: 41.7, 7: 5.0},\n        \"total_tonnes_co2eq\": 61.7,\n        \"total_fte\": 25.5\n    }",
-        "operationId": "get_validated_totals_v1_modules_stats__carbon_report_id__validated_totals_get",
-        "parameters": [
-          {
-            "name": "carbon_report_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Carbon Report Id"
-            }
-          },
-          {
-            "name": "auth_token",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Auth Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Validated Totals V1 Modules Stats  Carbon Report Id  Validated Totals Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/modules-stats/{unit_id}/{year}/{module_id}/stats": {
       "get": {
         "tags": [
@@ -3032,6 +3035,312 @@
         }
       }
     },
+    "/v1/modules-stats/unit/{unit_id}/multi-year-report-stats": {
+      "get": {
+        "tags": [
+          "modules-stats"
+        ],
+        "summary": "Get Multi Year Breakdown",
+        "description": "Return per-year emission breakdown (by module and by scope) for a unit.\n\nFeeds the \"Compare Years\" pop-up: one entry per year with stat-bucket\ntotals (``modules``) and scope totals (``scopes``) in tonnes CO2eq, read\nstraight off each report's persisted stats.\n\nReturns:\n    {\"years\": [{\"year\": 2023, \"total_tonnes_co2eq\": 61.7,\n                \"modules\": {...}, \"scopes\": {...}}, ...]}",
+        "operationId": "get_multi_year_breakdown_v1_modules_stats_unit__unit_id__multi_year_report_stats_get",
+        "parameters": [
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Unit Id"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Multi Year Breakdown V1 Modules Stats Unit  Unit Id  Multi Year Report Stats Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/modules-stats/merged/report-stats": {
+      "get": {
+        "tags": [
+          "modules-stats"
+        ],
+        "summary": "Get Merged Report Stats",
+        "description": "Sum several units' persisted report stats into one payload.\n\nSame shape as ``/{carbon_report_id}/report-stats``, so the frontend derives\nits charts from it unchanged. ``merge_report_stats`` drops per-unit\ntop-class detail on purpose, so the IT section's is re-ranked across all\nthe reports here rather than unioned.",
+        "operationId": "get_merged_report_stats_v1_modules_stats_merged_report_stats_get",
+        "parameters": [
+          {
+            "name": "unit_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "title": "Unit Ids"
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Year"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Merged Report Stats V1 Modules Stats Merged Report Stats Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/modules-stats/merged/results-summary": {
+      "get": {
+        "tags": [
+          "modules-stats"
+        ],
+        "summary": "Get Merged Results Summary",
+        "description": "Results summary over several units, summed per module.\n\nEach unit contributes its own validated module totals and its own\nprevious-year comparison basis, so the year-over-year figure stays\nmeaningful for a combined perimeter.",
+        "operationId": "get_merged_results_summary_v1_modules_stats_merged_results_summary_get",
+        "parameters": [
+          {
+            "name": "unit_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "title": "Unit Ids"
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Year"
+            }
+          },
+          {
+            "name": "exclude_modules",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "title": "Exclude Modules"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Merged Results Summary V1 Modules Stats Merged Results Summary Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/modules-stats/{carbon_report_id}/report-stats": {
+      "get": {
+        "tags": [
+          "modules-stats"
+        ],
+        "summary": "Get Report Stats",
+        "description": "Return the persisted report stats with the validated headline merged in.\n\nSame payload as the ``stats`` field of the workspace-home aggregate; used\nby the frontend to refresh charts after mutations without refetching the\nwhole home bundle.",
+        "operationId": "get_report_stats_v1_modules_stats__carbon_report_id__report_stats_get",
+        "parameters": [
+          {
+            "name": "carbon_report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Carbon Report Id"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Report Stats V1 Modules Stats  Carbon Report Id  Report Stats Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/modules-stats/{carbon_report_id}/validated-totals": {
+      "get": {
+        "tags": [
+          "modules-stats"
+        ],
+        "summary": "Get Validated Totals",
+        "description": "Validated-only totals per module (tonnes; FTE for headcount).",
+        "operationId": "get_validated_totals_v1_modules_stats__carbon_report_id__validated_totals_get",
+        "parameters": [
+          {
+            "name": "carbon_report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Carbon Report Id"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Validated Totals V1 Modules Stats  Carbon Report Id  Validated Totals Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/modules-stats/{carbon_report_id}/results-summary": {
       "get": {
         "tags": [
@@ -3081,138 +3390,6 @@
                   "type": "object",
                   "additionalProperties": true,
                   "title": "Response Get Results Summary V1 Modules Stats  Carbon Report Id  Results Summary Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/modules-stats/{carbon_report_id}/emission-breakdown": {
-      "get": {
-        "tags": [
-          "modules-stats"
-        ],
-        "summary": "Get Emission Breakdown",
-        "description": "Return chart-ready emission breakdown for a carbon report.\n\nServes both ModuleCarbonFootprintChart (module_breakdown +\nadditional_breakdown) and CarbonFootPrintPerPersonChart\n(per_person_breakdown).",
-        "operationId": "get_emission_breakdown_v1_modules_stats__carbon_report_id__emission_breakdown_get",
-        "parameters": [
-          {
-            "name": "carbon_report_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Carbon Report Id"
-            }
-          },
-          {
-            "name": "exclude_modules",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "title": "Exclude Modules"
-            }
-          },
-          {
-            "name": "auth_token",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Auth Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Emission Breakdown V1 Modules Stats  Carbon Report Id  Emission Breakdown Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/modules-stats/{carbon_report_id}/it-breakdown": {
-      "get": {
-        "tags": [
-          "modules-stats"
-        ],
-        "summary": "Get It Breakdown",
-        "description": "Return IT-focused emission breakdown for a carbon report.\n\nAggregates IT-related emissions from Equipment (IT electricity),\nPurchases (IT hardware), and External Cloud & AI into a single view.\nIncludes top-class breakdown per IT category.\n\n``exclude_modules`` matches emission-breakdown / results-summary filtering\n(e.g. hide research facilities).",
-        "operationId": "get_it_breakdown_v1_modules_stats__carbon_report_id__it_breakdown_get",
-        "parameters": [
-          {
-            "name": "carbon_report_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Carbon Report Id"
-            }
-          },
-          {
-            "name": "exclude_modules",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "title": "Exclude Modules"
-            }
-          },
-          {
-            "name": "auth_token",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Auth Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get It Breakdown V1 Modules Stats  Carbon Report Id  It Breakdown Get"
                 }
               }
             }
@@ -5934,6 +6111,360 @@
         }
       }
     },
+    "/v1/sync/admin/recompute-stats": {
+      "post": {
+        "tags": [
+          "data-sync"
+        ],
+        "summary": "Recompute Stats",
+        "description": "Force a full stats recompute for every ``(module_type_id, year)`` scope.\n\nDispatches one root ``aggregation`` job per scope \u2014 the same handler the\nrecalc chain uses to write ``carbon_report_module.stats`` /\n``carbon_report.stats``, but with no ``affected_module_ids`` scoping, so\nevery module in the scope is recomputed rather than just the ones a\nrecalc flagged as touched.\n\nScopes with no current, successful FACTORS job are skipped outright\n(counted in ``skipped_no_factors``): recomputing stats against missing\nreference data just writes zeros, so there's nothing worth spending a\njob \u2014 or a pooled DB connection \u2014 on.\n\nJobs for the same year are chained to run one at a time rather than\nfired concurrently, since they'd only queue up behind each other's\nPostgres advisory lock anyway; different years still dispatch in\nparallel.\n\nNeeded after any change to what recompute_stats persists (e.g. a stats\nJSON shape change): existing rows keep whatever an older deploy wrote\nuntil something re-triggers their aggregation, and most reports won't\nnaturally get one soon.  The dedup index makes re-triggering a safe\nno-op for scopes still in flight.",
+        "operationId": "recompute_stats_v1_sync_admin_recompute_stats_post",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Limit to a single year; omit to recompute every year.",
+              "title": "Year"
+            },
+            "description": "Limit to a single year; omit to recompute every year."
+          },
+          {
+            "name": "module_type_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Limit to a single module type; omit for every module type.",
+              "title": "Module Type Id"
+            },
+            "description": "Limit to a single module type; omit for every module type."
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecomputeStatsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/connectors": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Get Connectors",
+        "operationId": "get_connectors_v1_connectors_get",
+        "parameters": [
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ConnectorSpecRead"
+                  },
+                  "title": "Response Get Connectors V1 Connectors Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/connectors/{connector}/connection": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Get Connection",
+        "operationId": "get_connection_v1_connectors__connector__connection_get",
+        "parameters": [
+          {
+            "name": "connector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ConnectorType"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ConnectorConnectionRead"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Connection V1 Connectors  Connector  Connection Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Upsert Connection",
+        "operationId": "upsert_connection_v1_connectors__connector__connection_put",
+        "parameters": [
+          {
+            "name": "connector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ConnectorType"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorConnectionCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorConnectionRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/connectors/{connector}/datasources": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Upsert Datasource",
+        "operationId": "upsert_datasource_v1_connectors__connector__datasources_post",
+        "parameters": [
+          {
+            "name": "connector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ConnectorType"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorDatasourceCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorDatasourceRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/connectors/{connector}/test": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Test Connection",
+        "description": "Trigger a live connection test.\n\nEnforces a per-user cooldown so the outbound call is rate-limited, then\nruns the provider's JWT sign-in probe. ``detail`` is always a generic\nstring \u2014 never a raw exception, stack trace, or provider response body\n(A06/A10).\n\nThe test itself is audited (PRD): who + when + connector + the boolean\noutcome \u2014 never the secret, never a raw error. Rate-limited (429) calls\nraise before this point, so they leave no audit row.",
+        "operationId": "test_connection_v1_connectors__connector__test_post",
+        "parameters": [
+          {
+            "name": "connector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ConnectorType"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Test Connection V1 Connectors  Connector  Test Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/audit/activity": {
       "get": {
         "tags": [
@@ -6630,7 +7161,7 @@
           "year-configuration"
         ],
         "summary": "List Year Configurations",
-        "description": "List year configurations available to the caller.\n\nResults are always scoped to ``current_user.provider`` \u2014 a TEST user\nnever sees ACCRED rows and vice versa. Backoffice data managers\nadditionally bypass the ``is_started`` filter (regular users only\nsee opened years). This is what drives the workspace year selector\n\u2014 closed years stay hidden from regular users until backoffice\nopens them.\n\nSorted by year descending (latest first).",
+        "description": "List opened year configurations available to the caller.\n\nResults are always scoped to ``current_user.provider`` \u2014 a TEST user\nnever sees ACCRED rows and vice versa. Only ``is_started`` years are\nreturned, for every caller including backoffice data managers, since\nthis is what drives the workspace year selector \u2014 closed years stay\nhidden until backoffice opens them.\n\nSorted by year descending (latest first).",
         "operationId": "list_year_configurations_v1_year_configuration__get",
         "parameters": [
           {
@@ -6973,6 +7504,67 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workspace/{unit_id}/{year}/home": {
+      "get": {
+        "tags": [
+          "workspace"
+        ],
+        "summary": "Get Workspace Home",
+        "description": "Resolve the full workspace + home dashboard payload in one call.\n\nGets the carbon report for ``unit_id``/``year``, then bundles the year\nconfiguration, the persisted report stats (with the validated-only total\nmerged in) and the per-module states.",
+        "operationId": "get_workspace_home_v1_workspace__unit_id___year__home_get",
+        "parameters": [
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Unit Id"
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Year"
+            }
+          },
+          {
+            "name": "auth_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Auth Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceHomeResponse"
+                }
               }
             }
           },
@@ -7739,6 +8331,262 @@
         "title": "CarbonReportRead",
         "description": "Schema for reading a carbon report."
       },
+      "ConnectorConnectionCreate": {
+        "properties": {
+          "label": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Label"
+          },
+          "server_url": {
+            "type": "string",
+            "maxLength": 2048,
+            "title": "Server Url"
+          },
+          "site_content_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Site Content Url"
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Username"
+          },
+          "client_id": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Client Id"
+          },
+          "secret_id": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Secret Id"
+          },
+          "secret_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 4096
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "label",
+          "server_url",
+          "username",
+          "client_id",
+          "secret_id"
+        ],
+        "title": "ConnectorConnectionCreate"
+      },
+      "ConnectorConnectionRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "connector": {
+            "$ref": "#/components/schemas/ConnectorType"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "server_url": {
+            "type": "string",
+            "title": "Server Url"
+          },
+          "site_content_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Site Content Url"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
+          "secret_id": {
+            "type": "string",
+            "title": "Secret Id"
+          },
+          "has_secret": {
+            "type": "boolean",
+            "title": "Has Secret"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "connector",
+          "label",
+          "server_url",
+          "site_content_url",
+          "username",
+          "client_id",
+          "secret_id",
+          "has_secret",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ConnectorConnectionRead"
+      },
+      "ConnectorDatasourceCreate": {
+        "properties": {
+          "module_type_id": {
+            "type": "integer",
+            "title": "Module Type Id"
+          },
+          "data_entry_type_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Entry Type Id"
+          },
+          "connector_luid": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Connector Luid"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Label"
+          }
+        },
+        "type": "object",
+        "required": [
+          "module_type_id",
+          "connector_luid",
+          "label"
+        ],
+        "title": "ConnectorDatasourceCreate"
+      },
+      "ConnectorDatasourceRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "connection_id": {
+            "type": "integer",
+            "title": "Connection Id"
+          },
+          "module_type_id": {
+            "type": "integer",
+            "title": "Module Type Id"
+          },
+          "data_entry_type_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Entry Type Id"
+          },
+          "connector_luid": {
+            "type": "string",
+            "title": "Connector Luid"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "connection_id",
+          "module_type_id",
+          "data_entry_type_id",
+          "connector_luid",
+          "label",
+          "is_active"
+        ],
+        "title": "ConnectorDatasourceRead"
+      },
+      "ConnectorSpecRead": {
+        "properties": {
+          "connector": {
+            "$ref": "#/components/schemas/ConnectorType"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "form_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Form Fields"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connector",
+          "label",
+          "form_fields"
+        ],
+        "title": "ConnectorSpecRead"
+      },
+      "ConnectorType": {
+        "type": "string",
+        "enum": [
+          "EPFL_TABLEAU"
+        ],
+        "title": "ConnectorType"
+      },
       "DataEntryResponse": {
         "properties": {
           "data_entry_type_id": {
@@ -8367,16 +9215,42 @@
         "title": "HeadcountMemberDropdownItem",
         "description": "Lightweight member record used to populate traveler dropdowns."
       },
+      "HomeYearConfiguration": {
+        "properties": {
+          "year": {
+            "type": "integer",
+            "title": "Year"
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config"
+          },
+          "min_configurable_year": {
+            "type": "integer",
+            "title": "Min Configurable Year"
+          }
+        },
+        "type": "object",
+        "required": [
+          "year",
+          "config",
+          "min_configurable_year"
+        ],
+        "title": "HomeYearConfiguration",
+        "description": "Slim year-config for the home aggregate \u2014 only what workspace pages read.\n\nThe workspace pages (home / module / results / sidebar) read module\n``enabled``/``uncertainty_tag`` and submodule\n``enabled``/``threshold``/``inputs_deactivated``/``csv_deactivated`` (plus\n``reduction_objectives``) \u2014 all of which live under ``config``. Every other\nfield of the full ``YearConfigurationResponse`` (``is_started``,\n``updated_at``, ``configuration_completed``, ``pipeline_id``,\n``recalculation_status``) is read only on the backoffice data-management page,\nwhich refetches the full config via ``GET /year-configuration/{year}``. So\nhome omits them entirely."
+      },
       "IngestionMethod": {
         "type": "integer",
         "enum": [
           0,
           1,
           2,
-          3
+          3,
+          4
         ],
         "title": "IngestionMethod",
-        "description": "Docstring for IngestionMethod\n\n:var api: Description\n:vartype api: Literal[0]\n:var csv: Description\n:vartype csv: Literal[1]\n:var manual: Description\n:vartype manual: Literal[2]\n:var computed: Recompute factor values from existing emission data\n:vartype computed: Literal[3]"
+        "description": "Docstring for IngestionMethod\n\n:var api: Description\n:vartype api: Literal[0]\n:var csv: Description\n:vartype csv: Literal[1]\n:var manual: Description\n:vartype manual: Literal[2]\n:var computed: Recompute factor values from existing emission data\n:vartype computed: Literal[3]\n:var copy_previous_year: Historical only \u2014 the factor-copy feature\n    (#740) was removed and no provider is registered for this method;\n    the value persists on old ingestion-job rows.\n:vartype copy_previous_year: Literal[4]"
       },
       "IngestionResult": {
         "type": "integer",
@@ -8739,7 +9613,7 @@
           "pagination": {
             "$ref": "#/components/schemas/app__schemas__backoffice__PaginationMeta"
           },
-          "emission_breakdown": {
+          "stats": {
             "anyOf": [
               {
                 "additionalProperties": true,
@@ -8749,19 +9623,7 @@
                 "type": "null"
               }
             ],
-            "title": "Emission Breakdown"
-          },
-          "it_breakdown": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "It Breakdown"
+            "title": "Stats"
           },
           "validated_units_count": {
             "type": "integer",
@@ -8945,7 +9807,7 @@
           "job_id"
         ],
         "title": "PipelineJobListEntry",
-        "description": "One job inside a pipeline, as shown in the ops-console DAG (#1234).\n\nSlimmer than the pipeline read endpoint's ``PipelineJobResponse``:\ncarries timing for per-step duration and an **allow-listed** ``meta``\n(never the big ``error_details`` / ``affected_module_ids`` arrays).\n\n``state`` and ``result`` serialize as the enum NAME (string), not\nthe int value \u2014 Pydantic's int-enum default would ship ``3`` for\n``FINISHED`` which mismatches every frontend consumer (the TS\ninterface declares ``string | null`` and renders comparisons like\n``j.state === 'FINISHED'``).  The field_serializers below pin the\ncontract."
+        "description": "One job inside a pipeline, as shown in the ops-console DAG (#1234).\n\nSlimmer than the pipeline read endpoint's ``PipelineJobResponse``:\ncarries timing for per-step duration and an **allow-listed** ``meta``\n(never the big ``affected_module_ids`` array; ``error_details`` only\nfor FACTORS-target jobs \u2014 see ``_project_pipeline_meta``, #1591).\n\n``state`` and ``result`` serialize as the enum NAME (string), not\nthe int value \u2014 Pydantic's int-enum default would ship ``3`` for\n``FINISHED`` which mismatches every frontend consumer (the TS\ninterface declares ``string | null`` and renders comparisons like\n``j.state === 'FINISHED'``).  The field_serializers below pin the\ncontract."
       },
       "PipelineJobResponse": {
         "properties": {
@@ -9441,6 +10303,17 @@
               }
             ]
           },
+          "last_factor_job_error_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Factor Job Error Count"
+          },
           "last_recalculation_job_id": {
             "anyOf": [
               {
@@ -9472,6 +10345,72 @@
         ],
         "title": "RecalculationStatusEntry",
         "description": "Per-(module_type_id, data_entry_type_id) recalculation status."
+      },
+      "RecomputeStatsResponse": {
+        "properties": {
+          "dispatched": {
+            "type": "integer",
+            "title": "Dispatched"
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped"
+          },
+          "skipped_no_factors": {
+            "type": "integer",
+            "title": "Skipped No Factors",
+            "default": 0
+          },
+          "job_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Job Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dispatched",
+          "skipped",
+          "job_ids"
+        ],
+        "title": "RecomputeStatsResponse",
+        "description": "Result of the admin bulk stats-recompute trigger."
+      },
+      "SessionRead": {
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/UserRead"
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/UnitWithUserRole"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "configured_years": {
+            "items": {
+              "$ref": "#/components/schemas/YearConfigurationListItem"
+            },
+            "type": "array",
+            "title": "Configured Years"
+          },
+          "min_configurable_year": {
+            "type": "integer",
+            "title": "Min Configurable Year"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user",
+          "units",
+          "configured_years",
+          "min_configurable_year"
+        ],
+        "title": "SessionRead",
+        "description": "Bootstrap payload for ``GET /v1/session``.\n\nBundles everything the frontend needs at app-init in a single call: the\ncurrent user (unchanged ``UserRead`` shape), the units the user can access,\nand the globally-configured years for the workspace year selector. This\ncollapses what used to be three separate calls (``/session`` + ``/users/units``\n+ ``/year-configuration/``) into one.\n\n``min_configurable_year`` is also echoed on the single-year\n``YearConfigurationResponse``, but that one only exists once a row has\nbeen created for the requested year. Bundling it here too gives the\nfrontend a source that doesn't depend on any particular year existing \u2014\ne.g. the backoffice year selector can seed its lower bound even when the\ncurrent real-world year has no ``YearConfiguration`` row yet."
       },
       "StaleStatsEntry": {
         "properties": {
@@ -9848,17 +10787,6 @@
                 "type": "null"
               }
             ]
-          },
-          "source_job_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Job Id"
           }
         },
         "type": "object",
@@ -10692,6 +11620,45 @@
         "title": "WorkerResponse",
         "description": "One live pod entry for the workers view.\n\nReturned by ``GET /v1/sync/workers``.  Joins ``pods`` with a\ncheap count over ``data_ingestion_jobs.locked_by`` so the\noperator can see \"this pod has 3 claimed jobs right now\"."
       },
+      "WorkspaceHomeResponse": {
+        "properties": {
+          "carbon_report_id": {
+            "type": "integer",
+            "title": "Carbon Report Id"
+          },
+          "year_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HomeYearConfiguration"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "stats": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Stats"
+          },
+          "module_states": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Module States"
+          }
+        },
+        "type": "object",
+        "required": [
+          "carbon_report_id",
+          "stats",
+          "module_states"
+        ],
+        "title": "WorkspaceHomeResponse",
+        "description": "Minimal aggregate payload the frontend fans out across its stores."
+      },
       "YearConfigurationCreate": {
         "properties": {
           "is_started": {
@@ -10806,6 +11773,11 @@
             ],
             "title": "Pipeline Id",
             "description": "UUID of the unit_sync pipeline kicked off by the create endpoint (populated only on POST; None elsewhere)."
+          },
+          "min_configurable_year": {
+            "type": "integer",
+            "title": "Min Configurable Year",
+            "description": "Earliest year backoffice can create a configuration for."
           }
         },
         "type": "object",
@@ -10813,7 +11785,8 @@
           "year",
           "is_started",
           "config",
-          "updated_at"
+          "updated_at",
+          "min_configurable_year"
         ],
         "title": "YearConfigurationResponse",
         "description": "Schema for year configuration response with enriched submodule data."
@@ -10902,5 +11875,10 @@
         "description": "Pagination metadata."
       }
     }
-  }
+  },
+  "servers": [
+    {
+      "url": "/api"
+    }
+  ]
 }

--- a/frontend/scripts/openapi.snapshot.json
+++ b/frontend/scripts/openapi.snapshot.json
@@ -9820,6 +9820,17 @@
             ],
             "title": "Attempts"
           },
+          "worker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker"
+          },
           "is_stale": {
             "type": "boolean",
             "title": "Is Stale",

--- a/frontend/src/composables/uploadCardColor.ts
+++ b/frontend/src/composables/uploadCardColor.ts
@@ -1,0 +1,25 @@
+import { IngestionResult } from 'src/constant/ingestion';
+
+/**
+ * Pure color decision for the data-upload button (leaf module so the
+ * Playwright pure-function spec can import it — Issue #1216 + stage
+ * incident 2026-07-17). CSV result takes precedence (an errored CSV
+ * after a prior API success stays red); an API sync gets the same
+ * ERROR/WARNING/SUCCESS mapping as a CSV upload — a WARNING API sync
+ * (rows landed, some skipped) previously fell through to ``accent``
+ * and the card read as "no data" despite thousands of imported rows.
+ * An unrecognised result falls through to ``accent`` rather than
+ * silently going green.
+ */
+export function resolveDataButtonColor(
+  dataResult?: IngestionResult,
+  apiResult?: IngestionResult,
+): string {
+  if (dataResult === IngestionResult.ERROR) return 'negative';
+  if (dataResult === IngestionResult.WARNING) return 'warning';
+  if (dataResult === IngestionResult.SUCCESS) return 'positive';
+  if (apiResult === IngestionResult.ERROR) return 'negative';
+  if (apiResult === IngestionResult.WARNING) return 'warning';
+  if (apiResult === IngestionResult.SUCCESS) return 'positive';
+  return 'accent';
+}

--- a/frontend/src/composables/usePipelineJobRecovery.ts
+++ b/frontend/src/composables/usePipelineJobRecovery.ts
@@ -1,0 +1,38 @@
+import { ref } from 'vue';
+import { Notify } from 'quasar';
+import { useI18n } from 'vue-i18n';
+import { api } from 'src/api/http';
+import type { PipelineJobListEntry } from 'src/stores/pipelineOperationsConsole';
+
+/**
+ * Manual recovery of a stale RUNNING job (owning pod died mid-job).
+ * The button only renders on ``is_stale`` rows, matching the endpoint's
+ * own 409 rule; success requeues the job (state → NOT_STARTED) and the
+ * safety poller re-dispatches it within one sweep. ``refetch`` refreshes
+ * the caller's listing after a successful requeue.
+ */
+export function usePipelineJobRecovery(refetch: () => Promise<unknown>) {
+  const { t } = useI18n();
+  const recovering = ref<Set<number>>(new Set());
+
+  async function recoverJob(j: PipelineJobListEntry): Promise<void> {
+    recovering.value.add(j.job_id);
+    try {
+      await api.post(`sync/jobs/${j.job_id}/recover`);
+      Notify.create({
+        type: 'positive',
+        message: t('pipeops_recover_success'),
+        timeout: 1800,
+      });
+      await refetch();
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : t('pipeops_recover_failed');
+      Notify.create({ type: 'negative', message: msg });
+    } finally {
+      recovering.value.delete(j.job_id);
+    }
+  }
+
+  return { recovering, recoverJob };
+}

--- a/frontend/src/composables/useUploadCard.ts
+++ b/frontend/src/composables/useUploadCard.ts
@@ -14,6 +14,30 @@ import {
   type MissingSyncedUnitErrorGroup,
 } from 'src/utils/rowErrors';
 
+/**
+ * Pure color decision for the data-upload button (exported for the
+ * Playwright pure-function tests — Issue #1216 + stage incident
+ * 2026-07-17). CSV result takes precedence (an errored CSV after a
+ * prior API success stays red); an API sync gets the same
+ * ERROR/WARNING/SUCCESS mapping as a CSV upload — a WARNING API sync
+ * (rows landed, some skipped) previously fell through to ``accent``
+ * and the card read as "no data" despite thousands of imported rows.
+ * An unrecognised result falls through to ``accent`` rather than
+ * silently going green.
+ */
+export function resolveDataButtonColor(
+  dataResult?: IngestionResult,
+  apiResult?: IngestionResult,
+): string {
+  if (dataResult === IngestionResult.ERROR) return 'negative';
+  if (dataResult === IngestionResult.WARNING) return 'warning';
+  if (dataResult === IngestionResult.SUCCESS) return 'positive';
+  if (apiResult === IngestionResult.ERROR) return 'negative';
+  if (apiResult === IngestionResult.WARNING) return 'warning';
+  if (apiResult === IngestionResult.SUCCESS) return 'positive';
+  return 'accent';
+}
+
 export function useUploadCard() {
   const { t } = useI18n();
 
@@ -34,19 +58,11 @@ export function useUploadCard() {
   }
 
   function dataButtonColor(row: ImportRow): string {
-    // Issue #1216 — a successful API ingestion (no CSV upload) must
-    // turn the data card green just like a successful CSV does. CSV
-    // result still takes precedence (an errored CSV after a prior
-    // API success stays red), and only an explicit SUCCESS counts —
-    // an API job with an unrecognised result falls through to
-    // ``accent`` rather than silently going green.
     if (row.isDisabled) return 'grey-4';
-    if (row.lastDataJob?.result === IngestionResult.ERROR) return 'negative';
-    if (row.lastDataJob?.result === IngestionResult.WARNING) return 'warning';
-    if (row.lastDataJob?.result === IngestionResult.SUCCESS) return 'positive';
-    if (row.lastApiDataJob?.result === IngestionResult.SUCCESS)
-      return 'positive';
-    return 'accent';
+    return resolveDataButtonColor(
+      row.lastDataJob?.result,
+      row.lastApiDataJob?.result,
+    );
   }
 
   function factorButtonColor(row: ImportRow): string {
@@ -59,7 +75,9 @@ export function useUploadCard() {
 
   function dataButtonLabel(row: ImportRow): string {
     if (row.isDisabled) return '';
-    return row.lastDataJob
+    // An API sync counts as existing data too — without it the card
+    // read "Add Data" after a successful sync of thousands of rows.
+    return row.lastDataJob || row.lastApiDataJob
       ? t('data_management_reupload_data')
       : t('data_management_add_data');
   }

--- a/frontend/src/composables/useUploadCard.ts
+++ b/frontend/src/composables/useUploadCard.ts
@@ -14,29 +14,7 @@ import {
   type MissingSyncedUnitErrorGroup,
 } from 'src/utils/rowErrors';
 
-/**
- * Pure color decision for the data-upload button (exported for the
- * Playwright pure-function tests — Issue #1216 + stage incident
- * 2026-07-17). CSV result takes precedence (an errored CSV after a
- * prior API success stays red); an API sync gets the same
- * ERROR/WARNING/SUCCESS mapping as a CSV upload — a WARNING API sync
- * (rows landed, some skipped) previously fell through to ``accent``
- * and the card read as "no data" despite thousands of imported rows.
- * An unrecognised result falls through to ``accent`` rather than
- * silently going green.
- */
-export function resolveDataButtonColor(
-  dataResult?: IngestionResult,
-  apiResult?: IngestionResult,
-): string {
-  if (dataResult === IngestionResult.ERROR) return 'negative';
-  if (dataResult === IngestionResult.WARNING) return 'warning';
-  if (dataResult === IngestionResult.SUCCESS) return 'positive';
-  if (apiResult === IngestionResult.ERROR) return 'negative';
-  if (apiResult === IngestionResult.WARNING) return 'warning';
-  if (apiResult === IngestionResult.SUCCESS) return 'positive';
-  return 'accent';
-}
+import { resolveDataButtonColor } from 'src/composables/uploadCardColor';
 
 export function useUploadCard() {
   const { t } = useI18n();

--- a/frontend/src/constant/ingestion.ts
+++ b/frontend/src/constant/ingestion.ts
@@ -1,0 +1,17 @@
+// Leaf module (no store/api/i18n imports) so pure-function Playwright
+// specs can import these enums without dragging Vite-only APIs
+// (import.meta.glob in src/i18n) into the node test runner.
+// Values mirror the backend IngestionState/IngestionResult int enums.
+
+export enum IngestionState {
+  NOT_STARTED = 0,
+  QUEUED = 1,
+  RUNNING = 2,
+  FINISHED = 3,
+}
+
+export enum IngestionResult {
+  SUCCESS = 0,
+  WARNING = 1,
+  ERROR = 2,
+}

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -93,6 +93,25 @@ export default {
   pipeops_status_partial: { en: 'Partial', fr: 'Partiel' },
   pipeops_status_warning: { en: 'Warning', fr: 'Avertissement' },
 
+  // Queue wait (created → started) shown next to the run duration, so a
+  // sub-second job that waited long in the chain doesn't read as "<1s".
+  pipeops_queued: { en: 'queued {d}', fr: 'en file {d}' },
+
+  // Stale RUNNING job (owning pod died) + manual recovery.
+  pipeops_stale: { en: 'stale', fr: 'bloqué' },
+  pipeops_recover: {
+    en: 'Restart this stuck job now',
+    fr: 'Relancer cette tâche bloquée maintenant',
+  },
+  pipeops_recover_success: {
+    en: 'Job requeued — it will restart shortly',
+    fr: 'Tâche remise en file — elle redémarre sous peu',
+  },
+  pipeops_recover_failed: {
+    en: 'Failed to recover the job',
+    fr: 'Échec de la relance de la tâche',
+  },
+
   pipeops_msg_click_hint: {
     en: 'Click to view the full message',
     fr: 'Cliquer pour voir le message complet',

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -97,6 +97,13 @@ export default {
   // sub-second job that waited long in the chain doesn't read as "<1s".
   pipeops_queued: { en: 'queued {d}', fr: 'en file {d}' },
 
+  // Worker (pod / local process) that claimed the job — mixed ownership
+  // across a chain means several processes share the same DB.
+  pipeops_worker_hint: {
+    en: 'Worker (pod or local process) that executed this job',
+    fr: 'Worker (pod ou processus local) qui a exécuté cette tâche',
+  },
+
   // Stale RUNNING job (owning pod died) + manual recovery.
   pipeops_stale: { en: 'stale', fr: 'bloqué' },
   pipeops_recover: {

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -85,6 +85,33 @@ async function confirmAbort(): Promise<void> {
   }
 }
 
+// Manual recovery of a stale RUNNING job (owning pod died mid-job).
+// The button only renders on ``is_stale`` rows, matching the endpoint's
+// own 409 rule; success requeues the job (state → NOT_STARTED) and the
+// safety poller re-dispatches it within one sweep.
+const recovering = ref<Set<number>>(new Set());
+
+async function recoverJob(j: PipelineJobListEntry): Promise<void> {
+  recovering.value = new Set(recovering.value).add(j.job_id);
+  try {
+    await api.post(`sync/jobs/${j.job_id}/recover`);
+    Notify.create({
+      type: 'positive',
+      message: t('pipeops_recover_success'),
+      timeout: 1800,
+    });
+    await store.fetch();
+  } catch (err: unknown) {
+    const msg =
+      err instanceof Error ? err.message : t('pipeops_recover_failed');
+    Notify.create({ type: 'negative', message: msg });
+  } finally {
+    const next = new Set(recovering.value);
+    next.delete(j.job_id);
+    recovering.value = next;
+  }
+}
+
 // Processed-CSV download — surfaces ``meta.processed_file_path``
 // straight from the pipeline row so an operator triaging a stalled
 // or failed chain can grab the source CSV in one click.  Mirrors
@@ -256,6 +283,20 @@ function fmtDuration(a: string | null, b: string | null): string {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m${String(s % 60).padStart(2, '0')}s`;
   return `${Math.floor(m / 60)}h${String(m % 60).padStart(2, '0')}m`;
+}
+
+/**
+ * Queue wait (created → started), or null when it isn't worth showing
+ * (missing timestamps, or under 2s — chain/poller latency noise).
+ */
+function fmtQueued(
+  created: string | null,
+  started: string | null,
+): string | null {
+  if (!created || !started) return null;
+  const ms = new Date(started).getTime() - new Date(created).getTime();
+  if (ms < 2000) return null;
+  return fmtDuration(created, started);
 }
 
 function fmtWhen(s: string | null): string {
@@ -807,6 +848,26 @@ onUnmounted(() => {
                           {{ j.state ?? '?'
                           }}{{ j.result ? ' · ' + j.result : '' }}
                         </q-badge>
+                        <q-badge
+                          v-if="j.is_stale"
+                          color="deep-orange"
+                          text-color="white"
+                          class="q-mr-sm"
+                        >
+                          {{ $t('pipeops_stale') }}
+                        </q-badge>
+                        <q-btn
+                          v-if="j.is_stale"
+                          dense
+                          flat
+                          size="sm"
+                          icon="restart_alt"
+                          color="deep-orange"
+                          class="q-mr-sm"
+                          :loading="recovering.has(j.job_id)"
+                          :title="$t('pipeops_recover')"
+                          @click.stop="recoverJob(j)"
+                        />
                         <span class="text-weight-medium q-mr-sm">
                           #{{ j.job_id }} {{ j.job_type ?? '—' }}
                         </span>
@@ -818,6 +879,16 @@ onUnmounted(() => {
                               : '—')
                           }}
                           · {{ fmtDuration(j.started_at, j.finished_at) }}
+                          <template
+                            v-if="fmtQueued(j.created_at, j.started_at)"
+                          >
+                            ·
+                            {{
+                              $t('pipeops_queued', {
+                                d: fmtQueued(j.created_at, j.started_at),
+                              })
+                            }}
+                          </template>
                         </span>
                         <span
                           v-if="j.status_message"

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -889,6 +889,12 @@ onUnmounted(() => {
                               })
                             }}
                           </template>
+                          <template v-if="j.worker">
+                            ·
+                            <span :title="$t('pipeops_worker_hint')">
+                              ⚙ {{ j.worker }}
+                            </span>
+                          </template>
                         </span>
                         <span
                           v-if="j.status_message"

--- a/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
+++ b/frontend/src/pages/back-office/PipelineOperationsConsolePage.vue
@@ -10,6 +10,8 @@ import { usePipelineStream } from 'src/composables/usePipelineStream';
 import { usePipelineStreamStore } from 'src/stores/pipelineStream';
 import { useBackofficeDataManagement } from 'src/stores/backofficeDataManagement';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import { usePipelineJobRecovery } from 'src/composables/usePipelineJobRecovery';
+import { fmtDuration, fmtQueued, fmtWhen } from 'src/utils/pipelineFormat';
 import {
   usePipelineOperationsConsole,
   type PipelineListItem,
@@ -85,32 +87,7 @@ async function confirmAbort(): Promise<void> {
   }
 }
 
-// Manual recovery of a stale RUNNING job (owning pod died mid-job).
-// The button only renders on ``is_stale`` rows, matching the endpoint's
-// own 409 rule; success requeues the job (state → NOT_STARTED) and the
-// safety poller re-dispatches it within one sweep.
-const recovering = ref<Set<number>>(new Set());
-
-async function recoverJob(j: PipelineJobListEntry): Promise<void> {
-  recovering.value = new Set(recovering.value).add(j.job_id);
-  try {
-    await api.post(`sync/jobs/${j.job_id}/recover`);
-    Notify.create({
-      type: 'positive',
-      message: t('pipeops_recover_success'),
-      timeout: 1800,
-    });
-    await store.fetch();
-  } catch (err: unknown) {
-    const msg =
-      err instanceof Error ? err.message : t('pipeops_recover_failed');
-    Notify.create({ type: 'negative', message: msg });
-  } finally {
-    const next = new Set(recovering.value);
-    next.delete(j.job_id);
-    recovering.value = next;
-  }
-}
+const { recovering, recoverJob } = usePipelineJobRecovery(() => store.fetch());
 
 // Processed-CSV download — surfaces ``meta.processed_file_path``
 // straight from the pipeline row so an operator triaging a stalled
@@ -266,42 +243,6 @@ function pipelineMessage(p: PipelineListItem): string | null {
     return `${t('pipeops_phase_prefix')} ${p.progress.phase}/${p.progress.phases_total} · ${label}`;
   }
   return null;
-}
-
-function fmtDuration(a: string | null, b: string | null): string {
-  if (!a) return '—';
-  const start = new Date(a).getTime();
-  const end = b ? new Date(b).getTime() : Date.now();
-  const ms = Math.max(0, end - start);
-  // Sub-second jobs render "<1s" instead of "0s" — common for the
-  // trailing aggregation after 4A.3 scoped the write set down to just
-  // the affected modules.  "0s" read as "didn't run"; "<1s" says
-  // "ran, was just fast".
-  if (ms < 1000) return ms === 0 && !b ? '—' : '<1s';
-  const s = Math.round(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m${String(s % 60).padStart(2, '0')}s`;
-  return `${Math.floor(m / 60)}h${String(m % 60).padStart(2, '0')}m`;
-}
-
-/**
- * Queue wait (created → started), or null when it isn't worth showing
- * (missing timestamps, or under 2s — chain/poller latency noise).
- */
-function fmtQueued(
-  created: string | null,
-  started: string | null,
-): string | null {
-  if (!created || !started) return null;
-  const ms = new Date(started).getTime() - new Date(created).getTime();
-  if (ms < 2000) return null;
-  return fmtDuration(created, started);
-}
-
-function fmtWhen(s: string | null): string {
-  if (!s) return '—';
-  return new Date(s).toLocaleString();
 }
 
 // Scope label for the "Type" column.  Backend sends the entity_type

--- a/frontend/src/stores/backofficeDataManagement.ts
+++ b/frontend/src/stores/backofficeDataManagement.ts
@@ -1,4 +1,8 @@
 import { defineStore } from 'pinia';
+// Moved to a leaf module so pure-function Playwright specs can import the
+// enums without dragging api/i18n (import.meta.glob) into the node runner;
+// re-exported here so existing importers keep one canonical path.
+import { IngestionState, IngestionResult } from 'src/constant/ingestion';
 import { computed, ref } from 'vue';
 import { api } from 'src/api/http';
 import { Module } from 'src/constant/modules';
@@ -135,18 +139,7 @@ export enum FactorType {
 // that file or the per-row spinner rehydrate on page reload will
 // silently mis-map states — the unit test mirrors the literals so it
 // won't catch you either.
-export enum IngestionState {
-  NOT_STARTED = 0,
-  QUEUED = 1,
-  RUNNING = 2,
-  FINISHED = 3,
-}
-
-export enum IngestionResult {
-  SUCCESS = 0,
-  WARNING = 1,
-  ERROR = 2,
-}
+export { IngestionState, IngestionResult };
 
 export type InitiateSyncParams = {
   module_type_id: number;

--- a/frontend/src/stores/pipelineOperationsConsole.ts
+++ b/frontend/src/stores/pipelineOperationsConsole.ts
@@ -25,9 +25,13 @@ export interface PipelineJobListEntry {
   data_entry_type_id: number | null;
   data_entry_type_label: string | null;
   year: number | null;
+  created_at: string | null;
   started_at: string | null;
   finished_at: string | null;
   attempts: number | null;
+  // Derived server-side: RUNNING with a stale lock heartbeat (owning pod
+  // died). Gates the stale badge + manual Recover button.
+  is_stale: boolean;
   meta: Record<string, unknown>;
 }
 

--- a/frontend/src/stores/pipelineOperationsConsole.ts
+++ b/frontend/src/stores/pipelineOperationsConsole.ts
@@ -29,6 +29,9 @@ export interface PipelineJobListEntry {
   started_at: string | null;
   finished_at: string | null;
   attempts: number | null;
+  // Pod that claimed the job — surfaces which worker (local dev process
+  // vs cluster pod) actually executed it when several share one DB.
+  worker: string | null;
   // Derived server-side: RUNNING with a stale lock heartbeat (owning pod
   // died). Gates the stale badge + manual Recover button.
   is_stale: boolean;

--- a/frontend/src/types/api/openapi.d.ts
+++ b/frontend/src/types/api/openapi.d.ts
@@ -3360,6 +3360,8 @@ export interface components {
             finished_at?: string | null;
             /** Attempts */
             attempts?: number | null;
+            /** Worker */
+            worker?: string | null;
             /**
              * Is Stale
              * @default false

--- a/frontend/src/types/api/openapi.d.ts
+++ b/frontend/src/types/api/openapi.d.ts
@@ -3071,6 +3071,8 @@ export interface components {
             config: {
                 [key: string]: unknown;
             };
+            /** Min Configurable Year */
+            min_configurable_year: number;
         };
         /**
          * IngestionMethod
@@ -3283,12 +3285,8 @@ export interface components {
             /** Data */
             data: components["schemas"]["UnitReportingData"][];
             pagination: components["schemas"]["app__schemas__backoffice__PaginationMeta"];
-            /** Emission Breakdown */
-            emission_breakdown?: {
-                [key: string]: unknown;
-            } | null;
-            /** It Breakdown */
-            it_breakdown?: {
+            /** Stats */
+            stats?: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -4843,7 +4841,7 @@ export interface operations {
                 level?: number | null;
                 parent_id?: string | null;
                 unit_type_labels?: string[] | null;
-                parent_unit_type_label?: string | null;
+                parent_unit_type_label?: string[] | null;
                 /** @description Filter by unit name (partial match) */
                 name?: string | null;
                 page?: number;

--- a/frontend/src/types/api/openapi.d.ts
+++ b/frontend/src/types/api/openapi.d.ts
@@ -2886,6 +2886,11 @@ export interface components {
              */
             locked_at?: string | null;
             /**
+             * Created At
+             * @description Timestamp the job row was created.  created_at → started_at is queue wait (chain/lock/poller latency); started_at → finished_at is execution — the ops console shows both.
+             */
+            created_at?: string | null;
+            /**
              * Started At
              * @description Timestamp of the FIRST successful claim — stays put across retries (unlike locked_at, which updates every claim).  Combined with finished_at gives true total wall-clock duration.
              */
@@ -3347,12 +3352,19 @@ export interface components {
             data_entry_type_label?: string | null;
             /** Year */
             year?: number | null;
+            /** Created At */
+            created_at?: string | null;
             /** Started At */
             started_at?: string | null;
             /** Finished At */
             finished_at?: string | null;
             /** Attempts */
             attempts?: number | null;
+            /**
+             * Is Stale
+             * @default false
+             */
+            is_stale: boolean;
             /**
              * Meta
              * @default {}

--- a/frontend/src/utils/pipelineFormat.ts
+++ b/frontend/src/utils/pipelineFormat.ts
@@ -1,0 +1,39 @@
+// Duration/timestamp formatting for pipeline rows. Leaf module (no
+// store/api/i18n imports) extracted from PipelineOperationsConsolePage
+// while paying down its component-size overage.
+
+export function fmtDuration(a: string | null, b: string | null): string {
+  if (!a) return '—';
+  const start = new Date(a).getTime();
+  const end = b ? new Date(b).getTime() : Date.now();
+  const ms = Math.max(0, end - start);
+  // Sub-second jobs render "<1s" instead of "0s" — common for the
+  // trailing aggregation after 4A.3 scoped the write set down to just
+  // the affected modules.  "0s" read as "didn't run"; "<1s" says
+  // "ran, was just fast".
+  if (ms < 1000) return ms === 0 && !b ? '—' : '<1s';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m${String(s % 60).padStart(2, '0')}s`;
+  return `${Math.floor(m / 60)}h${String(m % 60).padStart(2, '0')}m`;
+}
+
+/**
+ * Queue wait (created → started), or null when it isn't worth showing
+ * (missing timestamps, or under 2s — chain/poller latency noise).
+ */
+export function fmtQueued(
+  created: string | null,
+  started: string | null,
+): string | null {
+  if (!created || !started) return null;
+  const ms = new Date(started).getTime() - new Date(created).getTime();
+  if (ms < 2000) return null;
+  return fmtDuration(created, started);
+}
+
+export function fmtWhen(s: string | null): string {
+  if (!s) return '—';
+  return new Date(s).toLocaleString();
+}

--- a/frontend/tests/unit/upload-card-data-color.spec.ts
+++ b/frontend/tests/unit/upload-card-data-color.spec.ts
@@ -10,12 +10,14 @@
  * Pure ``(dataResult?, apiResult?) => color`` function — a
  * pure-function test is the cheapest regression guard the existing
  * test infra (Playwright, no Vitest) supports; ``useUploadCard`` itself
- * needs a component mount for ``useI18n``.
+ * needs a component mount for ``useI18n``. Imports stay on leaf modules
+ * (uploadCardColor, constant/ingestion) — importing the store chain
+ * drags src/i18n's Vite-only import.meta.glob into the node runner.
  */
 
 import { test, expect } from '@playwright/test';
-import { resolveDataButtonColor } from '../../src/composables/useUploadCard';
-import { IngestionResult } from '../../src/stores/backofficeDataManagement';
+import { resolveDataButtonColor } from '../../src/composables/uploadCardColor';
+import { IngestionResult } from '../../src/constant/ingestion';
 
 test('no jobs at all stays accent (Add Data state)', () => {
   expect(resolveDataButtonColor(undefined, undefined)).toBe('accent');

--- a/frontend/tests/unit/upload-card-data-color.spec.ts
+++ b/frontend/tests/unit/upload-card-data-color.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression test for ``resolveDataButtonColor`` (stage incident
+ * 2026-07-17): a WARNING API sync (rows landed, some skipped) fell
+ * through to ``accent`` and the data card read "Add Data" / red
+ * despite thousands of imported rows — only an explicit API SUCCESS
+ * counted. The API result now gets the same ERROR/WARNING/SUCCESS
+ * mapping as a CSV result, with CSV precedence preserved (Issue #1216:
+ * an errored CSV after a prior API success stays red).
+ *
+ * Pure ``(dataResult?, apiResult?) => color`` function — a
+ * pure-function test is the cheapest regression guard the existing
+ * test infra (Playwright, no Vitest) supports; ``useUploadCard`` itself
+ * needs a component mount for ``useI18n``.
+ */
+
+import { test, expect } from '@playwright/test';
+import { resolveDataButtonColor } from '../../src/composables/useUploadCard';
+import { IngestionResult } from '../../src/stores/backofficeDataManagement';
+
+test('no jobs at all stays accent (Add Data state)', () => {
+  expect(resolveDataButtonColor(undefined, undefined)).toBe('accent');
+});
+
+test('API sync results map like CSV results', () => {
+  expect(resolveDataButtonColor(undefined, IngestionResult.SUCCESS)).toBe(
+    'positive',
+  );
+  // The incident case: WARNING sync must not render as "no data".
+  expect(resolveDataButtonColor(undefined, IngestionResult.WARNING)).toBe(
+    'warning',
+  );
+  expect(resolveDataButtonColor(undefined, IngestionResult.ERROR)).toBe(
+    'negative',
+  );
+});
+
+test('CSV result takes precedence over the API result', () => {
+  expect(
+    resolveDataButtonColor(IngestionResult.ERROR, IngestionResult.SUCCESS),
+  ).toBe('negative');
+  expect(
+    resolveDataButtonColor(IngestionResult.SUCCESS, IngestionResult.ERROR),
+  ).toBe('positive');
+});

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -48,7 +48,7 @@ backend:
     RUN_BACKGROUND_POLLER: "true"
     POLLER_INTERVAL_SECONDS: "2" # Seconds between poller sweeps
     POLLER_BATCH_LIMIT: "100" # Max NOT_STARTED jobs dispatched per sweep
-    STALE_JOB_TIMEOUT_MINUTES: "60" # RUNNING jobs older than this are auto-recovered
+    STALE_JOB_TIMEOUT_MINUTES: "5" # RUNNING jobs whose heartbeat is older than this are auto-recovered
     INGEST_COPY_BATCH_SIZE: "50000" # Rows per COPY batch for bulk CSV data_entries ingest
     ELASTICSEARCH_TIMEOUT: "30" # Key in the existing secret for Elasticsearch timeout
     ELASTICSEARCH_MAX_RETRIES: "3" # Key in the existing secret for Elasticsearch max retries


### PR DESCRIPTION
## Context

Testing #1564 headcount uploads on stage uncovered a chain of six distinct defects — data-model gaps, pipeline-recovery latency, and operator-visibility holes. Each fix below states the observed failure and the reasoning behind the chosen shape. Plan file: `docs/src/implementation-plans/1564-stage-incident-bulk-replace-and-stuck-job-recovery.md`.
@ymarcon  BEWARE of the alembic migration file (backfill)

## Fixes

### 1. Workspace-home aggregate missing `min_configurable_year` (`9a7b814b`)
**Observed:** "year-configuration response is missing min_configurable_year" error on the data-management page.
**Cause:** the #1204 follow-up made the yearConfig store hard-require the field, auditing the `GET /year-configuration/*` routes — but `workspaceGuard` also feeds `setConfig` from the workspace-home aggregate, whose slim `HomeYearConfiguration` predated the strict check (hidden by an `as` cast). The sticky store error then surfaced on an unrelated page.
**Fix:** the aggregate echoes the bound from settings (constant, zero DB cost). Regression test pins it.

### 2. Cross-source bulk replace (`22f390ae`, completed by `7f7081fd`)
**Observed:** CSV upload after an API sync mass-skipped 8465/8485 rows as `DUPLICATE_INSTITUTIONAL_ID`.
**Cause (two layers):** the per-year replace delete was scoped to `source=CSV_MODULE_PER_YEAR` while the `(uid, sius_code)` uniqueness check has no source filter — API-synced rows survived and collided with every CSV row. **Decision:** a bulk per-year ingest (CSV *or* API) is a complete yearly export and replaces all machine-owned bulk sources (`BULK_PER_YEAR_SOURCES`); manual and unit-specific entries are always preserved. Second layer: the API providers built entries **without the denormalized `year`/`unit_id`** the delete keys on, so the cross-source delete matched zero API rows — both providers now stamp them (module→unit map built during resolution; `_ingest_year` fails loudly), and migration `8eeff0a9fa26` backfills existing NULL rows from each entry's carbon report.
**Tests:** unit (both providers) + pg integration proving an API row is replaced; provider stamping regression test.

### 3. Stuck-job recovery: 60 min → ~5 min (`22f390ae`, `f613d1be`)
**Observed:** a pod SIGTERM 60s into the chained recalc left the job `RUNNING` and invisible for an hour.
**Root cause of the kill (confirmed by probe-latency measurement on stage):** the recalc loop yielded the event loop only every 1000 entries; during pure-CPU stretches `/healthz` (a no-op endpoint) missed the kubelet's 2s probe timeout — 3 failures × 20s period = killed at exactly 60s.
**Fixes:** both CPU loops (recalc, CSV rows) now yield on wall time (~50ms), bounding worst-case probe latency regardless of per-item cost; `STALE_JOB_TIMEOUT_MINUTES` 60→5 — safe because the 310-C per-job heartbeat refreshes `locked_at` every T/4, so the window bounds *crash-recovery latency*, not job runtime (5 not 2: the same window is the live runner's self-abort threshold on heartbeat failures, and 5 min tolerates transient DB blips). Stale "no heartbeat yet" docstrings rewritten.
**Why not just longer probes:** raising timeouts hides starvation; the yields remove it. (The cluster-side probe `timeoutSeconds` 2→5 is still recommended — see Ops actions.)

### 4. JSON-safe audit snapshot (`5a56fcb9`)
**Observed:** every `POST /v1/sync/dispatch` 500'd after `created_at` landed.
**Cause:** the audit trail snapshots the job row via python-mode `model_dump()` into a JSON column serialized by stdlib `json.dumps`; `created_at` is the first insert-time-populated datetime it ever carried.
**Fix:** `model_dump(mode="json")` (the pattern `connectors.py` already uses) + regression test.

### 5. Ingest performance: per-row SELECT → seeded set (`eccc7abc`)
**Observed:** stage parse rate collapsed to 14 rows/s (~10 min for 8.5k rows).
**Cause:** the row loop ran one `(uid, sius_code)` uniqueness SELECT per row — the same N+1 shape COPY batching had already removed on the write side.
**Fix:** the in-memory duplicate set is seeded with all existing member tuples in **one** bulk query (`get_member_role_keys`), gated to headcount ingests; per-row check becomes a set lookup, preserving per-row "Row N: DUPLICATE" reporting. Local re-test: 8454 rows in 14s. The manual-entry path keeps its single-row check.

### 6. Operator visibility (`22f390ae`, `f613d1be`, `7f7081fd`, `15d6be06`)
- **Queue wait vs run time:** jobs gain `created_at` (migration `7bfda0d45f14`); the console shows `queued Xs` next to run duration — a sub-second scoped aggregation that waited 20s behind its chain no longer reads as "<1s total".
- **Live recalc progress:** time-based (every 2s, was every 5000 entries — an 8488-entry slice got one update), with rate + ETA and a guaranteed terminal N/N.
- **Stale badge + Recover button:** server-derived `is_stale` (same predicate as the auto-recovery sweep) gates a badge and a button wiring the pre-existing `POST /jobs/{id}/recover`. Deliberately *not* a new persisted job state — staleness is derived, not stored.
- **Worker attribution:** each job row shows the claiming pod (`locked_by`) — with a local dev process and cluster pods sharing one DB, chains executing on old-code pods are otherwise indistinguishable from branch bugs (this chip diagnosed exactly that within minutes of shipping).
- **Data card:** an API sync now counts as existing data (re-upload label; ERROR/WARNING/SUCCESS color mapping identical to CSV, CSV precedence preserved) — a WARNING sync of 8468 rows previously rendered as a red "Add Data". Color decision extracted as a pure function with a Playwright spec on leaf modules (`0ab3a4e0` keeps Vite-only APIs out of the node runner).

## Migrations
- `7bfda0d45f14` — `data_ingestion_jobs.created_at` (server_default backfill).
- `8eeff0a9fa26` — backfill `data_entries.year`/`unit_id` from carbon reports (heals stage's NULL-year API rows on deploy).

## Ops actions (outside this repo)
- Stage probe overrides set `timeoutSeconds: 2` — raise to the chart-default 5 (liveness + readiness).
- Memory request (128Mi) far below real usage (~800Mi) makes the pod an eviction target — raise toward observed usage.

## Self-review (/code-review high) — all 10 findings addressed (`588ea94d`)

**Fixed:**
- Duplicate-set seeding made unconditional — the `module_type_id` gate could silently skip DB-level dedup for raw-API member uploads (regression test drives the member flow without `module_type_id`).
- Heartbeat lost-lock path now **arms the abort**: a preempted runner cancels its handler instead of finishing work whose pre-CAS commits another pod re-runs.
- `year`/`unit_id` stamping centralized in `DataEntryService.fill_denormalized_scope` (create / bulk_create / bulk_copy) — per-provider stamps deleted, nothing to forget in the next provider; manual entries are stamped too (a NULL-year manual entry silently matched no factor via the year join).
- Audit snapshots normalized with `jsonable_encoder` inside `create_version` — JSON-safety enforced at the boundary, not in N callers (regression test flushes a datetime/UUID-carrying snapshot).
- One staleness predicate (`stale_running_clause` + `is_job_stale` in the repo) shared by the sweep, `recover_job`, and the console badge, with a parity test locking the SQL and Python twins together.
- `as_utc` and `format_progress` extracted to shared utils (were duplicated); `recover_job` docstring corrected (claimed a 30-min default).
- Ops-console page shed duration formatting (`utils/pipelineFormat`) and the recover flow (`usePipelineJobRecovery`): 1069 → 1010 lines, direction reversed toward the 500 cap.

**Accepted + documented (not silently):** the seeded duplicate set is a snapshot; the per-year advisory lock drops at each batch commit, so a concurrent bulk writer committing mid-file is invisible to it. No weaker than the old per-row check-then-COPY class of race, and the airtight fix is the deferred DB unique index below — the trade-off is written at the query (`get_member_role_keys`).

## Deferred (parked in the plan, need reviewed proposals)
DB-enforced member-role uniqueness (partial unique index + staged COPY `ON CONFLICT`); `run_job` releasing claimed jobs on CancelledError (near-instant recovery after graceful kills); dedicated worker Deployment; central year/unit_id stamping in `bulk_create`/`bulk_copy`; intra-file duplicate key question (760 same-`(uid, sius)` rows in the source export).
