### PR TITLE
feat/1859 planner export pdf report

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -287,7 +287,6 @@ async def get_module(
     module_data = await DataEntryService(db).get_module_data(
         carbon_report_module_id=carbon_report_module_id,
         travel_institutional_id_filter=travel_institutional_id_filter,
-        reference_year=report.reference_year,
     )
 
     # if headcount compute FTE here
@@ -729,7 +728,6 @@ async def get_submodule(
         current_user=UserRead.model_validate(current_user),
         request_context=await get_request_context(request),
         background_tasks=background_tasks,
-        reference_year=report.reference_year,
     )
 
     if not submodule_data:

--- a/backend/app/repositories/data_entry_emission_repo.py
+++ b/backend/app/repositories/data_entry_emission_repo.py
@@ -21,10 +21,6 @@ from app.models.data_entry_emission import DataEntryEmission
 from app.models.factor import Factor
 from app.modules.emissions import EmissionType
 from app.modules.emissions.registry import ROLLUP_EMISSION_TYPE_IDS
-from app.repositories.data_entry_repo import (
-    reference_year_filter,
-    reference_year_filter_by_module,
-)
 
 # COPY target for ``bulk_copy`` — every non-defaulted column;
 # ``id`` is omitted so the sequence assigns it server-side.
@@ -222,20 +218,12 @@ class DataEntryEmissionRepository:
     async def get_stats_pair_many(
         self,
         carbon_report_module_ids: list[int],
-        reference_year_by_module: Optional[Dict[int, int]] = None,
     ) -> Dict[int, tuple[Dict[str, float | None], Dict[str, float | None]]]:
         """``get_stats_pair`` for a whole module set in ONE grouped query.
 
         Returns {module_id: (by_emission_type kg_co2eq, additional_value)}.
         Modules with no emissions are absent from the result — callers
         treat a miss as empty stats.
-
-        ``reference_year_by_module`` carries the live baseline of the Simulator
-        Plan modules in the set (Calculator modules have none, so a plain
-        recompute passes nothing and pays nothing). A plan module keeps the
-        prefilled rows of every baseline it has used; only the live one counts
-        toward its stats — and therefore toward the report rollup, the plan
-        total and the chart.
         """
         if not carbon_report_module_ids:
             return {}
@@ -255,10 +243,6 @@ class DataEntryEmissionRepository:
                 col(DataEntryEmission.emission_type_id),
             )
         )
-        if reference_year_by_module:
-            query = query.where(
-                reference_year_filter_by_module(reference_year_by_module),
-            )
         rows = (await self.session.execute(query)).all()
         result: Dict[int, tuple[Dict[str, float | None], Dict[str, float | None]]] = {}
         for module_id, emission_type_id, primary_total, secondary_total in rows:
@@ -278,7 +262,6 @@ class DataEntryEmissionRepository:
         aggregate_by: str = "emission_type_id",
         primary_field: str = "kg_co2eq",
         secondary_field: str = "additional_value",
-        reference_year: Optional[int] = None,
     ) -> tuple[Dict[str, float | None], Dict[str, float | None]]:
         """Aggregate DataEntryEmission data by a field and sum two numeric columns.
 
@@ -299,8 +282,6 @@ class DataEntryEmissionRepository:
             .where(DataEntry.carbon_report_module_id == carbon_report_module_id)
             .group_by(group_field)
         )
-        if reference_year is not None:
-            query = query.where(reference_year_filter(reference_year))
 
         result = await self.session.execute(query)
         rows = result.all()

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from psycopg.types.json import Json
 from pydantic import BaseModel
-from sqlalchemy import Select, and_, asc, case, desc, func, or_
+from sqlalchemy import Select, and_, asc, desc, func, or_
 from sqlalchemy import select as sa_select
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import aliased
@@ -53,41 +53,6 @@ COPY data_entries (
     source, created_by_id, created_at, updated_at, year, unit_id
 ) FROM STDIN
 """
-
-
-def reference_year_filter(reference_year: Optional[int]) -> Any:
-    """Keep only the rows of the live baseline.
-
-    A Simulator Plan year holds the prefilled rows of every reference year it
-    has used, so switching the baseline back and forth never loses the user's
-    sliders or edits. ``data['reference_year']`` says which baseline a row was
-    copied from; rows without it — every Calculator and Explore row, and any
-    row a planner user adds by hand — always count.
-
-    Callers pass the report's current ``reference_year``; the read stays
-    unfiltered when there is none.
-    """
-    stamped = DataEntry.data["reference_year"].as_integer()
-    return or_(stamped.is_(None), stamped == reference_year)
-
-
-def reference_year_filter_by_module(
-    reference_year_by_module: Dict[int, int],
-) -> Any:
-    """``reference_year_filter`` for a batch of modules, one baseline each.
-
-    Modules absent from the map — every Calculator one — are unconstrained, so
-    a batch without plan modules adds no condition at all.
-    """
-    stamped = DataEntry.data["reference_year"].as_integer()
-    expected = case(
-        *(
-            (col(DataEntry.carbon_report_module_id) == module_id, year)
-            for module_id, year in reference_year_by_module.items()
-        ),
-        else_=None,
-    )
-    return or_(stamped.is_(None), stamped == expected)
 
 
 class DataEntryRepository:
@@ -228,6 +193,22 @@ class DataEntryRepository:
         )
         await self.session.execute(statement)
         await self.session.flush()
+
+    async def bulk_delete_by_modules(self, carbon_report_module_ids: list[int]) -> int:
+        """Delete every data entry of the given modules. Returns the row count.
+
+        Used by the Simulator Plan when a plan-year's reference year changes:
+        the prefilled modules are emptied before being rebuilt from the new
+        baseline. Emissions follow through the ``data_entry_id`` cascade.
+        """
+        if not carbon_report_module_ids:
+            return 0
+        statement = delete(DataEntry).where(
+            col(DataEntry.carbon_report_module_id).in_(carbon_report_module_ids)
+        )
+        result = await self.session.execute(statement)
+        await self.session.flush()
+        return getattr(result, "rowcount", 0) or 0
 
     async def bulk_delete_by_source_year(
         self,
@@ -470,7 +451,6 @@ class DataEntryRepository:
         self,
         carbon_report_module_id: int,
         travel_institutional_id_filter: Optional[str] = None,
-        reference_year: Optional[int] = None,
     ) -> Dict[int, int]:
         """
         Docstring for get_total_count_by_submodule
@@ -509,8 +489,6 @@ class DataEntryRepository:
             .where(DataEntry.carbon_report_module_id == carbon_report_module_id)
             .group_by(col(DataEntry.data_entry_type_id))
         )
-        if reference_year is not None:
-            query = query.where(reference_year_filter(reference_year))
         if travel_institutional_id_filter is not None:
             travel_type_ids = (
                 DataEntryTypeEnum.plane.value,
@@ -721,7 +699,6 @@ class DataEntryRepository:
         sort_order: str,
         filter: Optional[str] = None,
         institutional_id_filter: Optional[str] = None,
-        reference_year: Optional[int] = None,
     ) -> SubmoduleResponse:
         is_travel_entry = data_entry_type_id in (
             DataEntryTypeEnum.plane.value,
@@ -988,8 +965,6 @@ class DataEntryRepository:
             col(DataEntry.carbon_report_module_id) == carbon_report_module_id,
             col(DataEntry.data_entry_type_id) == data_entry_type_id,
         )
-        if reference_year is not None:
-            statement = statement.where(reference_year_filter(reference_year))
 
         if institutional_id_filter is not None and is_travel_entry:
             statement = statement.where(
@@ -1064,8 +1039,6 @@ class DataEntryRepository:
             DataEntry.carbon_report_module_id == carbon_report_module_id,
             DataEntry.data_entry_type_id == data_entry_type_id,
         )
-        if reference_year is not None:
-            count_stmt = count_stmt.where(reference_year_filter(reference_year))
         if institutional_id_filter is not None and is_travel_entry:
             count_stmt = count_stmt.where(
                 DataEntry.data["user_institutional_id"].as_string()

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -23,10 +23,7 @@ from app.modules.emissions.buckets import BucketNodes
 from app.modules.emissions.registry import MODULE_STAT_BUCKETS
 from app.repositories.carbon_report_module_repo import CarbonReportModuleRepository
 from app.repositories.data_entry_emission_repo import DataEntryEmissionRepository
-from app.repositories.data_entry_repo import (
-    DataEntryRepository,
-    reference_year_filter_by_module,
-)
+from app.repositories.data_entry_repo import DataEntryRepository
 from app.schemas.carbon_report import (
     CarbonReportModuleCreate,
     CarbonReportModuleRead,
@@ -400,12 +397,8 @@ class CarbonReportModuleService:
             .all()
         )
 
-        reference_year_by_module = await self._reference_years_by_module(modules)
-
         emission_repo = DataEntryEmissionRepository(self.session)
-        pairs = await emission_repo.get_stats_pair_many(
-            carbon_report_module_ids, reference_year_by_module
-        )
+        pairs = await emission_repo.get_stats_pair_many(carbon_report_module_ids)
 
         count_rows = (
             await self.session.execute(
@@ -416,11 +409,6 @@ class CarbonReportModuleService:
                 .where(
                     col(DataEntry.carbon_report_module_id).in_(
                         carbon_report_module_ids
-                    ),
-                    *(
-                        [reference_year_filter_by_module(reference_year_by_module)]
-                        if reference_year_by_module
-                        else []
                     ),
                 )
                 .group_by(col(DataEntry.carbon_report_module_id))
@@ -509,32 +497,6 @@ class CarbonReportModuleService:
             )
         ).all()
         return {module_id: float(total or 0.0) for module_id, total in rows}
-
-    async def _reference_years_by_module(
-        self, modules: Sequence[CarbonReportModule]
-    ) -> dict[int, int]:
-        """Live baseline of each module whose report has one (plan years only).
-
-        Modules of a Calculator or Explore report are left out, so the batch
-        the aggregation pipeline recomputes carries no condition at all.
-        """
-        report_ids = {m.carbon_report_id for m in modules}
-        if not report_ids:
-            return {}
-        rows = (
-            await self.session.execute(
-                select(col(CarbonReport.id), col(CarbonReport.reference_year)).where(
-                    col(CarbonReport.id).in_(report_ids),
-                    col(CarbonReport.reference_year).isnot(None),
-                )
-            )
-        ).all()
-        reference_year_by_report = {report_id: year for report_id, year in rows}
-        return {
-            m.id: reference_year_by_report[m.carbon_report_id]
-            for m in modules
-            if m.id is not None and m.carbon_report_id in reference_year_by_report
-        }
 
     async def _years_by_report(
         self, modules: Sequence[CarbonReportModule]

--- a/backend/app/services/data_entry_service.py
+++ b/backend/app/services/data_entry_service.py
@@ -641,12 +641,10 @@ class DataEntryService:
         self,
         carbon_report_module_id: int,
         travel_institutional_id_filter: Optional[str] = None,
-        reference_year: Optional[int] = None,
     ) -> ModuleResponse:
         data_entry_types_total_items = await self.repo.get_total_count_by_submodule(
             carbon_report_module_id=carbon_report_module_id,
             travel_institutional_id_filter=travel_institutional_id_filter,
-            reference_year=reference_year,
         )
 
         incomplete_new_equipment_count = await self.repo.count_incomplete_new_equipment(
@@ -685,14 +683,8 @@ class DataEntryService:
         current_user: Optional[UserRead] = None,
         request_context: Optional[dict] = None,
         background_tasks: Optional[BackgroundTasks] = None,
-        reference_year: Optional[int] = None,
     ) -> SubmoduleResponse:
-        """Get module data for a unit and year.
-
-        ``reference_year`` is the plan-year report's live baseline: a Simulator
-        Plan module keeps the prefilled rows of every baseline it has used, and
-        only the matching ones belong in the table.
-        """
+        """Get module data for a unit and year."""
         response = await self.repo.get_submodule_data(
             carbon_report_module_id=carbon_report_module_id,
             data_entry_type_id=data_entry_type_id,
@@ -702,7 +694,6 @@ class DataEntryService:
             sort_order=sort_order,
             filter=filter,
             institutional_id_filter=institutional_id_filter,
-            reference_year=reference_year,
         )
 
         if (

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -229,15 +229,13 @@ class SimulatorPlanService:
     ) -> Optional[SimulatorPlanYearRead]:
         """Set the baseline year of one plan-year report; None if missing.
 
-        Nothing is deleted: the prefilled rows of every baseline the plan-year
-        has used stay in the module, each stamped with ``data['reference_year']``,
-        and readers keep only the live one (``DataEntryRepository.
-        reference_year_filter``). Coming back to a year therefore finds its
-        sliders and edits as they were left, and a baseline seen for the first
-        time is prefilled at 100%.
+        Destructive: every prefilled module of the plan-year is emptied and
+        rebuilt from the new baseline at 100%, so the percentages, edits and
+        hand-added rows made under the previous reference year are lost. The
+        dialog warns about it before calling this.
 
-        The live baseline's entries get their emissions recomputed, since factor
-        lookup follows the reference year; dormant rows keep theirs.
+        The rebuilt entries get their emissions recomputed, since factor lookup
+        follows the reference year.
         """
         reports = await self.repo.list_reports_for_project(plan_id)
         report = next((r for r in reports if r.year == year), None)
@@ -252,31 +250,42 @@ class SimulatorPlanService:
         return await self._year_read(report)
 
     async def _prefill_reference_modules(self, report: CarbonReport) -> None:
-        """Prefill every prefilled-behavior module from the reference year.
+        """Rebuild every prefilled-behavior module from the reference year.
 
         Runs on reference-year set/change (there is no manual prefill trigger).
-        Only baselines this plan-year has never used are copied — a baseline it
-        already holds rows for is left exactly as the user left it. No-op when
-        the reference year has no Calculator report for the unit: there is
-        nothing to copy.
+        The modules are emptied first, so a module never mixes two baselines.
+        When the reference year has no Calculator report for the unit there is
+        nothing to copy and they stay empty — showing the previous baseline's
+        rows under a new reference year would be a lie.
         """
         if report.id is None:
             raise ValueError("report must be persisted before use")
         if report.reference_year is None:
             return
+        modules = await self.report_service.module_service.list_modules(report.id)
+        prefilled = [
+            m for m in modules if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
+        ]
+        await self._clear_module_entries([m.id for m in prefilled if m.id is not None])
         ref_report = await self.repo.get_calculator_report(
             report.unit_id, report.reference_year
         )
         if ref_report is None:
             return
-        modules = await self.report_service.module_service.list_modules(report.id)
-        prefilled_ids = sorted(
-            m.module_type_id
-            for m in modules
-            if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
-        )
-        for module_type_id in prefilled_ids:
+        for module_type_id in sorted(m.module_type_id for m in prefilled):
             await self.prefill_module_from_reference(report, module_type_id)
+
+    async def _clear_module_entries(self, module_ids: list[int]) -> None:
+        """Delete every data entry of the given modules and refresh their stats.
+
+        Emissions follow through the ``data_entry_id`` cascade.
+        """
+        if not module_ids:
+            return
+        await DataEntryRepository(self.session).bulk_delete_by_modules(module_ids)
+        await self.report_service.module_service.recompute_stats_many(
+            sorted(module_ids)
+        )
 
     async def _year_read(self, report: CarbonReport) -> SimulatorPlanYearRead:
         """Build the per-year DTO (report + its modules)."""
@@ -294,18 +303,12 @@ class SimulatorPlanService:
     async def prefill_module_from_reference(
         self, report: CarbonReport | CarbonReportRead, module_type_id: int
     ) -> int:
-        """Snapshot-copy the reference-year Calculator entries into a plan module.
+        """Rebuild a plan module from the reference-year Calculator entries.
 
-        Copies at ``percentage_of_reference_year = 100``, stamping each row with
-        the baseline it came from (``reference_year``) so the module can hold
-        several baselines at once and show only the active one. Each copy keeps
-        ``source_data_entry_id`` so the % slider computes against the live
-        reference entry. Returns the copied count.
-
-        Idempotent by baseline: a module that already holds rows for this
-        reference year is left untouched (0 copied) — re-copying would discard
-        the sliders, edits and deletions the user made under it. Nothing is
-        ever deleted here.
+        Destructive and idempotent: the module's entries are deleted first, then
+        the reference year's are copied at ``percentage_of_reference_year =
+        100``. Each copy keeps ``source_data_entry_id`` so the % slider computes
+        against the live reference entry. Returns the copied count.
 
         Raises ValueError when the report has no reference year or the
         reference year has no Calculator report/module for the unit.
@@ -330,12 +333,7 @@ class SimulatorPlanService:
             raise ValueError(f"Module {module_type_id} not found on the reference year")
 
         entry_repo = DataEntryRepository(self.session)
-        existing = await entry_repo.list_by_module(plan_module.id)
-        if any(
-            entry.data.get("reference_year") == report.reference_year
-            for entry in existing
-        ):
-            return 0
+        await entry_repo.bulk_delete_by_modules([plan_module.id])
 
         emission_svc = DataEntryEmissionService(self.session)
         copied = 0
@@ -350,7 +348,6 @@ class SimulatorPlanService:
                     **src.data,
                     "percentage_of_reference_year": 100,
                     "source_data_entry_id": src.id,
-                    "reference_year": report.reference_year,
                 },
             )
             self.session.add(copy)
@@ -364,11 +361,10 @@ class SimulatorPlanService:
         return copied
 
     async def _recalculate_report_emissions(self, report: CarbonReport) -> None:
-        """Recompute emissions of the report's live entries + refresh stats.
+        """Recompute emissions of the report's entries + refresh stats.
 
-        Rows stamped with another baseline are dormant: nothing reads them until
-        that baseline is live again, and they keep the emissions they were
-        computed with.
+        Factor lookup follows the reference year, so every entry of the report
+        has to be recomputed when it changes.
         """
         if report.id is None:
             raise ValueError("report must be persisted before use")
@@ -378,9 +374,6 @@ class SimulatorPlanService:
         emission_svc = DataEntryEmissionService(self.session)
         module_ids: set[int] = set()
         for entry in entries:
-            stamped = entry.data.get("reference_year")
-            if stamped is not None and stamped != report.reference_year:
-                continue
             await emission_svc.upsert_by_data_entry(
                 DataEntryResponse.model_validate(entry)
             )

--- a/backend/tests/unit/services/test_simulator_plan_service.py
+++ b/backend/tests/unit/services/test_simulator_plan_service.py
@@ -2,16 +2,13 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlmodel import SQLModel, col, select
+from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
 
 from app.models.data_entry import DataEntry, DataEntrySourceEnum, DataEntryTypeEnum
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import User
-from app.repositories.data_entry_repo import (
-    DataEntryRepository,
-    reference_year_filter,
-)
+from app.repositories.data_entry_repo import DataEntryRepository
 from app.schemas.carbon_report import CarbonReportCreate
 from app.schemas.simulator_plan import SimulatorPlanUpdate
 from app.services.carbon_report_service import CarbonReportService
@@ -434,7 +431,6 @@ async def test_prefill_copies_reference_entries_at_100_percent(async_session, us
     rows = await DataEntryRepository(async_session).list_by_module(plan_module.id)
     assert len(rows) == 2
     assert all(r.source == DataEntrySourceEnum.PLANNER_SNAPSHOT.value for r in rows)
-    assert all(r.data["reference_year"] == 2024 for r in rows)
     assert all(r.data["percentage_of_reference_year"] == 100 for r in rows)
     assert {r.data["source_data_entry_id"] for r in rows} == {e.id for e in src_entries}
     # Snapshot keeps the reference quantities.
@@ -442,8 +438,8 @@ async def test_prefill_copies_reference_entries_at_100_percent(async_session, us
 
 
 @pytest.mark.asyncio
-async def test_prefill_leaves_an_already_prefilled_baseline_alone(async_session, user):
-    """Re-copying a baseline would discard the sliders set under it."""
+async def test_prefill_rebuilds_the_module(async_session, user):
+    """A prefill empties the module first, so it never mixes two baselines."""
     service = SimulatorPlanService(async_session)
     await _calculator_report_with_process_entries(service, async_session)
     plan = await service.create_plan(unit_id=1, user=user, name="proj")
@@ -464,17 +460,11 @@ async def test_prefill_leaves_an_already_prefilled_baseline_alone(async_session,
     copied = await service.prefill_module_from_reference(
         report, int(ModuleTypeEnum.process_emissions)
     )
-    assert copied == 0
+    assert copied == 2
 
     rows = await DataEntryRepository(async_session).list_by_module(plan_module.id)
-    snapshots = [
-        r for r in rows if r.source == DataEntrySourceEnum.PLANNER_SNAPSHOT.value
-    ]
-    manuals = [r for r in rows if r.source == DataEntrySourceEnum.USER_MANUAL.value]
-    assert len(snapshots) == 2  # not duplicated
-    assert len(manuals) == 1  # user rows survive
-    # A hand-added row belongs to the plan, not to a baseline.
-    assert "reference_year" not in manuals[0].data
+    assert len(rows) == 2  # the previous rows are gone, not duplicated
+    assert all(r.source == DataEntrySourceEnum.PLANNER_SNAPSHOT.value for r in rows)
 
 
 @pytest.mark.asyncio
@@ -511,26 +501,19 @@ async def _second_calculator_year(service, async_session):
     return entry
 
 
-async def _visible_rows(async_session, plan_module_id, reference_year):
-    """The module's rows as the table, the totals and the chart see them.
-
-    Applies the same filter the repo applies when a caller passes the report's
-    live baseline.
-    """
-    result = await async_session.execute(
-        select(DataEntry).where(
-            col(DataEntry.carbon_report_module_id) == plan_module_id,
-            reference_year_filter(reference_year),
-        )
+async def _plan_module_rows(service, async_session, report):
+    """The process-emissions rows of a plan-year report."""
+    plan_module = await service.report_service.module_service.get_module(
+        report.id, int(ModuleTypeEnum.process_emissions)
     )
-    return list(result.scalars().all())
+    return await DataEntryRepository(async_session).list_by_module(plan_module.id)
 
 
 @pytest.mark.asyncio
-async def test_reference_year_change_keeps_the_previous_baseline_rows(
+async def test_reference_year_change_wipes_the_previous_baseline_rows(
     async_session, user
 ):
-    """Nothing is deleted: the old baseline's rows stay, dormant."""
+    """The module is emptied and rebuilt from the new baseline."""
     service = SimulatorPlanService(async_session)
     await _calculator_report_with_process_entries(service, async_session, year=2024)
     entry_2025 = await _second_calculator_year(service, async_session)
@@ -540,32 +523,22 @@ async def test_reference_year_change_keeps_the_previous_baseline_rows(
 
     await service.set_reference_year(plan.id, 2027, 2025)
 
-    plan_module = await service.report_service.module_service.get_module(
-        report.id, int(ModuleTypeEnum.process_emissions)
-    )
-    stored = await DataEntryRepository(async_session).list_by_module(plan_module.id)
-    assert sorted(r.data["reference_year"] for r in stored) == [2024, 2024, 2025]
-
-    visible = await _visible_rows(async_session, plan_module.id, 2025)
-    assert len(visible) == 1
-    assert visible[0].data["quantity"] == 3.0
-    assert visible[0].data["source_data_entry_id"] == entry_2025.id
+    rows = await _plan_module_rows(service, async_session, report)
+    assert len(rows) == 1
+    assert rows[0].data["quantity"] == 3.0
+    assert rows[0].data["source_data_entry_id"] == entry_2025.id
 
 
 @pytest.mark.asyncio
-async def test_switching_back_restores_the_sliders_of_that_baseline(
-    async_session, user
-):
+async def test_switching_back_reprefills_at_100_percent(async_session, user):
+    """Coming back to a baseline starts over: the earlier edits are gone."""
     service = SimulatorPlanService(async_session)
     await _calculator_report_with_process_entries(service, async_session, year=2024)
     await _second_calculator_year(service, async_session)
 
     plan = await service.create_plan(unit_id=1, user=user, name="proj")
     report = await _plan_year_report(service, plan.id, reference_year=2024)
-    plan_module = await service.report_service.module_service.get_module(
-        report.id, int(ModuleTypeEnum.process_emissions)
-    )
-    rows_2024 = await _visible_rows(async_session, plan_module.id, 2024)
+    rows_2024 = await _plan_module_rows(service, async_session, report)
     rows_2024[0].data = {
         **rows_2024[0].data,
         "percentage_of_reference_year": 40,
@@ -577,15 +550,15 @@ async def test_switching_back_restores_the_sliders_of_that_baseline(
     await service.set_reference_year(plan.id, 2027, 2025)
     await service.set_reference_year(plan.id, 2027, 2024)
 
-    visible = await _visible_rows(async_session, plan_module.id, 2024)
-    assert len(visible) == 2
-    edited = next(r for r in visible if r.id == rows_2024[0].id)
-    assert edited.data["percentage_of_reference_year"] == 40
-    assert edited.data["quantity"] == 99.0
+    rows = await _plan_module_rows(service, async_session, report)
+    assert len(rows) == 2
+    assert all(r.data["percentage_of_reference_year"] == 100 for r in rows)
+    assert {r.data["quantity"] for r in rows} == {5.0, 7.0}
 
 
 @pytest.mark.asyncio
-async def test_hand_added_rows_show_under_every_baseline(async_session, user):
+async def test_hand_added_rows_are_wiped_on_switch(async_session, user):
+    """A prefilled module is rebuilt whole — hand-added rows go too."""
     service = SimulatorPlanService(async_session)
     await _calculator_report_with_process_entries(service, async_session, year=2024)
     await _second_calculator_year(service, async_session)
@@ -607,23 +580,24 @@ async def test_hand_added_rows_show_under_every_baseline(async_session, user):
 
     await service.set_reference_year(plan.id, 2027, 2025)
 
-    visible = await _visible_rows(async_session, plan_module.id, 2025)
-    manual = [r for r in visible if r.source == DataEntrySourceEnum.USER_MANUAL.value]
-    assert len(manual) == 1
-    assert len(visible) == 2  # the manual row + the 2025 snapshot
+    rows = await _plan_module_rows(service, async_session, report)
+    assert [r.source for r in rows] == [DataEntrySourceEnum.PLANNER_SNAPSHOT.value]
 
 
 @pytest.mark.asyncio
-async def test_calculator_rows_are_never_hidden(async_session, user):
-    """Outside the planner the filter is a no-op: no row carries a baseline."""
+async def test_switch_to_a_year_without_calculator_data_empties_the_modules(
+    async_session, user
+):
+    """No baseline to copy is still a wipe: stale rows would misreport the year."""
     service = SimulatorPlanService(async_session)
-    _, calc_module, _ = await _calculator_report_with_process_entries(
-        service, async_session, year=2024
-    )
+    await _calculator_report_with_process_entries(service, async_session, year=2024)
 
-    visible = await _visible_rows(async_session, calc_module.id, None)
+    plan = await service.create_plan(unit_id=1, user=user, name="proj")
+    report = await _plan_year_report(service, plan.id, reference_year=2024)
 
-    assert len(visible) == 2
+    await service.set_reference_year(plan.id, 2027, 2025)
+
+    assert await _plan_module_rows(service, async_session, report) == []
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/organisms/planner/PlannerHeadcountRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerHeadcountRows.vue
@@ -31,10 +31,10 @@ import { useQuasar } from 'quasar';
 import { useI18n } from 'vue-i18n';
 
 import { api } from 'src/api/http';
-
-// The 8 backend SIUS codes (headcount/data_entries.py SIUS_CODE_VALUES),
-// rendered as fixed rows in the order the design shows.
-const SIUS_CODES = ['51', '52', '53', '54', '56', '57', '58', '59'] as const;
+import {
+  PLANNER_HEADCOUNT_SUBMODULE,
+  PLANNER_SIUS_CODES as SIUS_CODES,
+} from 'src/constant/planner-headcount';
 
 interface HeadcountRow {
   sius_code: string;
@@ -62,7 +62,7 @@ const rows = ref<HeadcountRow[]>(
 const savingCode = ref<string | null>(null);
 
 const basePath = () =>
-  `carbon-reports/${props.carbonReportId}/modules/headcount/planner_headcount`;
+  `carbon-reports/${props.carbonReportId}/modules/headcount/${PLANNER_HEADCOUNT_SUBMODULE}`;
 
 async function load() {
   try {

--- a/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
+++ b/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
@@ -33,12 +33,34 @@
         <div class="text-body2 text-grey-8 q-mt-md">
           {{ $t('planner_reference_year_dialog_consequences') }}
         </div>
+
+        <template v-if="referenceYear !== null">
+          <q-banner dense rounded class="bg-red-1 text-negative q-mt-md">
+            <template #avatar>
+              <q-icon name="o_warning" color="negative" size="sm" />
+            </template>
+            <div class="text-body2">
+              {{ $t('planner_reference_year_dialog_wipe_warning') }}
+            </div>
+          </q-banner>
+          <q-checkbox
+            v-model="acknowledged"
+            dense
+            color="negative"
+            class="q-mt-md"
+            :label="
+              $t('planner_reference_year_dialog_wipe_ack', {
+                year: referenceYear,
+              })
+            "
+          />
+        </template>
       </q-card-section>
 
       <q-card-actions class="q-px-md q-pb-md">
         <q-btn
           :label="$t('common_validate_short')"
-          :disable="selected === null || selected === referenceYear"
+          :disable="confirmDisabled"
           :loading="loading"
           color="info"
           unelevated
@@ -61,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -79,6 +101,17 @@ const emit = defineEmits<{
 // Seeded once per mount: the parent keys the dialog on the current reference
 // year, so a re-open starts from what is set rather than the last pick.
 const selected = ref<number | null>(props.referenceYear);
+
+// Changing a baseline that is already set deletes the prefilled modules' data,
+// so the user has to acknowledge it. The first-time set deletes nothing.
+const acknowledged = ref(false);
+
+const confirmDisabled = computed(
+  () =>
+    selected.value === null ||
+    selected.value === props.referenceYear ||
+    (props.referenceYear !== null && !acknowledged.value),
+);
 
 function onConfirm() {
   if (selected.value === null) return;

--- a/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
+++ b/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
@@ -24,14 +24,14 @@
         <q-select
           v-model="selected"
           :options="options"
-          :label="$t('planner_reference_year_label')"
+          :label="$t('planner_reference_year_dialog_select_label')"
           outlined
           dense
           emit-value
           map-options
         />
         <div class="text-body2 text-grey-8 q-mt-md">
-          {{ $t('planner_reference_year_dialog_consequences') }}
+          {{ $t('planner_reference_year_dialog_consequences', { year }) }}
         </div>
 
         <template v-if="referenceYear !== null">
@@ -40,7 +40,7 @@
               <q-icon name="o_warning" color="negative" size="sm" />
             </template>
             <div class="text-body2">
-              {{ $t('planner_reference_year_dialog_wipe_warning') }}
+              {{ $t('planner_reference_year_dialog_wipe_warning', { year }) }}
             </div>
           </q-banner>
           <q-checkbox
@@ -48,11 +48,7 @@
             dense
             color="negative"
             class="q-mt-md"
-            :label="
-              $t('planner_reference_year_dialog_wipe_ack', {
-                year: referenceYear,
-              })
-            "
+            :label="$t('planner_reference_year_dialog_wipe_ack', { year })"
           />
         </template>
       </q-card-section>

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -244,8 +244,8 @@ async function onReferenceYearChange(referenceYear: number) {
       referenceYear,
     );
     referenceYearDialogOpen.value = false;
-    // The new baseline's rows are prefilled (or restored); refresh the open
-    // module so they appear without a manual reload.
+    // The prefilled modules were rebuilt from the new baseline; refresh the
+    // open module so its rows appear without a manual reload.
     const expanded = props.expandedKey?.startsWith(`${props.yearData.year}-`);
     const module = props.expandedKey?.split('-').slice(1).join('-') as
       Module | undefined;

--- a/frontend/src/components/organisms/print/PlannerPrintHeadcountTable.vue
+++ b/frontend/src/components/organisms/print/PlannerPrintHeadcountTable.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { PlannerHeadcountRow } from 'src/composables/print/useProjectPlannerPrintData';
+
+const props = defineProps<{ rows: PlannerHeadcountRow[] }>();
+
+const totalFte = computed(() =>
+  props.rows.reduce((sum, row) => sum + row.fte, 0),
+);
+</script>
+
+<template>
+  <h3 class="text-body1 table-title">
+    {{ $t('planner_headcount_table_title') }}
+  </h3>
+  <table class="print-table">
+    <thead>
+      <tr>
+        <th>{{ $t('planner_headcount_category_col') }}</th>
+        <th class="align-right">{{ $t('planner_headcount_fte_col') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="row in rows" :key="row.sius_code">
+        <td>{{ $t(row.sius_code) }}</td>
+        <td class="align-right">
+          {{ $nOrDash(row.fte, { options: { maximumFractionDigits: 1 } }) }}
+        </td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class="text-weight-medium">
+          {{ $t('planner_headcount_total_fte') }}
+        </td>
+        <td class="align-right text-weight-medium">
+          {{ $nOrDash(totalFte, { options: { maximumFractionDigits: 1 } }) }}
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</template>
+
+<style scoped lang="scss">
+.table-title {
+  font-weight: 500;
+  margin: 0 0 6px;
+  break-after: avoid;
+  page-break-after: avoid;
+}
+
+.print-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 9px;
+
+  th,
+  td {
+    border: 1px solid var(--half-muted-color);
+    padding: 2px 4px;
+    word-break: break-word;
+    vertical-align: top;
+  }
+
+  th {
+    font-weight: 600;
+  }
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+}
+
+.align-right {
+  text-align: right;
+}
+</style>

--- a/frontend/src/components/organisms/print/PlannerPrintModulePage.vue
+++ b/frontend/src/components/organisms/print/PlannerPrintModulePage.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import PrintModuleTable from 'src/components/organisms/print/PrintModuleTable.vue';
+import type { PlannerPrintTable } from 'src/composables/print/useProjectPlannerPrintData';
+import type { PlannerPrintModule } from 'src/utils/plannerPrintModules';
+
+interface Props {
+  module: PlannerPrintModule;
+  year: number;
+  pageNumber: number;
+  scope: string;
+  tables: PlannerPrintTable[];
+}
+
+const props = defineProps<Props>();
+
+const isPrefilled = computed(() => props.module.behavior === 'prefilled');
+</script>
+
+<template>
+  <ReportPage
+    :title="$t(module.type)"
+    :scope="scope"
+    :page-number="pageNumber"
+    flow
+  >
+    <div class="module-header">
+      <h2 class="text-h5 q-mt-none q-mb-none">{{ $t(module.type) }}</h2>
+      <span v-if="isPrefilled" class="module-badge">
+        {{ $t('planner_module_prefilled_badge') }}
+      </span>
+    </div>
+    <div class="text-body2 text-secondary q-mb-lg">
+      {{ $t('planner_print_module_subtitle', { year }) }}
+    </div>
+
+    <section
+      v-for="table in tables"
+      :key="table.sub.id"
+      class="submodule-section"
+    >
+      <h3 v-if="table.sub.tableNameKey" class="text-body1 submodule-title">
+        {{ $t(table.sub.tableNameKey, { count: table.rows.length }) }}
+      </h3>
+      <PrintModuleTable
+        :submodule="table.sub"
+        :module-config="module.config"
+        :rows="table.rows"
+        :show-reference-columns="isPrefilled"
+      />
+    </section>
+  </ReportPage>
+</template>
+
+<style scoped lang="scss">
+.module-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.module-badge {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border: 1px solid var(--half-muted-color);
+  border-radius: 999px;
+  opacity: 0.75;
+}
+
+.submodule-section {
+  margin-bottom: 16px;
+}
+
+.submodule-title {
+  font-weight: 500;
+  margin: 0 0 6px;
+  break-after: avoid;
+  page-break-after: avoid;
+}
+</style>

--- a/frontend/src/components/organisms/print/PlannerPrintYearPage.vue
+++ b/frontend/src/components/organisms/print/PlannerPrintYearPage.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import BigNumber from 'src/components/molecules/BigNumber.vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import { getModuleTypeId } from 'src/constant/moduleStates';
+import { PLANNER_MODULES } from 'src/constant/planner-module-config';
+import type { EmissionBreakdownResponse } from 'src/stores/modules';
+import type { SimulatorPlanYear } from 'src/stores/simulatorPlans';
+import { formatTonnesCO2 } from 'src/utils/number';
+
+interface Props {
+  year: SimulatorPlanYear;
+  pageNumber: number;
+  scope: string;
+  planName: string;
+  breakdown: EmissionBreakdownResponse | null;
+  totalTonnes: number;
+}
+
+const props = defineProps<Props>();
+
+// Inactive modules are excluded from the year's sums and charts, so the report
+// names them: a reader seeing a low total needs to know what was left out.
+const inactiveModules = computed(() =>
+  PLANNER_MODULES.filter((entry) => {
+    const module = props.year.modules.find(
+      (m) => m.module_type_id === getModuleTypeId(entry.module),
+    );
+    return module?.is_active === false;
+  }).map((entry) => entry.module),
+);
+</script>
+
+<template>
+  <ReportPage
+    :title="String(year.year)"
+    :scope="scope"
+    :page-number="pageNumber"
+  >
+    <h2 class="text-h5 q-mt-none">{{ year.year }}</h2>
+    <div class="text-body2 text-secondary">
+      {{ $t('planner_print_year_subtitle', { name: planName }) }}
+    </div>
+
+    <div class="year-facts q-mt-md">
+      <div>
+        <span class="year-facts__label">
+          {{ $t('planner_reference_year_label') }}
+        </span>
+        <span class="year-facts__value">
+          {{ year.reference_year ?? $t('planner_print_no_reference_year') }}
+        </span>
+      </div>
+      <div v-if="inactiveModules.length">
+        <span class="year-facts__label">
+          {{ $t('planner_print_excluded_modules') }}
+        </span>
+        <span class="year-facts__value">
+          {{ inactiveModules.map((module) => $t(module)).join(', ') }}
+        </span>
+      </div>
+    </div>
+
+    <div class="q-mt-md">
+      <BigNumber
+        :title="$t('planner_print_year_total')"
+        :number="formatTonnesCO2(totalTonnes)"
+        color="info"
+        :print-mode="true"
+      />
+    </div>
+
+    <section class="q-mt-md">
+      <ModuleCarbonFootprintChart
+        :breakdown-data="breakdown"
+        :title="$t('planner_print_year_chart_title', { year: year.year })"
+        :print-mode="true"
+      />
+    </section>
+  </ReportPage>
+</template>
+
+<style scoped lang="scss">
+.year-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+
+  &__label {
+    opacity: 0.7;
+    margin-right: 6px;
+  }
+
+  &__value {
+    font-weight: 600;
+  }
+}
+</style>

--- a/frontend/src/components/organisms/print/PrintModuleTable.vue
+++ b/frontend/src/components/organisms/print/PrintModuleTable.vue
@@ -15,10 +15,16 @@ interface Props {
   submodule: Submodule;
   moduleConfig: ModuleConfig;
   rows: PrintRow[];
-  headcountMembers: Map<string, string>;
+  /** Institutional id → name. Absent in the planner, which has no roster. */
+  headcountMembers?: Map<string, string>;
+  /** Planner prefilled modules: add the reference kgCO₂eq and % columns. */
+  showReferenceColumns?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  headcountMembers: () => new Map(),
+  showReferenceColumns: false,
+});
 
 const { t, te } = useI18n();
 const moduleStore = useModuleStore();
@@ -27,7 +33,11 @@ const translate = (key: string, params?: Record<string, unknown>) =>
   t(key, params ?? {});
 
 const columns = computed(() =>
-  buildPrintColumns(props.submodule.moduleFields, translate),
+  buildPrintColumns(
+    props.submodule.moduleFields,
+    translate,
+    props.showReferenceColumns,
+  ),
 );
 
 const taxonomyKindLabels = computed<Record<string, string>>(() => {

--- a/frontend/src/components/organisms/print/PrintReportShell.vue
+++ b/frontend/src/components/organisms/print/PrintReportShell.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+interface Props {
+  /** Report data is still on its way. */
+  loading?: boolean;
+  /** Loaded, but there is nothing to report. */
+  empty?: boolean;
+  /** What to say on an empty report; nothing is shown without it. */
+  emptyMessage?: string;
+}
+
+withDefaults(defineProps<Props>(), {
+  loading: false,
+  empty: false,
+  emptyMessage: undefined,
+});
+
+function printReport() {
+  window.print();
+}
+</script>
+
+<template>
+  <div class="bg-grey-2 print-report">
+    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
+      <q-space />
+      <q-btn
+        color="accent"
+        icon="o_print"
+        size="md"
+        class="text-weight-medium"
+        :label="$t('results_print')"
+        @click="printReport"
+      />
+    </q-toolbar>
+
+    <div v-if="loading" class="flex justify-center q-pa-xl print-hide">
+      <q-spinner color="accent" size="3em" />
+    </div>
+
+    <div v-else-if="empty" class="flex justify-center q-pa-xl print-hide">
+      <span v-if="emptyMessage" class="text-body1">{{ emptyMessage }}</span>
+    </div>
+
+    <div v-else class="report-container">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<!-- Not scoped: these rules hide layout chrome (.q-header/.q-footer/.q-drawer)
+     that lives outside this component, and reach into the .q-card elements the
+     report pages render into the slot. -->
+<style lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.report-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: tokens.$print-report-container-padding;
+  color: tokens.$color-text;
+}
+
+.print-toolbar {
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid var(--half-muted-color);
+  z-index: tokens.$print-toolbar-z-index;
+}
+
+@media print {
+  .print-hide,
+  .q-header,
+  .q-footer,
+  .q-drawer {
+    display: none;
+  }
+
+  .report-container {
+    display: block;
+    width: 100%;
+    padding: 0;
+  }
+
+  .print-report .q-card,
+  .print-report .q-card-section {
+    box-shadow: none;
+  }
+}
+</style>

--- a/frontend/src/composables/print/useProjectPlannerPrintData.ts
+++ b/frontend/src/composables/print/useProjectPlannerPrintData.ts
@@ -1,0 +1,388 @@
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { api } from 'src/api/http';
+import type { Submodule } from 'src/constant/moduleConfig';
+import { getModuleTypeId } from 'src/constant/moduleStates';
+import { MODULES } from 'src/constant/modules';
+import {
+  PLANNER_HEADCOUNT_SUBMODULE,
+  PLANNER_SIUS_CODES,
+} from 'src/constant/planner-headcount';
+import type { EmissionBreakdownResponse } from 'src/stores/modules';
+import { useModuleStore } from 'src/stores/modules';
+import {
+  useSimulatorPlansStore,
+  type SimulatorPlan,
+  type SimulatorPlanYear,
+} from 'src/stores/simulatorPlans';
+import { useWorkspaceStore } from 'src/stores/workspace';
+import { useYearConfigStore } from 'src/stores/yearConfig';
+import { sumBreakdownTonnes } from 'src/utils/breakdownTotal';
+import {
+  toEmissionBreakdown,
+  type ReportStats,
+} from 'src/utils/emissionStatsAdapter';
+import { buildModulePath } from 'src/utils/modulePath';
+import {
+  getPlannerPrintModules,
+  type PlannerPrintModule,
+} from 'src/utils/plannerPrintModules';
+import { fetchAllSubmoduleRows } from 'src/utils/printSubmoduleRows';
+import type { PrintRow } from 'src/utils/printTable';
+
+export interface PlannerHeadcountRow {
+  sius_code: string;
+  fte: number;
+}
+
+/** One printable submodule table: its config and the rows to draw. */
+export interface PlannerPrintTable {
+  sub: Submodule;
+  rows: PrintRow[];
+}
+
+/**
+ * One sheet of the report. The list is built after fetching so modules with no
+ * rows in a given year never emit an empty page, and page numbers stay
+ * contiguous.
+ */
+export type PlannerPrintSheet =
+  | { kind: 'year'; key: string; pageNumber: number; year: SimulatorPlanYear }
+  | {
+      kind: 'headcount';
+      key: string;
+      pageNumber: number;
+      year: SimulatorPlanYear;
+    }
+  | {
+      kind: 'module';
+      key: string;
+      pageNumber: number;
+      year: SimulatorPlanYear;
+      module: PlannerPrintModule;
+    };
+
+/** Rows are addressed per plan-year report, since a submodule repeats each year. */
+function rowsKey(carbonReportId: number, submoduleId: string): string {
+  return `${carbonReportId}:${submoduleId}`;
+}
+
+/**
+ * A plan report fans out to years × modules × submodules, so a ten-year plan
+ * would open well over a hundred requests at once — past the browser's
+ * per-host connection limit, where the tail just queues anyway.
+ */
+const FETCH_CONCURRENCY = 6;
+
+async function runPooled(tasks: (() => Promise<unknown>)[]): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.min(FETCH_CONCURRENCY, tasks.length) },
+    async () => {
+      for (;;) {
+        const task = tasks[cursor++];
+        if (!task) return;
+        await task();
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+export function useProjectPlannerPrintData() {
+  const route = useRoute();
+  const workspaceStore = useWorkspaceStore();
+  const moduleStore = useModuleStore();
+  const plansStore = useSimulatorPlansStore();
+  const yearConfigStore = useYearConfigStore();
+
+  const loading = ref(true);
+  const notFound = ref(false);
+  const plan = ref<SimulatorPlan | null>(null);
+  const submoduleRows = ref<Record<string, PrintRow[]>>({});
+  const headcountRows = ref<Record<number, PlannerHeadcountRow[]>>({});
+  /** "module · year" for every table that failed to load, named on the cover. */
+  const incompleteModules = ref<string[]>([]);
+
+  const printModules = getPlannerPrintModules();
+
+  const planYears = computed(() => plansStore.planYears);
+
+  const yearRangeLabel = computed(() => {
+    const years = planYears.value;
+    if (!years.length) return '';
+    const first = years[0]?.year;
+    const last = years[years.length - 1]?.year;
+    return first === last ? `${first}` : `${first}–${last}`;
+  });
+
+  const scopeLabel = computed(() => {
+    const unitName = workspaceStore.selectedUnit?.name ?? '';
+    const range = yearRangeLabel.value;
+    if (!range) return unitName;
+    return unitName ? `${unitName} · ${range}` : range;
+  });
+
+  const planBreakdown = computed<EmissionBreakdownResponse | null>(() =>
+    plansStore.aggregateStats
+      ? toEmissionBreakdown(plansStore.aggregateStats)
+      : null,
+  );
+
+  const totalTonnesCo2eq = computed(() =>
+    sumBreakdownTonnes(planBreakdown.value),
+  );
+
+  /** Per-year breakdowns, keyed by the plan-year carbon report id. */
+  const yearBreakdowns = computed<Record<number, EmissionBreakdownResponse>>(
+    () => {
+      const map: Record<number, EmissionBreakdownResponse> = {};
+      for (const year of planYears.value) {
+        if (!year.stats) continue;
+        map[year.id] = toEmissionBreakdown(
+          year.stats as unknown as ReportStats,
+        );
+      }
+      return map;
+    },
+  );
+
+  function yearTotalTonnes(year: SimulatorPlanYear): number {
+    return sumBreakdownTonnes(yearBreakdowns.value[year.id]);
+  }
+
+  /** Inactive modules are excluded from sums, graphs and results — and from the report. */
+  function isModuleActive(
+    year: SimulatorPlanYear,
+    module: PlannerPrintModule | typeof MODULES.Headcount,
+  ): boolean {
+    const moduleType = typeof module === 'string' ? module : module.type;
+    const entry = year.modules.find(
+      (m) => m.module_type_id === getModuleTypeId(moduleType),
+    );
+    return entry?.is_active ?? true;
+  }
+
+  /**
+   * The tables to print for one module in one plan-year. Submodules the plan
+   * never touched are dropped here, so both the page list and the page itself
+   * read the same answer instead of each re-deciding what is empty.
+   */
+  function moduleTables(
+    year: SimulatorPlanYear,
+    module: PlannerPrintModule,
+  ): PlannerPrintTable[] {
+    return module.submodules
+      .map((sub) => ({
+        sub,
+        rows: submoduleRows.value[rowsKey(year.id, sub.id)] ?? [],
+      }))
+      .filter((table) => table.rows.length > 0);
+  }
+
+  const sheets = computed<PlannerPrintSheet[]>(() => {
+    const list: PlannerPrintSheet[] = [];
+    // The cover is page 1.
+    let pageNumber = 2;
+
+    for (const year of planYears.value) {
+      list.push({
+        kind: 'year',
+        key: `year-${year.id}`,
+        pageNumber: pageNumber++,
+        year,
+      });
+
+      if (
+        isModuleActive(year, MODULES.Headcount) &&
+        (headcountRows.value[year.id] ?? []).length > 0
+      ) {
+        list.push({
+          kind: 'headcount',
+          key: `headcount-${year.id}`,
+          pageNumber: pageNumber++,
+          year,
+        });
+      }
+
+      for (const module of printModules) {
+        if (!isModuleActive(year, module)) continue;
+        if (moduleTables(year, module).length === 0) continue;
+        list.push({
+          kind: 'module',
+          key: `module-${year.id}-${module.type}`,
+          pageNumber: pageNumber++,
+          year,
+          module,
+        });
+      }
+    }
+
+    return list;
+  });
+
+  async function initWorkspaceFromRoute(): Promise<boolean> {
+    const unitParam = String(route.params.unit ?? '');
+    const yearParam = parseInt(String(route.params.year ?? '0'), 10);
+
+    workspaceStore.setSelectedParams({ unit: unitParam, year: yearParam });
+    await workspaceStore.getUnits();
+
+    const unitIdFromRoute = unitParam.split('-')[0];
+    const validUnit = workspaceStore.units.find(
+      (unit) =>
+        unit.id === parseInt(unitIdFromRoute, 10) || unit.name === unitParam,
+    );
+
+    if (!validUnit) {
+      workspaceStore.setUnit(null);
+      workspaceStore.setYear(null);
+      return false;
+    }
+
+    workspaceStore.setUnit(validUnit);
+    workspaceStore.setYear(yearParam || null);
+    return true;
+  }
+
+  async function fetchHeadcountRows(
+    carbonReportId: number,
+  ): Promise<PlannerHeadcountRow[]> {
+    const response = await api
+      .get(
+        `${buildModulePath(
+          MODULES.Headcount,
+          carbonReportId,
+        )}/${PLANNER_HEADCOUNT_SUBMODULE}?page=1&limit=100`,
+      )
+      .json<{ items: { sius_code?: string; fte?: number | null }[] }>();
+
+    const byCode = new Map(
+      response.items
+        .filter((item) => item.sius_code)
+        .map((item) => [item.sius_code as string, item]),
+    );
+    // A blank category is the plan saying "nobody here"; dropping it once means
+    // neither the page list nor the table has to ask again what is filled in.
+    const rows: PlannerHeadcountRow[] = [];
+    for (const code of PLANNER_SIUS_CODES) {
+      const fte = byCode.get(code)?.fte;
+      if (fte != null) rows.push({ sius_code: code, fte });
+    }
+    return rows;
+  }
+
+  /**
+   * Planner factors resolve from each year's reference year, so taxonomy labels
+   * are fetched against the first baseline the plan actually uses. The store
+   * keys taxonomies by submodule alone; one fetch per submodule is all it holds.
+   */
+  function taxonomyTasks(
+    taxonomyYear: number | null,
+  ): (() => Promise<unknown>)[] {
+    if (taxonomyYear == null) return [];
+    const tasks: (() => Promise<unknown>)[] = [];
+    for (const module of printModules) {
+      for (const sub of module.submodules) {
+        if (sub.moduleFields.some((field) => field.optionsId === 'kind')) {
+          tasks.push(() =>
+            moduleStore.getSubmoduleTaxonomy(
+              module.type,
+              sub.id,
+              String(taxonomyYear),
+            ),
+          );
+        }
+      }
+    }
+    return tasks;
+  }
+
+  async function fetchAllData(): Promise<void> {
+    loading.value = true;
+    try {
+      const unitId = workspaceStore.selectedUnit?.id;
+      if (unitId == null) {
+        notFound.value = true;
+        return;
+      }
+
+      try {
+        plan.value = await plansStore.getPlanByName(
+          unitId,
+          String(route.params.name),
+        );
+      } catch {
+        notFound.value = true;
+        return;
+      }
+
+      await Promise.all([
+        plansStore.fetchPlanYears(plan.value.id),
+        plansStore.fetchAggregateStats(plan.value.id),
+        yearConfigStore.fetchConfiguredYears(),
+      ]);
+
+      const years = plansStore.planYears;
+      const taxonomyYear =
+        years.find((year) => year.reference_year != null)?.reference_year ??
+        years[0]?.year ??
+        null;
+
+      const tasks: (() => Promise<unknown>)[] = taxonomyTasks(taxonomyYear);
+
+      for (const year of years) {
+        if (isModuleActive(year, MODULES.Headcount)) {
+          tasks.push(async () => {
+            try {
+              headcountRows.value[year.id] = await fetchHeadcountRows(year.id);
+            } catch {
+              // An untouched module has no rows yet; leave the year without one.
+              headcountRows.value[year.id] = [];
+            }
+          });
+        }
+        for (const module of printModules) {
+          if (!isModuleActive(year, module)) continue;
+          // One task per module, walking its submodules in series: concurrent
+          // reads of the same module on one report make the backend 500.
+          tasks.push(async () => {
+            for (const sub of module.submodules) {
+              try {
+                submoduleRows.value[rowsKey(year.id, sub.id)] =
+                  await fetchAllSubmoduleRows(module.type, sub.id, year.id);
+              } catch {
+                // A report that drops a table without saying so is worse than
+                // one that admits the gap.
+                incompleteModules.value.push(`${module.type} · ${year.year}`);
+              }
+            }
+          });
+        }
+      }
+
+      await runPooled(tasks);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return {
+    loading,
+    notFound,
+    plan,
+    planYears,
+    yearRangeLabel,
+    scopeLabel,
+    planBreakdown,
+    totalTonnesCo2eq,
+    yearBreakdowns,
+    yearTotalTonnes,
+    headcountRows,
+    incompleteModules,
+    sheets,
+    moduleTables,
+    initWorkspaceFromRoute,
+    fetchAllData,
+  };
+}

--- a/frontend/src/composables/print/useSimulationExplorePrintData.ts
+++ b/frontend/src/composables/print/useSimulationExplorePrintData.ts
@@ -1,17 +1,13 @@
 import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
-import { api } from 'src/api/http';
 import { getHeadcountMembers } from 'src/api/modules';
-import {
-  MODULES,
-  type Module,
-  type Submodule as SubmoduleResponse,
-} from 'src/constant/modules';
+import { MODULES } from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import { sumBreakdownTonnes } from 'src/utils/breakdownTotal';
 import { getExploreModules } from 'src/utils/exploreModules';
-import { buildModulePath } from 'src/utils/modulePath';
+import { fetchAllSubmoduleRows } from 'src/utils/printSubmoduleRows';
 import type { PrintRow } from 'src/utils/printTable';
 
 export function useSimulationExplorePrintData() {
@@ -30,20 +26,9 @@ export function useSimulationExplorePrintData() {
 
   const loading = ref(true);
 
-  const totalTonnesCo2eq = computed(() => {
-    const breakdown = moduleStore.state.emissionBreakdown;
-    if (!breakdown) return 0;
-    const moduleTotal = (breakdown.module_breakdown ?? []).reduce(
-      (sum, row) => {
-        const rowTotal = (row.emissions ?? []).reduce((rowSum, e) => {
-          return rowSum + (typeof e.value === 'number' ? e.value : 0);
-        }, 0);
-        return sum + rowTotal;
-      },
-      0,
-    );
-    return moduleTotal || breakdown.total_tonnes_co2eq || 0;
-  });
+  const totalTonnesCo2eq = computed(() =>
+    sumBreakdownTonnes(moduleStore.state.emissionBreakdown),
+  );
 
   const filteredBreakdown = computed(() => {
     const bd = moduleStore.state.emissionBreakdown;
@@ -98,38 +83,6 @@ export function useSimulationExplorePrintData() {
     return carbonReport?.id ?? null;
   }
 
-  async function fetchSubmoduleRows(
-    moduleType: Module,
-    submoduleId: string,
-    carbonReportId: number,
-  ): Promise<PrintRow[]> {
-    const basePath = `${buildModulePath(
-      moduleType,
-      carbonReportId,
-    )}/${encodeURIComponent(submoduleId)}`;
-
-    const rows: PrintRow[] = [];
-    let page = 1;
-    for (;;) {
-      const queryParams = new URLSearchParams({
-        page: String(page),
-        limit: '1000',
-      });
-      const response = (await api
-        .get(`${basePath}?${queryParams.toString()}`)
-        .json()) as SubmoduleResponse;
-      rows.push(...(response.items as unknown as PrintRow[]));
-      if (
-        !response.items.length ||
-        rows.length >= response.summary.total_items
-      ) {
-        break;
-      }
-      page += 1;
-    }
-    return rows;
-  }
-
   async function fetchAllData(carbonReportId: number) {
     try {
       loading.value = true;
@@ -144,9 +97,11 @@ export function useSimulationExplorePrintData() {
       for (const m of exploreModules.value) {
         for (const sub of m.submodules) {
           tasks.push(
-            fetchSubmoduleRows(m.type, sub.id, carbonReportId).then((rows) => {
-              submoduleRows.value[sub.id] = rows;
-            }),
+            fetchAllSubmoduleRows(m.type, sub.id, carbonReportId).then(
+              (rows) => {
+                submoduleRows.value[sub.id] = rows;
+              },
+            ),
           );
           if (sub.moduleFields.some((f) => f.optionsId === 'kind')) {
             tasks.push(

--- a/frontend/src/constant/planner-headcount.ts
+++ b/frontend/src/constant/planner-headcount.ts
@@ -1,0 +1,18 @@
+/**
+ * The 8 backend SIUS codes (headcount/data_entries.py SIUS_CODE_VALUES), in the
+ * order the planner design lists them. Labels live in i18n/headcount_factor.ts,
+ * keyed by the bare code.
+ */
+export const PLANNER_SIUS_CODES = [
+  '51',
+  '52',
+  '53',
+  '54',
+  '56',
+  '57',
+  '58',
+  '59',
+] as const;
+
+/** The planner's single headcount submodule (a fixed grid, not an add-row table). */
+export const PLANNER_HEADCOUNT_SUBMODULE = 'planner_headcount';

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -224,16 +224,24 @@ export default {
     fr: 'Modifier',
   },
   planner_reference_year_rebuild_hint: {
-    en: 'Prefilled modules are rebuilt from this year.',
-    fr: 'Les modules préremplis sont reconstruits à partir de cette année.',
+    en: 'Prefilled modules are rebuilt from this year — changing it deletes their current data.',
+    fr: 'Les modules préremplis sont reconstruits à partir de cette année — la changer supprime leurs données actuelles.',
   },
   planner_reference_year_dialog_title: {
     en: 'Reference year for {year}',
     fr: 'Année de référence pour {year}',
   },
   planner_reference_year_dialog_consequences: {
-    en: 'Every prefilled module is rebuilt from the year you pick, and its factors come from it. The rows of your current reference year are kept: come back to it and your percentages, edits and deletions are as you left them.',
-    fr: "Chaque module prérempli est reconstruit à partir de l'année choisie, et ses facteurs en proviennent. Les lignes de votre année de référence actuelle sont conservées : en y revenant, vos pourcentages, modifications et suppressions seront intacts.",
+    en: 'Every prefilled module is rebuilt from the year you pick, and its factors come from it.',
+    fr: "Chaque module prérempli est reconstruit à partir de l'année choisie, et ses facteurs en proviennent.",
+  },
+  planner_reference_year_dialog_wipe_warning: {
+    en: 'Changing the reference year deletes all the data of the prefilled modules for this year: the prefilled rows, your percentages, your edits and the rows you added yourself. This cannot be undone.',
+    fr: "Changer l'année de référence supprime toutes les données des modules préremplis de cette année : les lignes préremplies, vos pourcentages, vos modifications et les lignes que vous avez ajoutées. Cette action est irréversible.",
+  },
+  planner_reference_year_dialog_wipe_ack: {
+    en: 'I understand the data of {year} will be deleted',
+    fr: 'Je comprends que les données de {year} seront supprimées',
   },
   planner_module_active_tooltip: {
     en: 'Inactive modules are excluded from sums, graphs and results.',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -208,8 +208,8 @@ export default {
     fr: 'Année de référence',
   },
   planner_reference_year_hint: {
-    en: 'Select a reference year: all factors and prefilled data for this simulation year come from it. The modules below stay locked until you do.',
-    fr: "Sélectionnez une année de référence : tous les facteurs et données préremplies de cette année de simulation en proviennent. Les modules ci-dessous restent verrouillés tant qu'elle n'est pas définie.",
+    en: 'Select a reference year: all factors and prefilled data of this planned year come from it. The modules below stay locked until you do.',
+    fr: "Sélectionnez une année de référence : tous les facteurs et données préremplies de cette année planifiée en proviennent. Les modules ci-dessous restent verrouillés tant qu'elle n'est pas définie.",
   },
   planner_reference_year_error: {
     en: 'Could not set the reference year',
@@ -224,24 +224,28 @@ export default {
     fr: 'Modifier',
   },
   planner_reference_year_rebuild_hint: {
-    en: 'Prefilled modules are rebuilt from this year — changing it deletes their current data.',
-    fr: 'Les modules préremplis sont reconstruits à partir de cette année — la changer supprime leurs données actuelles.',
+    en: 'The prefilled modules of this planned year are rebuilt from the reference year — changing it deletes their current data.',
+    fr: "Les modules préremplis de cette année planifiée sont reconstruits à partir de l'année de référence — la changer supprime leurs données actuelles.",
   },
   planner_reference_year_dialog_title: {
-    en: 'Reference year for {year}',
-    fr: 'Année de référence pour {year}',
+    en: 'Planned year {year}: choose its reference year',
+    fr: 'Année planifiée {year} : choisir son année de référence',
+  },
+  planner_reference_year_dialog_select_label: {
+    en: 'Reference year (source of the data)',
+    fr: 'Année de référence (source des données)',
   },
   planner_reference_year_dialog_consequences: {
-    en: 'Every prefilled module is rebuilt from the year you pick, and its factors come from it.',
-    fr: "Chaque module prérempli est reconstruit à partir de l'année choisie, et ses facteurs en proviennent.",
+    en: 'The prefilled modules of planned year {year} are rebuilt from the reference year you pick, and use its emission factors.',
+    fr: "Les modules préremplis de l'année planifiée {year} sont reconstruits à partir de l'année de référence choisie et utilisent ses facteurs d'émission.",
   },
   planner_reference_year_dialog_wipe_warning: {
-    en: 'Changing the reference year deletes all the data of the prefilled modules for this year: the prefilled rows, your percentages, your edits and the rows you added yourself. This cannot be undone.',
-    fr: "Changer l'année de référence supprime toutes les données des modules préremplis de cette année : les lignes préremplies, vos pourcentages, vos modifications et les lignes que vous avez ajoutées. Cette action est irréversible.",
+    en: 'Changing the reference year deletes everything the prefilled modules of planned year {year} contain: the prefilled rows, your percentages, your edits and the rows you added yourself. The reference year itself keeps its data. This cannot be undone.',
+    fr: "Changer l'année de référence supprime tout ce que contiennent les modules préremplis de l'année planifiée {year} : les lignes préremplies, vos pourcentages, vos modifications et les lignes que vous avez ajoutées. L'année de référence, elle, conserve ses données. Cette action est irréversible.",
   },
   planner_reference_year_dialog_wipe_ack: {
-    en: 'I understand the data of {year} will be deleted',
-    fr: 'Je comprends que les données de {year} seront supprimées',
+    en: 'I understand that my planned data for {year} will be deleted',
+    fr: 'Je comprends que mes données planifiées de {year} seront supprimées',
   },
   planner_module_active_tooltip: {
     en: 'Inactive modules are excluded from sums, graphs and results.',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -279,4 +279,68 @@ export default {
     en: 'Internal EPFL',
     fr: 'Interne EPFL',
   },
+  planner_print_title: {
+    en: 'Project report',
+    fr: 'Rapport de projet',
+  },
+  planner_print_created_by: {
+    en: 'Created by',
+    fr: 'Créé par',
+  },
+  planner_print_created_on: {
+    en: 'Created on',
+    fr: 'Créé le',
+  },
+  planner_print_total_over_years: {
+    en: 'Summed over {count} planned year(s)',
+    fr: 'Somme sur {count} année(s) planifiée(s)',
+  },
+  planner_print_methodology_note: {
+    en: 'Planned figures are estimates: each year draws its emission factors from its reference year. Inactive modules are excluded from every total and chart.',
+    fr: "Les chiffres planifiés sont des estimations : chaque année tire ses facteurs d'émission de son année de référence. Les modules inactifs sont exclus de tous les totaux et graphiques.",
+  },
+  planner_print_incomplete_note: {
+    en: 'Some tables could not be loaded and are missing from this report: {modules}.',
+    fr: 'Certains tableaux n’ont pas pu être chargés et manquent dans ce rapport : {modules}.',
+  },
+  planner_print_year_subtitle: {
+    en: 'Planned carbon footprint — {name}',
+    fr: 'Empreinte carbone planifiée — {name}',
+  },
+  planner_print_year_total: {
+    en: 'Carbon footprint for this year',
+    fr: 'Empreinte carbone de cette année',
+  },
+  planner_print_year_chart_title: {
+    en: '{year} carbon footprint',
+    fr: 'Empreinte carbone {year}',
+  },
+  planner_print_no_reference_year: {
+    en: 'Not set',
+    fr: 'Non définie',
+  },
+  planner_print_excluded_modules: {
+    en: 'Excluded modules',
+    fr: 'Modules exclus',
+  },
+  planner_print_module_subtitle: {
+    en: 'Planned data {year}',
+    fr: 'Données planifiées {year}',
+  },
+  planner_headcount_table_title: {
+    en: 'Planned FTE per category',
+    fr: 'EPT planifiés par catégorie',
+  },
+  planner_headcount_category_col: {
+    en: 'Category',
+    fr: 'Catégorie',
+  },
+  planner_headcount_fte_col: {
+    en: 'FTE',
+    fr: 'EPT',
+  },
+  planner_headcount_total_fte: {
+    en: 'Total FTE',
+    fr: 'Total EPT',
+  },
 };

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -98,6 +98,7 @@
                 size="md"
                 color="accent"
                 class="text-weight-medium"
+                @click="downloadReport"
               />
             </div>
           </div>
@@ -114,6 +115,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
@@ -126,11 +128,13 @@ import {
 } from 'src/stores/simulatorPlans';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useYearConfigStore } from 'src/stores/yearConfig';
+import { sumBreakdownTonnes } from 'src/utils/breakdownTotal';
 import { toEmissionBreakdown } from 'src/utils/emissionStatsAdapter';
 import { formatTonnesCO2 } from 'src/utils/number';
 
 const route = useRoute();
 const router = useRouter();
+const { locale } = useI18n();
 const workspaceStore = useWorkspaceStore();
 const plansStore = useSimulatorPlansStore();
 const yearConfigStore = useYearConfigStore();
@@ -151,18 +155,20 @@ const breakdown = computed(() =>
     : null,
 );
 
-const totalTonnesCo2eq = computed(() => {
-  if (!breakdown.value) return 0;
-  // Summed off the same rows the chart draws, so headline and bars agree.
-  const moduleTotal = breakdown.value.module_breakdown.reduce((sum, row) => {
-    const rowTotal = (row.emissions ?? []).reduce(
-      (rowSum, e) => rowSum + (typeof e.value === 'number' ? e.value : 0),
-      0,
-    );
-    return sum + rowTotal;
-  }, 0);
-  return moduleTotal || breakdown.value.total_tonnes_co2eq || 0;
-});
+const totalTonnesCo2eq = computed(() => sumBreakdownTonnes(breakdown.value));
+
+function downloadReport() {
+  const url = router.resolve({
+    name: 'project-planner-print',
+    params: {
+      language: locale.value.split('-')[0],
+      unit: route.params.unit,
+      year: route.params.year,
+      name: route.params.name,
+    },
+  }).href;
+  window.open(url, '_blank');
+}
 
 // Reference years are constrained to years open in the Calculator.
 const referenceYearOptions = computed(() =>

--- a/frontend/src/pages/app/ProjectPlannerPrintPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPrintPage.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import BigNumber from 'src/components/molecules/BigNumber.vue';
+import ReportPage from 'src/components/organisms/ReportPage.vue';
+import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import PlannerPrintHeadcountTable from 'src/components/organisms/print/PlannerPrintHeadcountTable.vue';
+import PlannerPrintModulePage from 'src/components/organisms/print/PlannerPrintModulePage.vue';
+import PlannerPrintYearPage from 'src/components/organisms/print/PlannerPrintYearPage.vue';
+import PrintReportShell from 'src/components/organisms/print/PrintReportShell.vue';
+import { useProjectPlannerPrintData } from 'src/composables/print/useProjectPlannerPrintData';
+import { formatTonnesCO2 } from 'src/utils/number';
+import { toPrintDocumentTitle } from 'src/utils/unitPerimeterLabel';
+
+const { t } = useI18n();
+
+const {
+  loading,
+  notFound,
+  plan,
+  planYears,
+  yearRangeLabel,
+  scopeLabel,
+  planBreakdown,
+  totalTonnesCo2eq,
+  yearBreakdowns,
+  yearTotalTonnes,
+  headcountRows,
+  incompleteModules,
+  sheets,
+  moduleTables,
+  initWorkspaceFromRoute,
+  fetchAllData,
+} = useProjectPlannerPrintData();
+
+const createdAtLabel = computed(() => {
+  const createdAt = plan.value?.created_at;
+  if (!createdAt) return '';
+  const parsed = new Date(createdAt);
+  return Number.isNaN(parsed.getTime())
+    ? ''
+    : parsed.toLocaleDateString('de-CH');
+});
+
+onMounted(async () => {
+  const resolved = await initWorkspaceFromRoute();
+  if (!resolved) {
+    notFound.value = true;
+    loading.value = false;
+    return;
+  }
+
+  await fetchAllData();
+
+  // Chrome seeds the "Save as PDF" filename from the document title.
+  document.title = toPrintDocumentTitle(
+    plan.value?.name ?? scopeLabel.value,
+    t('planner_print_title'),
+  );
+});
+</script>
+
+<template>
+  <PrintReportShell
+    :loading="loading"
+    :empty="notFound || plan === null"
+    :empty-message="$t('project_planner_not_found')"
+  >
+    <template v-if="plan">
+      <ReportPage
+        :title="$t('planner_print_title')"
+        :scope="scopeLabel"
+        :page-number="1"
+        :is-first="true"
+      >
+        <h2 class="text-h5 q-mt-none report-h2">
+          {{ $t('planner_print_title') }}
+        </h2>
+        <div class="text-body2 text-secondary">{{ plan.name }}</div>
+
+        <dl class="project-facts q-mt-md">
+          <div class="project-facts__row">
+            <dt>{{ $t('planner_year_selection_label') }}</dt>
+            <dd>{{ yearRangeLabel || '–' }}</dd>
+          </div>
+          <div v-if="plan.creator_name" class="project-facts__row">
+            <dt>{{ $t('planner_print_created_by') }}</dt>
+            <dd>{{ plan.creator_name }}</dd>
+          </div>
+          <div v-if="createdAtLabel" class="project-facts__row">
+            <dt>{{ $t('planner_print_created_on') }}</dt>
+            <dd>{{ createdAtLabel }}</dd>
+          </div>
+        </dl>
+
+        <div class="q-mt-md">
+          <BigNumber
+            :title="$t('planner_results_total_tonnes_co2eq')"
+            :number="formatTonnesCO2(totalTonnesCo2eq)"
+            :comparison="
+              $t('planner_print_total_over_years', {
+                count: planYears.length,
+              })
+            "
+            color="info"
+            :print-mode="true"
+          />
+        </div>
+
+        <section class="q-mt-md">
+          <ModuleCarbonFootprintChart
+            :breakdown-data="planBreakdown"
+            :title="$t('planner_results_chart_title', { name: plan.name })"
+            :print-mode="true"
+          />
+        </section>
+
+        <p class="text-caption text-secondary q-mt-md q-mb-none">
+          {{ $t('planner_print_methodology_note') }}
+        </p>
+        <p
+          v-if="incompleteModules.length"
+          class="text-caption q-mt-sm q-mb-none"
+        >
+          {{
+            $t('planner_print_incomplete_note', {
+              modules: incompleteModules.join(', '),
+            })
+          }}
+        </p>
+      </ReportPage>
+
+      <template v-for="sheet in sheets" :key="sheet.key">
+        <PlannerPrintYearPage
+          v-if="sheet.kind === 'year'"
+          :year="sheet.year"
+          :page-number="sheet.pageNumber"
+          :scope="scopeLabel"
+          :plan-name="plan.name"
+          :breakdown="yearBreakdowns[sheet.year.id] ?? null"
+          :total-tonnes="yearTotalTonnes(sheet.year)"
+        />
+
+        <ReportPage
+          v-else-if="sheet.kind === 'headcount'"
+          :title="$t('headcount')"
+          :scope="scopeLabel"
+          :page-number="sheet.pageNumber"
+          flow
+        >
+          <h2 class="text-h5 q-mt-none">{{ $t('headcount') }}</h2>
+          <div class="text-body2 text-secondary q-mb-lg">
+            {{ $t('planner_print_module_subtitle', { year: sheet.year.year }) }}
+          </div>
+          <PlannerPrintHeadcountTable
+            :rows="headcountRows[sheet.year.id] ?? []"
+          />
+        </ReportPage>
+
+        <PlannerPrintModulePage
+          v-else
+          :module="sheet.module"
+          :year="sheet.year.year"
+          :page-number="sheet.pageNumber"
+          :scope="scopeLabel"
+          :tables="moduleTables(sheet.year, sheet.module)"
+        />
+      </template>
+    </template>
+  </PrintReportShell>
+</template>
+
+<style scoped lang="scss">
+.report-h2 {
+  letter-spacing: -0.01em;
+}
+
+.project-facts {
+  margin: 0;
+  font-size: 11px;
+
+  &__row {
+    display: flex;
+    gap: 6px;
+  }
+
+  dt {
+    opacity: 0.7;
+  }
+
+  dd {
+    margin: 0;
+    font-weight: 600;
+  }
+}
+</style>

--- a/frontend/src/pages/app/ResultsPrintPage.vue
+++ b/frontend/src/pages/app/ResultsPrintPage.vue
@@ -9,6 +9,7 @@ import CarbonFootPrintPerPersonChart from 'src/components/charts/results/CarbonF
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
 import AdditionalCategoriesSection from 'src/components/organisms/AdditionalCategoriesSection.vue';
 import ItFocusSection from 'src/components/organisms/ItFocusSection.vue';
+import PrintReportShell from 'src/components/organisms/print/PrintReportShell.vue';
 import ResultsPrintModulePage from 'src/components/organisms/print/ResultsPrintModulePage.vue';
 import { useResultsPrintData } from 'src/composables/print/useResultsPrintData';
 import { useModuleStore } from 'src/stores/modules';
@@ -117,10 +118,6 @@ function formatPercentChange(value: number | null | undefined): string {
   return percentChangeFormatter.format(value / 100);
 }
 
-function printReport() {
-  window.print();
-}
-
 onMounted(async () => {
   const carbonReportId = await initWorkspaceFromRoute();
   if (!carbonReportId) return;
@@ -137,23 +134,8 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="bg-grey-2 print-report">
-    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
-      <q-space />
-      <q-btn
-        color="accent"
-        icon="o_print"
-        size="md"
-        class="text-weight-medium"
-        :label="$t('results_print')"
-        @click="printReport"
-      />
-    </q-toolbar>
-
-    <div
-      v-if="resultsSummary && !resultsSummaryLoading"
-      class="report-container"
-    >
+  <PrintReportShell :loading="resultsSummaryLoading || !resultsSummary">
+    <template v-if="resultsSummary">
       <ReportPage
         :title="$t('results_print_title')"
         :scope="scopeLabel"
@@ -327,27 +309,12 @@ onMounted(async () => {
           />
         </q-card>
       </ReportPage>
-    </div>
-  </div>
+    </template>
+  </PrintReportShell>
 </template>
 
 <style scoped lang="scss">
 @use 'src/css/02-tokens' as tokens;
-
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: tokens.$print-report-container-padding;
-  color: tokens.$color-text !important;
-}
-
-.toolbar {
-  position: sticky;
-  top: 0;
-  border-bottom: 1px solid var(--half-muted-color);
-  z-index: tokens.$print-toolbar-z-index;
-}
 
 .module-page-header {
   margin-bottom: 0px;
@@ -437,47 +404,6 @@ onMounted(async () => {
   :deep(a) {
     color: var(--title-color) !important;
     text-decoration: underline !important;
-  }
-}
-</style>
-
-<!-- Not scoped: print rules hide layout chrome (.q-header/.q-footer/.q-drawer)
-     that lives outside this page's template, and reach into rendered .q-card. -->
-<style lang="scss">
-@use 'src/css/02-tokens' as tokens;
-
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: tokens.$print-report-container-padding;
-  color: tokens.$color-text;
-}
-
-.print-toolbar {
-  position: sticky;
-  top: 0;
-  border-bottom: 1px solid var(--half-muted-color);
-  z-index: tokens.$print-toolbar-z-index;
-}
-
-@media print {
-  .print-hide,
-  .q-header,
-  .q-footer,
-  .q-drawer {
-    display: none;
-  }
-
-  .report-container {
-    display: block;
-    width: 100%;
-    padding: 0;
-  }
-
-  .print-report .q-card,
-  .print-report .q-card-section {
-    box-shadow: none;
   }
 }
 </style>

--- a/frontend/src/pages/app/SimulationExplorePrintPage.vue
+++ b/frontend/src/pages/app/SimulationExplorePrintPage.vue
@@ -3,6 +3,7 @@ import { onMounted } from 'vue';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import PrintReportShell from 'src/components/organisms/print/PrintReportShell.vue';
 import SimulationExplorePrintModulePage from 'src/components/organisms/print/SimulationExplorePrintModulePage.vue';
 import { useSimulationExplorePrintData } from 'src/composables/print/useSimulationExplorePrintData';
 import { formatTonnesCO2 } from 'src/utils/number';
@@ -19,10 +20,6 @@ const {
   fetchAllData,
 } = useSimulationExplorePrintData();
 
-function printReport() {
-  window.print();
-}
-
 onMounted(async () => {
   const carbonReportId = await initWorkspaceFromRoute();
   if (!carbonReportId) return;
@@ -31,114 +28,49 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="bg-grey-2 print-report">
-    <q-toolbar class="bg-ac text-primary q-py-sm print-hide">
-      <q-space />
-      <q-btn
-        color="accent"
-        icon="o_print"
-        size="md"
-        class="text-weight-medium"
-        :label="$t('results_print')"
-        @click="printReport"
-      />
-    </q-toolbar>
+  <PrintReportShell :loading="loading">
+    <ReportPage
+      :title="$t('simulation_explore_page_title')"
+      :page-number="1"
+      :is-first="true"
+    >
+      <h2 class="text-h5 q-mt-none">
+        {{ $t('simulation_explore_page_title') }}
+      </h2>
+      <div class="text-body2 text-secondary q-mb-lg">
+        {{ $t('simulation_explore_print_subtitle', { year: currentYear }) }}
+      </div>
 
-    <div v-if="!loading" class="report-container">
-      <ReportPage
-        :title="$t('simulation_explore_page_title')"
-        :page-number="1"
-        :is-first="true"
-      >
-        <h2 class="text-h5 q-mt-none">
-          {{ $t('simulation_explore_page_title') }}
-        </h2>
-        <div class="text-body2 text-secondary q-mb-lg">
-          {{ $t('simulation_explore_print_subtitle', { year: currentYear }) }}
-        </div>
+      <div class="q-mb-lg">
+        <BigNumber
+          :title="$t('simulation_explore_page_results_total_tonnes_co2eq')"
+          :number="formatTonnesCO2(totalTonnesCo2eq)"
+          color="accent"
+          :print-mode="true"
+        />
+      </div>
 
-        <div class="q-mb-lg">
-          <BigNumber
-            :title="$t('simulation_explore_page_results_total_tonnes_co2eq')"
-            :number="formatTonnesCO2(totalTonnesCo2eq)"
-            color="accent"
-            :print-mode="true"
-          />
-        </div>
+      <section>
+        <ModuleCarbonFootprintChart :breakdown-data="filteredBreakdown" />
+      </section>
+    </ReportPage>
 
-        <section>
-          <ModuleCarbonFootprintChart :breakdown-data="filteredBreakdown" />
-        </section>
-      </ReportPage>
-
-      <SimulationExplorePrintModulePage
-        v-for="(m, idx) in exploreModules"
-        :key="m.type"
-        :module="m"
-        :page-number="idx + 2"
-        :current-year="currentYear"
-        :submodule-rows="submoduleRows"
-        :headcount-members="headcountMembers"
-      />
-    </div>
-  </div>
+    <SimulationExplorePrintModulePage
+      v-for="(m, idx) in exploreModules"
+      :key="m.type"
+      :module="m"
+      :page-number="idx + 2"
+      :current-year="currentYear"
+      :submodule-rows="submoduleRows"
+      :headcount-members="headcountMembers"
+    />
+  </PrintReportShell>
 </template>
 
 <style scoped lang="scss">
-@use 'src/css/02-tokens' as tokens;
-
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: tokens.$print-report-container-padding;
-  color: tokens.$color-text !important;
-}
-
 @media print {
   .bg-grey-3 {
     background: white !important;
-  }
-}
-</style>
-
-<!-- Not scoped: print rules hide layout chrome (.q-header/.q-footer/.q-drawer)
-     that lives outside this page's template, and reach into rendered .q-card. -->
-<style lang="scss">
-@use 'src/css/02-tokens' as tokens;
-
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: tokens.$print-report-container-padding;
-  color: tokens.$color-text;
-}
-
-.print-toolbar {
-  position: sticky;
-  top: 0;
-  border-bottom: 1px solid var(--half-muted-color);
-  z-index: tokens.$print-toolbar-z-index;
-}
-
-@media print {
-  .print-hide,
-  .q-header,
-  .q-footer,
-  .q-drawer {
-    display: none;
-  }
-
-  .report-container {
-    display: block;
-    width: 100%;
-    padding: 0;
-  }
-
-  .print-report .q-card,
-  .print-report .q-card-section {
-    box-shadow: none;
   }
 }
 </style>

--- a/frontend/src/pages/back-office/BackofficeResultsPrintPage.vue
+++ b/frontend/src/pages/back-office/BackofficeResultsPrintPage.vue
@@ -2,6 +2,7 @@
 import { onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
+import PrintReportShell from 'src/components/organisms/print/PrintReportShell.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
@@ -33,10 +34,6 @@ const hasData = computed(
   () => !loading.value && reportingEmissionBreakdown.value != null,
 );
 
-function printReport() {
-  window.print();
-}
-
 onMounted(async () => {
   await fetchData();
   // Chrome seeds the "Save as PDF" filename from the document title.
@@ -48,123 +45,105 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="bg-grey-2 print-report">
-    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
-      <q-space />
-      <q-btn
-        color="accent"
-        icon="o_print"
-        size="md"
-        class="text-weight-medium"
-        :label="$t('results_print')"
-        @click="printReport"
-      />
-    </q-toolbar>
+  <PrintReportShell :loading="loading" :empty="!hasData">
+    <!-- Page 1: Title, scope, big numbers -->
+    <ReportPage
+      :title="$t('backoffice_reporting_print_results_title')"
+      :scope="scopeLabel"
+      :page-number="1"
+      :is-first="true"
+    >
+      <h2 class="text-h5 q-mt-none">
+        {{ $t('backoffice_reporting_print_results_title') }}
+      </h2>
+      <div v-if="scopeLabel" class="text-body2 text-secondary q-mb-lg">
+        {{ scopeLabel }}
+      </div>
 
-    <div v-if="loading" class="flex justify-center q-pa-xl print-hide">
-      <q-spinner color="accent" size="3em" />
-    </div>
+      <div class="q-mt-md">
+        <CompletionRateBar
+          :validated-units="validatedCount"
+          :total-units="tableTotal"
+          :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
+          :print-mode="true"
+        />
+      </div>
 
-    <div v-else-if="hasData" class="report-container">
-      <!-- Page 1: Title, scope, big numbers -->
-      <ReportPage
-        :title="$t('backoffice_reporting_print_results_title')"
-        :scope="scopeLabel"
-        :page-number="1"
-        :is-first="true"
-      >
-        <h2 class="text-h5 q-mt-none">
-          {{ $t('backoffice_reporting_print_results_title') }}
-        </h2>
-        <div v-if="scopeLabel" class="text-body2 text-secondary q-mb-lg">
-          {{ scopeLabel }}
-        </div>
+      <div class="big-numbers-grid q-mt-lg">
+        <BigNumber
+          :title="$t('results_total_unit_carbon_footprint')"
+          :number="
+            $nOrDash(totalTonnes, {
+              options: {
+                minimumFractionDigits: 1,
+                maximumFractionDigits: 1,
+              },
+            })
+          "
+          color="negative"
+          :print-mode="true"
+        />
+        <BigNumber
+          :title="$t('results_carbon_footprint_per_person')"
+          :number="
+            $nOrDash(tonnesPerFte, {
+              options: {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              },
+            })
+          "
+          :unit="$t('results_units_tonnes')"
+          :print-mode="true"
+        />
+      </div>
+      <section class="q-mt-md">
+        <ModuleCarbonFootprintChart
+          :breakdown-data="reportingEmissionBreakdown"
+          :print-mode="true"
+          :title="$t('backoffice_reporting_aggregated_results_title')"
+        />
+      </section>
+      <section class="q-mt-md">
+        <CarbonFootPrintPerPersonChart
+          :per-person-breakdown="perPersonBreakdown"
+          :validated-categories="validatedCategories"
+          :headcount-validated="headcountValidated"
+          :show-validation-placeholder="false"
+          :print-mode="true"
+          :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
+        />
+      </section>
+    </ReportPage>
 
-        <div class="q-mt-md">
-          <CompletionRateBar
-            :validated-units="validatedCount"
-            :total-units="tableTotal"
-            :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
-            :print-mode="true"
-          />
-        </div>
+    <ReportPage :scope="scopeLabel">
+      <section v-if="reportingItBreakdown" class="q-mt-md">
+        <ItFocusBreakdownChart
+          :data="reportingItBreakdown"
+          :print-mode="true"
+          :compact="true"
+          :title="$t('backoffice_reporting_it_focus_title')"
+        />
+      </section>
+    </ReportPage>
 
-        <div class="big-numbers-grid q-mt-lg">
-          <BigNumber
-            :title="$t('results_total_unit_carbon_footprint')"
-            :number="
-              $nOrDash(totalTonnes, {
-                options: {
-                  minimumFractionDigits: 1,
-                  maximumFractionDigits: 1,
-                },
-              })
-            "
-            color="negative"
-            :print-mode="true"
-          />
-          <BigNumber
-            :title="$t('results_carbon_footprint_per_person')"
-            :number="
-              $nOrDash(tonnesPerFte, {
-                options: {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                },
-              })
-            "
-            :unit="$t('results_units_tonnes')"
-            :print-mode="true"
-          />
-        </div>
-        <section class="q-mt-md">
-          <ModuleCarbonFootprintChart
-            :breakdown-data="reportingEmissionBreakdown"
-            :print-mode="true"
-            :title="$t('backoffice_reporting_aggregated_results_title')"
-          />
-        </section>
-        <section class="q-mt-md">
-          <CarbonFootPrintPerPersonChart
-            :per-person-breakdown="perPersonBreakdown"
-            :validated-categories="validatedCategories"
-            :headcount-validated="headcountValidated"
-            :show-validation-placeholder="false"
-            :print-mode="true"
-            :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
-          />
-        </section>
-      </ReportPage>
-
-      <ReportPage :scope="scopeLabel">
-        <section v-if="reportingItBreakdown" class="q-mt-md">
-          <ItFocusBreakdownChart
-            :data="reportingItBreakdown"
-            :print-mode="true"
-            :compact="true"
-            :title="$t('backoffice_reporting_it_focus_title')"
-          />
-        </section>
-      </ReportPage>
-
-      <!-- One page per module: treemap + emission type breakdown -->
-      <ReportPage
-        v-for="(mod, i) in availableModules"
-        :key="mod"
-        :title="$t('backoffice_reporting_print_results_title')"
-        :page-number="2 + i"
-      >
-        <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>
-        <div class="q-mt-md">
-          <EmissionBreakdownChart
-            :breakdown-data="reportingEmissionBreakdown"
-            :forced-module="mod"
-            height="200px"
-          />
-        </div>
-      </ReportPage>
-    </div>
-  </div>
+    <!-- One page per module: treemap + emission type breakdown -->
+    <ReportPage
+      v-for="(mod, i) in availableModules"
+      :key="mod"
+      :title="$t('backoffice_reporting_print_results_title')"
+      :page-number="2 + i"
+    >
+      <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>
+      <div class="q-mt-md">
+        <EmissionBreakdownChart
+          :breakdown-data="reportingEmissionBreakdown"
+          :forced-module="mod"
+          height="200px"
+        />
+      </div>
+    </ReportPage>
+  </PrintReportShell>
 </template>
 
 <style scoped lang="scss">
@@ -172,46 +151,5 @@ onMounted(async () => {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
-}
-</style>
-
-<!-- Not scoped: print rules hide layout chrome (.q-header/.q-footer/.q-drawer)
-     that lives outside this page's template, and reach into rendered .q-card. -->
-<style lang="scss">
-@use 'src/css/02-tokens' as tokens;
-
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: tokens.$print-report-container-padding;
-  color: tokens.$color-text;
-}
-
-.print-toolbar {
-  position: sticky;
-  top: 0;
-  border-bottom: 1px solid var(--half-muted-color);
-  z-index: tokens.$print-toolbar-z-index;
-}
-
-@media print {
-  .print-hide,
-  .q-header,
-  .q-footer,
-  .q-drawer {
-    display: none;
-  }
-
-  .report-container {
-    display: block;
-    width: 100%;
-    padding: 0;
-  }
-
-  .print-report .q-card,
-  .print-report .q-card-section {
-    box-shadow: none;
-  }
 }
 </style>

--- a/frontend/src/pages/back-office/ReportingPrintPage.vue
+++ b/frontend/src/pages/back-office/ReportingPrintPage.vue
@@ -2,6 +2,7 @@
 import { onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
+import PrintReportShell from 'src/components/organisms/print/PrintReportShell.vue';
 import CompletionRateBar from 'src/components/organisms/backoffice/reporting/CompletionRateBar.vue';
 import ReportingStatCards from 'src/components/organisms/backoffice/reporting/ReportingStatCards.vue';
 import ReportingStatCardUnit from 'src/components/organisms/backoffice/reporting/ReportingStatCardUnit.vue';
@@ -33,10 +34,6 @@ const {
 const hasData = computed(() => !loading.value && tableTotal.value > 0);
 const showStatCards = computed(() => tableRows.value.length !== 1);
 
-function printReport() {
-  window.print();
-}
-
 onMounted(async () => {
   await fetchData();
   // Chrome seeds the "Save as PDF" filename from the document title.
@@ -48,148 +45,89 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="bg-grey-2 print-report">
-    <q-toolbar class="bg-ac text-primary q-py-sm print-toolbar print-hide">
-      <q-space />
-      <q-btn
-        color="accent"
-        icon="o_print"
-        size="md"
-        class="text-weight-medium"
-        :label="$t('results_print')"
-        @click="printReport"
-      />
-    </q-toolbar>
+  <PrintReportShell :loading="loading" :empty="!hasData">
+    <!-- Page 1: Title, completion rate, usage stats + aggregate charts -->
+    <ReportPage
+      :title="$t('backoffice_reporting_print_combined_title')"
+      :scope="scopeLabel"
+      :page-number="1"
+      :is-first="true"
+    >
+      <h2 class="text-h5 q-mt-none">
+        {{ $t('backoffice_reporting_print_combined_title') }}
+      </h2>
+      <div class="text-body2 text-secondary">{{ scopeLabel }}</div>
 
-    <div v-if="loading" class="flex justify-center q-pa-xl print-hide">
-      <q-spinner color="accent" size="3em" />
-    </div>
+      <div class="q-mt-md">
+        <CompletionRateBar
+          :validated-units="validatedCount"
+          :total-units="tableTotal"
+          :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
+          :print-mode="true"
+        />
+      </div>
 
-    <div v-else-if="hasData" class="report-container">
-      <!-- Page 1: Title, completion rate, usage stats + aggregate charts -->
-      <ReportPage
-        :title="$t('backoffice_reporting_print_combined_title')"
-        :scope="scopeLabel"
-        :page-number="1"
-        :is-first="true"
-      >
-        <h2 class="text-h5 q-mt-none">
-          {{ $t('backoffice_reporting_print_combined_title') }}
-        </h2>
-        <div class="text-body2 text-secondary">{{ scopeLabel }}</div>
+      <section class="q-mt-lg">
+        <ReportingStatCards v-if="showStatCards" :stats="usageStats" />
+        <ReportingStatCardUnit
+          v-else
+          :validated-modules="moduleStats[MODULE_STATES.Validated]"
+          :total-modules="totalModules"
+        />
+      </section>
 
-        <div class="q-mt-md">
-          <CompletionRateBar
-            :validated-units="validatedCount"
-            :total-units="tableTotal"
-            :scope-label="$t('backoffice_reporting_completion_bar_scope_table')"
-            :print-mode="true"
-          />
-        </div>
+      <section class="q-mt-md">
+        <ModuleCarbonFootprintChart
+          :breakdown-data="reportingEmissionBreakdown"
+          :print-mode="true"
+          :title="$t('backoffice_reporting_aggregated_results_title')"
+        />
+      </section>
+      <section class="q-mt-md">
+        <CarbonFootPrintPerPersonChart
+          :per-person-breakdown="
+            reportingEmissionBreakdown?.per_person_breakdown ?? null
+          "
+          :validated-categories="
+            reportingEmissionBreakdown?.validated_categories ?? null
+          "
+          :headcount-validated="
+            reportingEmissionBreakdown?.headcount_validated ?? false
+          "
+          :show-validation-placeholder="false"
+          :print-mode="true"
+          :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
+        />
+      </section>
+    </ReportPage>
 
-        <section class="q-mt-lg">
-          <ReportingStatCards v-if="showStatCards" :stats="usageStats" />
-          <ReportingStatCardUnit
-            v-else
-            :validated-modules="moduleStats[MODULE_STATES.Validated]"
-            :total-modules="totalModules"
-          />
-        </section>
+    <ReportPage :scope="scopeLabel">
+      <section v-if="reportingItBreakdown" class="q-mt-md">
+        <ItFocusBreakdownChart
+          :data="reportingItBreakdown"
+          :print-mode="true"
+          :compact="true"
+          :title="$t('backoffice_reporting_it_focus_title')"
+        />
+      </section>
+    </ReportPage>
 
-        <section class="q-mt-md">
-          <ModuleCarbonFootprintChart
-            :breakdown-data="reportingEmissionBreakdown"
-            :print-mode="true"
-            :title="$t('backoffice_reporting_aggregated_results_title')"
-          />
-        </section>
-        <section class="q-mt-md">
-          <CarbonFootPrintPerPersonChart
-            :per-person-breakdown="
-              reportingEmissionBreakdown?.per_person_breakdown ?? null
-            "
-            :validated-categories="
-              reportingEmissionBreakdown?.validated_categories ?? null
-            "
-            :headcount-validated="
-              reportingEmissionBreakdown?.headcount_validated ?? false
-            "
-            :show-validation-placeholder="false"
-            :print-mode="true"
-            :title="$t('backoffice_reporting_aggregated_results_per_fte_title')"
-          />
-        </section>
-      </ReportPage>
-
-      <ReportPage :scope="scopeLabel">
-        <section v-if="reportingItBreakdown" class="q-mt-md">
-          <ItFocusBreakdownChart
-            :data="reportingItBreakdown"
-            :print-mode="true"
-            :compact="true"
-            :title="$t('backoffice_reporting_it_focus_title')"
-          />
-        </section>
-      </ReportPage>
-
-      <!-- One page per module: treemap + emission type breakdown -->
-      <ReportPage
-        v-for="(mod, i) in availableModules"
-        :key="mod"
-        :title="$t('backoffice_reporting_print_combined_title')"
-        :scope="scopeLabel"
-        :page-number="2 + i"
-      >
-        <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>
-        <div class="q-mt-md">
-          <EmissionBreakdownChart
-            :breakdown-data="reportingEmissionBreakdown"
-            :forced-module="mod"
-            height="200px"
-          />
-        </div>
-      </ReportPage>
-    </div>
-  </div>
+    <!-- One page per module: treemap + emission type breakdown -->
+    <ReportPage
+      v-for="(mod, i) in availableModules"
+      :key="mod"
+      :title="$t('backoffice_reporting_print_combined_title')"
+      :scope="scopeLabel"
+      :page-number="2 + i"
+    >
+      <h2 class="text-h5 q-mt-none">{{ $t(mod) }}</h2>
+      <div class="q-mt-md">
+        <EmissionBreakdownChart
+          :breakdown-data="reportingEmissionBreakdown"
+          :forced-module="mod"
+          height="200px"
+        />
+      </div>
+    </ReportPage>
+  </PrintReportShell>
 </template>
-
-<!-- Not scoped: print rules hide layout chrome (.q-header/.q-footer/.q-drawer)
-     that lives outside this page's template, and reach into rendered .q-card. -->
-<style lang="scss">
-@use 'src/css/02-tokens' as tokens;
-
-.report-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: tokens.$print-report-container-padding;
-  color: tokens.$color-text;
-}
-
-.print-toolbar {
-  position: sticky;
-  top: 0;
-  border-bottom: 1px solid var(--half-muted-color);
-  z-index: tokens.$print-toolbar-z-index;
-}
-
-@media print {
-  .print-hide,
-  .q-header,
-  .q-footer,
-  .q-drawer {
-    display: none;
-  }
-
-  .report-container {
-    display: block;
-    width: 100%;
-    padding: 0;
-  }
-
-  .print-report .q-card,
-  .print-report .q-card-section {
-    box-shadow: none;
-  }
-}
-</style>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -79,6 +79,24 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // Project planner print preview — own layout, no header/sidebar
+  {
+    path: `/:language(${LANGUAGE_PATTERN})/:unit(${UNIT_PATTERN})/:year(${YEAR_PATTERN})/simulation/project-planner/:name(${SIMULATION_ID_PATTERN})/print`,
+    component: () => import('layouts/PrintLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: 'project-planner-print',
+        component: () => import('pages/app/ProjectPlannerPrintPage.vue'),
+        meta: {
+          requiresAuth: true,
+          note: 'Project Planner – Print/PDF preview (no chrome)',
+          breadcrumb: false,
+          carbonProject: CARBON_PROJECT.planner,
+        },
+      },
+    ],
+  },
   // Backoffice reporting print previews — own layout, no header/sidebar
   {
     path: `/:language(${LANGUAGE_PATTERN})/back-office/reporting/print`,

--- a/frontend/src/utils/breakdownTotal.ts
+++ b/frontend/src/utils/breakdownTotal.ts
@@ -1,0 +1,29 @@
+import type { EmissionBreakdownResponse } from 'src/stores/modules';
+
+/**
+ * Total tonnes summed off the same rows the module chart draws, so a headline
+ * figure and the bars beneath it always agree.
+ *
+ * Deliberately not `stats.total` from the backend: that counts every bucket,
+ * including the additional categories (commuting, food, waste, embodied
+ * energy) which `module_breakdown` — and so the chart — leaves out. Reading it
+ * here would put a headline on the page that the bars below it contradict,
+ * which is the buildings-banner discrepancy all over again.
+ *
+ * The backend has no module-only total to read instead; adding one (as the
+ * banner fix did for a single module) would retire this helper.
+ */
+export function sumBreakdownTonnes(
+  breakdown: EmissionBreakdownResponse | null | undefined,
+): number {
+  if (!breakdown) return 0;
+  const moduleTotal = (breakdown.module_breakdown ?? []).reduce((sum, row) => {
+    const rowTotal = (row.emissions ?? []).reduce(
+      (rowSum, emission) =>
+        rowSum + (typeof emission.value === 'number' ? emission.value : 0),
+      0,
+    );
+    return sum + rowTotal;
+  }, 0);
+  return moduleTotal || breakdown.total_tonnes_co2eq || 0;
+}

--- a/frontend/src/utils/plannerPrintModules.ts
+++ b/frontend/src/utils/plannerPrintModules.ts
@@ -1,0 +1,36 @@
+import type { ModuleConfig, Submodule } from 'src/constant/moduleConfig';
+import { MODULES, type Module } from 'src/constant/modules';
+import {
+  PLANNER_MODULES,
+  type PlannerBehavior,
+} from 'src/constant/planner-module-config';
+import { getPlannerModuleConfig } from 'src/constant/planner-module-config/module-configs';
+
+export interface PlannerPrintModule {
+  type: Module;
+  behavior: PlannerBehavior;
+  config: ModuleConfig;
+  submodules: Submodule[];
+}
+
+/**
+ * The planner's data-table modules, in Calculator order, rendered with the same
+ * configs the Simulator Plan page uses (planner Purchase, no CSV top bar,
+ * traveler categories).
+ *
+ * Headcount is excluded: it is a fixed SIUS-category grid, not a data table —
+ * the print report renders it through PlannerPrintHeadcountTable.
+ */
+export function getPlannerPrintModules(): PlannerPrintModule[] {
+  return PLANNER_MODULES.filter((entry) => entry.module !== MODULES.Headcount)
+    .map((entry) => {
+      const config = getPlannerModuleConfig(entry.module);
+      return {
+        type: entry.module,
+        behavior: entry.behavior,
+        config,
+        submodules: config.submodules ?? [],
+      };
+    })
+    .filter((module) => module.submodules.length > 0);
+}

--- a/frontend/src/utils/printSubmoduleRows.ts
+++ b/frontend/src/utils/printSubmoduleRows.ts
@@ -1,0 +1,43 @@
+import { api } from 'src/api/http';
+import type {
+  Module,
+  Submodule as SubmoduleResponse,
+} from 'src/constant/modules';
+import { buildModulePath } from 'src/utils/modulePath';
+import type { PrintRow } from 'src/utils/printTable';
+
+/** The API caps `limit` at 1000, so that is the largest page worth asking for. */
+const PAGE_LIMIT = 1000;
+
+/**
+ * Every row of one submodule, following pagination to the end — a print report
+ * shows the whole table, not the first page of it.
+ */
+export async function fetchAllSubmoduleRows(
+  moduleType: Module,
+  submoduleId: string,
+  carbonReportId: number,
+): Promise<PrintRow[]> {
+  const basePath = `${buildModulePath(
+    moduleType,
+    carbonReportId,
+  )}/${encodeURIComponent(submoduleId)}`;
+
+  const rows: PrintRow[] = [];
+  let page = 1;
+  for (;;) {
+    const queryParams = new URLSearchParams({
+      page: String(page),
+      limit: String(PAGE_LIMIT),
+    });
+    const response = (await api
+      .get(`${basePath}?${queryParams.toString()}`)
+      .json()) as SubmoduleResponse;
+    rows.push(...(response.items as unknown as PrintRow[]));
+    if (!response.items.length || rows.length >= response.summary.total_items) {
+      break;
+    }
+    page += 1;
+  }
+  return rows;
+}

--- a/frontend/src/utils/printTable.ts
+++ b/frontend/src/utils/printTable.ts
@@ -27,9 +27,44 @@ export interface PrintCellContext {
   numberFormatOptions?: Intl.NumberFormatOptions;
 }
 
+/**
+ * Planner prefilled tables carry the reference-year kgCO₂eq and the "% of
+ * reference year" the row was scaled by — the two values that explain how a
+ * planned figure was derived. Mirrors the column placement ModuleTable uses
+ * on screen: reference before the current kgCO₂eq, percentage after it.
+ */
+function withReferenceColumns(
+  columns: PrintColumn[],
+  t: PrintTranslateFn,
+): PrintColumn[] {
+  const referenceColumn: PrintColumn = {
+    name: 'reference_kg_co2eq',
+    label: t('planner_reference_kg_col'),
+    field: 'reference_kg_co2eq',
+    align: 'right',
+  };
+  const percentageColumn: PrintColumn = {
+    name: 'percentage_of_reference_year',
+    label: t('planner_percentage_col'),
+    field: 'percentage_of_reference_year',
+    align: 'right',
+  };
+
+  const kgIndex = columns.findIndex((column) => column.name === 'kg_co2eq');
+  if (kgIndex < 0) return [...columns, referenceColumn, percentageColumn];
+  return [
+    ...columns.slice(0, kgIndex),
+    referenceColumn,
+    columns[kgIndex] as PrintColumn,
+    percentageColumn,
+    ...columns.slice(kgIndex + 1),
+  ];
+}
+
 export function buildPrintColumns(
   fields: ModuleField[],
   t: PrintTranslateFn,
+  showReferenceColumns = false,
 ): PrintColumn[] {
   const columns: PrintColumn[] = [];
 
@@ -60,7 +95,7 @@ export function buildPrintColumns(
       });
     });
 
-  return columns;
+  return showReferenceColumns ? withReferenceColumns(columns, t) : columns;
 }
 
 export function renderPrintCell(
@@ -81,44 +116,63 @@ export function renderPrintCell(
   if (col.field === 'traveler_name') {
     const userInstitutionalId = row['user_institutional_id'] as
       string | undefined;
-    if (userInstitutionalId != null) {
-      return ctx.headcountMembers.get(userInstitutionalId) ?? '-';
-    }
-    return '-';
+    if (userInstitutionalId == null) return '-';
+    const member = ctx.headcountMembers.get(userInstitutionalId);
+    if (member) return member;
+    // The planner has no per-person roster; its travelers are categories.
+    const categoryKey = `planner_traveler_category.${userInstitutionalId}`;
+    return ctx.te(categoryKey) ? ctx.t(categoryKey) : '-';
   }
 
   const val = row[col.field];
   if (val === undefined || val === null || val === '') return '-';
 
-  if (col.name === 'kg_co2eq' || col.name === 't_co2eq') {
+  if (
+    col.name === 'kg_co2eq' ||
+    col.name === 't_co2eq' ||
+    col.name === 'reference_kg_co2eq'
+  ) {
     return ctx.formatNumber(val as number, {
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     });
   }
 
-  if (col.options && typeof val === 'string') {
-    const option = col.options.find((opt) => opt.value === val);
-    if (option) {
-      return ctx.te(option.label) ? ctx.t(option.label) : option.label;
+  if (col.name === 'percentage_of_reference_year') {
+    return `${ctx.formatNumber(val as number, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })}%`;
+  }
+
+  // Label sources are tried in order and only a translatable one wins: the
+  // planner's option lists carry the raw value as their label and rely on
+  // `optionLabelKey`, so an untranslatable option must not short-circuit.
+  if (typeof val === 'string') {
+    const option = col.options?.find((opt) => opt.value === val);
+    if (option && ctx.te(option.label)) return ctx.t(option.label);
+
+    if (col.optionLabelPrefix) {
+      const key = val.toLowerCase();
+      if (ctx.te(key)) return ctx.t(key);
     }
+
+    if (col.optionLabelKey) {
+      const key = col.optionLabelKey.replace('{value}', val.toLowerCase());
+      // The planner borrows Calculator table titles as category labels, and
+      // those carry a "({count})" suffix that means nothing on a value cell.
+      if (ctx.te(key)) {
+        return ctx.t(key, { count: '' }).replace(/\s*\(\s*\)$/, '');
+      }
+    }
+
+    if (col.optionsId === 'kind') {
+      return ctx.taxonomyKindLabels[val] ?? val;
+    }
+
+    return option?.label ?? val;
   }
 
-  if (col.optionLabelPrefix && typeof val === 'string') {
-    const key = val.toLowerCase();
-    return ctx.te(key) ? ctx.t(key) : val;
-  }
-
-  if (col.optionLabelKey && typeof val === 'string') {
-    const key = col.optionLabelKey.replace('{value}', val.toLowerCase());
-    return ctx.te(key) ? ctx.t(key) : val;
-  }
-
-  if (col.optionsId === 'kind' && typeof val === 'string') {
-    return ctx.taxonomyKindLabels[val] ?? val;
-  }
-
-  if (typeof val === 'string') return val;
   if (typeof val === 'number') {
     return ctx.formatNumber(val, ctx.numberFormatOptions);
   }


### PR DESCRIPTION
## What does this change?
Adds a printable/exportable PDF report for the Simulator Planner (Project Planner), following the same pattern as the existing Calculator and Simulator Explore print pages. Also includes several related fixes and refactors:

- New `ProjectPlannerPrintPage.vue` with cover page, per-year pages, per-module pages, and a headcount table, built via a new `useProjectPlannerPrintData` composable.
- Extracted a shared `PrintReportShell.vue` component, deduplicating the print toolbar/loading/empty-state markup across all print pages (Results, Simulation Explore, Backoffice Results, Reporting).
- the PLANNER_SNAPSHOT copies with their percentages and edits, and the rows the user added by hand — then the new reference year's Calculator entries are copied in at 100%. Rows are no longer stamped with data['reference_year'] and a module holds exactly one baseline, so the multi-baseline read path is gone (no reference_year_filter helpers, no reference_year parameters threaded through the submodule/stats queries). The wipe runs before the reference year's Calculator report is resolved, so switching to a year with no Calculator data leaves the modules empty instead of showing the previous baseline's rows. Backed by a new DataEntryRepository.bulk_delete_by_modules(); emissions follow the data_entry_id cascade.
- Fixed a bug where the Comment button was disabled on Planner tables due to a global timeline store leaking Calculator validation state; introduced `utils/module-table-access.ts` (`isModuleTableDisabled` / `isModuleNoteDisabled`) and renamed `isSimulator` → `isExplorer`.
- Added a new `PlannerReferenceYearDialog.vue` for changing the reference year, replacing the inline select.
- Removed `bootstrap_years.py`, `seed_reduction_objectives.py`, `seed_reference_data.py`, and the `make bootstrap-years` target; repointed `seed_generic_factors.py` at `backend/seed_data/`.
- New `constant/carbon-project.ts` to centralize resolving unit/year to a carbon report id across Calculator/Explorer/Planner contexts.

<img width="692" height="473" alt="Screenshot 2026-07-27 at 13 41 52" src="https://github.com/user-attachments/assets/f9bc2e83-1a4e-4984-b78c-40cc7d5d14e7" />



## Why is this needed?
Users planning multi-year carbon reduction projects had no way to export/print their plan as a shareable PDF report, unlike the Calculator and Explore views. Additionally, switching the Planner's reference year was destructive (losing user-edited sliders/percentages), and a UI bug was silently disabling comments in the Planner due to state leaking from the Calculator's validation lock.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1859
- Related to #1557 (Planner frontend follow-ups — Comment button fix)

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.