### PR TITLE
fix 1818: prevent x-axis label overlap in HeadCount chart (#1818)

### DIFF
--- a/frontend/src/components/molecules/HeadCountBarChart.vue
+++ b/frontend/src/components/molecules/HeadCountBarChart.vue
@@ -120,10 +120,11 @@ const chartOptions = computed<EChartsOption>(() => {
       type: 'category',
       axisLabel: {
         interval: 0,
-        rotate: 35,
         fontSize: 11,
-        overflow: 'truncate',
         width: 90,
+        overflow: 'break',
+        lineHeight: 14,
+        hideOverlap: false,
       },
     },
     yAxis: { type: 'value', boundaryGap: [0, 0.01] },


### PR DESCRIPTION
## What does this change?
Adjusts the x-axis label configuration of the `HeadCountBarChart` component (`frontend/src/components/molecules/HeadCountBarChart.vue`):

- Removes the 35° label rotation
- Switches `overflow` from `truncate` to `break`, so long labels wrap onto multiple lines instead of being cut off
- Adds `lineHeight: 14` for readable spacing between wrapped lines
- Adds `hideOverlap: false` so every category label stays visible
- Keeps `interval: 0`, `fontSize: 11` and `width: 90`

## Why is this needed?
Long category names on the head count chart were overlapping each other and being truncated, making some labels unreadable and hiding information from users. Wrapping the text horizontally instead of rotating and truncating keeps every label fully visible and legible without changing the chart layout or data.

Fixes the x-axis label overlap reported in #1818.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [x] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features <!-- N/A: no new feature -->
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum) <!-- N/A: presentational chart option change, no behavioural logic added -->
- [x] No test failures introduced

## Related issues
- Related to #1818

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.