### PR TITLE
feat(unit-view): Add scenario presets and slider UI (#1829)

### DIFF
--- a/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
+++ b/frontend/src/components/charts/results/ReductionObjectiveUnitView.vue
@@ -22,7 +22,6 @@ import {
   normalizeAxisParams,
   extractSeriesValue,
   formatTooltipTonnes,
-  formatTooltipPopulation,
 } from 'src/utils/chart-tooltip-extractors';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { useWorkspaceStore } from 'src/stores/workspace';
@@ -63,10 +62,6 @@ use([
 type PopulationRow = { year: number; pop: number };
 
 const { t, te } = useI18n();
-
-const INT_FORMATTER = new Intl.NumberFormat(undefined, {
-  maximumFractionDigits: 0,
-});
 
 const yearConfigStore = useYearConfigStore();
 const workspaceStore = useWorkspaceStore();
@@ -122,8 +117,11 @@ function categoryLabel(categoryKey: string): string {
   return categoryKey;
 }
 
-function categoryTooltipKey(categoryKey: string): string {
-  return `results-reduction-${categoryKey}`;
+// Empty tooltip copy means the category has nothing to explain — hide the icon.
+function categoryTooltipText(categoryKey: string): string {
+  const key = `results-reduction-${categoryKey}`;
+  if (!te(key)) return '';
+  return t(key, { category: categoryLabel(categoryKey) });
 }
 
 // ── Unit-mode sliders (right panel) ─────────────────────────────────────────
@@ -136,6 +134,48 @@ const ADDITIONAL_UNIT_CATEGORY_KEYS = new Set([
   'embodied_energy',
 ]);
 const TOOLTIP_CATEGORY_ORDER = RESULTS_CATEGORY_ORDER;
+
+const SLIDER_LEVEL_LABEL_KEYS = [
+  'results_objectives_scenario_bau',
+  'results_objectives_scenario_low_effort',
+  'results_objectives_scenario_middle',
+  'results_objectives_scenario_high_effort',
+  'results_objectives_scenario_ambitious',
+] as const;
+
+const SCENARIO_PRESETS = [
+  {
+    value: 'bau',
+    labelKey: 'results_objectives_scenario_bau',
+    descriptionKey: 'results_objectives_scenario_bau_description',
+  },
+  {
+    value: 'middle',
+    labelKey: 'results_objectives_scenario_middle',
+    descriptionKey: 'results_objectives_scenario_middle_description',
+  },
+  {
+    value: 'ambitious',
+    labelKey: 'results_objectives_scenario_ambitious',
+    descriptionKey: 'results_objectives_scenario_ambitious_description',
+  },
+] as const;
+
+function sliderLevelLabel(level: number): string {
+  const clamped = Math.max(1, Math.min(SLIDER_LEVEL_LABEL_KEYS.length, level));
+  return t(SLIDER_LEVEL_LABEL_KEYS[clamped - 1]);
+}
+
+const scenarioOptions = computed(() =>
+  SCENARIO_PRESETS.map((p) => ({ label: t(p.labelKey), value: p.value })),
+);
+
+const scenarioDescription = computed(() => {
+  const preset = SCENARIO_PRESETS.find(
+    (p) => p.value === unitScenarioPreset.value,
+  );
+  return preset ? t(preset.descriptionKey) : '';
+});
 
 // ── Teleport tooltip composable ───────────────────────────────────────────────
 const { tooltip, style, attach, emitTooltip } = useEchartsTooltip();
@@ -167,13 +207,8 @@ function buildTooltipState(rawParams: unknown): TooltipState {
 
   const title = String(params[0]?.axisValue ?? '');
 
-  const populationParam = params.find(
-    (p) => String(p.seriesName) === 'population' && p.value != null,
-  );
-
   const rows: TooltipRow[] = params
     .filter((p) => p.seriesName && p.value != null)
-    .filter((p) => String(p.seriesName) !== 'population')
     .sort(
       (a, b) =>
         tooltipSortIndex(String(a.seriesName ?? '')) -
@@ -185,17 +220,7 @@ function buildTooltipState(rawParams: unknown): TooltipState {
       color: categoryColor(String(p.seriesName)),
     }));
 
-  const separatorRow: TooltipRow | undefined = populationParam
-    ? {
-        label: t('results_objectives_population_forecast'),
-        value: formatTooltipPopulation(
-          extractSeriesValue(populationParam.value),
-        ),
-        color: '#ff0000',
-      }
-    : undefined;
-
-  return { title, rows, separatorRow };
+  return { title, rows };
 }
 
 const validatedEmissionCategoryKeys = computed(() => {
@@ -313,42 +338,6 @@ onUpdated(async () => {
   ensureSlidersResetIfLocked();
 });
 
-const populationSeries = computed(() => {
-  const pop = epflPopulationRows.value;
-  if (!pop.length) return null;
-  const popByYear = Object.fromEntries(pop.map((r) => [r.year, r.pop]));
-  const firstPopYear = pop.reduce<number | null>((min, r) => {
-    if (typeof r.year !== 'number') return min;
-    if (typeof r.pop !== 'number') return min;
-    return min == null ? r.year : Math.min(min, r.year);
-  }, null);
-  const firstPopValue =
-    firstPopYear == null ? null : (popByYear[firstPopYear] ?? null);
-
-  return {
-    name: 'population',
-    type: 'line',
-    yAxisIndex: 1,
-    showSymbol: false,
-    symbol: 'circle',
-    symbolSize: 7,
-    zlevel: 6,
-    z: 60,
-    lineStyle: { type: 'dotted', width: 2, color: '#ff0000' },
-    itemStyle: {
-      color: '#ff0000',
-      borderColor: '#ffffff',
-      borderWidth: 2,
-    },
-    data: years.value.map((y) => {
-      const v = popByYear[y];
-      if (typeof v === 'number') return v;
-      if (firstPopYear != null && y < firstPopYear) return firstPopValue;
-      return null;
-    }),
-  };
-});
-
 const unitSeriesData = computed(() => {
   const payload = moduleStore.state.emissionBreakdown;
   if (!payload) return null;
@@ -443,7 +432,6 @@ const showUnitEmptyState = computed(() => !hasAnyInteractiveUnitCategory.value);
 const chartOption = computed<EChartsOption | null>(() => {
   const payload = unitSeriesData.value;
   if (!payload) return null;
-  const popSeries = populationSeries.value;
 
   return {
     tooltip: {
@@ -460,7 +448,7 @@ const chartOption = computed<EChartsOption | null>(() => {
     legend: { show: false },
     grid: {
       left: 48,
-      right: 64,
+      right: 24,
       top: 24,
       bottom: 24,
       containLabel: true,
@@ -486,22 +474,8 @@ const chartOption = computed<EChartsOption | null>(() => {
         axisLabel: { formatter: (v: number) => `${v.toFixed(1)}` },
         splitLine: { show: false },
       },
-      {
-        type: 'value',
-        name: t('results_objectives_population_axis'),
-        min: 0,
-        position: 'right',
-        nameGap: 56,
-        nameLocation: 'middle',
-        axisLine: { show: false },
-        axisTick: { show: false },
-        axisLabel: { formatter: (v: number) => INT_FORMATTER.format(v) },
-        splitLine: { show: false },
-      },
     ],
-    series: popSeries
-      ? [...payload.stackedSeries, popSeries]
-      : [...payload.stackedSeries],
+    series: [...payload.stackedSeries],
     aria: {
       enabled: true,
       decal: buildChartDecal(colorblindStore.enabled, {
@@ -545,17 +519,20 @@ const chartOption = computed<EChartsOption | null>(() => {
 
     <div v-if="!showUnitEmptyState" class="col-12 col-lg-3">
       <section class="unit-controls">
-        <div class="q-pt-xl q-px-lg">
+        <div class="q-pt-lg q-px-lg">
           <div class="row items-center justify-between q-mb-xs">
-            <div class="text-caption text-secondary">Scenario</div>
+            <div class="text-caption text-secondary">
+              {{ $t('results_objectives_scenario_label') }}
+            </div>
             <q-btn
+              flat
+              dense
               no-caps
-              unelevated
-              outline
-              color="accent"
-              label="Reset"
               size="sm"
-              class="text-weight-medium"
+              color="secondary"
+              icon="o_restart_alt"
+              :label="$t('results_objectives_scenario_reset')"
+              class="scenario-reset text-weight-medium q-px-xs"
               :disable="!hasAnyInteractiveUnitCategory"
               @click="resetUnitSliders"
             />
@@ -568,46 +545,47 @@ const chartOption = computed<EChartsOption | null>(() => {
             map-options
             hide-bottom-space
             :disable="!hasAnyInteractiveUnitCategory"
-            :options="[
-              { label: 'BAU', value: 'bau' },
-              { label: 'Middle of the road', value: 'middle' },
-              { label: 'Ambitious', value: 'ambitious' },
-            ]"
-          />
+            :options="scenarioOptions"
+          >
+            <template #append>
+              <q-icon
+                name="o_info"
+                size="18px"
+                class="text-secondary"
+                @click.stop
+              >
+                <q-tooltip class="text-body2 text-black" max-width="260px">
+                  {{ scenarioDescription }}
+                </q-tooltip>
+              </q-icon>
+            </template>
+          </q-select>
         </div>
 
-        <q-separator class="q-my-lg" />
+        <q-separator class="q-my-md" />
 
         <div class="unit-controls__sliders">
-          <div class="unit-controls__scroll column">
+          <div class="unit-controls__scroll column no-wrap">
             <div
               v-for="cat in visibleUnitCategoryKeys"
               :key="cat"
-              class="objective-slider q-px-xl"
+              class="objective-slider"
               :style="{ '--cat-color': categoryColor(cat) }"
             >
-              <div class="objective-slider__header">
-                <div class="objective-slider__label text-caption text-primary">
-                  <span class="objective-slider__label-text">
-                    {{ categoryLabel(cat) }}
-                  </span>
-                  <q-icon
-                    name="o_info"
-                    size="14px"
-                    class="objective-slider__label-info text-secondary"
-                  >
-                    <q-tooltip class="text-body2 text-black" max-width="260px">
-                      {{
-                        $t(categoryTooltipKey(cat), {
-                          category: categoryLabel(cat),
-                        })
-                      }}
-                    </q-tooltip>
-                  </q-icon>
-                </div>
-                <div class="objective-slider__value text-caption text-primary">
-                  {{ unitSliderLevels[cat] }}
-                </div>
+              <div class="objective-slider__label text-caption text-primary">
+                <span class="objective-slider__label-text">
+                  {{ categoryLabel(cat) }}
+                </span>
+                <q-icon
+                  v-if="categoryTooltipText(cat)"
+                  name="o_info"
+                  size="14px"
+                  class="objective-slider__label-info text-secondary"
+                >
+                  <q-tooltip class="text-body2 text-black" max-width="260px">
+                    {{ categoryTooltipText(cat) }}
+                  </q-tooltip>
+                </q-icon>
               </div>
               <q-slider
                 v-model="unitSliderLevels[cat]"
@@ -620,6 +598,9 @@ const chartOption = computed<EChartsOption | null>(() => {
                 thumb-size="12px"
                 track-size="2px"
               />
+              <div class="objective-slider__value text-caption text-secondary">
+                {{ sliderLevelLabel(unitSliderLevels[cat] ?? 1) }}
+              </div>
             </div>
           </div>
         </div>
@@ -692,8 +673,8 @@ const chartOption = computed<EChartsOption | null>(() => {
 }
 
 .unit-controls :deep(.q-slider) {
-  margin-left: 6px;
-  margin-right: 6px;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .unit-controls__scroll {
@@ -715,21 +696,22 @@ const chartOption = computed<EChartsOption | null>(() => {
   border-radius: 999px !important;
 }
 
-.objective-slider__header {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: start;
-  column-gap: 12px;
+.objective-slider {
+  padding: 0 20px;
+}
+
+.objective-slider :deep(.q-slider__track-container--h) {
+  padding: 4px 0;
 }
 
 .objective-slider__label {
   min-width: 0;
-  display: inline-flex;
+  display: flex;
   align-items: flex-start;
   gap: 6px;
   white-space: normal;
   overflow-wrap: anywhere;
-  line-height: 1.55;
+  line-height: 1.25;
 }
 
 .objective-slider__label-text {
@@ -742,8 +724,14 @@ const chartOption = computed<EChartsOption | null>(() => {
 }
 
 .objective-slider__value {
-  font-variant-numeric: tabular-nums;
-  text-align: right;
-  line-height: 1.5;
+  text-align: left;
+  line-height: 1.2;
+  margin-top: -4px;
+  margin-bottom: 10px;
+}
+
+.scenario-reset :deep(.q-icon) {
+  font-size: 16px;
+  margin-right: 4px;
 }
 </style>

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -381,6 +381,46 @@ export default {
     en: 'Validate at least one module/category to unlock the unit simulation sliders.',
     fr: 'Validez au moins un module/catégorie pour déverrouiller les curseurs de simulation.',
   },
+  results_objectives_scenario_label: {
+    en: 'Scenario',
+    fr: 'Scénario',
+  },
+  results_objectives_scenario_reset: {
+    en: 'Reset',
+    fr: 'Réinitialiser',
+  },
+  results_objectives_scenario_bau: {
+    en: 'BAU',
+    fr: 'BAU',
+  },
+  results_objectives_scenario_low_effort: {
+    en: 'Low effort',
+    fr: 'Effort faible',
+  },
+  results_objectives_scenario_middle: {
+    en: 'Middle of the road',
+    fr: 'Voie intermédiaire',
+  },
+  results_objectives_scenario_high_effort: {
+    en: 'High effort',
+    fr: 'Effort élevé',
+  },
+  results_objectives_scenario_ambitious: {
+    en: 'Ambitious',
+    fr: 'Ambitieux',
+  },
+  results_objectives_scenario_bau_description: {
+    en: 'In the Business As Usual scenario, emissions continue to grow at the current rate, in line with population growth.',
+    fr: 'Dans le scénario « Business As Usual », les émissions continuent d’augmenter au rythme actuel, parallèlement à la croissance de la population.',
+  },
+  results_objectives_scenario_middle_description: {
+    en: 'This is an intermediate scenario between BAU and fulfilling the reduction goals set by the Climate Act.',
+    fr: 'Il s’agit d’un scénario intermédiaire entre le scénario BAU et la réalisation des objectifs de réduction fixés par la loi sur le climat.',
+  },
+  results_objectives_scenario_ambitious_description: {
+    en: 'This scenario represents the fulfilment of the Climate Act’s reduction goals, ultimately achieving a 90% reduction by 2040 and carbon neutrality.',
+    fr: 'Ce scénario correspond à la réalisation des objectifs de réduction fixés par la Loi Climat, à savoir une réduction de 90 % d’ici 2040 et la neutralité carbone.',
+  },
   results_additional_data: {
     en: 'Additional data',
     fr: 'Données additionnelles',

--- a/frontend/src/i18n/tooltips.ts
+++ b/frontend/src/i18n/tooltips.ts
@@ -589,8 +589,8 @@ export default {
   //   Research Facilities → Commuting → Food → Waste → Embodied Energy
 
   'results-reduction-title': {
-    en: 'This section presents two graphs. The first illustrates the reference "net zero" trajectory for EPFL, aligned with the CO₂ emission reduction targets set by the Swiss Confederation and the Climate Act. The second allows you to simulate the evolution of your unit\'s emissions and adjust each category in order to converge towards this reference trajectory.',
-    fr: "Cette section présente deux graphiques. Le premier illustre la trajectoire « net zéro » de référence pour l'EPFL, alignée sur les objectifs de réduction des émissions de CO₂ fixés par la Confédération et la Loi Climat. Le second vous permet de simuler l'évolution des émissions de votre unité et d'ajuster chaque catégorie afin de converger vers cette trajectoire de référence.",
+    en: 'This section presents two graphs. The first allows you to simulate the evolution of your unit emissions and adjust each category in order to converge towards the net zero trajectory. The second illustrates the reference net zero trajectory for EPFL, aligned with the CO₂ emission reduction targets set by the Swiss Confederation and the Climate Act.',
+    fr: "Cette section présente deux graphiques. Le premier vous permet de simuler l'évolution des émissions de votre unité et d'ajuster chaque catégorie afin de converger vers la trajectoire net zéro. Le deuxième illustre la trajectoire net zéro de référence pour l'EPFL, alignée sur les objectifs de réduction des émissions de CO₂ fixés par la Confédération et la Loi Climat.",
   },
   'results-reduction-process_emissions': { en: '', fr: '' },
   'results-reduction-buildings_energy_combustion': { en: '', fr: '' },


### PR DESCRIPTION
## What does this change?
Reworks the unit-view reduction objective chart and its right-hand control panel:

- **Removed the EPFL population overlay** from the unit chart — the dotted population line series, the secondary right-hand Y axis, the population tooltip row, and the now-unused `INT_FORMATTER` / `formatTooltipPopulation` import were all dropped. Chart grid right padding reduced from 64px to 24px to reclaim the freed space.
- **Added scenario presets** (BAU / Middle of the road / Ambitious) driven by a `SCENARIO_PRESETS` constant, with an info icon in the select's `append` slot showing a per-scenario description tooltip.
- **Replaced numeric slider values with named effort levels** (BAU → Low effort → Middle of the road → High effort → Ambitious) via `sliderLevelLabel()`, moved below each slider instead of right-aligned in the header.
- **Info icons now hide when a category has no tooltip copy** — `categoryTooltipKey()` was replaced by `categoryTooltipText()`, which returns an empty string when `te()` reports no translation.
- **Extracted hardcoded UI strings to i18n** — the "Scenario" label, "Reset" button and the three scenario option labels are now keys in `i18n/results.ts` with EN/FR translations, alongside new scenario description strings.
- **Restyled the reset button** from an outlined accent button to a flat secondary button with a `o_restart_alt` icon.
- **Updated `results-reduction-title` tooltip copy** (EN + FR) to match the new graph ordering: the simulation graph is now described first, the reference net-zero trajectory second.
- Assorted CSS adjustments: slider padding/margins, label line-height, header grid removed in favour of a simpler flex layout.

## Why is this needed?
The population overlay on the unit chart added a second Y axis and a competing series that made the emissions trajectory harder to read, without giving unit-level users actionable information. Removing it simplifies the chart and frees horizontal space.

On the controls side, raw slider numbers (1–5) gave users no sense of what a given position actually means. Named effort levels plus scenario descriptions make the simulation self-explanatory. The hardcoded English strings in the template also meant the scenario panel didn't translate for French users, and info icons were rendering on categories with empty tooltip copy, showing users an icon that opened a blank tooltip.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [x] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [x] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1829

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.