### PR TITLE
feat: sort segments by total (#1465)

### DIFF
--- a/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
+++ b/frontend/src/components/charts/results/EmissionTypeBreakdownChart.vue
@@ -141,13 +141,29 @@ const ROOM_TYPE_SEGMENT_ORDER = [
   'miscellaneous',
 ];
 
-function sortSegmentKeys(keys: string[]): string[] {
+// Combustion fuel segments stack largest-first within the decentralized
+// heating bar; other categories keep their backend order.
+const COMBUSTION_SEGMENT_PREFIX = 'buildings_energy_combustion_';
+
+function sortSegmentKeys(
+  keys: string[],
+  segmentTotals?: Map<string, number>,
+): string[] {
   return keys.slice().sort((a, b) => {
     const aSuffix = a.split('_').pop() ?? a;
     const bSuffix = b.split('_').pop() ?? b;
     const aIdx = ROOM_TYPE_SEGMENT_ORDER.indexOf(aSuffix);
     const bIdx = ROOM_TYPE_SEGMENT_ORDER.indexOf(bSuffix);
-    if (aIdx === -1 && bIdx === -1) return 0;
+    if (aIdx === -1 && bIdx === -1) {
+      if (
+        segmentTotals &&
+        a.startsWith(COMBUSTION_SEGMENT_PREFIX) &&
+        b.startsWith(COMBUSTION_SEGMENT_PREFIX)
+      ) {
+        return (segmentTotals.get(b) ?? 0) - (segmentTotals.get(a) ?? 0);
+      }
+      return 0;
+    }
     if (aIdx === -1) return 1;
     if (bIdx === -1) return -1;
     return aIdx - bIdx;
@@ -288,12 +304,14 @@ const chartData = computed(() => {
 
   // Collect all unique segment keys
   const segmentKeysSet = new Set<string>();
+  const segmentTotals = new Map<string, number>();
   const bars: Record<string, unknown>[] = [];
 
   for (const [compoundKey, segments] of barMap) {
     const barData: Record<string, unknown> = { xx_category: compoundKey };
     for (const [key, val] of Object.entries(segments)) {
       segmentKeysSet.add(key);
+      segmentTotals.set(key, (segmentTotals.get(key) ?? 0) + val);
       barData[key] = val;
     }
     bars.push(barData);
@@ -303,7 +321,7 @@ const chartData = computed(() => {
 
   return {
     bars,
-    segmentKeys: sortSegmentKeys(Array.from(segmentKeysSet)),
+    segmentKeys: sortSegmentKeys(Array.from(segmentKeysSet), segmentTotals),
     barKey: 'xx_category',
     barCategoryMap,
     barLabelMap,


### PR DESCRIPTION
## What does this change?
In `EmissionTypeBreakdownChart.vue`, combustion fuel segments (keys prefixed with `buildings_energy_combustion_`) within the decentralized heating bar are now sorted largest-total-first, using a new `segmentTotals` map computed from summed values across all bars. Other segment categories retain their existing backend order.

## Why is this needed?
Combustion segments (e.g. propane) were appearing in an arbitrary/backend order within the stacked bar, making the chart harder to read. Sorting by total emission size gives a more intuitive, consistent visual ordering.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🎨 Design/UI improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1465

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.