### PR TITLE
feat(print): add loading skeleton (#1859)

### DIFF
--- a/frontend/src/components/organisms/print/PrintReportShell.vue
+++ b/frontend/src/components/organisms/print/PrintReportShell.vue
@@ -33,8 +33,31 @@ function printReport() {
       />
     </q-toolbar>
 
-    <div v-if="loading" class="flex justify-center q-pa-xl print-hide">
-      <q-spinner color="accent" size="3em" />
+    <div v-if="loading" class="print-loading print-hide">
+      <div class="print-loading__sheet" aria-hidden="true">
+        <div class="print-loading__sheet-head">
+          <span class="print-loading__bone print-loading__bone--brand" />
+          <span class="print-loading__bone print-loading__bone--page" />
+        </div>
+        <span class="print-loading__bone print-loading__bone--title" />
+        <span class="print-loading__bone" style="width: 46%" />
+        <span class="print-loading__block" />
+        <span class="print-loading__bone" style="width: 72%" />
+        <span class="print-loading__bone" style="width: 88%" />
+        <span class="print-loading__bone" style="width: 60%" />
+      </div>
+
+      <div class="print-loading__status" role="status" aria-live="polite">
+        <div class="print-loading__label">{{ $t('print_report_loading') }}</div>
+        <q-linear-progress
+          indeterminate
+          rounded
+          size="6px"
+          color="accent"
+          track-color="grey-4"
+          class="print-loading__bar"
+        />
+      </div>
     </div>
 
     <div v-else-if="empty" class="flex justify-center q-pa-xl print-hide">
@@ -53,6 +76,10 @@ function printReport() {
 <style lang="scss">
 @use 'src/css/02-tokens' as tokens;
 
+.print-report {
+  min-height: 100vh;
+}
+
 .report-container {
   display: flex;
   flex-direction: column;
@@ -68,12 +95,109 @@ function printReport() {
   z-index: tokens.$print-toolbar-z-index;
 }
 
+.print-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 70vh;
+  padding: tokens.$print-report-container-padding;
+
+  &__sheet {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 210mm;
+    max-width: 100%;
+    padding: 10mm;
+    background: white;
+    box-sizing: border-box;
+    // Only the top of the sheet is drawn: it stands for a page still filling in,
+    // not an empty one.
+    mask-image: linear-gradient(to bottom, black 55%, transparent);
+  }
+
+  &__sheet-head {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+
+  &__bone {
+    display: block;
+    height: 12px;
+    width: 100%;
+    border-radius: 4px;
+    background: linear-gradient(90deg, #e9e9e9 0%, #f5f5f5 40%, #e9e9e9 80%);
+    background-size: 300% 100%;
+    animation: print-loading-shimmer 1.6s ease-in-out infinite;
+
+    &--brand {
+      width: 130px;
+      height: 16px;
+    }
+
+    &--page {
+      width: 20px;
+      height: 12px;
+    }
+
+    &--title {
+      height: 22px;
+      width: 62%;
+    }
+  }
+
+  &__block {
+    display: block;
+    height: 110px;
+    border-radius: 6px;
+    background: #f1f1f1;
+  }
+
+  &__status {
+    width: 320px;
+    max-width: 100%;
+    margin-top: 24px;
+    text-align: center;
+  }
+
+  &__label {
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  &__bar {
+    margin-top: 10px;
+  }
+}
+
+@keyframes print-loading-shimmer {
+  from {
+    background-position: 150% 0;
+  }
+
+  to {
+    background-position: -150% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .print-loading__bone {
+    animation: none;
+  }
+}
+
 @media print {
   .print-hide,
   .q-header,
   .q-footer,
   .q-drawer {
     display: none;
+  }
+
+  // A viewport-tall shell pushes the last page onto a trailing blank sheet.
+  .print-report {
+    min-height: 0;
   }
 
   .report-container {

--- a/frontend/src/composables/print/useProjectPlannerPrintData.ts
+++ b/frontend/src/composables/print/useProjectPlannerPrintData.ts
@@ -3,7 +3,12 @@ import { useRoute } from 'vue-router';
 import { api } from 'src/api/http';
 import type { Submodule } from 'src/constant/moduleConfig';
 import { getModuleTypeId } from 'src/constant/moduleStates';
-import { MODULES } from 'src/constant/modules';
+import {
+  MODULES,
+  enumSubmodule,
+  type EnumSubmoduleType,
+  type Module,
+} from 'src/constant/modules';
 import {
   PLANNER_HEADCOUNT_SUBMODULE,
   PLANNER_SIUS_CODES,
@@ -67,6 +72,11 @@ function rowsKey(carbonReportId: number, submoduleId: string): string {
   return `${carbonReportId}:${submoduleId}`;
 }
 
+/** Counts are addressed per plan-year report and module. */
+function countsKey(carbonReportId: number, moduleType: Module): string {
+  return `${carbonReportId}:${moduleType}`;
+}
+
 /**
  * A plan report fans out to years × modules × submodules, so a ten-year plan
  * would open well over a hundred requests at once — past the browser's
@@ -74,10 +84,19 @@ function rowsKey(carbonReportId: number, submoduleId: string): string {
  */
 const FETCH_CONCURRENCY = 6;
 
-async function runPooled(tasks: (() => Promise<unknown>)[]): Promise<void> {
+/**
+ * Count probes read no rows and write no audit records, so they neither trip
+ * the same-module conflict nor cost much per request; they can fan out wider.
+ */
+const PROBE_CONCURRENCY = 12;
+
+async function runPooled(
+  tasks: (() => Promise<unknown>)[],
+  concurrency = FETCH_CONCURRENCY,
+): Promise<void> {
   let cursor = 0;
   const workers = Array.from(
-    { length: Math.min(FETCH_CONCURRENCY, tasks.length) },
+    { length: Math.min(concurrency, tasks.length) },
     async () => {
       for (;;) {
         const task = tasks[cursor++];
@@ -273,29 +292,44 @@ export function useProjectPlannerPrintData() {
   }
 
   /**
+   * How many rows each submodule of one module holds in one plan-year, in a
+   * single request. A planner module owns up to eight submodules and a plan
+   * typically fills two or three, so asking the module once beats asking every
+   * submodule for a page of rows it does not have.
+   */
+  async function fetchSubmoduleCounts(
+    carbonReportId: number,
+    moduleType: Module,
+  ): Promise<Record<number, number>> {
+    const response = await api
+      .get(`${buildModulePath(moduleType, carbonReportId)}?preview_limit=0`)
+      .json<{ data_entry_types_total_items?: Record<number, number> }>();
+    return response.data_entry_types_total_items ?? {};
+  }
+
+  /**
    * Planner factors resolve from each year's reference year, so taxonomy labels
    * are fetched against the first baseline the plan actually uses. The store
    * keys taxonomies by submodule alone; one fetch per submodule is all it holds.
    */
   function taxonomyTasks(
     taxonomyYear: number | null,
+    submodules: { module: PlannerPrintModule; sub: Submodule }[],
   ): (() => Promise<unknown>)[] {
     if (taxonomyYear == null) return [];
-    const tasks: (() => Promise<unknown>)[] = [];
-    for (const module of printModules) {
-      for (const sub of module.submodules) {
-        if (sub.moduleFields.some((field) => field.optionsId === 'kind')) {
-          tasks.push(() =>
+    return submodules
+      .filter(({ sub }) =>
+        sub.moduleFields.some((field) => field.optionsId === 'kind'),
+      )
+      .map(
+        ({ module, sub }) =>
+          () =>
             moduleStore.getSubmoduleTaxonomy(
               module.type,
               sub.id,
               String(taxonomyYear),
             ),
-          );
-        }
-      }
-    }
-    return tasks;
+      );
   }
 
   async function fetchAllData(): Promise<void> {
@@ -329,7 +363,32 @@ export function useProjectPlannerPrintData() {
         years[0]?.year ??
         null;
 
-      const tasks: (() => Promise<unknown>)[] = taxonomyTasks(taxonomyYear);
+      const activePairs = years.flatMap((year) =>
+        printModules
+          .filter((module) => isModuleActive(year, module))
+          .map((module) => ({ year, module })),
+      );
+
+      // Pass 1 — ask each module-year which of its submodules hold anything.
+      const counts: Record<string, Record<number, number>> = {};
+      await runPooled(
+        activePairs.map(({ year, module }) => async () => {
+          try {
+            counts[countsKey(year.id, module.type)] =
+              await fetchSubmoduleCounts(year.id, module.type);
+          } catch {
+            // Leave it unknown: pass 2 then fetches the module's submodules.
+          }
+        }),
+        PROBE_CONCURRENCY,
+      );
+
+      // Pass 2 — fetch only the tables the report will actually draw.
+      const tasks: (() => Promise<unknown>)[] = [];
+      const taxonomySubmodules = new Map<
+        string,
+        { module: PlannerPrintModule; sub: Submodule }
+      >();
 
       for (const year of years) {
         if (isModuleActive(year, MODULES.Headcount)) {
@@ -342,24 +401,40 @@ export function useProjectPlannerPrintData() {
             }
           });
         }
-        for (const module of printModules) {
-          if (!isModuleActive(year, module)) continue;
-          // One task per module, walking its submodules in series: concurrent
-          // reads of the same module on one report make the backend 500.
-          tasks.push(async () => {
-            for (const sub of module.submodules) {
-              try {
-                submoduleRows.value[rowsKey(year.id, sub.id)] =
-                  await fetchAllSubmoduleRows(module.type, sub.id, year.id);
-              } catch {
-                // A report that drops a table without saying so is worse than
-                // one that admits the gap.
-                incompleteModules.value.push(`${module.type} · ${year.year}`);
-              }
-            }
-          });
-        }
       }
+
+      for (const { year, module } of activePairs) {
+        // A failed probe or a submodule the enum does not know reads as "fetch
+        // it": a table dropped on a missing answer is a silently short report.
+        const filled = module.submodules.filter((sub) => {
+          const moduleCounts = counts[countsKey(year.id, module.type)];
+          if (!moduleCounts) return true;
+          const typeId = enumSubmodule[sub.id as EnumSubmoduleType];
+          return typeId == null || (moduleCounts[typeId] ?? 0) > 0;
+        });
+        if (!filled.length) continue;
+        for (const sub of filled) {
+          taxonomySubmodules.set(`${module.type}:${sub.id}`, { module, sub });
+        }
+        // One task per module, walking its submodules in series: concurrent
+        // reads of the same module on one report make the backend 500.
+        tasks.push(async () => {
+          for (const sub of filled) {
+            try {
+              submoduleRows.value[rowsKey(year.id, sub.id)] =
+                await fetchAllSubmoduleRows(module.type, sub.id, year.id);
+            } catch {
+              // A report that drops a table without saying so is worse than
+              // one that admits the gap.
+              incompleteModules.value.push(`${module.type} · ${year.year}`);
+            }
+          }
+        });
+      }
+
+      tasks.push(
+        ...taxonomyTasks(taxonomyYear, [...taxonomySubmodules.values()]),
+      );
 
       await runPooled(tasks);
     } finally {

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -23,6 +23,10 @@ export default {
     en: 'Loading…',
     fr: 'Chargement…',
   },
+  print_report_loading: {
+    en: 'Building the report…',
+    fr: 'Construction du rapport…',
+  },
   results_module_chart_emission_types: {
     en: '{module} — Emission types',
     fr: "{module} — Types d'émissions",


### PR DESCRIPTION
## What does this change?
Reworks the planner print/export view on two fronts:

- **Loading state** — replaces the bare spinner in `PrintReportShell.vue` with a page-shaped skeleton (masked A4 sheet, shimmering placeholder bones, indeterminate progress bar) plus an `aria-live="polite"` status region and a new i18n key `print_report_loading` (EN/FR). Shimmer is disabled under `prefers-reduced-motion`.
- **Data fetching** — `useProjectPlannerPrintData.ts` now fetches in two passes. Pass 1 probes each active module-year once via `?preview_limit=0` to read `data_entry_types_total_items`; pass 2 only fetches submodules that actually hold rows. Probes run at a wider concurrency (`PROBE_CONCURRENCY = 12`) than row fetches (`FETCH_CONCURRENCY = 6`), and `runPooled` now takes concurrency as a parameter. Taxonomy requests are scoped to the submodules that were actually fetched instead of every declared submodule.
- **Print layout** — `.print-report` gets `min-height: 100vh` on screen and `min-height: 0` inside `@media print`, so the viewport-tall shell no longer pushes a trailing blank page into the PDF.

Failure handling stays conservative: a failed probe or an unknown submodule id falls through to "fetch it", and per-submodule fetch errors still register in `incompleteModules` rather than silently dropping a table.

## Why is this needed?
The planner PDF export was effectively broken for multi-year plans. A ten-year plan fanned out to years × modules × submodules requests, most of them for empty tables, which made export slow enough to look hung — and the only feedback was a spinner with no indication of progress. The export also emitted a trailing blank page because the screen-oriented `min-height: 100vh` shell carried into print.

Probing counts first cuts the request volume down to the tables the report will actually draw, and the skeleton makes the wait legible while it happens.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

> No secrets introduced, but the skeleton styles use literal greys (`#e9e9e9`, `#f5f5f5`, `#f1f1f1`, `white`) and literal sizes (`210mm`, `10mm`) rather than design tokens — happy to move them into `02-tokens` if reviewers prefer.

## Testing checklist
- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [x] No test failures introduced

> No unit tests added for the two-pass fetch yet. `fetchSubmoduleCounts` and the count-based filtering in `fetchAllData` are the parts worth covering (probe failure → fetch anyway, unknown submodule id → fetch anyway, zero count → skip); tell me if that should block the merge.

## Related issues
- Related to #1859

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.