### PR TITLE
feat: add merged multi-year report stats (#834)

### DIFF
--- a/backend/app/api/v1/carbon_report_module_stats.py
+++ b/backend/app/api/v1/carbon_report_module_stats.py
@@ -17,7 +17,6 @@ from app.core.constants import ModuleStatus
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import check_module_permission as _check_module_permission
-from app.core.policy import require_unit_access
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportModule, CarbonReportType
 from app.models.module_type import ModuleTypeEnum
@@ -157,65 +156,17 @@ async def get_module_stats(
     return stats
 
 
-# Declared before the ``/{carbon_report_id}/...`` dynamic routes so the literal
-# ``unit`` segment is matched first and never captured as a carbon_report_id.
-@router.get("/unit/{unit_id}/multi-year-report-stats", response_model=dict)
-async def get_multi_year_breakdown(
-    unit_id: int,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-) -> dict:
-    """Return per-year emission breakdown (by module and by scope) for a unit.
-
-    Feeds the "Compare Years" pop-up: one entry per year with stat-bucket
-    totals (``modules``) and scope totals (``scopes``) in tonnes CO2eq, read
-    straight off each report's persisted stats.
-
-    Returns:
-        {"years": [{"year": 2023, "total_tonnes_co2eq": 61.7,
-                    "modules": {...}, "scopes": {...}}, ...]}
-    """
-    logger.info(f"GET multi-year breakdown: unit_id={sanitize(unit_id)}")
-
-    unit = await db.get(Unit, unit_id)
-    require_unit_access(current_user, unit)
-
-    reports = await CarbonReportRepository(db).list_by_unit(unit_id)
-
-    # A unit can own more than one Calculator project, and uniqueness is on
-    # (carbon_project_id, year) -- not (unit_id, year) -- so a year may map to
-    # several reports. Fold them into one aggregate of the same stats shape.
-    stats_by_year: dict[int, list[dict]] = {}
-    for report in reports:
-        if report.stats:
-            stats_by_year.setdefault(report.year, []).append(report.stats)
-
-    years = []
-    for year in sorted(stats_by_year):
-        stats_list = stats_by_year[year]
-        stats = (
-            stats_list[0] if len(stats_list) == 1 else merge_report_stats(stats_list)
-        )
-        years.append({"year": year, **build_year_comparison(stats)})
-
-    return {"years": years}
-
-
-async def _authorize_and_resolve_reports(
+async def _authorize_unit_ids(
     db: AsyncSession,
     current_user: User,
     unit_ids: list[int],
-    year: int,
-) -> list[CarbonReport]:
-    """Resolve the CALCULATOR report of each requested unit, for one year.
+) -> list[int]:
+    """Validate requested units against the caller's allow-list, deduped.
 
     Every unit must be one the caller may see, per the same allow-list the
     workspace switcher is built from. A unit outside it yields 404 rather than
     403: the frontend turns any 403 into a hard redirect to /unauthorized, so a
     forged id must look like "not found", not trip that redirect.
-
-    Units with no report for ``year`` are skipped, so the aggregate simply
-    covers the units that do have one.
     """
     if not unit_ids:
         raise HTTPException(
@@ -237,13 +188,73 @@ async def _authorize_and_resolve_reports(
             detail=f"Unit(s) not found: {', '.join(str(u) for u in unknown)}",
         )
 
+    return list(dict.fromkeys(unit_ids))
+
+
+async def _authorize_and_resolve_reports(
+    db: AsyncSession,
+    current_user: User,
+    unit_ids: list[int],
+    year: int,
+) -> list[CarbonReport]:
+    """Resolve the CALCULATOR report of each requested unit, for one year.
+
+    Units with no report for ``year`` are skipped, so the aggregate simply
+    covers the units that do have one.
+    """
+    authorized_unit_ids = await _authorize_unit_ids(db, current_user, unit_ids)
+
     report_repo = CarbonReportRepository(db)
     reports: list[CarbonReport] = []
-    for unit_id in dict.fromkeys(unit_ids):
+    for unit_id in authorized_unit_ids:
         report = await report_repo.get_by_unit_and_year(unit_id=unit_id, year=year)
         if report is not None:
             reports.append(report)
     return reports
+
+
+@router.get("/merged/multi-year-report-stats", response_model=dict)
+async def get_merged_multi_year_breakdown(
+    unit_ids: list[int] = Query(default_factory=list),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Return per-year emission breakdown summed over the requested units.
+
+    Feeds the "Compare Years" pop-up: one entry per year with stat-bucket
+    totals (``modules``) and scope totals (``scopes``) in tonnes CO2eq, read
+    straight off each report's persisted stats. Units with no reports simply
+    contribute nothing; no report at all yields ``{"years": []}``.
+
+    Returns:
+        {"years": [{"year": 2023, "total_tonnes_co2eq": 61.7,
+                    "modules": {...}, "scopes": {...}}, ...]}
+    """
+    logger.info(f"GET merged multi-year breakdown: unit_ids={sanitize(unit_ids)}")
+
+    authorized_unit_ids = await _authorize_unit_ids(db, current_user, unit_ids)
+
+    # A unit can own more than one Calculator project, and uniqueness is on
+    # (carbon_project_id, year) -- not (unit_id, year) -- so a year may map to
+    # several reports, on top of one report per requested unit. Fold them into
+    # one aggregate of the same stats shape.
+    report_repo = CarbonReportRepository(db)
+    stats_by_year: dict[int, list[dict]] = {}
+    for unit_id in authorized_unit_ids:
+        reports = await report_repo.list_by_unit(unit_id)
+        for report in reports:
+            if report.stats:
+                stats_by_year.setdefault(report.year, []).append(report.stats)
+
+    years = []
+    for year in sorted(stats_by_year):
+        stats_list = stats_by_year[year]
+        stats = (
+            stats_list[0] if len(stats_list) == 1 else merge_report_stats(stats_list)
+        )
+        years.append({"year": year, **build_year_comparison(stats)})
+
+    return {"years": years}
 
 
 @router.get("/merged/report-stats", response_model=dict)

--- a/docs/src/implementation-plans/834-compare-years-unit-aggregation.md
+++ b/docs/src/implementation-plans/834-compare-years-unit-aggregation.md
@@ -1,0 +1,87 @@
+---
+status: delivered
+issue: 834
+last_updated: 2026-08-04
+title: "Compare Years: aggregate across combined units + reword target box"
+summary: "Replace the single-unit multi-year-report-stats endpoint with GET /merged/multi-year-report-stats (unit_ids query, allow-list auth factored out of the year-scoped helper), wire combined units from ResultsPage through CompareYearsDialog, and reword the target-gap KPI to the approved 'Reduction needed to reach {year} target' phrasing with a template-side minus sign."
+---
+
+# Compare Years: aggregate across combined units + reword target box
+
+## Problem (follow-up feedback on #834)
+
+Two collaborator asks before closing the issue:
+
+1. On the Results page, "Add a Unit" combines units and every `/merged/*`
+   stats endpoint respects the combined perimeter — but the Compare Years
+   pop-up ignored it. `CompareYearsDialog` received a single `unit-id` and
+   called `GET /modules-stats/unit/{unit_id}/multi-year-report-stats`, so
+   with N units combined the dialog silently showed only the selected
+   unit's numbers.
+2. The target KPI box wording "Missing to reach 2040 target / 11% /
+   target 1.3 t CO₂-eq" was unclear. Approved rewording:
+   - EN: "Reduction needed to reach 2040 target" / "-11%" /
+     "2040 target: 1.3 t CO₂-eq"
+   - FR: "Réduction nécessaire pour atteindre l'objectif 2040" / "-11 %" /
+     "Objectif pour 2040 : 1.3 t CO₂-eq"
+
+## Decisions
+
+- **Aggregation is server-side** (backend is the source of truth). The
+  frontend sends the unit list; the backend groups every unit's report
+  stats by year and folds each year with the existing
+  `merge_report_stats`, then `build_year_comparison` — the same primitives
+  the single-unit endpoint already used for multi-project years.
+- **The single-unit endpoint is deleted** (no backward-compatibility
+  paths). The single-unit case is a list of one on the merged endpoint.
+  Its access semantics therefore shift from `require_unit_access` to the
+  `/merged/*` family's allow-list check, which 404s (never 403s, to avoid
+  the frontend's hard `/unauthorized` redirect on 403).
+- The allow-list check is factored out of the year-scoped
+  `_authorize_and_resolve_reports` into `_authorize_unit_ids`, because the
+  multi-year endpoint needs all years (`list_by_unit`), not one
+  (`get_by_unit_and_year`).
+- **No 404 when no unit has any report** — the endpoint returns
+  `{"years": []}` like its predecessor; the dialog has a proper no-data
+  state.
+- The minus sign on the gap percentage is presentation, hardcoded in the
+  template for the "missing" case only; `pctMagnitude` stays a positive
+  magnitude and the "below target" case stays unsigned.
+- `results_compare_years_gap_beaten_label` is untouched — the approved
+  proposition only covers the "missing" case.
+- The `%` stays glued to the number in both locales (uniform rendering);
+  the FR-typography `-11 %` spacing was not adopted.
+
+## Changes
+
+### Backend — `backend/app/api/v1/carbon_report_module_stats.py`
+
+- New `_authorize_unit_ids(db, current_user, unit_ids) -> list[int]`:
+  empty → 400, allow-list from `UnitService.get_user_units` → 404 for
+  unknown units, deduped ids returned.
+- `_authorize_and_resolve_reports` now delegates to it and keeps only the
+  per-unit `get_by_unit_and_year` loop; `/merged/report-stats` and
+  `/merged/results-summary` behavior unchanged.
+- New `GET /merged/multi-year-report-stats?unit_ids=…` returning the same
+  `{"years": [...]}` shape as the deleted
+  `GET /unit/{unit_id}/multi-year-report-stats`.
+
+### Frontend
+
+- `frontend/src/stores/modules.ts` — `getMultiYearReportStats(unitIds:
+number[])` calls the merged endpoint with repeated `unit_ids` params
+  (mirrors `getMergedResultsSummary`).
+- `frontend/src/components/charts/results/CompareYearsDialog.vue` — prop
+  `unitId` → `unitIds: number[]`; KPI template adds the conditional minus
+  and passes `year` to `results_compare_years_gap_target`. The dialog
+  re-fetches on every open, so changing combined units between opens is
+  covered. Objectives need no change: year config is global and
+  `computeCompareYearsObjectives` baselines on the aggregated years.
+- `frontend/src/pages/app/ResultsPage.vue` — `compareYearsUnitIds` =
+  `mergedContext.unitIds` when combining, else the selected report's unit.
+- `frontend/src/i18n/results.ts` — reworded
+  `results_compare_years_gap_label`, `results_compare_years_gap_target`
+  (now takes `{year}`).
+- `frontend/scripts/openapi.snapshot.json` + generated
+  `frontend/src/types/api/openapi.d.ts` regenerated; the snapshot was
+  stale since #1564, so the diff also catches up on routes shipped since.

--- a/frontend/src/components/charts/results/CompareYearsDialog.vue
+++ b/frontend/src/components/charts/results/CompareYearsDialog.vue
@@ -27,9 +27,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  unitId: {
-    type: Number as PropType<number | null | undefined>,
-    default: null,
+  unitIds: {
+    type: Array as PropType<number[]>,
+    default: () => [],
   },
 });
 
@@ -78,14 +78,14 @@ const selectedScopes = ref<string[]>([...SCOPE_KEYS]);
 const showObjective = ref(true);
 
 async function load() {
-  if (props.unitId == null) return;
+  if (props.unitIds.length === 0) return;
   loading.value = true;
   error.value = null;
   infoColorHex.value = readCssVarHex('--q-info');
   try {
     const year = workspaceStore.selectedYear ?? new Date().getFullYear();
     const [res] = await Promise.all([
-      moduleStore.getMultiYearReportStats(props.unitId),
+      moduleStore.getMultiYearReportStats(props.unitIds),
       // Populate reduction_objectives.goals for the objective bar.
       yearConfigStore.fetchConfig(year),
     ]);
@@ -346,7 +346,8 @@ const scopeObjectiveBars = computed(() =>
                   class="compare-years-kpi__delta"
                   :class="objectiveGap.missing ? 'text-negative' : 'text-info'"
                 >
-                  {{
+                  {{ objectiveGap.missing ? '-' : ''
+                  }}{{
                     $nOrDash(objectiveGap.pctMagnitude * 100, {
                       options: { maximumFractionDigits: 0 },
                     })
@@ -355,6 +356,7 @@ const scopeObjectiveBars = computed(() =>
                 <span class="compare-years-kpi__sub">
                   {{
                     $t('results_compare_years_gap_target', {
+                      year: objectiveGap.targetYear,
                       value: `${formatTonnes(objectiveGap.objectiveTonnes)} ${$t(
                         'results_units_tonnes',
                       )}`,

--- a/frontend/src/i18n/results.ts
+++ b/frontend/src/i18n/results.ts
@@ -92,16 +92,16 @@ export default {
     fr: 'Objectif',
   },
   results_compare_years_gap_label: {
-    en: 'Missing to reach {year} target',
-    fr: 'Manque pour atteindre l’objectif {year}',
+    en: 'Reduction needed to reach {year} target',
+    fr: 'Réduction nécessaire pour atteindre l’objectif {year}',
   },
   results_compare_years_gap_beaten_label: {
     en: 'Below {year} target',
     fr: 'Sous l’objectif {year}',
   },
   results_compare_years_gap_target: {
-    en: 'target {value}',
-    fr: 'cible {value}',
+    en: '{year} target: {value}',
+    fr: 'Objectif pour {year} : {value}',
   },
   results_compare_years_by_module: {
     en: 'Emissions by category',

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -451,9 +451,11 @@ function getModuleCarComparison(module: string): string | undefined {
 const viewUncertainties = ref(false);
 const viewAdditionalData = computed(() => !hideAdditionalData.value);
 const compareYearsOpen = ref(false);
-const compareYearsUnitId = computed(
-  () => workspaceStore.selectedCarbonReport?.unit_id ?? null,
-);
+const compareYearsUnitIds = computed<number[]>(() => {
+  if (mergedContext.value) return mergedContext.value.unitIds;
+  const unitId = workspaceStore.selectedCarbonReport?.unit_id;
+  return unitId != null ? [unitId] : [];
+});
 
 const additionalBreakdown = computed(
   () => moduleStore.state.emissionBreakdown?.additional_breakdown ?? [],
@@ -1061,7 +1063,7 @@ const getUncertainty = (
 
     <CompareYearsDialog
       v-model="compareYearsOpen"
-      :unit-id="compareYearsUnitId"
+      :unit-ids="compareYearsUnitIds"
     />
   </q-page>
 </template>

--- a/frontend/src/stores/modules.ts
+++ b/frontend/src/stores/modules.ts
@@ -1209,10 +1209,17 @@ export const useModuleStore = defineStore('modules', () => {
   }
 
   async function getMultiYearReportStats(
-    unitId: number,
+    unitIds: number[],
   ): Promise<MultiYearReportStatsResponse> {
-    const path = `modules-stats/unit/${encodeURIComponent(unitId)}/multi-year-report-stats`;
-    return api.get(path).json<MultiYearReportStatsResponse>();
+    const searchParams = new URLSearchParams();
+    for (const id of unitIds) {
+      searchParams.append('unit_ids', String(id));
+    }
+    return api
+      .get(
+        `modules-stats/merged/multi-year-report-stats?${searchParams.toString()}`,
+      )
+      .json<MultiYearReportStatsResponse>();
   }
 
   // Track which carbon report the cached validated totals belong to


### PR DESCRIPTION
## What does this change?
Replaces the single-unit `GET /modules-stats/unit/{unit_id}/multi-year-report-stats` endpoint with a new `GET /modules-stats/merged/multi-year-report-stats` endpoint that accepts a list of `unit_ids` and aggregates per-year stats across all of them. The shared allow-list authorization logic is factored out of `_authorize_and_resolve_reports` into a new `_authorize_unit_ids` helper. On the frontend, `CompareYearsDialog` now takes `unitIds: number[]` instead of a single `unitId`, `ResultsPage` passes the combined unit list when units are merged, and the module store's `getMultiYearReportStats` calls the new merged endpoint. Also rewords the target-gap KPI label/sub-label (EN/FR) to "Reduction needed to reach {year} target" with a hardcoded minus sign for the "missing" case, and regenerates the stale OpenAPI snapshot/types.

## Why is this needed?
Follow-up feedback on issue #834: when units were combined via "Add a Unit" on the Results page, every other `/merged/*` stats endpoint respected the combined perimeter, but the "Compare Years" pop-up ignored it and silently showed only the originally selected unit's numbers. Additionally, the target KPI wording ("Missing to reach 2040 target") was unclear and needed approved rewording.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #834

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.