### PR TITLE
feat/1861 purchases submodule totals global budget ux

### DIFF
--- a/backend/app/modules_planner/purchase/__init__.py
+++ b/backend/app/modules_planner/purchase/__init__.py
@@ -1,4 +1,4 @@
-"""Planner purchases: manual CHF totals per submodule XOR one global budget.
+"""Planner purchases: manual EUR totals per submodule XOR one global budget.
 
 Importing this package registers the module and factor handlers
 (metaclass side effect in ``handlers``/``factors``).

--- a/backend/app/modules_planner/purchase/data_entries.py
+++ b/backend/app/modules_planner/purchase/data_entries.py
@@ -21,14 +21,14 @@ def _validate_category(v: str) -> str:
 
 class PlannerPurchaseResponse(DataEntryResponseGen):
     purchase_category: str
-    amount_chf: float
+    amount_eur: float
     note: Optional[str] = None
     kg_co2eq: Optional[float] = None
 
 
 class PlannerPurchaseCreate(DataEntryCreate):
     purchase_category: str
-    amount_chf: float = Field(ge=0)
+    amount_eur: float = Field(ge=0)
     note: Optional[str] = None
 
     @field_validator("purchase_category", mode="after")
@@ -39,7 +39,7 @@ class PlannerPurchaseCreate(DataEntryCreate):
 
 class PlannerPurchaseUpdate(DataEntryUpdate):
     purchase_category: Optional[str] = None
-    amount_chf: Optional[float] = Field(default=None, ge=0)
+    amount_eur: Optional[float] = Field(default=None, ge=0)
     note: Optional[str] = None
 
     @field_validator("purchase_category", mode="after")
@@ -51,16 +51,16 @@ class PlannerPurchaseUpdate(DataEntryUpdate):
 
 
 class PlannerPurchaseBudgetResponse(DataEntryResponseGen):
-    amount_chf: float
+    amount_eur: float
     note: Optional[str] = None
     kg_co2eq: Optional[float] = None
 
 
 class PlannerPurchaseBudgetCreate(DataEntryCreate):
-    amount_chf: float = Field(ge=0)
+    amount_eur: float = Field(ge=0)
     note: Optional[str] = None
 
 
 class PlannerPurchaseBudgetUpdate(DataEntryUpdate):
-    amount_chf: Optional[float] = Field(default=None, ge=0)
+    amount_eur: Optional[float] = Field(default=None, ge=0)
     note: Optional[str] = None

--- a/backend/app/modules_planner/purchase/derived_factors.py
+++ b/backend/app/modules_planner/purchase/derived_factors.py
@@ -1,0 +1,130 @@
+"""Planner purchase factors, derived from the Calculator's.
+
+The planner prices a budget with one average EF per category, plus one for a
+global budget; the Calculator stores one EF per procurement code. A category's
+planner factor is the mean over its codes, and the global one is the mean of
+those category means — so it weights categories equally rather than following
+whichever category happens to carry the most codes.
+
+Both sides are per EUR, the currency the Calculator's purchase factors are
+uploaded in, so nothing is converted anywhere.
+
+Derivation runs as part of a purchase factor upload, for the year that upload
+covers — planner reports resolve every factor from their reference year, so a
+plan whose reference year has no Calculator purchase factors resolves nothing.
+"""
+
+from collections.abc import Mapping, Sequence
+
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.data_entry import DataEntryTypeEnum
+from app.models.factor import Factor
+from app.modules.emissions import EmissionType
+from app.modules_planner.purchase.emissions import PLANNER_PURCHASE_EMISSIONS
+from app.repositories.factor_repo import FactorRepository
+
+logger = get_logger(__name__)
+
+# The planner's category slugs are the Calculator's purchase entry types by
+# the same name — derived, so the two cannot drift.
+SOURCE_TYPE_BY_CATEGORY: dict[str, DataEntryTypeEnum] = {
+    category: DataEntryTypeEnum[category] for category in PLANNER_PURCHASE_EMISSIONS
+}
+PURCHASE_SOURCE_TYPES: frozenset[DataEntryTypeEnum] = frozenset(
+    SOURCE_TYPE_BY_CATEGORY.values()
+)
+
+SOURCE_EF_KEY = "ef_kg_co2eq_per_currency"
+PLANNER_EF_KEY = "ef_kg_co2eq_per_eur"
+
+
+def category_means(
+    efs_by_category: Mapping[str, Sequence[float]],
+) -> dict[str, float]:
+    """The mean EF of each category that the year has factors for.
+
+    A category with none is left out rather than defaulted: the planner then
+    shows it as unpriced, which is what it is.
+    """
+    return {
+        category: sum(efs) / len(efs)
+        for category, efs in efs_by_category.items()
+        if efs
+    }
+
+
+def global_mean(means: Mapping[str, float]) -> float:
+    """The global budget weights every category equally, not every code."""
+    return sum(means.values()) / len(means)
+
+
+def build_factors(means: Mapping[str, float], year: int) -> list[Factor]:
+    """One factor per priced category, plus the global-budget one."""
+    factors = [
+        Factor(
+            emission_type_id=PLANNER_PURCHASE_EMISSIONS[category].value,
+            data_entry_type_id=DataEntryTypeEnum.planner_purchase.value,
+            classification={"purchase_category": category},
+            values={PLANNER_EF_KEY: round(mean, 6)},
+            year=year,
+        )
+        for category, mean in means.items()
+    ]
+    factors.append(
+        Factor(
+            emission_type_id=EmissionType.purchases__goods_and_services.value,
+            data_entry_type_id=DataEntryTypeEnum.planner_purchase_budget.value,
+            classification={},
+            values={PLANNER_EF_KEY: round(global_mean(means), 6)},
+            year=year,
+        )
+    )
+    return factors
+
+
+async def _collect_source_efs(
+    session: AsyncSession, year: int
+) -> dict[str, list[float]]:
+    """Read the Calculator's purchase factors for ``year``, keyed by category."""
+    category_by_type = {
+        source.value: category for category, source in SOURCE_TYPE_BY_CATEGORY.items()
+    }
+    stmt = select(Factor).where(
+        col(Factor.data_entry_type_id).in_(list(category_by_type)),
+        col(Factor.year) == year,
+    )
+    efs: dict[str, list[float]] = {category: [] for category in SOURCE_TYPE_BY_CATEGORY}
+    for factor in (await session.exec(stmt)).all():
+        ef = factor.values.get(SOURCE_EF_KEY)
+        if ef is None:
+            raise ValueError(
+                f"Factor {factor.id} carries no {SOURCE_EF_KEY} — cannot average it "
+                "into a planner purchase factor"
+            )
+        efs[category_by_type[factor.data_entry_type_id]].append(float(ef))
+    return efs
+
+
+async def derive_planner_purchase_factors(
+    session: AsyncSession, year: int, job_id: int | None
+) -> int:
+    """Recompute the planner purchase factors for ``year``. Returns rows written.
+
+    Upserts on the factor identity key, so the rows keep their ids across
+    re-uploads and the emissions pointing at them stay valid. Runs in the
+    caller's transaction.
+    """
+    means = category_means(await _collect_source_efs(session, year))
+    if not means:
+        raise ValueError(
+            f"No Calculator purchase factors for {year} to derive planner "
+            "purchase factors from"
+        )
+    affected = await FactorRepository(session).upsert_factors(
+        build_factors(means, year), job_id
+    )
+    logger.info(f"Derived {affected} planner purchase factors for {year}")
+    return affected

--- a/backend/app/modules_planner/purchase/emissions.py
+++ b/backend/app/modules_planner/purchase/emissions.py
@@ -1,4 +1,4 @@
-"""Emission resolution for planner purchases (manual CHF totals)."""
+"""Emission resolution for planner purchases (manual EUR totals)."""
 
 from app.modules.emissions.taxonomy import EmissionType
 

--- a/backend/app/modules_planner/purchase/factors.py
+++ b/backend/app/modules_planner/purchase/factors.py
@@ -15,7 +15,7 @@ from app.schemas.factor import (
 
 class PlannerPurchaseFactorCreate(FactorCreate):
     purchase_category: str
-    ef_kg_co2eq_per_chf: float = Field(ge=0)
+    ef_kg_co2eq_per_eur: float = Field(ge=0)
 
     @field_validator("purchase_category", mode="after")
     @classmethod
@@ -25,16 +25,16 @@ class PlannerPurchaseFactorCreate(FactorCreate):
 
 class PlannerPurchaseFactorUpdate(FactorUpdate):
     purchase_category: Optional[str] = None
-    ef_kg_co2eq_per_chf: Optional[float] = Field(default=None, ge=0)
+    ef_kg_co2eq_per_eur: Optional[float] = Field(default=None, ge=0)
 
 
 class PlannerPurchaseFactorResponse(FactorResponseGen):
     purchase_category: str
-    ef_kg_co2eq_per_chf: float
+    ef_kg_co2eq_per_eur: float
 
 
 class PlannerPurchaseFactorHandler(BaseFactorHandler):
-    """Average EF (kg CO2e per CHF) per purchase submodule."""
+    """Average EF (kg CO2e per EUR) per purchase submodule."""
 
     data_entry_type: DataEntryTypeEnum | None = None
     registration_keys = [DataEntryTypeEnum.planner_purchase]
@@ -45,23 +45,23 @@ class PlannerPurchaseFactorHandler(BaseFactorHandler):
     response_dto = PlannerPurchaseFactorResponse
 
     classification_fields: list[str] = ["purchase_category"]
-    value_fields: list[str] = ["ef_kg_co2eq_per_chf"]
+    value_fields: list[str] = ["ef_kg_co2eq_per_eur"]
 
 
 class PlannerPurchaseBudgetFactorCreate(FactorCreate):
-    ef_kg_co2eq_per_chf: float = Field(ge=0)
+    ef_kg_co2eq_per_eur: float = Field(ge=0)
 
 
 class PlannerPurchaseBudgetFactorUpdate(FactorUpdate):
-    ef_kg_co2eq_per_chf: Optional[float] = Field(default=None, ge=0)
+    ef_kg_co2eq_per_eur: Optional[float] = Field(default=None, ge=0)
 
 
 class PlannerPurchaseBudgetFactorResponse(FactorResponseGen):
-    ef_kg_co2eq_per_chf: float
+    ef_kg_co2eq_per_eur: float
 
 
 class PlannerPurchaseBudgetFactorHandler(BaseFactorHandler):
-    """Average EF (kg CO2e per CHF) for a global research budget."""
+    """Average EF (kg CO2e per EUR) for a global research budget."""
 
     data_entry_type: DataEntryTypeEnum | None = None
     registration_keys = [DataEntryTypeEnum.planner_purchase_budget]
@@ -72,4 +72,4 @@ class PlannerPurchaseBudgetFactorHandler(BaseFactorHandler):
     response_dto = PlannerPurchaseBudgetFactorResponse
 
     classification_fields: list[str] = []
-    value_fields: list[str] = ["ef_kg_co2eq_per_chf"]
+    value_fields: list[str] = ["ef_kg_co2eq_per_eur"]

--- a/backend/app/modules_planner/purchase/handlers.py
+++ b/backend/app/modules_planner/purchase/handlers.py
@@ -20,10 +20,10 @@ from app.schemas.data_entry import BaseModuleHandler
 class _PlannerPurchaseBase(BaseModuleHandler):
     """Shared behavior of the two planner purchase kinds.
 
-    Emissions are ``amount_chf × ef_kg_co2eq_per_chf`` from factors keyed
-    on the planner kind itself — the methodology (average EF per CHF)
-    ships as factor data, not code. Entries without a matching factor
-    simply carry no kg_co2eq yet.
+    Emissions are ``amount_eur × ef_kg_co2eq_per_eur`` from factors keyed
+    on the planner kind itself — averages of the Calculator's purchase
+    factors, derived when those are uploaded (see ``derived_factors``).
+    Entries without a matching factor carry no kg_co2eq.
     """
 
     module_type: ModuleTypeEnum = ModuleTypeEnum.purchase
@@ -73,14 +73,14 @@ class _PlannerPurchaseBase(BaseModuleHandler):
                     kind=kind,
                     subkind=None,
                 ),
-                formula_key="ef_kg_co2eq_per_chf",
-                quantity_key="amount_chf",
+                formula_key="ef_kg_co2eq_per_eur",
+                quantity_key="amount_eur",
             )
         ]
 
 
 class PlannerPurchaseModuleHandler(_PlannerPurchaseBase):
-    """Manual CHF total per purchase submodule."""
+    """Manual EUR total per purchase submodule."""
 
     data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.planner_purchase
     create_dto = PlannerPurchaseCreate
@@ -94,12 +94,12 @@ class PlannerPurchaseModuleHandler(_PlannerPurchaseBase):
     sort_map = {
         "id": DataEntry.id,
         "purchase_category": DataEntry.data["purchase_category"].as_string(),
-        "amount_chf": DataEntry.data["amount_chf"].as_float(),
+        "amount_eur": DataEntry.data["amount_eur"].as_float(),
     }
 
 
 class PlannerPurchaseBudgetModuleHandler(_PlannerPurchaseBase):
-    """Single global CHF budget (mutually exclusive with submodule totals)."""
+    """Single global EUR budget (mutually exclusive with submodule totals)."""
 
     data_entry_type: DataEntryTypeEnum = DataEntryTypeEnum.planner_purchase_budget
     create_dto = PlannerPurchaseBudgetCreate
@@ -110,5 +110,5 @@ class PlannerPurchaseBudgetModuleHandler(_PlannerPurchaseBase):
     filter_map: dict[str, Any] = {}
     sort_map = {
         "id": DataEntry.id,
-        "amount_chf": DataEntry.data["amount_chf"].as_float(),
+        "amount_eur": DataEntry.data["amount_eur"].as_float(),
     }

--- a/backend/app/repositories/factor_repo.py
+++ b/backend/app/repositories/factor_repo.py
@@ -127,7 +127,7 @@ class FactorRepository:
     async def upsert_factors(
         self,
         factors: List[Factor],
-        current_job_id: int,
+        current_job_id: Optional[int],
     ) -> int:
         """Insert-or-update factors keyed on the identity index.
 
@@ -140,7 +140,8 @@ class FactorRepository:
         Preserves ``factor.id`` for existing rows so downstream references —
         including the ``DataEntryEmission.primary_factor_id`` FK — stay valid
         across reuploads.  Stamps ``last_seen_job_id`` so callers can later
-        detect rows not present in the current batch.
+        detect rows not present in the current batch; seed runs have no job
+        and leave it NULL.
 
         Postgres-only: relies on ``INSERT ... ON CONFLICT DO UPDATE``.
 
@@ -177,7 +178,7 @@ class FactorRepository:
     async def _upsert_via_copy(
         self,
         factors: List[Factor],
-        current_job_id: int,
+        current_job_id: Optional[int],
     ) -> int:
         """COPY → staging → ``INSERT … SELECT … ON CONFLICT`` upsert.
 
@@ -225,7 +226,7 @@ class FactorRepository:
     async def _upsert_subset(
         self,
         factors: List[Factor],
-        current_job_id: int,
+        current_job_id: Optional[int],
         *,
         year_present: bool,
     ) -> int:

--- a/backend/app/services/data_ingestion/base_factor_csv_provider.py
+++ b/backend/app/services/data_ingestion/base_factor_csv_provider.py
@@ -20,6 +20,10 @@ from app.models.data_ingestion import (
 from app.models.factor import Factor
 from app.models.module_type import MODULE_TYPE_TO_DATA_ENTRY_TYPES, ModuleTypeEnum
 from app.models.user import User
+from app.modules_planner.purchase.derived_factors import (
+    PURCHASE_SOURCE_TYPES,
+    derive_planner_purchase_factors,
+)
 from app.repositories.factor_repo import FactorRepository
 from app.schemas.factor import BaseFactorHandler
 from app.seed.seed_helper import get_factor_emission_type_id
@@ -232,9 +236,11 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
                             extra_metadata=dict(stats),
                         )
 
-            return await self._finalize_and_commit(
+            result = await self._finalize_and_commit(
                 batch, factor_service, stats, setup_result, factor_repo
             )
+            await self._derive_dependent_factors(result)
+            return result
         except Exception as e:
             logger.error(f"CSV processing failed: {str(e)}", exc_info=True)
             await self.data_session.rollback()
@@ -588,6 +594,28 @@ class BaseFactorCSVProvider(DataIngestionProvider, ABC):
             "skipped": stats["rows_skipped"],
             "stats": stats,
         }
+
+    async def _derive_dependent_factors(self, result: Dict[str, Any]) -> None:
+        """Refresh factors that are averages of the ones this upload carried.
+
+        The planner's purchase factors are one such: they exist so a plan can
+        price a budget, and they are only correct while they match the
+        Calculator factors they average — so they are rebuilt here, in the
+        upload's own transaction, rather than maintained apart.
+
+        Skipped on a partial upload: averaging a set where some rows are the
+        new upload's and some are the previous one's publishes a number that
+        matches neither.
+        """
+        if result["result"] != IngestionResult.SUCCESS or self.year is None:
+            return
+        # What the rows actually carried, not what the module allows: the
+        # centralized-purchases CSV is valid for the same module and prices
+        # none of the categories these averages are taken over.
+        if self._upserted_det_ids & {det.value for det in PURCHASE_SOURCE_TYPES}:
+            await derive_planner_purchase_factors(
+                self.data_session, self.year, self.job_id
+            )
 
     async def _delete_stale_factors(self, factor_repo: FactorRepository) -> int:
         """Delete factors this job's upsert just superseded.

--- a/backend/app/services/data_ingestion/csv_providers/local_seed.py
+++ b/backend/app/services/data_ingestion/csv_providers/local_seed.py
@@ -178,6 +178,10 @@ class LocalFactorCSVProvider(ModulePerYearFactorCSVProvider):
 
         factor_service = FactorService(self.data_session)
         await self._process_batch(batch, factor_service)
+        # Recorded here too: the base class tracks it in the upsert this
+        # override replaces, and post-ingest steps read it to know what
+        # the run actually wrote.
+        self._upserted_det_ids.update(f.data_entry_type_id for f in batch)
         return len(batch)
 
     async def _finalize_and_commit(
@@ -192,7 +196,7 @@ class LocalFactorCSVProvider(ModulePerYearFactorCSVProvider):
     ) -> Dict[str, Any]:
 
         if batch:
-            await self._process_batch(batch, factor_service)
+            await self._upsert_batch(batch, factor_repo)
 
         await self.data_session.flush()
 

--- a/backend/tests/integration/services/data_ingestion/test_backoffice_factor_upload_green_box_pg.py
+++ b/backend/tests/integration/services/data_ingestion/test_backoffice_factor_upload_green_box_pg.py
@@ -42,6 +42,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 import app.api.deps as deps_module
 from app.main import app
+from app.models.data_entry import DataEntryTypeEnum
 from app.models.data_ingestion import (
     DataIngestionJob,
     IngestionMethod,
@@ -49,6 +50,7 @@ from app.models.data_ingestion import (
     IngestionState,
     TargetType,
 )
+from app.models.factor import Factor
 from app.models.module_type import ModuleTypeEnum
 from app.models.user import UserProvider
 from app.models.year_configuration import YearConfiguration
@@ -215,6 +217,50 @@ async def test_factor_csv_upload_dispatches_and_finishes_without_error(
     assert job.job_type == "factor_ingest"
     assert job.target_type == TargetType.FACTORS
     assert job.result == IngestionResult.SUCCESS, job.status_message
+
+    # The planner's per-CHF averages are derived from this upload, in its own
+    # transaction — a plan priced against them can never lag the Calculator.
+    async with factory() as s:
+        derived = (
+            (
+                await s.execute(
+                    select(Factor).where(
+                        col(Factor.data_entry_type_id)
+                        == DataEntryTypeEnum.planner_purchase.value,
+                        col(Factor.year) == YEAR,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {f.classification["purchase_category"] for f in derived} == {
+        "scientific_equipment",
+        "it_equipment",
+        "consumable_accessories",
+        "biological_chemical_gaseous_product",
+        "services",
+    }, "one derived factor per category the CSV priced"
+    assert all(f.values["ef_kg_co2eq_per_eur"] > 0 for f in derived)
+
+    async with factory() as s:
+        budget = (
+            (
+                await s.execute(
+                    select(Factor).where(
+                        col(Factor.data_entry_type_id)
+                        == DataEntryTypeEnum.planner_purchase_budget.value
+                    )
+                )
+            )
+            .scalars()
+            .one()
+        )
+    # The global budget averages the category means, so it is not pulled by
+    # whichever category the CSV happens to carry the most codes for.
+    assert budget.values["ef_kg_co2eq_per_eur"] == pytest.approx(
+        sum(f.values["ef_kg_co2eq_per_eur"] for f in derived) / len(derived), rel=1e-4
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/modules/test_planner_purchase_derived_factors.py
+++ b/backend/tests/unit/modules/test_planner_purchase_derived_factors.py
@@ -1,0 +1,63 @@
+"""Deriving the planner purchase factors from the Calculator's."""
+
+import pytest
+
+from app.models.data_entry import DataEntryTypeEnum
+from app.modules.emissions import EmissionType
+from app.modules_planner.purchase.derived_factors import (
+    PLANNER_EF_KEY,
+    SOURCE_TYPE_BY_CATEGORY,
+    build_factors,
+    category_means,
+    global_mean,
+)
+
+
+def test_a_category_factor_is_the_mean_of_its_codes():
+    means = category_means({"services": [0.2, 0.4, 0.9]})
+    assert means["services"] == pytest.approx(0.5)
+
+
+def test_a_category_without_source_factors_is_left_unpriced():
+    means = category_means({"services": [0.3], "vehicles": []})
+    assert set(means) == {"services"}
+
+
+def test_every_planner_category_maps_to_a_calculator_type():
+    assert SOURCE_TYPE_BY_CATEGORY["it_equipment"] is DataEntryTypeEnum.it_equipment
+    assert len(SOURCE_TYPE_BY_CATEGORY) == 7
+
+
+def test_global_budget_weights_categories_not_codes():
+    # 'services' has one code and 'vehicles' three; both still count once.
+    means = category_means({"services": [0.2], "vehicles": [0.3, 0.4, 0.5]})
+    assert global_mean(means) == pytest.approx(0.3)
+
+
+def test_build_factors_emits_one_row_per_category_plus_the_budget():
+    factors = build_factors({"services": 0.2, "vehicles": 0.4}, year=2025)
+
+    per_category = [
+        f
+        for f in factors
+        if f.data_entry_type_id == DataEntryTypeEnum.planner_purchase.value
+    ]
+    assert {f.classification["purchase_category"] for f in per_category} == {
+        "services",
+        "vehicles",
+    }
+    assert {f.emission_type_id for f in per_category} == {
+        EmissionType.purchases__services.value,
+        EmissionType.purchases__vehicles.value,
+    }
+    assert all(f.year == 2025 for f in factors)
+
+    budget = next(
+        f
+        for f in factors
+        if f.data_entry_type_id == DataEntryTypeEnum.planner_purchase_budget.value
+    )
+    # The global budget resolves with no classification (kind is None).
+    assert budget.classification == {}
+    assert budget.emission_type_id == EmissionType.purchases__goods_and_services.value
+    assert budget.values[PLANNER_EF_KEY] == pytest.approx(0.3)

--- a/backend/tests/unit/modules/test_planner_purchase_schemas.py
+++ b/backend/tests/unit/modules/test_planner_purchase_schemas.py
@@ -16,7 +16,7 @@ def test_planner_purchase_create_validates_category():
         data_entry_type_id=DataEntryTypeEnum.planner_purchase.value,
         carbon_report_module_id=1,
         purchase_category="services",
-        amount_chf=1500.0,
+        amount_eur=1500.0,
     )
     assert dto.data["purchase_category"] == "services"
 
@@ -25,7 +25,7 @@ def test_planner_purchase_create_validates_category():
             data_entry_type_id=DataEntryTypeEnum.planner_purchase.value,
             carbon_report_module_id=1,
             purchase_category="not-a-category",
-            amount_chf=1500.0,
+            amount_eur=1500.0,
         )
 
 
@@ -34,7 +34,7 @@ def test_planner_purchase_rejects_negative_amount():
         PlannerPurchaseBudgetCreate(
             data_entry_type_id=DataEntryTypeEnum.planner_purchase_budget.value,
             carbon_report_module_id=1,
-            amount_chf=-1.0,
+            amount_eur=-1.0,
         )
 
 
@@ -53,6 +53,6 @@ def test_submodule_total_resolves_matching_purchases_emission():
 
 def test_global_budget_resolves_generic_purchases_node():
     resolved = resolve_emission_types(
-        DataEntryTypeEnum.planner_purchase_budget, {"amount_chf": 1000.0}
+        DataEntryTypeEnum.planner_purchase_budget, {"amount_eur": 1000.0}
     )
     assert resolved == [EmissionType.purchases__goods_and_services]

--- a/backend/tests/unit/workflows/test_planner_purchase_exclusivity.py
+++ b/backend/tests/unit/workflows/test_planner_purchase_exclusivity.py
@@ -1,6 +1,6 @@
 """Planner purchases XOR rule (PRD #1555, #1556).
 
-A plan's Purchases module holds EITHER per-submodule CHF totals OR one
+A plan's Purchases module holds EITHER per-submodule EUR totals OR one
 global budget — never both, and no duplicate submodule category.
 """
 
@@ -48,7 +48,7 @@ async def test_first_submodule_total_is_allowed():
 @pytest.mark.asyncio
 async def test_submodule_total_rejected_when_budget_exists():
     workflow = _workflow_with_rows(
-        [_row(DataEntryTypeEnum.planner_purchase_budget, {"amount_chf": 1000.0})]
+        [_row(DataEntryTypeEnum.planner_purchase_budget, {"amount_eur": 1000.0})]
     )
     with pytest.raises(HTTPException) as exc:
         await workflow._check_planner_purchase_exclusivity(
@@ -63,7 +63,7 @@ async def test_duplicate_submodule_category_rejected():
         [
             _row(
                 DataEntryTypeEnum.planner_purchase,
-                {"purchase_category": "services", "amount_chf": 5.0},
+                {"purchase_category": "services", "amount_eur": 5.0},
             )
         ]
     )
@@ -80,13 +80,13 @@ async def test_budget_rejected_when_totals_exist():
         [
             _row(
                 DataEntryTypeEnum.planner_purchase,
-                {"purchase_category": "vehicles", "amount_chf": 5.0},
+                {"purchase_category": "vehicles", "amount_eur": 5.0},
             )
         ]
     )
     with pytest.raises(HTTPException) as exc:
         await workflow._check_planner_purchase_exclusivity(
-            1, DataEntryTypeEnum.planner_purchase_budget, {"amount_chf": 1000.0}
+            1, DataEntryTypeEnum.planner_purchase_budget, {"amount_eur": 1000.0}
         )
     assert exc.value.detail == "PURCHASES_SUBMODULE_TOTALS_SET"
 
@@ -94,11 +94,11 @@ async def test_budget_rejected_when_totals_exist():
 @pytest.mark.asyncio
 async def test_second_budget_rejected():
     workflow = _workflow_with_rows(
-        [_row(DataEntryTypeEnum.planner_purchase_budget, {"amount_chf": 1000.0})]
+        [_row(DataEntryTypeEnum.planner_purchase_budget, {"amount_eur": 1000.0})]
     )
     with pytest.raises(HTTPException) as exc:
         await workflow._check_planner_purchase_exclusivity(
-            1, DataEntryTypeEnum.planner_purchase_budget, {"amount_chf": 2000.0}
+            1, DataEntryTypeEnum.planner_purchase_budget, {"amount_eur": 2000.0}
         )
     assert exc.value.detail == "PURCHASES_GLOBAL_BUDGET_EXISTS"
 
@@ -110,7 +110,7 @@ async def test_update_excludes_edited_row_from_duplicate_scan():
         [
             _row(
                 DataEntryTypeEnum.planner_purchase,
-                {"purchase_category": "services", "amount_chf": 5.0},
+                {"purchase_category": "services", "amount_eur": 5.0},
                 row_id=7,
             )
         ]
@@ -131,12 +131,12 @@ async def test_update_rejects_change_to_existing_category():
         [
             _row(
                 DataEntryTypeEnum.planner_purchase,
-                {"purchase_category": "services", "amount_chf": 5.0},
+                {"purchase_category": "services", "amount_eur": 5.0},
                 row_id=7,
             ),
             _row(
                 DataEntryTypeEnum.planner_purchase,
-                {"purchase_category": "vehicles", "amount_chf": 9.0},
+                {"purchase_category": "vehicles", "amount_eur": 9.0},
                 row_id=8,
             ),
         ]

--- a/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
+++ b/frontend/src/components/charts/GenericEmissionTreeMapChart.vue
@@ -74,6 +74,7 @@ const LABEL_KEY_MAP: Record<string, string> = {
   vehicles: 'charts-vehicles-subcategory',
   other_purchases: 'charts-other-purchases-subcategory',
   centralized: 'charts-purchases-centralized-subcategory',
+  goods_and_services: 'charts-global-budget-subcategory',
   // research facilities
   facilities: 'charts-research-facilities-subcategory',
   it_facilities: 'charts-research-it-facilities-subcategory',

--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -81,7 +81,7 @@ const SUBCATEGORY_LABEL_MAP: Record<string, string> = {
   vehicles: 'charts-vehicles-subcategory',
   centralized: 'charts-purchases-centralized-subcategory',
   other_purchases: 'charts-other-purchases-subcategory',
-  goods_and_services: 'charts-services-subcategory',
+  goods_and_services: 'charts-global-budget-subcategory',
   plane: 'charts-plane-subcategory',
   train: 'charts-train-subcategory',
   class_1: 'charts-class-1-subcategory',

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1103,7 +1103,11 @@ const chartOption = computed((): EChartsOption => {
         stack: 'total',
         animation: true,
         encode: { x: 'category', y: 'purch_rest' },
-        itemStyle: { color: colors.value.lightGreen.lighter },
+        // Sits directly above the ranked segments, so it continues their ramp
+        // instead of jumping a shade.
+        itemStyle: {
+          color: stackShade(colors.value.lightGreen, top3Series.length),
+        },
         label: { show: false },
       };
       return [...top3Series, restSeries];
@@ -1565,7 +1569,7 @@ const downloadCSV = () => {
           :class="['chart', { 'chart--print': isPrintMode }]"
           autoresize
           :option="chartOption"
-          :update-options="{ replaceMerge: ['dataset'] }"
+          :update-options="{ replaceMerge: ['dataset', 'series'] }"
           @rendered="recalculateScopeRects"
           @vue:mounted="onChartReady"
         />

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -742,6 +742,9 @@ const PURCHASES_SUBKEYS = [
   'vehicles',
   'other_purchases',
   'centralized',
+  // A planner global budget prices all purchases as one figure, so it lands
+  // on the parent node rather than any of the categories above it.
+  'goods_and_services',
 ] as const;
 
 const equipPurchRankings = computed(() => {
@@ -1083,6 +1086,7 @@ const chartOption = computed((): EChartsOption => {
         vehicles: t('charts-vehicles-subcategory'),
         other_purchases: t('charts-other-purchases-subcategory'),
         centralized: t('charts-purchases-centralized-subcategory'),
+        goods_and_services: t('charts-global-budget-subcategory'),
       };
       const top3Series = equipPurchRankings.value.purchTop3.map((item, i) => ({
         name: purchSubcatLabels[item.key] ?? item.key,
@@ -1382,6 +1386,7 @@ const chartOption = computed((): EChartsOption => {
         'vehicles',
         'other_purchases',
         'centralized',
+        'goods_and_services',
         'equip_rank1',
         'equip_rank2',
         'equip_rank3',

--- a/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
@@ -1,0 +1,440 @@
+<template>
+  <div>
+    <!-- The backend accepts a global budget XOR per-category totals (PRD
+         #1555), so the two modes are one explicit choice rather than two
+         tables the user discovers are incompatible. -->
+    <div class="planner-purchase-mode row items-center no-wrap">
+      <button
+        type="button"
+        class="planner-purchase-mode__label text-body1"
+        :class="mode === 'global' ? 'text-weight-medium' : 'text-grey-6'"
+        :disabled="disable || switching"
+        :aria-pressed="mode === 'global'"
+        @click="onModeRequest('global')"
+      >
+        {{ $t('planner_purchase_mode_global') }}
+      </button>
+      <q-toggle
+        :model-value="mode === 'per_category'"
+        color="info"
+        keep-color
+        size="lg"
+        :disable="disable || switching"
+        @update:model-value="
+          (on: boolean) => onModeRequest(on ? 'per_category' : 'global')
+        "
+      />
+      <button
+        type="button"
+        class="planner-purchase-mode__label text-body1"
+        :class="mode === 'per_category' ? 'text-weight-medium' : 'text-grey-6'"
+        :disabled="disable || switching"
+        :aria-pressed="mode === 'per_category'"
+        @click="onModeRequest('per_category')"
+      >
+        {{ $t('planner_purchase_mode_per_category') }}
+      </button>
+    </div>
+    <div class="text-body2 text-grey-7">
+      {{ $t('planner_purchase_mode_hint') }}
+    </div>
+
+    <!-- Full-bleed: the mode choice governs the fields below it, so the rule
+         between them runs to the card edges like the section headers do. -->
+    <q-separator class="planner-purchase-divider q-my-md" />
+
+    <div class="q-gutter-y-sm">
+      <div v-for="row in visibleRows" :key="row.key" class="q-py-xs">
+        <div class="row items-center justify-between">
+          <div class="text-body1">{{ $t(row.labelKey) }}</div>
+          <div class="row items-center no-wrap q-gutter-md">
+            <div class="text-body2 text-grey-7">
+              <template v-if="row.kg !== null">
+                {{ formatKgCO2(row.kg) }} {{ $t('planner_purchase_kg_unit') }}
+              </template>
+              <template v-else>
+                <span class="planner-purchase-kg-empty">–</span>
+                <q-tooltip>{{
+                  $t('planner_purchase_missing_factor_tooltip')
+                }}</q-tooltip>
+              </template>
+            </div>
+            <q-input
+              v-model.number="row.amount"
+              type="number"
+              outlined
+              dense
+              hide-bottom-space
+              min="0"
+              suffix="CHF"
+              style="max-width: 200px"
+              :aria-label="$t('planner_purchase_amount_label')"
+              :disable="disable || switching || savingKey === row.key"
+              :loading="savingKey === row.key"
+              :error="row.error !== null"
+              @blur="save(row)"
+              @keyup.enter="save(row)"
+            />
+          </div>
+        </div>
+        <!-- Full width: the rule that was broken needs a sentence, which does
+             not fit under a 200px field. -->
+        <div v-if="row.error" class="text-body2 text-negative q-mt-xs">
+          {{ row.error }}
+        </div>
+      </div>
+    </div>
+
+    <q-dialog v-model="confirmOpen" :persistent="switching">
+      <q-card style="min-width: 420px">
+        <q-card-section class="text-h4 text-weight-medium">
+          {{ $t('planner_purchase_switch_dialog_title') }}
+        </q-card-section>
+        <q-card-section class="text-body2 text-grey-8 q-pt-none">
+          {{ $t(switchDialogMessageKey) }}
+        </q-card-section>
+        <q-card-actions class="q-px-md q-pb-md">
+          <q-btn
+            :label="$t('common_validate_short')"
+            :loading="switching"
+            color="info"
+            unelevated
+            no-caps
+            class="text-weight-medium"
+            @click="confirmSwitch"
+          />
+          <q-btn
+            v-close-popup
+            :label="$t('common_cancel')"
+            :disable="switching"
+            color="primary"
+            unelevated
+            outline
+            no-caps
+            class="text-weight-medium"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useQuasar } from 'quasar';
+import { useI18n } from 'vue-i18n';
+
+import { api } from 'src/api/http';
+import { useSimulatorPlansStore } from 'src/stores/simulatorPlans';
+import { formatKgCO2 } from 'src/utils/number';
+
+// The 7 backend categories (modules_planner/purchase/emissions.py
+// PLANNER_PURCHASE_EMISSIONS), rendered as fixed rows in the design's order.
+const CATEGORIES = [
+  'scientific_equipment',
+  'it_equipment',
+  'consumable_accessories',
+  'biological_chemical_gaseous_product',
+  'services',
+  'vehicles',
+  'other_purchases',
+] as const;
+
+type Mode = 'global' | 'per_category';
+
+const SUBMODULE: Record<Mode, string> = {
+  global: 'planner_purchase_budget',
+  per_category: 'planner_purchase',
+};
+
+// The XOR and duplicate-category rules are 422 `detail` codes raised by
+// CarbonReportModuleWorkflow._check_planner_purchase_exclusivity. The mode
+// toggle prevents them, but a second tab can still lose the race.
+const ERROR_MESSAGE_KEYS: Record<string, string> = {
+  PURCHASES_GLOBAL_BUDGET_SET: 'planner_purchase_error_global_budget_set',
+  PURCHASES_SUBMODULE_TOTALS_SET: 'planner_purchase_error_totals_set',
+  PURCHASES_GLOBAL_BUDGET_EXISTS: 'planner_purchase_error_budget_exists',
+  DUPLICATE_PURCHASE_CATEGORY: 'planner_purchase_error_duplicate_category',
+};
+
+interface PurchaseRow {
+  key: string;
+  labelKey: string;
+  /** The category slug sent on create; null for the global budget. */
+  category: string | null;
+  amount: number | null;
+  /** Last persisted amount — `blur` after `Enter` must not save twice. */
+  saved: number | null;
+  entryId: number | null;
+  kg: number | null;
+  error: string | null;
+}
+
+interface SubmoduleItem {
+  id: number;
+  purchase_category?: string;
+  amount_chf?: number | null;
+  kg_co2eq?: number | null;
+}
+
+const props = defineProps<{
+  carbonReportId: number;
+  disable: boolean;
+}>();
+
+const $q = useQuasar();
+const { t } = useI18n();
+const plansStore = useSimulatorPlansStore();
+
+const mode = ref<Mode>('global');
+const savingKey = ref<string | null>(null);
+const switching = ref(false);
+const confirmOpen = ref(false);
+const pendingMode = ref<Mode | null>(null);
+
+const budgetRow = ref<PurchaseRow>(emptyRow('global'));
+const categoryRows = ref<PurchaseRow[]>(
+  CATEGORIES.map((category) => emptyRow(category)),
+);
+
+const visibleRows = computed(() => rowsFor(mode.value));
+
+const switchDialogMessageKey = computed(() =>
+  mode.value === 'global'
+    ? 'planner_purchase_switch_from_global_message'
+    : 'planner_purchase_switch_from_categories_message',
+);
+
+function emptyRow(key: string): PurchaseRow {
+  return {
+    key,
+    labelKey:
+      key === 'global'
+        ? 'planner_purchase_global_budget_label'
+        : `planner_purchase_category.${key}`,
+    category: key === 'global' ? null : key,
+    amount: null,
+    saved: null,
+    entryId: null,
+    kg: null,
+    error: null,
+  };
+}
+
+function rowsFor(target: Mode): PurchaseRow[] {
+  return target === 'global' ? [budgetRow.value] : categoryRows.value;
+}
+
+function pathFor(target: Mode): string {
+  return `carbon-reports/${props.carbonReportId}/modules/purchase/${SUBMODULE[target]}`;
+}
+
+async function fetchItems(target: Mode): Promise<SubmoduleItem[]> {
+  try {
+    const res = await api
+      .get(`${pathFor(target)}?page=1&limit=100`)
+      .json<{ items: SubmoduleItem[] }>();
+    return res.items;
+  } catch {
+    // Empty module → no rows yet; leave the blank inputs.
+    return [];
+  }
+}
+
+function fillRow(row: PurchaseRow, item: SubmoduleItem | undefined) {
+  row.amount = item?.amount_chf ?? null;
+  row.saved = row.amount;
+  row.entryId = item?.id ?? null;
+  row.kg = item?.kg_co2eq ?? null;
+  row.error = null;
+}
+
+async function load() {
+  const [totals, budgets] = await Promise.all([
+    fetchItems('per_category'),
+    fetchItems('global'),
+  ]);
+  const byCategory = new Map(
+    totals
+      .filter((it) => it.purchase_category)
+      .map((it) => [it.purchase_category as string, it]),
+  );
+  categoryRows.value.forEach((row) =>
+    fillRow(row, byCategory.get(row.key)),
+  );
+  fillRow(budgetRow.value, budgets[0]);
+  // The mode the data is already in wins; an untouched module opens on the
+  // single-field path.
+  mode.value = budgets.length
+    ? 'global'
+    : totals.length
+      ? 'per_category'
+      : 'global';
+}
+
+/** Re-read the emissions of the saved kind without touching typed amounts. */
+async function refreshKg() {
+  const items = await fetchItems(mode.value);
+  const byId = new Map(items.map((it) => [it.id, it.kg_co2eq ?? null]));
+  rowsFor(mode.value).forEach((row) => {
+    row.kg = row.entryId === null ? null : (byId.get(row.entryId) ?? null);
+  });
+}
+
+async function errorDetail(error: unknown): Promise<string | null> {
+  if (!error || typeof error !== 'object' || !('response' in error)) return null;
+  try {
+    const body = await (error as { response: Response }).response
+      .clone()
+      .json();
+    return typeof body?.detail === 'string' ? body.detail : null;
+  } catch {
+    return null;
+  }
+}
+
+function statusOf(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('response' in error)) return null;
+  return (error as { response: Response }).response.status ?? null;
+}
+
+/**
+ * Saves run one after another: `Enter` then `blur` fire on the same edit, and
+ * concurrently they would each see "no entry yet" and create a duplicate.
+ * Queueing (rather than dropping) also keeps a second row's edit, made while
+ * the first is still in flight.
+ */
+let saveQueue: Promise<void> = Promise.resolve();
+
+function save(row: PurchaseRow): Promise<void> {
+  saveQueue = saveQueue.then(() => persist(row));
+  return saveQueue;
+}
+
+async function persist(row: PurchaseRow) {
+  const amount =
+    typeof row.amount === 'number' && Number.isFinite(row.amount)
+      ? row.amount
+      : null;
+  // Re-checked here, not when queued: the duplicate call runs after the first
+  // one has recorded what it persisted.
+  if (amount === row.saved) return;
+  row.error = null;
+  savingKey.value = row.key;
+  try {
+    if (amount === null) {
+      // Clearing the field deletes the entry — that is also how a mode with
+      // one leftover value stops blocking the other one.
+      await api.delete(`${pathFor(mode.value)}/${row.entryId}`, {
+        skipErrorCodes: [422],
+      });
+      row.entryId = null;
+      row.kg = null;
+    } else if (row.entryId === null) {
+      const created = await api
+        .post(pathFor(mode.value), {
+          json: row.category
+            ? { purchase_category: row.category, amount_chf: amount }
+            : { amount_chf: amount },
+          skipErrorCodes: [422],
+        })
+        .json<{ id: number }>();
+      row.entryId = created.id;
+    } else {
+      await api
+        .patch(`${pathFor(mode.value)}/${row.entryId}`, {
+          json: { amount_chf: amount },
+          skipErrorCodes: [422],
+        })
+        .json();
+    }
+    row.saved = amount;
+    await refreshKg();
+    await plansStore.refreshAggregateIfActive();
+  } catch (error: unknown) {
+    // 422 is the business rule and belongs on the field; anything else has
+    // already been surfaced by the http hook.
+    if (statusOf(error) !== 422) return;
+    const detail = await errorDetail(error);
+    const messageKey = detail ? ERROR_MESSAGE_KEYS[detail] : undefined;
+    row.error = messageKey ? t(messageKey) : t('planner_purchase_save_error');
+  } finally {
+    savingKey.value = null;
+  }
+}
+
+function filledRows(target: Mode): PurchaseRow[] {
+  return rowsFor(target).filter((row) => row.entryId !== null);
+}
+
+function onModeRequest(next: Mode) {
+  if (next === mode.value) return;
+  // The backend refuses both kinds at once, so switching means dropping what
+  // the current mode holds — never silently.
+  if (filledRows(mode.value).length > 0) {
+    pendingMode.value = next;
+    confirmOpen.value = true;
+    return;
+  }
+  mode.value = next;
+}
+
+async function confirmSwitch() {
+  const next = pendingMode.value;
+  if (next === null) return;
+  const previous = mode.value;
+  switching.value = true;
+  try {
+    // A pending blur-save would otherwise re-create what we are deleting.
+    await saveQueue;
+    // Read the server rather than the rows: another tab may have added an
+    // entry this component never bound, and one leftover blocks the mode
+    // being switched to.
+    for (const item of await fetchItems(previous)) {
+      await api.delete(`${pathFor(previous)}/${item.id}`);
+    }
+    rowsFor(previous).forEach((row) => fillRow(row, undefined));
+    mode.value = next;
+    pendingMode.value = null;
+    confirmOpen.value = false;
+    await plansStore.refreshAggregateIfActive();
+  } catch {
+    $q.notify({ type: 'negative', message: t('planner_purchase_save_error') });
+  } finally {
+    switching.value = false;
+  }
+}
+
+onMounted(load);
+</script>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+// Cancels the q-pa-md the planner wraps this section in, so the rule meets the
+// module card's border instead of stopping short of it.
+.planner-purchase-divider {
+  margin-left: -#{tokens.$spacing-md};
+  margin-right: -#{tokens.$spacing-md};
+}
+
+// Both modes are named on either side of the switch; the one not in use reads
+// as unavailable rather than disappearing.
+.planner-purchase-mode__label {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+// The dash stands for "no factor yet", not for zero — it should not read as a
+// computed result.
+.planner-purchase-kg-empty {
+  cursor: help;
+}
+</style>

--- a/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
@@ -50,13 +50,7 @@
           <div class="row items-center no-wrap q-gutter-md">
             <div class="text-body2 text-grey-7">
               <template v-if="row.kg !== null">
-                {{ formatKgCO2(row.kg) }} {{ $t('planner_purchase_kg_unit') }}
-              </template>
-              <template v-else>
-                <span class="planner-purchase-kg-empty">–</span>
-                <q-tooltip>{{
-                  $t('planner_purchase_missing_factor_tooltip')
-                }}</q-tooltip>
+                {{ formatTonnesCO2(row.kg / 1000) }} {{ $t('tco2eq') }}
               </template>
             </div>
             <q-input
@@ -66,7 +60,7 @@
               dense
               hide-bottom-space
               min="0"
-              suffix="CHF"
+              suffix="EUR"
               style="max-width: 200px"
               :aria-label="$t('planner_purchase_amount_label')"
               :disable="disable || switching || savingKey === row.key"
@@ -126,7 +120,7 @@ import { useI18n } from 'vue-i18n';
 
 import { api } from 'src/api/http';
 import { useSimulatorPlansStore } from 'src/stores/simulatorPlans';
-import { formatKgCO2 } from 'src/utils/number';
+import { formatTonnesCO2 } from 'src/utils/number';
 
 // The 7 backend categories (modules_planner/purchase/emissions.py
 // PLANNER_PURCHASE_EMISSIONS), rendered as fixed rows in the design's order.
@@ -173,7 +167,7 @@ interface PurchaseRow {
 interface SubmoduleItem {
   id: number;
   purchase_category?: string;
-  amount_chf?: number | null;
+  amount_eur?: number | null;
   kg_co2eq?: number | null;
 }
 
@@ -242,7 +236,7 @@ async function fetchItems(target: Mode): Promise<SubmoduleItem[]> {
 }
 
 function fillRow(row: PurchaseRow, item: SubmoduleItem | undefined) {
-  row.amount = item?.amount_chf ?? null;
+  row.amount = item?.amount_eur ?? null;
   row.saved = row.amount;
   row.entryId = item?.id ?? null;
   row.kg = item?.kg_co2eq ?? null;
@@ -259,9 +253,7 @@ async function load() {
       .filter((it) => it.purchase_category)
       .map((it) => [it.purchase_category as string, it]),
   );
-  categoryRows.value.forEach((row) =>
-    fillRow(row, byCategory.get(row.key)),
-  );
+  categoryRows.value.forEach((row) => fillRow(row, byCategory.get(row.key)));
   fillRow(budgetRow.value, budgets[0]);
   // The mode the data is already in wins; an untouched module opens on the
   // single-field path.
@@ -282,7 +274,8 @@ async function refreshKg() {
 }
 
 async function errorDetail(error: unknown): Promise<string | null> {
-  if (!error || typeof error !== 'object' || !('response' in error)) return null;
+  if (!error || typeof error !== 'object' || !('response' in error))
+    return null;
   try {
     const body = await (error as { response: Response }).response
       .clone()
@@ -294,7 +287,8 @@ async function errorDetail(error: unknown): Promise<string | null> {
 }
 
 function statusOf(error: unknown): number | null {
-  if (!error || typeof error !== 'object' || !('response' in error)) return null;
+  if (!error || typeof error !== 'object' || !('response' in error))
+    return null;
   return (error as { response: Response }).response.status ?? null;
 }
 
@@ -334,8 +328,8 @@ async function persist(row: PurchaseRow) {
       const created = await api
         .post(pathFor(mode.value), {
           json: row.category
-            ? { purchase_category: row.category, amount_chf: amount }
-            : { amount_chf: amount },
+            ? { purchase_category: row.category, amount_eur: amount }
+            : { amount_eur: amount },
           skipErrorCodes: [422],
         })
         .json<{ id: number }>();
@@ -343,7 +337,7 @@ async function persist(row: PurchaseRow) {
     } else {
       await api
         .patch(`${pathFor(mode.value)}/${row.entryId}`, {
-          json: { amount_chf: amount },
+          json: { amount_eur: amount },
           skipErrorCodes: [422],
         })
         .json();
@@ -430,11 +424,5 @@ onMounted(load);
   &:disabled {
     cursor: default;
   }
-}
-
-// The dash stands for "no factor yet", not for zero — it should not read as a
-// computed result.
-.planner-purchase-kg-empty {
-  cursor: help;
 }
 </style>

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -121,10 +121,16 @@
               v-if="expandedKey === expansionKey(entry.config.module)"
               class="q-pa-md"
             >
-              <!-- Headcount is a fixed SIUS-category grid, not an add-row
-                   table (design). Other modules reuse the Calculator tables. -->
+              <!-- Headcount is a fixed SIUS-category grid and Purchases a
+                   global-budget XOR per-category grid, not add-row tables
+                   (design). Other modules reuse the Calculator tables. -->
               <planner-headcount-rows
                 v-if="entry.config.module === MODULES.Headcount"
+                :carbon-report-id="yearData.id"
+                :disable="entry.module?.is_active === false"
+              />
+              <planner-purchase-rows
+                v-else-if="entry.config.module === MODULES.Purchase"
                 :carbon-report-id="yearData.id"
                 :disable="entry.module?.is_active === false"
               />
@@ -159,6 +165,7 @@ import { useI18n } from 'vue-i18n';
 import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import ModuleTableSection from 'src/components/organisms/module/ModuleTableSection.vue';
 import PlannerHeadcountRows from 'src/components/organisms/planner/PlannerHeadcountRows.vue';
+import PlannerPurchaseRows from 'src/components/organisms/planner/PlannerPurchaseRows.vue';
 import PlannerReferenceYearDialog from 'src/components/organisms/planner/PlannerReferenceYearDialog.vue';
 import {
   PLANNER_MODULES,

--- a/frontend/src/composables/useEmissionTreemap.ts
+++ b/frontend/src/composables/useEmissionTreemap.ts
@@ -74,6 +74,7 @@ export const CATEGORY_CHART_KEYS: Record<string, string[]> = {
     'vehicles',
     'other_purchases',
     'centralized',
+    'goods_and_services',
   ],
   research_facilities: ['facilities', 'it_facilities', 'animal'],
   professional_travel: ['plane', 'train'],

--- a/frontend/src/constant/planner-module-config/module-configs.ts
+++ b/frontend/src/constant/planner-module-config/module-configs.ts
@@ -3,7 +3,7 @@ import type {
   ModuleField,
   Submodule,
 } from 'src/constant/moduleConfig';
-import { MODULES, type Module } from 'src/constant/modules';
+import type { Module } from 'src/constant/modules';
 import { MODULES_CONFIG } from 'src/constant/module-config';
 import { PLANNER_MODULE_CONFIG } from 'src/constant/planner-module-config';
 
@@ -11,85 +11,16 @@ import { PLANNER_MODULE_CONFIG } from 'src/constant/planner-module-config';
  * ModuleConfig objects rendered inside the Simulator Plan by
  * ModuleTableSection.
  *
- * Purchases gets its own config (submodule CHF totals XOR one global
- * budget); the others reuse the Calculator config with two planner
+ * Every module here reuses the Calculator config with two planner
  * adaptations applied by `withPlannerAdaptations`:
  * - no CSV top bar (bulk ingest pipelines are unit/year-scoped and would
  *   bypass the plan's report addressing)
  * - Travel's traveler dropdown offers categories instead of headcount names.
  *
- * Headcount is NOT here — it renders through PlannerHeadcountRows (fixed
- * SIUS-category grid), not a data table.
+ * Headcount and Purchases are NOT here — they render through
+ * PlannerHeadcountRows (fixed SIUS-category grid) and PlannerPurchaseRows
+ * (global budget XOR per-category grid), not data tables.
  */
-
-const PURCHASE_CATEGORY_OPTIONS = [
-  'scientific_equipment',
-  'it_equipment',
-  'consumable_accessories',
-  'biological_chemical_gaseous_product',
-  'services',
-  'vehicles',
-  'other_purchases',
-].map((value) => ({ value, label: value }));
-
-const plannerPurchaseFields: ModuleField[] = [
-  {
-    id: 'purchase_category',
-    labelKey: 'planner_purchase_category_label',
-    type: 'select',
-    sortable: true,
-    ratio: '1/2',
-    // Reuses the Calculator purchase submodule titles as category labels.
-    optionLabelKey: `${MODULES.Purchase}.{value}-table-title`,
-    options: PURCHASE_CATEGORY_OPTIONS,
-  },
-  {
-    id: 'amount_chf',
-    labelKey: 'planner_purchase_amount_label',
-    type: 'number',
-    min: 0,
-    sortable: true,
-    ratio: '1/2',
-    unit: 'CHF',
-  },
-];
-
-const plannerPurchaseBudgetFields: ModuleField[] = [
-  {
-    id: 'amount_chf',
-    labelKey: 'planner_purchase_amount_label',
-    type: 'number',
-    min: 0,
-    sortable: true,
-    ratio: '12/12',
-    unit: 'CHF',
-  },
-];
-
-const plannerPurchase: ModuleConfig = {
-  id: 'planner_module_purchase',
-  type: MODULES.Purchase as Module,
-  hasDescription: false,
-  hasSubmodules: true,
-  formStructure: 'perSubmodule',
-  totalFormatter: (value) => String(value ?? ''),
-  submodules: [
-    {
-      id: 'planner_purchase',
-      type: 'planner_purchase',
-      tableNameKey: 'planner_purchase_totals_table_title',
-      hasTableTopBar: false,
-      moduleFields: plannerPurchaseFields,
-    },
-    {
-      id: 'planner_purchase_budget',
-      type: 'planner_purchase_budget',
-      tableNameKey: 'planner_purchase_budget_table_title',
-      hasTableTopBar: false,
-      moduleFields: plannerPurchaseBudgetFields,
-    },
-  ],
-};
 
 function plannerTravelerField(categories: string[]): Partial<ModuleField> {
   return {
@@ -116,11 +47,7 @@ function withPlannerAdaptations(module: Module): ModuleConfig {
   return { ...base, submodules };
 }
 
-const plannerConfigs: Partial<Record<Module, ModuleConfig>> = {
-  [MODULES.Purchase]: plannerPurchase,
-};
-
 /** The ModuleConfig to render for a module inside the Simulator Plan. */
 export function getPlannerModuleConfig(module: Module): ModuleConfig {
-  return plannerConfigs[module] ?? withPlannerAdaptations(module);
+  return withPlannerAdaptations(module);
 }

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -575,6 +575,10 @@ export default {
     en: 'Centralized purchases',
     fr: 'Achats centralisés',
   },
+  'charts-global-budget-subcategory': {
+    en: 'Global budget',
+    fr: 'Budget global',
+  },
   'charts-other-equipment-subcategory': {
     en: 'Other equipment',
     fr: 'Autres équipements',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -264,8 +264,8 @@ export default {
     fr: "Prérempli depuis l'année de référence",
   },
   planner_purchase_amount_label: {
-    en: 'Amount (CHF)',
-    fr: 'Montant (CHF)',
+    en: 'Amount (EUR)',
+    fr: 'Montant (EUR)',
   },
   planner_purchase_mode_global: {
     en: 'Global budget',
@@ -282,14 +282,6 @@ export default {
   planner_purchase_global_budget_label: {
     en: 'Global budget',
     fr: 'Budget global',
-  },
-  planner_purchase_kg_unit: {
-    en: 'kgCO₂eq',
-    fr: 'kgCO₂eq',
-  },
-  planner_purchase_missing_factor_tooltip: {
-    en: 'No emission factor available yet for this category: the amount is saved, its emissions will appear once the factors are loaded.',
-    fr: "Aucun facteur d'émission disponible pour cette catégorie : le montant est enregistré, ses émissions apparaîtront une fois les facteurs chargés.",
   },
   planner_purchase_switch_dialog_title: {
     en: 'Switch entry mode',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -263,21 +263,93 @@ export default {
     en: 'Prefilled from reference year',
     fr: "Prérempli depuis l'année de référence",
   },
-  planner_purchase_totals_table_title: {
-    en: 'CHF total per purchase submodule',
-    fr: "Total CHF par sous-module d'achats",
-  },
-  planner_purchase_budget_table_title: {
-    en: 'Global budget (mutually exclusive with submodule totals)',
-    fr: 'Budget global (exclusif avec les totaux par sous-module)',
-  },
-  planner_purchase_category_label: {
-    en: 'Purchase submodule',
-    fr: "Sous-module d'achats",
-  },
   planner_purchase_amount_label: {
     en: 'Amount (CHF)',
     fr: 'Montant (CHF)',
+  },
+  planner_purchase_mode_global: {
+    en: 'Global budget',
+    fr: 'Budget global',
+  },
+  planner_purchase_mode_per_category: {
+    en: 'Per category',
+    fr: 'Par catégorie',
+  },
+  planner_purchase_mode_hint: {
+    en: 'Fill in one global budget or an amount per category — the two cannot be used together.',
+    fr: 'Renseignez un budget global ou un montant par catégorie — les deux ne peuvent pas coexister.',
+  },
+  planner_purchase_global_budget_label: {
+    en: 'Global budget',
+    fr: 'Budget global',
+  },
+  planner_purchase_kg_unit: {
+    en: 'kgCO₂eq',
+    fr: 'kgCO₂eq',
+  },
+  planner_purchase_missing_factor_tooltip: {
+    en: 'No emission factor available yet for this category: the amount is saved, its emissions will appear once the factors are loaded.',
+    fr: "Aucun facteur d'émission disponible pour cette catégorie : le montant est enregistré, ses émissions apparaîtront une fois les facteurs chargés.",
+  },
+  planner_purchase_switch_dialog_title: {
+    en: 'Switch entry mode',
+    fr: 'Changer de mode de saisie',
+  },
+  planner_purchase_switch_from_global_message: {
+    en: 'The global budget you entered will be deleted so the amounts per category can be used instead.',
+    fr: 'Le budget global saisi sera supprimé afin de pouvoir utiliser les montants par catégorie.',
+  },
+  planner_purchase_switch_from_categories_message: {
+    en: 'The amounts you entered per category will be deleted so a global budget can be used instead.',
+    fr: 'Les montants saisis par catégorie seront supprimés afin de pouvoir utiliser un budget global.',
+  },
+  planner_purchase_save_error: {
+    en: 'The purchase amount could not be saved.',
+    fr: "Le montant d'achat n'a pas pu être enregistré.",
+  },
+  planner_purchase_error_global_budget_set: {
+    en: 'A global budget is already set for this year: delete it to enter amounts per category.',
+    fr: 'Un budget global est déjà défini pour cette année : supprimez-le pour saisir des montants par catégorie.',
+  },
+  planner_purchase_error_totals_set: {
+    en: 'Amounts per category are already set for this year: delete them to enter a global budget.',
+    fr: 'Des montants par catégorie sont déjà définis pour cette année : supprimez-les pour saisir un budget global.',
+  },
+  planner_purchase_error_budget_exists: {
+    en: 'A global budget already exists for this year.',
+    fr: 'Un budget global existe déjà pour cette année.',
+  },
+  planner_purchase_error_duplicate_category: {
+    en: 'An amount already exists for this category.',
+    fr: 'Un montant existe déjà pour cette catégorie.',
+  },
+  'planner_purchase_category.scientific_equipment': {
+    en: 'Scientific equipment',
+    fr: 'Équipements scientifiques',
+  },
+  'planner_purchase_category.it_equipment': {
+    en: 'IT equipment',
+    fr: 'Équipements informatiques',
+  },
+  'planner_purchase_category.consumable_accessories': {
+    en: 'Consumables & accessories',
+    fr: 'Consommables et accessoires',
+  },
+  'planner_purchase_category.biological_chemical_gaseous_product': {
+    en: 'Biological, chemical & gaseous products',
+    fr: 'Produits biologiques, chimiques et gazeux',
+  },
+  'planner_purchase_category.services': {
+    en: 'Services',
+    fr: 'Services',
+  },
+  'planner_purchase_category.vehicles': {
+    en: 'Vehicles',
+    fr: 'Véhicules',
+  },
+  'planner_purchase_category.other_purchases': {
+    en: 'Other purchases',
+    fr: 'Autres achats',
   },
   'planner_traveler_category.internal': {
     en: 'Internal',


### PR DESCRIPTION
## Summary

Planner Purchases module: switches the currency from CHF to EUR, derives the
planner's purchase emission factors from the Calculator's instead of shipping
them as hand-maintained factor data, and replaces the two add-row tables with a
single global-budget XOR per-category grid.

Closes #1861.

## Backend

- **CHF → EUR** across the planner purchase DTOs, factor schemas and handlers
  (`amount_chf` → `amount_eur`, `ef_kg_co2eq_per_chf` → `ef_kg_co2eq_per_eur`).
  The Calculator's purchase factors are already uploaded per EUR, so no
  conversion happens anywhere.
- **New `modules_planner/purchase/derived_factors.py`**: a category's planner
  factor is the mean EF over its procurement codes; the global-budget factor is
  the mean of those category means, so it weights categories equally rather than
  following whichever category carries the most codes. A category with no source
  factors for the year is left unpriced rather than defaulted.
- **Derivation hooks into factor upload** (`_derive_dependent_factors` in
  `BaseFactorCSVProvider`), keyed on what the rows actually carried rather than
  what the module allows, and skipped on partial uploads so an average is never
  taken across a mix of old and new rows.
- `FactorRepository.upsert_factors` now accepts `current_job_id=None` for seed
  runs, which have no job.
- `LocalFactorCSVProvider` routes its trailing batch through `_upsert_batch` and
  records `_upserted_det_ids` in its streaming path.

## Frontend

- **New `PlannerPurchaseRows.vue`**: an explicit mode toggle (global budget /
  per category), fixed rows for the 7 backend categories, inline kg CO2e per
  row, save-on-blur with a serialized save queue, and a confirm dialog before a
  mode switch deletes the other mode's entries. The 422 `detail` codes from
  `_check_planner_purchase_exclusivity` are surfaced on the field for the
  second-tab race the toggle can't prevent.
- Dropped the bespoke planner Purchases `ModuleConfig`; `getPlannerModuleConfig`
  is now uniformly `withPlannerAdaptations`.
- Charts: `goods_and_services` (the global budget) added to the purchases
  subkeys, treemap keys, and label maps, and given its own "Global budget"
  label instead of reusing "Services". `ModuleCarbonFootprintChart` now
  `replaceMerge`s `series` so the stack doesn't retain stale segments, and the
  "rest" segment continues the ranked colour ramp via `stackShade`.

## Tests

- Unit: `test_planner_purchase_derived_factors.py` covers the category mean, the
  unpriced-category case, category-vs-code weighting, and factor shape.
- Integration: the green-box upload test now asserts one derived factor per
  category the CSV priced and that the budget factor equals the mean of the
  category means.