### PR TITLE
fix: Filter Calculator project in CSV ingest (#1518)

### DIFF
--- a/backend/app/services/data_ingestion/base_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_csv_provider.py
@@ -13,7 +13,8 @@ from sqlmodel import col, select
 from app.api.v1.files import make_files_store
 from app.core.config import get_settings
 from app.core.logging import get_logger
-from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReport, CarbonReportModule, CarbonReportType
 from app.models.data_entry import (
     BULK_PER_YEAR_SOURCES,
     DataEntry,
@@ -592,14 +593,22 @@ class BaseCSVProvider(DataIngestionProvider, ABC):
         # instead of 2 queries per unit.  ~2.5k units → one round-trip;
         # the per-unit path below only runs for units that still need a
         # carbon_report created for this year.
+        # A unit holds one report per carbon project per year, so without the
+        # Calculator predicate the join returns several candidates per unit and
+        # the ingest writes into whichever simulator project came back last.
         map_stmt = (
             select(Unit.institutional_id, CarbonReportModule.id, Unit.id)
             .join(CarbonReport, col(CarbonReport.unit_id) == col(Unit.id))
+            .join(
+                CarbonProject,
+                col(CarbonReport.carbon_project_id) == col(CarbonProject.id),
+            )
             .join(
                 CarbonReportModule,
                 col(CarbonReportModule.carbon_report_id) == col(CarbonReport.id),
             )
             .where(
+                col(CarbonProject.carbon_report_type) == CarbonReportType.CALCULATOR,
                 col(CarbonReport.year) == self.year,
                 col(CarbonReportModule.module_type_id) == module_type_id,
             )


### PR DESCRIPTION
## What does this change?
Adds a filter on `CarbonProject.carbon_report_type == CarbonReportType.CALCULATOR` to the bulk unit/module mapping query in `BaseCSVProvider`, joining through the new `CarbonProject` model.

## Why is this needed?
A unit can hold one carbon report per carbon project per year. Without filtering on the Calculator report type, the join returns multiple candidate reports per unit (including simulator projects), and data ingestion could end up writing into whichever simulator project happened to be returned last instead of the correct Calculator report — causing research facility data to land in the wrong carbon report.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1518

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.