### PR TITLE
perf(planner): added specific frontend timeout when setting plan ref year

### DIFF
--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -181,6 +181,7 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     const updated = await api
       .patch(`project-plans/${planId}/years/${year}`, {
         json: { reference_year: referenceYear },
+        timeout: 300000, // 5 minutes; TODO: backend to make a background task instead!
       })
       .json<SimulatorPlanYear>();
     planYears.value = planYears.value.map((y) =>


### PR DESCRIPTION
## What does this change?

Extended request timeout when changing planner reference year. For temporary usability only: backend should make this in a background task instead

## Type of change

Please check the type that applies:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist 

- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements


## Testing checklist

- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

---

See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.
