### PR TITLE
feat: add report-aware module permission gate (#1988)

### DIFF
--- a/backend/app/api/v1/carbon_report_module.py
+++ b/backend/app/api/v1/carbon_report_module.py
@@ -24,6 +24,7 @@ from app.api.deps import get_current_user, get_db
 from app.core.logging import _sanitize_for_log as sanitize
 from app.core.logging import get_logger
 from app.core.policy import (
+    check_module_permission_for_report,
     check_module_permission_for_unit,
     get_module_permission_decision,
     require_plan_scope_for_report,
@@ -268,12 +269,12 @@ async def get_module(
     report, module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user
     )
-    unit = await check_module_permission_for_unit(
+    unit = await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
     carbon_report_module_id = module.id
     travel_institutional_id_filter: Optional[str] = None
@@ -357,12 +358,12 @@ async def get_stats_by_class(
     report, module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     stats = await DataEntryEmissionService(db).get_travel_stats_by_class(
@@ -421,12 +422,12 @@ async def get_top_class_breakdown(
         carbon_report_id, module_id, db, current_user
     )
     year = report.year
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     module_key = module_id.replace("-", "_")
@@ -617,12 +618,12 @@ async def get_professional_travel_trips_map(
     report, module = await resolve_report_module(
         carbon_report_id, "professional-travel", db, current_user
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id="professional-travel",
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     # Use the train data_entry_type to drive the scoping helper — the helper
@@ -682,12 +683,12 @@ async def get_submodule(
     report, module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     logger.info(
@@ -778,12 +779,12 @@ async def check_unique(
     report, module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     submodule_key = submodule_id.replace("-", "_")
@@ -836,12 +837,12 @@ async def create(
     report, carbon_report_module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user, action="edit"
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="edit",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     logger.info(
@@ -891,12 +892,12 @@ async def get(
     report, _module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="view",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     logger.info(
@@ -937,12 +938,12 @@ async def update(
     report, carbon_report_module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user, action="edit"
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="edit",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     logger.info(
@@ -993,12 +994,12 @@ async def delete(
     report, carbon_report_module = await resolve_report_module(
         carbon_report_id, module_id, db, current_user, action="edit"
     )
-    await check_module_permission_for_unit(
+    await check_module_permission_for_report(
         current_user=current_user,
         module_id=module_id,
         action="edit",
         db=db,
-        unit_id=report.unit_id,
+        report=report,
     )
 
     if current_user.id is None:

--- a/backend/app/api/v1/taxonomies.py
+++ b/backend/app/api/v1/taxonomies.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_current_user, get_db
-from app.core.policy import check_module_permission
 from app.models.data_entry import DataEntryTypeEnum
 from app.models.module_type import (
     ModuleTypeEnum,
@@ -34,13 +33,9 @@ async def get_taxonomy_for_module_type(
     current_user: User = Depends(get_current_user),
 ) -> TaxonomyNode:
     """Get taxonomy for a given module type."""
-    # Taxonomies are module-level reference data with no unit context.
-    # ``any_scope=True`` accepts any scoped variant (``modules.X/*``), so a user
-    # authorised on ANY unit for module X can read X's taxonomy. See
-    # ``app.utils.permissions.has_permission`` for the exception's rationale.
-    await check_module_permission(
-        current_user, module_type.name, "view", any_scope=True
-    )
+    # Taxonomies are year-parameterized classification metadata with no unit
+    # data; authentication is the only gate — the simulators render every
+    # module's form for any unit member.
     handler_service = ModuleHandlerService(db)
     nodes = []
     for data_entry_type in get_data_entry_types_for_module_type(module_type):
@@ -72,13 +67,9 @@ async def get_taxonomy_for_data_entry_type(
     module_type = get_module_type_for_data_entry_type(data_entry_type)
     if not module_type:
         raise HTTPException(status_code=404, detail="Module type not found")
-    # Taxonomies are module-level reference data with no unit context.
-    # ``any_scope=True`` accepts any scoped variant (``modules.X/*``), so a user
-    # authorised on ANY unit for module X can read X's taxonomy. See
-    # ``app.utils.permissions.has_permission`` for the exception's rationale.
-    await check_module_permission(
-        current_user, module_type.name, "view", any_scope=True
-    )
+    # Taxonomies are year-parameterized classification metadata with no unit
+    # data; authentication is the only gate — the simulators render every
+    # module's form for any unit member.
     handler = BaseModuleHandler.get_by_type(data_entry_type)
     handler_service = ModuleHandlerService(db)
     return await handler_service.get_taxonomy(handler, data_entry_type, year)
@@ -103,13 +94,6 @@ async def get_taxonomy_for_module(
     if module_name not in ModuleTypeEnum.__members__:
         raise HTTPException(status_code=404, detail="Module not found")
     module_type = ModuleTypeEnum[module_name]
-    # Taxonomies are module-level reference data with no unit context.
-    # ``any_scope=True`` accepts any scoped variant (``modules.X/*``), so a user
-    # authorised on ANY unit for module X can read X's taxonomy. See
-    # ``app.utils.permissions.has_permission`` for the exception's rationale.
-    await check_module_permission(
-        current_user, module_type.name, "view", any_scope=True
-    )
     return await get_taxonomy_for_module_type(module_type, year, db, current_user)
 
 

--- a/backend/app/core/policy.py
+++ b/backend/app/core/policy.py
@@ -746,3 +746,45 @@ async def check_module_permission_for_unit(
         institutional_id=unit.institutional_id,
     )
     return unit
+
+
+async def check_module_permission_for_report(
+    *,
+    current_user: User,
+    module_id: str,
+    action: str,
+    db: AsyncSession,
+    report: Any,
+) -> Unit:
+    """Module gate for report-addressed routes.
+
+    Calculator reports keep the full per-module permission gate
+    (``check_module_permission_for_unit``). Simulator reports (Explore and
+    Plan) drop to unit membership: any unit member may read and write the
+    sandbox/plan modules. Plan creator/share rules are enforced separately by
+    ``require_plan_scope_for_report``, and the professional-travel own-rows
+    filter stays keyed on the caller's role at the data layer.
+
+    Returns the loaded ``Unit`` so callers can reuse it (e.g. for travel
+    filters or principal/global checks) without re-fetching.
+    """
+    if report.carbon_project_id is not None:
+        project = await db.get(CarbonProject, report.carbon_project_id)
+        if project is not None and project.carbon_report_type in (
+            CarbonReportType.SIMULATOR_EXPLORE,
+        ):
+            unit = await db.get(Unit, report.unit_id)
+            if unit is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Unit {report.unit_id} not found",
+                )
+            require_unit_access(current_user, unit)
+            return unit
+    return await check_module_permission_for_unit(
+        current_user=current_user,
+        module_id=module_id,
+        action=action,
+        db=db,
+        unit_id=report.unit_id,
+    )

--- a/backend/tests/integration/v1/test_permission_scope_e2e.py
+++ b/backend/tests/integration/v1/test_permission_scope_e2e.py
@@ -105,21 +105,38 @@ def _superadmin() -> Role:
     return Role(role=RoleName.CO2_SUPERADMIN, on=GlobalScope())
 
 
-def _wire(monkeypatch, user, unit_iid: str = UNIT_IID) -> None:
+def _wire(
+    monkeypatch,
+    user,
+    unit_iid: str = UNIT_IID,
+    carbon_report_type: CarbonReportType | None = None,
+) -> None:
     """Wire dependency overrides + service stubs.
 
     Crucially, ``get_module_permission_decision`` is NOT patched — the real
     policy chain runs. Only the data layer (Unit fetch, DataEntryService,
     carbon-report id lookup) is stubbed so the test stays in-process.
+
+    ``carbon_report_type`` selects the resolved report's project type:
+    ``None`` pins a Calculator report with no project at all; an enum value
+    attaches a project of that type (the simulator gate branches on it).
     """
     app.dependency_overrides[deps_module.get_current_user] = lambda: user
 
     mock_unit = MagicMock()
     mock_unit.institutional_id = unit_iid
 
+    mock_project = MagicMock()
+    mock_project.carbon_report_type = carbon_report_type
+
+    async def mock_db_get(model, key):
+        if model is CarbonProject:
+            return mock_project
+        return mock_unit
+
     async def mock_get_db():
         db = MagicMock()
-        db.get = AsyncMock(return_value=mock_unit)
+        db.get = AsyncMock(side_effect=mock_db_get)
         yield db
 
     app.dependency_overrides[deps_module.get_db] = mock_get_db
@@ -137,12 +154,14 @@ def _wire(monkeypatch, user, unit_iid: str = UNIT_IID) -> None:
 
     mock_service.get_headcount_members = mock_get_members
     mock_service.get_member_by_institutional_id = mock_get_member_by_iid
+    mock_service.check_json_field_unique = AsyncMock(return_value=True)
     monkeypatch.setattr(
         "app.api.v1.carbon_report_module.DataEntryService", lambda db: mock_service
     )
     _resolved_report = MagicMock()
     _resolved_report.unit_id = 1
     _resolved_report.year = 2024
+    _resolved_report.carbon_project_id = None if carbon_report_type is None else 5
     _resolved_module = MagicMock()
     _resolved_module.id = 1
     monkeypatch.setattr(
@@ -227,6 +246,81 @@ class TestPermissionScopeEndToEnd:
         data = r.json()
         assert len(data) == 1
         assert data[0]["institutional_id"] == "11111"
+
+
+CHECK_UNIQUE_URL = (
+    "/api/v1/carbon-reports/1/modules/headcount/member/check-unique"
+    "?field=user_institutional_id&value=x"
+)
+
+
+class TestSimulatorReportGate:
+    """#1988: reports of a simulator project (Explore/Plan) drop the module
+    gate to unit membership; Calculator reports keep the strict per-module
+    gate. Exercised through the real policy chain on the check-unique route,
+    which a std user's form calls for modules they hold no permission on."""
+
+    def test_std_on_calculator_report_denied(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire(
+            monkeypatch,
+            user,
+            unit_iid=UNIT_IID,
+            carbon_report_type=CarbonReportType.CALCULATOR,
+        )
+        r = client.get(CHECK_UNIQUE_URL)
+        assert r.status_code == 403, r.text
+
+    def test_std_on_projectless_report_denied(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire(monkeypatch, user, unit_iid=UNIT_IID, carbon_report_type=None)
+        r = client.get(CHECK_UNIQUE_URL)
+        assert r.status_code == 403, r.text
+
+    def test_std_on_explore_report_passes(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire(
+            monkeypatch,
+            user,
+            unit_iid=UNIT_IID,
+            carbon_report_type=CarbonReportType.SIMULATOR_EXPLORE,
+        )
+        r = client.get(CHECK_UNIQUE_URL)
+        assert r.status_code == 200, r.text
+        assert r.json() == {"unique": True}
+
+    def test_std_on_plan_report_passes(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire(
+            monkeypatch,
+            user,
+            unit_iid=UNIT_IID,
+            carbon_report_type=CarbonReportType.SIMULATOR_PLAN,
+        )
+        r = client.get(CHECK_UNIQUE_URL)
+        assert r.status_code == 200, r.text
+
+    def test_std_of_other_unit_denied_on_explore_report(self, client, monkeypatch):
+        user = _user("11111", [_std(UNIT_IID)])
+        _wire(
+            monkeypatch,
+            user,
+            unit_iid=OTHER_IID,
+            carbon_report_type=CarbonReportType.SIMULATOR_EXPLORE,
+        )
+        r = client.get(CHECK_UNIQUE_URL)
+        assert r.status_code == 403, r.text
+
+    def test_principal_on_calculator_report_passes(self, client, monkeypatch):
+        user = _user("11111", [_principal(UNIT_IID)])
+        _wire(
+            monkeypatch,
+            user,
+            unit_iid=UNIT_IID,
+            carbon_report_type=CarbonReportType.CALCULATOR,
+        )
+        r = client.get(CHECK_UNIQUE_URL)
+        assert r.status_code == 200, r.text
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/tests/integration/v1/test_professional_travel_trips_map.py
+++ b/backend/tests/integration/v1/test_professional_travel_trips_map.py
@@ -100,6 +100,7 @@ def _wire(monkeypatch, user, decision_fn):
     _resolved_report = MagicMock()
     _resolved_report.unit_id = 1
     _resolved_report.year = 2024
+    _resolved_report.carbon_project_id = None
     _resolved_module = MagicMock()
     _resolved_module.id = 1
     monkeypatch.setattr(

--- a/backend/tests/unit/core/test_policy.py
+++ b/backend/tests/unit/core/test_policy.py
@@ -8,13 +8,14 @@ from fastapi import HTTPException
 from app.core.policy import (
     _get_module_permission_path,
     check_module_permission,
+    check_module_permission_for_report,
     is_module_permitted,
     plan_is_visible_to,
     query_policy,
     require_plan_access,
     require_plan_scope_for_report,
 )
-from app.models.user import GlobalScope, Role, RoleName, UnitScope
+from app.models.user import GlobalScope, OwnScope, Role, RoleName, UnitScope
 
 
 class TestGetModulePermissionPath:
@@ -691,3 +692,149 @@ class TestRequirePlanScopeForReport:
                 db, non_creator, self._report(5), "edit"
             )
         assert exc.value.status_code == 404
+
+
+class TestCheckModulePermissionForReport:
+    """Simulator reports drop the module gate to unit membership (#1988);
+    Calculator reports delegate to the strict per-module gate unchanged."""
+
+    @staticmethod
+    def _report(project_id=5, unit_id=1):
+        report = MagicMock()
+        report.carbon_project_id = project_id
+        report.unit_id = unit_id
+        return report
+
+    @staticmethod
+    def _db(project_type, unit):
+        from app.models.carbon_project import CarbonProject
+
+        project = MagicMock()
+        project.carbon_report_type = project_type
+
+        async def _get(model, key):
+            if model is CarbonProject:
+                return project
+            return unit
+
+        db = MagicMock()
+        db.get = AsyncMock(side_effect=_get)
+        return db
+
+    @staticmethod
+    def _std_user(iid):
+        user = MagicMock()
+        user.roles = [
+            Role(role=RoleName.CO2_USER_STD, on=OwnScope(institutional_id=iid))
+        ]
+        return user
+
+    @staticmethod
+    def _unit(iid="0184"):
+        unit = MagicMock()
+        unit.institutional_id = iid
+        return unit
+
+    @pytest.mark.asyncio
+    async def test_explore_report_passes_for_std_unit_member(self):
+        from app.models.carbon_report import CarbonReportType
+
+        unit = self._unit("0184")
+        result = await check_module_permission_for_report(
+            current_user=self._std_user("0184"),
+            module_id="headcount",
+            action="view",
+            db=self._db(CarbonReportType.SIMULATOR_EXPLORE, unit),
+            report=self._report(),
+        )
+        assert result is unit
+
+    @pytest.mark.asyncio
+    async def test_plan_report_passes_for_std_unit_member(self):
+        from app.models.carbon_report import CarbonReportType
+
+        unit = self._unit("0184")
+        result = await check_module_permission_for_report(
+            current_user=self._std_user("0184"),
+            module_id="equipment",
+            action="edit",
+            db=self._db(CarbonReportType.SIMULATOR_PLAN, unit),
+            report=self._report(),
+        )
+        assert result is unit
+
+    @pytest.mark.asyncio
+    async def test_explore_report_denies_std_of_other_unit(self):
+        from app.models.carbon_report import CarbonReportType
+
+        with pytest.raises(HTTPException) as exc:
+            await check_module_permission_for_report(
+                current_user=self._std_user("9999"),
+                module_id="headcount",
+                action="view",
+                db=self._db(CarbonReportType.SIMULATOR_EXPLORE, self._unit("0184")),
+                report=self._report(),
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_simulator_report_missing_unit_is_404(self):
+        from app.models.carbon_report import CarbonReportType
+
+        with pytest.raises(HTTPException) as exc:
+            await check_module_permission_for_report(
+                current_user=self._std_user("0184"),
+                module_id="headcount",
+                action="view",
+                db=self._db(CarbonReportType.SIMULATOR_EXPLORE, None),
+                report=self._report(),
+            )
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_calculator_report_delegates_to_unit_gate(self):
+        from app.models.carbon_report import CarbonReportType
+
+        unit = self._unit("0184")
+        user = self._std_user("0184")
+        db = self._db(CarbonReportType.CALCULATOR, unit)
+        with patch(
+            "app.core.policy.check_module_permission_for_unit",
+            AsyncMock(return_value=unit),
+        ) as delegate:
+            result = await check_module_permission_for_report(
+                current_user=user,
+                module_id="headcount",
+                action="view",
+                db=db,
+                report=self._report(unit_id=7),
+            )
+        assert result is unit
+        delegate.assert_awaited_once_with(
+            current_user=user,
+            module_id="headcount",
+            action="view",
+            db=db,
+            unit_id=7,
+        )
+
+    @pytest.mark.asyncio
+    async def test_report_without_project_delegates_to_unit_gate(self):
+        unit = self._unit("0184")
+        user = self._std_user("0184")
+        db = MagicMock()
+        db.get = AsyncMock()
+        with patch(
+            "app.core.policy.check_module_permission_for_unit",
+            AsyncMock(return_value=unit),
+        ) as delegate:
+            result = await check_module_permission_for_report(
+                current_user=user,
+                module_id="headcount",
+                action="view",
+                db=db,
+                report=self._report(project_id=None, unit_id=7),
+            )
+        assert result is unit
+        db.get.assert_not_awaited()
+        delegate.assert_awaited_once()

--- a/backend/tests/unit/v1/test_carbon_report_module.py
+++ b/backend/tests/unit/v1/test_carbon_report_module.py
@@ -532,7 +532,7 @@ async def test_get_module_headcount_does_not_raise_name_error():
     with (
         patch.object(
             crm,
-            "check_module_permission_for_unit",
+            "check_module_permission_for_report",
             AsyncMock(return_value=unit),
         ),
         patch.object(

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -249,7 +249,7 @@
               </q-tooltip>
             </q-btn>
             <q-btn
-              v-if="showTableRowActions && canEdit && hasModuleUpload"
+              v-if="showTableRowActions && canEditRows && hasModuleUpload"
               icon="o_delete"
               color="black"
               :disable="isDisabled"
@@ -528,6 +528,7 @@ import {
   REFERENCE_PERCENTAGE_MIN,
 } from 'src/utils/reference-percentage';
 import {
+  hasRowEditPermission,
   isModuleNoteDisabled,
   isModuleTableDisabled,
   type ModuleTableAccess,
@@ -985,6 +986,8 @@ const tableAccess = computed<ModuleTableAccess>(() => ({
 }));
 
 const isDisabled = computed(() => isModuleTableDisabled(tableAccess.value));
+
+const canEditRows = computed(() => hasRowEditPermission(tableAccess.value));
 
 const showTableRowActions = computed(
   () => props.submoduleConfig?.hasTableAction !== false,

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -53,7 +53,7 @@
       </div>
       <q-separator />
       <div
-        v-if="isInputDeactivated && !isExplorer"
+        v-if="isInputDeactivated && !isExplorer && !isPlanner"
         class="q-mx-lg q-my-md inputs-deactivated-notice"
       >
         <div class="inputs-deactivated-notice__content">
@@ -193,6 +193,7 @@ import {
   getSubmoduleIconColor,
   getSubmoduleLighterColor,
 } from 'src/composables/useModuleIconColors';
+import { canShowModuleForm } from 'src/utils/module-table-access';
 interface Option {
   label: string;
   value: string;
@@ -288,9 +289,13 @@ const isInputDeactivated = computed(() => {
   return subConfig?.inputs_deactivated ?? false;
 });
 
-const isTableDisabled = computed(
-  () => !props.isExplorer && (props.disable || isInputDeactivated.value),
-);
+// Planner tables address a plan-year report by id; the Calculator never does.
+const isPlanner = computed(() => props.carbonReportId != null);
+
+const isTableDisabled = computed(() => {
+  if (props.isExplorer) return false;
+  return props.disable || (!isPlanner.value && isInputDeactivated.value);
+});
 
 const backendThreshold = computed<Threshold | null>(() => {
   const unifiedConfig = yearConfigStore.getModule(props.moduleType as Module);
@@ -320,8 +325,6 @@ const canEdit = computed(() => {
     PermissionAction.EDIT,
   );
 });
-
-const isFormDisabled = computed(() => props.disable);
 
 const submoduleCount = computed(() => {
   const submoduleEnumId =
@@ -365,7 +368,14 @@ const hasModuleForm = computed(() => {
 });
 
 const showModuleForm = computed(
-  () => hasModuleForm.value && !isFormDisabled.value && canEdit.value,
+  () =>
+    hasModuleForm.value &&
+    canShowModuleForm({
+      isExplorer: props.isExplorer === true,
+      isPlanner: isPlanner.value,
+      canEdit: canEdit.value,
+      disable: props.disable,
+    }),
 );
 
 const hasTableTooltip = computed(() => {

--- a/frontend/src/utils/module-table-access.ts
+++ b/frontend/src/utils/module-table-access.ts
@@ -25,8 +25,9 @@ export interface ModuleTableAccess {
 /** Editing, inline edits, row deletion and the Planner % slider. */
 export function isModuleTableDisabled(ctx: ModuleTableAccess): boolean {
   if (ctx.isExplorer) return false;
-  if (ctx.disable || !ctx.canEdit) return true;
+  if (ctx.disable) return true;
   if (ctx.isPlanner) return false;
+  if (!ctx.canEdit) return true;
   return ctx.isValidated;
 }
 
@@ -36,7 +37,23 @@ export function isModuleTableDisabled(ctx: ModuleTableAccess): boolean {
  * validated lock.
  */
 export function isModuleNoteDisabled(ctx: ModuleTableAccess): boolean {
-  if (!ctx.canEdit) return true;
   if (ctx.isExplorer || ctx.isPlanner) return false;
+  if (!ctx.canEdit) return true;
   return ctx.isValidated;
+}
+
+/** The add/edit form under a table (SubModuleSection). */
+export function canShowModuleForm(
+  ctx: Omit<ModuleTableAccess, 'isValidated'>,
+): boolean {
+  if (ctx.disable) return false;
+  if (ctx.isExplorer || ctx.isPlanner) return true;
+  return ctx.canEdit;
+}
+
+/** Row-level edit affordances, e.g. the delete button in ModuleTable. */
+export function hasRowEditPermission(
+  ctx: Omit<ModuleTableAccess, 'isValidated' | 'disable'>,
+): boolean {
+  return ctx.isExplorer || ctx.isPlanner || ctx.canEdit;
 }


### PR DESCRIPTION
## What does this change?
Introduces `check_module_permission_for_report`, which drops module-level permission checks to plain unit-membership for reports belonging to a Simulator project (Explore or Plan), while Calculator reports keep the strict per-module gate (`check_module_permission_for_unit`). All report-addressed routes in `carbon_report_module.py` are switched over to this new helper. Taxonomy endpoints in `taxonomies.py` drop their module-permission check entirely (authentication only, since taxonomies are unit-agnostic reference data). On the frontend, `module-table-access.ts` gains `canShowModuleForm` and `hasRowEditPermission` helpers, reorders some existing conditionals, and `SubModuleSection.vue`/`ModuleTable.vue` are updated to use them so Planner/Explorer forms and row actions render correctly for standard users. Adds unit and integration tests covering the new gating behavior.

## Why is this needed?
Bug fix (#1988): standard users were being denied access to Simulator (Explore/Plan) module forms and table row actions because the permission checks were scoped too strictly (per-module Calculator-style checks) instead of the intended unit-membership gate for simulator reports.

## Type of change
Please check the type that applies:
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [x] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [x] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1988

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.