### PR TITLE
feat/1922 project planner feedbacks

### DIFF
--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -38,8 +38,11 @@ DEFAULT_COMPLETION_PROGRESS = f"0/{TOTAL_MODULE_TYPES}"
 
 # Simulator Plan "prefilled" (type-2) modules: snapshot-copied from the
 # reference year. Mirrors the frontend planner-module-config
-# ``behavior === 'prefilled'`` set.
+# ``behavior === 'prefilled'`` set. Headcount is prefilled too, but its
+# Calculator rows are aggregated per SIUS category instead of copied one to
+# one — see ``SimulatorPlanService.prefill_headcount_from_reference``.
 PLANNER_PREFILLED_MODULE_TYPES: set[ModuleTypeEnum] = {
+    ModuleTypeEnum.headcount,
     ModuleTypeEnum.process_emissions,
     ModuleTypeEnum.buildings,
     ModuleTypeEnum.equipment,

--- a/backend/app/modules/professional_travel/handlers.py
+++ b/backend/app/modules/professional_travel/handlers.py
@@ -34,6 +34,7 @@ from app.utils.distance_geography import (
     calculate_train_distance,
     get_haul_category,
 )
+from app.utils.factor_year import resolve_factor_year
 
 logger = get_logger(__name__)
 
@@ -48,7 +49,7 @@ async def _get_report_year_for_module(
     if carbon_report_module_id is None:
         return None
     stmt = (
-        select(CarbonReport.year, CarbonReport.reference_year)
+        select(CarbonReport)
         .join(
             CarbonReportModule,
             col(CarbonReportModule.carbon_report_id) == col(CarbonReport.id),
@@ -56,13 +57,10 @@ async def _get_report_year_for_module(
         .where(col(CarbonReportModule.id) == carbon_report_module_id)
     )
     result = await session.exec(stmt)
-    row = result.one_or_none()
-    if row is None:
+    report = result.one_or_none()
+    if report is None:
         return None
-    year, reference_year = row
-    # reference_year wins: Simulator Plan reports source factors from their
-    # baseline year (see DataEntryEmissionService._get_year_from_data_entry).
-    return reference_year if reference_year is not None else year
+    return await resolve_factor_year(session, report)
 
 
 class ProfessionalTravelBaseModuleHandler(BaseModuleHandler):

--- a/backend/app/modules_planner/purchase/derived_factors.py
+++ b/backend/app/modules_planner/purchase/derived_factors.py
@@ -23,15 +23,22 @@ from app.core.logging import get_logger
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.factor import Factor
 from app.modules.emissions import EmissionType
-from app.modules_planner.purchase.emissions import PLANNER_PURCHASE_EMISSIONS
+from app.modules_planner.purchase.emissions import (
+    PLANNER_PURCHASE_EMISSIONS,
+    PLANNER_PURCHASE_UNPRICED_CATEGORIES,
+)
 from app.repositories.factor_repo import FactorRepository
 
 logger = get_logger(__name__)
 
 # The planner's category slugs are the Calculator's purchase entry types by
-# the same name — derived, so the two cannot drift.
+# the same name — derived, so the two cannot drift. Categories the Calculator
+# does not price per EUR are left out: their factors carry no
+# ``ef_kg_co2eq_per_currency`` to average.
 SOURCE_TYPE_BY_CATEGORY: dict[str, DataEntryTypeEnum] = {
-    category: DataEntryTypeEnum[category] for category in PLANNER_PURCHASE_EMISSIONS
+    category: DataEntryTypeEnum[category]
+    for category in PLANNER_PURCHASE_EMISSIONS
+    if category not in PLANNER_PURCHASE_UNPRICED_CATEGORIES
 }
 PURCHASE_SOURCE_TYPES: frozenset[DataEntryTypeEnum] = frozenset(
     SOURCE_TYPE_BY_CATEGORY.values()

--- a/backend/app/modules_planner/purchase/emissions.py
+++ b/backend/app/modules_planner/purchase/emissions.py
@@ -15,7 +15,15 @@ PLANNER_PURCHASE_EMISSIONS: dict[str, EmissionType] = {
     "services": EmissionType.purchases__services,
     "vehicles": EmissionType.purchases__vehicles,
     "other_purchases": EmissionType.purchases__other,
+    "purchases_centralized": EmissionType.purchases__centralized,
 }
+
+# Additional (centralized) purchases are priced per kg of product in the
+# Calculator, not per EUR, so no average EF can be derived for them and an
+# amount entered against the category stays unpriced.
+PLANNER_PURCHASE_UNPRICED_CATEGORIES: frozenset[str] = frozenset(
+    {"purchases_centralized"}
+)
 
 
 def resolve_planner_purchase(data: dict) -> list[EmissionType] | None:

--- a/backend/app/repositories/carbon_project_repo.py
+++ b/backend/app/repositories/carbon_project_repo.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from sqlmodel import col, select
+from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logging import get_logger
@@ -97,6 +97,25 @@ class CarbonProjectRepository:
             .where(
                 col(CarbonReport.unit_id) == unit_id,
                 col(CarbonReport.year) == year,
+                col(CarbonProject.carbon_report_type) == CarbonReportType.CALCULATOR,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    async def get_latest_calculator_year(self, unit_id: int) -> Optional[int]:
+        """Year of the unit's most recent Calculator report, or None.
+
+        The default factor year of plan years without a reference year.
+        """
+        statement = (
+            select(func.max(col(CarbonReport.year)))
+            .join(
+                CarbonProject,
+                col(CarbonReport.carbon_project_id) == col(CarbonProject.id),
+            )
+            .where(
+                col(CarbonReport.unit_id) == unit_id,
                 col(CarbonProject.carbon_report_type) == CarbonReportType.CALCULATOR,
             )
         )

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -47,6 +47,12 @@ class SimulatorPlanUpdate(BaseModel):
     start_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     end_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     is_viewable_by_unit_members: Optional[bool] = None
+    default_reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
+    """Reference year for year reports newly created by this range change.
+
+    The workspace year the planner was opened from. Applied (with the usual
+    prefill) only to reports the sync creates; existing reports keep theirs.
+    """
 
     @field_validator("name")
     @classmethod
@@ -57,9 +63,13 @@ class SimulatorPlanUpdate(BaseModel):
 
 
 class SimulatorPlanReferenceYearUpdate(BaseModel):
-    """Schema for setting the baseline year of one plan-year report."""
+    """Schema for setting the baseline year of one plan-year report.
 
-    reference_year: int = Field(ge=1000, le=9999)
+    ``None`` removes the reference year: the prefilled modules are emptied
+    (same wipe as a change) and the year becomes manual-input.
+    """
+
+    reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
 
 
 class SimulatorPlanRead(BaseModel):
@@ -71,6 +81,7 @@ class SimulatorPlanRead(BaseModel):
     start_year: Optional[int] = None
     end_year: Optional[int] = None
     is_viewable_by_unit_members: bool = False
+    default_factor_year: Optional[int] = None
     created_by: Optional[int] = None
     created_at: Optional[datetime] = None
     creator_name: Optional[str] = None

--- a/backend/app/services/data_entry_emission_service.py
+++ b/backend/app/services/data_entry_emission_service.py
@@ -31,6 +31,7 @@ from app.repositories.data_entry_emission_repo import (
 from app.schemas.data_entry import BaseModuleHandler, DataEntryResponse
 from app.services.factor_resolver import FactorResolver
 from app.services.factor_service import FactorService
+from app.utils.factor_year import resolve_factor_year
 
 settings = get_settings()
 logger = get_logger(__name__)
@@ -135,12 +136,7 @@ class DataEntryEmissionService:
         report = await self._get_report_for_data_entry(data_entry)
         if report is None:
             return None
-        # reference_year wins: Simulator Plan reports source all factors from
-        # their baseline year (plan years can be in the future, where no
-        # factors exist). reference_year is NULL for Calculator/Explore.
-        if report.reference_year is not None:
-            return report.reference_year
-        return report.year
+        return await resolve_factor_year(self.session, report)
 
     async def _get_percentage_override_kg(
         self,
@@ -349,11 +345,7 @@ class DataEntryEmissionService:
             if report is not None:
                 # Same precedence as _get_year_from_data_entry: the plan's
                 # reference year drives factor lookup.
-                year = (
-                    report.reference_year
-                    if report.reference_year is not None
-                    else report.year
-                )
+                year = await resolve_factor_year(self.session, report)
         if year is None:
             logger.warning(
                 "Could not determine year for data entry, factors may not match"

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -55,6 +55,7 @@ def _to_read(
     project: CarbonProject,
     creator_name: Optional[str],
     total_tonnes_co2eq: Optional[float] = None,
+    default_factor_year: Optional[int] = None,
 ) -> SimulatorPlanRead:
     if project.id is None:
         raise ValueError("project must be persisted before use")
@@ -69,6 +70,7 @@ def _to_read(
         created_at=project.created_at,
         creator_name=creator_name,
         total_tonnes_co2eq=total_tonnes_co2eq,
+        default_factor_year=default_factor_year,
     )
 
 
@@ -90,8 +92,14 @@ class SimulatorPlanService:
         totals = await self._totals_by_plan(
             [project.id for project, _ in rows if project.id is not None]
         )
+        default_factor_year = await self.repo.get_latest_calculator_year(unit_id)
         return [
-            _to_read(project, creator_name, totals.get(project.id or -1))
+            _to_read(
+                project,
+                creator_name,
+                totals.get(project.id or -1),
+                default_factor_year,
+            )
             for project, creator_name in rows
         ]
 
@@ -119,7 +127,11 @@ class SimulatorPlanService:
         if row is None:
             return None
         project, creator_name = row
-        return _to_read(project, creator_name)
+        return _to_read(
+            project,
+            creator_name,
+            default_factor_year=await self.repo.get_latest_calculator_year(unit_id),
+        )
 
     async def create_plan(
         self, *, unit_id: int, user: User, name: Optional[str] = None
@@ -143,7 +155,11 @@ class SimulatorPlanService:
             created_at=datetime.now(timezone.utc),
         )
         project = await self._flush_guarded(self.repo.create(project))
-        return _to_read(project, user.display_name)
+        return _to_read(
+            project,
+            user.display_name,
+            default_factor_year=await self.repo.get_latest_calculator_year(unit_id),
+        )
 
     async def update_plan(
         self, plan_id: int, update: SimulatorPlanUpdate
@@ -177,15 +193,26 @@ class SimulatorPlanService:
         ):
             raise ValueError("start_year must be <= end_year")
         project = await self._flush_guarded(self.repo.create(project))
-        await self._sync_year_reports(project)
+        await self._sync_year_reports(
+            project, default_reference_year=update.default_reference_year
+        )
         return await self._read_with_creator(project)
 
-    async def _sync_year_reports(self, project: CarbonProject) -> None:
+    async def _sync_year_reports(
+        self,
+        project: CarbonProject,
+        default_reference_year: Optional[int] = None,
+    ) -> None:
         """Make the plan's reports match ``start_year..end_year``, one per year.
 
         Out-of-range reports are deleted together with their entries
         (destructive by design — the user shrank the range deliberately).
         No-op until both bounds are set.
+
+        Newly created year reports default their reference year to
+        ``default_reference_year`` (the workspace year the range was set
+        from) and are prefilled from it, exactly as if the user had picked
+        it in the dialog. Existing reports keep their reference year.
         """
         if project.start_year is None or project.end_year is None:
             return
@@ -199,13 +226,19 @@ class SimulatorPlanService:
             elif report.id is not None:
                 await self.report_service.delete(report.id)
         for year in sorted(target_years - existing_years):
-            await self.report_service.create(
+            report_read = await self.report_service.create(
                 CarbonReportCreate(
                     unit_id=project.unit_id,
                     year=year,
                     carbon_project_id=project.id,
+                    reference_year=default_reference_year,
                 )
             )
+            if default_reference_year is not None:
+                # Prefill computes the copied rows' emissions itself; only
+                # the report rollup is missing (no other entries exist yet).
+                await self._prefill_reference_modules(report_read)
+                await self.report_service.recompute_report_stats(report_read.id)
 
     async def list_plan_years(
         self, plan_id: int
@@ -226,18 +259,19 @@ class SimulatorPlanService:
         return years
 
     async def set_reference_year(
-        self, plan_id: int, year: int, reference_year: int
+        self, plan_id: int, year: int, reference_year: Optional[int]
     ) -> Optional[SimulatorPlanYearRead]:
-        """Set the baseline year of one plan-year report; None if missing.
+        """Set or remove the baseline year of one plan-year report; None if missing.
 
-        Destructive: every module of the plan-year is emptied — the prefilled
-        ones rebuilt from the new baseline at 100%, the manually filled ones
-        left blank — so the percentages, edits and hand-entered values made
-        under the previous reference year are lost. The dialog warns about it
-        before calling this.
+        Destructive: every prefilled module of the plan-year is emptied and,
+        when a baseline is set, rebuilt from it at 100% — the percentages,
+        edits and hand-added rows made under the previous reference year are
+        lost. Removing the baseline (``reference_year=None``) empties them
+        the same way and leaves the year manual-input. The dialog warns
+        about it before calling this.
 
-        The rebuilt entries get their emissions recomputed, since factor lookup
-        follows the reference year.
+        The remaining entries get their emissions recomputed, since factor
+        lookup follows the reference year.
         """
         reports = await self.repo.list_reports_for_project(plan_id)
         report = next((r for r in reports if r.year == year), None)
@@ -251,24 +285,28 @@ class SimulatorPlanService:
             await self._recalculate_report_emissions(report)
         return await self._year_read(report)
 
-    async def _prefill_reference_modules(self, report: CarbonReport) -> None:
-        """Empty the whole plan-year, then rebuild its prefilled modules.
+    async def _prefill_reference_modules(
+        self, report: CarbonReport | CarbonReportRead
+    ) -> None:
+        """Rebuild every prefilled-behavior module from the reference year.
 
-        Runs on reference-year set/change (there is no manual prefill trigger).
-        Every entry of the plan-year is deleted first — all of them hang on the
-        baseline, whether copied from it (prefilled modules) or entered against
-        it and priced with its factors (headcount, purchases, travel) — and only
-        then are the prefilled modules copied from the new reference year.
-        When the reference year has no Calculator report for the unit there is
-        nothing to copy and they stay empty — showing the previous baseline's
-        rows under a new reference year would be a lie.
+        Runs on reference-year set/change/removal (there is no manual prefill
+        trigger). The modules are emptied first, so a module never mixes two
+        baselines; on removal the wipe is all that happens and the year
+        becomes manual-input. When the reference year has no Calculator
+        report for the unit there is nothing to copy and they stay empty —
+        showing the previous baseline's rows under a new reference year
+        would be a lie.
         """
         if report.id is None:
             raise ValueError("report must be persisted before use")
+        modules = await self.report_service.module_service.list_modules(report.id)
+        prefilled = [
+            m for m in modules if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
+        ]
+        await self._clear_module_entries([m.id for m in prefilled if m.id is not None])
         if report.reference_year is None:
             return
-        modules = await self.report_service.module_service.list_modules(report.id)
-        await self._clear_module_entries([m.id for m in modules if m.id is not None])
         ref_report = await self.repo.get_calculator_report(
             report.unit_id, report.reference_year
         )
@@ -560,7 +598,13 @@ class SimulatorPlanService:
         )
         copy = await self._flush_guarded(self.repo.create(copy))
         await self._sync_year_reports(copy)
-        return _to_read(copy, user.display_name)
+        return _to_read(
+            copy,
+            user.display_name,
+            default_factor_year=await self.repo.get_latest_calculator_year(
+                copy.unit_id
+            ),
+        )
 
     async def delete_plan(self, plan_id: int) -> bool:
         """Delete a plan and any carbon reports attached to it.
@@ -579,11 +623,16 @@ class SimulatorPlanService:
 
     async def _read_with_creator(self, project: CarbonProject) -> SimulatorPlanRead:
         """Build a Read DTO resolving the creator display name via the join."""
+        default_factor_year = await self.repo.get_latest_calculator_year(
+            project.unit_id
+        )
         row = await self.repo.get_plan_by_name(project.unit_id, project.name or "")
         if row is None:
-            return _to_read(project, None)
+            return _to_read(project, None, default_factor_year=default_factor_year)
         refreshed, creator_name = row
-        return _to_read(refreshed, creator_name)
+        return _to_read(
+            refreshed, creator_name, default_factor_year=default_factor_year
+        )
 
     @staticmethod
     async def _flush_guarded(awaitable) -> CarbonProject:

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -15,7 +15,7 @@ from app.core.logging import get_logger
 from app.models.carbon_project import CarbonProject
 from app.models.carbon_report import CarbonReport, CarbonReportType
 from app.models.data_entry import DataEntry, DataEntrySourceEnum, DataEntryTypeEnum
-from app.models.module_type import PLANNER_PREFILLED_MODULE_TYPES
+from app.models.module_type import PLANNER_PREFILLED_MODULE_TYPES, ModuleTypeEnum
 from app.models.user import User
 from app.repositories.carbon_project_repo import CarbonProjectRepository
 from app.repositories.data_entry_repo import DataEntryRepository
@@ -274,14 +274,15 @@ class SimulatorPlanService:
         )
         if ref_report is None:
             return
-        for module_type_id in sorted(
-            m.module_type_id
-            for m in modules
-            if m.module_type_id in PLANNER_PREFILLED_MODULE_TYPES
-        ):
-            await self.prefill_module_from_reference(
-                report, module_type_id, ref_report=ref_report
-            )
+        for module_type_id in sorted(m.module_type_id for m in prefilled):
+            if module_type_id == ModuleTypeEnum.headcount:
+                await self.prefill_headcount_from_reference(
+                    report, ref_report=ref_report
+                )
+            else:
+                await self.prefill_module_from_reference(
+                    report, module_type_id, ref_report=ref_report
+                )
 
     async def _clear_module_entries(self, module_ids: list[int]) -> None:
         """Delete every data entry of the given modules and refresh their stats.
@@ -322,11 +323,8 @@ class SimulatorPlanService:
         100``. Each copy keeps ``source_data_entry_id`` so the % slider computes
         against the live reference entry. Returns the copied count.
 
-        The copy + emission-compute loop is batched (one flush for every new
-        row, one shared ``FactorResolver``/factor-query cache, one grouped
-        ``prefetch_slice`` per data_entry_type, one bulk emission insert) so
-        an N-row module costs a small constant number of round trips instead
-        of ``O(N)`` — see plan/perf notes on this function.
+        The copy + emission-compute loop is batched by
+        ``_persist_prefill_entries`` — see plan/perf notes on this function.
 
         Args:
             ref_report: The reference year's Calculator report, when the
@@ -359,15 +357,8 @@ class SimulatorPlanService:
         entry_repo = DataEntryRepository(self.session)
         await entry_repo.bulk_delete_by_modules([plan_module.id])
 
-        src_entries = await entry_repo.list_by_module(ref_module.id)
-        if not src_entries:
-            await self.report_service.module_service.recompute_stats_many(
-                [plan_module.id]
-            )
-            return 0
-
         copies: list[DataEntry] = []
-        for src in src_entries:
+        for src in await entry_repo.list_by_module(ref_module.id):
             copy = DataEntry(
                 data_entry_type_id=src.data_entry_type_id,
                 carbon_report_module_id=plan_module.id,
@@ -382,21 +373,120 @@ class SimulatorPlanService:
             )
             self.session.add(copy)
             copies.append(copy)
+
+        await self._persist_prefill_entries(
+            copies, plan_module.id, year=report.reference_year
+        )
+        return len(copies)
+
+    async def prefill_headcount_from_reference(
+        self,
+        report: CarbonReport | CarbonReportRead,
+        *,
+        ref_report: Optional[CarbonReport] = None,
+    ) -> int:
+        """Rebuild the plan's headcount grid from the reference-year members.
+
+        Not a one-to-one copy like the other prefilled modules: the Calculator
+        holds one row per person, the planner grid one row per SIUS category,
+        so the members' FTE are summed by category (students carry no category
+        and stay out of the grid). Each row starts at the reference year's full
+        FTE, for the user to lower to the project's share; a category nobody
+        staffed gets no row, leaving its input blank. Destructive and
+        idempotent — the grid is emptied first. Returns the rows created.
+        """
+        if report.id is None:
+            raise ValueError("report must be persisted before use")
+        if report.reference_year is None:
+            raise ValueError("Set a reference year before prefilling")
+        module_service = self.report_service.module_service
+        plan_module = await module_service.get_module(
+            report.id, ModuleTypeEnum.headcount
+        )
+        if plan_module is None or plan_module.id is None:
+            raise ValueError("Headcount module not found on the plan year")
+        if ref_report is None:
+            ref_report = await self.repo.get_calculator_report(
+                report.unit_id, report.reference_year
+            )
+        if ref_report is None or ref_report.id is None:
+            raise ValueError(
+                f"No Calculator report for reference year {report.reference_year}"
+            )
+        ref_module = await module_service.get_module(
+            ref_report.id, ModuleTypeEnum.headcount
+        )
+        if ref_module is None or ref_module.id is None:
+            raise ValueError("Headcount module not found on the reference year")
+
+        entry_repo = DataEntryRepository(self.session)
+        await entry_repo.bulk_delete_by_modules([plan_module.id])
+
+        fte_by_code: dict[str, float] = {}
+        for src in await entry_repo.list_by_module(ref_module.id):
+            if src.data_entry_type_id != DataEntryTypeEnum.member:
+                continue
+            code = src.data.get("sius_code")
+            if not code:
+                continue
+            try:
+                fte = float(src.data.get("fte") or 0)
+            except TypeError, ValueError:
+                logger.warning(
+                    "Skipping headcount entry %r with non-numeric fte=%r",
+                    src.id,
+                    src.data.get("fte"),
+                )
+                continue
+            fte_by_code[code] = fte_by_code.get(code, 0.0) + fte
+
+        rows = [
+            DataEntry(
+                data_entry_type_id=DataEntryTypeEnum.planner_headcount,
+                carbon_report_module_id=plan_module.id,
+                unit_id=report.unit_id,
+                year=report.year,
+                source=DataEntrySourceEnum.PLANNER_SNAPSHOT.value,
+                data={"sius_code": code, "fte": fte},
+            )
+            for code, fte in sorted(fte_by_code.items())
+            if fte > 0
+        ]
+        for row in rows:
+            self.session.add(row)
+
+        await self._persist_prefill_entries(
+            rows, plan_module.id, year=report.reference_year
+        )
+        return len(rows)
+
+    async def _persist_prefill_entries(
+        self, entries: list[DataEntry], module_id: int, *, year: int
+    ) -> None:
+        """Flush new prefill rows, compute their emissions, refresh the stats.
+
+        Batched (one flush for the whole set, one shared
+        ``FactorResolver``/factor-query cache, one grouped ``prefetch_slice``
+        per data_entry_type, one bulk emission insert) so an N-row module costs
+        a small constant number of round trips instead of ``O(N)``.
+        """
+        if not entries:
+            await self.report_service.module_service.recompute_stats_many([module_id])
+            return
         # One round trip for the whole batch (vs. one flush per row) —
-        # needed so every copy gets its id before emissions are computed.
+        # needed so every row gets its id before emissions are computed.
         await self.session.flush()
 
         emission_svc = DataEntryEmissionService(self.session)
         factor_resolver = FactorResolver(self.session)
         factor_query_cache: dict = {}
-        year = report.reference_year
 
         # Group by data_entry_type_id: a module can mix subtypes (e.g.
         # headcount's student/member rows), and prefetch_slice/handler
         # selection are per-type, same as the recalc workflow.
         by_type: dict[int, list[DataEntry]] = {}
-        for copy in copies:
-            by_type.setdefault(copy.data_entry_type_id, []).append(copy)
+        for entry in entries:
+            by_type.setdefault(entry.data_entry_type_id, []).append(entry)
 
         prepared_emissions = []
         for data_entry_type_id, group in by_type.items():
@@ -404,22 +494,21 @@ class SimulatorPlanService:
                 DataEntryTypeEnum(data_entry_type_id)
             )
             slice_cache = await handler.prefetch_slice(group, self.session, year=year)
-            for copy in group:
+            for entry in group:
                 prepared_emissions.extend(
                     await emission_svc.prepare_create(
-                        DataEntryResponse.model_validate(copy),
+                        DataEntryResponse.model_validate(entry),
                         year=year,
                         factor_resolver=factor_resolver,
                         factor_query_cache=factor_query_cache,
                         slice_cache=slice_cache,
                     )
                 )
-        # Single bulk insert: the copies are brand new, so unlike
+        # Single bulk insert: the rows are brand new, so unlike
         # upsert_by_data_entry there is nothing stale to delete first.
         await emission_svc.bulk_create(prepared_emissions)
 
-        await self.report_service.module_service.recompute_stats_many([plan_module.id])
-        return len(copies)
+        await self.report_service.module_service.recompute_stats_many([module_id])
 
     async def _recalculate_report_emissions(self, report: CarbonReport) -> None:
         """Recompute emissions of the report's entries + refresh stats.

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -469,7 +469,7 @@ class SimulatorPlanService:
                 continue
             try:
                 fte = float(src.data.get("fte") or 0)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 logger.warning(
                     "Skipping headcount entry %r with non-numeric fte=%r",
                     src.id,

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -469,7 +469,7 @@ class SimulatorPlanService:
                 continue
             try:
                 fte = float(src.data.get("fte") or 0)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 logger.warning(
                     "Skipping headcount entry %r with non-numeric fte=%r",
                     src.id,

--- a/backend/app/utils/factor_year.py
+++ b/backend/app/utils/factor_year.py
@@ -1,0 +1,38 @@
+"""Factor-year resolution shared by emission computation paths."""
+
+from typing import Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReport, CarbonReportType
+from app.repositories.carbon_project_repo import CarbonProjectRepository
+
+
+async def resolve_factor_year(
+    session: AsyncSession, report: CarbonReport
+) -> Optional[int]:
+    """Return the year whose factors apply to ``report``'s entries.
+
+    The reference year wins: Simulator Plan reports source all factors from
+    their baseline year (plan years can be in the future, where no factors
+    exist). A plan year without a reference year falls back to the year of
+    the unit's most recent Calculator report, so an "en amont" project (no
+    baseline chosen) still computes with real factors. Calculator and
+    Explore reports, and plans of units without any Calculator report, use
+    their own year.
+    """
+    if report.reference_year is not None:
+        return report.reference_year
+    if report.carbon_project_id is not None:
+        project = await session.get(CarbonProject, report.carbon_project_id)
+        if (
+            project is not None
+            and project.carbon_report_type == CarbonReportType.SIMULATOR_PLAN
+        ):
+            latest = await CarbonProjectRepository(session).get_latest_calculator_year(
+                report.unit_id
+            )
+            if latest is not None:
+                return latest
+    return report.year

--- a/backend/tests/unit/services/test_data_entry_emission_service.py
+++ b/backend/tests/unit/services/test_data_entry_emission_service.py
@@ -1919,6 +1919,7 @@ class TestFactorYearResolution:
         report = MagicMock()
         report.year = year
         report.reference_year = reference_year
+        report.carbon_project_id = None
         return report
 
     @pytest.mark.asyncio

--- a/backend/tests/unit/services/test_simulator_plan_service.py
+++ b/backend/tests/unit/services/test_simulator_plan_service.py
@@ -254,6 +254,47 @@ async def test_setting_year_range_creates_reports_with_modules(async_session, us
 
 
 @pytest.mark.asyncio
+async def test_year_range_defaults_reference_year_on_new_reports(async_session, user):
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="proj")
+
+    await service.update_plan(
+        created.id,
+        SimulatorPlanUpdate(
+            start_year=2027, end_year=2028, default_reference_year=2026
+        ),
+    )
+    years = await service.list_plan_years(created.id)
+    assert years is not None
+    assert [y.reference_year for y in years] == [2026, 2026]
+
+    # Growing the range only defaults the new report; 2027-2028 keep theirs.
+    await service.update_plan(
+        created.id, SimulatorPlanUpdate(end_year=2029, default_reference_year=2025)
+    )
+    years = await service.list_plan_years(created.id)
+    assert years is not None
+    assert [(y.year, y.reference_year) for y in years] == [
+        (2027, 2026),
+        (2028, 2026),
+        (2029, 2025),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_year_range_without_default_leaves_reference_unset(async_session, user):
+    service = SimulatorPlanService(async_session)
+    created = await service.create_plan(unit_id=1, user=user, name="proj")
+
+    await service.update_plan(
+        created.id, SimulatorPlanUpdate(start_year=2027, end_year=2027)
+    )
+    years = await service.list_plan_years(created.id)
+    assert years is not None
+    assert [y.reference_year for y in years] == [None]
+
+
+@pytest.mark.asyncio
 async def test_shrinking_year_range_deletes_out_of_range_reports(async_session, user):
     service = SimulatorPlanService(async_session)
     created = await service.create_plan(unit_id=1, user=user, name="proj")
@@ -367,6 +408,25 @@ async def test_set_reference_year_auto_prefills_prefilled_modules(async_session,
         report.id, int(ModuleTypeEnum.purchase)
     )
     assert await entry_repo.list_by_module(plan_purchase.id) == []
+
+
+@pytest.mark.asyncio
+async def test_remove_reference_year_wipes_prefilled_modules(async_session, user):
+    """Removing the baseline empties the prefilled modules, same as a change."""
+    service = SimulatorPlanService(async_session)
+    await _calculator_report_with_process_entries(service, async_session)
+    plan = await service.create_plan(unit_id=1, user=user, name="proj")
+    report = await _plan_year_report(service, plan.id)
+
+    plan_module = await service.report_service.module_service.get_module(
+        report.id, int(ModuleTypeEnum.process_emissions)
+    )
+    entry_repo = DataEntryRepository(async_session)
+    assert len(await entry_repo.list_by_module(plan_module.id)) == 2
+
+    result = await service.set_reference_year(plan.id, 2027, None)
+    assert result is not None and result.reference_year is None
+    assert await entry_repo.list_by_module(plan_module.id) == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/utils/test_factor_year.py
+++ b/backend/tests/unit/utils/test_factor_year.py
@@ -1,0 +1,80 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
+
+from app.models.carbon_project import CarbonProject
+from app.models.carbon_report import CarbonReport, CarbonReportType
+from app.utils.factor_year import resolve_factor_year
+
+DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+UNIT_ID = 1
+
+
+@pytest_asyncio.fixture
+async def async_session():
+    engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async_session = sessionmaker(
+        engine, class_=SQLModelAsyncSession, expire_on_commit=False
+    )
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _add_project(session, report_type: CarbonReportType) -> CarbonProject:
+    project = CarbonProject(unit_id=UNIT_ID, carbon_report_type=report_type)
+    session.add(project)
+    await session.flush()
+    return project
+
+
+async def _add_report(session, project: CarbonProject, year: int, **kw) -> CarbonReport:
+    report = CarbonReport(
+        unit_id=UNIT_ID, year=year, carbon_project_id=project.id, **kw
+    )
+    session.add(report)
+    await session.flush()
+    return report
+
+
+@pytest.mark.asyncio
+async def test_reference_year_wins(async_session):
+    plan = await _add_project(async_session, CarbonReportType.SIMULATOR_PLAN)
+    report = await _add_report(async_session, plan, 2030, reference_year=2024)
+
+    assert await resolve_factor_year(async_session, report) == 2024
+
+
+@pytest.mark.asyncio
+async def test_plan_without_reference_year_uses_latest_calculator_year(async_session):
+    calculator = await _add_project(async_session, CarbonReportType.CALCULATOR)
+    await _add_report(async_session, calculator, 2023)
+    await _add_report(async_session, calculator, 2025)
+    plan = await _add_project(async_session, CarbonReportType.SIMULATOR_PLAN)
+    report = await _add_report(async_session, plan, 2030)
+
+    assert await resolve_factor_year(async_session, report) == 2025
+
+
+@pytest.mark.asyncio
+async def test_plan_without_any_calculator_report_uses_own_year(async_session):
+    plan = await _add_project(async_session, CarbonReportType.SIMULATOR_PLAN)
+    report = await _add_report(async_session, plan, 2030)
+
+    assert await resolve_factor_year(async_session, report) == 2030
+
+
+@pytest.mark.asyncio
+async def test_calculator_report_uses_own_year(async_session):
+    calculator = await _add_project(async_session, CarbonReportType.CALCULATOR)
+    await _add_report(async_session, calculator, 2025)
+    report = await _add_report(async_session, calculator, 2023)
+
+    assert await resolve_factor_year(async_session, report) == 2023

--- a/docs/src/implementation-plans/1922-planner-without-reference-year.md
+++ b/docs/src/implementation-plans/1922-planner-without-reference-year.md
@@ -1,0 +1,87 @@
+---
+status: delivered
+issue: 1922
+last_updated: 2026-08-04
+title: "Project Planner: default reference year + no locked modules"
+summary: "New plan-year sections default their reference year to the workspace year the planner was opened from (sent with the range PATCH, normal prefill runs); the reference year is removable; module drawers are never locked, so a year whose reference is unset is fully usable for manual input with factors falling back to the unit's latest Calculator report year. No schema change."
+---
+
+# Project Planner: default reference year + no locked modules
+
+Part of the planner feedback batch
+([#1556](1556-simulation-plan-backend.md),
+[#1557](1557-planner-frontend-followups.md)). Previously a plan year was
+locked until a reference year was set: every module drawer was disabled, and
+factor lookups fell back to the plan year itself (usually a future year with
+no factors, so entries computed no emissions).
+
+## Decision (with the lead, 2026-08-04)
+
+- **Default the reference year itself.** When the year range is set and new
+  plan-year reports are created, each gets `reference_year` = the workspace
+  year the planner page is under (the Assessment Year selector), and the
+  normal prefill runs from it — exactly as if the user had picked it in the
+  dialog. Changing it later keeps today's destructive rebuild.
+- **No migration.** Three designs were discarded: persisting a
+  `factor_year` column on `carbon_projects` (workspace year frozen at plan
+  creation), deriving the default from the latest opened year
+  configuration, and an `assessment_year` column scoping the plan list per
+  workspace year (implemented then rolled back at the lead's request).
+- **The reference year is removable.** The dialog offers a "No reference
+  year (manual data entry)" option; removal empties the prefilled modules
+  exactly like a change does (`SimulatorPlanReferenceYearUpdate.reference_year`
+  is nullable, `_prefill_reference_modules` wipes before the None
+  early-return), and any change now requires the acknowledgment checkbox,
+  since manual rows can exist before a first set.
+- **Modules are never locked.** All planner modules (not just the four the
+  spec names) accept manual input even when a year's reference is unset
+  (legacy plans, duplicated plans — `duplicate_plan` copies the range but
+  not the reference years). For those, factor lookups fall back to the year
+  of the unit's most recent Calculator report, derived by joining
+  `carbon_projects` (type Calculator) with `carbon_reports`; stored
+  emissions of such entries keep their old factors until an entry is edited
+  (same staleness rule as factor re-uploads).
+
+## Backend
+
+- `SimulatorPlanUpdate.default_reference_year` — sent by the frontend with
+  the range PATCH; `_sync_year_reports` applies it (create report with
+  `reference_year`, run `_prefill_reference_modules`, refresh the report
+  rollup) **only to reports the sync creates** — existing reports keep
+  their reference year.
+- `app/utils/factor_year.py` — `resolve_factor_year(session, report)`, the
+  single factor-year chain: `reference_year` → (Simulator Plan reports only)
+  unit's latest Calculator report year → `report.year`. Backed by
+  `CarbonProjectRepository.get_latest_calculator_year(unit_id)`.
+- Routed through the helper (was three hand-rolled copies of
+  "reference_year wins"):
+  - `DataEntryEmissionService._get_year_from_data_entry`
+  - the inline fallback in `DataEntryEmissionService.prepare_create`
+  - `_get_report_year_for_module` in `app/modules/professional_travel/handlers.py`
+- `SimulatorPlanRead.default_factor_year` (derived, read-only) exposes the
+  unset-reference fallback so the frontend's dropdowns use the same year
+  the backend computes with.
+
+## Frontend
+
+- `PlannerProjectInfo.vue` sends `default_reference_year:
+Number(route.params.year)` with the range PATCH; the store gives that
+  PATCH the same 5-minute timeout as `setReferenceYear` (it now prefills).
+- `PlannerYearSection.vue`: the `!hasReferenceYear` drawer gate is removed;
+  `factorYear` mirrors the backend chain (`reference_year ??
+plan.default_factor_year ?? yearData.year`) and feeds
+  `ModuleTableSection`'s `:factor-year` and the `factorMountKey` remount
+  keys; the "% of reference year" columns only render when a reference year
+  exists.
+- `planner_reference_year_hint` (en/fr) presents the reference year as
+  optional and names the fallback factor year. The print composable's
+  taxonomy year follows the same chain.
+
+## Tests
+
+- `backend/tests/unit/utils/test_factor_year.py` — the resolution chain
+  (reference year wins; plan without reference → latest Calculator year;
+  no Calculator report → own year; Calculator report → own year).
+- `test_simulator_plan_service.py` — range sync defaults the reference year
+  on newly created reports only; without `default_reference_year` the
+  reference stays unset; removal wipes the prefilled modules.

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -102,6 +102,7 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useQuasar } from 'quasar';
+import { useRoute } from 'vue-router';
 
 import {
   useSimulatorPlansStore,
@@ -115,6 +116,7 @@ const emit = defineEmits<{ updated: [plan: SimulatorPlan] }>();
 
 const { t } = useI18n();
 const $q = useQuasar();
+const route = useRoute();
 const plansStore = useSimulatorPlansStore();
 const yearConfigStore = useYearConfigStore();
 
@@ -201,6 +203,7 @@ async function generateYears() {
     const updated = await plansStore.updatePlan(props.plan.id, {
       start_year: start,
       end_year: end,
+      default_reference_year: Number(route.params.year),
     });
     emit('updated', updated);
     $q.notify({ type: 'positive', message: t('planner_years_generated') });

--- a/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
@@ -131,7 +131,7 @@ import { api } from 'src/api/http';
 import { useSimulatorPlansStore } from 'src/stores/simulatorPlans';
 import { formatTonnesCO2 } from 'src/utils/number';
 
-// The 7 backend categories (modules_planner/purchase/emissions.py
+// The 8 backend categories (modules_planner/purchase/emissions.py
 // PLANNER_PURCHASE_EMISSIONS), rendered as fixed rows in the design's order.
 const CATEGORIES = [
   'scientific_equipment',
@@ -141,6 +141,7 @@ const CATEGORIES = [
   'services',
   'vehicles',
   'other_purchases',
+  'purchases_centralized',
 ] as const;
 
 type Mode = 'global' | 'per_category';
@@ -248,7 +249,9 @@ function fillRow(row: PurchaseRow, item: SubmoduleItem | undefined) {
   row.amount = item?.amount_eur ?? null;
   row.saved = row.amount;
   row.entryId = item?.id ?? null;
-  row.kg = item?.kg_co2eq ?? null;
+  // A saved amount always reads a figure: a category the reference year has no
+  // factor for is 0, not blank.
+  row.kg = item ? (item.kg_co2eq ?? 0) : null;
   row.error = null;
 }
 
@@ -276,9 +279,9 @@ async function load() {
 /** Re-read the emissions of the saved kind without touching typed amounts. */
 async function refreshKg() {
   const items = await fetchItems(mode.value);
-  const byId = new Map(items.map((it) => [it.id, it.kg_co2eq ?? null]));
+  const byId = new Map(items.map((it) => [it.id, it.kg_co2eq ?? 0]));
   rowsFor(mode.value).forEach((row) => {
-    row.kg = row.entryId === null ? null : (byId.get(row.entryId) ?? null);
+    row.kg = row.entryId === null ? null : (byId.get(row.entryId) ?? 0);
   });
 }
 

--- a/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
+++ b/frontend/src/components/organisms/planner/PlannerReferenceYearDialog.vue
@@ -23,7 +23,7 @@
       <q-card-section>
         <q-select
           v-model="selected"
-          :options="options"
+          :options="allOptions"
           :label="$t('planner_reference_year_dialog_select_label')"
           outlined
           dense
@@ -31,26 +31,28 @@
           map-options
         />
         <div class="text-body2 text-grey-8 q-mt-md">
-          {{ $t('planner_reference_year_dialog_consequences', { year }) }}
+          {{
+            selected === NONE
+              ? $t('planner_reference_year_dialog_none_consequences', { year })
+              : $t('planner_reference_year_dialog_consequences', { year })
+          }}
         </div>
 
-        <template v-if="referenceYear !== null">
-          <q-banner dense rounded class="bg-red-1 text-negative q-mt-md">
-            <template #avatar>
-              <q-icon name="o_warning" color="negative" size="sm" />
-            </template>
-            <div class="text-body2">
-              {{ $t('planner_reference_year_dialog_wipe_warning', { year }) }}
-            </div>
-          </q-banner>
-          <q-checkbox
-            v-model="acknowledged"
-            dense
-            color="negative"
-            class="q-mt-md"
-            :label="$t('planner_reference_year_dialog_wipe_ack', { year })"
-          />
-        </template>
+        <q-banner dense rounded class="bg-red-1 text-negative q-mt-md">
+          <template #avatar>
+            <q-icon name="o_warning" color="negative" size="sm" />
+          </template>
+          <div class="text-body2">
+            {{ $t('planner_reference_year_dialog_wipe_warning', { year }) }}
+          </div>
+        </q-banner>
+        <q-checkbox
+          v-model="acknowledged"
+          dense
+          color="negative"
+          class="q-mt-md"
+          :label="$t('planner_reference_year_dialog_wipe_ack', { year })"
+        />
       </q-card-section>
 
       <q-card-actions class="q-px-md q-pb-md">
@@ -80,6 +82,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -91,26 +94,33 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   'update:modelValue': [open: boolean];
-  confirm: [referenceYear: number];
+  confirm: [referenceYear: number | null];
 }>();
+
+const { t } = useI18n();
+
+// Sentinel for the "no reference year" choice: q-select's map-options cannot
+// display a null-valued option, so null maps to this in and out.
+const NONE = 0;
+
+const allOptions = computed(() => [
+  ...props.options,
+  { label: t('planner_reference_year_dialog_none_option'), value: NONE },
+]);
 
 // Seeded once per mount: the parent keys the dialog on the current reference
 // year, so a re-open starts from what is set rather than the last pick.
-const selected = ref<number | null>(props.referenceYear);
+const selected = ref<number>(props.referenceYear ?? NONE);
 
-// Changing a baseline that is already set deletes the prefilled modules' data,
-// so the user has to acknowledge it. The first-time set deletes nothing.
+// Any change (set, switch or removal) deletes the prefilled modules' data,
+// so the user has to acknowledge it.
 const acknowledged = ref(false);
 
 const confirmDisabled = computed(
-  () =>
-    selected.value === null ||
-    selected.value === props.referenceYear ||
-    (props.referenceYear !== null && !acknowledged.value),
+  () => selected.value === (props.referenceYear ?? NONE) || !acknowledged.value,
 );
 
 function onConfirm() {
-  if (selected.value === null) return;
-  emit('confirm', selected.value);
+  emit('confirm', selected.value === NONE ? null : selected.value);
 }
 </script>

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -136,7 +136,7 @@
                    (design). Other modules reuse the Calculator tables. -->
             <planner-headcount-rows
               v-if="entry.config.module === MODULES.Headcount"
-              :key="factorScopedKey(entry.config.module)"
+              :key="`headcount-${yearData.reference_year}`"
               :carbon-report-id="yearData.id"
               :disable="entry.module?.is_active === false"
             />

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -57,7 +57,7 @@
           {{
             yearData.reference_year
               ? $t('planner_reference_year_rebuild_hint')
-              : $t('planner_reference_year_hint')
+              : $t('planner_reference_year_hint', { year: factorYear })
           }}
         </div>
       </q-card-section>
@@ -83,7 +83,6 @@
         <q-separator v-if="entryIdx > 0" />
         <q-expansion-item
           :model-value="isExpanded(entry.config.module)"
-          :disable="!hasReferenceYear"
           header-class="q-py-md"
           @update:model-value="
             (open: boolean) => onToggle(entry.config.module, open)
@@ -156,9 +155,11 @@
               :error="moduleStore.state.error"
               :unit-id="unitId"
               :year="yearData.year"
-              :factor-year="yearData.reference_year"
+              :factor-year="factorYear"
               :carbon-report-id="yearData.id"
-              :show-reference-columns="entry.config.behavior === 'prefilled'"
+              :show-reference-columns="
+                entry.config.behavior === 'prefilled' && hasReferenceYear
+              "
               :disable="entry.module?.is_active === false"
             />
           </div>
@@ -202,6 +203,8 @@ const props = defineProps<{
   planId: number;
   yearData: SimulatorPlanYear;
   unitId: number;
+  /** Latest Calculator report year of the unit (factor fallback). */
+  defaultFactorYear: number | null;
   referenceYearOptions: { label: string; value: number }[];
   /** `${year}-${module}` of every expanded module across the page. */
   expandedKeys: string[];
@@ -220,9 +223,19 @@ const settingReferenceYear = ref(false);
 const referenceYearDialogOpen = ref(false);
 const togglingModuleId = ref<number | null>(null);
 
-// Every module resolves its factors from the reference year; without one there
-// is nothing to enter data against, so the drawers stay shut.
+// The reference year only gates the prefill columns; data entry itself is
+// always open. Its rows and dropdowns follow `factorYear` below.
 const hasReferenceYear = computed(() => props.yearData.reference_year !== null);
+
+// Factor year, mirroring the backend chain (`resolve_factor_year`): the
+// reference year wins, then the unit's latest Calculator report year, then
+// the plan year itself (units without any Calculator report).
+const factorYear = computed(
+  () =>
+    props.yearData.reference_year ??
+    props.defaultFactorYear ??
+    props.yearData.year,
+);
 
 const GRID_MODULES: Module[] = [MODULES.Headcount, MODULES.Purchase];
 
@@ -248,7 +261,7 @@ function isExpanded(module: Module): boolean {
 }
 
 function factorScopedKey(module: Module): string {
-  return factorMountKey(module, props.yearData.reference_year);
+  return factorMountKey(module, factorYear.value);
 }
 
 async function refreshExpandedModule(module: Module) {
@@ -265,7 +278,7 @@ function onToggle(module: Module, open: boolean) {
   if (open) void refreshExpandedModule(module);
 }
 
-async function onReferenceYearChange(referenceYear: number) {
+async function onReferenceYearChange(referenceYear: number | null) {
   settingReferenceYear.value = true;
   try {
     await plansStore.setReferenceYear(

--- a/frontend/src/composables/print/useProjectPlannerPrintData.ts
+++ b/frontend/src/composables/print/useProjectPlannerPrintData.ts
@@ -360,6 +360,7 @@ export function useProjectPlannerPrintData() {
       const years = plansStore.planYears;
       const taxonomyYear =
         years.find((year) => year.reference_year != null)?.reference_year ??
+        plan.value.default_factor_year ??
         years[0]?.year ??
         null;
 

--- a/frontend/src/constant/planner-module-config/index.ts
+++ b/frontend/src/constant/planner-module-config/index.ts
@@ -29,7 +29,7 @@ export const PLANNER_MODULE_CONFIG: Partial<
 > = {
   [MODULES.Headcount]: {
     module: MODULES.Headcount,
-    behavior: 'manual',
+    behavior: 'prefilled',
   },
   [MODULES.ProfessionalTravel]: {
     module: MODULES.ProfessionalTravel,

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -343,6 +343,10 @@ export default {
     en: 'Other purchases',
     fr: 'Autres achats',
   },
+  'planner_purchase_category.purchases_centralized': {
+    en: 'Additional purchases',
+    fr: 'Achats supplémentaires',
+  },
   'planner_traveler_category.internal': {
     en: 'Internal',
     fr: 'Interne',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -208,8 +208,8 @@ export default {
     fr: 'Année de référence',
   },
   planner_reference_year_hint: {
-    en: 'Select a reference year: all factors and prefilled data of this planned year come from it. The modules below stay locked until you do.',
-    fr: "Sélectionnez une année de référence : tous les facteurs et données préremplies de cette année planifiée en proviennent. Les modules ci-dessous restent verrouillés tant qu'elle n'est pas définie.",
+    en: 'Optional: select a reference year to prefill the modules below and use its factors. Without one, you enter data manually and factors come from year {year}.',
+    fr: "Facultatif : sélectionnez une année de référence pour préremplir les modules ci-dessous et utiliser ses facteurs. Sans année de référence, vous saisissez les données manuellement et les facteurs proviennent de l'année {year}.",
   },
   planner_reference_year_error: {
     en: 'Could not set the reference year',
@@ -234,6 +234,14 @@ export default {
   planner_reference_year_dialog_select_label: {
     en: 'Reference year (source of the data)',
     fr: 'Année de référence (source des données)',
+  },
+  planner_reference_year_dialog_none_option: {
+    en: 'No reference year (manual data entry)',
+    fr: 'Aucune année de référence (saisie manuelle des données)',
+  },
+  planner_reference_year_dialog_none_consequences: {
+    en: 'Without a reference year, the modules of planned year {year} start empty and you enter their data manually.',
+    fr: "Sans année de référence, les modules de l'année planifiée {year} démarrent vides et vous saisissez leurs données manuellement.",
   },
   planner_reference_year_dialog_consequences: {
     en: 'The prefilled modules of planned year {year} are rebuilt from the reference year you pick, and every module uses its emission factors.',

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -59,6 +59,7 @@
           :plan-id="plan.id"
           :year-data="yearData"
           :unit-id="unitId"
+          :default-factor-year="plan.default_factor_year"
           :reference-year-options="referenceYearOptions"
           :expanded-keys="expandedKeys"
           @toggle-module="onToggleModule"

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -15,6 +15,9 @@ export interface SimulatorPlan {
   start_year: number | null;
   end_year: number | null;
   is_viewable_by_unit_members: boolean;
+  /** Latest Calculator report year of the unit; factor fallback when a plan
+   * year has no reference year (backend-derived, read-only). */
+  default_factor_year: number | null;
   created_by: number | null;
   created_at: string | null;
   creator_name: string | null;
@@ -45,6 +48,9 @@ export interface SimulatorPlanUpdatePayload {
   start_year?: number;
   end_year?: number;
   is_viewable_by_unit_members?: boolean;
+  /** Reference year defaulted onto (and prefilled into) year reports newly
+   * created by this range change; send the current workspace year. */
+  default_reference_year?: number;
 }
 
 export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
@@ -120,12 +126,19 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     planId: number,
     payload: SimulatorPlanUpdatePayload,
   ): Promise<SimulatorPlan> {
+    const rangeChange =
+      payload.start_year !== undefined || payload.end_year !== undefined;
     const plan = await api
-      .patch(`project-plans/${planId}`, { json: payload })
+      .patch(`project-plans/${planId}`, {
+        json: payload,
+        // A range change prefills every new year report from the default
+        // reference year, same workload as setReferenceYear below.
+        ...(rangeChange ? { timeout: 300000 } : {}),
+      })
       .json<SimulatorPlan>();
 
     markPlansStale();
-    if (payload.start_year !== undefined || payload.end_year !== undefined) {
+    if (rangeChange) {
       await fetchPlanYears(planId);
     }
     return plan;
@@ -173,11 +186,11 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     aggregateStats.value = null;
   }
 
-  /** Set the reference (baseline) year of one plan-year report. */
+  /** Set or remove (null) the reference (baseline) year of one plan-year report. */
   async function setReferenceYear(
     planId: number,
     year: number,
-    referenceYear: number,
+    referenceYear: number | null,
   ): Promise<SimulatorPlanYear> {
     const updated = await api
       .patch(`project-plans/${planId}/years/${year}`, {

--- a/frontend/src/utils/factor-year.ts
+++ b/frontend/src/utils/factor-year.ts
@@ -9,9 +9,13 @@
  *
  * - ``undefined`` — Calculator: the report has no reference year, so its own
  *   year is the factor year.
- * - ``null`` — a Simulator Plan year with no reference year picked yet. There
- *   is no year to resolve against; callers must not fall back to the plan year,
- *   since the backend would not use it either.
+ * - a number — a Simulator Plan year: the reference year when picked, else the
+ *   unit's latest Calculator report year (``default_factor_year`` on the plan
+ *   DTO), mirroring the backend chain in
+ *   ``app/utils/factor_year.resolve_factor_year``.
+ * - ``null`` — no resolvable factor year; callers must not fall back to the
+ *   plan year, since the backend would not use it either. The planner no
+ *   longer produces this case.
  */
 export function resolveFactorYear(
   factorYear: number | null | undefined,


### PR DESCRIPTION
## What does this change?

Adds a default reference year for newly created Project Planner year reports, makes the reference year on a plan-year removable (switching to manual entry), removes the "locked modules until reference year is set" restriction, and adds a new "Additional purchases" (centralized) purchase category alongside a Headcount prefill from the reference year's Calculator report.

## Why is this needed?

Plan years were previously unusable until a reference year was manually picked, since every module drawer stayed locked and factors couldn't resolve. This defaults the reference year from the workspace year the planner was opened from, allows removing it for manual-only years, and adds a robust factor-year fallback (`resolve_factor_year`) so entries always compute against real factors — plus fills gaps in the purchase categories and headcount prefill logic.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1922

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.