### PR TITLE
fix: match plane search to joined airport names (#1436)

### DIFF
--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -728,6 +728,7 @@ class DataEntryRepository:
         # an implicit cross join (0 or inflated counts). Each branch records
         # its join chain here.
         count_factor_joins: list[tuple[Any, Any]] = []
+        count_location_joins: list[tuple[Any, Any]] = []
         if (
             not is_travel_entry
             and not is_headcount_entry
@@ -939,26 +940,21 @@ class DataEntryRepository:
                         isouter=True,
                     )
                 elif is_plane_entry:
+                    plane_origin_on = (
+                        col(OriginLocation.iata_code)
+                        == DataEntry.data["origin_iata"].as_string()
+                    ) & (col(OriginLocation.transport_mode) == TransportModeEnum.plane)
+                    plane_dest_on = (
+                        col(DestLocation.iata_code)
+                        == DataEntry.data["destination_iata"].as_string()
+                    ) & (col(DestLocation.transport_mode) == TransportModeEnum.plane)
                     statement = statement.join(
-                        OriginLocation,
-                        (
-                            col(OriginLocation.iata_code)
-                            == DataEntry.data["origin_iata"].as_string()
-                        )
-                        & (
-                            col(OriginLocation.transport_mode)
-                            == TransportModeEnum.plane
-                        ),
-                        isouter=True,
-                    ).join(
-                        DestLocation,
-                        (
-                            col(DestLocation.iata_code)
-                            == DataEntry.data["destination_iata"].as_string()
-                        )
-                        & (col(DestLocation.transport_mode) == TransportModeEnum.plane),
-                        isouter=True,
-                    )
+                        OriginLocation, plane_origin_on, isouter=True
+                    ).join(DestLocation, plane_dest_on, isouter=True)
+                    count_location_joins = [
+                        (OriginLocation, plane_origin_on),
+                        (DestLocation, plane_dest_on),
+                    ]
             kg_sort_expr = emission_agg.c.total_kg_co2eq
 
         statement = statement.where(
@@ -976,6 +972,11 @@ class DataEntryRepository:
         if handler_default:
             statement = statement.where(*handler_default)
         filter_map = dict(getattr(handler, "filter_map", {}) or DEFAULT_FILTER_MAP)
+        if is_plane_entry and OriginLocation is not None:
+            # Plane entries store only IATA codes; the displayed from/to are
+            # the joined airport names, so search must match those too.
+            filter_map["origin_name"] = OriginLocation.name
+            filter_map["destination_name"] = DestLocation.name
         statement, filter_pattern = self._apply_name_filter(
             statement, filter, filter_map
         )
@@ -1054,14 +1055,18 @@ class DataEntryRepository:
                 "factors" in str(expr) or "building_rooms" in str(expr)
                 for expr in filter_map.values()
             )
-            if count_factor_joins and filter_reads_factor:
-                # Join Factor (and whatever it hangs off) exactly like the
-                # page query so the count sees the same rows — without this
-                # a Factor-referencing filter degenerates into an implicit
-                # cross join (0 or inflated counts).
+            needs_factor_joins = bool(count_factor_joins) and filter_reads_factor
+            if needs_factor_joins or count_location_joins:
+                # Join Factor/Location (and whatever they hang off) exactly
+                # like the page query so the count sees the same rows —
+                # without this a joined-table filter degenerates into an
+                # implicit cross join (0 or inflated counts).
                 count_stmt = count_stmt.select_from(DataEntry)
+            if needs_factor_joins:
                 for target, onclause in count_factor_joins:
                     count_stmt = count_stmt.join(target, onclause, isouter=True)
+            for target, onclause in count_location_joins:
+                count_stmt = count_stmt.join(target, onclause, isouter=True)
             conditions = [
                 filter_expr.ilike(filter_pattern) for filter_expr in filter_map.values()
             ]

--- a/backend/tests/integration/modules/plane/test_search_uses_location.py
+++ b/backend/tests/integration/modules/plane/test_search_uses_location.py
@@ -1,0 +1,103 @@
+"""Integration test: plane table search matches joined airport names (#1436).
+
+Plane entries store only IATA codes in ``DataEntry.data``; the displayed
+from/to columns are ``Location.name`` resolved through the plane Location
+JOIN. Searching must therefore match the airport name (and still match the
+raw IATA code), and the pagination count query must apply the same JOINs so
+``total_items`` agrees with the returned page.
+"""
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.constants import ModuleStatus
+from app.models.carbon_report import CarbonReport, CarbonReportModule
+from app.models.data_entry import DataEntry, DataEntryStatusEnum, DataEntryTypeEnum
+from app.models.location import Location, TransportModeEnum
+from app.models.module_type import ModuleTypeEnum
+from app.repositories.data_entry_repo import DataEntryRepository
+
+
+def _plane_location(
+    name: str, iata: str, latitude: float, longitude: float, country_code: str
+) -> Location:
+    return Location(
+        transport_mode=TransportModeEnum.plane,
+        name=name,
+        iata_code=iata,
+        latitude=latitude,
+        longitude=longitude,
+        country_code=country_code,
+        natural_key=Location.compute_natural_key(
+            transport_mode=TransportModeEnum.plane, iata_code=iata
+        ),
+    )
+
+
+def _plane_entry(module_id: int, origin_iata: str, destination_iata: str) -> DataEntry:
+    return DataEntry(
+        carbon_report_module_id=module_id,
+        data_entry_type_id=DataEntryTypeEnum.plane,
+        status=DataEntryStatusEnum.PENDING,
+        data={
+            "origin_iata": origin_iata,
+            "destination_iata": destination_iata,
+            "user_institutional_id": "u1",
+            "number_of_trips": 1,
+            "cabin_class": "economy",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_plane_search_matches_airport_names_and_iata(db_session: AsyncSession):
+    repo = DataEntryRepository(db_session)
+
+    report = CarbonReport(year=2025, unit_id=1, overall_status=0)
+    db_session.add(report)
+    await db_session.flush()
+    module = CarbonReportModule(
+        carbon_report_id=report.id,
+        module_type_id=ModuleTypeEnum.professional_travel.value,
+        status=ModuleStatus.NOT_STARTED,
+    )
+    db_session.add(module)
+    await db_session.flush()
+
+    db_session.add(
+        _plane_location("Paris Charles de Gaulle", "CDG", 49.0097, 2.5479, "FR")
+    )
+    db_session.add(_plane_location("Zurich Airport", "ZRH", 47.4647, 8.5492, "CH"))
+    db_session.add(_plane_location("Geneva Airport", "GVA", 46.2381, 6.1089, "CH"))
+    db_session.add(_plane_entry(module.id, "CDG", "ZRH"))
+    db_session.add(_plane_entry(module.id, "GVA", "ZRH"))
+    await db_session.commit()
+
+    async def search(term: str):
+        return await repo.get_submodule_data(
+            carbon_report_module_id=module.id,
+            data_entry_type_id=DataEntryTypeEnum.plane.value,
+            limit=10,
+            offset=0,
+            sort_by="origin_name",
+            sort_order="asc",
+            filter=term,
+        )
+
+    # Origin airport name — only the CDG entry matches, and the pagination
+    # count must agree with the page (guards the count-query JOINs).
+    result = await search("Paris")
+    assert result.count == 1, f"expected 1 item for 'Paris', got {result.count}"
+    assert result.items[0].origin_iata == "CDG"  # type: ignore[attr-defined]
+    assert result.summary.total_items == 1
+
+    # Destination airport name — both entries fly to Zurich.
+    result = await search("Zurich")
+    assert result.count == 2, f"expected 2 items for 'Zurich', got {result.count}"
+    assert result.summary.total_items == 2
+
+    # Raw IATA code search keeps working.
+    result = await search("CDG")
+    assert result.count == 1, f"expected 1 item for 'CDG', got {result.count}"
+    assert result.items[0].origin_iata == "CDG"  # type: ignore[attr-defined]
+    assert result.summary.total_items == 1


### PR DESCRIPTION
## What does this change?
Fixes plane travel entry search/pagination in `data_entry_repo.py`:
- Search filtering now matches against the joined `OriginLocation.name` / `DestLocation.name` (airport names) in addition to raw IATA codes, since plane entries only store IATA codes but the UI displays resolved airport names.
- The pagination count query now applies the same Origin/Destination Location JOINs as the main page query (via a new `count_location_joins` list), preventing the count from diverging from the actual returned rows (implicit cross join causing 0 or inflated counts).
- Refactored the plane join `on` clauses into named variables (`plane_origin_on`, `plane_dest_on`) so they can be reused between the main statement and the count statement.
- Adds a new integration test `test_search_uses_location.py` covering search by origin airport name, destination airport name, and raw IATA code, verifying both `count` and `summary.total_items` are correct.

## Why is this needed?
Searching the plane travel table by airport name (e.g. "Paris") didn't work because the search only matched raw IATA codes stored in the entry data, not the airport names actually shown to users. Additionally, the count query didn't mirror the Location joins used by the page query, risking incorrect pagination counts for plane entries.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1436

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.