### PR TITLE
fix(module): commit selects only on change (#1958)

### DIFF
--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -212,7 +212,10 @@
               :dropdown-icon="col.type === 'select' ? 'expand_more' : undefined"
               :error="!!getError(slotProps.row, col)"
               :error-message="getError(slotProps.row, col)"
-              @blur="commitInline(slotProps.row, col)"
+              @blur="col.type !== 'select' && commitInline(slotProps.row, col)"
+              @update:model-value="
+                col.type === 'select' && commitInline(slotProps.row, col)
+              "
             >
               <template v-if="col.type !== 'select'" #append>
                 <q-icon


### PR DESCRIPTION
## What does this change?
In `ModuleTable.vue`, select-type inline editors now commit their value on `@update:model-value` (i.e., when the selection actually changes) instead of on `@blur`. Non-select columns keep committing on `@blur` as before.

## Why is this needed?
For select/dropdown fields, committing on blur meant a class switch (or other select change) followed by a click elsewhere wasn't reliably saved, causing a click bug where the selected value didn't persist. Committing directly on value change fixes this.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1595

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.