### PR TITLE
feat 259: add identify Equipment  data entry different from previous years (#259)

### DIFF
--- a/backend/app/modules/equipment/data_entries.py
+++ b/backend/app/modules/equipment/data_entries.py
@@ -69,6 +69,8 @@ class EquipmentHandlerResponse(DataEntryResponseGen):
     active_power_w: Optional[int] = None
     standby_power_w: Optional[int] = None
 
+    is_new: bool = False
+
 
 class EquipmentHandlerCreate(_EquipmentUsageHoursValidationMixin, DataEntryCreate):
     equipment_id: str

--- a/backend/app/modules/equipment/handlers.py
+++ b/backend/app/modules/equipment/handlers.py
@@ -138,6 +138,14 @@ class EquipmentModuleHandler(BaseModuleHandler):
     ) -> EquipmentHandlerResponse:
         data = enriched_data if enriched_data is not None else data_entry.data
         primary_factor = data.get("primary_factor", {})
+        is_new = bool(data.get("is_new", False))
+
+        def _displayed_usage(field: str) -> Optional[float]:
+            entered = data.get(field)
+            if entered is not None or is_new:
+                return entered
+            return primary_factor.get(field)
+
         new_entry = {
             "id": data_entry.id,
             "data_entry_type_id": data_entry.data_entry_type_id,
@@ -145,15 +153,11 @@ class EquipmentModuleHandler(BaseModuleHandler):
             **data,
             "active_power_w": primary_factor.get("active_power_w", None),
             "standby_power_w": primary_factor.get("standby_power_w", None),
-            "active_usage_hours_per_week": (
-                data.get("active_usage_hours_per_week")
-                if data.get("active_usage_hours_per_week") is not None
-                else primary_factor.get("active_usage_hours_per_week")
+            "active_usage_hours_per_week": _displayed_usage(
+                "active_usage_hours_per_week"
             ),
-            "standby_usage_hours_per_week": (
-                data.get("standby_usage_hours_per_week")
-                if data.get("standby_usage_hours_per_week") is not None
-                else primary_factor.get("standby_usage_hours_per_week")
+            "standby_usage_hours_per_week": _displayed_usage(
+                "standby_usage_hours_per_week"
             ),
             "equipment_class": primary_factor.get("class")
             or data.get("equipment_class"),

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from psycopg.types.json import Json
 from pydantic import BaseModel
-from sqlalchemy import Select, asc, desc, func, or_
+from sqlalchemy import Select, and_, asc, desc, func, or_
 from sqlalchemy import select as sa_select
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import aliased
@@ -36,6 +36,14 @@ logger = get_logger(__name__)
 
 # Default filter map when handler doesn't provide one
 DEFAULT_FILTER_MAP = {"name": DataEntry.data["name"].as_string()}
+
+# data_entry_type ids that make up the Equipment module (issue #259 "new vs
+# previous year" detection applies only to these).
+EQUIPMENT_DATA_ENTRY_TYPE_IDS = {
+    DataEntryTypeEnum.scientific.value,
+    DataEntryTypeEnum.it.value,
+    DataEntryTypeEnum.other.value,
+}
 
 # COPY target for ``bulk_copy`` — every non-defaulted data_entries column.
 # ``id`` is omitted so the sequence assigns it server-side.
@@ -574,6 +582,97 @@ class DataEntryRepository:
         else:
             return statement.order_by(desc(sort_expr))
 
+    async def get_prior_year_equipment_ids(
+        self, unit_id: int, current_year: int
+    ) -> set[str]:
+        """Return the set of ``equipment_id`` present in the unit's most recent
+        prior year (issue #259).
+
+        "Previous year" is the greatest year strictly before ``current_year``
+        that still has equipment entries for the unit — robust to skipped
+        years. Returns an empty set when the unit has no earlier equipment data
+        (e.g. its first campaign year), in which case nothing is flagged new.
+        """
+        type_ids = list(EQUIPMENT_DATA_ENTRY_TYPE_IDS)
+        prior_year = (
+            await self.session.execute(
+                select(func.max(DataEntry.year)).where(
+                    col(DataEntry.unit_id) == unit_id,
+                    col(DataEntry.year) < current_year,
+                    col(DataEntry.data_entry_type_id).in_(type_ids),
+                )
+            )
+        ).scalar_one_or_none()
+        if prior_year is None:
+            return set()
+        rows = (
+            (
+                await self.session.execute(
+                    select(DataEntry.data["equipment_id"].as_string())
+                    .where(
+                        col(DataEntry.unit_id) == unit_id,
+                        col(DataEntry.year) == prior_year,
+                        col(DataEntry.data_entry_type_id).in_(type_ids),
+                    )
+                    .distinct()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return {r for r in rows if r is not None}
+
+    async def _equipment_module_scope(
+        self, carbon_report_module_id: int
+    ) -> Optional[tuple[int, int]]:
+        """Return ``(unit_id, year)`` for an Equipment module, or ``None`` when
+        the module has no equipment entries to derive them from."""
+        meta = (
+            await self.session.execute(
+                select(DataEntry.unit_id, DataEntry.year)
+                .where(
+                    col(DataEntry.carbon_report_module_id) == carbon_report_module_id,
+                    col(DataEntry.data_entry_type_id).in_(
+                        list(EQUIPMENT_DATA_ENTRY_TYPE_IDS)
+                    ),
+                )
+                .limit(1)
+            )
+        ).first()
+        if meta is None or meta[0] is None or meta[1] is None:
+            return None
+        return int(meta[0]), int(meta[1])
+
+    async def count_incomplete_new_equipment(self, carbon_report_module_id: int) -> int:
+        """Count equipment that is new vs the previous year (issue #259) yet is
+        still missing usage data (active or standby hours). Returns ``0`` for
+        non-equipment modules and for units with no prior-year equipment data,
+        so it is safe to call unconditionally on any module."""
+        scope = await self._equipment_module_scope(carbon_report_module_id)
+        if scope is None:
+            return 0
+        unit_id, current_year = scope
+        prev_ids = await self.get_prior_year_equipment_ids(unit_id, current_year)
+        if not prev_ids:
+            return 0
+        active = DataEntry.data["active_usage_hours_per_week"].as_string()
+        standby = DataEntry.data["standby_usage_hours_per_week"].as_string()
+        count = (
+            await self.session.execute(
+                select(func.count())
+                .select_from(DataEntry)
+                .where(
+                    col(DataEntry.carbon_report_module_id) == carbon_report_module_id,
+                    col(DataEntry.data_entry_type_id).in_(
+                        list(EQUIPMENT_DATA_ENTRY_TYPE_IDS)
+                    ),
+                    DataEntry.data["equipment_id"].as_string().notin_(list(prev_ids)),
+                    or_(active.is_(None), standby.is_(None)),
+                )
+            )
+        ).scalar_one()
+        return int(count)
+
     async def get_submodule_data(
         self,
         carbon_report_module_id: int,
@@ -599,6 +698,8 @@ class DataEntryRepository:
             DataEntryTypeEnum.member.value,
             DataEntryTypeEnum.student.value,
         )
+        is_equipment_entry = data_entry_type_id in EQUIPMENT_DATA_ENTRY_TYPE_IDS
+        prev_equipment_ids: set[str] = set()
         handler = BaseModuleHandler.get_by_type(DataEntryTypeEnum(data_entry_type_id))
 
         # Classification-resolved factor in SQL (plan 1661-sql-factor-resolution):
@@ -890,6 +991,28 @@ class DataEntryRepository:
         if (is_train_entry or is_plane_entry) and OriginLocation is not None:
             sort_map["origin_name"] = OriginLocation.name
             sort_map["destination_name"] = DestLocation.name
+
+        if is_equipment_entry:
+            scope = await self._equipment_module_scope(carbon_report_module_id)
+            if scope is not None:
+                prev_equipment_ids = await self.get_prior_year_equipment_ids(*scope)
+            if prev_equipment_ids:
+                is_new_expr = (
+                    DataEntry.data["equipment_id"]
+                    .as_string()
+                    .notin_(list(prev_equipment_ids))
+                )
+
+                missing_usage_expr = or_(
+                    DataEntry.data["active_usage_hours_per_week"].as_string().is_(None),
+                    DataEntry.data["standby_usage_hours_per_week"]
+                    .as_string()
+                    .is_(None),
+                )
+                statement = statement.order_by(
+                    desc(and_(is_new_expr, missing_usage_expr))
+                )
+
         statement = self._apply_sort(statement, sort_by, sort_order, sort_map)
 
         statement = statement.offset(offset).limit(limit)
@@ -995,6 +1118,11 @@ class DataEntryRepository:
                     **primary_factor_classification,
                 },
             }
+
+            if is_equipment_entry:
+                enriched_data["is_new"] = bool(prev_equipment_ids) and (
+                    data_entry.data.get("equipment_id") not in prev_equipment_ids
+                )
 
             if is_travel_entry:
                 distance_km = (

--- a/backend/app/schemas/carbon_report_response.py
+++ b/backend/app/schemas/carbon_report_response.py
@@ -72,6 +72,14 @@ class ModuleResponse(BaseModel):
         None, description="Module statistics"
     )
     totals: ModuleTotals = Field(..., description="Module totals")
+    incomplete_new_equipment_count: int = Field(
+        0,
+        description=(
+            "Equipment new vs the previous year that is still missing usage "
+            "data (#259). Non-zero only for the Equipment module; blocks "
+            "validation until zero."
+        ),
+    )
 
 
 class TripLeg(BaseModel):

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -23,6 +23,7 @@ from app.modules.emissions.buckets import BucketNodes
 from app.modules.emissions.registry import MODULE_STAT_BUCKETS
 from app.repositories.carbon_report_module_repo import CarbonReportModuleRepository
 from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
+from app.repositories.data_entry_repo import DataEntryRepository
 from app.schemas.carbon_report import (
     CarbonReportModuleCreate,
     CarbonReportModuleRead,
@@ -319,6 +320,20 @@ class CarbonReportModuleService:
                 f"Invalid status {status}. Must be one of: "
                 f"{[s.value for s in ModuleStatus]}"
             )
+
+        if (
+            status == ModuleStatus.VALIDATED
+            and module_type_id == ModuleTypeEnum.equipment.value
+        ):
+            module = await self.repo.get_by_report_and_module_type(
+                carbon_report_id, module_type_id
+            )
+            if module is not None and module.id is not None:
+                incomplete = await DataEntryRepository(
+                    self.session
+                ).count_incomplete_new_equipment(module.id)
+                if incomplete > 0:
+                    raise ValueError("NEW_EQUIPMENT_USAGE_REQUIRED")
 
         logger.info(
             f"Updating report {sanitize(carbon_report_id)} module "

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -646,6 +646,10 @@ class DataEntryService:
             carbon_report_module_id=carbon_report_module_id,
             travel_institutional_id_filter=travel_institutional_id_filter,
         )
+
+        incomplete_new_equipment_count = await self.repo.count_incomplete_new_equipment(
+            carbon_report_module_id
+        )
         # more info in routes carbon_report_module (cf DataEntryEmissionService)
         # we just return empty stats and totals, it's computed in routes
         totals = ModuleTotals(
@@ -662,6 +666,7 @@ class DataEntryService:
             data_entry_types_total_items=data_entry_types_total_items,
             stats=None,
             totals=totals,
+            incomplete_new_equipment_count=incomplete_new_equipment_count,
         )
         return module_response
 

--- a/backend/tests/integration/modules/equipment_electric_consumption/test_new_vs_previous_year.py
+++ b/backend/tests/integration/modules/equipment_electric_consumption/test_new_vs_previous_year.py
@@ -1,0 +1,169 @@
+"""Integration tests: equipment new vs the previous year (issue #259).
+
+An equipment entry is "new" when its ``equipment_id`` did not exist in the
+unit's most recent prior year with equipment data. New entries are flagged
+(``is_new``), floated to the top of the listing, and — while still missing
+usage data — block module validation.
+
+Behaviours pinned here (all at the repository layer, like ``test_sort.py``):
+
+1. ``test_new_equipment_flagged_and_sorted_first`` — an equipment_id absent
+   from the prior year is flagged ``is_new`` and sorts ahead of an existing
+   one, overriding the user's secondary sort.
+2. ``test_first_year_flags_nothing`` — a unit with no earlier equipment data
+   flags nothing new and reports a zero incomplete count.
+3. ``test_count_incomplete_new_equipment`` — the count reflects only new
+   equipment still missing active/standby usage, and drops to zero once the
+   usage is filled.
+"""
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.constants import ModuleStatus
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryStatusEnum, DataEntryTypeEnum
+from app.models.module_type import ModuleTypeEnum
+from app.repositories.data_entry_repo import DataEntryRepository
+
+UNIT_ID = 1
+
+
+async def _seed_module(session: AsyncSession, year: int) -> CarbonReportModule:
+    """Seed a CarbonReport + equipment CarbonReportModule for ``year``."""
+    report = CarbonReport(year=year, unit_id=UNIT_ID, overall_status=0)
+    session.add(report)
+    await session.flush()
+
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.equipment.value,
+        status=ModuleStatus.NOT_STARTED,
+    )
+    session.add(module)
+    await session.flush()
+    return module
+
+
+async def _seed_entry(
+    session: AsyncSession,
+    module: CarbonReportModule,
+    *,
+    year: int,
+    equipment_id: str,
+    with_usage: bool = True,
+) -> DataEntry:
+    """Seed one scientific equipment entry with its denormalized unit/year.
+
+    ``get_prior_year_equipment_ids`` and ``_equipment_module_scope`` read the
+    denormalized ``unit_id``/``year`` off the entry, so both must be set.
+    """
+    data: dict = {
+        "name": f"eq-{equipment_id}",
+        "equipment_id": equipment_id,
+        "equipment_class": "microscope",
+    }
+    if with_usage:
+        data["active_usage_hours_per_week"] = 12
+        data["standby_usage_hours_per_week"] = 150
+    entry = DataEntry(
+        carbon_report_module_id=module.id,
+        data_entry_type_id=DataEntryTypeEnum.scientific,
+        status=DataEntryStatusEnum.PENDING,
+        data=data,
+        unit_id=UNIT_ID,
+        year=year,
+    )
+    session.add(entry)
+    await session.flush()
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_new_equipment_flagged_and_sorted_first(db_session: AsyncSession):
+    """The equipment_id absent from the prior year is flagged and floats up.
+
+    Prior year (2024) has {E1, E2}. Current year (2025) has E1 (existing) and
+    E3 (new). Sorting by name ascending would place ``eq-E1`` before ``eq-E3``;
+    the new-first primary sort must override that so E3 comes back first.
+    """
+    repo = DataEntryRepository(db_session)
+
+    prev_module = await _seed_module(db_session, 2024)
+    for eid in ("E1", "E2"):
+        await _seed_entry(db_session, prev_module, year=2024, equipment_id=eid)
+
+    cur_module = await _seed_module(db_session, 2025)
+    await _seed_entry(db_session, cur_module, year=2025, equipment_id="E1")
+    await _seed_entry(db_session, cur_module, year=2025, equipment_id="E3")
+    await db_session.commit()
+
+    result = await repo.get_submodule_data(
+        carbon_report_module_id=cur_module.id,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        limit=10,
+        offset=0,
+        sort_by="name",
+        sort_order="asc",
+    )
+
+    by_name = {item.name: item.is_new for item in result.items}  # type: ignore[attr-defined]
+    assert by_name == {"eq-E1": False, "eq-E3": True}
+    assert result.items[0].name == "eq-E3", (  # type: ignore[attr-defined]
+        "new equipment must float to the top, above the user's name sort"
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_year_flags_nothing(db_session: AsyncSession):
+    """A unit with no earlier equipment data flags nothing new."""
+    repo = DataEntryRepository(db_session)
+
+    cur_module = await _seed_module(db_session, 2025)
+    await _seed_entry(db_session, cur_module, year=2025, equipment_id="E1")
+    await _seed_entry(db_session, cur_module, year=2025, equipment_id="E2")
+    await db_session.commit()
+
+    result = await repo.get_submodule_data(
+        carbon_report_module_id=cur_module.id,
+        data_entry_type_id=DataEntryTypeEnum.scientific.value,
+        limit=10,
+        offset=0,
+        sort_by="name",
+        sort_order="asc",
+    )
+
+    assert all(item.is_new is False for item in result.items)  # type: ignore[attr-defined]
+    assert await repo.count_incomplete_new_equipment(cur_module.id) == 0
+
+
+@pytest.mark.asyncio
+async def test_count_incomplete_new_equipment(db_session: AsyncSession):
+    """Only new equipment missing usage is counted; filling usage clears it."""
+    repo = DataEntryRepository(db_session)
+
+    prev_module = await _seed_module(db_session, 2024)
+    await _seed_entry(db_session, prev_module, year=2024, equipment_id="E1")
+
+    cur_module = await _seed_module(db_session, 2025)
+    # Existing equipment missing usage must NOT count (only new equipment does).
+    await _seed_entry(
+        db_session, cur_module, year=2025, equipment_id="E1", with_usage=False
+    )
+    # New equipment missing usage → counts.
+    new_incomplete = await _seed_entry(
+        db_session, cur_module, year=2025, equipment_id="E3", with_usage=False
+    )
+    await db_session.commit()
+
+    assert await repo.count_incomplete_new_equipment(cur_module.id) == 1
+
+    new_incomplete.data = {
+        **new_incomplete.data,
+        "active_usage_hours_per_week": 8,
+        "standby_usage_hours_per_week": 40,
+    }
+    db_session.add(new_incomplete)
+    await db_session.commit()
+
+    assert await repo.count_incomplete_new_equipment(cur_module.id) == 0

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -55,6 +55,23 @@
       </template>
     </q-input>
   </div>
+  <!-- #259: new equipment (vs previous year) still missing usage data must be
+       filled before the module can be validated. Sits below the CSV toolbar. -->
+  <q-banner
+    v-if="newEquipmentIncompleteCount > 0"
+    dense
+    rounded
+    class="equipment-new-banner q-mb-md"
+  >
+    <template #avatar>
+      <q-icon name="o_warning" class="equipment-new-banner__icon" />
+    </template>
+    {{
+      $t('equipment_new_usage_required_banner', {
+        count: newEquipmentIncompleteCount,
+      })
+    }}
+  </q-banner>
   <q-table
     v-model:pagination="moduleStore.state.paginationSubmodule[submoduleType]"
     class="co2-table border"
@@ -179,7 +196,18 @@
               :max="col.max"
               :step="col.step"
               :rules="getColumnRules(col)"
-              class="inline-input"
+              :placeholder="
+                isRequiredEmptyUsageCell(slotProps.row, col) ? '—' : undefined
+              "
+              :class="[
+                'inline-input',
+                {
+                  'inline-input--required-empty': isRequiredEmptyUsageCell(
+                    slotProps.row,
+                    col,
+                  ),
+                },
+              ]"
               :dropdown-icon="col.type === 'select' ? 'expand_more' : undefined"
               :error="!!getError(slotProps.row, col)"
               :error-message="getError(slotProps.row, col)"
@@ -269,9 +297,8 @@
             <div class="cell-content">
               <span>{{ renderCell(slotProps.row, col) }}</span>
               <q-badge
-                v-if="col.name === 'name' && isNew(slotProps.row)"
-                color="accent"
-                class="q-ml-xs"
+                v-if="col.name === 'name' && isNewIncomplete(slotProps.row)"
+                class="q-ml-md badge-new"
                 rounded
                 outline
                 dense
@@ -817,6 +844,14 @@ const props = withDefaults(defineProps<ModuleTableProps>(), {
 const moduleStore = useModuleStore();
 const timelineStore = useTimelineStore();
 const yearConfigStore = useYearConfigStore();
+
+// #259: only the Equipment module reports new-vs-previous-year equipment still
+// missing usage data; the banner warns the user before they try to validate.
+const newEquipmentIncompleteCount = computed(() =>
+  isEquipmentModule.value
+    ? (moduleStore.state.data?.incomplete_new_equipment_count ?? 0)
+    : 0,
+);
 
 const isInputDeactivated = computed(() => {
   const unifiedConfig = yearConfigStore.getModule(props.moduleType as Module);
@@ -1447,7 +1482,7 @@ async function commitInline(
 
 function rowClasses(row: ModuleRow) {
   return {
-    'row-new': isNew(row),
+    'row-new': isNewIncomplete(row),
     'row-incomplete': !isComplete(row),
   };
 }
@@ -1496,6 +1531,36 @@ function getColumnClasses(row: ModuleRow, col: TableViewColumn) {
 
 function isNew(row: ModuleRow) {
   return Boolean(row.is_new);
+}
+
+// Usage fields a new equipment (#259) must fill before the module can validate.
+const EQUIPMENT_REQUIRED_USAGE_FIELDS = [
+  'active_usage_hours_per_week',
+  'standby_usage_hours_per_week',
+];
+
+// Highlight (orange contour + em-dash placeholder) an empty active/standby
+// usage cell of a new equipment row, so the user knows it needs filling.
+function isRequiredEmptyUsageCell(
+  row: ModuleRow,
+  col: { field: string },
+): boolean {
+  return (
+    props.moduleType === MODULES.Equipment &&
+    isNew(row) &&
+    EQUIPMENT_REQUIRED_USAGE_FIELDS.includes(col.field) &&
+    !hasValue(row[col.field])
+  );
+}
+
+// A new equipment only needs the "new" emphasis (badge, row highlight, float to
+// top) until its usage is entered; once active + standby are filled it behaves
+// like a normal row (#259).
+function isNewIncomplete(row: ModuleRow): boolean {
+  return (
+    isNew(row) &&
+    EQUIPMENT_REQUIRED_USAGE_FIELDS.some((field) => !hasValue(row[field]))
+  );
 }
 
 function hasValue(value: unknown): boolean {
@@ -1922,12 +1987,43 @@ onUnmounted(() => {
   min-width: 240px;
 }
 
-.row-new {
-  border-left: 4px solid #f2c037;
+/* New / incomplete equipment rows (#259) are tinted with the banner colour.
+   The :deep + .q-tr selector must out-specify the striped-row rule below,
+   which otherwise repaints every even row. */
+.co2-table :deep(tbody tr.q-tr.row-new),
+.co2-table :deep(tbody tr.q-tr.row-incomplete) {
+  background: #fff4e5;
 }
 
-.row-incomplete {
+.co2-table :deep(tbody tr.q-tr.row-new) {
+  border-left: 4px solid #ffa503;
+}
+
+/* NEW badge next to a new equipment's name (#259). Outline badge follows
+   currentColor for both text and border. */
+.badge-new {
+  color: #ffa503;
+}
+
+/* Banner reminding the user to fill new equipment usage (#259): no border,
+   orange info icon. */
+.equipment-new-banner {
   background: #fff4e5;
+}
+
+.equipment-new-banner__icon {
+  color: #ffa503;
+}
+
+/* Empty required usage cell on a new equipment row (#259): orange contour so
+   the user immediately sees what must be filled before validating. */
+.inline-input--required-empty :deep(.q-field__control) {
+  border: 1px solid #ffa503;
+  border-radius: 4px;
+}
+
+.inline-input--required-empty :deep(.q-field__control):hover {
+  border-color: #e09400;
 }
 
 .cell-content {
@@ -2061,6 +2157,16 @@ onUnmounted(() => {
   td .inline-input .q-field__append,
   td .inline-select-wrapper .q-field__append {
     padding-left: tokens.$spacing-xs;
+  }
+
+  td .inline-input--required-empty {
+    width: 100%;
+  }
+
+  td .inline-input--required-empty .q-field__native,
+  td .inline-input--required-empty .q-field__input {
+    field-sizing: auto;
+    width: 100%;
   }
 
   .inline-edit-icon {

--- a/frontend/src/components/organisms/module/ModuleTotalResult.vue
+++ b/frontend/src/components/organisms/module/ModuleTotalResult.vue
@@ -25,6 +25,7 @@
       <q-btn
         v-if="canValidate"
         :icon="toggleIcon"
+        :disable="validateBlockedByNewEquipment"
         unelevated
         no-caps
         size="xs"
@@ -89,21 +90,27 @@
       </div>
 
       <!-- action button -->
-      <q-btn
-        v-if="canValidate"
-        :icon="toggleIcon"
-        :label="validationShortActionLabel"
-        unelevated
-        no-caps
-        class="mtr-sidebar__btn text-weight-medium full-width"
-        size="md"
-        :style="{
-          background: moduleColors.bgColorLighter,
-          color: moduleColors.buttonTextColor,
-          border: `1px solid ${moduleColors.buttonTextColor}`,
-        }"
-        @click="toggleValidation"
-      />
+      <div v-if="canValidate" class="mtr-sidebar__btn-wrap full-width">
+        <q-btn
+          :icon="toggleIcon"
+          :label="validationShortActionLabel"
+          :disable="validateBlockedByNewEquipment"
+          unelevated
+          no-caps
+          class="mtr-sidebar__btn text-weight-medium full-width"
+          size="md"
+          :style="{
+            background: moduleColors.bgColorLighter,
+            color: moduleColors.buttonTextColor,
+            border: `1px solid ${moduleColors.buttonTextColor}`,
+          }"
+          @click="toggleValidation"
+        />
+        <!-- Tooltip on the wrapper: a disabled q-btn cannot receive hover. -->
+        <q-tooltip v-if="validateBlockedByNewEquipment">
+          {{ $t('equipment_validate_blocked_tooltip') }}
+        </q-tooltip>
+      </div>
       <q-btn
         v-else-if="showContactHead && isValidated"
         icon="o_mail"
@@ -165,6 +172,7 @@
         <q-btn
           :outline="isValidated"
           :label="validationLabel"
+          :disable="validateBlockedByNewEquipment"
           unelevated
           no-caps
           size="md"
@@ -172,6 +180,16 @@
           :style="validationBtnStyle"
           @click="toggleValidation"
         />
+        <!-- Tooltip on the wrapper, not the button: a disabled q-btn has
+             pointer-events:none, so a tooltip on it would never fire (#259). -->
+        <q-tooltip
+          v-if="validateBlockedByNewEquipment"
+          anchor="top middle"
+          self="bottom middle"
+          :offset="[0, 8]"
+        >
+          {{ $t('equipment_validate_blocked_tooltip') }}
+        </q-tooltip>
       </div>
       <div
         v-else-if="showContactHead && isValidated"
@@ -200,10 +218,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useTimelineStore } from 'src/stores/modules';
+import { useTimelineStore, useModuleStore } from 'src/stores/modules';
 import { useAuthStore } from 'src/stores/auth';
 import { useWorkspaceStore } from 'src/stores/workspace';
-import { Module } from 'src/constant/modules';
+import { Module, MODULES } from 'src/constant/modules';
 import { ModuleConfig } from 'src/constant/moduleConfig';
 import {
   MODULE_STATES,
@@ -220,9 +238,17 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const timelineStore = useTimelineStore();
+const moduleStore = useModuleStore();
 const authStore = useAuthStore();
 const workspaceStore = useWorkspaceStore();
 const moduleColors = computed(() => getModuleIconColors(props.type));
+
+const validateBlockedByNewEquipment = computed(
+  () =>
+    props.type === MODULES.Equipment &&
+    !isValidated.value &&
+    (moduleStore.state.data?.incomplete_new_equipment_count ?? 0) > 0,
+);
 
 // Validating a module's status is a unit-level action: hide the button from
 // standard (own-scope) users, who never hold the `module.status` permission.
@@ -460,6 +486,10 @@ function toggleValidation() {
 
   &__btn {
     border-radius: tokens.$mtr-sidebar-btn-border-radius;
+  }
+
+  &__btn-wrap {
+    display: block;
   }
 }
 

--- a/frontend/src/constant/module-config/equipment.ts
+++ b/frontend/src/constant/module-config/equipment.ts
@@ -18,6 +18,7 @@ const nameField: ModuleField = {
   align: 'left',
   readOnly: false,
   ratio: '1/1',
+  columnSize: 'xl',
 };
 
 const equipmentIdField: ModuleField = {
@@ -78,7 +79,8 @@ const baseModuleFields: ModuleField[] = [
     readOnly: false,
     ratio: '1/2',
     icon: 'o_category',
-    columnSize: 'lg',
+    columnSize: 'sm',
+    maxColumnWidth: 160,
   },
   {
     id: 'active_usage_hours_per_week',

--- a/frontend/src/constant/modules.ts
+++ b/frontend/src/constant/modules.ts
@@ -266,6 +266,7 @@ export interface ModuleResponse {
   retrieved_at: string;
   submodules: Record<string, Submodule>;
   totals: Totals;
+  incomplete_new_equipment_count?: number;
 }
 
 // TODO refactor: delete this vibe coded code and use your brain

--- a/frontend/src/i18n/equipment.ts
+++ b/frontend/src/i18n/equipment.ts
@@ -14,6 +14,16 @@ export default {
     fr: 'Estimez la consommation électrique de vos équipements',
   },
 
+  equipment_new_usage_required_banner: {
+    en: '{count} new equipment needs its active and standby usage entered before this module can be validated. | {count} new equipment need their active and standby usage entered before this module can be validated.',
+    fr: '{count} nouvel équipement nécessite la saisie de son usage actif et standby avant de pouvoir valider ce module. | {count} nouveaux équipements nécessitent la saisie de leur usage actif et standby avant de pouvoir valider ce module.',
+  },
+
+  equipment_validate_blocked_tooltip: {
+    en: 'Enter the active and standby usage of all new equipment before validating this module.',
+    fr: "Saisissez l'usage actif et standby de tous les nouveaux équipements avant de pouvoir valider ce module.",
+  },
+
   [`${MODULES.Equipment}-title-subtext`]: {
     en: `This module allows you to estimate the electrical consumption of your scientific, IT, and other equipment. The equipment list comes from the inventory carried out by your unit for the faculty.
 


### PR DESCRIPTION
## What does this change?
Adds detection of equipment that is "new" compared to the unit's most recent prior year in the Equipment module. New equipment is flagged (`is_new`), floated to the top of the submodule listing, displayed with its own entered usage instead of falling back to the factor default, and visually highlighted in the UI (badge, row tint, required-field outline) until active/standby usage hours are filled in. A banner and disabled/tooltip-explained validate button block module validation (both frontend and backend) while any new equipment is still missing usage data.

## Why is this needed?
Previously, newly added equipment could silently inherit reference/default usage values from the emission factor, making it easy for users to validate a module without actually confirming real usage for equipment that wasn't present in prior years. This change (issue #259) ensures new equipment usage is explicitly entered and reviewed before a module can be validated.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #259

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.