### PR TITLE
fix/1958 sim explorer errors

### DIFF
--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Any, Dict, Optional
 
 from psycopg.types.json import Json
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import Select, and_, asc, desc, func, or_
 from sqlalchemy import select as sa_select
 from sqlalchemy.exc import InvalidRequestError
@@ -1166,11 +1166,18 @@ class DataEntryRepository:
                     int(source_entry_id)
                 )
 
-            items.append(handler.to_response(data_entry, enriched_data))
+            try:
+                items.append(handler.to_response(data_entry, enriched_data))
+            except ValidationError as exc:
+                logger.warning(
+                    f"Skipping data_entry id={data_entry.id} "
+                    f"(type={data_entry_type_id}) in submodule listing: "
+                    f"stored data does not match the response schema: {exc}"
+                )
 
         response = SubmoduleResponse(
             id=data_entry_type_id,
-            count=count,
+            count=len(items),
             items=items,
             summary=SubmoduleSummary(
                 total_items=total_items,

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -6,11 +6,12 @@ Provides append-only versioning with hash chain integrity for any entity type.
 import hashlib
 import json
 from datetime import datetime, timezone
-from sqlite3 import IntegrityError
 from typing import Any, Dict, List, Optional
 
 from fastapi import BackgroundTasks
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -214,6 +215,18 @@ class AuditDocumentService:
         data_snapshot = jsonable_encoder(data_snapshot)
         if route_payload is not None:
             route_payload = jsonable_encoder(route_payload)
+
+        # Serialize concurrent writers on the same entity: the head read,
+        # version increment and is_current flip below are a read-modify-write
+        # that two parallel requests (e.g. the print page fetching plane and
+        # train at once, both auditing the same CarbonReportModule) would race,
+        # violating audit_document_one_current_idx. The advisory xact lock is
+        # released at commit/rollback; the second writer then sees the new head.
+        if self.session.get_bind().dialect.name == "postgresql":
+            await self.session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
+                {"key": f"{entity_type}:{entity_id}"},
+            )
 
         # Get current version to compute diff and hash chain
         current = await self.get_current_version(entity_type, entity_id)

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -63,7 +63,13 @@
           </q-expansion-item>
         </template>
       </q-card>
-      <q-card flat bordered>
+      <q-skeleton
+        v-if="!breakdownReady"
+        type="rect"
+        height="200px"
+        class="full-width"
+      />
+      <q-card v-else flat bordered>
         <div class="q-pt-lg q-px-lg">
           <h2 class="text-h3 text-weight-medium">
             {{ $t('simulation_explore_page_results_title') }}
@@ -193,6 +199,9 @@ const defaultThreshold: Threshold = {
 
 const mountPrimaryCharts = ref(false);
 const simulatorReady = ref(false);
+// Gates the results card: until the Explorer's own breakdown is fetched, the
+// shared store still holds the Calculator's data from the workspace guard.
+const breakdownReady = ref(false);
 
 const modules = computed(() => getExploreModules(yearConfigStore.getModule));
 
@@ -253,8 +262,8 @@ onMounted(async () => {
     // so that module table requests don't 404 before the record is created.
     simulatorReady.value = true;
   }
-  await prefetchSubmoduleCounts();
-  await fetchEmissionBreakdown();
+  await Promise.all([prefetchSubmoduleCounts(), fetchEmissionBreakdown()]);
+  breakdownReady.value = true;
 });
 </script>
 

--- a/frontend/src/router/guards/workspaceGuard.ts
+++ b/frontend/src/router/guards/workspaceGuard.ts
@@ -16,6 +16,10 @@ import {
 } from 'src/stores/yearConfig';
 import { resolveLanguage } from 'src/utils/language';
 import {
+  CARBON_PROJECT,
+  resolveCarbonProject,
+} from 'src/constant/carbon-project';
+import {
   DEFAULT_ROUTE_NAME,
   WORKSPACE_ROUTE_NAME,
 } from 'src/router/routeNames';
@@ -146,9 +150,18 @@ export default async function workspaceGuard(
   // Nothing workspace-relevant changed (e.g. only :module or :language moved) —
   // skip the reload. On first entry `from` has no unit/year, so this differs
   // and the loader runs.
+  //
+  // Leaving a Simulator page (Explorer/Planner) for a Calculator route counts
+  // as a change even on the same unit/year: those pages repoint
+  // `selectedCarbonReport` and the emission breakdown at their own report, and
+  // Calculator pages render straight from the stores without fetching.
+  const returningToCalculator =
+    resolveCarbonProject(to.meta) === CARBON_PROJECT.calculator &&
+    resolveCarbonProject(from.meta) !== CARBON_PROJECT.calculator;
   if (
     to.params.unit === from.params.unit &&
-    to.params.year === from.params.year
+    to.params.year === from.params.year &&
+    !returningToCalculator
   ) {
     return true;
   }


### PR DESCRIPTION
## What does this change?
Fixes several bugs in the Simulation Explorer flow:
- Backend: `data_entry_repo.py` now catches `ValidationError` when converting stored data entries to response schemas, logging and skipping malformed items instead of crashing, and corrects the returned `count` to match the actual number of items returned.
- Backend: `audit_service.py` adds a Postgres advisory transaction lock (`pg_advisory_xact_lock`) keyed by entity type/id to serialize concurrent audit writes to the same entity, preventing a race that could violate the `audit_document_one_current_idx` constraint. Also fixes an import bug where `IntegrityError` was mistakenly imported from `sqlite3` instead of `sqlalchemy.exc`.
- Frontend: `SimulationExplorePage.vue` now shows a skeleton loader for the results card until the emission breakdown data is actually ready (`breakdownReady`), avoiding a flash of stale/incorrect data carried over from the Calculator workspace. Also parallelizes `prefetchSubmoduleCounts()` and `fetchEmissionBreakdown()` instead of awaiting them sequentially.
- Frontend: `workspaceGuard.ts` now forces a workspace reload when navigating from a Simulator page (Explorer/Planner) back to a Calculator route, even if unit/year are unchanged, since Simulator pages repoint shared stores to their own report.

## Why is this needed?
The Simulation Explorer page was throwing errors / showing stale or incorrect data due to: malformed stored data entries crashing the submodule listing, a race condition corrupting audit history under concurrent writes, and shared state (emission breakdown, carbon report) leaking between the Calculator and Simulator workspaces without triggering a proper reload.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1958

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.