### PR TITLE
feat: allow unit members to edit shared plans (#1922)

### DIFF
--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -288,9 +288,6 @@ async def update_carbon_report_module_active(
 
     unit = await db.get(Unit, report.unit_id)
     require_unit_access(current_user, unit)
-    # Plan modules are creator/global-only to edit; shared plans are
-    # read-only for other unit members (same scoping as every other plan
-    # write path).
     await require_plan_scope_for_report(db, current_user, report, "edit")
 
     module_service = CarbonReportModuleService(db)

--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -91,7 +91,7 @@ async def resolve_report_module(
     When the report belongs to a Simulator Plan project, plan scoping is
     enforced on top of the module permission checks the routes perform:
     unshared plans are invisible to non-creators, shared plans are
-    read-only for them.
+    editable by every unit member.
 
     Args:
         carbon_report_id: The addressed carbon report (any project type —

--- a/backend/app/api/v1/simulator_plan.py
+++ b/backend/app/api/v1/simulator_plan.py
@@ -8,6 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.deps import get_current_user, get_db
 from app.core.logging import get_logger
 from app.core.policy import (
+    plan_can_manage,
     plan_is_visible_to,
     require_plan_access,
     require_unit_access,
@@ -28,13 +29,22 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
+def _with_can_manage(
+    current_user: User, plans: List[SimulatorPlanRead]
+) -> List[SimulatorPlanRead]:
+    """Stamp the caller's delete rights onto plan payloads for the frontend."""
+    for plan in plans:
+        plan.can_manage = plan_can_manage(current_user, plan)
+    return plans
+
+
 async def _require_plan_unit_access(
     db: AsyncSession, current_user: User, plan_id: int, action: str
 ) -> SimulatorPlanService:
     """Load the plan's unit and enforce access; 404 if the plan is missing.
 
-    ``action``: "view" allows the creator, global roles, and unit members
-    of a shared plan; "edit" is creator/global only (shared = read-only).
+    ``action``: "view" and "edit" both allow the creator, global roles, and
+    unit members of a shared plan; "manage" (deletion) is creator/global only.
     """
     service = SimulatorPlanService(db)
     plan = await service.repo.get_plan(plan_id)
@@ -60,7 +70,9 @@ async def list_simulator_plans(
     require_unit_access(current_user, unit)
     service = SimulatorPlanService(db)
     plans = await service.list_plans(unit_id)
-    return [p for p in plans if plan_is_visible_to(current_user, p)]
+    return _with_can_manage(
+        current_user, [p for p in plans if plan_is_visible_to(current_user, p)]
+    )
 
 
 @router.post(
@@ -87,7 +99,7 @@ async def create_simulator_plan(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     await db.commit()
-    return result
+    return _with_can_manage(current_user, [result])[0]
 
 
 @router.get("/unit/{unit_id}/by-name/{name}", response_model=SimulatorPlanRead)
@@ -105,7 +117,7 @@ async def get_simulator_plan_by_name(
     if result is None:
         raise HTTPException(status_code=404, detail="Plan not found")
     require_plan_access(current_user, result, "view")
-    return result
+    return _with_can_manage(current_user, [result])[0]
 
 
 @router.patch("/{plan_id}", response_model=SimulatorPlanRead)
@@ -129,7 +141,7 @@ async def update_simulator_plan(
     if result is None:
         raise HTTPException(status_code=404, detail="Plan not found")
     await db.commit()
-    return result
+    return _with_can_manage(current_user, [result])[0]
 
 
 @router.get("/{plan_id}/years", response_model=List[SimulatorPlanYearRead])
@@ -207,7 +219,7 @@ async def duplicate_simulator_plan(
     if result is None:
         raise HTTPException(status_code=404, detail="Plan not found")
     await db.commit()
-    return result
+    return _with_can_manage(current_user, [result])[0]
 
 
 @router.delete("/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -217,7 +229,7 @@ async def delete_simulator_plan(
     current_user: User = Depends(get_current_user),
 ):
     """Delete a simulator plan (and any carbon reports attached to it)."""
-    service = await _require_plan_unit_access(db, current_user, plan_id, "edit")
+    service = await _require_plan_unit_access(db, current_user, plan_id, "manage")
     deleted = await service.delete_plan(plan_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Plan not found")

--- a/backend/app/api/v1/workspace_home.py
+++ b/backend/app/api/v1/workspace_home.py
@@ -48,7 +48,7 @@ from app.api.deps import get_current_user, get_db
 from app.api.v1.carbon_report_module_stats import build_validated_totals
 from app.core.config import get_settings
 from app.core.logging import get_logger
-from app.core.policy import plan_is_visible_to, require_unit_access
+from app.core.policy import plan_can_manage, plan_is_visible_to, require_unit_access
 from app.models.carbon_report import CarbonReportModule
 from app.models.unit import Unit
 from app.models.user import User
@@ -166,11 +166,14 @@ async def get_workspace_home(
     ]
 
     plans = await SimulatorPlanService(db).list_plans(unit_id)
+    visible_plans = [p for p in plans if plan_is_visible_to(current_user, p)]
+    for plan in visible_plans:
+        plan.can_manage = plan_can_manage(current_user, plan)
 
     return WorkspaceHomeResponse(
         carbon_report_id=report.id,
         year_config=year_config,
         stats=stats,
         module_states=module_states,
-        project_plans=[p for p in plans if plan_is_visible_to(current_user, p)],
+        project_plans=visible_plans,
     )

--- a/backend/app/core/policy.py
+++ b/backend/app/core/policy.py
@@ -628,14 +628,25 @@ def plan_is_visible_to(current_user: User, project: Any) -> bool:
     return bool(project.is_viewable_by_unit_members)
 
 
+def plan_can_manage(current_user: User, project: Any) -> bool:
+    """Whether the user may delete a Simulator Plan project.
+
+    Creators and global-scope roles only. Accepts either the ORM row or the
+    ``SimulatorPlanRead`` DTO — both expose ``created_by``.
+    """
+    if any(isinstance(role.on, GlobalScope) for role in current_user.roles):
+        return True
+    return project.created_by == current_user.id
+
+
 async def require_plan_scope_for_report(
     db: AsyncSession, current_user: User, report: Any, action: str
 ) -> None:
     """Enforce Simulator Plan scoping when ``report`` belongs to a plan.
 
     No-op for Calculator/Explore reports (and reports with no project). The
-    single place every report-addressed write consults so plan read-only /
-    creator-only rules can't be forgotten on a new route.
+    single place every report-addressed write consults so plan visibility
+    rules can't be forgotten on a new route.
     """
     if report.carbon_project_id is None:
         return
@@ -650,30 +661,28 @@ async def require_plan_scope_for_report(
 def require_plan_access(current_user: User, project: Any, action: str) -> None:
     """Enforce Simulator Plan scoping on top of unit access.
 
-    Shared plans are read-only for non-creators: ``view`` follows
-    :func:`plan_is_visible_to`; ``edit`` requires the creator (or a
-    global-scope role). Unshared plans 404 for other unit members so
-    their existence is not leaked.
+    Shared plans are fully editable by unit members: ``view`` and ``edit``
+    both follow :func:`plan_is_visible_to`. ``manage`` (deletion) requires
+    the creator or a global-scope role. Unshared plans 404 for other unit
+    members so their existence is not leaked.
 
     Args:
         current_user: The authenticated user.
         project: The plan's CarbonProject row.
-        action: ``"view"`` or ``"edit"``.
+        action: ``"view"``, ``"edit"`` or ``"manage"``.
     """
     if not plan_is_visible_to(current_user, project):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Plan not found",
         )
-    if action == "view":
+    if action in ("view", "edit"):
         return
-    if any(isinstance(role.on, GlobalScope) for role in current_user.roles):
-        return
-    if project.created_by == current_user.id:
+    if plan_can_manage(current_user, project):
         return
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
-        detail="Only the plan's creator can modify it.",
+        detail="Only the plan's creator can delete it.",
     )
 
 

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -75,6 +75,7 @@ class SimulatorPlanRead(BaseModel):
     created_at: Optional[datetime] = None
     creator_name: Optional[str] = None
     total_tonnes_co2eq: Optional[float] = None
+    can_manage: bool = False
 
     class Config:
         from_attributes = True

--- a/backend/tests/unit/core/test_policy.py
+++ b/backend/tests/unit/core/test_policy.py
@@ -588,7 +588,8 @@ class TestQueryPolicyLegacy:
 
 
 class TestRequirePlanAccess:
-    """Simulator Plan scoping: creator-only writes, shared plans read-only."""
+    """Simulator Plan scoping: shared plans are editable by unit members,
+    deletion stays creator-only."""
 
     @staticmethod
     def _user(user_id: int, *, is_global: bool = False):
@@ -619,12 +620,13 @@ class TestRequirePlanAccess:
             require_plan_access(user, plan, "view")
         assert exc.value.status_code == 404
 
-    def test_shared_plan_is_read_only_for_other_members(self):
+    def test_shared_plan_is_editable_but_not_deletable_by_other_members(self):
         user = self._user(2)
         plan = self._plan(created_by=1, shared=True)
         require_plan_access(user, plan, "view")
+        require_plan_access(user, plan, "edit")
         with pytest.raises(HTTPException) as exc:
-            require_plan_access(user, plan, "edit")
+            require_plan_access(user, plan, "manage")
         assert exc.value.status_code == 403
 
     def test_global_scope_bypasses_plan_scoping(self):
@@ -675,14 +677,17 @@ class TestRequirePlanScopeForReport:
         project = MagicMock()
         project.carbon_report_type = CarbonReportType.SIMULATOR_PLAN
         project.created_by = 1
-        project.is_viewable_by_unit_members = True  # shared → read-only
+        project.is_viewable_by_unit_members = True
         db = MagicMock()
         db.get = AsyncMock(return_value=project)
         non_creator = MagicMock()
         non_creator.id = 2
         non_creator.roles = []
+        await require_plan_scope_for_report(db, non_creator, self._report(5), "edit")
+
+        project.is_viewable_by_unit_members = False
         with pytest.raises(HTTPException) as exc:
             await require_plan_scope_for_report(
                 db, non_creator, self._report(5), "edit"
             )
-        assert exc.value.status_code == 403
+        assert exc.value.status_code == 404

--- a/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
+++ b/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
@@ -221,10 +221,15 @@ onMounted(() => {
                     dense
                     flat
                     class="action-btn action-btn--delete"
+                    :disable="!props.row.can_manage"
                     @click="onAskDelete(props.row)"
                   >
                     <q-tooltip class="tooltip action-tooltip" :offset="[0, 8]">
-                      {{ $t('common_delete') }}
+                      {{
+                        props.row.can_manage
+                          ? $t('common_delete')
+                          : $t('planner_delete_creator_only')
+                      }}
                     </q-tooltip>
                   </q-btn>
                 </div>

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -236,6 +236,9 @@ async function saveIfDirty(field: 'name' | 'is_viewable_by_unit_members') {
   saving.value = true;
   try {
     emit('updated', await plansStore.updatePlan(props.plan.id, payload));
+  } catch {
+    nameInput.value = props.plan.name;
+    shareWithLab.value = props.plan.is_viewable_by_unit_members;
   } finally {
     saving.value = false;
   }

--- a/frontend/src/i18n/home.ts
+++ b/frontend/src/i18n/home.ts
@@ -240,4 +240,8 @@ export default {
     en: 'Action',
     fr: 'Action',
   },
+  planner_delete_creator_only: {
+    en: 'Only the project creator can delete this project.',
+    fr: 'Seul le créateur du projet peut supprimer ce projet.',
+  },
 } as const;

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -19,6 +19,7 @@ export interface SimulatorPlan {
   created_at: string | null;
   creator_name: string | null;
   total_tonnes_co2eq: number | null;
+  can_manage: boolean;
 }
 
 export interface SimulatorPlanModule {


### PR DESCRIPTION
## What does this change?
Changes Simulator Plan permission scoping so shared plans are fully editable by all unit members, rather than read-only. Deletion remains restricted to the plan's creator (or global-scope roles) via a new "manage" action, distinct from "view"/"edit". Adds a `can_manage` field to `SimulatorPlanRead`/`SimulatorPlan` (frontend) so the UI knows whether the current user may delete a given plan, and disables the delete button (with an explanatory tooltip) for non-creators. Also adds error handling in `PlannerProjectInfo.vue` to revert the name/share-toggle inputs if a save fails, and updates backend tests to reflect the new edit/manage split.

## Why is this needed?
Previously, shared Simulator Plans were read-only for unit members other than the creator, which limited collaboration on planning within a unit/lab. This change opens editing to all unit members with visibility on a shared plan, while still protecting destructive actions (deletion) as creator-only, preventing accidental data loss while enabling collaborative planning.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1919

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.