### PR TITLE
fix: updated animals factors recompute by keeping provided values (#1597)

### DIFF
--- a/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
+++ b/backend/app/services/data_ingestion/computed_providers/research_facilities_animal.py
@@ -132,6 +132,11 @@ class ResearchFacilitiesAnimalFactorUpdateProvider(BaseFactorUpdateProvider):
         source_totals: Dict[str, float] = {src: 0.0 for src in SOURCE_EMISSION_MAP}
         for emission_type_id, kg in breakdown:
             for source, valid_ids in SOURCE_EMISSION_MAP.items():
+                # Compute only sources that have 0 or missing factor.values
+                existing = factor.values.get(f"kg_co2eq_sum_{source}")
+                if existing is not None and existing != 0:
+                    source_totals[source] = float(existing)
+                    continue
                 if emission_type_id in valid_ids:
                     source_share = factor.values.get(f"{source}_share", 0)
                     source_totals[source] += kg * source_share


### PR DESCRIPTION
## What does this change?

All animal factor values were updated, now only the ones that are missing (or 0) are computed, using share. 

## Why is this needed?

A provided factor value is not to be updated.

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues

- Related to #1597

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
