### PR TITLE
feat/1858  planner results per year refining

### DIFF
--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -144,9 +144,11 @@ async def create_simulator_explore_carbon_report(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Create a new Simulator Explore carbon report seeded from the Calculator report.
+    """Create a new, empty Simulator Explore carbon report.
 
-    The explore report is seeded from the unit's Calculator report.
+    The report is created with its modules and no entries — Simulator Explore is
+    never seeded from the Calculator. Only the Simulator Plan prefills, and only
+    from the reference year its user picks.
     """
     unit = await db.get(Unit, unit_id)
     require_unit_access(current_user, unit)

--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -287,6 +287,7 @@ async def get_module(
     module_data = await DataEntryService(db).get_module_data(
         carbon_report_module_id=carbon_report_module_id,
         travel_institutional_id_filter=travel_institutional_id_filter,
+        reference_year=report.reference_year,
     )
 
     # if headcount compute FTE here
@@ -728,6 +729,7 @@ async def get_submodule(
         current_user=UserRead.model_validate(current_user),
         request_context=await get_request_context(request),
         background_tasks=background_tasks,
+        reference_year=report.reference_year,
     )
 
     if not submodule_data:

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -21,6 +21,10 @@ from app.models.data_entry_emission import DataEntryEmission
 from app.models.factor import Factor
 from app.modules.emissions import EmissionType
 from app.modules.emissions.registry import ROLLUP_EMISSION_TYPE_IDS
+from app.repositories.data_entry_repo import (
+    reference_year_filter,
+    reference_year_filter_by_module,
+)
 
 # COPY target for ``bulk_copy`` — every non-defaulted column;
 # ``id`` is omitted so the sequence assigns it server-side.
@@ -218,12 +222,20 @@ class DataEntryEmissionRepository:
     async def get_stats_pair_many(
         self,
         carbon_report_module_ids: list[int],
+        reference_year_by_module: Optional[Dict[int, int]] = None,
     ) -> Dict[int, tuple[Dict[str, float | None], Dict[str, float | None]]]:
         """``get_stats_pair`` for a whole module set in ONE grouped query.
 
         Returns {module_id: (by_emission_type kg_co2eq, additional_value)}.
         Modules with no emissions are absent from the result — callers
         treat a miss as empty stats.
+
+        ``reference_year_by_module`` carries the live baseline of the Simulator
+        Plan modules in the set (Calculator modules have none, so a plain
+        recompute passes nothing and pays nothing). A plan module keeps the
+        prefilled rows of every baseline it has used; only the live one counts
+        toward its stats — and therefore toward the report rollup, the plan
+        total and the chart.
         """
         if not carbon_report_module_ids:
             return {}
@@ -243,6 +255,10 @@ class DataEntryEmissionRepository:
                 col(DataEntryEmission.emission_type_id),
             )
         )
+        if reference_year_by_module:
+            query = query.where(
+                reference_year_filter_by_module(reference_year_by_module),
+            )
         rows = (await self.session.execute(query)).all()
         result: Dict[int, tuple[Dict[str, float | None], Dict[str, float | None]]] = {}
         for module_id, emission_type_id, primary_total, secondary_total in rows:
@@ -262,6 +278,7 @@ class DataEntryEmissionRepository:
         aggregate_by: str = "emission_type_id",
         primary_field: str = "kg_co2eq",
         secondary_field: str = "additional_value",
+        reference_year: Optional[int] = None,
     ) -> tuple[Dict[str, float | None], Dict[str, float | None]]:
         """Aggregate DataEntryEmission data by a field and sum two numeric columns.
 
@@ -282,6 +299,8 @@ class DataEntryEmissionRepository:
             .where(DataEntry.carbon_report_module_id == carbon_report_module_id)
             .group_by(group_field)
         )
+        if reference_year is not None:
+            query = query.where(reference_year_filter(reference_year))
 
         result = await self.session.execute(query)
         rows = result.all()

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from psycopg.types.json import Json
 from pydantic import BaseModel
-from sqlalchemy import Select, and_, asc, desc, func, or_
+from sqlalchemy import Select, and_, asc, case, desc, func, or_
 from sqlalchemy import select as sa_select
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import aliased
@@ -53,6 +53,41 @@ COPY data_entries (
     source, created_by_id, created_at, updated_at, year, unit_id
 ) FROM STDIN
 """
+
+
+def reference_year_filter(reference_year: Optional[int]) -> Any:
+    """Keep only the rows of the live baseline.
+
+    A Simulator Plan year holds the prefilled rows of every reference year it
+    has used, so switching the baseline back and forth never loses the user's
+    sliders or edits. ``data['reference_year']`` says which baseline a row was
+    copied from; rows without it — every Calculator and Explore row, and any
+    row a planner user adds by hand — always count.
+
+    Callers pass the report's current ``reference_year``; the read stays
+    unfiltered when there is none.
+    """
+    stamped = DataEntry.data["reference_year"].as_integer()
+    return or_(stamped.is_(None), stamped == reference_year)
+
+
+def reference_year_filter_by_module(
+    reference_year_by_module: Dict[int, int],
+) -> Any:
+    """``reference_year_filter`` for a batch of modules, one baseline each.
+
+    Modules absent from the map — every Calculator one — are unconstrained, so
+    a batch without plan modules adds no condition at all.
+    """
+    stamped = DataEntry.data["reference_year"].as_integer()
+    expected = case(
+        *(
+            (col(DataEntry.carbon_report_module_id) == module_id, year)
+            for module_id, year in reference_year_by_module.items()
+        ),
+        else_=None,
+    )
+    return or_(stamped.is_(None), stamped == expected)
 
 
 class DataEntryRepository:
@@ -435,6 +470,7 @@ class DataEntryRepository:
         self,
         carbon_report_module_id: int,
         travel_institutional_id_filter: Optional[str] = None,
+        reference_year: Optional[int] = None,
     ) -> Dict[int, int]:
         """
         Docstring for get_total_count_by_submodule
@@ -473,6 +509,8 @@ class DataEntryRepository:
             .where(DataEntry.carbon_report_module_id == carbon_report_module_id)
             .group_by(col(DataEntry.data_entry_type_id))
         )
+        if reference_year is not None:
+            query = query.where(reference_year_filter(reference_year))
         if travel_institutional_id_filter is not None:
             travel_type_ids = (
                 DataEntryTypeEnum.plane.value,
@@ -683,6 +721,7 @@ class DataEntryRepository:
         sort_order: str,
         filter: Optional[str] = None,
         institutional_id_filter: Optional[str] = None,
+        reference_year: Optional[int] = None,
     ) -> SubmoduleResponse:
         is_travel_entry = data_entry_type_id in (
             DataEntryTypeEnum.plane.value,
@@ -949,6 +988,8 @@ class DataEntryRepository:
             col(DataEntry.carbon_report_module_id) == carbon_report_module_id,
             col(DataEntry.data_entry_type_id) == data_entry_type_id,
         )
+        if reference_year is not None:
+            statement = statement.where(reference_year_filter(reference_year))
 
         if institutional_id_filter is not None and is_travel_entry:
             statement = statement.where(
@@ -1023,6 +1064,8 @@ class DataEntryRepository:
             DataEntry.carbon_report_module_id == carbon_report_module_id,
             DataEntry.data_entry_type_id == data_entry_type_id,
         )
+        if reference_year is not None:
+            count_stmt = count_stmt.where(reference_year_filter(reference_year))
         if institutional_id_filter is not None and is_travel_entry:
             count_stmt = count_stmt.where(
                 DataEntry.data["user_institutional_id"].as_string()

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -23,7 +23,10 @@ from app.modules.emissions.buckets import BucketNodes
 from app.modules.emissions.registry import MODULE_STAT_BUCKETS
 from app.repositories.carbon_report_module_repo import CarbonReportModuleRepository
 from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
-from app.repositories.data_entry_repo import DataEntryRepository
+from app.repositories.data_entry_repo import (
+    DataEntryRepository,
+    reference_year_filter_by_module,
+)
 from app.schemas.carbon_report import (
     CarbonReportModuleCreate,
     CarbonReportModuleRead,
@@ -400,8 +403,12 @@ class CarbonReportModuleService:
             .all()
         )
 
+        reference_year_by_module = await self._reference_years_by_module(modules)
+
         emission_repo = DataEntryEmissionRepository(self.session)
-        pairs = await emission_repo.get_stats_pair_many(carbon_report_module_ids)
+        pairs = await emission_repo.get_stats_pair_many(
+            carbon_report_module_ids, reference_year_by_module
+        )
 
         count_rows = (
             await self.session.execute(
@@ -410,7 +417,14 @@ class CarbonReportModuleService:
                     func.count(),
                 )
                 .where(
-                    col(DataEntry.carbon_report_module_id).in_(carbon_report_module_ids)
+                    col(DataEntry.carbon_report_module_id).in_(
+                        carbon_report_module_ids
+                    ),
+                    *(
+                        [reference_year_filter_by_module(reference_year_by_module)]
+                        if reference_year_by_module
+                        else []
+                    ),
                 )
                 .group_by(col(DataEntry.carbon_report_module_id))
             )
@@ -498,6 +512,32 @@ class CarbonReportModuleService:
             )
         ).all()
         return {module_id: float(total or 0.0) for module_id, total in rows}
+
+    async def _reference_years_by_module(
+        self, modules: Sequence[CarbonReportModule]
+    ) -> dict[int, int]:
+        """Live baseline of each module whose report has one (plan years only).
+
+        Modules of a Calculator or Explore report are left out, so the batch
+        the aggregation pipeline recomputes carries no condition at all.
+        """
+        report_ids = {m.carbon_report_id for m in modules}
+        if not report_ids:
+            return {}
+        rows = (
+            await self.session.execute(
+                select(col(CarbonReport.id), col(CarbonReport.reference_year)).where(
+                    col(CarbonReport.id).in_(report_ids),
+                    col(CarbonReport.reference_year).isnot(None),
+                )
+            )
+        ).all()
+        reference_year_by_report = {report_id: year for report_id, year in rows}
+        return {
+            m.id: reference_year_by_report[m.carbon_report_id]
+            for m in modules
+            if m.id is not None and m.carbon_report_id in reference_year_by_report
+        }
 
     async def _years_by_report(
         self, modules: Sequence[CarbonReportModule]

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -641,10 +641,12 @@ class DataEntryService:
         self,
         carbon_report_module_id: int,
         travel_institutional_id_filter: Optional[str] = None,
+        reference_year: Optional[int] = None,
     ) -> ModuleResponse:
         data_entry_types_total_items = await self.repo.get_total_count_by_submodule(
             carbon_report_module_id=carbon_report_module_id,
             travel_institutional_id_filter=travel_institutional_id_filter,
+            reference_year=reference_year,
         )
 
         incomplete_new_equipment_count = await self.repo.count_incomplete_new_equipment(
@@ -683,8 +685,14 @@ class DataEntryService:
         current_user: Optional[UserRead] = None,
         request_context: Optional[dict] = None,
         background_tasks: Optional[BackgroundTasks] = None,
+        reference_year: Optional[int] = None,
     ) -> SubmoduleResponse:
-        """Get module data for a unit and year."""
+        """Get module data for a unit and year.
+
+        ``reference_year`` is the plan-year report's live baseline: a Simulator
+        Plan module keeps the prefilled rows of every baseline it has used, and
+        only the matching ones belong in the table.
+        """
         response = await self.repo.get_submodule_data(
             carbon_report_module_id=carbon_report_module_id,
             data_entry_type_id=data_entry_type_id,
@@ -694,6 +702,7 @@ class DataEntryService:
             sort_order=sort_order,
             filter=filter,
             institutional_id_filter=institutional_id_filter,
+            reference_year=reference_year,
         )
 
         if (

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -15,11 +15,7 @@ from app.core.logging import get_logger
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportType
 from app.models.data_entry import DataEntry, DataEntrySourceEnum
-from app.models.module_type import (
-    MODULE_TYPE_TO_DATA_ENTRY_TYPES,
-    PLANNER_PREFILLED_MODULE_TYPES,
-    ModuleTypeEnum,
-)
+from app.models.module_type import PLANNER_PREFILLED_MODULE_TYPES
 from app.models.user import User
 from app.repositories.carbon_project_repo import CarbonProjectRepository
 from app.repositories.data_entry_repo import DataEntryRepository
@@ -233,8 +229,15 @@ class SimulatorPlanService:
     ) -> Optional[SimulatorPlanYearRead]:
         """Set the baseline year of one plan-year report; None if missing.
 
-        Existing entries of the report get their emissions recomputed, since
-        factor lookup follows the reference year.
+        Nothing is deleted: the prefilled rows of every baseline the plan-year
+        has used stay in the module, each stamped with ``data['reference_year']``,
+        and readers keep only the live one (``DataEntryRepository.
+        reference_year_filter``). Coming back to a year therefore finds its
+        sliders and edits as they were left, and a baseline seen for the first
+        time is prefilled at 100%.
+
+        The live baseline's entries get their emissions recomputed, since factor
+        lookup follows the reference year; dormant rows keep theirs.
         """
         reports = await self.repo.list_reports_for_project(plan_id)
         report = next((r for r in reports if r.year == year), None)
@@ -249,13 +252,13 @@ class SimulatorPlanService:
         return await self._year_read(report)
 
     async def _prefill_reference_modules(self, report: CarbonReport) -> None:
-        """Auto-prefill every prefilled-behavior module from the reference year.
+        """Prefill every prefilled-behavior module from the reference year.
 
-        Runs on reference-year set/change (there is no manual prefill trigger):
-        each prefilled module gets its PLANNER_SNAPSHOT rows wiped and re-copied
-        at 100% from the reference year's Calculator data; user-added rows
-        survive. No-op when the reference year has no Calculator report for the
-        unit — there is simply nothing to copy.
+        Runs on reference-year set/change (there is no manual prefill trigger).
+        Only baselines this plan-year has never used are copied — a baseline it
+        already holds rows for is left exactly as the user left it. No-op when
+        the reference year has no Calculator report for the unit: there is
+        nothing to copy.
         """
         if report.id is None:
             raise ValueError("report must be persisted before use")
@@ -293,10 +296,16 @@ class SimulatorPlanService:
     ) -> int:
         """Snapshot-copy the reference-year Calculator entries into a plan module.
 
-        Idempotent: previous snapshot rows (source=PLANNER_SNAPSHOT) are wiped
-        and re-copied at ``percentage_of_reference_year = 100``; user-added rows
-        survive. Each copy keeps ``source_data_entry_id`` so the % slider
-        computes against the live reference entry. Returns the copied count.
+        Copies at ``percentage_of_reference_year = 100``, stamping each row with
+        the baseline it came from (``reference_year``) so the module can hold
+        several baselines at once and show only the active one. Each copy keeps
+        ``source_data_entry_id`` so the % slider computes against the live
+        reference entry. Returns the copied count.
+
+        Idempotent by baseline: a module that already holds rows for this
+        reference year is left untouched (0 copied) — re-copying would discard
+        the sliders, edits and deletions the user made under it. Nothing is
+        ever deleted here.
 
         Raises ValueError when the report has no reference year or the
         reference year has no Calculator report/module for the unit.
@@ -321,12 +330,12 @@ class SimulatorPlanService:
             raise ValueError(f"Module {module_type_id} not found on the reference year")
 
         entry_repo = DataEntryRepository(self.session)
-        for det in MODULE_TYPE_TO_DATA_ENTRY_TYPES.get(
-            ModuleTypeEnum(module_type_id), []
+        existing = await entry_repo.list_by_module(plan_module.id)
+        if any(
+            entry.data.get("reference_year") == report.reference_year
+            for entry in existing
         ):
-            await entry_repo.bulk_delete_by_source(
-                plan_module.id, det, DataEntrySourceEnum.PLANNER_SNAPSHOT.value
-            )
+            return 0
 
         emission_svc = DataEntryEmissionService(self.session)
         copied = 0
@@ -341,6 +350,7 @@ class SimulatorPlanService:
                     **src.data,
                     "percentage_of_reference_year": 100,
                     "source_data_entry_id": src.id,
+                    "reference_year": report.reference_year,
                 },
             )
             self.session.add(copy)
@@ -354,7 +364,12 @@ class SimulatorPlanService:
         return copied
 
     async def _recalculate_report_emissions(self, report: CarbonReport) -> None:
-        """Recompute emissions of every entry in a report + refresh stats."""
+        """Recompute emissions of the report's live entries + refresh stats.
+
+        Rows stamped with another baseline are dormant: nothing reads them until
+        that baseline is live again, and they keep the emissions they were
+        computed with.
+        """
         if report.id is None:
             raise ValueError("report must be persisted before use")
         entries = await DataEntryRepository(self.session).list_by_carbon_report(
@@ -363,6 +378,9 @@ class SimulatorPlanService:
         emission_svc = DataEntryEmissionService(self.session)
         module_ids: set[int] = set()
         for entry in entries:
+            stamped = entry.data.get("reference_year")
+            if stamped is not None and stamped != report.reference_year:
+                continue
             await emission_svc.upsert_by_data_entry(
                 DataEntryResponse.model_validate(entry)
             )

--- a/backend/tests/unit/services/test_simulator_plan_service.py
+++ b/backend/tests/unit/services/test_simulator_plan_service.py
@@ -2,13 +2,16 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlmodel import SQLModel
+from sqlmodel import SQLModel, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
 
 from app.models.data_entry import DataEntry, DataEntrySourceEnum, DataEntryTypeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
-from app.repositories.data_entry_repo import DataEntryRepository
+from app.repositories.data_entry_repo import (
+    DataEntryRepository,
+    reference_year_filter,
+)
 from app.schemas.carbon_report import CarbonReportCreate
 from app.schemas.simulator_plan import SimulatorPlanUpdate
 from app.services.carbon_report_service import CarbonReportService
@@ -422,12 +425,8 @@ async def test_prefill_copies_reference_entries_at_100_percent(async_session, us
         service, async_session
     )
     plan = await service.create_plan(unit_id=1, user=user, name="proj")
+    # Setting the reference year already prefills every prefilled module.
     report = await _plan_year_report(service, plan.id)
-
-    copied = await service.prefill_module_from_reference(
-        report, int(ModuleTypeEnum.process_emissions)
-    )
-    assert copied == 2
 
     plan_module = await service.report_service.module_service.get_module(
         report.id, int(ModuleTypeEnum.process_emissions)
@@ -435,6 +434,7 @@ async def test_prefill_copies_reference_entries_at_100_percent(async_session, us
     rows = await DataEntryRepository(async_session).list_by_module(plan_module.id)
     assert len(rows) == 2
     assert all(r.source == DataEntrySourceEnum.PLANNER_SNAPSHOT.value for r in rows)
+    assert all(r.data["reference_year"] == 2024 for r in rows)
     assert all(r.data["percentage_of_reference_year"] == 100 for r in rows)
     assert {r.data["source_data_entry_id"] for r in rows} == {e.id for e in src_entries}
     # Snapshot keeps the reference quantities.
@@ -442,14 +442,12 @@ async def test_prefill_copies_reference_entries_at_100_percent(async_session, us
 
 
 @pytest.mark.asyncio
-async def test_prefill_is_idempotent_and_keeps_user_rows(async_session, user):
+async def test_prefill_leaves_an_already_prefilled_baseline_alone(async_session, user):
+    """Re-copying a baseline would discard the sliders set under it."""
     service = SimulatorPlanService(async_session)
     await _calculator_report_with_process_entries(service, async_session)
     plan = await service.create_plan(unit_id=1, user=user, name="proj")
     report = await _plan_year_report(service, plan.id)
-    await service.prefill_module_from_reference(
-        report, int(ModuleTypeEnum.process_emissions)
-    )
 
     plan_module = await service.report_service.module_service.get_module(
         report.id, int(ModuleTypeEnum.process_emissions)
@@ -466,15 +464,17 @@ async def test_prefill_is_idempotent_and_keeps_user_rows(async_session, user):
     copied = await service.prefill_module_from_reference(
         report, int(ModuleTypeEnum.process_emissions)
     )
-    assert copied == 2
+    assert copied == 0
 
     rows = await DataEntryRepository(async_session).list_by_module(plan_module.id)
     snapshots = [
         r for r in rows if r.source == DataEntrySourceEnum.PLANNER_SNAPSHOT.value
     ]
     manuals = [r for r in rows if r.source == DataEntrySourceEnum.USER_MANUAL.value]
-    assert len(snapshots) == 2  # replaced, not accumulated
+    assert len(snapshots) == 2  # not duplicated
     assert len(manuals) == 1  # user rows survive
+    # A hand-added row belongs to the plan, not to a baseline.
+    assert "reference_year" not in manuals[0].data
 
 
 @pytest.mark.asyncio
@@ -492,45 +492,138 @@ async def test_prefill_without_reference_year_raises(async_session, user):
         )
 
 
-@pytest.mark.asyncio
-async def test_reference_year_change_resnapshots_prefilled_modules(async_session, user):
-    service = SimulatorPlanService(async_session)
-    await _calculator_report_with_process_entries(service, async_session, year=2024)
-    # Second Calculator year with a single, different entry.
-    report_2025 = await service.report_service.create(
+async def _second_calculator_year(service, async_session):
+    """A 2025 Calculator report for unit 1 with a single process entry."""
+    report = await service.report_service.create(
         CarbonReportCreate(year=2025, unit_id=1)
     )
-    modules_2025 = await service.report_service.module_service.list_modules(
-        report_2025.id
+    modules = await service.report_service.module_service.list_modules(report.id)
+    module = next(
+        m for m in modules if m.module_type_id == int(ModuleTypeEnum.process_emissions)
     )
-    module_2025 = next(
-        m
-        for m in modules_2025
-        if m.module_type_id == int(ModuleTypeEnum.process_emissions)
-    )
-    entry_2025 = DataEntry(
+    entry = DataEntry(
         data_entry_type_id=DataEntryTypeEnum.process_emissions.value,
-        carbon_report_module_id=module_2025.id,
+        carbon_report_module_id=module.id,
         data={"category": "n2o", "quantity": 3.0},
     )
-    async_session.add(entry_2025)
+    async_session.add(entry)
     await async_session.flush()
+    return entry
+
+
+async def _visible_rows(async_session, plan_module_id, reference_year):
+    """The module's rows as the table, the totals and the chart see them.
+
+    Applies the same filter the repo applies when a caller passes the report's
+    live baseline.
+    """
+    result = await async_session.execute(
+        select(DataEntry).where(
+            col(DataEntry.carbon_report_module_id) == plan_module_id,
+            reference_year_filter(reference_year),
+        )
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_reference_year_change_keeps_the_previous_baseline_rows(
+    async_session, user
+):
+    """Nothing is deleted: the old baseline's rows stay, dormant."""
+    service = SimulatorPlanService(async_session)
+    await _calculator_report_with_process_entries(service, async_session, year=2024)
+    entry_2025 = await _second_calculator_year(service, async_session)
 
     plan = await service.create_plan(unit_id=1, user=user, name="proj")
     report = await _plan_year_report(service, plan.id, reference_year=2024)
-    await service.prefill_module_from_reference(
-        report, int(ModuleTypeEnum.process_emissions)
-    )
 
     await service.set_reference_year(plan.id, 2027, 2025)
 
     plan_module = await service.report_service.module_service.get_module(
         report.id, int(ModuleTypeEnum.process_emissions)
     )
-    rows = await DataEntryRepository(async_session).list_by_module(plan_module.id)
-    assert len(rows) == 1
-    assert rows[0].data["quantity"] == 3.0
-    assert rows[0].data["source_data_entry_id"] == entry_2025.id
+    stored = await DataEntryRepository(async_session).list_by_module(plan_module.id)
+    assert sorted(r.data["reference_year"] for r in stored) == [2024, 2024, 2025]
+
+    visible = await _visible_rows(async_session, plan_module.id, 2025)
+    assert len(visible) == 1
+    assert visible[0].data["quantity"] == 3.0
+    assert visible[0].data["source_data_entry_id"] == entry_2025.id
+
+
+@pytest.mark.asyncio
+async def test_switching_back_restores_the_sliders_of_that_baseline(
+    async_session, user
+):
+    service = SimulatorPlanService(async_session)
+    await _calculator_report_with_process_entries(service, async_session, year=2024)
+    await _second_calculator_year(service, async_session)
+
+    plan = await service.create_plan(unit_id=1, user=user, name="proj")
+    report = await _plan_year_report(service, plan.id, reference_year=2024)
+    plan_module = await service.report_service.module_service.get_module(
+        report.id, int(ModuleTypeEnum.process_emissions)
+    )
+    rows_2024 = await _visible_rows(async_session, plan_module.id, 2024)
+    rows_2024[0].data = {
+        **rows_2024[0].data,
+        "percentage_of_reference_year": 40,
+        "quantity": 99.0,
+    }
+    async_session.add(rows_2024[0])
+    await async_session.flush()
+
+    await service.set_reference_year(plan.id, 2027, 2025)
+    await service.set_reference_year(plan.id, 2027, 2024)
+
+    visible = await _visible_rows(async_session, plan_module.id, 2024)
+    assert len(visible) == 2
+    edited = next(r for r in visible if r.id == rows_2024[0].id)
+    assert edited.data["percentage_of_reference_year"] == 40
+    assert edited.data["quantity"] == 99.0
+
+
+@pytest.mark.asyncio
+async def test_hand_added_rows_show_under_every_baseline(async_session, user):
+    service = SimulatorPlanService(async_session)
+    await _calculator_report_with_process_entries(service, async_session, year=2024)
+    await _second_calculator_year(service, async_session)
+
+    plan = await service.create_plan(unit_id=1, user=user, name="proj")
+    report = await _plan_year_report(service, plan.id, reference_year=2024)
+    plan_module = await service.report_service.module_service.get_module(
+        report.id, int(ModuleTypeEnum.process_emissions)
+    )
+    async_session.add(
+        DataEntry(
+            data_entry_type_id=DataEntryTypeEnum.process_emissions.value,
+            carbon_report_module_id=plan_module.id,
+            source=DataEntrySourceEnum.USER_MANUAL.value,
+            data={"category": "ch4", "quantity": 1.0},
+        )
+    )
+    await async_session.flush()
+
+    await service.set_reference_year(plan.id, 2027, 2025)
+
+    visible = await _visible_rows(async_session, plan_module.id, 2025)
+    manual = [r for r in visible if r.source == DataEntrySourceEnum.USER_MANUAL.value]
+    assert len(manual) == 1
+    assert len(visible) == 2  # the manual row + the 2025 snapshot
+
+
+@pytest.mark.asyncio
+async def test_calculator_rows_are_never_hidden(async_session, user):
+    """Outside the planner the filter is a no-op: no row carries a baseline."""
+    service = SimulatorPlanService(async_session)
+    _, calc_module, _ = await _calculator_report_with_process_entries(
+        service, async_session, year=2024
+    )
+
+    visible = await _visible_rows(async_session, calc_module.id, None)
+
+    assert len(visible) == 2
 
 
 @pytest.mark.asyncio

--- a/docs/src/implementation-plans/1557-planner-frontend-followups.md
+++ b/docs/src/implementation-plans/1557-planner-frontend-followups.md
@@ -1,9 +1,9 @@
 ---
 status: in-progress
 issue: 1557
-last_updated: 2026-07-22
+last_updated: 2026-07-23
 title: "Simulator Plan — frontend follow-ups"
-summary: "Three planner-frontend pieces: the type-2 prefilled slider table (delivered; ModuleTable decomposition deferred to its own plan), the wrong-plan report resolution fix (delivered; overlapping-plans regression test outstanding), and dropdowns resolving factors from the plan year instead of the reference year (delivered)."
+summary: "Four planner-frontend pieces: the type-2 prefilled slider table (delivered; ModuleTable decomposition deferred to its own plan), the wrong-plan report resolution fix (delivered; overlapping-plans regression test outstanding), dropdowns resolving factors from the plan year instead of the reference year (delivered), and the Comment button disabled by the Calculator's validated state (delivered)."
 ---
 
 # Simulator Plan — frontend follow-ups
@@ -182,3 +182,36 @@ row for PATCH and bounds the date pickers). The two components share
       pinned in `tests/unit/factor-year.spec.ts`).
 - [x] Disable the module drawers until a reference year is set; extend the
       hint copy.
+
+## D. The Comment button was disabled in the Planner
+
+**Defect:** the per-row Comment button was greyed out on Planner tables while
+every other control in the same table (inline edits, delete, the % slider)
+stayed live. `ModuleTable.vue` held two twin computeds: `isDisabled` already
+carved the Planner out of the Calculator's validated lock
+(`props.carbonReportId != null` — see A), `isNoteDisabled` did not and still
+read `timelineStore.itemStates[moduleType] === Validated`. The workspace guard
+(`router/guards/workspaceGuard.ts`) fills that store with the **Calculator**
+module statuses of the selected workspace year on every workspace route, so a
+module validated in the Calculator disabled comments on every plan year of every
+plan — plan reports are never validated and have no lock of their own.
+
+**Fix (2026-07-23):** both rules moved to `utils/module-table-access.ts`
+(`isModuleTableDisabled` / `isModuleNoteDisabled`), which names the three
+contexts a table renders in — Calculator, Explorer, Planner. Notes are blocked
+by the validated lock in the Calculator only; in the Explorer and the Planner
+they need `canEdit` alone. `canEdit` stays a condition everywhere: the backend
+gates the underlying PATCH with `check_module_permission_for_unit("edit")`, and
+`api/http.ts` turns that 403 into a whole-page `/unauthorized` redirect.
+
+The ambiguous `isSimulator` prop (set only by `SimulationExplorePage`) is
+renamed `isExplorer` through `SubModuleSection → ModuleTable`; the Planner is
+identified by `carbonReportId`, which the Calculator never passes.
+
+**Steps**
+
+- [x] Extract `isModuleTableDisabled` / `isModuleNoteDisabled` into
+      `utils/module-table-access.ts`; both `ModuleTable` computeds delegate.
+- [x] Regression: `tests/unit/module-table-access.spec.ts` pins the Planner +
+      validated-Calculator-module case, plus the Calculator and permission cases.
+- [x] Rename `isSimulator` → `isExplorer`.

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -524,6 +524,11 @@ import {
   REFERENCE_PERCENTAGE_MAX,
   REFERENCE_PERCENTAGE_MIN,
 } from 'src/utils/reference-percentage';
+import {
+  isModuleNoteDisabled,
+  isModuleTableDisabled,
+  type ModuleTableAccess,
+} from 'src/utils/module-table-access';
 
 function getNumericRules(col: TableViewColumn) {
   const rules = [];
@@ -854,7 +859,8 @@ type CommonProps = {
   moduleConfig: ModuleConfig;
   submoduleConfig: Submodule;
   disable: boolean;
-  isSimulator?: boolean;
+  /** Simulator Explorer page — see `utils/module-table-access`. */
+  isExplorer?: boolean;
   moduleColor?: string;
   moduleColorLighter?: string;
 };
@@ -965,18 +971,17 @@ const canEdit = computed(() => {
   );
 });
 
-// Disable all table editing/deleting interactions when input is disabled in backoffice configuration.
-const isDisabled = computed(() => {
-  if (props.isSimulator) return false;
-  if (props.disable || !canEdit.value) return true;
-  // Planner year-report tables are governed by their own Active toggle
-  // (props.disable) and plan access — NOT the global timeline's validated
-  // state. That store tracks a single report and can't represent the planner's
-  // many year-reports, so a Validated state leaking from the Calculator context
-  // would spuriously lock editing (and the % slider) here.
-  if (props.carbonReportId != null) return false;
-  return timelineStore.itemStates[props.moduleType] === MODULE_STATES.Validated;
-});
+// Planner tables address a plan-year report by id; the Calculator never does.
+const tableAccess = computed<ModuleTableAccess>(() => ({
+  isExplorer: props.isExplorer === true,
+  isPlanner: props.carbonReportId != null,
+  canEdit: canEdit.value,
+  disable: props.disable === true,
+  isValidated:
+    timelineStore.itemStates[props.moduleType] === MODULE_STATES.Validated,
+}));
+
+const isDisabled = computed(() => isModuleTableDisabled(tableAccess.value));
 
 const showTableRowActions = computed(
   () => props.submoduleConfig?.hasTableAction !== false,
@@ -989,13 +994,7 @@ const showTableNote = computed(
 
 const showTableActions = computed(() => showTableNote.value);
 
-// Notes stay available on read-only tables; only permission and validation block them.
-const isNoteDisabled = computed(
-  () =>
-    !props.isSimulator &&
-    (timelineStore.itemStates[props.moduleType] === MODULE_STATES.Validated ||
-      !canEdit.value),
-);
+const isNoteDisabled = computed(() => isModuleNoteDisabled(tableAccess.value));
 
 const filterTerm = ref('');
 const confirmDelete = ref(false);

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -46,14 +46,14 @@
           :module-config="moduleConfig"
           :submodule-config="submodule"
           :disable="isTableDisabled"
-          :is-simulator="isSimulator"
+          :is-explorer="isExplorer"
           :module-color="submoduleColor"
           :module-color-lighter="submoduleLighterColor"
         />
       </div>
       <q-separator />
       <div
-        v-if="isInputDeactivated && !isSimulator"
+        v-if="isInputDeactivated && !isExplorer"
         class="q-mx-lg q-my-md inputs-deactivated-notice"
       >
         <div class="inputs-deactivated-notice__content">
@@ -131,7 +131,7 @@
           :module-config="moduleConfig"
           :submodule-config="submodule"
           :disable="disable"
-          :is-simulator="isSimulator"
+          :is-explorer="isExplorer"
         />
       </div>
       <q-separator />
@@ -244,7 +244,7 @@ type CommonProps = {
   showReferenceColumns?: boolean;
   threshold: Threshold;
   disable: boolean;
-  isSimulator?: boolean;
+  isExplorer?: boolean;
 };
 
 type ModuleTypeProps = {
@@ -289,7 +289,7 @@ const isInputDeactivated = computed(() => {
 });
 
 const isTableDisabled = computed(
-  () => !props.isSimulator && (props.disable || isInputDeactivated.value),
+  () => !props.isExplorer && (props.disable || isInputDeactivated.value),
 );
 
 const backendThreshold = computed<Threshold | null>(() => {

--- a/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
+++ b/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
@@ -1,0 +1,87 @@
+<template>
+  <q-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <q-card style="min-width: 460px">
+      <q-card-section class="row items-center q-pb-none">
+        <q-icon
+          name="o_calendar_month"
+          size="sm"
+          color="info"
+          class="q-mr-sm"
+        />
+        <div class="text-h4 text-weight-medium">
+          {{ $t('planner_reference_year_dialog_title', { year }) }}
+        </div>
+        <q-space />
+        <q-btn v-close-popup flat size="md" icon="o_close" color="grey-6" />
+      </q-card-section>
+
+      <q-separator class="q-mt-sm" />
+
+      <q-card-section>
+        <q-select
+          v-model="selected"
+          :options="options"
+          :label="$t('planner_reference_year_label')"
+          outlined
+          dense
+          emit-value
+          map-options
+        />
+        <div class="text-body2 text-grey-8 q-mt-md">
+          {{ $t('planner_reference_year_dialog_consequences') }}
+        </div>
+      </q-card-section>
+
+      <q-card-actions class="q-px-md q-pb-md">
+        <q-btn
+          :label="$t('common_validate_short')"
+          :disable="selected === null || selected === referenceYear"
+          :loading="loading"
+          color="info"
+          unelevated
+          no-caps
+          class="text-weight-medium"
+          @click="onConfirm"
+        />
+        <q-btn
+          v-close-popup
+          :label="$t('common_cancel')"
+          color="primary"
+          unelevated
+          outline
+          no-caps
+          class="text-weight-medium"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{
+  modelValue: boolean;
+  /** The plan year this dialog sets the baseline for. */
+  year: number;
+  referenceYear: number | null;
+  options: { label: string; value: number }[];
+  loading: boolean;
+}>();
+const emit = defineEmits<{
+  'update:modelValue': [open: boolean];
+  confirm: [referenceYear: number];
+}>();
+
+// Seeded once per mount: the parent keys the dialog on the current reference
+// year, so a re-open starts from what is set rather than the last pick.
+const selected = ref<number | null>(props.referenceYear);
+
+function onConfirm() {
+  if (selected.value === null) return;
+  emit('confirm', selected.value);
+}
+</script>

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -13,28 +13,65 @@
         <div class="text-weight-bold q-mb-sm">
           {{ $t('planner_reference_year_label') }}
         </div>
-        <q-select
-          :model-value="yearData.reference_year"
-          :options="referenceYearOptions"
-          outlined
-          dense
-          emit-value
-          map-options
-          class="planner-reference-year"
-          :loading="settingReferenceYear"
-          @update:model-value="onReferenceYearChange"
-        >
-          <template #prepend>
-            <q-icon name="o_calendar_month" color="negative" />
-          </template>
-        </q-select>
+        <!-- Set: the value reads first, the action stays quiet beside it.
+             Unset: nothing to read yet, so the action carries the label. -->
         <div
-          v-if="!yearData.reference_year"
-          class="text-body2 text-grey-7 q-mt-sm"
+          v-if="yearData.reference_year"
+          class="reference-year-row row items-center no-wrap"
         >
-          {{ $t('planner_reference_year_hint') }}
+          <q-icon
+            name="o_calendar_month"
+            color="info"
+            class="reference-year-row__icon"
+          />
+          <span class="reference-year-row__value text-weight-bold">
+            {{ yearData.reference_year }}
+          </span>
+          <q-separator vertical class="reference-year-row__divider" />
+          <q-btn
+            :label="$t('planner_reference_year_change_link')"
+            color="info"
+            flat
+            dense
+            no-caps
+            padding="none"
+            class="reference-year-row__action text-weight-medium"
+            :loading="settingReferenceYear"
+            @click="referenceYearDialogOpen = true"
+          />
+        </div>
+        <q-btn
+          v-else
+          color="info"
+          flat
+          no-caps
+          align="left"
+          class="reference-year-empty text-weight-medium"
+          :loading="settingReferenceYear"
+          @click="referenceYearDialogOpen = true"
+        >
+          <q-icon name="o_calendar_month" class="reference-year-row__icon" />
+          <span>{{ $t('planner_reference_year_set_button') }}</span>
+        </q-btn>
+        <div class="text-body2 text-grey-7 q-mt-xs">
+          {{
+            yearData.reference_year
+              ? $t('planner_reference_year_rebuild_hint')
+              : $t('planner_reference_year_hint')
+          }}
         </div>
       </q-card-section>
+
+      <planner-reference-year-dialog
+        v-if="referenceYearDialogOpen"
+        :key="`ref-year-${yearData.reference_year}`"
+        v-model="referenceYearDialogOpen"
+        :year="yearData.year"
+        :reference-year="yearData.reference_year"
+        :options="referenceYearOptions"
+        :loading="settingReferenceYear"
+        @confirm="onReferenceYearChange"
+      />
 
       <!-- One bordered card per module, in Calculator order -->
       <q-card-section class="q-gutter-md">
@@ -122,6 +159,7 @@ import { useI18n } from 'vue-i18n';
 import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import ModuleTableSection from 'src/components/organisms/module/ModuleTableSection.vue';
 import PlannerHeadcountRows from 'src/components/organisms/planner/PlannerHeadcountRows.vue';
+import PlannerReferenceYearDialog from 'src/components/organisms/planner/PlannerReferenceYearDialog.vue';
 import {
   PLANNER_MODULES,
   type PlannerModuleConfig,
@@ -159,6 +197,7 @@ const plansStore = useSimulatorPlansStore();
 
 const yearOpen = ref(true);
 const settingReferenceYear = ref(false);
+const referenceYearDialogOpen = ref(false);
 const togglingModuleId = ref<number | null>(null);
 
 // Every module resolves its factors from the reference year; without one there
@@ -204,8 +243,9 @@ async function onReferenceYearChange(referenceYear: number) {
       props.yearData.year,
       referenceYear,
     );
-    // Setting the reference year auto-prefills every prefilled module; refresh
-    // the open module so its snapshot rows appear without a manual reload.
+    referenceYearDialogOpen.value = false;
+    // The new baseline's rows are prefilled (or restored); refresh the open
+    // module so they appear without a manual reload.
     const expanded = props.expandedKey?.startsWith(`${props.yearData.year}-`);
     const module = props.expandedKey?.split('-').slice(1).join('-') as
       Module | undefined;
@@ -233,7 +273,51 @@ async function onToggleActive(entry: ModuleEntry, active: boolean) {
 </script>
 
 <style scoped lang="scss">
-.planner-reference-year {
-  max-width: 320px;
+@use 'src/css/02-tokens' as tokens;
+
+// Setting row: the current value reads as the content, the action sits quietly
+// beside it — changing the baseline is deliberate, not a stray click.
+.reference-year-row {
+  display: inline-flex;
+  gap: tokens.$reference-year-row-gap;
+  padding: tokens.$reference-year-row-padding-y
+    tokens.$reference-year-row-padding-x;
+  border: tokens.$reference-year-row-border-weight solid
+    tokens.$reference-year-row-border-color;
+  border-radius: tokens.$reference-year-row-border-radius;
+
+  &__icon {
+    font-size: tokens.$reference-year-row-icon-size;
+  }
+
+  &__value {
+    font-size: tokens.$reference-year-row-value-font-size;
+    line-height: 1;
+  }
+
+  &__divider {
+    height: tokens.$reference-year-row-divider-height;
+    align-self: center;
+  }
+
+  &__action {
+    font-size: tokens.$reference-year-row-action-font-size;
+  }
+}
+
+// The same slot before it holds anything: dashed, so it reads as waiting to be
+// filled rather than as a call to action competing with the module list.
+.reference-year-empty {
+  padding: tokens.$reference-year-row-padding-y
+    tokens.$reference-year-row-padding-x;
+  border: tokens.$reference-year-row-border-weight
+    tokens.$reference-year-row-empty-border-style
+    tokens.$reference-year-row-empty-border-color;
+  border-radius: tokens.$reference-year-row-border-radius;
+  font-size: tokens.$reference-year-row-value-font-size;
+
+  :deep(.q-btn__content) {
+    gap: tokens.$reference-year-row-gap;
+  }
 }
 </style>

--- a/frontend/src/composables/print/useSimulationExplorePrintData.ts
+++ b/frontend/src/composables/print/useSimulationExplorePrintData.ts
@@ -114,7 +114,6 @@ export function useSimulationExplorePrintData() {
       const queryParams = new URLSearchParams({
         page: String(page),
         limit: '1000',
-        carbon_project_type: String(moduleStore.carbonProjectType),
       });
       const response = (await api
         .get(`${basePath}?${queryParams.toString()}`)

--- a/frontend/src/constant/carbon-project.ts
+++ b/frontend/src/constant/carbon-project.ts
@@ -1,0 +1,59 @@
+/**
+ * Which carbon project a page's module calls address.
+ *
+ * Each project stores its data in its own `carbon_reports` row, so this decides
+ * where a page reads and — more importantly — writes. Pages declare it on their
+ * route (`meta.carbonProject`); routes that declare nothing are the Calculator,
+ * which is the only project addressed by unit + year.
+ *
+ * The values are names, not the legacy 0/1/2 codes: those were the
+ * `carbon_project_type` query param the backend dropped in #1556, and the
+ * backend's own enum is `CarbonReportType` ("Calculator" / "Simulator_Explore"
+ * / "Simulator_Plan").
+ */
+export const CARBON_PROJECT = {
+  calculator: 'calculator',
+  explorer: 'explorer',
+  planner: 'planner',
+} as const;
+
+export type CarbonProject =
+  (typeof CARBON_PROJECT)[keyof typeof CARBON_PROJECT];
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    /** Simulator routes declare theirs; the Calculator's routes declare none. */
+    carbonProject?: CarbonProject;
+  }
+}
+
+export function resolveCarbonProject(
+  meta: { carbonProject?: CarbonProject } | undefined,
+): CarbonProject {
+  return meta?.carbonProject ?? CARBON_PROJECT.calculator;
+}
+
+/**
+ * The endpoint that resolves unit + year to this project's report id.
+ *
+ * A plan holds one report per year per plan, so unit/year cannot identify one:
+ * planner callers pass the report id and never come here. Reaching this with
+ * the planner is a bug, and it throws rather than falling back to the
+ * Calculator — that fallback would write plan edits into real Calculator data.
+ */
+export function carbonReportLookupPath(
+  project: CarbonProject,
+  unit: number | string,
+  year: number | string,
+): string {
+  const u = encodeURIComponent(unit);
+  const y = encodeURIComponent(year);
+  switch (project) {
+    case CARBON_PROJECT.explorer:
+      return `carbon-reports/simulator/explore/unit/${u}/reference-year/${y}/`;
+    case CARBON_PROJECT.calculator:
+      return `carbon-reports/unit/${u}/year/${y}/`;
+    case CARBON_PROJECT.planner:
+      throw new Error('Planner module calls must pass a carbonReportId');
+  }
+}

--- a/frontend/src/css/02-tokens/_components.scss
+++ b/frontend/src/css/02-tokens/_components.scss
@@ -340,3 +340,21 @@ $mtr-sidebar-value-letter-spacing: opt.$tokens-typography-letter-spacing-tight !
 $mtr-sidebar-unit-font-size: opt.$tokens-mtr-sidebar-unit-font-size !default;
 $mtr-sidebar-unit-margin-top: opt.$tokens-mtr-sidebar-unit-margin-top !default;
 $mtr-sidebar-btn-border-radius: opt.$tokens-module-icon-box-border-radius !default;
+
+// Planner reference-year setting row: bordered value + quiet "Change" action.
+// Sized to sit under its label without competing with it — the year reads at
+// body size, not as a heading.
+$reference-year-row-gap: opt.$tokens-spacing-8 !default;
+$reference-year-row-padding-x: opt.$tokens-spacing-12 !default;
+$reference-year-row-padding-y: opt.$tokens-spacing-4 !default;
+$reference-year-row-border-weight: opt.$tokens-spacing-1 !default;
+$reference-year-row-border-color: opt.$tokens-colors-grey-scale-grey-300 !default;
+$reference-year-row-border-radius: opt.$tokens-border-radius-lg-border-radius !default;
+$reference-year-row-value-font-size: opt.$tokens-typography-font-size-md !default;
+$reference-year-row-icon-size: opt.$tokens-spacing-16 !default;
+$reference-year-row-divider-height: opt.$tokens-spacing-16 !default;
+$reference-year-row-action-font-size: opt.$tokens-typography-font-size-sm !default;
+
+// Empty state: the same slot, drawn as waiting to be filled.
+$reference-year-row-empty-border-style: dashed !default;
+$reference-year-row-empty-border-color: opt.$tokens-colors-grey-scale-grey-400 !default;

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -215,6 +215,26 @@ export default {
     en: 'Could not set the reference year',
     fr: "Impossible de définir l'année de référence",
   },
+  planner_reference_year_set_button: {
+    en: 'Choose a reference year',
+    fr: 'Choisir une année de référence',
+  },
+  planner_reference_year_change_link: {
+    en: 'Change',
+    fr: 'Modifier',
+  },
+  planner_reference_year_rebuild_hint: {
+    en: 'Prefilled modules are rebuilt from this year.',
+    fr: 'Les modules préremplis sont reconstruits à partir de cette année.',
+  },
+  planner_reference_year_dialog_title: {
+    en: 'Reference year for {year}',
+    fr: 'Année de référence pour {year}',
+  },
+  planner_reference_year_dialog_consequences: {
+    en: 'Every prefilled module is rebuilt from the year you pick, and its factors come from it. The rows of your current reference year are kept: come back to it and your percentages, edits and deletions are as you left them.',
+    fr: "Chaque module prérempli est reconstruit à partir de l'année choisie, et ses facteurs en proviennent. Les lignes de votre année de référence actuelle sont conservées : en y revenant, vos pourcentages, modifications et suppressions seront intacts.",
+  },
   planner_module_active_tooltip: {
     en: 'Inactive modules are excluded from sums, graphs and results.',
     fr: 'Les modules inactifs sont exclus des sommes, graphiques et résultats.',

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -49,7 +49,7 @@
                   :module-config="m.config"
                   :module-type="m.type"
                   :disable="false"
-                  :is-simulator="true"
+                  :is-explorer="true"
                   :submodule-type="sub.type"
                   :data="null"
                   :loading="false"

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -1,5 +1,6 @@
 import { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
 import { MODULES_PATTERN } from 'src/constant/modules';
+import { CARBON_PROJECT } from 'src/constant/carbon-project';
 import { resolveLanguage } from 'src/utils/language';
 import { BACKOFFICE_NAV } from 'src/constant/navigation';
 import redirectToDefaultRoute from './guards/redirectToDefaultRoute';
@@ -73,6 +74,7 @@ const routes: RouteRecordRaw[] = [
           requiresAuth: true,
           note: 'Simulation Explore – Print/PDF preview (no chrome)',
           breadcrumb: false,
+          carbonProject: CARBON_PROJECT.explorer,
         },
       },
     ],
@@ -222,6 +224,7 @@ const routes: RouteRecordRaw[] = [
                   requiresAuth: true,
                   note: 'Project Planner - plan a project simulation',
                   breadcrumb: true,
+                  carbonProject: CARBON_PROJECT.planner,
                 },
               },
               {
@@ -232,6 +235,7 @@ const routes: RouteRecordRaw[] = [
                   requiresAuth: true,
                   note: 'Simulation - Explore a simulation',
                   breadcrumb: true,
+                  carbonProject: CARBON_PROJECT.explorer,
                 },
               },
 

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -25,14 +25,10 @@ import {
   toItBreakdown,
   type ReportStats,
 } from 'src/utils/emissionStatsAdapter';
-
-// Maps route names to their carbon project type (0 = Calculator,
-// 1 = Simulator Explore, 2 = Simulator Plan). Drives how unit/year
-// resolve to a carbon report id in resolveCarbonReportId.
-const SIMULATION_ROUTE_CARBON_PROJECT_TYPE: Record<string, number> = {
-  'simulation-explore-print': 1,
-  'project-planner': 2,
-};
+import {
+  carbonReportLookupPath,
+  resolveCarbonProject,
+} from 'src/constant/carbon-project';
 
 /**
  * API response for validated totals endpoint.
@@ -351,12 +347,8 @@ export const useTimelineStore = defineStore('timeline', () => {
 export const useModuleStore = defineStore('modules', () => {
   const workspaceStore = useWorkspaceStore();
   const $route = useRoute();
-  const carbonProjectType = computed(() => {
-    const name = $route.name;
-    return typeof name === 'string'
-      ? (SIMULATION_ROUTE_CARBON_PROJECT_TYPE[name] ?? 0)
-      : 0;
-  });
+  // Declared by the page's route; see `constant/carbon-project`.
+  const carbonProject = computed(() => resolveCarbonProject($route.meta));
 
   const state = reactive<{
     loading: boolean;
@@ -448,13 +440,10 @@ export const useModuleStore = defineStore('modules', () => {
     unit: number | string,
     year: number | string,
   ): Promise<number> {
-    const key = `${unit}|${year}|${carbonProjectType.value}`;
+    const key = `${unit}|${year}|${carbonProject.value}`;
     const cached = reportIdCache[key];
     if (cached) return cached;
-    const path =
-      carbonProjectType.value === 1
-        ? `carbon-reports/simulator/explore/unit/${encodeURIComponent(unit)}/reference-year/${encodeURIComponent(year)}/`
-        : `carbon-reports/unit/${encodeURIComponent(unit)}/year/${encodeURIComponent(year)}/`;
+    const path = carbonReportLookupPath(carbonProject.value, unit, year);
     const report = await api.get(path).json<{ id: number }>();
     reportIdCache[key] = report.id;
     return report.id;
@@ -469,11 +458,8 @@ export const useModuleStore = defineStore('modules', () => {
     if (carbonReportId != null) {
       return buildModulePath(moduleType, carbonReportId);
     }
-    // No silent fallback to the Calculator report when a planner call forgot
-    // to pass its report id — fail loud instead of writing to the wrong report.
-    if (carbonProjectType.value === 2) {
-      throw new Error('Planner module calls must pass a carbonReportId');
-    }
+    // A planner call that forgot its report id throws in carbonReportLookupPath
+    // rather than silently writing to the Calculator report.
     return buildModulePath(moduleType, await resolveCarbonReportId(unit, year));
   }
 
@@ -993,7 +979,7 @@ export const useModuleStore = defineStore('modules', () => {
     year: string,
     force = false,
   ) {
-    const cacheKey = `${unit}|${year}|${carbonProjectType.value}`;
+    const cacheKey = `${unit}|${year}|${carbonProject.value}`;
     if (
       !force &&
       tripsMapCacheKey.value === cacheKey &&
@@ -1324,7 +1310,7 @@ export const useModuleStore = defineStore('modules', () => {
     getItBreakdown,
     prefetchAllModuleCounts,
     validatedTotalsCarbonReportId,
-    carbonProjectType,
+    carbonProject,
     resolveCarbonReportId,
     state,
   };

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -195,12 +195,13 @@ export const useWorkspaceStore = defineStore(
       const url = `carbon-reports/simulator/explore/unit/${unitId}/reference-year/${referenceYear}/`;
       let inv: CarbonReport;
       try {
-        // 404 is expected here — the catch branch seeds an explore report.
+        // 404 is expected here — the catch branch creates the explore report.
         // Opt out of the global error toast for that status only.
         inv = await api.get(url, { skipErrorCodes: [404] }).json();
       } catch (err) {
         if (err instanceof HTTPError && err.response.status === 404) {
-          // No explore report exists yet — seed one from the Calculator report.
+          // No explore report exists yet. It is created empty — the Explorer is
+          // never seeded from the Calculator; only the Planner prefills.
           inv = await api.post(url).json();
         } else {
           throw err;

--- a/frontend/src/utils/module-table-access.ts
+++ b/frontend/src/utils/module-table-access.ts
@@ -1,0 +1,42 @@
+/**
+ * Who may interact with a module table's rows, across the three contexts a
+ * table renders in: Calculator, Explorer and Planner.
+ *
+ * The Calculator locks a module once it is validated, which the timeline store
+ * (`stores/modules.ts`) carries. That store tracks a *single* carbon report and
+ * cannot represent the two simulators: the Explorer has no validated state at
+ * all, and a plan holds one report per year. A Validated state read there while
+ * an Explorer or Planner table is on screen belongs to the Calculator report of
+ * the selected workspace year — never to the table being rendered.
+ */
+export interface ModuleTableAccess {
+  /** Simulator Explorer (`SimulationExplorePage`). */
+  isExplorer: boolean;
+  /** Simulator Planner — the table addresses a plan-year report by id. */
+  isPlanner: boolean;
+  /** Module EDIT permission; mirrors the backend gate on every write route. */
+  canEdit: boolean;
+  /** Parent-driven lock: Planner Active toggle, deactivated inputs. */
+  disable: boolean;
+  /** Calculator timeline state for this module. */
+  isValidated: boolean;
+}
+
+/** Editing, inline edits, row deletion and the Planner % slider. */
+export function isModuleTableDisabled(ctx: ModuleTableAccess): boolean {
+  if (ctx.isExplorer) return false;
+  if (ctx.disable || !ctx.canEdit) return true;
+  if (ctx.isPlanner) return false;
+  return ctx.isValidated;
+}
+
+/**
+ * The per-row Comment button. Notes stay available on read-only tables, so
+ * `disable` does not block them — only permission and, in the Calculator, the
+ * validated lock.
+ */
+export function isModuleNoteDisabled(ctx: ModuleTableAccess): boolean {
+  if (!ctx.canEdit) return true;
+  if (ctx.isExplorer || ctx.isPlanner) return false;
+  return ctx.isValidated;
+}


### PR DESCRIPTION
## What does this change?
Reworks how the Simulator Plan handles switching a plan-year's reference (baseline) year, and fixes a couple of related planner/frontend bugs:

- **Multi-baseline prefill (backend):** Changing a plan-year's reference year no longer wipes and re-copies prefilled rows. Instead, each prefilled row is stamped with the `reference_year` it was copied from, so a plan module can hold rows from multiple baselines at once. Reads (module stats, submodule tables, counts) filter to only the *live* baseline via new `reference_year_filter` / `reference_year_filter_by_module` helpers, so switching back to a previously-used baseline restores exactly the sliders/edits/deletions left there, while unrelated data (Calculator/Explore rows, hand-added rows) is always shown.
- **Simulator Explore is never seeded from the Calculator** — `create_simulator_explore_carbon_report` now creates an empty report (only the Planner prefills); matching frontend change in `workspace.ts`.
- **Emission recalculation** on reference-year change now only recomputes the live baseline's entries; dormant rows keep their previously computed emissions.
- **Frontend planner UI:** New `PlannerReferenceYearDialog.vue` for changing the reference year (replaces inline `q-select`), plus a redesigned "reference year set/unset" row in `PlannerYearSection.vue` with new i18n strings and design tokens.
- **Bug fix — Comment button disabled in Planner:** `ModuleTable.vue`'s note-disabled logic incorrectly inherited the Calculator's validated-lock state via the global timeline store, which represents only one report and leaked into Planner/Explorer tables. Extracted shared logic into `utils/module-table-access.ts` (`isModuleTableDisabled` / `isModuleNoteDisabled`), and renamed the ambiguous `isSimulator` prop to `isExplorer` throughout (`ModuleTable`, `SubModuleSection`, `SimulationExplorePage`).
- **Carbon project resolution cleanup:** Replaced the route-name-keyed `SIMULATION_ROUTE_CARBON_PROJECT_TYPE` numeric map (0/1/2) with a named `CARBON_PROJECT` enum (`calculator`/`explorer`/`planner`) declared via route `meta.carbonProject`, with a new `carbonReportLookupPath` helper in `constant/carbon-project.ts`.
- Removed an unused `carbon_project_type` query param from `useSimulationExplorePrintData.ts` (dropped by the backend in #1556).
- Backend tests in `test_simulator_plan_service.py` updated/added to cover multi-baseline retention, restoring sliders on baseline switch, hand-added rows showing under every baseline, and Calculator rows being unaffected by the filter.

## Why is this needed?
Previously, switching a Simulator Plan's reference year would delete and re-copy all `PLANNER_SNAPSHOT` rows from the new baseline, discarding any percentage-slider adjustments, edits, or deletions the user had made under the old baseline. Users comparing multiple reference years lost their work every time they switched back and forth.

Separately, the Comment button was incorrectly disabled across all Planner tables whenever the corresponding Calculator module had been validated, because the global timeline store (built for a single Calculator report) was being read from Explorer/Planner contexts it doesn't represent.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1858

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.