### PR TITLE
chore: use inclusive French user labels (#1654)

### DIFF
--- a/frontend/src/i18n/admin.ts
+++ b/frontend/src/i18n/admin.ts
@@ -29,18 +29,18 @@ export default {
   },
   user_management_page_description_system: {
     en: 'User management at EPFL is handled via Accred.',
-    fr: "La gestion des utilisateurs à l'EPFL est gérée via Accred.",
+    fr: "La gestion des utilisateur·rices à l'EPFL est gérée via Accred.",
   },
   user_management_page_button_label_system: {
     en: 'Go to User management system (Accred)',
-    fr: 'Accéder au système de gestion des utilisateurs (Accred)',
+    fr: 'Accéder au système de gestion des utilisateur·rices (Accred)',
   },
   user_management_page_button_documentation_label_system: {
     en: 'Go to User management system documentation',
-    fr: 'Documentation de la gestion des utilisateurs',
+    fr: 'Documentation de la gestion des utilisateur·rices',
   },
   user_management_system_button_label: {
     en: 'Go to System User Management',
-    fr: 'Accéder à la gestion des utilisateurs du système',
+    fr: 'Accéder à la gestion des utilisateur·rices du système',
   },
 } as const;

--- a/frontend/src/i18n/audit_logs.ts
+++ b/frontend/src/i18n/audit_logs.ts
@@ -45,7 +45,7 @@ export default {
   },
   audit_entity_user: {
     en: 'User',
-    fr: 'Utilisateur',
+    fr: 'Utilisateur·rice',
   },
   audit_entity_factor: {
     en: 'Factor',
@@ -153,7 +153,7 @@ export default {
   },
   audit_col_user: {
     en: 'User or Job',
-    fr: 'Utilisateur ou tâche',
+    fr: 'Utilisateur·rice ou tâche',
   },
   audit_col_sync_status: {
     en: 'Sync Status',
@@ -223,7 +223,7 @@ export default {
   // Search bar
   audit_search_placeholder: {
     en: 'Search by user, entity, or reason...',
-    fr: 'Rechercher par utilisateur, entité ou raison...',
+    fr: 'Rechercher par utilisateur·rice, entité ou raison...',
   },
 
   // Pagination
@@ -291,7 +291,7 @@ export default {
   },
   audit_detail_user: {
     en: 'User or Job (created_by)',
-    fr: 'Utilisateur ou tâche (créé par)',
+    fr: 'Utilisateur·rice ou tâche (créé par)',
   },
   audit_detail_handler_id: {
     en: 'Handler ID',

--- a/frontend/src/i18n/backoffice.ts
+++ b/frontend/src/i18n/backoffice.ts
@@ -3,7 +3,7 @@ import { BACKOFFICE_NAV } from 'src/constant/navigation';
 export default {
   [BACKOFFICE_NAV.BACKOFFICE_USER_MANAGEMENT.routeName]: {
     en: 'User Management',
-    fr: 'Gestion des utilisateurs',
+    fr: 'Gestion des utilisateur·rices',
   },
   [BACKOFFICE_NAV.BACKOFFICE_USER_MANAGEMENT.description]: {
     en: 'backoffice-user-management-description',

--- a/frontend/src/i18n/backoffice_data_management.ts
+++ b/frontend/src/i18n/backoffice_data_management.ts
@@ -366,7 +366,7 @@ export default {
   },
   data_management_year_sync_success_caption: {
     en: 'All units and principal users have been imported. You can now upload module data.',
-    fr: 'Toutes les unités et les utilisateurs principaux ont été importés. Vous pouvez maintenant téléverser les données des modules.',
+    fr: 'Toutes les unités et les utilisateur·rices principaux·ales ont été importé·es. Vous pouvez maintenant téléverser les données des modules.',
   },
   data_management_year_sync_error: {
     en: 'Unit sync failed for year {year}',
@@ -438,7 +438,7 @@ export default {
   },
   data_management_submodule_inputs_deactivation_description: {
     en: 'When checked, users will not be able to add or edit data entries for this submodule.',
-    fr: 'Lorsque cette option est cochée, les utilisateurs ne pourront pas ajouter ou modifier des entrées de données pour ce sous-module.',
+    fr: 'Lorsque cette option est cochée, les utilisateur·rices ne pourront pas ajouter ou modifier des entrées de données pour ce sous-module.',
   },
   data_management_submodule_inputs_deactivation_label: {
     en: 'Deactivate input form',
@@ -791,7 +791,7 @@ export default {
   },
   data_management_year_is_open: {
     en: 'Open to users',
-    fr: 'Ouverte aux utilisateurs',
+    fr: 'Ouverte aux utilisateur·rices',
   },
   data_management_year_is_not_open: {
     en: 'Not yet open',
@@ -803,6 +803,6 @@ export default {
   },
   data_management_year_opened_success: {
     en: 'Year {year} opened to users',
-    fr: 'Année {year} ouverte aux utilisateurs avec succès',
+    fr: 'Année {year} ouverte aux utilisateur·rices avec succès',
   },
 } as const;

--- a/frontend/src/i18n/backoffice_documentation_editing.ts
+++ b/frontend/src/i18n/backoffice_documentation_editing.ts
@@ -45,11 +45,11 @@ export default {
   },
   documentation_editing_calculator_user_documentation_title: {
     en: 'User Documentation',
-    fr: 'Documentation utilisateur-ice',
+    fr: 'Documentation utilisateur·rice',
   },
   documentation_editing_calculator_user_documentation_description: {
     en: 'Repository link to the user documentation of the CO₂ calculator application.',
-    fr: 'Lien vers le repository de la documentation utilisateur-ice de l’application Calculateur CO₂.',
+    fr: 'Lien vers le repository de la documentation utilisateur·rice de l’application Calculateur CO₂.',
   },
 
   documentation_editing_calculator_backoffice_documentation_title: {
@@ -199,7 +199,7 @@ export default {
   },
   documentation_editing_rows_backoffice_user_management_topic: {
     en: 'Backoffice User Management',
-    fr: 'Gestion des Utilisateurs Backoffice',
+    fr: 'Gestion des Utilisateur·rices Backoffice',
   },
   documentation_editing_rows_backoffice_user_management_description: {
     en: 'Find all text related to backoffice user management within the application.',

--- a/frontend/src/i18n/backoffice_reporting.ts
+++ b/frontend/src/i18n/backoffice_reporting.ts
@@ -289,6 +289,6 @@ export default {
   },
   open_year_for_users: {
     en: 'Open year for users',
-    fr: 'Ouvrir l’année pour les utilisateurs',
+    fr: 'Ouvrir l’année pour les utilisateur·rices',
   },
 } as const;

--- a/frontend/src/i18n/backoffice_user_management.ts
+++ b/frontend/src/i18n/backoffice_user_management.ts
@@ -5,15 +5,15 @@ export default {
   },
   user_management_page_description: {
     en: 'User management at EPFL is handled via Accred.',
-    fr: "La gestion des utilisateurs à l'EPFL est gérée via Accred.",
+    fr: "La gestion des utilisateur·rices à l'EPFL est gérée via Accred.",
   },
   user_management_page_button_label: {
     en: 'Go to User management system (Accred)',
-    fr: 'Accéder au système de gestion des utilisateurs (Accred)',
+    fr: 'Accéder au système de gestion des utilisateur·rices (Accred)',
   },
   user_management_page_button_documentation_label: {
     en: 'Go to User management system documentation',
-    fr: 'Documentation de la gestion des utilisateurs',
+    fr: 'Documentation de la gestion des utilisateur·rices',
   },
   user_management_access_button: {
     en: 'Back-office Management',

--- a/frontend/src/i18n/headcount.ts
+++ b/frontend/src/i18n/headcount.ts
@@ -37,7 +37,7 @@ export default {
 
   [`${MODULES.Headcount}-student-table-title-info-label`]: {
     en: 'Students table information',
-    fr: 'Informations sur le tableau des étudiant•es',
+    fr: 'Informations sur le tableau des étudiant·es',
   },
   [`${MODULES.Headcount}-charts-title`]: {
     en: 'FTE per function',
@@ -101,6 +101,6 @@ export default {
   },
   'headcount-member-error-duplicate-uid': {
     en: "This user's {label} already exists.",
-    fr: 'Le {label} de cet utilisateur•rice existe déjà.',
+    fr: 'Le {label} de cet·te utilisateur·rice existe déjà.',
   },
 } as const;

--- a/frontend/src/i18n/home.ts
+++ b/frontend/src/i18n/home.ts
@@ -234,7 +234,7 @@ export default {
   },
   planner_table_creator: {
     en: 'Creator',
-    fr: 'Créateur',
+    fr: 'Créateur·rice',
   },
   planner_table_action: {
     en: 'Action',

--- a/frontend/src/i18n/pipeline_operations_console.ts
+++ b/frontend/src/i18n/pipeline_operations_console.ts
@@ -64,7 +64,7 @@ export default {
   pipeops_col_jobs: { en: 'Jobs', fr: 'Jobs' },
   pipeops_col_duration: { en: 'Duration', fr: 'Durée' },
   pipeops_col_when: { en: 'Started', fr: 'Démarré' },
-  pipeops_col_author: { en: 'Author', fr: 'Auteur' },
+  pipeops_col_author: { en: 'Author', fr: 'Auteur·e' },
   pipeops_col_message: { en: 'Message', fr: 'Message' },
   pipeops_col_actions: { en: 'Actions', fr: 'Actions' },
 

--- a/frontend/src/i18n/professional_travel.ts
+++ b/frontend/src/i18n/professional_travel.ts
@@ -218,7 +218,7 @@ export default {
   },
   [`${MODULES.ProfessionalTravel}-trips-map-popup-travelers`]: {
     en: 'Traveler | Travelers',
-    fr: 'Voyageur | Voyageurs',
+    fr: 'Voyageur·euse | Voyageur·euses',
   },
   [`${MODULES.ProfessionalTravel}-trips-map-legend-emissions`]: {
     en: 'Emissions',

--- a/frontend/src/i18n/roles.ts
+++ b/frontend/src/i18n/roles.ts
@@ -29,7 +29,7 @@ export default {
   },
   role_backoffice_description: {
     en: 'Day-to-day back-office operations: reporting, user management, documentation',
-    fr: 'Opérations courantes du back-office : reporting, gestion des utilisateurs, documentation',
+    fr: 'Opérations courantes du back-office : reporting, gestion des utilisateur·rices, documentation',
   },
   role_superadmin_description: {
     en: 'Full back-office access including sensitive configuration and pipeline controls',


### PR DESCRIPTION
## What does this change?
Updates French UI translation strings across multiple i18n files (`admin.ts`, `audit_logs.ts`, `backoffice.ts`, `backoffice_data_management.ts`, `backoffice_documentation_editing.ts`, `backoffice_reporting.ts`, `backoffice_user_management.ts`, `headcount.ts`, `home.ts`, `pipeline_operations_console.ts`, `professional_travel.ts`, `roles.ts`) to use inclusive French language forms (e.g. "utilisateur·rice" instead of "utilisateur", "Créateur·rice" instead of "Créateur", "Auteur·e" instead of "Auteur"). Also standardizes inconsistent inclusive notation (e.g. "étudiant•es" → "étudiant·es", "utilisateur-ice" → "utilisateur·rice") to use the middle dot (·) consistently.

## Why is this needed?
Ensures the French translations use consistent, inclusive gender-neutral language for user-facing roles and labels, aligning with EPFL's inclusive language standards.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [x] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1654

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.