### PR TITLE
fix: guard travel fetch and module visibility (#1596)

### DIFF
--- a/frontend/src/components/organisms/module/ModuleCharts.vue
+++ b/frontend/src/components/organisms/module/ModuleCharts.vue
@@ -381,7 +381,16 @@ async function loadTravelerNames(unitId: number, year: number | string) {
 function fetchTripsMapIfNeeded() {
   const unitId = workspaceStore.selectedUnit?.id;
   const year = workspaceStore.selectedYear;
-  if (unitId && year && props.type === MODULES.ProfessionalTravel) {
+  if (props.type !== MODULES.ProfessionalTravel) return;
+  if (
+    !authStore.hasUserModulePermission(
+      MODULES.ProfessionalTravel,
+      PermissionAction.VIEW,
+    )
+  ) {
+    return;
+  }
+  if (unitId && year) {
     void moduleStore.getProfessionalTravelTripsMap(unitId, String(year));
     void loadTravelerNames(unitId, year);
   }

--- a/frontend/src/pages/app/ResultsPage.vue
+++ b/frontend/src/pages/app/ResultsPage.vue
@@ -33,7 +33,6 @@ import { IT_FOCUS_SOURCE_MODULES } from 'src/constant/itFocus';
 import { MODULE_STATES, getModuleTypeId } from 'src/constant/moduleStates';
 import { useI18n } from 'vue-i18n';
 import { useYearConfigStore } from 'src/stores/yearConfig';
-import { isModuleFullyAvailable } from 'src/composables/useModuleAvailability';
 import ReductionObjectiveChart from 'src/components/charts/results/ReductionObjectiveChart.vue';
 import { useRoute, useRouter } from 'vue-router';
 import { nOrDash } from 'src/utils/number';
@@ -338,13 +337,15 @@ const getModuleResult = (module: string): ModuleResult | undefined => {
 };
 
 /**
- * Same enabled/greyed decision Home's chart icon axis and the backoffice
- * Reporting page use (isModuleFullyAvailable) — deactivated, no EDIT
- * permission, or no computed stats all render the row greyed out rather
- * than hiding or fully enabling it.
+ * Unlike Home's chart icon axis (isModuleFullyAvailable), these rows ignore
+ * the user's module permissions: the page only shows validated, aggregated
+ * results, so every member of the unit may open every category. A row is
+ * greyed out only when the module is deactivated in the back-office or has
+ * no computed stats yet.
  */
 const isModuleAvailable = (module: string): boolean =>
-  isModuleFullyAvailable(module as Module, Boolean(getModuleResult(module)));
+  Boolean(getModuleResult(module)) &&
+  yearConfigStore.isModuleVisible(module as Module);
 const { t, te } = useI18n();
 
 const combinedUnitNames = computed(() =>
@@ -1134,9 +1135,8 @@ $combine-chip-padding-x: 1.125rem;
   }
 }
 
-// Deactivated / no-EDIT-permission / no-stats-yet — same muted treatment
-// Home's module-icon-axis chart uses for the same three reasons (see
-// isModuleFullyAvailable).
+// Deactivated / no-stats-yet — same muted treatment Home's
+// module-icon-axis chart uses (see isModuleAvailable).
 .results-module-header--unavailable {
   opacity: 0.4;
   filter: grayscale(1);


### PR DESCRIPTION
## What does this change?

Changes the Results page's module-availability logic so it no longer depends on the viewing user's EDIT permission — rows are now shown/greyed based only on whether the module is deactivated or has no computed stats yet, since Results only displays validated aggregated data that any unit member should be able to view.

## Why is this needed?

Standard users without EDIT permission on Professional Travel were triggering an unguarded fetch, and the Results page was incorrectly hiding/greying module rows based on the viewer's edit permissions rather than the module's actual availability, preventing standard users from seeing results they should have access to.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1596

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.