### PR TITLE
feat: add bootstrap-years seeding

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -138,6 +138,13 @@ seed-units: ## Seed units from accred
 seed-generic-data: ## Seed data entries from seed_data CSVs
 	$(UV) run -m app.seed.seed_generic_data_entries
 
+# Years provisioned by `bootstrap-years`; override on the command line.
+YEARS ?= 2025 2026
+
+.PHONY: bootstrap-years
+bootstrap-years: ## Provision years from INPUT_DATA: config + unit sync + factors + references + reduction objectives, no data entries (usage: make bootstrap-years YEARS="2025 2026")
+	$(UV) run -m app.seed.bootstrap_years --years $(YEARS)
+
 .PHONY: exchange-rates
 exchange-rates: ## Fetch exchange rates from ECB API and store in database
 	$(UV) run exchange-rates

--- a/backend/app/seed/bootstrap_years.py
+++ b/backend/app/seed/bootstrap_years.py
@@ -1,0 +1,283 @@
+"""Bootstrap a freshly-created database from ``backend/INPUT_DATA``.
+
+Replays, per year, the whole backoffice click-path that otherwise has to be
+redone by hand after every ``make db-drop``:
+
+1. create the ``year_configuration`` row (default config, every module on);
+2. run the ``unit_sync`` pipeline — units + principal users from the unit
+   provider, then ``carbon_reports`` + ``carbon_report_modules`` for the
+   year, and the ``configuration_completed`` stamp that unblocks uploads;
+3. ingest every factor CSV for that year;
+4. ingest the reference CSVs (airports, train stations, building rooms);
+5. load the three reduction-objective CSVs and the institutional goals;
+6. open the year for end users (``is_started``).
+
+Data entries are deliberately NOT seeded — the modules are left empty.
+Use ``make seed-generic-data`` if you want rows too.
+"""
+
+import argparse
+import asyncio
+from datetime import datetime
+from typing import Sequence
+from uuid import uuid4
+
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db import SessionLocal
+from app.models.data_ingestion import (
+    DataIngestionJob,
+    EntityType,
+    IngestionMethod,
+    IngestionResult,
+    IngestionState,
+    TargetType,
+)
+from app.models.module_type import (
+    ModuleTypeEnum,
+    get_module_type_for_data_entry_type,
+)
+from app.models.user import UserProvider
+from app.models.year_configuration import YearConfiguration
+from app.providers.unit_provider import get_unit_provider
+from app.repositories.data_ingestion import DataIngestionRepository
+from app.seed.seed_generic_factors import FACTOR_SEEDS, seed_all_factors
+from app.seed.seed_reduction_objectives import seed_reduction_objectives
+from app.seed.seed_reference_data import seed_all_reference_data
+from app.services.year_config_service import generate_default_year_config
+from app.tasks._background import wait_for_background_tasks
+from app.tasks.runner import run_job
+
+logger = get_logger(__name__)
+
+DEFAULT_YEARS: tuple[int, ...] = (2025, 2026)
+
+
+def _validate_year(year: int) -> None:
+    """Reject years ``POST /year-configuration/{year}`` would refuse."""
+    settings = get_settings()
+    current_year = datetime.now().year
+    if year < settings.MIN_CONFIGURABLE_YEAR or year > current_year:
+        raise ValueError(
+            f"Year {year} is out of range — must be between "
+            f"{settings.MIN_CONFIGURABLE_YEAR} and {current_year}"
+        )
+
+
+async def _ensure_year_configuration(
+    session: AsyncSession, year: int, provider: UserProvider
+) -> None:
+    """Create the year row if it does not exist yet (idempotent re-runs)."""
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == provider,
+    )
+    existing = (await session.exec(stmt)).first()
+    if existing is not None:
+        print(f"Year {year} ({provider.name}) already configured — reusing it")
+        return
+
+    session.add(
+        YearConfiguration(
+            year=year,
+            provider=provider,
+            is_started=False,
+            config=generate_default_year_config(),
+        )
+    )
+    await session.commit()
+    print(f"Created year configuration {year} ({provider.name})")
+
+
+async def _enqueue(job: DataIngestionJob, kind: str) -> int:
+    """Persist a job under a fresh pipeline and return its id."""
+    async with SessionLocal() as session:
+        repo = DataIngestionRepository(session)
+        pipeline_id = uuid4()
+        job.pipeline_id = pipeline_id
+        await repo.ensure_pipeline_exists(
+            pipeline_id,
+            kind=kind,
+            entity_type=job.entity_type.value,
+            ingestion_method=job.ingestion_method.value,
+            module_type_id=job.module_type_id,
+            year=job.year,
+        )
+        created = await repo.create_ingestion_job(job)
+        await session.commit()
+        if created.id is None:
+            raise RuntimeError(f"{kind} job for {job.year} was not persisted")
+        return created.id
+
+
+async def _run_and_check(job_id: int, label: str) -> None:
+    """Await ``run_job`` and fail loudly on an ERROR outcome.
+
+    ``run_job`` turns handler failures into FINISHED+ERROR rather than
+    raising, so the outcome has to be read back explicitly.
+    """
+    await run_job(job_id)
+    async with SessionLocal() as session:
+        finished = await DataIngestionRepository(session).get_job_by_id(job_id)
+        if finished is None:
+            raise RuntimeError(f"{label} job {job_id} disappeared")
+        if finished.result is None or finished.result == IngestionResult.ERROR:
+            raise RuntimeError(
+                f"{label} job {job_id} ended {finished.state}/{finished.result} — "
+                f"{finished.status_message}"
+            )
+        if finished.result != IngestionResult.SUCCESS:
+            print(f"  {label}: {finished.result} — {finished.status_message}")
+
+
+async def _run_unit_sync(year: int, provider: UserProvider) -> None:
+    """Enqueue and await the ``unit_sync`` job for one year.
+
+    Mirrors the job ``create_year_configuration`` enqueues, but awaits
+    ``run_job`` instead of firing it in the background so the CLI blocks
+    until the units, carbon reports and modules exist.
+    """
+    job_id = await _enqueue(
+        DataIngestionJob(
+            job_type="unit_sync",
+            module_type_id=None,
+            data_entry_type_id=None,
+            year=year,
+            ingestion_method=IngestionMethod.api,
+            target_type=TargetType.REFERENCE_DATA,
+            entity_type=EntityType.GLOBAL_PER_YEAR,
+            state=IngestionState.NOT_STARTED,
+            provider=provider,
+            meta={"config": {"target_year": year}},
+        ),
+        kind="unit_sync",
+    )
+    print(f"Running unit_sync for {year} (job {job_id})…")
+    await _run_and_check(job_id, f"unit_sync {year}")
+    print(f"unit_sync for {year} finished")
+
+
+def _seeded_types_by_module() -> dict[int, list[int]]:
+    """Map every module the factor seeds touch to its data-entry types.
+
+    Read off ``FACTOR_SEEDS`` rather than
+    ``get_recalculation_status_by_year``: a multi-type CSV (equipment,
+    purchases_common) plants its stub job with ``data_entry_type_id=NULL``,
+    and that query filters NULLs out — so the status rows do not name every
+    type that just got new factors.
+    """
+    by_module: dict[int, list[int]] = {}
+    for config in FACTOR_SEEDS:
+        for det in config.data_entry_types:
+            module_type = get_module_type_for_data_entry_type(det)
+            if module_type is None:
+                raise ValueError(
+                    f"Cannot determine module_type for data_entry_type: {det.name}"
+                )
+            types = by_module.setdefault(module_type.value, [])
+            if det.value not in types:
+                types.append(det.value)
+    return by_module
+
+
+async def _run_emission_recalculations(year: int, provider: UserProvider) -> None:
+    """Recalculate emissions per module, as a factor upload's chain would.
+
+    Seeded factors go in through ``LocalFactorCSVProvider``, which bypasses
+    ``factor_ingest`` and therefore never fans out the ``emission_recalc``
+    children.  Without them the backoffice configuration page shows
+    "Recalculation needed" on every module: ``get_recalculation_status_by_year``
+    flags a type whose latest FACTORS job is newer than its latest computed
+    DATA_ENTRIES job.  This replays
+    ``POST /sync/recalculate-emissions/{module_type_id}`` per module, whose
+    handler also writes the per-type stub jobs that query matches on.
+    """
+    for module_type_id, det_ids in _seeded_types_by_module().items():
+        job_id = await _enqueue(
+            DataIngestionJob(
+                job_type="module_emission_recalc",
+                module_type_id=module_type_id,
+                data_entry_type_id=None,
+                year=year,
+                ingestion_method=IngestionMethod.computed,
+                target_type=TargetType.DATA_ENTRIES,
+                entity_type=EntityType.MODULE_PER_YEAR,
+                state=IngestionState.NOT_STARTED,
+                provider=provider,
+                meta={
+                    "config": {
+                        "year": year,
+                        "data_entry_type_ids": det_ids,
+                        "only_stale": False,
+                    }
+                },
+            ),
+            kind="module_emission_recalc",
+        )
+        label = ModuleTypeEnum(module_type_id).name
+        await _run_and_check(job_id, f"recalc {label} {year}")
+        print(f"Recalculated {label} ({len(det_ids)} types) for {year}")
+
+    # Each module recalc chains an ``aggregation`` child through
+    # ``fire_and_forget``.  A CLI has to wait for those before the loop
+    # closes, or they are cancelled mid-run and left stuck in RUNNING.
+    await wait_for_background_tasks()
+
+
+async def _open_year(session: AsyncSession, year: int, provider: UserProvider) -> None:
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == provider,
+    )
+    row = (await session.exec(stmt)).first()
+    if row is None:
+        raise ValueError(f"No year_configuration row for year={year}")
+    row.is_started = True
+    session.add(row)
+
+
+async def bootstrap_year(year: int, provider: UserProvider) -> None:
+    """Run the full bootstrap for a single year."""
+    _validate_year(year)
+    print(f"\n=== Bootstrapping {year} ({provider.name}) ===")
+
+    async with SessionLocal() as session:
+        await _ensure_year_configuration(session, year, provider)
+
+    await _run_unit_sync(year, provider)
+
+    async with SessionLocal() as session:
+        await seed_all_factors(session, year)
+        await seed_all_reference_data(session, year)
+
+    await _run_emission_recalculations(year, provider)
+
+    async with SessionLocal() as session:
+        await seed_reduction_objectives(session, year, provider)
+        await _open_year(session, year, provider)
+        await session.commit()
+
+    print(f"=== {year} ready ===")
+
+
+async def main(years: Sequence[int] = DEFAULT_YEARS) -> None:
+    provider = get_unit_provider().type
+    for year in years:
+        await bootstrap_year(year, provider)
+    print(f"\nBootstrapped years: {', '.join(str(y) for y in years)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--years",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_YEARS),
+        help="Years to bootstrap (default: 2025 2026)",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(args.years))

--- a/backend/app/seed/seed_generic_factors.py
+++ b/backend/app/seed/seed_generic_factors.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -19,8 +20,8 @@ logger = get_logger(__name__)
 settings = get_settings()
 versionapi = settings.FORMULA_VERSION_SHA256_SHORT
 
-BACKEND_FOLDER = Path(__file__).parent.parent.parent / "seed_data"
-YEAR = 2025
+INPUT_DATA_FOLDER = Path(__file__).parent.parent.parent / "INPUT_DATA"
+DEFAULT_YEAR = 2025
 
 
 @dataclass
@@ -57,29 +58,29 @@ class FactorSeedConfig:
 # waste_factors.csv
 FACTOR_SEEDS: list[FactorSeedConfig] = [
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "building_energycombustions_factors.csv",
+        path=INPUT_DATA_FOLDER / "building_energycombustions_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.energy_combustion,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "building_rooms_factors.csv",
+        path=INPUT_DATA_FOLDER / "building_rooms_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.building,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "buildings_construction_renovation_factors.csv",
+        path=INPUT_DATA_FOLDER / "buildings_construction_renovation_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.building_embodied_energy,
         ],
     ),
     # FactorSeedConfig(
-    #     path=BACKEND_FOLDER / "commuting_factors.csv", data_entry_types=[]
+    #     path=INPUT_DATA_FOLDER / "commuting_factors.csv", data_entry_types=[]
     # ),
     # Multi data_entry_type CSV — column differentiates (other, it, scientific)
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "equipment_factors.csv",
+        path=INPUT_DATA_FOLDER / "equipment_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.scientific,
             DataEntryTypeEnum.it,
@@ -88,38 +89,40 @@ FACTOR_SEEDS: list[FactorSeedConfig] = [
         data_entry_type_column="equipment_category",
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "external_ai_factors.csv",
+        path=INPUT_DATA_FOLDER / "external_ai_factors.csv",
         data_entry_types=[DataEntryTypeEnum.external_ai],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "external_clouds_factors.csv",
+        path=INPUT_DATA_FOLDER / "external_clouds_factors.csv",
         data_entry_types=[DataEntryTypeEnum.external_clouds],
     ),
-    # FactorSeedConfig(path=BACKEND_FOLDER / "food_factors.csv", data_entry_types=[]),
+    # FactorSeedConfig(
+    #     path=INPUT_DATA_FOLDER / "food_factors.csv", data_entry_types=[]
+    # ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "headcount_member_factors.csv",
+        path=INPUT_DATA_FOLDER / "headcount_member_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.member,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "headcount_students_factors.csv",
+        path=INPUT_DATA_FOLDER / "headcount_students_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.student,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "processemissions_factors.csv",
+        path=INPUT_DATA_FOLDER / "processemissions_factors.csv",
         data_entry_types=[DataEntryTypeEnum.process_emissions],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "purchases_centralized_factors.csv",
+        path=INPUT_DATA_FOLDER / "purchases_centralized_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.purchases_centralized,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "purchases_common_factors.csv",
+        path=INPUT_DATA_FOLDER / "purchases_common_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.scientific_equipment,
             DataEntryTypeEnum.it_equipment,
@@ -132,34 +135,40 @@ FACTOR_SEEDS: list[FactorSeedConfig] = [
         data_entry_type_column="purchase_category",
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "researchfacilities_animals_factors.csv",
+        path=INPUT_DATA_FOLDER / "researchfacilities_animals_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.animal_facilities,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "researchfacilities_common_factors.csv",
+        path=INPUT_DATA_FOLDER / "researchfacilities_common_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.research_facilities,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "travel_planes_factors.csv",
+        path=INPUT_DATA_FOLDER / "travel_planes_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.plane,
         ],
     ),
     FactorSeedConfig(
-        path=BACKEND_FOLDER / "travel_trains_factors.csv",
+        path=INPUT_DATA_FOLDER / "travel_trains_factors.csv",
         data_entry_types=[
             DataEntryTypeEnum.train,
         ],
     ),
-    # FactorSeedConfig(path=BACKEND_FOLDER / "waste_factors.csv", data_entry_types=[]),
+    # FactorSeedConfig(
+    #     path=INPUT_DATA_FOLDER / "waste_factors.csv", data_entry_types=[]
+    # ),
 ]
 
 
-async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
+async def seed_factors(
+    session: AsyncSession,
+    config: FactorSeedConfig,
+    year: int = DEFAULT_YEAR,
+) -> None:
     """Seed factors from a CSV using the ingestion pipeline."""
     if not config.data_entry_types:
         raise ValueError("At least one data_entry_type must be provided")
@@ -185,7 +194,7 @@ async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
     provider_config: dict = {
         "local_file_path": str(config.path),
         "module_type_id": module_type.value,
-        "year": YEAR,
+        "year": year,
         "data_entry_type_id": (
             config.data_entry_types[0].value
             if config.data_entry_type_column is None
@@ -200,7 +209,7 @@ async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
     label = ", ".join(det.name for det in config.data_entry_types)
     inserted = result.get("inserted", 0)
     skipped = result.get("skipped", 0)
-    print(f"Created {inserted} factors for [{label}] ({skipped} skipped)")
+    print(f"Created {inserted} factors for [{label}] in {year} ({skipped} skipped)")
 
     # Plant a stub ``factor_ingest`` job so the data-management
     # cards show the seed.  Mirror the real dispatch path's
@@ -218,7 +227,7 @@ async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
             if config.data_entry_type_column is None
             else None
         ),
-        year=YEAR,
+        year=year,
         target_type=TargetType.FACTORS,
         job_type="factor_ingest",
         file_path=config.path,
@@ -227,15 +236,21 @@ async def seed_factors(session: AsyncSession, config: FactorSeedConfig) -> None:
     )
 
     await session.commit()
-    logger.info(f"Seeded factors for [{label}].")
+    logger.info(f"Seeded factors for [{label}] in {year}.")
 
 
-async def main() -> None:
+async def seed_all_factors(session: AsyncSession, year: int = DEFAULT_YEAR) -> None:
+    """Seed every CSV in ``FACTOR_SEEDS`` for one reference year."""
+    for config in FACTOR_SEEDS:
+        await seed_factors(session, config, year)
+
+
+async def main(years: Iterable[int] = (DEFAULT_YEAR,)) -> None:
     """Main seed function."""
 
     async with SessionLocal() as session:
-        for config in FACTOR_SEEDS:
-            await seed_factors(session, config)
+        for year in years:
+            await seed_all_factors(session, year)
 
 
 if __name__ == "__main__":

--- a/backend/app/seed/seed_reduction_objectives.py
+++ b/backend/app/seed/seed_reduction_objectives.py
@@ -1,0 +1,148 @@
+"""Seed the three reduction-objective CSVs and the institutional goals.
+
+Replays what an operator does in backoffice → Configuration → Reduction
+objectives: upload the institutional footprint, the population forecast and
+the unit scenarios, then enter the reduction goals.  Both endpoints
+(``POST /year-configuration/{year}/upload`` and ``PATCH
+/year-configuration/{year}``) write into the same
+``year_configuration.config['reduction_objectives']`` blob, so the seed
+writes that blob directly — reusing the endpoints' own CSV validator and
+storage-path helpers so the two can't drift.
+"""
+
+import asyncio
+import copy
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.v1.year_configuration import (
+    generate_unique_filename,
+    get_files_storage_path,
+)
+from app.core.logging import get_logger
+from app.db import SessionLocal
+from app.models.user import UserProvider
+from app.models.year_configuration import YearConfiguration
+from app.schemas.year_configuration import (
+    ReductionObjectiveGoal,
+    validate_reduction_objective_csv,
+)
+
+logger = get_logger(__name__)
+
+INPUT_DATA_FOLDER = Path(__file__).parent.parent.parent / "INPUT_DATA"
+
+# Category → source CSV.  Categories are the ``FileCategory`` literals the
+# upload endpoint accepts.
+CSV_BY_CATEGORY: Dict[str, Path] = {
+    "footprint": INPUT_DATA_FOLDER / "reduction_obj_epfl_footprint(in).csv",
+    "population": INPUT_DATA_FOLDER / "reduction_obj_population_forecast(in).csv",
+    "scenarios": INPUT_DATA_FOLDER / "reduction_obj_unit_scenarios_reduction(in).csv",
+}
+
+# Same mapping the upload endpoint applies before writing into the config.
+CONFIG_KEY_BY_CATEGORY: Dict[str, str] = {
+    "footprint": "institutional_footprint",
+    "population": "population_projections",
+    "scenarios": "unit_scenarios",
+}
+
+DEFAULT_GOALS: list[ReductionObjectiveGoal] = [
+    ReductionObjectiveGoal(
+        target_year=2030, reduction_percentage=0.1, reference_year=2016
+    ),
+    ReductionObjectiveGoal(
+        target_year=2035, reduction_percentage=0.1, reference_year=2016
+    ),
+    ReductionObjectiveGoal(
+        target_year=2040, reduction_percentage=0.1, reference_year=2016
+    ),
+]
+
+
+def _store_file(source: Path, category: str) -> Dict[str, str]:
+    """Copy a CSV into the files store under the endpoint's own layout.
+
+    Returns the ``{path, filename, uploaded_at}`` metadata dict that
+    ``upload_reduction_objective_file`` writes into
+    ``reduction_objectives.files[<key>]``.
+    """
+    storage_root = Path(get_files_storage_path()).resolve()
+    category_dir = f"reduction_objectives/{category}"
+    target_dir = storage_root / category_dir
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    unique_filename = generate_unique_filename(source.name)
+    shutil.copyfile(source, target_dir / unique_filename)
+
+    return {
+        "path": f"{category_dir}/{unique_filename}",
+        "filename": unique_filename,
+        "uploaded_at": datetime.utcnow().isoformat(),
+    }
+
+
+async def seed_reduction_objectives(
+    session: AsyncSession,
+    year: int,
+    provider: UserProvider,
+    goals: Sequence[ReductionObjectiveGoal] = tuple(DEFAULT_GOALS),
+) -> None:
+    """Fill the three reduction-objective files and the goals for one year."""
+    stmt = select(YearConfiguration).where(
+        col(YearConfiguration.year) == year,
+        col(YearConfiguration.provider) == provider,
+    )
+    row = (await session.exec(stmt)).first()
+    if row is None:
+        raise ValueError(
+            f"No year_configuration row for year={year} provider={provider.name} — "
+            "create the year before seeding its reduction objectives"
+        )
+
+    # Same invariant PATCH /year-configuration/{year} enforces.
+    for goal in goals:
+        if goal.target_year <= year:
+            raise ValueError(
+                f"Goal target_year ({goal.target_year}) must be greater than "
+                f"configuration year ({year})"
+            )
+
+    config: Dict[str, Any] = copy.deepcopy(row.config)
+    objectives = config.setdefault("reduction_objectives", {})
+    files = objectives.setdefault("files", {})
+
+    for category, source in CSV_BY_CATEGORY.items():
+        if not source.is_file():
+            raise FileNotFoundError(f"Reduction-objective CSV not found: {source}")
+        # Raises ValueError(list[str]) on a bad header or any bad row.
+        rows = validate_reduction_objective_csv(source.read_bytes(), category)
+        config_key = CONFIG_KEY_BY_CATEGORY[category]
+        files[config_key] = _store_file(source, category)
+        objectives[config_key] = rows
+        print(f"Loaded {len(rows)} {config_key} rows for {year}")
+
+    objectives["goals"] = [goal.model_dump() for goal in goals]
+
+    # Whole-dict reassignment so SQLAlchemy detects the JSON column change.
+    row.config = config
+    session.add(row)
+    logger.info(
+        f"Seeded reduction objectives for {year}: "
+        f"{len(goals)} goals, {len(CSV_BY_CATEGORY)} files."
+    )
+
+
+async def main(year: int, provider: UserProvider = UserProvider.ACCRED) -> None:
+    async with SessionLocal() as session:
+        await seed_reduction_objectives(session, year, provider)
+        await session.commit()
+
+
+if __name__ == "__main__":
+    asyncio.run(main(2025))

--- a/backend/app/seed/seed_reference_data.py
+++ b/backend/app/seed/seed_reference_data.py
@@ -1,0 +1,179 @@
+"""Seed reference data (airports, train stations, building rooms) from CSV.
+
+Reference data is year-agnostic global state: the rows land in ``locations``
+and ``building_rooms``, which carry no year column.  The seed reuses
+``ReferenceDataCSVProvider`` — the exact provider the backoffice
+"reference data" upload runs — reading from local disk instead of the file
+store, so seeded rows are indistinguishable from uploaded ones.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.db import SessionLocal
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.data_ingestion import IngestionResult, IngestionState, TargetType
+from app.models.module_type import ModuleTypeEnum
+from app.seed._stub_jobs import create_seed_stub_job
+from app.services.data_ingestion.csv_providers.reference_data import (
+    ReferenceDataCSVProvider,
+)
+
+logger = get_logger(__name__)
+
+INPUT_DATA_FOLDER = Path(__file__).parent.parent.parent / "INPUT_DATA"
+DEFAULT_YEAR = 2025
+
+
+@dataclass
+class ReferenceSeedConfig:
+    """One reference CSV and the (module, data-entry) pair it belongs to."""
+
+    path: Path
+    data_entry_type: DataEntryTypeEnum
+    module_type: ModuleTypeEnum
+
+
+REFERENCE_SEEDS: list[ReferenceSeedConfig] = [
+    ReferenceSeedConfig(
+        path=INPUT_DATA_FOLDER / "travel_planes_reference.csv",
+        data_entry_type=DataEntryTypeEnum.plane,
+        module_type=ModuleTypeEnum.professional_travel,
+    ),
+    ReferenceSeedConfig(
+        path=INPUT_DATA_FOLDER / "travel_trains_reference.csv",
+        data_entry_type=DataEntryTypeEnum.train,
+        module_type=ModuleTypeEnum.professional_travel,
+    ),
+    ReferenceSeedConfig(
+        path=INPUT_DATA_FOLDER / "building_rooms_reference.csv",
+        data_entry_type=DataEntryTypeEnum.building,
+        module_type=ModuleTypeEnum.buildings,
+    ),
+]
+
+
+class LocalReferenceCSVProvider(ReferenceDataCSVProvider):
+    """Reference CSV provider that reads from local disk.
+
+    Mirrors ``LocalFactorCSVProvider`` (``csv_providers/local_seed.py``):
+    no ``DataIngestionJob`` row, no file-store staging.  Header validation,
+    the locations COPY + natural-key UPSERT and the building-rooms
+    delete-and-insert are all inherited untouched.
+
+    Config keys
+    -----------
+    local_file_path : str
+        Absolute path to the CSV file on disk.
+    data_entry_type_id : int
+        plane (20), train (21) or building (30) — the base class dispatches
+        on this.
+    """
+
+    def __init__(self, config: Dict[str, Any], data_session: AsyncSession):
+        super().__init__(
+            config=config,
+            user=None,
+            job_session=None,
+            data_session=data_session,
+        )
+        self._local_file_path = Path(config["local_file_path"])
+
+    async def validate_connection(self) -> bool:
+        exists = self._local_file_path.is_file()
+        if not exists:
+            logger.warning(f"Local CSV file not found: {self._local_file_path}")
+        return exists
+
+    async def _stage_file(self) -> tuple[str, str, str]:
+        """Read the CSV off disk instead of moving it through the file store."""
+        if not self._local_file_path.is_file():
+            raise FileNotFoundError(f"CSV file not found: {self._local_file_path}")
+        # utf-8-sig so a BOM-prefixed export does not poison the first header.
+        csv_text = self._local_file_path.read_text(encoding="utf-8-sig")
+        return csv_text, str(self._local_file_path), self._local_file_path.name
+
+    async def _move_to_processed(self, processing_path: str) -> str:
+        # Seed CSVs live in the repo, not the file store — nothing to archive.
+        return processing_path
+
+    async def _update_job(
+        self,
+        status_message: str,
+        extra_metadata: dict | None = None,
+        state: Optional[IngestionState] = None,
+        result: Optional[IngestionResult] = None,
+    ) -> None:
+        # Local seed runs do not persist ingestion jobs.
+        logger.debug(
+            "LocalReferenceCSVProvider state=%s, message=%s", state, status_message
+        )
+        return None
+
+
+async def seed_reference_data_file(
+    session: AsyncSession,
+    config: ReferenceSeedConfig,
+    year: int = DEFAULT_YEAR,
+) -> None:
+    """Ingest one reference CSV and plant the matching data-management stub job."""
+    if not config.path.is_file():
+        raise FileNotFoundError(f"Reference CSV not found: {config.path}")
+
+    provider = LocalReferenceCSVProvider(
+        config={
+            "local_file_path": str(config.path),
+            "module_type_id": config.module_type.value,
+            "data_entry_type_id": config.data_entry_type.value,
+            "year": year,
+        },
+        data_session=session,
+    )
+    result = await provider.ingest()
+
+    data = result.get("data", {})
+    inserted = data.get("inserted", 0)
+    skipped = data.get("skipped", 0)
+    print(
+        f"Ingested {inserted} {config.data_entry_type.name} reference rows "
+        f"({skipped} skipped)"
+    )
+
+    # Same rationale as the factor seed: without a stub job the rows exist in
+    # the DB but the backoffice data-management card stays blank.
+    await create_seed_stub_job(
+        session,
+        module_type_id=config.module_type.value,
+        data_entry_type_id=config.data_entry_type.value,
+        year=year,
+        target_type=TargetType.REFERENCE_DATA,
+        job_type="reference_ingest",
+        file_path=config.path,
+        rows_processed=inserted,
+        rows_skipped=skipped,
+    )
+
+    await session.commit()
+    logger.info(f"Seeded {config.data_entry_type.name} reference data.")
+
+
+async def seed_all_reference_data(
+    session: AsyncSession, year: int = DEFAULT_YEAR
+) -> None:
+    """Ingest every CSV in ``REFERENCE_SEEDS``."""
+    for config in REFERENCE_SEEDS:
+        await seed_reference_data_file(session, config, year)
+
+
+async def main(year: int = DEFAULT_YEAR) -> None:
+    async with SessionLocal() as session:
+        await seed_all_reference_data(session, year)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/app/tasks/_background.py
+++ b/backend/app/tasks/_background.py
@@ -42,6 +42,29 @@ def fire_and_forget(coro: Coroutine, *, name: str | None = None) -> asyncio.Task
     return task
 
 
+async def wait_for_background_tasks(timeout: float = 600.0) -> None:
+    """Block until every in-flight fire-and-forget task has finished.
+
+    Long-lived processes (the API) let these run to completion on their own.
+    A CLI cannot: ``asyncio.run`` cancels whatever is still pending when the
+    loop closes, so a chained job would die mid-flight and leave its
+    ``DataIngestionJob`` row stuck in RUNNING.  Draining also covers tasks
+    spawned by the ones we're waiting on — each pass re-reads the set.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        pending = {task for task in _BACKGROUND_TASKS if not task.done()}
+        if not pending:
+            return
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"{len(pending)} background task(s) still running after {timeout}s"
+            )
+        await asyncio.wait(pending, timeout=remaining)
+
+
 def _on_done(task: asyncio.Task) -> None:
     _BACKGROUND_TASKS.discard(task)
     if task.cancelled():

--- a/docs/src/implementation-plans/bootstrap-years-from-input-data.md
+++ b/docs/src/implementation-plans/bootstrap-years-from-input-data.md
@@ -1,0 +1,133 @@
+---
+status: delivered
+last_updated: 2026-07-23
+title: "Bootstrap year configurations from INPUT_DATA"
+summary: "make bootstrap-years replays the whole post-db-drop backoffice click-path — year configuration, unit sync, every factor CSV, the three reference CSVs, and the reduction-objective files + goals — from backend/INPUT_DATA, for 2025 and 2026. No data entries."
+---
+
+# Bootstrap year configurations from INPUT_DATA
+
+## Problem
+
+After every `make db-drop` / `make clean-db`, a developer had to redo the whole
+backoffice click-path by hand: create the year, wait for the Accred unit sync,
+upload ~15 factor CSVs plus the 3 reference CSVs, then fill the three
+reduction-objective file slots and re-enter the institutional goals. Several
+times a week, ~15 minutes each.
+
+Second problem found on the way: `app/seed/seed_generic_factors.py` (behind
+`make seed-data`) pointed at `backend/seed_data/` while listing the _current_
+filenames, which only exist in `backend/INPUT_DATA/` — `equipment_factors.csv`,
+`purchases_centralized_factors.csv`, `headcount_students_factors.csv`,
+`buildings_construction_renovation_factors.csv`. It died on
+`FileNotFoundError`.
+
+## What shipped
+
+`make bootstrap-years` (in `backend/Makefile`, `YEARS ?= 2025 2026`) runs
+`app.seed.bootstrap_years`. Per year, in order:
+
+1. **Year configuration** — insert the `year_configuration` row with
+   `generate_default_year_config()` if absent. Years are validated against
+   `settings.MIN_CONFIGURABLE_YEAR` and the current year, the same bounds
+   `POST /year-configuration/{year}` enforces.
+2. **Unit sync** — build the same `unit_sync` `DataIngestionJob` the endpoint
+   enqueues (`ensure_pipeline_exists` → `create_ingestion_job` →
+   `meta.config.target_year`) and **await** `run_job(job_id)` instead of firing
+   it in the background. `run_job` converts handler failures into
+   FINISHED+ERROR rather than raising, so the job row is re-read afterwards and
+   a non-`SUCCESS` result raises. This is what creates `units`, `users`,
+   `carbon_reports`, `carbon_report_modules` and the `configuration_completed`
+   stamp that unblocks uploads.
+3. **Factors** — `seed_all_factors(session, year)` over `FACTOR_SEEDS`.
+4. **Reference data** — `seed_all_reference_data(session, year)`.
+5. **Emission recalculation** — one `module_emission_recalc` job per module,
+   mirroring `POST /sync/recalculate-emissions/{module_type_id}`. See
+   [Why recalculation has to run](#why-recalculation-has-to-run) below.
+6. **Reduction objectives + goals** — the three CSVs plus goals
+   `2030 / 10 % / ref 2016`, `2035 / 10 % / ref 2016`, `2040 / 10 % / ref 2016`.
+7. **Open the year** — `is_started = True`.
+
+Data entries are deliberately not seeded;
+
+### Files
+
+| File                                            | Change                                                                  |
+| ----------------------------------------------- | ----------------------------------------------------------------------- |
+| `backend/app/seed/bootstrap_years.py`           | New — the orchestrator + `--years` CLI                                  |
+| `backend/app/seed/seed_reference_data.py`       | New — `LocalReferenceCSVProvider` + `REFERENCE_SEEDS`                   |
+| `backend/app/seed/seed_reduction_objectives.py` | New — CSV loading, file storage, `DEFAULT_GOALS`                        |
+| `backend/app/seed/seed_generic_factors.py`      | Repointed at `INPUT_DATA/`; `seed_factors`/`main` parameterized by year |
+| `backend/app/tasks/_background.py`              | New `wait_for_background_tasks()` drain helper                          |
+| `backend/Makefile`                              | `bootstrap-years` target                                                |
+
+### Reuse over reinvention
+
+- `LocalReferenceCSVProvider` subclasses the production
+  `ReferenceDataCSVProvider` and overrides only `validate_connection`,
+  `_stage_file` (read from disk), `_move_to_processed` (no-op) and `_update_job`
+  (no-op) — exactly the shape `LocalFactorCSVProvider` already uses in
+  `csv_providers/local_seed.py`. Header validation, the locations
+  COPY + natural-key UPSERT, the per-mode replace and the building-rooms
+  delete-and-insert are inherited untouched.
+- Reduction-objective CSVs go through the endpoint's own
+  `validate_reduction_objective_csv()`, and are stored using the endpoint's own
+  `get_files_storage_path()` / `generate_unique_filename()`, so the on-disk
+  layout cannot drift from a real upload.
+- Every seeded CSV plants a `create_seed_stub_job(...)` row so the backoffice
+  data-management cards show the seed instead of staying blank.
+
+### Why recalculation has to run
+
+Seeded factors go in through `LocalFactorCSVProvider`, which bypasses
+`factor_ingest` and therefore never fans out the `emission_recalc` children a
+real upload chains. `get_recalculation_status_by_year` flags any type whose
+latest FACTORS job is newer than its latest computed DATA_ENTRIES job — so
+without this step backoffice showed **"Recalculation needed"** on every module
+right after a clean bootstrap.
+
+The fan-out targets are read off `FACTOR_SEEDS`, not off
+`get_recalculation_status_by_year`: a multi-type CSV (`equipment_factors.csv`,
+`purchases_common_factors.csv`) plants its stub job with
+`data_entry_type_id = NULL`, and that query filters NULLs out, so it does not
+name every type that just received factors.
+
+`module_emission_recalc` (rather than per-type `emission_recalc`) is used
+because its handler already writes the per-type stub jobs the status query
+matches on, and chains a single `aggregation` child per module instead of one
+per type.
+
+Those chained aggregations are dispatched through `fire_and_forget`. A CLI has
+to wait for them before the event loop closes or they are cancelled mid-run and
+left stuck in RUNNING — hence `wait_for_background_tasks()` in
+`app/tasks/_background.py`.
+
+### Reference seeds
+
+| CSV in `INPUT_DATA/`           | data_entry_type | module_type               |
+| ------------------------------ | --------------- | ------------------------- |
+| `travel_planes_reference.csv`  | `plane` (20)    | `professional_travel` (2) |
+| `travel_trains_reference.csv`  | `train` (21)    | `professional_travel` (2) |
+| `building_rooms_reference.csv` | `building` (30) | `buildings` (3)           |
+
+`seed_locations.py` / `seed_building_rooms.py` are untouched — they still back
+`make seed-data` from `seed_data/`, and `_NATURAL_KEY_EXPR` still lives in
+`seed_locations.py` where `reference_data.py` imports it.
+
+## Verification
+
+Ran twice against a local Postgres, second run confirming idempotency
+(identical counts, no unique-index collisions on `is_current` or factor
+identity):
+
+- `year_configuration`: 2025 + 2026, `is_started=t`, `configuration_completed`
+  set, 3 goals and 3 file entries each
+- `factors`: 24 296 per year
+- `locations`: 4 478 plane + 51 299 train
+- `building_rooms`: 19 925
+- `data_entries`: 0
+- 18 seeded `is_current` ingestion jobs per year (15 FACTORS + 3 REFERENCE_DATA)
+- `needs_recalculation = false` for every `(module, data_entry_type)` — no
+  "Recalculation needed" badges in backoffice
+- every `data_ingestion_jobs` row FINISHED/SUCCESS, including the chained
+  `aggregation` children — nothing stuck in RUNNING


### PR DESCRIPTION
## What does this change?
Adds a `make bootstrap-years` command that replays the full post-`db-drop` backoffice click-path from `backend/INPUT_DATA` for a given set of years (default 2025 2026): creates the year configuration, runs unit sync, ingests all factor CSVs, ingests reference data (airports, train stations, building rooms), runs emission recalculation per module, seeds the three reduction-objective CSVs plus default goals, and opens the year. Data entries are intentionally not seeded.

Also fixes `app/seed/seed_generic_factors.py`, which pointed at the stale `backend/seed_data/` folder while referencing filenames that only exist in `backend/INPUT_DATA/`, causing a `FileNotFoundError`. `seed_factors`/`main` are now parameterized by year instead of hardcoded to 2025.

New files:
- `backend/app/seed/bootstrap_years.py` — orchestrator + `--years` CLI
- `backend/app/seed/seed_reference_data.py` — `LocalReferenceCSVProvider` + `REFERENCE_SEEDS`
- `backend/app/seed/seed_reduction_objectives.py` — CSV loading, file storage, `DEFAULT_GOALS`
- `docs/src/implementation-plans/bootstrap-years-from-input-data.md` — implementation plan/doc

Modified:
- `backend/app/seed/seed_generic_factors.py` — repointed at `INPUT_DATA/`, parameterized by year
- `backend/app/tasks/_background.py` — new `wait_for_background_tasks()` drain helper
- `backend/Makefile` — new `bootstrap-years` target

## Why is this needed?
After every `make db-drop` / `make clean-db`, developers had to manually redo the entire backoffice setup click-path (~15 minutes, several times a week): create the year, wait for unit sync, upload ~15 factor CSVs plus 3 reference CSVs, then fill in reduction-objective files and goals by hand. This automates that whole flow from existing `INPUT_DATA` CSVs. It also fixes a broken seed script that referenced a stale folder/filenames and would crash immediately.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.