### PR TITLE
fix(backoffice): exclude simulator reports (#462)

### DIFF
--- a/backend/app/api/v1/backoffice.py
+++ b/backend/app/api/v1/backoffice.py
@@ -43,8 +43,10 @@ from app.core.constants import (
 )
 from app.core.logging import get_logger
 from app.core.security import get_current_active_user
+from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import (
     CarbonReport,
+    CarbonReportType,
 )
 from app.models.module_type import (
     DEFAULT_COMPLETION_PROGRESS,
@@ -421,7 +423,15 @@ async def get_available_years(
     exist for units inside their scope subtree (#862).
     """
     is_global, affiliations = gate_backoffice(current_user, "view")
-    stmt = select(CarbonReport.year).distinct()
+    stmt = (
+        select(CarbonReport.year)
+        .distinct()
+        .join(
+            CarbonProject,
+            col(CarbonReport.carbon_project_id) == col(CarbonProject.id),
+        )
+        .where(col(CarbonProject.carbon_report_type) == CarbonReportType.CALCULATOR)
+    )
     if not is_global:
         if not affiliations:
             return {"years": [], "latest": ""}

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -419,6 +419,18 @@ class CarbonReportModuleRepository:
         return stmt
 
     @staticmethod
+    def _calculator_only(stmt: Any) -> Any:
+        """Restrict a CarbonReport-joined statement to Calculator projects.
+
+        Simulator Explore and Simulator Plan reports are ``carbon_reports`` rows
+        as well; backoffice reporting must never mix them into the assessment.
+        """
+        return stmt.join(
+            CarbonProject,
+            col(CarbonReport.carbon_project_id) == col(CarbonProject.id),
+        ).where(col(CarbonProject.carbon_report_type) == CarbonReportType.CALCULATOR)
+
+    @staticmethod
     def _get_completion_status_from_progress(
         completion_progress: Optional[str],
     ) -> ModuleStatus:
@@ -509,6 +521,7 @@ class CarbonReportModuleRepository:
                 .where(col(CarbonReport.year).in_(years))
                 .group_by(col(CarbonReport.unit_id))
             )
+            unit_rollup_stmt = self._calculator_only(unit_rollup_stmt)
             if hierarchy_unit_ids is not None:
                 unit_rollup_stmt = unit_rollup_stmt.where(
                     col(CarbonReport.unit_id).in_(hierarchy_unit_ids)
@@ -541,6 +554,7 @@ class CarbonReportModuleRepository:
                 .where(col(CarbonReport.year).in_(years))
                 .group_by(col(CarbonReport.overall_status))
             )
+            status_count_stmt = self._calculator_only(status_count_stmt)
             if hierarchy_unit_ids is not None:
                 status_count_stmt = status_count_stmt.where(
                     col(Unit.id).in_(hierarchy_unit_ids)
@@ -560,6 +574,7 @@ class CarbonReportModuleRepository:
             .join(CarbonReport, col(CarbonReport.unit_id) == Unit.id)
             .where(col(CarbonReport.year).in_(years))
         )
+        base_count_stmt = self._calculator_only(base_count_stmt)
         if hierarchy_unit_ids is not None:
             base_count_stmt = base_count_stmt.where(
                 col(Unit.id).in_(hierarchy_unit_ids)
@@ -600,9 +615,11 @@ class CarbonReportModuleRepository:
 
             # Correlated subquery: stats from the most recent selected year.
             latest_stats_subq = (
-                select(CarbonReport.stats)
-                .where(CarbonReport.unit_id == Unit.id)
-                .where(col(CarbonReport.year).in_(years))
+                self._calculator_only(
+                    select(CarbonReport.stats)
+                    .where(CarbonReport.unit_id == Unit.id)
+                    .where(col(CarbonReport.year).in_(years))
+                )
                 .order_by(desc(CarbonReport.year))
                 .limit(1)
                 .correlate(Unit)
@@ -630,6 +647,7 @@ class CarbonReportModuleRepository:
                 .where(col(CarbonReport.year).in_(years))
                 .group_by(Unit.id, Unit.name, Unit.path_name, User.display_name)
             )
+            units_stmt = self._calculator_only(units_stmt)
         else:
             # Single year: one row per unit, module-level completion progress.
             units_stmt_columns = [
@@ -652,15 +670,18 @@ class CarbonReportModuleRepository:
                 )
                 .where(col(CarbonReport.year).in_(years))
             )
+            units_stmt = self._calculator_only(units_stmt)
 
         units_stmt = self._apply_report_filters(
             units_stmt, hierarchy_unit_ids, overall_status
         )
 
         filtered_report_ids_stmt = self._apply_report_filters(
-            select(col(CarbonReport.id))
-            .join(Unit, col(CarbonReport.unit_id) == col(Unit.id))
-            .where(col(CarbonReport.year).in_(years)),
+            self._calculator_only(
+                select(col(CarbonReport.id))
+                .join(Unit, col(CarbonReport.unit_id) == col(Unit.id))
+                .where(col(CarbonReport.year).in_(years))
+            ),
             hierarchy_unit_ids,
             overall_status,
         )
@@ -885,6 +906,7 @@ class CarbonReportModuleRepository:
             .join(Unit, Unit.id == CarbonReport.unit_id)
             .order_by(CarbonReport.id, CarbonReportModule.module_type_id)
         )
+        statement = self._calculator_only(statement)
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
         if overall_status is not None:
@@ -1058,6 +1080,7 @@ class CarbonReportModuleRepository:
                 col(User.display_name),
             )
         )
+        statement = self._calculator_only(statement)
 
         # Additional filters based on provided parameters
         if years:
@@ -1186,6 +1209,7 @@ class CarbonReportModuleRepository:
             .join(Unit, Unit.id == CarbonReport.unit_id)
             .order_by(CarbonReport.id)
         )
+        statement = self._calculator_only(statement)
         if years:
             statement = statement.where(col(CarbonReport.year).in_(years))
         if overall_status is not None:

--- a/backend/tests/unit/repositories/test_carbon_report_module_repo.py
+++ b/backend/tests/unit/repositories/test_carbon_report_module_repo.py
@@ -7,6 +7,8 @@ Covers CRUD operations, static helpers, and reporting queries
 import pytest
 
 from app.core.constants import ModuleStatus
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReportType
 from app.models.module_type import ModuleTypeEnum
 from app.repositories.carbon_report_module_repo import CarbonReportModuleRepository
 from app.schemas.carbon_report import CarbonReportModuleCreate
@@ -527,6 +529,43 @@ class TestGetReportingOverview:
         result = await repo.get_reporting_overview(years=[2024])
         assert result["total"] == 0
         assert result["data"] == []
+
+    async def test_excludes_simulator_reports(
+        self, db_session, make_unit, make_carbon_report
+    ):
+        unit = await make_unit(db_session, name="LAB-SIM")
+        await make_carbon_report(
+            db_session,
+            unit_id=unit.id,
+            year=2024,
+            completion_progress="8/8",
+            overall_status=ModuleStatus.VALIDATED,
+            stats={"total": 12000.0},
+        )
+        for report_type in (
+            CarbonReportType.SIMULATOR_PLAN,
+            CarbonReportType.SIMULATOR_EXPLORE,
+        ):
+            project = CarbonProject(unit_id=unit.id, carbon_report_type=report_type)
+            db_session.add(project)
+            await db_session.flush()
+            await make_carbon_report(
+                db_session,
+                unit_id=unit.id,
+                year=2024,
+                carbon_project_id=project.id,
+                completion_progress="0/8",
+                stats={"total": 5000.0},
+            )
+
+        repo = CarbonReportModuleRepository(db_session)
+        result = await repo.get_reporting_overview(years=[2024])
+
+        assert result["total"] == 1
+        assert result["total_units_count"] == 1
+        assert result["validated_units_count"] == 1
+        assert [row["total_carbon_footprint"] for row in result["data"]] == [12.0]
+        assert result["stats"]["total"] == 12000.0
 
     async def test_scoped_overview_clamps_to_subtree(
         self, db_session, make_unit, make_carbon_report


### PR DESCRIPTION
## What does this change?
Restricts backoffice reporting queries to only include Carbon Calculator reports, excluding Simulator (Plan and Explore) reports. Adds a `_calculator_only` helper to `CarbonReportModuleRepository` that joins to `CarbonProject` and filters on `carbon_report_type == CarbonReportType.CALCULATOR`, and applies it across all relevant reporting queries (unit rollups, status counts, base counts, latest stats subquery, units statements, filtered report IDs, and other reporting statements). Also updates the `get_available_years` endpoint in `backoffice.py` to join `CarbonProject` and filter to Calculator-type reports. Adds a new unit test verifying simulator reports are excluded from the reporting overview.

## Why is this needed?
Simulator Explore and Simulator Plan reports are stored as `carbon_reports` rows just like Calculator reports, but they were being included in backoffice reporting/statistics, producing incorrect totals and counts (wrong results, #462). This change ensures only actual Calculator submissions are counted in backoffice views.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #462

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.