### PR TITLE
feat: improve table action buttons and selects (#1355)

### DIFF
--- a/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
+++ b/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
@@ -135,43 +135,46 @@ const planRows = [
               class="q-pa-xs"
             >
               <template v-if="col.name === 'action'">
-                <div class="row no-wrap justify-end q-gutter-xs">
+                <div class="row no-wrap justify-end">
                   <q-btn
                     icon="o_content_copy"
-                    color="grey-4"
-                    text-color="primary"
+                    color="black"
                     unelevated
                     no-caps
                     dense
-                    outline
-                    square
-                    size="xs"
-                    class="square-button"
-                  />
+                    flat
+                    class="action-btn"
+                  >
+                    <q-tooltip class="action-tooltip" :offset="[0, 8]">
+                      {{ $t('common_duplicate') }}
+                    </q-tooltip>
+                  </q-btn>
                   <q-btn
                     icon="o_edit"
-                    color="grey-4"
-                    text-color="primary"
+                    color="black"
                     unelevated
                     no-caps
                     dense
-                    outline
-                    square
-                    size="xs"
-                    class="square-button"
-                  />
+                    flat
+                    class="action-btn"
+                  >
+                    <q-tooltip class="action-tooltip" :offset="[0, 8]">
+                      {{ $t('common_edit') }}
+                    </q-tooltip>
+                  </q-btn>
                   <q-btn
                     icon="o_delete"
-                    color="grey-4"
-                    text-color="primary"
+                    color="black"
                     unelevated
                     no-caps
                     dense
-                    outline
-                    square
-                    size="xs"
-                    class="square-button"
-                  />
+                    flat
+                    class="action-btn action-btn--delete"
+                  >
+                    <q-tooltip class="action-tooltip" :offset="[0, 8]">
+                      {{ $t('common_delete') }}
+                    </q-tooltip>
+                  </q-btn>
                 </div>
               </template>
               <template v-else>{{ props.row[col.field] }}</template>

--- a/frontend/src/components/organisms/module/ModuleInlineSelect.vue
+++ b/frontend/src/components/organisms/module/ModuleInlineSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="inline-select-wrapper">
-    <div v-if="showPlaceholder" class="inline-subclass-placeholder"></div>
+    <div v-if="showPlaceholder" class="inline-subclass-placeholder">-</div>
     <VirtualSelectField
       v-else
       :model-value="model"
@@ -9,6 +9,7 @@
       :disable="props.disable"
       :title="props.hint ? $t(props.hint) : undefined"
       hide-bottom-space
+      dropdown-icon="expand_more"
       @update:model-value="onValueChange"
     />
   </div>
@@ -191,19 +192,9 @@ async function onValueChange(val: string | number | null) {
   width: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  color: #999;
-  border-radius: tokens.$field-border-radius;
-  border: 1px solid rgba(0, 0, 0, 0.18);
-  transition: border-color 0.36s cubic-bezier(0.4, 0, 0.2, 1);
   height: 2.5rem;
-  background: linear-gradient(
-    to bottom right,
-    transparent 0%,
-    transparent 49.5%,
-    #e0e0e0 50.5%,
-    #e0e0e0 100%
-  );
-  cursor: not-allowed;
+  padding-left: tokens.$spacing-sm;
+  color: tokens.$table-color-disabled;
+  cursor: default;
 }
 </style>

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -180,10 +180,20 @@
               :step="col.step"
               :rules="getColumnRules(col)"
               class="inline-input"
+              :dropdown-icon="col.type === 'select' ? 'expand_more' : undefined"
               :error="!!getError(slotProps.row, col)"
               :error-message="getError(slotProps.row, col)"
               @blur="commitInline(slotProps.row, col)"
-            ></component>
+            >
+              <template v-if="col.type !== 'select'" #append>
+                <q-icon
+                  v-if="hasValue(slotProps.row[col.field])"
+                  name="o_edit"
+                  size="14px"
+                  class="inline-edit-icon"
+                />
+              </template>
+            </component>
           </template>
           <template v-else-if="col.name === 'action' && showTableActions">
             <q-btn
@@ -191,40 +201,42 @@
               :icon="noteButtonIcon(slotProps.row.note)"
               :color="noteButtonColor(slotProps.row.note)"
               :style="noteButtonStyle(slotProps.row.note)"
-              :text-color="noteButtonTextColor(slotProps.row.note)"
               :disable="isNoteDisabled"
               unelevated
               no-caps
               dense
-              round
-              :outline="!slotProps.row.note"
-              class="q-mr-sm"
+              :flat="!slotProps.row.note"
+              class="action-btn"
               @click="openNoteDialog(slotProps.row)"
             >
               <q-tooltip v-if="slotProps.row.note" class="tooltip">
                 {{ slotProps.row.note }}
               </q-tooltip>
+              <q-tooltip v-else class="tooltip action-tooltip" :offset="[0, 8]">
+                {{ $t('common_comment') }}
+              </q-tooltip>
             </q-btn>
             <q-btn
               v-if="showTableRowActions && canEdit && hasModuleUpload"
               icon="o_delete"
-              color="grey-4"
-              text-color="primary"
+              color="black"
               :disable="isDisabled"
               unelevated
               no-caps
               dense
-              outline
-              square
-              size="xs"
-              class="square-button"
+              flat
+              class="action-btn action-btn--delete"
               @click="
                 ItemName = getItemName(slotProps.row);
                 deleteItemName = getItemName(slotProps.row);
                 deleteRowId = getRowId(slotProps.row);
                 confirmDelete = true;
               "
-            />
+            >
+              <q-tooltip class="tooltip action-tooltip" :offset="[0, 8]">
+                {{ $t('common_delete') }}
+              </q-tooltip>
+            </q-btn>
           </template>
           <template v-else>
             <div class="cell-content">
@@ -797,7 +809,7 @@ function noteButtonIcon(note: unknown): string {
 }
 
 function noteButtonColor(note: unknown): string | undefined {
-  if (!note) return 'grey-4';
+  if (!note) return 'black';
   return props.moduleColor ? undefined : 'accent';
 }
 
@@ -809,10 +821,6 @@ function noteButtonStyle(note: unknown) {
         border: `1px solid ${moduleColors.value.buttonTextColor}`,
       }
     : undefined;
-}
-
-function noteButtonTextColor(note: unknown): string | undefined {
-  return note ? undefined : 'primary';
 }
 
 const noteDialogMode = computed<'add' | 'edit'>(() =>
@@ -1853,6 +1861,11 @@ onUnmounted(() => {
     border: none;
   }
 
+  th,
+  td {
+    padding: tokens.$spacing-xs tokens.$spacing-md;
+  }
+
   tbody .q-tr:nth-child(even) {
     background-color: tokens.$table-bg-even;
   }
@@ -1884,8 +1897,94 @@ onUnmounted(() => {
     }
   }
 
-  .square-button {
-    padding: tokens.$spacing-sm tokens.$spacing-sm;
+  td
+    .q-field--outlined:not(.q-field--focused):not(.q-field--error)
+    .q-field__control::before {
+    border-color: transparent;
   }
+
+  td
+    .q-field--outlined:not(.q-field--focused):not(.q-field--error):not(
+      .q-field--disabled
+    ):hover
+    .q-field__control {
+    background: tokens.$table-field-hover-bg;
+  }
+
+  td .inline-input,
+  td .inline-select-wrapper .q-select {
+    display: inline-flex;
+    width: auto;
+    max-width: 100%;
+    vertical-align: middle;
+  }
+
+  td .inline-input .q-field__native,
+  td .inline-input .q-field__input,
+  td .inline-select-wrapper .q-field__native,
+  td .inline-select-wrapper .q-field__input {
+    field-sizing: content;
+    min-width: 1ch;
+    font-size: tokens.$text-size-sm;
+  }
+
+  td .inline-input .q-field__append,
+  td .inline-select-wrapper .q-field__append {
+    padding-left: tokens.$spacing-xs;
+  }
+
+  .inline-edit-icon {
+    color: tokens.$table-inline-icon-color;
+  }
+
+  .q-field--focused .inline-edit-icon,
+  .q-field--disabled .inline-edit-icon {
+    display: none;
+  }
+
+  td .q-select__dropdown-icon {
+    font-size: 18px;
+    color: tokens.$table-inline-icon-color;
+  }
+
+  td .q-select:not(.q-field--disabled),
+  td .q-select:not(.q-field--disabled) * {
+    cursor: pointer;
+  }
+
+  .action-btn {
+    width: 32px;
+    height: 32px;
+    min-height: 0;
+    padding: 0;
+    border-radius: tokens.$radius-default;
+  }
+
+  .action-btn .q-icon {
+    font-size: 18px;
+  }
+
+  .action-btn + .action-btn {
+    margin-left: tokens.$spacing-xs;
+  }
+
+  .action-btn:not(.disabled):hover {
+    background: tokens.$table-action-hover-bg;
+  }
+
+  .action-btn--delete:not(.disabled):hover {
+    background: tokens.$table-action-delete-hover-bg;
+  }
+
+  .action-btn--delete:not(.disabled):hover .q-icon {
+    color: tokens.$icon-color-white;
+  }
+}
+
+/* Teleported to <body>, so it must be styled outside .co2-table and unscoped. */
+.q-tooltip.action-tooltip {
+  padding: tokens.$spacing-lg tokens.$spacing-xl;
+  font-size: tokens.$text-size-sm;
+  line-height: normal;
 }
 </style>

--- a/frontend/src/constant/module-config/buildings.ts
+++ b/frontend/src/constant/module-config/buildings.ts
@@ -87,7 +87,8 @@ const roomFields: ModuleField[] = [
     disableUntilField: 'room_name',
     icon: 'o_image_aspect_ratio',
     tooltip: 'module-buildings-submodule-building-table-room_allocation_ratio',
-    columnSize: 'md',
+    columnSize: 'xs',
+    maxColumnWidth: 100,
   },
   {
     id: 'heating_kwh_per_square_meter',
@@ -151,6 +152,7 @@ const roomFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     readOnly: true,
@@ -212,6 +214,7 @@ const energyCombustionFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     readOnly: true,

--- a/frontend/src/constant/module-config/equipment.ts
+++ b/frontend/src/constant/module-config/equipment.ts
@@ -159,17 +159,18 @@ const baseModuleFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: {
       form: true,
     },
     sortable: true,
-    align: 'left',
     tooltip: 'module-equipment-submodule-scientific-table-kg_co2eq',
   },
   {
     id: 't_co2eq',
+    align: 'right',
     label: 't CO₂-eq',
     type: 'number',
     hideIn: {
@@ -177,7 +178,6 @@ const baseModuleFields: ModuleField[] = [
       table: true,
     },
     sortable: true,
-    align: 'left',
     tooltip: 'module-equipment-submodule-scientific-table-t_co2eq',
   },
 ];

--- a/frontend/src/constant/module-config/external-cloud-and-ai.ts
+++ b/frontend/src/constant/module-config/external-cloud-and-ai.ts
@@ -89,6 +89,7 @@ const cloudFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: { form: true },
@@ -181,6 +182,7 @@ const externalAIFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: { form: true },

--- a/frontend/src/constant/module-config/process_emissions.ts
+++ b/frontend/src/constant/module-config/process_emissions.ts
@@ -60,6 +60,7 @@ const processEmissionsFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     readOnly: true,

--- a/frontend/src/constant/module-config/professional-travel.ts
+++ b/frontend/src/constant/module-config/professional-travel.ts
@@ -106,6 +106,7 @@ const commonTravelFields: ModuleField[] = [
     unit: 'km',
     sortable: true,
     ratio: '1/1',
+
     editableInline: false,
     readOnly: true,
     disable: true,
@@ -115,6 +116,7 @@ const commonTravelFields: ModuleField[] = [
 // Emissions column, kept separate so the class column can be placed just before it.
 const emissionsField: ModuleField = {
   id: 'kg_co2eq',
+  align: 'right',
   labelKey: `${MODULES.ProfessionalTravel}-field-emissions`,
   type: 'number',
   unit: 'kg CO₂-eq',
@@ -143,10 +145,15 @@ const planeCabinClassField: ModuleField = {
 };
 
 const planeFields: ModuleField[] = buildTravelFields(
-  { id: 'origin_name', labelKey: `${MODULES.ProfessionalTravel}-field-from` },
+  {
+    id: 'origin_name',
+    labelKey: `${MODULES.ProfessionalTravel}-field-from`,
+    columnSize: 'lg',
+  },
   {
     id: 'destination_name',
     labelKey: `${MODULES.ProfessionalTravel}-field-to`,
+    columnSize: 'lg',
   },
   planeCabinClassField,
 );
@@ -173,11 +180,13 @@ const trainFields: ModuleField[] = buildTravelFields(
     id: 'origin_name',
     labelKey: `${MODULES.ProfessionalTravel}-field-from`,
     tooltip: trainLocationTooltip,
+    columnSize: 'lg',
   },
   {
     id: 'destination_name',
     labelKey: `${MODULES.ProfessionalTravel}-field-to`,
     tooltip: trainLocationTooltip,
+    columnSize: 'lg',
   },
   trainCabinClassField,
   { directionInputTooltip: trainLocationTooltip },
@@ -259,11 +268,13 @@ function buildTravelFields(
     id: string;
     labelKey: string;
     tooltip?: string;
+    columnSize?: ModuleField['columnSize'];
   },
   destination: {
     id: string;
     labelKey: string;
     tooltip?: string;
+    columnSize?: ModuleField['columnSize'];
   },
   classField: ModuleField,
   options?: { directionInputTooltip?: string },
@@ -293,6 +304,7 @@ function buildTravelFields(
       editableInline: false,
       hideIn: { form: true },
       tooltip: origin.tooltip,
+      columnSize: origin.columnSize,
     },
     {
       id: destination.id,
@@ -304,6 +316,7 @@ function buildTravelFields(
       editableInline: false,
       hideIn: { form: true },
       tooltip: destination.tooltip,
+      columnSize: destination.columnSize,
     },
     ...commonTravelFields.slice(3),
     classField,

--- a/frontend/src/constant/module-config/purchase.ts
+++ b/frontend/src/constant/module-config/purchase.ts
@@ -122,6 +122,7 @@ const purchaseFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: { form: true },
@@ -165,6 +166,7 @@ const additionalPurchaseFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: { form: true },

--- a/frontend/src/constant/module-config/research-facilities.ts
+++ b/frontend/src/constant/module-config/research-facilities.ts
@@ -44,6 +44,7 @@ const researchFacilitiesFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: { form: true },
@@ -91,6 +92,7 @@ const animalFields: ModuleField[] = [
   },
   {
     id: 'kg_co2eq',
+    align: 'right',
     labelKey: 'results_units_kg',
     type: 'number',
     hideIn: { form: true },

--- a/frontend/src/css/02-tokens/_components.scss
+++ b/frontend/src/css/02-tokens/_components.scss
@@ -174,6 +174,13 @@ $table-color-warning: opt.$tokens-colors-status-red !default;
 $table-color-success: opt.$tokens-colors-status-green !default;
 $table-max-height: opt.$tokens-table-max-height !default;
 $table-header-z-index: opt.$tokens-z-index-sticky !default;
+$table-action-hover-bg: opt.$tokens-colors-grey-scale-grey-200 !default;
+$table-action-delete-hover-bg: rgba(
+  opt.$tokens-colors-red-red-100,
+  80%
+) !default;
+$table-field-hover-bg: rgb(0 0 0 / 4%) !default;
+$table-inline-icon-color: opt.$tokens-colors-grey-scale-grey-400 !default;
 
 // Chart Tooltip
 $chart-tooltip-min-width: opt.$tokens-chart-tooltip-min-width !default;

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -347,6 +347,14 @@ export default {
     en: 'Edit',
     fr: 'Modifier',
   },
+  common_comment: {
+    en: 'Comment',
+    fr: 'Commenter',
+  },
+  common_duplicate: {
+    en: 'Duplicate',
+    fr: 'Dupliquer',
+  },
   common_view_only: {
     en: 'View Only',
     fr: 'Lecture seule',


### PR DESCRIPTION
## What does this change?
Design refinement pass on module tables and forms across the app:

- **Table row action buttons** (duplicate/edit/delete on `CO2ProjectPlanner.vue`, note/delete on `ModuleTable.vue`): restyled from outlined `grey-4` square buttons to flat `black` icon buttons in a new `.action-btn` / `.action-btn--delete` style, with hover backgrounds and added tooltips (new `common_comment` / `common_duplicate` i18n keys, reusing existing `common_edit` / `common_delete`).
- **Inline table editing polish** (`ModuleTable.vue`): inline inputs/selects are now sized to their content (`field-sizing: content`) rather than full column width, non-select inline fields show a small edit-pencil icon (hidden while focused/disabled), select fields get an explicit dropdown chevron icon, and table cells get consistent padding.
- **`ModuleInlineSelect.vue`**: the "placeholder" state (shown when a subclass select isn't applicable) changes from an empty diagonal-hatched box to a simple left-aligned dash (`-`) with a dropdown chevron matching real selects.
- **Column alignment/sizing**: `kg_co2eq`/`t_co2eq` result columns across Buildings, Equipment, External Cloud & AI, Process Emissions, Purchase, Research Facilities, and Professional Travel are now right-aligned (previously left or default); the Buildings `room_allocation_ratio` column narrows (`md` → `xs`, `maxColumnWidth: 100`); Professional Travel's origin/destination columns get an explicit `lg` size.
- New SCSS design tokens (`$table-action-hover-bg`, `$table-action-delete-hover-bg`, `$table-field-hover-bg`, `$table-inline-icon-color`) backing the above styles, plus a new unscoped `.q-tooltip.action-tooltip` style (needed since Quasar tooltips teleport to `<body>`).

## Why is this needed?
Brings the module data-entry tables and forms in line with an updated visual design: clearer, more discoverable row actions (with tooltips instead of unlabeled icon buttons), inline-edit affordances that make it obvious a table cell is editable, right-aligned numeric columns for easier scanning, and tighter column widths where content doesn't need much space.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🎨 Design/UI improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1355

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.