### PR TITLE
fix(module): change rendered chart by default (#1913)

### DIFF
--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -215,7 +215,7 @@ const props = withDefaults(
   }>(),
   {
     showControls: true,
-    forcedView: 'breakdown',
+    forcedView: 'type',
     combineUnitIds: () => [],
     excludeModules: () => [],
   },


### PR DESCRIPTION
## What does this change?
Changes the default value of the prop in `ModuleCharts.vue` from `'breakdown'` to `'type'`, altering which chart view is rendered by default for the module.

## Why is this needed?
The chart previously defaulted to the "breakdown" view; this update changes the default rendered chart to the "type" view instead, per issue #1913.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1913

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.