### PR TITLE
fix(i18n): Centralize documentation title (#1649)

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTitle.vue
+++ b/frontend/src/components/organisms/module/ModuleTitle.vue
@@ -73,16 +73,13 @@ const props = withDefaults(
 const { t, te } = useI18n();
 const tooltipText = computed(() => t(`module-${props.type}-title`));
 
-// Per-module documentation link: label + URL live in each module's i18n file.
-// Rendered only when the module defines a non-empty link.
+// Per-module documentation URL lives in each module's i18n file; the label is
+// shared. Rendered only when the module defines a non-empty link.
 const documentationLink = computed(() => {
   const key = `${props.type}-documentation-link`;
   return te(key) ? t(key) : '';
 });
-const documentationTitle = computed(() => {
-  const key = `${props.type}-documentation-title`;
-  return te(key) && t(key) ? t(key) : t('documentation');
-});
+const documentationTitle = computed(() => t('module_documentation_title'));
 </script>
 
 <style scoped lang="scss">

--- a/frontend/src/i18n/buildings.ts
+++ b/frontend/src/i18n/buildings.ts
@@ -13,10 +13,6 @@ export default {
     en: 'This module estimates the carbon footprint related to energy combustion sources (if your unit uses a non-centralized energy source) as well as to other building functions (heating, air conditioning, ventilation, and lighting).',
     fr: "Ce module permet d'estimer l'empreinte carbone liée aux émissions de combustion d'énergie (au cas où votre unité utilise une source d'énergie non-centralisée) ainsi que celles liées au bâtiment (chauffage, climatisation, ventilation et éclairage).",
   },
-  [`${MODULES.Buildings}-documentation-title`]: {
-    en: 'For more information',
-    fr: "Pour plus d'information",
-  },
   [`${MODULES.Buildings}-documentation-link`]: {
     en: 'https://epfl-enac.github.io/co2-calculator-user-doc/building/',
     fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/building/',

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -49,6 +49,10 @@ export default {
     en: 'Documentation',
     fr: 'Documentation',
   },
+  module_documentation_title: {
+    en: 'For more information',
+    fr: "Pour plus d'information",
+  },
   logout: {
     en: 'Logout',
     fr: 'Se déconnecter',

--- a/frontend/src/i18n/equipment.ts
+++ b/frontend/src/i18n/equipment.ts
@@ -44,10 +44,6 @@ Veuillez remplir les colonnes suivantes:
 
 Si la puissance moyenne active ou standby de votre équipement est différente de celle utilisée par défaut, merci de contacter l'administrateur.`,
   },
-  [`${MODULES.Equipment}-documentation-title`]: {
-    en: 'For more information',
-    fr: "Pour plus d'information",
-  },
   [`${MODULES.Equipment}-documentation-link`]: {
     en: 'https://epfl-enac.github.io/co2-calculator-user-doc/equipment/',
     fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/equipment/',

--- a/frontend/src/i18n/external_cloud.ts
+++ b/frontend/src/i18n/external_cloud.ts
@@ -13,10 +13,6 @@ export default {
     en: 'This module calculates the carbon footprint associated with the use of external cloud services and AI. Some cells may or may not be editable depending on the type of service selected. For external cloud services, it is necessary to enter the provider name, used type of service (compute or storage), spending and associated currency. For AI services, it is necessary to enter the provider name, type of use (text, code or image generation), number of users and frequency of use.',
     fr: "Ce module calcule l'empreinte carbone liée à l'utilisation de services de clouds externes et d'intelligence artificielle. Certaines cellules seront ou non éditables en fonction du type de service sélectionné. Pour les services de clouds externes, il est nécessaire de saisir le nom du fournisseur, le type de service utilisé (calcul ou stockage), le montant dépensé et la devise associée. Pour les services d'IAs, il faut fournir le nom du fournisseur, le type d'utilisation (génération de texte, de code ou d'image), le nombre d'utilisateurs et la fréquence d'utilisation.",
   },
-  [`${MODULES.ExternalCloudAndAI}-documentation-title`]: {
-    en: 'For more information',
-    fr: "Pour plus d'information",
-  },
   [`${MODULES.ExternalCloudAndAI}-documentation-link`]: {
     en: 'https://epfl-enac.github.io/co2-calculator-user-doc/external-cloud/',
     fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/external-cloud/',

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -14,10 +14,6 @@ export default {
     en: `This module automatically displays the names, functions, SCIPERs, and FTE values of your unit’s members as of the reference year. For student contributions, please manually add their total accumulated FTE over the year. The total number of FTEs is used to generate the indicators for the additional categories (Food, Commuting, and Waste), as well as the total carbon footprint per FTE for your unit.`,
     fr: `Ce module affiche automatiquement les noms, fonctions, SCIPERs et valeurs EPT des membres de votre unité pour l'année de référence. Pour les contributions des étudiant·e·s, veuillez ajouter manuellement leur EPT total sur l'ensemble de l'année. Le nombre total d'EPT est utilisé pour générer les indicateurs des catégories additionnelles (Alimentation, Pendularité et Déchets), ainsi que l'empreinte carbone totale par EPT pour votre unité.`,
   },
-  [`${MODULES.Headcount}-documentation-title`]: {
-    en: 'For more information',
-    fr: "Pour plus d'information",
-  },
   [`${MODULES.Headcount}-documentation-link`]: {
     en: 'https://epfl-enac.github.io/co2-calculator-user-doc/headcount/',
     fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/headcount/',

--- a/frontend/src/i18n/process_emissions.ts
+++ b/frontend/src/i18n/process_emissions.ts
@@ -21,10 +21,6 @@ export default {
     en: 'This module allows to estimate the carbon footprint of greenhouse gases generated during your lab processes (e.g. CO₂ emissions in some lab activities, SF₆ emissions when it is used as refrigerant). Emissions generated in the research facilities that you use are excluded, as they are already accounted in the relavant module.',
     fr: 'Ce module permet d’estimer l’empreinte carbone des gaz à effet de serre générés lors de vos activités de laboratoire (e.g. émissions de CO₂ dans certaines activités de laboratoire, émissions de SF₆ quand celui-ci est utilisé en tant que fluide frigorigène). Les émissions générées dans les infrastructures de recherche que vous utilisez sont exclues, car elles sont déjà prises en compte dans le module relatif.',
   },
-  [`${MODULES.ProcessEmissions}-documentation-title`]: {
-    en: 'For more information',
-    fr: "Pour plus d'information",
-  },
   [`${MODULES.ProcessEmissions}-documentation-link`]: {
     en: 'https://epfl-enac.github.io/co2-calculator-user-doc/processes/',
     fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/processes/',

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -117,10 +117,6 @@ export default {
     en: "This module allows you to estimate and visualize the impact of your (or your unit's) travel by train and plane. Data relating to your air travel is provided to us by the EPFL Travel Agency, and the associated carbon footprint is calculated taking into account several factors such as distance, class booked, flight altitude, number of people on the plane, airline, etc. If you have traveled outside of the agency, please enter the departure city and arrival city in the tab below. The calculation methodology will then be different and will take into account the distance and type of flight (very short-haul, short-haul, medium-haul, or long-haul).",
     fr: "Ce module permet d'estimer et de visualiser l'impact de vos voyages (ou de votre unité) en train et en avion. Les données relatives à vos voyages en avion nous sont communiquées par l’Agence de voyages EPFL et l’empreinte carbone associée est calculée en considérant plusieurs facteurs tels que la distance, la classe réservée, la hauteur de vol, le nombre de personne dans l’avion, la compagnie aérienne, etc. Si vous avez effectué un voyage hors agence, merci de saisir dans l’onglet ci-dessous, la ville de départ et la ville d’arrivée. La méthodologie de calcul sera alors différente et considérera la distance et le type de vol (très court-courrier, court-courrier, moyen-courrier ou long-courrier).",
   },
-  [`${MODULES.ProfessionalTravel}-documentation-title`]: {
-    en: 'For more information',
-    fr: "Pour plus d'information",
-  },
   [`${MODULES.ProfessionalTravel}-documentation-link`]: {
     en: 'https://epfl-enac.github.io/co2-calculator-user-doc/professional-travel/',
     fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/professional-travel/',

--- a/frontend/src/i18n/purchase.ts
+++ b/frontend/src/i18n/purchase.ts
@@ -13,6 +13,10 @@ export default {
     en: 'Review annual purchase data and its carbon footprint.',
     fr: "Vérifiez vos données d'achats annuelles et leur empreinte carbone.",
   },
+  [`${MODULES.Purchase}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/purchases/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/purchases/',
+  },
   [`${MODULES.Purchase}-title-subtext`]: {
     en: "This module calculates the carbon footprint of your unit’s purchases on an item-by-item basis by using procurement data registered in the EPFL's invoice system. You can review the entries and manually add any missing purchases. By default, emissions are estimated using financial spend-based emission factors. However, for specific centralized purchase categories where you can enter usage data, the system will automatically apply usage-based emission factors. Please note that purchases, such that made through internal shops or via units' credit cards, are not currently included in the automatic sync. We highly encourage you to manually fill in these expenses to receive a complete overview for your unit.",
     fr: "Ce module calcule l'empreinte carbone des achats de votre unité, article par article, en utilisant les données d'approvisionnement enregistrées dans le système EPFL de facturation. Vous pouvez vérifier les entrées et ajouter manuellement les achats manquants. Par défaut, les émissions sont estimées à l'aide de facteurs d'émission basés sur les dépenses financières. Cependant, pour certaines catégories d'achats centralisés où vous pouvez saisir des données d'utilisation, le système appliquera automatiquement des facteurs d'émission basés sur l'utilisation. Veuillez noter qu'actuellement les achats effectués auprès de magasins internes ou via les cartes de crédit des unités, ne remontent pas automatiquement. Nous vous encourageons vivement à renseigner manuellement ces dépenses afin d'obtenir une image de vos achats aussi précise que possible.",

--- a/frontend/src/i18n/research_facilities.ts
+++ b/frontend/src/i18n/research_facilities.ts
@@ -12,6 +12,10 @@ export default {
     en: "Review the use of your unit's research facilities at EPFL.",
     fr: "Examinez l'utilisation des infrastructures de recherche EPFL de votre unité.",
   },
+  [`${MODULES.ResearchFacilities}-documentation-link`]: {
+    en: 'https://epfl-enac.github.io/co2-calculator-user-doc/services/',
+    fr: 'https://epfl-enac.github.io/co2-calculator-user-doc/fr/services/',
+  },
   [`${MODULES.ResearchFacilities}-title-subtext`]: {
     en: 'EPFL provides many research facilities such as cleanrooms, high‑performance computing centers, IT infrastructures and services as well as animal facilities, to name just a few. In total, there are more than 40 research facilities and several research centers that are used by the EPFL community, (as well as by other academic institutions, start-ups, companies, and industries). This sharing of resources is an excellent way to reduce carbon footprint.',
     fr: "L'EPFL mutualise de nombreux services internes tels que des salles blanches, des centres de calculs de hautes performances, des services informatiques ou des animaleries, pour n'en nommer que quelques-uns. Au total, il y a plus de 40 plateformes et centres de recherches qui sont utilisés par la communauté EPFL (mais également d'autres institutions académiques ainsi que des start-ups, entreprises et industries). Cette mutualisation des ressources est un excellent moyen de réduire l'empreinte carbone.",


### PR DESCRIPTION
## What does this change?
Centralizes the "For more information" documentation link label into a single shared i18n key and adds the two documentation links that were missing.

- Added `module_documentation_title` to `i18n/common.ts` (EN/FR).
- `ModuleTitle.vue` now resolves the label from that shared key instead of looking up a per-module `<module>-documentation-title` key with a fallback to `documentation`.
- Removed the now-redundant `<module>-documentation-title` entries from `buildings`, `equipment`, `external_cloud`, `headcount`, `process_emissions` and `professional_travel`.
- Added the missing `<module>-documentation-link` entries for **Purchase** (`/purchases/`) and **Research Facilities** (`/services/`), in both EN and FR.
- Updated the explanatory comment in `ModuleTitle.vue` to reflect the new split (URL is per-module, label is shared).

## Why is this needed?
The Purchase and Research Facilities modules had no `-documentation-link` key, so their documentation link was never rendered — users had no way to reach the user documentation from those modules.

At the same time, the label "For more information" / "Pour plus d'information" was duplicated identically across every module's i18n file. That duplication meant six places to update for a single wording or translation change, and it made the `te()` + fallback logic in `ModuleTitle.vue` unnecessarily complex. Keeping only the URL per module and sharing the label removes both problems.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features (n/a — no new features)
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum) (n/a — i18n string changes only)
- [x] No test failures introduced

## Related issues
- Related to #1649

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.