### PR TITLE
feat: add FTE hint for Headcount module (#1999)

### DIFF
--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -133,12 +133,15 @@
             <!-- Headcount is a fixed SIUS-category grid and Purchases a
                    global-budget XOR per-category grid, not add-row tables
                    (design). Other modules reuse the Calculator tables. -->
-            <planner-headcount-rows
-              v-if="entry.config.module === MODULES.Headcount"
-              :key="`headcount-${yearData.reference_year}`"
-              :carbon-report-id="yearData.id"
-              :disable="entry.module?.is_active === false"
-            />
+            <template v-if="entry.config.module === MODULES.Headcount">
+              <p class="text-body2 text-grey-7 q-px-md q-pt-md q-mb-md">
+                {{ $t('simulation_headcount_fte_hint') }}
+              </p>
+              <planner-headcount-rows
+                :carbon-report-id="yearData.id"
+                :disable="entry.module?.is_active === false"
+              />
+            </template>
             <planner-purchase-rows
               v-else-if="entry.config.module === MODULES.Purchase"
               :key="factorScopedKey(entry.config.module)"

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -3,6 +3,10 @@ export default {
     en: 'Could not save the headcount value',
     fr: "Impossible d'enregistrer la valeur d'effectif",
   },
+  simulation_headcount_fte_hint: {
+    en: 'Total number of FTEs is used to generate the indicators for the additional categories (Food, Commuting, and Waste).',
+    fr: "Le nombre total d'EPT est utilisé pour générer les indicateurs des catégories additionnelles (Alimentation, Pendularité et Déchets).",
+  },
   documentation_editing_rows_simulation_topic: {
     en: 'Simulation',
     fr: 'Simulation',

--- a/frontend/src/pages/app/SimulationExplorePage.vue
+++ b/frontend/src/pages/app/SimulationExplorePage.vue
@@ -39,6 +39,12 @@
             <q-separator />
 
             <div class="q-px-lg q-py-md">
+              <p
+                v-if="m.type === MODULES.Headcount"
+                class="text-body2 text-grey-7 q-mb-md"
+              >
+                {{ $t('simulation_headcount_fte_hint') }}
+              </p>
               <div
                 v-for="(sub, subIdx) in m.submodules"
                 :key="`${m.type}-${sub.id}`"
@@ -129,7 +135,11 @@ import { useI18n } from 'vue-i18n';
 
 import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import SubModuleSection from 'src/components/organisms/module/SubModuleSection.vue';
-import { MODULES_THRESHOLD_TYPES, type Threshold } from 'src/constant/modules';
+import {
+  MODULES,
+  MODULES_THRESHOLD_TYPES,
+  type Threshold,
+} from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
 import { useWorkspaceStore } from 'src/stores/workspace';
 import { useYearConfigStore } from 'src/stores/yearConfig';


### PR DESCRIPTION
## What does this change?

Adds an explanatory hint text under the Headcount module in both the Project Planner and Simulation Explore pages, explaining that total FTE count drives the indicators for additional categories (Food, Commuting, Waste).

## Why is this needed?

Users had no context for what the Headcount/FTE numbers are used for. This hint clarifies the purpose of the field directly in the UI.

## Type of change
Please check the type that applies:
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1999

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.