### PR TITLE
refactor: remove Convert to Plan CTA (#1963)

### DIFF
--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -117,30 +117,6 @@
             />
           </div>
         </div>
-
-        <q-separator />
-
-        <div
-          class="row no-wrap items-center justify-center q-pa-xl"
-          style="gap: 24px"
-        >
-          <q-icon name="o_calendar_month" color="info" size="md" />
-          <div class="col">
-            <div class="text-h5 text-weight-medium q-mb-xs">
-              {{ $t('simulation_explore_page_convert_to_plan_title') }}
-            </div>
-            <div class="text-body2 text-secondary">
-              {{ $t('simulation_explore_page_convert_to_plan_description') }}
-            </div>
-          </div>
-          <q-btn
-            unelevated
-            no-caps
-            :label="$t('simulation_explore_page_convert_to_plan_button')"
-            color="info"
-            class="text-weight-medium"
-          />
-        </div>
       </q-card>
     </template>
   </q-page>


### PR DESCRIPTION
## What does this change?
Removes the "Convert to Plan" call-to-action section from `SimulationExplorePage.vue` — the separator, icon, title/description text, and button that previously prompted users to convert their exploration into a plan.

## Why is this needed?
The Convert to Plan CTA is being removed from the Simulation Explorer page (presumably not yet functional or no longer part of the intended flow).

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1963

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.