### PR TITLE
docs: clarify setup and DB env notes (#1298)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,45 @@ for the dev / stage / pre-production URLs and deployment topology.
 - **Python** 3.14+ with **uv** (install: `brew install uv`)
 - **Docker** (for database)
 
-### Installation
+### 1. Install dependencies
 
 ```bash
-# Install all dependencies and set up git hooks
+# Install all dependencies, set up git hooks, and create the
+# env files below from their .example templates if missing
 make install
 # List helpful targets
 make help
 ```
 
-### Development Workflow
+### 2. Configure environment files
 
-**Option 1: Run services separately (recommended)**
+The repo contains several `.env.example` files. For local development only one
+needs editing:
+
+| File                  | Created by `make install`         | What to do                                                                                            |
+| --------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `backend/.env`        | ✅ (from `backend/.env.example`)  | **Required:** uncomment the `localhost` `DB_URL` line (PostgreSQL — SQLite cannot run the migrations) |
+| `.database.env`       | ✅ (from `.database.env.example`) | Nothing — credentials for the Dockerized PostgreSQL, already matching the `DB_URL` above              |
+| `frontend/.env.local` | ❌ (copy `frontend/.env.example`) | Optional — only needed for Sentry/GlitchTip and other `APP_*` extras; the app runs fine without it    |
+
+Keep the defaults from `backend/.env.example` — in particular `DEBUG=True`,
+which enables the test login used below. No OAuth/OIDC or Accred credentials
+are needed for local development.
+
+### 3. Set up the database
+
+```bash
+# Start PostgreSQL (docker compose reads backend/.env and .database.env)
+docker compose up -d postgres
+
+# Create the database, run migrations, and seed development data
+cd backend
+make db-create
+make db-migrate
+make seed-data
+```
+
+### 4. Run the app
 
 ```bash
 # Terminal 1 - Start backend (http://localhost:8000)
@@ -40,15 +67,16 @@ cd backend && make dev
 cd frontend && make dev
 ```
 
-**Option 2: Database management (if needed)**
+### 5. Log in
 
-```bash
-# Start PostgreSQL
-docker compose up -d postgres
+Open **<http://localhost:9000/en/login-test>** (or `/fr/login-test`) and pick a
+test role.
 
-# Run migrations
-cd backend && make db-migrate
-```
+- The language prefix is required — a bare `/login-test` is a 404.
+- The default `/login` page goes through the real OAuth flow, which is not
+  configured locally (it fails with `Missing "authorize_url"`).
+- The test login page only exists when the backend runs with `DEBUG=True` and
+  is never available in production builds.
 
 ### CI Validation (before pushing to dev/stage/main)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,12 +24,13 @@ API_DOCS_PREFIX=/api
 # -----------------------------------------------------------------------------
 # Configure the database connection using DB_URL
 #
-# If DB_URL is not set, SQLite will be used by default for local development
-# Default SQLite database file: ./co2_calculator.db
+# PostgreSQL is REQUIRED for a running app: the Alembic migrations use
+# PostgreSQL-only features (e.g. CREATE COLLATION). The SQLite fallback used
+# when DB_URL is unset (./co2_calculator.db) cannot run the migrations and
+# only suits isolated unit tests.
 #
-# Examples:
-# - SQLite: DB_URL=sqlite+aiosqlite:///./co2_calculator.db
-# - PostgreSQL: DB_URL=postgresql://user:pass@host:5432/dbname?sslmode=disable
+# For local development, uncomment the localhost DB_URL line below.
+# Example: DB_URL=postgresql://user:pass@host:5432/dbname?sslmode=disable
 
 ## CF .database.env.example file for docker-compose setup (same user and password)
 ## +asyncpg is dynamically added by our core/db module


### PR DESCRIPTION
## What does this change?
Rewrites and expands the local development setup instructions in `README.md`, restructuring the old two-option "Development Workflow" section into a clearer, numbered 5-step onboarding flow (install → configure env files → set up the database → run the app → log in). Adds a new table explaining each `.env`/`.env.example` file, what `make install` does/doesn't create automatically, and what (if anything) needs editing. Also updates `backend/.env.example` to state explicitly that PostgreSQL is required (Alembic migrations use PostgreSQL-only features like `CREATE COLLATION`), clarifying that the previously-documented SQLite fallback only works for isolated unit tests, not for running the app. Adds explicit instructions for logging in locally via the `/en/login-test` (or `/fr/login-test`) test-role page, noting the language prefix is required, that the real `/login` OAuth flow isn't configured locally, and that the test login only exists when the backend runs with `DEBUG=True`.

## Why is this needed?
The previous README onboarding steps were incomplete/misleading: they implied SQLite could be used for local development (it can't, because migrations require Postgres-only features), didn't explain which `.env` files needed manual edits, and didn't document how to actually log in locally (the real OAuth login isn't configured in dev, and the test-login page's language-prefix requirement is easy to miss, resulting in a 404). This update removes friction and guesswork for new contributors setting up the project for the first time.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1298

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.