### PR TITLE
fix: clear all plan-year entries on reference change (#1920)

### DIFF
--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -230,10 +230,11 @@ class SimulatorPlanService:
     ) -> Optional[SimulatorPlanYearRead]:
         """Set the baseline year of one plan-year report; None if missing.
 
-        Destructive: every prefilled module of the plan-year is emptied and
-        rebuilt from the new baseline at 100%, so the percentages, edits and
-        hand-added rows made under the previous reference year are lost. The
-        dialog warns about it before calling this.
+        Destructive: every module of the plan-year is emptied — the prefilled
+        ones rebuilt from the new baseline at 100%, the manually filled ones
+        left blank — so the percentages, edits and hand-entered values made
+        under the previous reference year are lost. The dialog warns about it
+        before calling this.
 
         The rebuilt entries get their emissions recomputed, since factor lookup
         follows the reference year.
@@ -251,10 +252,13 @@ class SimulatorPlanService:
         return await self._year_read(report)
 
     async def _prefill_reference_modules(self, report: CarbonReport) -> None:
-        """Rebuild every prefilled-behavior module from the reference year.
+        """Empty the whole plan-year, then rebuild its prefilled modules.
 
         Runs on reference-year set/change (there is no manual prefill trigger).
-        The modules are emptied first, so a module never mixes two baselines.
+        Every entry of the plan-year is deleted first — all of them hang on the
+        baseline, whether copied from it (prefilled modules) or entered against
+        it and priced with its factors (headcount, purchases, travel) — and only
+        then are the prefilled modules copied from the new reference year.
         When the reference year has no Calculator report for the unit there is
         nothing to copy and they stay empty — showing the previous baseline's
         rows under a new reference year would be a lie.
@@ -264,16 +268,17 @@ class SimulatorPlanService:
         if report.reference_year is None:
             return
         modules = await self.report_service.module_service.list_modules(report.id)
-        prefilled = [
-            m for m in modules if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
-        ]
-        await self._clear_module_entries([m.id for m in prefilled if m.id is not None])
+        await self._clear_module_entries([m.id for m in modules if m.id is not None])
         ref_report = await self.repo.get_calculator_report(
             report.unit_id, report.reference_year
         )
         if ref_report is None:
             return
-        for module_type_id in sorted(m.module_type_id for m in prefilled):
+        for module_type_id in sorted(
+            m.module_type_id
+            for m in modules
+            if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
+        ):
             await self.prefill_module_from_reference(
                 report, module_type_id, ref_report=ref_report
             )

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -136,11 +136,13 @@
                    (design). Other modules reuse the Calculator tables. -->
             <planner-headcount-rows
               v-if="entry.config.module === MODULES.Headcount"
+              :key="factorScopedKey(entry.config.module)"
               :carbon-report-id="yearData.id"
               :disable="entry.module?.is_active === false"
             />
             <planner-purchase-rows
               v-else-if="entry.config.module === MODULES.Purchase"
+              :key="factorScopedKey(entry.config.module)"
               :carbon-report-id="yearData.id"
               :disable="entry.module?.is_active === false"
             />

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -224,8 +224,8 @@ export default {
     fr: 'Modifier',
   },
   planner_reference_year_rebuild_hint: {
-    en: 'The prefilled modules of this planned year are rebuilt from the reference year — changing it deletes their current data.',
-    fr: "Les modules préremplis de cette année planifiée sont reconstruits à partir de l'année de référence — la changer supprime leurs données actuelles.",
+    en: 'This planned year is built on its reference year. Changing it deletes the current data of every module, then rebuilds the prefilled ones from the new reference year.',
+    fr: 'Cette année planifiée repose sur son année de référence. La changer supprime les données actuelles de tous les modules, puis reconstruit les modules préremplis à partir de la nouvelle année de référence.',
   },
   planner_reference_year_dialog_title: {
     en: 'Planned year {year}: choose its reference year',
@@ -236,12 +236,12 @@ export default {
     fr: 'Année de référence (source des données)',
   },
   planner_reference_year_dialog_consequences: {
-    en: 'The prefilled modules of planned year {year} are rebuilt from the reference year you pick, and use its emission factors.',
-    fr: "Les modules préremplis de l'année planifiée {year} sont reconstruits à partir de l'année de référence choisie et utilisent ses facteurs d'émission.",
+    en: 'The prefilled modules of planned year {year} are rebuilt from the reference year you pick, and every module uses its emission factors.',
+    fr: "Les modules préremplis de l'année planifiée {year} sont reconstruits à partir de l'année de référence choisie, et tous les modules utilisent ses facteurs d'émission.",
   },
   planner_reference_year_dialog_wipe_warning: {
-    en: 'Changing the reference year deletes everything the prefilled modules of planned year {year} contain: the prefilled rows, your percentages, your edits and the rows you added yourself. The reference year itself keeps its data. This cannot be undone.',
-    fr: "Changer l'année de référence supprime tout ce que contiennent les modules préremplis de l'année planifiée {year} : les lignes préremplies, vos pourcentages, vos modifications et les lignes que vous avez ajoutées. L'année de référence, elle, conserve ses données. Cette action est irréversible.",
+    en: 'Changing the reference year deletes every entry of planned year {year}: the prefilled rows, your percentages, your edits, and everything you filled in yourself in the other modules. The prefilled modules are then rebuilt from the new reference year. The reference year itself keeps its data. This cannot be undone.',
+    fr: "Changer l'année de référence supprime toutes les saisies de l'année planifiée {year} : les lignes préremplies, vos pourcentages, vos modifications et tout ce que vous avez renseigné vous-même dans les autres modules. Les modules préremplis sont ensuite reconstruits à partir de la nouvelle année de référence. L'année de référence, elle, conserve ses données. Cette action est irréversible.",
   },
   planner_reference_year_dialog_wipe_ack: {
     en: 'I understand that my planned data for {year} will be deleted',


### PR DESCRIPTION
## What does this change?
Changes reference-year behavior on planner years so that changing the reference year clears **all** module entries (not just prefilled ones). Previously, only prefilled modules (e.g. modules copied from the reference year) were emptied on reference-year change; now manually-filled modules like Headcount and Purchase — which are priced using the reference year's emission factors — are also cleared. The prefilled modules are still rebuilt afterward from the new reference year, while manually-entered ones (Headcount, Purchase) are left blank for the user to re-enter. Also adds a `:key` binding on the Headcount and Purchase row components (`factorScopedKey`) so Vue force-remounts them on reference-year change, and updates the English/French i18n strings for the reference-year hint and warning dialogs to reflect the broader wipe behavior.

## Why is this needed?
Headcount and Purchase entries are priced using the plan-year's reference-year emission factors. If only prefilled modules were cleared on reference change, these manually-entered modules would silently retain values costed against the old reference year's factors, leading to inconsistent/incorrect emissions data. This fix ensures all module data tied to the previous reference year is cleared, avoiding stale or mispriced entries after a reference-year change.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1920

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.