### PR TITLE
feat/1862 planner design refactor

### DIFF
--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1655,13 +1655,6 @@ const downloadCSV = () => {
   border: none !important;
 }
 
-/* Borderless: the surrounding layout adds its own gap under the card, so the
-   action row drops its bottom padding — otherwise the space under the buttons
-   reads as twice the space above them. */
-.module-carbon-chart--borderless .module-carbon-chart__actions {
-  padding-bottom: 0;
-}
-
 .module-carbon-chart__body {
   flex: 1;
 }

--- a/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
+++ b/frontend/src/components/charts/results/ModuleCarbonFootprintChart.vue
@@ -1616,7 +1616,7 @@ const downloadCSV = () => {
     <q-separator v-if="!isPrintMode && !props.hideActions" />
     <q-card-section
       v-if="!isPrintMode && !props.hideActions"
-      class="flex justify-start q-gutter-sm"
+      class="module-carbon-chart__actions flex justify-start q-gutter-x-sm"
     >
       <q-btn
         unelevated
@@ -1653,6 +1653,13 @@ const downloadCSV = () => {
 
 .module-carbon-chart--borderless {
   border: none !important;
+}
+
+/* Borderless: the surrounding layout adds its own gap under the card, so the
+   action row drops its bottom padding — otherwise the space under the buttons
+   reads as twice the space above them. */
+.module-carbon-chart--borderless .module-carbon-chart__actions {
+  padding-bottom: 0;
 }
 
 .module-carbon-chart__body {

--- a/frontend/src/components/molecules/BigNumber.vue
+++ b/frontend/src/components/molecules/BigNumber.vue
@@ -9,6 +9,8 @@ const props = withDefaults(
     unit?: string;
     hideUnit?: boolean;
     bordered?: boolean;
+    /** Tightens the gap between the title and the value. */
+    compact?: boolean;
     comparison?: string;
     comparisonHighlight?: string;
     color?: string;
@@ -18,6 +20,7 @@ const props = withDefaults(
   }>(),
   {
     bordered: true,
+    compact: false,
     unit: undefined,
     hideUnit: false,
     comparison: undefined,
@@ -76,10 +79,11 @@ const comparisonParts = computed(() => {
       'container--pa-none',
       'big-number',
       { 'big-number--borderless': !bordered },
+      { 'big-number--compact': compact },
       { 'big-number--print': printMode },
     ]"
   >
-    <q-card-section class="flex items-center q-mb-xs">
+    <q-card-section class="flex items-center" :class="{ 'q-mb-xs': !compact }">
       <span
         class="text-body1 text-weight-medium q-mb-none"
         :class="{
@@ -155,6 +159,19 @@ const comparisonParts = computed(() => {
 
 .big-number--borderless {
   border: none !important;
+}
+
+// Standalone (not in an equal-height row of tiles): the title reads as a
+// caption for the value right under it, so the two sections stop padding
+// against each other.
+.big-number--compact {
+  :deep(.q-card__section:first-child) {
+    padding-bottom: 0;
+  }
+
+  .big-number__content {
+    padding-top: tokens.$spacing-sm;
+  }
 }
 
 .big-number__content {

--- a/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
+++ b/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
@@ -184,43 +184,49 @@ onMounted(() => {
               class="q-pa-xs"
             >
               <template v-if="col.name === 'action'">
-                <div class="row no-wrap justify-end">
+                <div class="row no-wrap justify-end items-center">
                   <q-btn
                     icon="o_content_copy"
                     color="black"
                     unelevated
                     no-caps
                     dense
-                    outline
-                    square
-                    size="xs"
-                    class="square-button"
+                    flat
+                    class="action-btn"
                     @click="onDuplicate(props.row)"
-                  />
+                  >
+                    <q-tooltip class="tooltip action-tooltip" :offset="[0, 8]">
+                      {{ $t('common_duplicate') }}
+                    </q-tooltip>
+                  </q-btn>
                   <q-btn
                     icon="o_edit"
                     color="black"
                     unelevated
                     no-caps
                     dense
-                    outline
-                    square
-                    size="xs"
-                    class="square-button"
+                    flat
+                    class="action-btn"
                     @click="onEdit(props.row)"
-                  />
+                  >
+                    <q-tooltip class="tooltip action-tooltip" :offset="[0, 8]">
+                      {{ $t('common_edit') }}
+                    </q-tooltip>
+                  </q-btn>
                   <q-btn
                     icon="o_delete"
                     color="black"
                     unelevated
                     no-caps
                     dense
-                    outline
-                    square
-                    size="xs"
-                    class="square-button"
+                    flat
+                    class="action-btn action-btn--delete"
                     @click="onAskDelete(props.row)"
-                  />
+                  >
+                    <q-tooltip class="tooltip action-tooltip" :offset="[0, 8]">
+                      {{ $t('common_delete') }}
+                    </q-tooltip>
+                  </q-btn>
                 </div>
               </template>
               <template v-else>{{ col.value }}</template>
@@ -313,6 +319,36 @@ onMounted(() => {
 // Intro/description text under a section title is capped at three-quarters width.
 .section-intro {
   max-width: 75%;
+}
+
+// Row actions read the same as the module tables: quiet icon buttons that
+// only take a surface on hover, delete turning red.
+.action-btn {
+  width: 32px;
+  height: 32px;
+  min-height: 0;
+  padding: 0;
+  border-radius: tokens.$radius-default;
+
+  .q-icon {
+    font-size: 18px;
+  }
+
+  & + .action-btn {
+    margin-left: tokens.$spacing-xs;
+  }
+
+  &:not(.disabled):hover {
+    background: tokens.$table-action-hover-bg;
+  }
+
+  &--delete:not(.disabled):hover {
+    background: tokens.$table-action-delete-hover-bg;
+
+    .q-icon {
+      color: tokens.$icon-color-white;
+    }
+  }
 }
 
 // Perfect-circle count badge next to the title.

--- a/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
+++ b/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
@@ -324,14 +324,14 @@ onMounted(() => {
 // Row actions read the same as the module tables: quiet icon buttons that
 // only take a surface on hover, delete turning red.
 .action-btn {
-  width: 32px;
-  height: 32px;
+  width: tokens.$table-action-size;
+  height: tokens.$table-action-size;
   min-height: 0;
   padding: 0;
   border-radius: tokens.$radius-default;
 
   .q-icon {
-    font-size: 18px;
+    font-size: tokens.$table-action-icon-size;
   }
 
   & + .action-btn {

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -2331,15 +2331,15 @@ onUnmounted(() => {
   }
 
   .action-btn {
-    width: 32px;
-    height: 32px;
+    width: tokens.$table-action-size;
+    height: tokens.$table-action-size;
     min-height: 0;
     padding: 0;
     border-radius: tokens.$radius-default;
   }
 
   .action-btn .q-icon {
-    font-size: 18px;
+    font-size: tokens.$table-action-icon-size;
   }
 
   .action-btn + .action-btn {

--- a/frontend/src/components/organisms/planner/PlannerHeadcountRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerHeadcountRows.vue
@@ -134,7 +134,7 @@ onMounted(load);
   }
 
   &__input {
-    width: 7.5rem;
+    width: tokens.$planner-grid-fte-input-width;
 
     // The field keeps its own white surface so it stays legible on the
     // shaded stripes instead of picking up the row behind it.

--- a/frontend/src/components/organisms/planner/PlannerHeadcountRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerHeadcountRows.vue
@@ -1,21 +1,28 @@
 <template>
-  <div class="q-gutter-y-sm">
+  <!-- Reads as a table: full-width striped rows carry the eye from the
+       category across to its field, the way the Calculator tables do. -->
+  <div class="headcount-table">
     <div
       v-for="row in rows"
       :key="row.sius_code"
-      class="row items-center justify-between q-py-xs"
+      class="headcount-table__row row items-center no-wrap"
     >
       <!-- Canonical SIUS-category labels from i18n/headcount_factor.ts
            (keyed by the bare code) — same source the Calculator uses. -->
-      <div class="text-body1">{{ $t(row.sius_code) }}</div>
+      <label :for="`fte-${row.sius_code}`" class="col text-body2">
+        {{ $t(row.sius_code) }}
+      </label>
       <q-input
+        :id="`fte-${row.sius_code}`"
         v-model.number="row.fte"
+        class="headcount-table__input"
         type="number"
         outlined
         dense
+        hide-bottom-space
         min="0"
         step="0.5"
-        style="max-width: 180px"
+        input-class="text-right"
         :disable="disable || savingCode === row.sius_code"
         :loading="savingCode === row.sius_code"
         @blur="save(row)"
@@ -111,3 +118,29 @@ async function save(row: HeadcountRow) {
 
 onMounted(load);
 </script>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.headcount-table {
+  &__row {
+    gap: tokens.$spacing-lg;
+    padding: tokens.$spacing-xs tokens.$spacing-md;
+    background-color: tokens.$table-bg-odd;
+
+    &:nth-child(even) {
+      background-color: tokens.$table-bg-even;
+    }
+  }
+
+  &__input {
+    width: 7.5rem;
+
+    // The field keeps its own white surface so it stays legible on the
+    // shaded stripes instead of picking up the row behind it.
+    :deep(.q-field__control) {
+      background-color: tokens.$table-bg-odd;
+    }
+  }
+}
+</style>

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -1,13 +1,15 @@
 <template>
   <q-card flat bordered>
     <q-card-section class="row items-center q-gutter-sm">
-      <q-icon name="o_folder_open" color="negative" size="24px" />
-      <span class="text-h5">{{ $t('planner_project_info_title') }}</span>
+      <q-icon name="o_folder_open" color="info" size="24px" />
+      <span class="text-h5 text-weight-medium">
+        {{ $t('planner_project_info_title') }}
+      </span>
     </q-card-section>
     <q-separator />
 
     <q-card-section>
-      <div class="text-weight-bold q-mb-sm">
+      <div class="text-weight-medium q-mb-sm">
         {{ $t('planner_project_label') }}
       </div>
       <q-input
@@ -15,6 +17,7 @@
         :label="`${$t('project_planner_name_label')} *`"
         outlined
         dense
+        hide-bottom-space
         :error="nameTouched && nameInput.trim().length === 0"
         @blur="saveIfDirty('name')"
         @keyup.enter="saveIfDirty('name')"
@@ -23,7 +26,7 @@
     <q-separator />
 
     <q-card-section>
-      <div class="text-weight-bold q-mb-sm">
+      <div class="text-weight-medium q-mb-sm">
         {{ $t('planner_year_selection_label') }}
       </div>
       <div class="row q-col-gutter-md">
@@ -34,11 +37,12 @@
             :options="startYearOptions"
             outlined
             dense
+            hide-bottom-space
             emit-value
             map-options
           >
             <template #prepend>
-              <q-icon name="o_calendar_month" color="negative" />
+              <q-icon name="o_calendar_month" color="info" />
             </template>
           </q-select>
         </div>
@@ -49,11 +53,12 @@
             :options="endYearOptions"
             outlined
             dense
+            hide-bottom-space
             emit-value
             map-options
           >
             <template #prepend>
-              <q-icon name="o_calendar_month" color="negative" />
+              <q-icon name="o_calendar_month" color="info" />
             </template>
           </q-select>
         </div>
@@ -65,7 +70,9 @@
         <q-btn
           unelevated
           no-caps
-          color="negative"
+          size="sm"
+          color="info"
+          class="text-weight-regular"
           icon="o_playlist_add"
           :label="$t('planner_generate_years_button')"
           :disable="!yearsDirty || !yearsValid"
@@ -83,7 +90,8 @@
       <q-checkbox
         v-model="shareWithLab"
         :label="$t('planner_share_with_lab_label')"
-        color="negative"
+        color="info"
+        size="sm"
         @update:model-value="saveIfDirty('is_viewable_by_unit_members')"
       />
     </q-card-section>

--- a/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
@@ -3,76 +3,85 @@
     <!-- The backend accepts a global budget XOR per-category totals (PRD
          #1555), so the two modes are one explicit choice rather than two
          tables the user discovers are incompatible. -->
-    <div class="planner-purchase-mode row items-center no-wrap">
-      <button
-        type="button"
-        class="planner-purchase-mode__label text-body1"
-        :class="mode === 'global' ? 'text-weight-medium' : 'text-grey-6'"
-        :disabled="disable || switching"
-        :aria-pressed="mode === 'global'"
-        @click="onModeRequest('global')"
-      >
-        {{ $t('planner_purchase_mode_global') }}
-      </button>
-      <q-toggle
-        :model-value="mode === 'per_category'"
-        color="info"
-        keep-color
-        size="lg"
-        :disable="disable || switching"
-        @update:model-value="
-          (on: boolean) => onModeRequest(on ? 'per_category' : 'global')
-        "
-      />
-      <button
-        type="button"
-        class="planner-purchase-mode__label text-body1"
-        :class="mode === 'per_category' ? 'text-weight-medium' : 'text-grey-6'"
-        :disabled="disable || switching"
-        :aria-pressed="mode === 'per_category'"
-        @click="onModeRequest('per_category')"
-      >
-        {{ $t('planner_purchase_mode_per_category') }}
-      </button>
-    </div>
-    <div class="text-body2 text-grey-7">
-      {{ $t('planner_purchase_mode_hint') }}
+    <div class="planner-purchase__header">
+      <div class="planner-purchase-mode row items-center no-wrap">
+        <button
+          type="button"
+          class="planner-purchase-mode__label text-body1"
+          :class="mode === 'global' ? 'text-weight-medium' : 'text-grey-6'"
+          :disabled="disable || switching"
+          :aria-pressed="mode === 'global'"
+          @click="onModeRequest('global')"
+        >
+          {{ $t('planner_purchase_mode_global') }}
+        </button>
+        <q-toggle
+          :model-value="mode === 'per_category'"
+          color="info"
+          keep-color
+          size="lg"
+          :disable="disable || switching"
+          @update:model-value="
+            (on: boolean) => onModeRequest(on ? 'per_category' : 'global')
+          "
+        />
+        <button
+          type="button"
+          class="planner-purchase-mode__label text-body1"
+          :class="
+            mode === 'per_category' ? 'text-weight-medium' : 'text-grey-6'
+          "
+          :disabled="disable || switching"
+          :aria-pressed="mode === 'per_category'"
+          @click="onModeRequest('per_category')"
+        >
+          {{ $t('planner_purchase_mode_per_category') }}
+        </button>
+      </div>
+      <div class="text-body2 text-grey-7">
+        {{ $t('planner_purchase_mode_hint') }}
+      </div>
     </div>
 
-    <!-- Full-bleed: the mode choice governs the fields below it, so the rule
-         between them runs to the card edges like the section headers do. -->
-    <q-separator class="planner-purchase-divider q-my-md" />
+    <q-separator />
 
-    <div class="q-gutter-y-sm">
-      <div v-for="row in visibleRows" :key="row.key" class="q-py-xs">
-        <div class="row items-center justify-between">
-          <div class="text-body1">{{ $t(row.labelKey) }}</div>
-          <div class="row items-center no-wrap q-gutter-md">
-            <div class="text-body2 text-grey-7">
-              <template v-if="row.kg !== null">
-                {{ formatTonnesCO2(row.kg / 1000) }} {{ $t('tco2eq') }}
-              </template>
-            </div>
-            <q-input
-              v-model.number="row.amount"
-              type="number"
-              outlined
-              dense
-              hide-bottom-space
-              min="0"
-              suffix="EUR"
-              style="max-width: 200px"
-              :aria-label="$t('planner_purchase_amount_label')"
-              :disable="disable || switching || savingKey === row.key"
-              :loading="savingKey === row.key"
-              :error="row.error !== null"
-              @blur="save(row)"
-              @keyup.enter="save(row)"
-            />
+    <!-- Reads as a table, like the headcount grid: full-width striped rows
+         carry the eye from the category across to its field. -->
+    <div class="planner-purchase-table">
+      <div
+        v-for="row in visibleRows"
+        :key="row.key"
+        class="planner-purchase-table__row"
+      >
+        <div class="row items-center no-wrap">
+          <label :for="`purchase-${row.key}`" class="col text-body2">
+            {{ $t(row.labelKey) }}
+          </label>
+          <div class="planner-purchase-table__kg text-body2 text-grey-7">
+            <template v-if="row.kg !== null">
+              {{ formatTonnesCO2(row.kg / 1000) }} {{ $t('tco2eq') }}
+            </template>
           </div>
+          <q-input
+            :id="`purchase-${row.key}`"
+            v-model.number="row.amount"
+            class="planner-purchase-table__input"
+            type="number"
+            outlined
+            dense
+            hide-bottom-space
+            min="0"
+            suffix="EUR"
+            :aria-label="$t('planner_purchase_amount_label')"
+            :disable="disable || switching || savingKey === row.key"
+            :loading="savingKey === row.key"
+            :error="row.error !== null"
+            @blur="save(row)"
+            @keyup.enter="save(row)"
+          />
         </div>
         <!-- Full width: the rule that was broken needs a sentence, which does
-             not fit under a 200px field. -->
+             not fit under the field. -->
         <div v-if="row.error" class="text-body2 text-negative q-mt-xs">
           {{ row.error }}
         </div>
@@ -405,11 +414,40 @@ onMounted(load);
 <style scoped lang="scss">
 @use 'src/css/02-tokens' as tokens;
 
-// Cancels the q-pa-md the planner wraps this section in, so the rule meets the
-// module card's border instead of stopping short of it.
-.planner-purchase-divider {
-  margin-left: -#{tokens.$spacing-md};
-  margin-right: -#{tokens.$spacing-md};
+// The stripes run edge to edge, so only the mode choice above them is inset.
+.planner-purchase__header {
+  padding: tokens.$spacing-md;
+}
+
+.planner-purchase-table {
+  &__row {
+    padding: tokens.$spacing-xs tokens.$spacing-md;
+    background-color: tokens.$table-bg-odd;
+
+    &:nth-child(even) {
+      background-color: tokens.$table-bg-even;
+    }
+  }
+
+  &__kg {
+    padding-right: tokens.$spacing-lg;
+  }
+
+  &__input {
+    width: tokens.$planner-grid-amount-input-width;
+
+    // The field keeps its own white surface so it stays legible on the
+    // shaded stripes instead of picking up the row behind it.
+    :deep(.q-field__control) {
+      background-color: tokens.$table-bg-odd;
+    }
+
+    // The currency is a unit, not part of the value the user typed.
+    :deep(.q-field__suffix) {
+      font-size: tokens.$text-size-sm;
+      color: tokens.$color-text-muted;
+    }
+  }
 }
 
 // Both modes are named on either side of the switch; the one not in use reads

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -53,7 +53,7 @@
           <q-icon name="o_calendar_month" class="reference-year-row__icon" />
           <span>{{ $t('planner_reference_year_set_button') }}</span>
         </q-btn>
-        <div class="text-body2 text-grey-7 q-mt-xs">
+        <div class="text-body2 text-grey-7 q-mt-sm">
           {{
             yearData.reference_year
               ? $t('planner_reference_year_rebuild_hint')
@@ -82,7 +82,7 @@
       >
         <q-separator v-if="entryIdx > 0" />
         <q-expansion-item
-          :model-value="expandedKey === expansionKey(entry.config.module)"
+          :model-value="isExpanded(entry.config.module)"
           :disable="!hasReferenceYear"
           header-class="q-py-md"
           @update:model-value="
@@ -108,6 +108,8 @@
                   :model-value="entry.module?.is_active ?? true"
                   :label="$t('planner_module_active_label')"
                   color="info"
+                  size="sm"
+                  dense
                   :disable="
                     !entry.module || togglingModuleId === entry.module.id
                   "
@@ -124,9 +126,12 @@
           </template>
 
           <q-separator />
+          <!-- Headcount stripes run edge to edge, so it carries no padding. -->
           <div
-            v-if="expandedKey === expansionKey(entry.config.module)"
-            class="q-pa-md"
+            v-if="isExpanded(entry.config.module)"
+            :class="
+              entry.config.module === MODULES.Headcount ? undefined : 'q-pa-md'
+            "
           >
             <!-- Headcount is a fixed SIUS-category grid, not an add-row
                    table (design). Other modules reuse the Calculator tables. -->
@@ -192,10 +197,12 @@ const props = defineProps<{
   yearData: SimulatorPlanYear;
   unitId: number;
   referenceYearOptions: { label: string; value: number }[];
-  /** `${year}-${module}` of the single expanded module across the page. */
-  expandedKey: string | null;
+  /** `${year}-${module}` of every expanded module across the page. */
+  expandedKeys: string[];
 }>();
-const emit = defineEmits<{ 'update:expandedKey': [key: string | null] }>();
+const emit = defineEmits<{
+  toggleModule: [payload: { key: string; module: Module; open: boolean }];
+}>();
 
 const $q = useQuasar();
 const { t } = useI18n();
@@ -224,6 +231,10 @@ function expansionKey(module: Module): string {
   return `${props.yearData.year}-${module}`;
 }
 
+function isExpanded(module: Module): boolean {
+  return props.expandedKeys.includes(expansionKey(module));
+}
+
 function factorScopedKey(module: Module): string {
   return factorMountKey(module, props.yearData.reference_year);
 }
@@ -238,7 +249,7 @@ async function refreshExpandedModule(module: Module) {
 }
 
 function onToggle(module: Module, open: boolean) {
-  emit('update:expandedKey', open ? expansionKey(module) : null);
+  emit('toggleModule', { key: expansionKey(module), module, open });
   if (open) void refreshExpandedModule(module);
 }
 
@@ -251,12 +262,13 @@ async function onReferenceYearChange(referenceYear: number) {
       referenceYear,
     );
     referenceYearDialogOpen.value = false;
-    // The prefilled modules were rebuilt from the new baseline; refresh the
-    // open module so its rows appear without a manual reload.
-    const expanded = props.expandedKey?.startsWith(`${props.yearData.year}-`);
-    const module = props.expandedKey?.split('-').slice(1).join('-') as
-      Module | undefined;
-    if (expanded && module) await refreshExpandedModule(module);
+    // The prefilled modules were rebuilt from the new baseline; refresh this
+    // year's open modules so their rows appear without a manual reload.
+    const prefix = `${props.yearData.year}-`;
+    for (const key of props.expandedKeys) {
+      if (!key.startsWith(prefix)) continue;
+      await refreshExpandedModule(key.slice(prefix.length) as Module);
+    }
   } catch {
     $q.notify({ type: 'negative', message: t('planner_reference_year_error') });
   } finally {

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -100,7 +100,7 @@
                   <q-checkbox
                     :model-value="entry.module?.is_active ?? true"
                     :label="$t('planner_module_active_label')"
-                    color="negative"
+                    color="info"
                     :disable="
                       !entry.module || togglingModuleId === entry.module.id
                     "

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -126,17 +126,21 @@
           </template>
 
           <q-separator />
-          <!-- Headcount stripes run edge to edge, so it carries no padding. -->
+          <!-- Grid stripes run edge to edge, so they carry no padding. -->
           <div
             v-if="isExpanded(entry.config.module)"
-            :class="
-              entry.config.module === MODULES.Headcount ? undefined : 'q-pa-md'
-            "
+            :class="isGridModule(entry.config.module) ? undefined : 'q-pa-md'"
           >
-            <!-- Headcount is a fixed SIUS-category grid, not an add-row
-                   table (design). Other modules reuse the Calculator tables. -->
+            <!-- Headcount is a fixed SIUS-category grid and Purchases a
+                   global-budget XOR per-category grid, not add-row tables
+                   (design). Other modules reuse the Calculator tables. -->
             <planner-headcount-rows
               v-if="entry.config.module === MODULES.Headcount"
+              :carbon-report-id="yearData.id"
+              :disable="entry.module?.is_active === false"
+            />
+            <planner-purchase-rows
+              v-else-if="entry.config.module === MODULES.Purchase"
               :carbon-report-id="yearData.id"
               :disable="entry.module?.is_active === false"
             />
@@ -217,6 +221,12 @@ const togglingModuleId = ref<number | null>(null);
 // Every module resolves its factors from the reference year; without one there
 // is nothing to enter data against, so the drawers stay shut.
 const hasReferenceYear = computed(() => props.yearData.reference_year !== null);
+
+const GRID_MODULES: Module[] = [MODULES.Headcount, MODULES.Purchase];
+
+function isGridModule(module: Module): boolean {
+  return GRID_MODULES.includes(module);
+}
 
 const moduleEntries = computed<ModuleEntry[]>(() =>
   PLANNER_MODULES.map((config) => ({

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -2,7 +2,7 @@
   <q-card flat bordered>
     <q-expansion-item
       v-model="yearOpen"
-      header-class="text-h5 text-weight-bold"
+      header-class="text-h5 text-weight-medium"
     >
       <template #header>
         <q-item-section>{{ yearData.year }}</q-item-section>
@@ -10,21 +10,21 @@
 
       <q-separator />
       <q-card-section>
-        <div class="text-weight-bold q-mb-sm">
+        <div class="text-weight-medium q-mb-sm">
           {{ $t('planner_reference_year_label') }}
         </div>
         <!-- Set: the value reads first, the action stays quiet beside it.
              Unset: nothing to read yet, so the action carries the label. -->
         <div
           v-if="yearData.reference_year"
-          class="reference-year-row row items-center no-wrap"
+          class="reference-year-box reference-year-row row items-center no-wrap"
         >
           <q-icon
             name="o_calendar_month"
             color="info"
             class="reference-year-row__icon"
           />
-          <span class="reference-year-row__value text-weight-bold">
+          <span class="reference-year-row__value text-weight-medium">
             {{ yearData.reference_year }}
           </span>
           <q-separator vertical class="reference-year-row__divider" />
@@ -46,7 +46,7 @@
           flat
           no-caps
           align="left"
-          class="reference-year-empty text-weight-medium"
+          class="reference-year-box reference-year-empty text-weight-medium"
           :loading="settingReferenceYear"
           @click="referenceYearDialogOpen = true"
         >
@@ -62,6 +62,8 @@
         </div>
       </q-card-section>
 
+      <q-separator />
+
       <planner-reference-year-dialog
         v-if="referenceYearDialogOpen"
         :key="`ref-year-${yearData.reference_year}`"
@@ -73,86 +75,84 @@
         @confirm="onReferenceYearChange"
       />
 
-      <!-- One bordered card per module, in Calculator order -->
-      <q-card-section class="q-gutter-md">
-        <q-card
-          v-for="entry in moduleEntries"
-          :key="entry.config.module"
-          flat
-          bordered
+      <!-- Flat separator-joined list, in Calculator order — same as the Explorer -->
+      <template
+        v-for="(entry, entryIdx) in moduleEntries"
+        :key="entry.config.module"
+      >
+        <q-separator v-if="entryIdx > 0" />
+        <q-expansion-item
+          :model-value="expandedKey === expansionKey(entry.config.module)"
+          :disable="!hasReferenceYear"
+          header-class="q-py-md"
+          @update:model-value="
+            (open: boolean) => onToggle(entry.config.module, open)
+          "
         >
-          <q-expansion-item
-            :model-value="expandedKey === expansionKey(entry.config.module)"
-            :disable="!hasReferenceYear"
-            @update:model-value="
-              (open: boolean) => onToggle(entry.config.module, open)
-            "
-          >
-            <template #header>
-              <q-item-section avatar>
-                <module-icon-box :name="entry.config.module" size="md" />
-              </q-item-section>
-              <q-item-section class="text-weight-medium">
-                {{ $t(entry.config.module) }}
-              </q-item-section>
-              <q-item-section side @click.stop>
-                <div class="row items-center no-wrap q-gutter-sm">
-                  <q-checkbox
-                    :model-value="entry.module?.is_active ?? true"
-                    :label="$t('planner_module_active_label')"
-                    color="info"
-                    :disable="
-                      !entry.module || togglingModuleId === entry.module.id
-                    "
-                    @update:model-value="
-                      (active: boolean) => onToggleActive(entry, active)
-                    "
-                  >
-                    <q-tooltip>{{
-                      $t('planner_module_active_tooltip')
-                    }}</q-tooltip>
-                  </q-checkbox>
+          <template #header>
+            <q-item-section>
+              <div class="flex items-center">
+                <module-icon-box
+                  :name="entry.config.module"
+                  size="sm"
+                  class="q-mr-sm"
+                />
+                <div class="text-h5 text-weight-medium">
+                  {{ $t(entry.config.module) }}
                 </div>
-              </q-item-section>
-            </template>
+              </div>
+            </q-item-section>
+            <q-item-section side @click.stop>
+              <div class="row items-center no-wrap q-gutter-sm">
+                <q-checkbox
+                  :model-value="entry.module?.is_active ?? true"
+                  :label="$t('planner_module_active_label')"
+                  color="info"
+                  :disable="
+                    !entry.module || togglingModuleId === entry.module.id
+                  "
+                  @update:model-value="
+                    (active: boolean) => onToggleActive(entry, active)
+                  "
+                >
+                  <q-tooltip>{{
+                    $t('planner_module_active_tooltip')
+                  }}</q-tooltip>
+                </q-checkbox>
+              </div>
+            </q-item-section>
+          </template>
 
-            <q-separator />
-            <div
-              v-if="expandedKey === expansionKey(entry.config.module)"
-              class="q-pa-md"
-            >
-              <!-- Headcount is a fixed SIUS-category grid and Purchases a
-                   global-budget XOR per-category grid, not add-row tables
-                   (design). Other modules reuse the Calculator tables. -->
-              <planner-headcount-rows
-                v-if="entry.config.module === MODULES.Headcount"
-                :carbon-report-id="yearData.id"
-                :disable="entry.module?.is_active === false"
-              />
-              <planner-purchase-rows
-                v-else-if="entry.config.module === MODULES.Purchase"
-                :carbon-report-id="yearData.id"
-                :disable="entry.module?.is_active === false"
-              />
-              <module-table-section
-                v-else
-                :key="factorScopedKey(entry.config.module)"
-                :type="entry.config.module"
-                :config-override="getPlannerModuleConfig(entry.config.module)"
-                :data="moduleStore.state.data"
-                :loading="moduleStore.state.loading"
-                :error="moduleStore.state.error"
-                :unit-id="unitId"
-                :year="yearData.year"
-                :factor-year="yearData.reference_year"
-                :carbon-report-id="yearData.id"
-                :show-reference-columns="entry.config.behavior === 'prefilled'"
-                :disable="entry.module?.is_active === false"
-              />
-            </div>
-          </q-expansion-item>
-        </q-card>
-      </q-card-section>
+          <q-separator />
+          <div
+            v-if="expandedKey === expansionKey(entry.config.module)"
+            class="q-pa-md"
+          >
+            <!-- Headcount is a fixed SIUS-category grid, not an add-row
+                   table (design). Other modules reuse the Calculator tables. -->
+            <planner-headcount-rows
+              v-if="entry.config.module === MODULES.Headcount"
+              :carbon-report-id="yearData.id"
+              :disable="entry.module?.is_active === false"
+            />
+            <module-table-section
+              v-else
+              :key="factorScopedKey(entry.config.module)"
+              :type="entry.config.module"
+              :config-override="getPlannerModuleConfig(entry.config.module)"
+              :data="moduleStore.state.data"
+              :loading="moduleStore.state.loading"
+              :error="moduleStore.state.error"
+              :unit-id="unitId"
+              :year="yearData.year"
+              :factor-year="yearData.reference_year"
+              :carbon-report-id="yearData.id"
+              :show-reference-columns="entry.config.behavior === 'prefilled'"
+              :disable="entry.module?.is_active === false"
+            />
+          </div>
+        </q-expansion-item>
+      </template>
     </q-expansion-item>
   </q-card>
 </template>
@@ -282,23 +282,37 @@ async function onToggleActive(entry: ModuleEntry, active: boolean) {
 <style scoped lang="scss">
 @use 'src/css/02-tokens' as tokens;
 
-// Setting row: the current value reads as the content, the action sits quietly
-// beside it — changing the baseline is deliberate, not a stray click.
-.reference-year-row {
+// Both states share one box so the set and unset slots stay the same size.
+// q-btn brings its own min-height / line-height; drop both so the padding
+// tokens alone decide the box, as they already do for the filled row.
+.reference-year-box {
   display: inline-flex;
   gap: tokens.$reference-year-row-gap;
   padding: tokens.$reference-year-row-padding-y
     tokens.$reference-year-row-padding-x;
-  border: tokens.$reference-year-row-border-weight solid
-    tokens.$reference-year-row-border-color;
+  border-width: tokens.$reference-year-row-border-weight;
   border-radius: tokens.$reference-year-row-border-radius;
+  font-size: tokens.$reference-year-row-value-font-size;
+  min-height: 0;
+  line-height: 1;
 
-  &__icon {
+  .reference-year-row__icon {
     font-size: tokens.$reference-year-row-icon-size;
   }
 
+  :deep(.q-btn__content) {
+    gap: tokens.$reference-year-row-gap;
+    line-height: 1;
+  }
+}
+
+// Setting row: the current value reads as the content, the action sits quietly
+// beside it — changing the baseline is deliberate, not a stray click.
+.reference-year-row {
+  border-style: solid;
+  border-color: tokens.$reference-year-row-border-color;
+
   &__value {
-    font-size: tokens.$reference-year-row-value-font-size;
     line-height: 1;
   }
 
@@ -315,16 +329,7 @@ async function onToggleActive(entry: ModuleEntry, active: boolean) {
 // The same slot before it holds anything: dashed, so it reads as waiting to be
 // filled rather than as a call to action competing with the module list.
 .reference-year-empty {
-  padding: tokens.$reference-year-row-padding-y
-    tokens.$reference-year-row-padding-x;
-  border: tokens.$reference-year-row-border-weight
-    tokens.$reference-year-row-empty-border-style
-    tokens.$reference-year-row-empty-border-color;
-  border-radius: tokens.$reference-year-row-border-radius;
-  font-size: tokens.$reference-year-row-value-font-size;
-
-  :deep(.q-btn__content) {
-    gap: tokens.$reference-year-row-gap;
-  }
+  border-style: tokens.$reference-year-row-empty-border-style;
+  border-color: tokens.$reference-year-row-empty-border-color;
 }
 </style>

--- a/frontend/src/css/02-tokens/_components.scss
+++ b/frontend/src/css/02-tokens/_components.scss
@@ -174,6 +174,8 @@ $table-color-warning: opt.$tokens-colors-status-red !default;
 $table-color-success: opt.$tokens-colors-status-green !default;
 $table-max-height: opt.$tokens-table-max-height !default;
 $table-header-z-index: opt.$tokens-z-index-sticky !default;
+$table-action-size: opt.$tokens-table-action-size !default;
+$table-action-icon-size: opt.$tokens-typography-font-size-lg !default;
 $table-action-hover-bg: opt.$tokens-colors-grey-scale-grey-200 !default;
 $table-action-delete-hover-bg: rgba(
   opt.$tokens-colors-red-red-100,
@@ -358,3 +360,8 @@ $reference-year-row-action-font-size: opt.$tokens-typography-font-size-sm !defau
 // Empty state: the same slot, drawn as waiting to be filled.
 $reference-year-row-empty-border-style: dashed !default;
 $reference-year-row-empty-border-color: opt.$tokens-colors-grey-scale-grey-400 !default;
+
+// Planner fixed-category grids (headcount, purchases): striped rows whose
+// field is sized to its value, not to the row.
+$planner-grid-fte-input-width: opt.$tokens-planner-grid-fte-input-width !default;
+$planner-grid-amount-input-width: opt.$tokens-planner-grid-amount-input-width !default;

--- a/frontend/src/css/02-tokens/_options.scss
+++ b/frontend/src/css/02-tokens/_options.scss
@@ -138,6 +138,11 @@ $tokens-z-index-top: 99 !default;
 
 // Table
 $tokens-table-max-height: 600px !default;
+$tokens-table-action-size: 2rem !default;
+
+// Planner
+$tokens-planner-grid-fte-input-width: 7.5rem !default;
+$tokens-planner-grid-amount-input-width: 12rem !default;
 
 // Chart Tooltip
 $tokens-chart-tooltip-min-width: 12rem !default;

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -108,8 +108,8 @@ export default {
     fr: "Planifiez l'empreinte carbone d'un projet à venir. Donnez un nom à votre projet ; son contenu apparaîtra ici.",
   },
   planner_page_title: {
-    en: 'Simulator',
-    fr: 'Simulateur',
+    en: 'CO₂ Project Planner',
+    fr: 'Planificateur de projet CO₂',
   },
   planner_page_subtitle: {
     en: 'Estimating the carbon footprint of a project or category of emissions.',

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -74,12 +74,17 @@
 
           <q-separator class="q-mt-lg" />
 
-          <div class="grid-1-col">
+          <!-- Gapless grid: each block's own padding is the only spacing, so
+               its top and bottom read alike (a gap would land above every
+               separator but never at the card edges). Still a grid, because
+               BigNumber sizes itself against its row. -->
+          <div class="results-blocks">
             <BigNumber
               :title="$t('planner_results_total_tonnes_co2eq')"
               :number="formatTonnesCO2(totalTonnesCo2eq)"
               comparison=""
               color="info"
+              compact
               :bordered="false"
             />
 
@@ -93,7 +98,7 @@
 
             <q-separator />
 
-            <div class="column items-center justify-center q-pa-lg q-gutter-md">
+            <div class="column items-center justify-center q-pa-xl q-gutter-md">
               <h3 class="text-h4 text-weight-medium">
                 {{ $t('planner_results_download_title') }}
               </h3>
@@ -244,3 +249,10 @@ onUnmounted(() => {
   plansStore.clearAggregate();
 });
 </script>
+
+<style scoped lang="scss">
+.results-blocks {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+</style>

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -60,8 +60,8 @@
           :year-data="yearData"
           :unit-id="unitId"
           :reference-year-options="referenceYearOptions"
-          :expanded-key="expandedKey"
-          @update:expanded-key="expandedKey = $event"
+          :expanded-keys="expandedKeys"
+          @toggle-module="onToggleModule"
         />
 
         <!-- Whole-plan results: every year of the range summed together -->
@@ -152,9 +152,25 @@ const unitId = computed(() => workspaceStore.selectedUnit!.id);
 
 const plan = ref<SimulatorPlan | null>(null);
 const notFound = ref(false);
-// `${year}-${module}` of the single expanded module across all year
-// sections — the module store holds one module's data at a time.
-const expandedKey = ref<string | null>(null);
+// `${year}-${module}` of every expanded module. Any number can be open at
+// once, except the same module in two years: the module store keys its
+// submodule rows by submodule id alone, so both would read one another's data.
+const expandedKeys = ref<string[]>([]);
+
+function onToggleModule({
+  key,
+  module,
+  open,
+}: {
+  key: string;
+  module: string;
+  open: boolean;
+}) {
+  const others = expandedKeys.value.filter(
+    (k) => k !== key && !k.endsWith(`-${module}`),
+  );
+  expandedKeys.value = open ? [...others, key] : others;
+}
 
 const breakdown = computed(() =>
   plansStore.aggregateStats

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -23,22 +23,29 @@
 
     <template v-else-if="plan">
       <!-- Title box -->
-      <q-card flat bordered class="container q-pa-lg">
-        <q-icon name="o_tune" color="negative" size="32px" class="q-mb-md" />
-        <h1 class="text-h3 q-mt-none q-mb-xs">
-          {{ $t('planner_page_title') }}
-        </h1>
-        <p class="text-subtitle1 text-weight-medium q-mb-md">
-          {{ $t('planner_page_subtitle') }}
-        </p>
-        <p class="text-body1 q-mb-none text-grey-8">
-          {{ $t('planner_page_intro') }}
-          <q-icon name="o_info" size="18px" class="q-ml-xs cursor-pointer">
-            <q-tooltip max-width="360px">
+      <q-card flat class="container">
+        <div class="row justify-between items-start no-wrap">
+          <div class="col">
+            <q-icon name="o_tune" color="info" size="32px" class="q-mb-md" />
+            <h1 class="text-h2 q-mb-md">{{ $t('planner_page_title') }}</h1>
+            <p class="text-body1 q-mb-sm">
+              {{ $t('planner_page_subtitle') }}
+            </p>
+            <p class="text-body1 q-mb-none">
+              {{ $t('planner_page_intro') }}
+            </p>
+          </div>
+          <q-icon
+            name="o_info"
+            size="sm"
+            class="cursor-pointer"
+            :aria-label="$t('module-info-label')"
+          >
+            <q-tooltip anchor="center right" self="top right" class="u-tooltip">
               {{ $t('planner_methodology_tooltip') }}
             </q-tooltip>
           </q-icon>
-        </p>
+        </div>
       </q-card>
 
       <!-- Project information box -->

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -72,9 +72,9 @@
             </h2>
           </div>
 
-          <q-separator class="q-mt-xl" />
+          <q-separator class="q-mt-lg" />
 
-          <div class="grid-1-col q-mt-lg q-mb-lg">
+          <div class="grid-1-col">
             <BigNumber
               :title="$t('planner_results_total_tonnes_co2eq')"
               :number="formatTonnesCO2(totalTonnesCo2eq)"
@@ -93,7 +93,7 @@
 
             <q-separator />
 
-            <div class="column items-center justify-center q-pa-xl q-gutter-lg">
+            <div class="column items-center justify-center q-pa-lg q-gutter-md">
               <h3 class="text-h4 text-weight-medium">
                 {{ $t('planner_results_download_title') }}
               </h3>
@@ -103,7 +103,7 @@
                 icon="o_download"
                 :label="$t('planner_results_download_button')"
                 size="md"
-                color="accent"
+                color="info"
                 class="text-weight-medium"
                 @click="downloadReport"
               />

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -70,18 +70,24 @@
           </h2>
         </div>
 
-        <q-separator class="q-mt-xl" />
+        <q-separator class="q-mt-lg" />
 
-        <!-- Summary numbers -->
-        <div class="grid-1-col q-mt-lg q-mb-lg">
+        <!-- Summary numbers. Gapless grid: each block's own padding is the
+             only spacing, so its top and bottom read alike (a gap would land
+             above every separator but never at the card edges). Still a grid,
+             because BigNumber sizes itself against its row. -->
+        <div class="results-blocks">
           <BigNumber
             :title="$t('simulation_explore_page_results_total_tonnes_co2eq')"
             :number="`${formatTonnesCO2(totalTonnesCo2eq)}`"
             comparison=""
             color="info"
+            compact
             :bordered="false"
           />
+
           <q-separator />
+
           <ModuleCarbonFootprintChart
             :breakdown-data="filteredBreakdown"
             :bordered="false"
@@ -89,7 +95,7 @@
 
           <q-separator />
 
-          <div class="column items-center justify-center q-pa-xl q-gutter-lg">
+          <div class="column items-center justify-center q-pa-xl q-gutter-md">
             <h3 class="text-h4 text-weight-medium">
               {{ $t('simulation_explore_page_results_download_title') }}
             </h3>
@@ -99,7 +105,7 @@
               icon="o_download"
               :label="$t('simulation_explore_page_results_download_button')"
               size="md"
-              color="accent"
+              color="info"
               class="text-weight-medium"
               @click="downloadReport"
             />
@@ -112,7 +118,7 @@
           class="row no-wrap items-center justify-center q-pa-xl"
           style="gap: 24px"
         >
-          <q-icon name="o_calendar_month" color="accent" size="md" />
+          <q-icon name="o_calendar_month" color="info" size="md" />
           <div class="col">
             <div class="text-h5 text-weight-medium q-mb-xs">
               {{ $t('simulation_explore_page_convert_to_plan_title') }}
@@ -255,5 +261,10 @@ onMounted(async () => {
 <style scoped>
 .chart-wrapper {
   height: 600px;
+}
+
+.results-blocks {
+  display: grid;
+  grid-template-columns: 1fr;
 }
 </style>


### PR DESCRIPTION
## What does this change?
Design refactor of the CO₂ Project Planner (and the closely-related Simulation Explore page) to align it with the Calculator/Explorer visual language:

- **Planner year sections** — module cards replaced by a flat, separator-joined expansion list (same pattern as the Explorer). Multiple modules can now be expanded at once: `expandedKey: string | null` becomes `expandedKeys: string[]`, with a new `toggleModule` event. The same module in two different years still stays mutually exclusive, because the module store keys submodule rows by submodule id alone.
- **Fixed-category grids** — `PlannerHeadcountRows` and `PlannerPurchaseRows` now render as striped, full-bleed tables with `<label for>`/`id` pairing, right-aligned FTE inputs, `hide-bottom-space`, and token-sized field widths.
- **Row actions** — `CO2ProjectPlanner` duplicate/edit/delete buttons switch from small outlined squares to quiet flat icon buttons with hover surfaces (red on delete) and tooltips, matching `ModuleTable`.
- **Colour pass** — `negative`/`accent` accents replaced by `info` across the planner, project info card, year sections and download buttons; `text-weight-bold` headings softened to `text-weight-medium`.
- **Reference-year slot** — set and unset states now share a `.reference-year-box` so both variants occupy the same box size.
- **BigNumber** — new optional `compact` prop that tightens the gap between title and value for standalone (non-tile-row) usage; adopted in both results panels via a new gapless `.results-blocks` grid.
- **Tokens** — new `$tokens-table-action-size`, `$tokens-planner-grid-fte-input-width`, `$tokens-planner-grid-amount-input-width` and the `$table-action-size` / `$table-action-icon-size` component tokens; `ModuleTable`'s hardcoded `32px` / `18px` now read from them.
- **i18n** — `planner_page_title` renamed from "Simulator" / "Simulateur" to "CO₂ Project Planner" / "Planificateur de projet CO₂".

## Why is this needed?
The planner had drifted from the rest of the app: it used `negative`/`accent` as accent colours where the rest of the product uses `info`, nested bordered cards where the Explorer uses a flat separator list, outlined mini-buttons where the module tables use quiet hover-surface icons, and ad-hoc inline widths (`max-width: 180px`, `200px`) and hardcoded pixel sizes instead of tokens. The result read as a different product.

Beyond consistency:
- Only one module could be open at a time, which forced constant re-expansion when filling in a year across several modules.
- The headcount and purchase rows were loose label/field pairs, so the eye had to bridge a gap from the category to its input; striped table rows plus proper `label`/`id` association fix both the scanning problem and the accessibility one.
- The page title said "Simulator", which no longer matches the feature's name.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1862

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.