### PR TITLE
feat/1976 grant proposal mode

### DIFF
--- a/backend/alembic/versions/2026_08_05_0910-3d74009feee4_grant_proposal_flag_and_project_grant_.py
+++ b/backend/alembic/versions/2026_08_05_0910-3d74009feee4_grant_proposal_flag_and_project_grant_.py
@@ -1,0 +1,66 @@
+# codeql[py/unused-global-variable]
+"""grant proposal flag and project grant report
+
+Revision ID: 3d74009feee4
+Revises: 2c7f5cf1c9de
+Create Date: 2026-08-05 09:10:41.031375
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3d74009feee4"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "2c7f5cf1c9de"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "carbon_projects",
+        sa.Column(
+            "is_grant_proposal", sa.Boolean(), server_default="false", nullable=False
+        ),
+    )
+    op.add_column(
+        "carbon_reports",
+        sa.Column("is_grant", sa.Boolean(), server_default="false", nullable=False),
+    )
+    # Widened with is_grant: a plan's Project Grant report shares its year
+    # with the start-year report.
+    op.drop_constraint(
+        op.f("uq_carbon_reports_project_year"), "carbon_reports", type_="unique"
+    )
+    op.create_unique_constraint(
+        "uq_carbon_reports_project_year",
+        "carbon_reports",
+        ["carbon_project_id", "year", "is_grant"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "uq_carbon_reports_project_year", "carbon_reports", type_="unique"
+    )
+    op.create_unique_constraint(
+        op.f("uq_carbon_reports_project_year"),
+        "carbon_reports",
+        ["carbon_project_id", "year"],
+    )
+    op.drop_column("carbon_reports", "is_grant")
+    op.drop_column("carbon_projects", "is_grant_proposal")

--- a/backend/alembic/versions/2026_08_05_0955-9539986fa17b_grant_budget_on_reports_and_modules.py
+++ b/backend/alembic/versions/2026_08_05_0955-9539986fa17b_grant_budget_on_reports_and_modules.py
@@ -1,0 +1,47 @@
+# codeql[py/unused-global-variable]
+"""grant budget on reports and modules
+
+Revision ID: 9539986fa17b
+Revises: 3d74009feee4
+Create Date: 2026-08-05 09:55:48.679830
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+]
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9539986fa17b"  # noqa: F841
+down_revision: Union[str, Sequence[str], None] = "3d74009feee4"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, Sequence[str], None] = None  # noqa: F841
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "carbon_report_modules", sa.Column("budgets", sa.JSON(), nullable=True)
+    )
+    op.add_column("carbon_reports", sa.Column("budget", sa.Float(), nullable=True))
+    op.add_column(
+        "carbon_reports",
+        sa.Column("budget_currency", sa.String(length=8), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("carbon_reports", "budget_currency")
+    op.drop_column("carbon_reports", "budget")
+    op.drop_column("carbon_report_modules", "budgets")

--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -18,11 +18,13 @@ from app.models.module_type import GRANT_LOCKED_MODULE_TYPES
 from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.carbon_report import (
+    CarbonReportBudgetUpdate,
     CarbonReportCreate,
     CarbonReportModuleActiveUpdate,
     CarbonReportModuleRead,
     CarbonReportModuleUpdate,
     CarbonReportRead,
+    CarbonReportSubmoduleBudgetUpdate,
 )
 from app.services.carbon_report_module_service import CarbonReportModuleService
 from app.services.carbon_report_service import CarbonReportService
@@ -315,5 +317,81 @@ async def update_carbon_report_module_active(
 
     await report_service.recompute_report_stats(carbon_report_id)
     await report_service.recompute_report_progress(carbon_report_id)
+    await db.commit()
+    return result
+
+
+async def _require_grant_report_edit(
+    db: AsyncSession, current_user: User, carbon_report_id: int
+) -> CarbonReportService:
+    """Load a Project Grant report and enforce plan-edit access on it.
+
+    404 when the report is missing, 409 when it is not a grant report —
+    budgets exist only on the Project Grant section (#1978).
+    """
+    report_service = CarbonReportService(db)
+    report = await report_service.get(carbon_report_id)
+    if not report:
+        raise HTTPException(status_code=404, detail="Carbon report not found")
+    unit = await db.get(Unit, report.unit_id)
+    require_unit_access(current_user, unit)
+    await require_plan_scope_for_report(db, current_user, report, "edit")
+    if not report.is_grant:
+        raise HTTPException(
+            status_code=409,
+            detail="Budgets only apply to Project Grant reports",
+        )
+    return report_service
+
+
+@router.patch("/{carbon_report_id}/budget", response_model=CarbonReportRead)
+async def update_carbon_report_budget(
+    carbon_report_id: int,
+    update: CarbonReportBudgetUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Set a Project Grant report's total budget (#1978)."""
+    report_service = await _require_grant_report_edit(
+        db, current_user, carbon_report_id
+    )
+    result = await report_service.set_budget(
+        carbon_report_id, update.budget, update.budget_currency
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Carbon report not found")
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{carbon_report_id}/modules/{module_type_id}/budget",
+    response_model=CarbonReportModuleRead,
+)
+async def update_carbon_report_submodule_budget(
+    carbon_report_id: int,
+    module_type_id: int,
+    update: CarbonReportSubmoduleBudgetUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Set a grant submodule's share of the budget (#1978).
+
+    The frontend checks the submodule budgets against the grant's total and
+    surfaces the non-distributed or over-distributed remainder.
+    """
+    await _require_grant_report_edit(db, current_user, carbon_report_id)
+    module_service = CarbonReportModuleService(db)
+    result = await module_service.update_submodule_budget(
+        carbon_report_id, module_type_id, update.submodule, update.budget
+    )
+    if not result:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Module type {module_type_id} not found for "
+                f"carbon report {carbon_report_id}"
+            ),
+        )
     await db.commit()
     return result

--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -297,9 +297,7 @@ async def update_carbon_report_module_active(
         if module_type_id in GRANT_LOCKED_MODULE_TYPES:
             raise HTTPException(
                 status_code=409,
-                detail=(
-                    "Equipment and Research Facilities always count in a grant proposal"
-                ),
+                detail="Equipment always counts in a grant proposal",
             )
 
     module_service = CarbonReportModuleService(db)

--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -14,6 +14,7 @@ from app.core.policy import (
     require_unit_access,
 )
 from app.db import SessionLocal
+from app.models.module_type import GRANT_LOCKED_MODULE_TYPES
 from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.carbon_report import (
@@ -289,6 +290,15 @@ async def update_carbon_report_module_active(
     unit = await db.get(Unit, report.unit_id)
     require_unit_access(current_user, unit)
     await require_plan_scope_for_report(db, current_user, report, "edit")
+
+    if report.is_grant and not update.is_active:
+        if module_type_id in GRANT_LOCKED_MODULE_TYPES:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Equipment and Research Facilities always count in a grant proposal"
+                ),
+            )
 
     module_service = CarbonReportModuleService(db)
     result = await module_service.update_is_active(

--- a/backend/app/api/v1/carbon_report.py
+++ b/backend/app/api/v1/carbon_report.py
@@ -14,7 +14,6 @@ from app.core.policy import (
     require_unit_access,
 )
 from app.db import SessionLocal
-from app.models.module_type import GRANT_LOCKED_MODULE_TYPES
 from app.models.unit import Unit
 from app.models.user import User
 from app.schemas.carbon_report import (
@@ -24,6 +23,7 @@ from app.schemas.carbon_report import (
     CarbonReportModuleRead,
     CarbonReportModuleUpdate,
     CarbonReportRead,
+    CarbonReportReferencePercentageUpdate,
     CarbonReportSubmoduleBudgetUpdate,
 )
 from app.services.carbon_report_module_service import CarbonReportModuleService
@@ -293,13 +293,6 @@ async def update_carbon_report_module_active(
     require_unit_access(current_user, unit)
     await require_plan_scope_for_report(db, current_user, report, "edit")
 
-    if report.is_grant and not update.is_active:
-        if module_type_id in GRANT_LOCKED_MODULE_TYPES:
-            raise HTTPException(
-                status_code=409,
-                detail="Equipment always counts in a grant proposal",
-            )
-
     module_service = CarbonReportModuleService(db)
     result = await module_service.update_is_active(
         carbon_report_id, module_type_id, update.is_active
@@ -360,6 +353,43 @@ async def update_carbon_report_budget(
         raise HTTPException(status_code=404, detail="Carbon report not found")
     await db.commit()
     return result
+
+
+@router.patch(
+    "/{carbon_report_id}/modules/{module_type_id}/reference-percentage",
+    response_model=dict,
+)
+async def update_carbon_report_module_reference_percentage(
+    carbon_report_id: int,
+    module_type_id: int,
+    update: CarbonReportReferencePercentageUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Apply one reference percentage to every snapshot entry of a module.
+
+    Backs the grant equipment "global percentage" mode (#1981): the
+    calculator's prefilled lines are kept and one percentage prices them
+    all. Only Project Grant reports carry this mode.
+    """
+    report_service = await _require_grant_report_edit(
+        db, current_user, carbon_report_id
+    )
+    module_service = CarbonReportModuleService(db)
+    updated = await module_service.set_reference_percentage_all(
+        carbon_report_id, module_type_id, update.percentage
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Module type {module_type_id} not found for "
+                f"carbon report {carbon_report_id}"
+            ),
+        )
+    await report_service.recompute_report_stats(carbon_report_id)
+    await db.commit()
+    return {"updated_entries": updated}
 
 
 @router.patch(

--- a/backend/app/api/v1/factors.py
+++ b/backend/app/api/v1/factors.py
@@ -37,6 +37,25 @@ async def get_class_subclass_map(
     )
 
 
+@router.get("/{data_entry_type}/list", response_model=list[dict])
+async def list_factors(
+    data_entry_type: DataEntryTypeEnum,
+    year: int = Query(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[dict]:
+    """List every factor of a type for a year, classification + values merged.
+
+    Backs the Project Grant research-facilities grid, which offers the
+    reference year's whole platform list for selection (#1980).
+    """
+    factors = await FactorService(db).list_by_data_entry_type(data_entry_type, year)
+    return [
+        {"factor_id": f.id, **(f.classification or {}), **(f.values or {})}
+        for f in factors
+    ]
+
+
 # example of call
 #
 # http://localhost:9000/api/v1/factors/scientific/classes/Milling%20machine/values

--- a/backend/app/api/v1/simulator_plan.py
+++ b/backend/app/api/v1/simulator_plan.py
@@ -164,21 +164,26 @@ async def get_simulator_plan_aggregate_stats(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
-    """Sum the plan's per-year report stats into one payload.
+    """Aggregate the plan's report stats into the results payload.
 
-    Same shape as ``/modules-stats/{carbon_report_id}/report-stats``, so the
-    planner results chart derives from it through the same frontend adapter.
-    Per-year stats already exclude modules whose Active checkbox is off.
-    The Project Grant report is excluded until #1977 settles how grant
-    results combine with the per-year results.
+    ``years`` sums the per-year reports (same shape as
+    ``/modules-stats/{carbon_report_id}/report-stats``, so the planner
+    results chart derives from it through the same frontend adapter);
+    ``grant`` carries the Project Grant report's own stats, or null —
+    the two are charted side by side, never summed together (#1977).
+    Per-report stats already exclude modules whose Active checkbox is off.
     """
     service = await _require_plan_unit_access(db, current_user, plan_id, "view")
     years = await service.list_plan_years(plan_id)
     if years is None:
         raise HTTPException(status_code=404, detail="Plan not found")
-    return merge_report_stats(
-        [dict(year.stats or {}) for year in years if not year.is_grant]
-    )
+    grant = next((dict(y.stats or {}) for y in years if y.is_grant), None)
+    return {
+        "years": merge_report_stats(
+            [dict(year.stats or {}) for year in years if not year.is_grant]
+        ),
+        "grant": grant,
+    }
 
 
 @router.patch("/{plan_id}/years/{year}", response_model=SimulatorPlanYearRead)

--- a/backend/app/api/v1/simulator_plan.py
+++ b/backend/app/api/v1/simulator_plan.py
@@ -102,18 +102,15 @@ async def create_simulator_plan(
     return _with_can_manage(current_user, [result])[0]
 
 
-@router.get("/unit/{unit_id}/by-name/{name}", response_model=SimulatorPlanRead)
-async def get_simulator_plan_by_name(
-    unit_id: int,
-    name: str,
+@router.get("/{plan_id}", response_model=SimulatorPlanRead)
+async def get_simulator_plan(
+    plan_id: int,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Get a simulator plan of a unit by its name."""
-    unit = await db.get(Unit, unit_id)
-    require_unit_access(current_user, unit)
-    service = SimulatorPlanService(db)
-    result = await service.get_plan_by_name(unit_id, name)
+    """Get a simulator plan by ID."""
+    service = await _require_plan_unit_access(db, current_user, plan_id, "view")
+    result = await service.get_plan(plan_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Plan not found")
     require_plan_access(current_user, result, "view")

--- a/backend/app/api/v1/simulator_plan.py
+++ b/backend/app/api/v1/simulator_plan.py
@@ -169,12 +169,16 @@ async def get_simulator_plan_aggregate_stats(
     Same shape as ``/modules-stats/{carbon_report_id}/report-stats``, so the
     planner results chart derives from it through the same frontend adapter.
     Per-year stats already exclude modules whose Active checkbox is off.
+    The Project Grant report is excluded until #1977 settles how grant
+    results combine with the per-year results.
     """
     service = await _require_plan_unit_access(db, current_user, plan_id, "view")
     years = await service.list_plan_years(plan_id)
     if years is None:
         raise HTTPException(status_code=404, detail="Plan not found")
-    return merge_report_stats([dict(year.stats or {}) for year in years])
+    return merge_report_stats(
+        [dict(year.stats or {}) for year in years if not year.is_grant]
+    )
 
 
 @router.patch("/{plan_id}/years/{year}", response_model=SimulatorPlanYearRead)
@@ -192,7 +196,9 @@ async def set_simulator_plan_reference_year(
     """
     service = await _require_plan_unit_access(db, current_user, plan_id, "edit")
     try:
-        result = await service.set_reference_year(plan_id, year, update.reference_year)
+        result = await service.set_reference_year(
+            plan_id, year, update.reference_year, is_grant=update.is_grant
+        )
     except ValueError as exc:
         # Re-snapshot of prefilled modules can fail when the new reference
         # year has no Calculator report for the unit.

--- a/backend/app/models/carbon_project.py
+++ b/backend/app/models/carbon_project.py
@@ -33,6 +33,15 @@ class CarbonProjectBase(SQLModel):
     end_year: Optional[int] = Field(default=None, nullable=True, index=True)
     name: Optional[str] = Field(default=None, nullable=True, index=True)
     is_viewable_by_unit_members: bool = Field(default=False, nullable=False)
+    is_grant_proposal: bool = Field(
+        default=False,
+        nullable=False,
+        sa_column_kwargs={"server_default": "false"},
+        description=(
+            "Simulator Plan only: the plan carries a Project Grant section"
+            " (a dedicated grant carbon report) in addition to its year reports"
+        ),
+    )
     created_by: Optional[int] = Field(
         default=None,
         foreign_key="users.id",

--- a/backend/app/models/carbon_report.py
+++ b/backend/app/models/carbon_report.py
@@ -43,6 +43,15 @@ class CarbonReportBase(SQLModel):
         index=True,
         description="FK to carbon_projects.id — every report may belong to a project",
     )
+    is_grant: bool = Field(
+        default=False,
+        nullable=False,
+        sa_column_kwargs={"server_default": "false"},
+        description=(
+            "Simulator Plan only: the plan's Project Grant report"
+            " (anchored to the plan's start year), as opposed to a year report"
+        ),
+    )
     last_updated: Optional[int] = Field(
         default=None,
         description=(
@@ -100,6 +109,7 @@ class CarbonReport(CarbonReportBase, table=True):
         UniqueConstraint(
             "carbon_project_id",
             "year",
+            "is_grant",
             name="uq_carbon_reports_project_year",
         ),
     )

--- a/backend/app/models/carbon_report.py
+++ b/backend/app/models/carbon_report.py
@@ -52,6 +52,23 @@ class CarbonReportBase(SQLModel):
             " (anchored to the plan's start year), as opposed to a year report"
         ),
     )
+    budget: Optional[float] = Field(
+        default=None,
+        nullable=True,
+        description=(
+            "Project Grant reports only: the grant's total budget,"
+            " checked against the per-submodule budgets (#1978)"
+        ),
+    )
+    budget_currency: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        max_length=8,
+        description=(
+            "Currency code of the grant budget (lowercase, same set as the"
+            " purchase module, e.g. 'chf'); display-only, no conversion"
+        ),
+    )
     last_updated: Optional[int] = Field(
         default=None,
         description=(
@@ -137,6 +154,15 @@ class CarbonReportModuleBase(SQLModel):
             "Whether the module counts toward report sums/stats."
             " Toggled by the Simulator Plan 'Active' checkbox;"
             " always true for Calculator/Explore modules."
+        ),
+    )
+    budgets: Optional[dict] = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+        description=(
+            "Project Grant reports only: the submodules' shares of the grant"
+            " budget, keyed by submodule id (#1978); null everywhere else"
+            ".e.g: { 'building': 200000, 'energy_combustion': 50000 }"
         ),
     )
     carbon_report_id: int = Field(

--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -50,15 +50,6 @@ PLANNER_PREFILLED_MODULE_TYPES: set[ModuleTypeEnum] = {
     ModuleTypeEnum.external_cloud_and_ai,
 }
 
-# Modules a Project Grant report always counts: a grant proposal is first and
-# foremost about the equipment it funds, so its Active checkbox is locked on
-# (#1976). Research facilities left the set with their opt-in platform grid
-# (#1980). Mirrors the frontend PlannerYearSection GRANT_LOCKED_MODULES set.
-GRANT_LOCKED_MODULE_TYPES: set[ModuleTypeEnum] = {
-    ModuleTypeEnum.equipment,
-}
-
-
 # corresponding data_entry_type enum for each module type
 
 MODULE_TYPE_TO_DATA_ENTRY_TYPES = {

--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -50,6 +50,15 @@ PLANNER_PREFILLED_MODULE_TYPES: set[ModuleTypeEnum] = {
     ModuleTypeEnum.external_cloud_and_ai,
 }
 
+# Modules a Project Grant report always counts: a grant proposal is first and
+# foremost about the equipment and research facilities it funds, so their
+# Active checkbox is locked on (#1976). Mirrors the frontend
+# planner-module-config GRANT_LOCKED_MODULES set.
+GRANT_LOCKED_MODULE_TYPES: set[ModuleTypeEnum] = {
+    ModuleTypeEnum.equipment,
+    ModuleTypeEnum.research_facilities,
+}
+
 
 # corresponding data_entry_type enum for each module type
 

--- a/backend/app/models/module_type.py
+++ b/backend/app/models/module_type.py
@@ -51,12 +51,11 @@ PLANNER_PREFILLED_MODULE_TYPES: set[ModuleTypeEnum] = {
 }
 
 # Modules a Project Grant report always counts: a grant proposal is first and
-# foremost about the equipment and research facilities it funds, so their
-# Active checkbox is locked on (#1976). Mirrors the frontend
-# planner-module-config GRANT_LOCKED_MODULES set.
+# foremost about the equipment it funds, so its Active checkbox is locked on
+# (#1976). Research facilities left the set with their opt-in platform grid
+# (#1980). Mirrors the frontend PlannerYearSection GRANT_LOCKED_MODULES set.
 GRANT_LOCKED_MODULE_TYPES: set[ModuleTypeEnum] = {
     ModuleTypeEnum.equipment,
-    ModuleTypeEnum.research_facilities,
 }
 
 

--- a/backend/app/providers/role_provider.py
+++ b/backend/app/providers/role_provider.py
@@ -567,8 +567,11 @@ class AccredRoleProvider(RoleProvider):
                     continue
 
                 accred_unit_institutional_code = auth.get("accredunitid")
-                accred_unit_institutional_id = (
-                    auth.get("reason").get("resource").get("cf")
+                # Prod Accred exposes the unit cf as resource.cf; api-test's
+                # newer schema renamed it to resource.altname.
+                resource = auth.get("reason").get("resource")
+                accred_unit_institutional_id = resource.get("cf") or resource.get(
+                    "altname"
                 )
                 if not accred_unit_institutional_code:
                     logger.warning(

--- a/backend/app/repositories/carbon_project_repo.py
+++ b/backend/app/repositories/carbon_project_repo.py
@@ -129,12 +129,19 @@ class CarbonProjectRepository:
 
         Backs the plan totals shown in the home-page planner table: one query
         for the whole unit instead of one per plan.
+
+        Project Grant reports are excluded: how grant results combine with the
+        per-year results is still open (#1977), and summing both would count
+        the same project twice.
         """
         if not project_ids:
             return []
         statement = select(
             col(CarbonReport.carbon_project_id), col(CarbonReport.stats)
-        ).where(col(CarbonReport.carbon_project_id).in_(project_ids))
+        ).where(
+            col(CarbonReport.carbon_project_id).in_(project_ids),
+            col(CarbonReport.is_grant).is_(False),
+        )
         result = await self.session.execute(statement)
         return [(project_id, stats) for project_id, stats in result.all()]
 

--- a/backend/app/repositories/carbon_project_repo.py
+++ b/backend/app/repositories/carbon_project_repo.py
@@ -52,14 +52,11 @@ class CarbonProjectRepository:
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
-    async def get_plan_by_name(
-        self, unit_id: int, name: str
+    async def get_plan_with_creator(
+        self, plan_id: int
     ) -> Optional[tuple[CarbonProject, Optional[str]]]:
-        """Get a plan project by unit and name, with the creator name."""
-        statement = self._plan_with_creator_stmt().where(
-            CarbonProject.unit_id == unit_id,
-            CarbonProject.name == name,
-        )
+        """Get a plan project by ID, with the creator name."""
+        statement = self._plan_with_creator_stmt().where(CarbonProject.id == plan_id)
         result = await self.session.execute(statement)
         row = result.first()
         if row is None:

--- a/backend/app/repositories/carbon_report_module_repo.py
+++ b/backend/app/repositories/carbon_report_module_repo.py
@@ -224,6 +224,37 @@ class CarbonReportModuleRepository:
         await self.session.refresh(db_obj)
         return db_obj
 
+    async def update_submodule_budget(
+        self,
+        carbon_report_id: int,
+        module_type_id: int,
+        submodule: str,
+        budget: float | None,
+    ) -> Optional[CarbonReportModule]:
+        """Set a grant submodule's share of the budget (#1978).
+
+        A null ``budget`` removes the submodule's entry. The dict is
+        reassigned (not mutated) so SQLAlchemy detects the JSON change.
+        """
+        statement = select(CarbonReportModule).where(
+            col(CarbonReportModule.carbon_report_id) == carbon_report_id,
+            col(CarbonReportModule.module_type_id) == module_type_id,
+        )
+        result = await self.session.execute(statement)
+        db_obj = result.scalar_one_or_none()
+        if not db_obj:
+            return None
+        budgets = dict(db_obj.budgets or {})
+        if budget is None:
+            budgets.pop(submodule, None)
+        else:
+            budgets[submodule] = budget
+        db_obj.budgets = budgets or None
+        self.session.add(db_obj)
+        await self.session.flush()
+        await self.session.refresh(db_obj)
+        return db_obj
+
     async def delete(self, carbon_report_module_id: int) -> bool:
         """Delete a carbon report module by ID."""
         statement = select(CarbonReportModule).where(

--- a/backend/app/repositories/carbon_report_repo.py
+++ b/backend/app/repositories/carbon_report_repo.py
@@ -33,8 +33,9 @@ class CarbonReportRepository:
     async def bulk_upsert(self, data: list[CarbonReportCreate]) -> list[CarbonReport]:
         """Bulk upsert carbon reports using INSERT ... ON CONFLICT DO NOTHING.
 
-        Uses the uq_carbon_reports_project_year constraint (carbon_project_id, year)
-        as the conflict target. Callers must resolve carbon_project_id before
+        Uses the uq_carbon_reports_project_year constraint (carbon_project_id,
+        year, is_grant) as the conflict target. Callers must resolve
+        carbon_project_id before
         calling this method (it must be non-null for conflict detection to work).
         """
         stmt = (

--- a/backend/app/repositories/data_entry_repo.py
+++ b/backend/app/repositories/data_entry_repo.py
@@ -1174,11 +1174,11 @@ class DataEntryRepository:
             try:
                 items.append(handler.to_response(data_entry, enriched_data))
             except ValidationError as exc:
-                logger.warning(
-                    f"Skipping data_entry id={data_entry.id} "
-                    f"(type={data_entry_type_id}) in submodule listing: "
-                    f"stored data does not match the response schema: {exc}"
-                )
+                raise ValueError(
+                    f"data_entry id={data_entry.id} "
+                    f"(type={data_entry_type_id}) does not match the "
+                    f"response schema"
+                ) from exc
 
         response = SubmoduleResponse(
             id=data_entry_type_id,

--- a/backend/app/schemas/carbon_report.py
+++ b/backend/app/schemas/carbon_report.py
@@ -105,6 +105,12 @@ class CarbonReportBudgetUpdate(BaseModel):
     budget_currency: Optional[str] = Field(default=None, min_length=3, max_length=8)
 
 
+class CarbonReportReferencePercentageUpdate(BaseModel):
+    """Schema for the grant equipment global percentage (#1981)."""
+
+    percentage: float = Field(ge=0, le=100)
+
+
 class CarbonReportSubmoduleBudgetUpdate(BaseModel):
     """Schema for setting a grant submodule's share of the budget (#1978).
 

--- a/backend/app/schemas/carbon_report.py
+++ b/backend/app/schemas/carbon_report.py
@@ -14,6 +14,7 @@ class CarbonReportBase(BaseModel):
     reference_year: Optional[int] = None
     unit_id: int
     carbon_project_id: Optional[int] = None
+    is_grant: bool = False
 
 
 class CarbonReportCreate(CarbonReportBase):

--- a/backend/app/schemas/carbon_report.py
+++ b/backend/app/schemas/carbon_report.py
@@ -15,6 +15,8 @@ class CarbonReportBase(BaseModel):
     unit_id: int
     carbon_project_id: Optional[int] = None
     is_grant: bool = False
+    budget: Optional[float] = None
+    budget_currency: Optional[str] = None
 
 
 class CarbonReportCreate(CarbonReportBase):
@@ -68,6 +70,7 @@ class CarbonReportModuleRead(BaseModel):
     module_type_id: int
     status: int
     is_active: bool = True
+    budgets: Optional[dict[str, float]] = None
     stats: Optional[dict] = None
 
     class Config:
@@ -89,3 +92,24 @@ class CarbonReportModuleActiveUpdate(BaseModel):
     """Schema for toggling a module's Active flag (Simulator Plan)."""
 
     is_active: bool
+
+
+class CarbonReportBudgetUpdate(BaseModel):
+    """Schema for setting a Project Grant report's total budget (#1978).
+
+    ``budget_currency`` is a lowercase code from the purchase module's
+    currency set; like purchase entries it is not validated server-side.
+    """
+
+    budget: Optional[float] = Field(default=None, ge=0)
+    budget_currency: Optional[str] = Field(default=None, min_length=3, max_length=8)
+
+
+class CarbonReportSubmoduleBudgetUpdate(BaseModel):
+    """Schema for setting a grant submodule's share of the budget (#1978).
+
+    A null ``budget`` clears the submodule's entry.
+    """
+
+    submodule: str = Field(min_length=1, max_length=100)
+    budget: Optional[float] = Field(default=None, ge=0)

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -41,6 +41,11 @@ class SimulatorPlanUpdate(BaseModel):
     Setting/changing the year range syncs the plan's per-year reports:
     missing years are created, out-of-range years are deleted with their
     entries (destructive by design).
+
+    ``with_year_sections`` is not persisted: whether a plan has per-year
+    sections is derived from its non-grant reports. Omitted, the sync keeps
+    the plan's current shape; ``False`` deletes the per-year reports (the
+    plan must then be a grant proposal); ``True`` (re)creates them.
     """
 
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
@@ -48,8 +53,13 @@ class SimulatorPlanUpdate(BaseModel):
     end_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     is_viewable_by_unit_members: Optional[bool] = None
     is_grant_proposal: Optional[bool] = None
+    with_year_sections: Optional[bool] = None
     default_reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     """Reference year for year reports newly created by this range change.
+
+    The workspace year the planner was opened from. Applied (with the usual
+    prefill) only to reports the sync creates; existing reports keep theirs.
+    """
 
     The workspace year the planner was opened from. Applied (with the usual
     prefill) only to reports the sync creates; existing reports keep theirs.

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -47,6 +47,7 @@ class SimulatorPlanUpdate(BaseModel):
     start_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     end_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     is_viewable_by_unit_members: Optional[bool] = None
+    is_grant_proposal: Optional[bool] = None
     default_reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
     """Reference year for year reports newly created by this range change.
 
@@ -65,8 +66,15 @@ class SimulatorPlanUpdate(BaseModel):
 class SimulatorPlanReferenceYearUpdate(BaseModel):
     """Schema for setting the baseline year of one plan-year report.
 
+    reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
+    """
     ``None`` removes the reference year: the prefilled modules are emptied
     (same wipe as a change) and the year becomes manual-input.
+    """
+    is_grant: bool = False
+    """
+    ``is_grant`` disambiguates the Project Grant report from the year report
+    sharing its year (the grant report is anchored to the plan's start year).
     """
 
     reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
@@ -98,6 +106,7 @@ class SimulatorPlanYearRead(BaseModel):
     id: int
     year: int
     reference_year: Optional[int] = None
+    is_grant: bool = False
     stats: Optional[dict] = None
     modules: list[CarbonReportModuleRead] = []
 

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -61,10 +61,6 @@ class SimulatorPlanUpdate(BaseModel):
     prefill) only to reports the sync creates; existing reports keep theirs.
     """
 
-    The workspace year the planner was opened from. Applied (with the usual
-    prefill) only to reports the sync creates; existing reports keep theirs.
-    """
-
     @field_validator("name")
     @classmethod
     def validate_name(cls, value: Optional[str]) -> Optional[str]:
@@ -76,18 +72,15 @@ class SimulatorPlanUpdate(BaseModel):
 class SimulatorPlanReferenceYearUpdate(BaseModel):
     """Schema for setting the baseline year of one plan-year report.
 
-    reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
-    """
     ``None`` removes the reference year: the prefilled modules are emptied
     (same wipe as a change) and the year becomes manual-input.
-    """
-    is_grant: bool = False
-    """
+
     ``is_grant`` disambiguates the Project Grant report from the year report
     sharing its year (the grant report is anchored to the plan's start year).
     """
 
     reference_year: Optional[int] = Field(default=None, ge=1000, le=9999)
+    is_grant: bool = False
 
 
 class SimulatorPlanRead(BaseModel):
@@ -99,6 +92,7 @@ class SimulatorPlanRead(BaseModel):
     start_year: Optional[int] = None
     end_year: Optional[int] = None
     is_viewable_by_unit_members: bool = False
+    is_grant_proposal: bool = False
     default_factor_year: Optional[int] = None
     created_by: Optional[int] = None
     created_at: Optional[datetime] = None

--- a/backend/app/schemas/simulator_plan.py
+++ b/backend/app/schemas/simulator_plan.py
@@ -107,6 +107,8 @@ class SimulatorPlanYearRead(BaseModel):
     year: int
     reference_year: Optional[int] = None
     is_grant: bool = False
+    budget: Optional[float] = None
+    budget_currency: Optional[str] = None
     stats: Optional[dict] = None
     modules: list[CarbonReportModuleRead] = []
 

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -29,6 +29,8 @@ from app.schemas.carbon_report import (
     CarbonReportModuleRead,
     CarbonReportRead,
 )
+from app.schemas.data_entry import DataEntryResponse
+from app.services.data_entry_emission_service import DataEntryEmissionService
 
 logger = get_logger(__name__)
 
@@ -357,6 +359,44 @@ class CarbonReportModuleService:
         if carbon_report_module is None:
             return None
         return CarbonReportModuleRead.model_validate(carbon_report_module)
+
+    async def set_reference_percentage_all(
+        self, carbon_report_id: int, module_type_id: int, percentage: float
+    ) -> Optional[int]:
+        """Set the reference percentage of every snapshot entry of a module.
+
+        Backs the grant equipment "global percentage" mode (#1981): one value
+        applied to every prefilled line at once. Hand-added entries carry no
+        ``source_data_entry_id`` and keep their own values. Emissions are
+        recomputed per entry, then the module stats. Returns the number of
+        entries updated, or None when the module does not exist.
+        """
+        logger.info(
+            f"Setting report {sanitize(carbon_report_id)} module "
+            f"{sanitize(module_type_id)} reference percentage to "
+            f"{sanitize(percentage)} on all snapshot entries"
+        )
+        module = await self.get_module(carbon_report_id, module_type_id)
+        if module is None:
+            return None
+        entry_repo = DataEntryRepository(self.session)
+        entries = await entry_repo.list_by_module(module.id)
+        snapshots = [
+            entry
+            for entry in entries
+            if entry.data.get("source_data_entry_id") is not None
+        ]
+        for entry in snapshots:
+            entry.data = {**entry.data, "percentage_of_reference_year": percentage}
+            self.session.add(entry)
+        await self.session.flush()
+        emission_service = DataEntryEmissionService(self.session)
+        for entry in snapshots:
+            await emission_service.upsert_by_data_entry(
+                DataEntryResponse.model_validate(entry)
+            )
+        await self.recompute_stats_many([module.id])
+        return len(snapshots)
 
     async def update_submodule_budget(
         self,

--- a/backend/app/services/carbon_report_module_service.py
+++ b/backend/app/services/carbon_report_module_service.py
@@ -358,6 +358,26 @@ class CarbonReportModuleService:
             return None
         return CarbonReportModuleRead.model_validate(carbon_report_module)
 
+    async def update_submodule_budget(
+        self,
+        carbon_report_id: int,
+        module_type_id: int,
+        submodule: str,
+        budget: float | None,
+    ) -> Optional[CarbonReportModuleRead]:
+        """Set a grant submodule's share of the budget (#1978)."""
+        logger.info(
+            f"Setting report {sanitize(carbon_report_id)} module "
+            f"{sanitize(module_type_id)} submodule {sanitize(submodule)} "
+            f"budget={sanitize(budget)}"
+        )
+        carbon_report_module = await self.repo.update_submodule_budget(
+            carbon_report_id, module_type_id, submodule, budget
+        )
+        if carbon_report_module is None:
+            return None
+        return CarbonReportModuleRead.model_validate(carbon_report_module)
+
     async def recompute_stats_many(
         self, carbon_report_module_ids: list[int], *, bump_status: bool = True
     ) -> int:

--- a/backend/app/services/carbon_report_service.py
+++ b/backend/app/services/carbon_report_service.py
@@ -207,6 +207,22 @@ class CarbonReportService:
         await self.module_service.create_all_modules_for_report(carbon_report_read.id)
         return carbon_report_read
 
+    async def set_budget(
+        self,
+        carbon_report_id: int,
+        budget: float | None,
+        budget_currency: str | None,
+    ) -> Optional[CarbonReportRead]:
+        """Set a Project Grant report's total budget (#1978); None if missing."""
+        report = await self.repo.get(carbon_report_id)
+        if report is None:
+            return None
+        report.budget = budget
+        report.budget_currency = budget_currency
+        self.session.add(report)
+        await self.session.flush()
+        return CarbonReportRead.model_validate(report)
+
     async def get_explore(
         self,
         *,

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -467,6 +467,18 @@ class SimulatorPlanService:
         entry_repo = DataEntryRepository(self.session)
         await entry_repo.bulk_delete_by_modules([plan_module.id])
 
+        src_entries = await entry_repo.list_by_module(ref_module.id)
+        if not src_entries:
+            await self.report_service.module_service.recompute_stats_many(
+                [plan_module.id]
+            )
+            return 0
+        # Grant equipment plans from scratch: every prefilled line starts at
+        # 0% and the user raises what the project actually uses (#1981).
+        # Everywhere else the snapshot starts as a full copy of the baseline.
+        default_percentage = (
+            0 if report.is_grant and module_type_id == ModuleTypeEnum.equipment else 100
+        )
         copies: list[DataEntry] = []
         for src in await entry_repo.list_by_module(ref_module.id):
             copy = DataEntry(
@@ -477,7 +489,7 @@ class SimulatorPlanService:
                 source=DataEntrySourceEnum.PLANNER_SNAPSHOT.value,
                 data={
                     **src.data,
-                    "percentage_of_reference_year": 100,
+                    "percentage_of_reference_year": default_percentage,
                     "source_data_entry_id": src.id,
                 },
             )

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -260,12 +260,12 @@ class SimulatorPlanService:
                     reference_year=default_reference_year,
                 )
             )
+            if default_reference_year is not None:
+                # Prefill computes the copied rows' emissions itself; only
+                # the report rollup is missing (no other entries exist yet).
+                await self._prefill_reference_modules(report_read)
+                await self.report_service.recompute_report_stats(report_read.id)
         await self._sync_grant_report(project, grant_report)
-        if default_reference_year is not None:
-            # Prefill computes the copied rows' emissions itself; only
-            # the report rollup is missing (no other entries exist yet).
-            await self._prefill_reference_modules(report_read)
-            await self.report_service.recompute_report_stats(report_read.id)
 
     async def _sync_grant_report(
         self, project: CarbonProject, grant_report: Optional[CarbonReport]

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -356,6 +356,11 @@ class SimulatorPlanService:
         if ref_report is None:
             return
         for module_type_id in sorted(m.module_type_id for m in prefilled):
+            # The grant RF grid starts from the reference year's platform
+            # list, not from copied entries (#1980) — cleared above, left
+            # empty for the user's own selection.
+            if report.is_grant and module_type_id == ModuleTypeEnum.research_facilities:
+                continue
             if module_type_id == ModuleTypeEnum.headcount:
                 await self.prefill_headcount_from_reference(
                     report, ref_report=ref_report

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -387,6 +387,8 @@ class SimulatorPlanService:
             year=report.year,
             reference_year=report.reference_year,
             is_grant=report.is_grant,
+            budget=report.budget,
+            budget_currency=report.budget_currency,
             stats=report.stats,
             modules=modules,
         )

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -66,6 +66,7 @@ def _to_read(
         start_year=project.start_year,
         end_year=project.end_year,
         is_viewable_by_unit_members=project.is_viewable_by_unit_members,
+        is_grant_proposal=project.is_grant_proposal,
         created_by=project.created_by,
         created_at=project.created_at,
         creator_name=creator_name,
@@ -182,6 +183,8 @@ class SimulatorPlanService:
             project.name = update.name
         if update.is_viewable_by_unit_members is not None:
             project.is_viewable_by_unit_members = update.is_viewable_by_unit_members
+        if update.is_grant_proposal is not None:
+            project.is_grant_proposal = update.is_grant_proposal
         if update.start_year is not None:
             project.start_year = update.start_year
         if update.end_year is not None:
@@ -220,8 +223,11 @@ class SimulatorPlanService:
             raise ValueError("project must be persisted before use")
         target_years = set(range(project.start_year, project.end_year + 1))
         existing_years: set[int] = set()
+        grant_report: Optional[CarbonReport] = None
         for report in await self.repo.list_reports_for_project(project.id):
-            if report.year in target_years:
+            if report.is_grant:
+                grant_report = report
+            elif report.year in target_years:
                 existing_years.add(report.year)
             elif report.id is not None:
                 await self.report_service.delete(report.id)
@@ -234,11 +240,43 @@ class SimulatorPlanService:
                     reference_year=default_reference_year,
                 )
             )
-            if default_reference_year is not None:
-                # Prefill computes the copied rows' emissions itself; only
-                # the report rollup is missing (no other entries exist yet).
-                await self._prefill_reference_modules(report_read)
-                await self.report_service.recompute_report_stats(report_read.id)
+        await self._sync_grant_report(project, grant_report)
+        if default_reference_year is not None:
+            # Prefill computes the copied rows' emissions itself; only
+            # the report rollup is missing (no other entries exist yet).
+            await self._prefill_reference_modules(report_read)
+            await self.report_service.recompute_report_stats(report_read.id)
+
+    async def _sync_grant_report(
+        self, project: CarbonProject, grant_report: Optional[CarbonReport]
+    ) -> None:
+        """Make the plan's Project Grant report match ``is_grant_proposal``.
+
+        Unchecking the checkbox deletes the grant report together with its
+        entries (destructive by design, like shrinking the year range). The
+        report is anchored to the plan's start year: when the range moves it
+        follows, keeping its data — grant entries resolve their factors from
+        the reference year, not the report year.
+        """
+        if not project.is_grant_proposal:
+            if grant_report is not None and grant_report.id is not None:
+                await self.report_service.delete(grant_report.id)
+            return
+        if project.start_year is None or project.id is None:
+            return
+        if grant_report is None:
+            await self.report_service.create(
+                CarbonReportCreate(
+                    unit_id=project.unit_id,
+                    year=project.start_year,
+                    carbon_project_id=project.id,
+                    is_grant=True,
+                )
+            )
+        elif grant_report.year != project.start_year:
+            grant_report.year = project.start_year
+            self.session.add(grant_report)
+            await self.session.flush()
 
     async def list_plan_years(
         self, plan_id: int
@@ -253,15 +291,18 @@ class SimulatorPlanService:
             return None
         if project.id is None:
             raise ValueError("project must be persisted before use")
-        years: list[SimulatorPlanYearRead] = []
-        for report in await self.repo.list_reports_for_project(project.id):
-            years.append(await self._year_read(report))
-        return years
+        reports = await self.repo.list_reports_for_project(project.id)
+        # The Project Grant section renders before the year sections.
+        reports.sort(key=lambda r: (not r.is_grant, r.year))
+        return [await self._year_read(report) for report in reports]
 
     async def set_reference_year(
-        self, plan_id: int, year: int, reference_year: Optional[int]
+        self, plan_id: int, year: int, reference_year: Optional[int], *, is_grant: bool = False
     ) -> Optional[SimulatorPlanYearRead]:
         """Set or remove the baseline year of one plan-year report; None if missing.
+
+        ``is_grant`` targets the Project Grant report, which shares its year
+        with the start-year report.
 
         Destructive: every prefilled module of the plan-year is emptied and,
         when a baseline is set, rebuilt from it at 100% — the percentages,
@@ -274,7 +315,9 @@ class SimulatorPlanService:
         lookup follows the reference year.
         """
         reports = await self.repo.list_reports_for_project(plan_id)
-        report = next((r for r in reports if r.year == year), None)
+        report = next(
+            (r for r in reports if r.year == year and r.is_grant == is_grant), None
+        )
         if report is None:
             return None
         if report.reference_year != reference_year:
@@ -343,6 +386,7 @@ class SimulatorPlanService:
             id=report.id,
             year=report.year,
             reference_year=report.reference_year,
+            is_grant=report.is_grant,
             stats=report.stats,
             modules=modules,
         )
@@ -593,6 +637,7 @@ class SimulatorPlanService:
             end_year=source.end_year,
             name=new_name,
             is_viewable_by_unit_members=source.is_viewable_by_unit_members,
+            is_grant_proposal=source.is_grant_proposal,
             created_by=user.id,
             created_at=datetime.now(timezone.utc),
         )

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -197,7 +197,9 @@ class SimulatorPlanService:
             raise ValueError("start_year must be <= end_year")
         project = await self._flush_guarded(self.repo.create(project))
         await self._sync_year_reports(
-            project, default_reference_year=update.default_reference_year
+            project,
+            default_reference_year=update.default_reference_year,
+            with_year_sections=update.with_year_sections,
         )
         return await self._read_with_creator(project)
 
@@ -205,29 +207,47 @@ class SimulatorPlanService:
         self,
         project: CarbonProject,
         default_reference_year: Optional[int] = None,
+        *,
+        with_year_sections: Optional[bool] = None,
     ) -> None:
         """Make the plan's reports match ``start_year..end_year``, one per year.
 
         Out-of-range reports are deleted together with their entries
         (destructive by design — the user shrank the range deliberately).
-        No-op until both bounds are set.
+        Until both bounds are set, only the grant report is synced.
 
         Newly created year reports default their reference year to
         ``default_reference_year`` (the workspace year the range was set
         from) and are prefilled from it, exactly as if the user had picked
         it in the dialog. Existing reports keep their reference year.
+
+        ``with_year_sections`` opts the plan out of (or back into) per-year
+        reports; ``None`` keeps the plan's current shape, derived from its
+        existing non-grant reports (a plan with no reports yet gets them).
+        A plan must keep either its year sections or its grant proposal.
         """
-        if project.start_year is None or project.end_year is None:
-            return
         if project.id is None:
             raise ValueError("project must be persisted before use")
-        target_years = set(range(project.start_year, project.end_year + 1))
+        reports = await self.repo.list_reports_for_project(project.id)
+        grant_report = next((r for r in reports if r.is_grant), None)
+        if project.start_year is None or project.end_year is None:
+            await self._sync_grant_report(project, grant_report)
+            return
+        want_years = with_year_sections
+        if want_years is None:
+            want_years = not reports or any(not r.is_grant for r in reports)
+        if not want_years and not project.is_grant_proposal:
+            raise ValueError("A plan needs year-by-year sections or a grant proposal")
+        target_years = (
+            set(range(project.start_year, project.end_year + 1))
+            if want_years
+            else set()
+        )
         existing_years: set[int] = set()
-        grant_report: Optional[CarbonReport] = None
-        for report in await self.repo.list_reports_for_project(project.id):
+        for report in reports:
             if report.is_grant:
-                grant_report = report
-            elif report.year in target_years:
+                continue
+            if report.year in target_years:
                 existing_years.add(report.year)
             elif report.id is not None:
                 await self.report_service.delete(report.id)
@@ -254,26 +274,27 @@ class SimulatorPlanService:
 
         Unchecking the checkbox deletes the grant report together with its
         entries (destructive by design, like shrinking the year range). The
-        report is anchored to the plan's start year: when the range moves it
-        follows, keeping its data — grant entries resolve their factors from
-        the reference year, not the report year.
+        report is anchored to the plan's start year — or the current year
+        until one is set: when the range moves (or arrives) it follows,
+        keeping its data — grant entries resolve their factors from the
+        reference year, not the report year.
         """
         if not project.is_grant_proposal:
             if grant_report is not None and grant_report.id is not None:
                 await self.report_service.delete(grant_report.id)
             return
-        if project.start_year is None or project.id is None:
+        if project.id is None:
             return
         if grant_report is None:
             await self.report_service.create(
                 CarbonReportCreate(
                     unit_id=project.unit_id,
-                    year=project.start_year,
+                    year=project.start_year or datetime.now(timezone.utc).year,
                     carbon_project_id=project.id,
                     is_grant=True,
                 )
             )
-        elif grant_report.year != project.start_year:
+        elif project.start_year is not None and grant_report.year != project.start_year:
             grant_report.year = project.start_year
             self.session.add(grant_report)
             await self.session.flush()
@@ -649,7 +670,14 @@ class SimulatorPlanService:
             created_at=datetime.now(timezone.utc),
         )
         copy = await self._flush_guarded(self.repo.create(copy))
-        await self._sync_year_reports(copy)
+        # The copy has no reports yet, so its shape (with or without per-year
+        # sections) cannot be derived from itself — carry the source's over.
+        source_reports = await self.repo.list_reports_for_project(plan_id)
+        await self._sync_year_reports(
+            copy,
+            with_year_sections=not source_reports
+            or any(not r.is_grant for r in source_reports),
+        )
         return _to_read(
             copy,
             user.display_name,

--- a/backend/app/services/simulator_plan_service.py
+++ b/backend/app/services/simulator_plan_service.py
@@ -120,18 +120,18 @@ class SimulatorPlanService:
             for plan_id, stats_list in by_plan.items()
         }
 
-    async def get_plan_by_name(
-        self, unit_id: int, name: str
-    ) -> Optional[SimulatorPlanRead]:
-        """Get a plan by unit and name, or None."""
-        row = await self.repo.get_plan_by_name(unit_id, name)
+    async def get_plan(self, plan_id: int) -> Optional[SimulatorPlanRead]:
+        """Get a plan by ID, or None."""
+        row = await self.repo.get_plan_with_creator(plan_id)
         if row is None:
             return None
         project, creator_name = row
         return _to_read(
             project,
             creator_name,
-            default_factor_year=await self.repo.get_latest_calculator_year(unit_id),
+            default_factor_year=await self.repo.get_latest_calculator_year(
+                project.unit_id
+            ),
         )
 
     async def create_plan(
@@ -318,7 +318,12 @@ class SimulatorPlanService:
         return [await self._year_read(report) for report in reports]
 
     async def set_reference_year(
-        self, plan_id: int, year: int, reference_year: Optional[int], *, is_grant: bool = False
+        self,
+        plan_id: int,
+        year: int,
+        reference_year: Optional[int],
+        *,
+        is_grant: bool = False,
     ) -> Optional[SimulatorPlanYearRead]:
         """Set or remove the baseline year of one plan-year report; None if missing.
 
@@ -718,7 +723,7 @@ class SimulatorPlanService:
         default_factor_year = await self.repo.get_latest_calculator_year(
             project.unit_id
         )
-        row = await self.repo.get_plan_by_name(project.unit_id, project.name or "")
+        row = await self.repo.get_plan_with_creator(project.id or -1)
         if row is None:
             return _to_read(project, None, default_factor_year=default_factor_year)
         refreshed, creator_name = row

--- a/backend/tests/integration/v1/test_simulator_plan_aggregate_stats.py
+++ b/backend/tests/integration/v1/test_simulator_plan_aggregate_stats.py
@@ -132,12 +132,15 @@ async def test_aggregate_stats_sums_plan_years(client, plan_workspace):
 
     assert response.status_code == 200, response.text
     payload = response.json()
+    years = payload["years"]
     # 2027 has no stats yet and contributes nothing rather than breaking the sum.
-    assert payload["total"] == 4000.0
-    assert payload["total_fte"] == 15.0
-    assert payload["buckets"]["equipment"]["total_kg"] == 4000.0
-    assert payload["buckets"]["equipment"]["by_emission_type"][EMISSION_ID] == 4000.0
-    assert payload["scope2"] == 4000.0
+    assert years["total"] == 4000.0
+    assert years["total_fte"] == 15.0
+    assert years["buckets"]["equipment"]["total_kg"] == 4000.0
+    assert years["buckets"]["equipment"]["by_emission_type"][EMISSION_ID] == 4000.0
+    assert years["scope2"] == 4000.0
+    # No Project Grant report on this plan: grant stays null, never summed in.
+    assert payload["grant"] is None
 
 
 async def test_aggregate_stats_empty_range_is_zero_shaped(client, plan_workspace):
@@ -148,9 +151,11 @@ async def test_aggregate_stats_empty_range_is_zero_shaped(client, plan_workspace
 
     assert response.status_code == 200, response.text
     payload = response.json()
-    assert payload["buckets"] == {}
-    assert payload["total"] == 0.0
-    assert payload["total_fte"] == 0.0
+    years = payload["years"]
+    assert years["buckets"] == {}
+    assert years["total"] == 0.0
+    assert years["total_fte"] == 0.0
+    assert payload["grant"] is None
 
 
 async def test_aggregate_stats_unknown_plan_is_404(client, plan_workspace):

--- a/backend/tests/unit/services/test_simulator_plan_service.py
+++ b/backend/tests/unit/services/test_simulator_plan_service.py
@@ -103,20 +103,19 @@ async def test_create_plan_explicit_name_collision_raises(async_session, user):
         await service.create_plan(unit_id=1, user=user, name="my-plan")
 
 
-# ── get_plan_by_name / list_plans ─────────────────────────────────────────────
+# ── get_plan / list_plans ─────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_get_plan_by_name(async_session, user):
+async def test_get_plan(async_session, user):
     service = SimulatorPlanService(async_session)
     created = await service.create_plan(unit_id=1, user=user, name="my-plan")
-    fetched = await service.get_plan_by_name(1, "my-plan")
+    fetched = await service.get_plan(created.id)
 
     assert fetched is not None
     assert fetched.id == created.id
     assert fetched.creator_name == "Ada Lovelace"
-    assert await service.get_plan_by_name(1, "unknown") is None
-    assert await service.get_plan_by_name(2, "my-plan") is None
+    assert await service.get_plan(9999) is None
 
 
 @pytest.mark.asyncio
@@ -144,8 +143,9 @@ async def test_rename_plan(async_session, user):
     assert renamed is not None
     assert renamed.name == "new-name"
     assert renamed.creator_name == "Ada Lovelace"
-    assert await service.get_plan_by_name(1, "old-name") is None
-    assert await service.get_plan_by_name(1, "new-name") is not None
+    refetched = await service.get_plan(created.id)
+    assert refetched is not None
+    assert refetched.name == "new-name"
 
 
 @pytest.mark.asyncio
@@ -204,7 +204,7 @@ async def test_delete_plan(async_session, user):
     created = await service.create_plan(unit_id=1, user=user, name="doomed")
 
     assert await service.delete_plan(created.id) is True
-    assert await service.get_plan_by_name(1, "doomed") is None
+    assert await service.get_plan(created.id) is None
     assert await service.delete_plan(created.id) is False
 
 

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -46,6 +46,7 @@ erDiagram
     INTEGER unit_id FK
   }
   carbon_report_modules {
+    JSON budgets
     INTEGER carbon_report_id FK
     INTEGER id PK
     BOOLEAN is_active
@@ -55,6 +56,8 @@ erDiagram
     INTEGER status "indexed"
   }
   carbon_reports {
+    FLOAT budget
+    VARCHAR budget_currency
     INTEGER carbon_project_id FK
     VARCHAR completion_progress
     INTEGER id PK

--- a/docs/src/database/erd.md
+++ b/docs/src/database/erd.md
@@ -39,6 +39,7 @@ erDiagram
     INTEGER created_by FK
     INTEGER end_year "indexed"
     INTEGER id PK
+    BOOLEAN is_grant_proposal
     BOOLEAN is_viewable_by_unit_members
     VARCHAR name "indexed"
     INTEGER start_year "indexed"
@@ -57,6 +58,7 @@ erDiagram
     INTEGER carbon_project_id FK
     VARCHAR completion_progress
     INTEGER id PK
+    BOOLEAN is_grant
     INTEGER last_updated
     INTEGER overall_status
     INTEGER reference_year

--- a/docs/src/implementation-plans/1976-grant-proposal-mode.md
+++ b/docs/src/implementation-plans/1976-grant-proposal-mode.md
@@ -3,7 +3,7 @@ status: in-progress
 issue: 1976
 last_updated: 2026-08-05
 title: "Simulator Plan — Grant proposal mode (first increment)"
-summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections with the same module list; Equipment and Research Facilities cannot be excluded from it. Custom Equipment/RF grant modules (#1980/#1981), the over-all-years column and budget tracking (#1978/#1979) and grant results (#1977) are follow-ups."
+summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections with the same module list; Equipment and Research Facilities cannot be excluded from it. Grant tables carry a kgCO₂eq-over-project-years column (#1979 first cut) and the section carries a total grant budget plus per-submodule budgets with a distribution check (#1978). Custom Equipment/RF grant modules (#1980/#1981) and grant results (#1977) are follow-ups."
 ---
 
 # Simulator Plan — Grant proposal mode (first increment)
@@ -63,14 +63,50 @@ Grant section renders **before** (not instead of) the year sections.
 - For now the grant section reuses the standard planner module list
   unchanged (same reference-year gate, same prefilled behavior).
 
+### #1979 first cut: kgCO₂eq over the project's years
+
+- In grant tables only (not year sections, not the grant-locked
+  Equipment/RF, not headcount), the kgCO₂eq column is relabeled
+  "kgCO₂eq / year" and a "kgCO₂eq over {n} years" column follows it —
+  same `kg_co2eq` field multiplied by the plan's year count in
+  `ModuleTable` (presentation only, no stored derived value). The
+  Purchases grid shows the same pair inline per row (in tCO₂eq).
+- `projectYearsCount` (end − start + 1) flows
+  page → PlannerYearSection → ModuleTableSection → SubModuleSection →
+  ModuleTable.
+- Width: grant tables wrap their header cells
+  (`co2-table--wrap-headers`) and narrow the % slider to 150px, so every
+  module fits without horizontal scroll except Buildings' Rooms table
+  (14 columns, ~1509px intrinsic width — it already overflowed narrow
+  viewports before this change; revisit with the module redesign).
+
+### #1978: grant budget with distribution check
+
+- `carbon_reports.budget` + `budget_currency` (grant total) and
+  `carbon_report_modules.budgets` (JSON, keyed by submodule id) — migration
+  `9539986fa17b`.
+- `PATCH /carbon-reports/{id}/budget` (`{budget, budget_currency}`) and
+  `PATCH /carbon-reports/{id}/modules/{module_type_id}/budget`
+  (`{submodule, budget}`; null clears the entry). Both 409 on non-grant
+  reports and enforce plan-edit scope. Like purchase entries, the currency
+  code is not validated server-side; the select constrains it.
+- UI: a Grant budget section right after the reference year — total input
+  plus a currency select (the purchase module's currency set, extracted to
+  `constant/currencies.ts` and shared) and the check line
+  "X of Y distributed, Z remaining", red when the distributed budgets
+  exceed the total. Each submodule table carries a "Budget"-titled block:
+  a "{submodule} budget" field (chosen currency as suffix) and a one-line
+  hint, separated from the table. Single-grid Headcount and Purchases
+  carry one field each, keyed by module name. The wording never says
+  "submodule" and only shows the currency the user picked.
+
 ## Deferred to follow-up issues
 
 - **#1977 Results**: grant results in the chart/aggregates and the PDF
   export (grant is currently excluded from all three).
-- **#1978 Budget**: per-module budget entry + non-distributed budget
-  counter.
-- **#1979 Modules**: the "over all project years" multiplied column in every
-  grant module table; headcount not prefilled in grant mode.
+- **#1979 remainder**: the over-project-years column for Equipment and RF
+  once their custom grant modules land (planner headcount is already
+  manual, so the "not prefilled" requirement holds by construction).
 - **#1980 RF / #1981 Equipment**: the custom grant-mode modules (manual
   per-row percentages, global percentage toggle, platform selection). Until
   then both render the standard planner tables but cannot be excluded.

--- a/docs/src/implementation-plans/1976-grant-proposal-mode.md
+++ b/docs/src/implementation-plans/1976-grant-proposal-mode.md
@@ -1,0 +1,78 @@
+---
+status: in-progress
+issue: 1976
+last_updated: 2026-08-05
+title: "Simulator Plan — Grant proposal mode (first increment)"
+summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections with the same module list; Equipment and Research Facilities cannot be excluded from it. Custom Equipment/RF grant modules (#1980/#1981), the over-all-years column and budget tracking (#1978/#1979) and grant results (#1977) are follow-ups."
+---
+
+# Simulator Plan — Grant proposal mode (first increment)
+
+Umbrella issue [#1976](https://github.com/EPFL-ENAC/co2-calculator/issues/1976).
+This plan delivers the structural first cut and settles the open design
+question from the issue: the Grant proposal checkbox lives in the Project
+information panel **in addition to** the year selection, and the Project
+Grant section renders **before** (not instead of) the year sections.
+
+## Shipped in this increment
+
+### Data model
+
+- `carbon_projects.is_grant_proposal` (bool, default false): the plan-level
+  checkbox state.
+- `carbon_reports.is_grant` (bool, default false): marks the plan's single
+  Project Grant report. It is anchored to the plan's **start year** (grant
+  entries resolve factors from the reference year, not the report year, so
+  the anchor is only an ordering/identity anchor).
+- `uq_carbon_reports_project_year` widened to
+  `(carbon_project_id, year, is_grant)` — the grant report shares its year
+  with the start-year report. Migration `3d74009feee4`.
+
+### Backend behavior
+
+- `SimulatorPlanService._sync_year_reports` also syncs the grant report:
+  created when `is_grant_proposal` and the year range are set, its year
+  follows `start_year` (keeping its entries), and it is **deleted with its
+  entries** when the checkbox is unchecked (destructive by design, like
+  shrinking the year range).
+- `PATCH /project-plans/{id}/years/{year}` takes `is_grant` in the body to
+  disambiguate the grant report from the start-year report.
+- `GET /project-plans/{id}/years` returns the grant report first
+  (`is_grant` on the DTO); the frontend renders sections in list order.
+- Grant stats are **excluded** from `/aggregate-stats`, the home-table plan
+  totals (`list_report_stats_by_project`) and the print report until #1977
+  settles how grant results combine with per-year results — summing both
+  would count the project twice.
+- `PATCH /carbon-reports/{id}/modules/{module_type_id}/active` rejects (409)
+  deactivating Equipment or Research Facilities on a grant report
+  (`GRANT_LOCKED_MODULE_TYPES`): a grant proposal is first and foremost
+  about the equipment and research facilities it funds.
+
+### Frontend
+
+- `PlannerProjectInfo`: Grant proposal section (checkbox + hint) between the
+  Project name and the Year selection; the generate button moved to the
+  bottom of the panel, full-width and one size up, relabeled "Create project
+  sections" since it now syncs the grant section too. Dirty tracking covers
+  the checkbox; the PATCH carries `is_grant_proposal`.
+- `PlannerYearSection` handles both section kinds: grant sections title
+  "Project Grant" instead of the year, use a `grant-` expansion-key prefix
+  (the year prefix would collide with the start-year section), pass
+  `is_grant` on reference-year updates, and disable the Active checkbox for
+  Equipment and Research Facilities with a dedicated tooltip.
+- For now the grant section reuses the standard planner module list
+  unchanged (same reference-year gate, same prefilled behavior).
+
+## Deferred to follow-up issues
+
+- **#1977 Results**: grant results in the chart/aggregates and the PDF
+  export (grant is currently excluded from all three).
+- **#1978 Budget**: per-module budget entry + non-distributed budget
+  counter.
+- **#1979 Modules**: the "over all project years" multiplied column in every
+  grant module table; headcount not prefilled in grant mode.
+- **#1980 RF / #1981 Equipment**: the custom grant-mode modules (manual
+  per-row percentages, global percentage toggle, platform selection). Until
+  then both render the standard planner tables but cannot be excluded.
+- Cosmetic: the reference-year dialog wording says "Planned year {year}"
+  for the grant section (it shows the start year).

--- a/docs/src/implementation-plans/1976-grant-proposal-mode.md
+++ b/docs/src/implementation-plans/1976-grant-proposal-mode.md
@@ -39,10 +39,11 @@ Grant section renders **before** (not instead of) the year sections.
   disambiguate the grant report from the start-year report.
 - `GET /project-plans/{id}/years` returns the grant report first
   (`is_grant` on the DTO); the frontend renders sections in list order.
-- Grant stats are **excluded** from `/aggregate-stats`, the home-table plan
-  totals (`list_report_stats_by_project`) and the print report until #1977
-  settles how grant results combine with per-year results — summing both
-  would count the project twice.
+- `/aggregate-stats` returns `{years, grant}`: the year aggregate and the
+  Project Grant report's own stats, charted side by side and never summed
+  together — summing both would count the project twice (#1977). The
+  home-table plan totals (`list_report_stats_by_project`) stay years-only
+  for the same reason.
 - `PATCH /carbon-reports/{id}/modules/{module_type_id}/active` rejects (409)
   deactivating Equipment on a grant report (`GRANT_LOCKED_MODULE_TYPES`): a
   grant proposal is first and foremost about the equipment it funds.
@@ -130,10 +131,21 @@ Grant section renders **before** (not instead of) the year sections.
   formula requires an exact `use_unit` match — deferred with #1980's
   remaining design.
 
+### #1977: grant results (first cut)
+
+- On grant proposals the planner results card shows one grouped chart
+  (`PlannerGrantComparisonChart`): two bars per category — Project Grant
+  vs year by year, legend-labeled, colorblind-aware palette. Its CSV
+  button downloads one file per view; the headline row shows both totals
+  side by side, split by a vertical separator. Non-grant plans keep the
+  single chart and total.
+- The PDF gains a "Project Grant" summary page right after the cover
+  (reference year, grant total, breakdown chart) — `PlannerPrintYearPage`
+  reused with a name title instead of the anchor year. Grant module
+  detail pages in the PDF remain open.
+
 ## Deferred to follow-up issues
 
-- **#1977 Results**: grant results in the chart/aggregates and the PDF
-  export (grant is currently excluded from all three).
 - **#1979 remainder**: the over-project-years column for Equipment once its
   custom grant module lands (planner headcount is already manual, so the
   "not prefilled" requirement holds by construction; the RF grid shows the

--- a/docs/src/implementation-plans/1976-grant-proposal-mode.md
+++ b/docs/src/implementation-plans/1976-grant-proposal-mode.md
@@ -3,7 +3,7 @@ status: in-progress
 issue: 1976
 last_updated: 2026-08-05
 title: "Simulator Plan — Grant proposal mode (first increment)"
-summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections; Equipment cannot be excluded from it. Grant tables carry a kgCO₂eq-over-project-years column (#1979 first cut), the section carries a total grant budget plus per-submodule budgets with a distribution check (#1978), and Research Facilities render a custom platform-selection grid (#1980). The custom Equipment module (#1981) and grant results (#1977) are follow-ups."
+summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections. Grant tables carry a kgCO₂eq-over-project-years column (#1979), the section carries a total grant budget with currency plus per-submodule budgets and a distribution check (#1978), Research Facilities render a platform-selection grid (#1980), Equipment gets a per-line vs global-percentage planning toggle (#1981), and results show a grant vs year-by-year comparison chart plus a grant page in the PDF (#1977)."
 ---
 
 # Simulator Plan — Grant proposal mode (first increment)
@@ -44,11 +44,10 @@ Grant section renders **before** (not instead of) the year sections.
   together — summing both would count the project twice (#1977). The
   home-table plan totals (`list_report_stats_by_project`) stay years-only
   for the same reason.
-- `PATCH /carbon-reports/{id}/modules/{module_type_id}/active` rejects (409)
-  deactivating Equipment on a grant report (`GRANT_LOCKED_MODULE_TYPES`): a
-  grant proposal is first and foremost about the equipment it funds.
-  Research Facilities left the locked set once their opt-in platform grid
-  shipped (#1980) — an unselected platform list already means "not used".
+- Every grant module's Active checkbox is toggleable. An earlier iteration
+  locked Equipment/RF on (`GRANT_LOCKED_MODULE_TYPES`); the lock was removed
+  once both modules got their own grant-mode UIs (#1980/#1981) — the
+  machinery was deleted, not kept dormant.
 
 ### Frontend
 
@@ -59,16 +58,15 @@ Grant section renders **before** (not instead of) the year sections.
   the checkbox; the PATCH carries `is_grant_proposal`.
 - `PlannerYearSection` handles both section kinds: grant sections title
   "Project Grant" instead of the year, use a `grant-` expansion-key prefix
-  (the year prefix would collide with the start-year section), pass
-  `is_grant` on reference-year updates, and disable the Active checkbox for
-  Equipment and Research Facilities with a dedicated tooltip.
-- For now the grant section reuses the standard planner module list
-  unchanged (same reference-year gate, same prefilled behavior).
+  (the year prefix would collide with the start-year section), and pass
+  `is_grant` on reference-year updates.
+- The grant section reuses the standard planner module list (same
+  reference-year gate) except where #1980/#1981 swap in custom UIs below.
 
 ### #1979 first cut: kgCO₂eq over the project's years
 
-- In grant tables only (not year sections, not the grant-locked
-  Equipment, not headcount), the kgCO₂eq column is relabeled
+- In grant tables only (not year sections, not headcount), the kgCO₂eq
+  column is relabeled
   "kgCO₂eq / year" and a "kgCO₂eq over {n} years" column follows it —
   same `kg_co2eq` field multiplied by the plan's year count in
   `ModuleTable` (presentation only, no stored derived value). The
@@ -144,14 +142,29 @@ Grant section renders **before** (not instead of) the year sections.
   reused with a name title instead of the anchor year. Grant module
   detail pages in the PDF remain open.
 
+### #1981: grant-mode Equipment module
+
+- In the Project Grant section only, Equipment carries a "Planning mode"
+  toggle: **Manual entry per line** (each prefilled line has its own
+  reference-year percentage — grant prefill starts at 0% instead of the
+  planner's usual 100%) vs **Global percentage** (one value applied to all
+  prefilled lines at once). Adding an equipment through the usual form
+  stays available in both modes; hand-added lines are untouched by the
+  global value.
+- Global mode: `PATCH
+/carbon-reports/{id}/modules/{module_type_id}/reference-percentage`
+  (`{percentage: 0..100}`, grant reports only) updates every snapshot
+  entry (`source_data_entry_id` set), recomputes their emissions and the
+  stats; the table remounts to refetch its rows. Per-row % controls are
+  read-only in global mode (`percentageLocked` prop chain).
+- Budgets follow the mode: per-submodule budget fields in per-line mode,
+  one module-level budget (key `equipment`) in global mode. Values saved
+  in one mode keep counting in the distribution check when the other mode
+  is shown.
+
 ## Deferred to follow-up issues
 
-- **#1979 remainder**: the over-project-years column for Equipment once its
-  custom grant module lands (planner headcount is already manual, so the
-  "not prefilled" requirement holds by construction; the RF grid shows the
-  over-project values inline).
-- **#1981 Equipment**: the custom grant-mode equipment module (manual
-  per-row percentages, global percentage toggle, add via dropdown). Until
-  then it renders the standard planner table but cannot be excluded.
+- Grant module detail pages in the PDF (#1977 remainder): the grant is
+  still a summary page only.
 - Cosmetic: the reference-year dialog wording says "Planned year {year}"
   for the grant section (it shows the start year).

--- a/docs/src/implementation-plans/1976-grant-proposal-mode.md
+++ b/docs/src/implementation-plans/1976-grant-proposal-mode.md
@@ -3,7 +3,7 @@ status: in-progress
 issue: 1976
 last_updated: 2026-08-05
 title: "Simulator Plan — Grant proposal mode (first increment)"
-summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections with the same module list; Equipment and Research Facilities cannot be excluded from it. Grant tables carry a kgCO₂eq-over-project-years column (#1979 first cut) and the section carries a total grant budget plus per-submodule budgets with a distribution check (#1978). Custom Equipment/RF grant modules (#1980/#1981) and grant results (#1977) are follow-ups."
+summary: "Plans gain a persisted Grant proposal checkbox and, when checked, a Project Grant section (a dedicated grant carbon report) rendered before the year sections; Equipment cannot be excluded from it. Grant tables carry a kgCO₂eq-over-project-years column (#1979 first cut), the section carries a total grant budget plus per-submodule budgets with a distribution check (#1978), and Research Facilities render a custom platform-selection grid (#1980). The custom Equipment module (#1981) and grant results (#1977) are follow-ups."
 ---
 
 # Simulator Plan — Grant proposal mode (first increment)
@@ -44,9 +44,10 @@ Grant section renders **before** (not instead of) the year sections.
   settles how grant results combine with per-year results — summing both
   would count the project twice.
 - `PATCH /carbon-reports/{id}/modules/{module_type_id}/active` rejects (409)
-  deactivating Equipment or Research Facilities on a grant report
-  (`GRANT_LOCKED_MODULE_TYPES`): a grant proposal is first and foremost
-  about the equipment and research facilities it funds.
+  deactivating Equipment on a grant report (`GRANT_LOCKED_MODULE_TYPES`): a
+  grant proposal is first and foremost about the equipment it funds.
+  Research Facilities left the locked set once their opt-in platform grid
+  shipped (#1980) — an unselected platform list already means "not used".
 
 ### Frontend
 
@@ -66,7 +67,7 @@ Grant section renders **before** (not instead of) the year sections.
 ### #1979 first cut: kgCO₂eq over the project's years
 
 - In grant tables only (not year sections, not the grant-locked
-  Equipment/RF, not headcount), the kgCO₂eq column is relabeled
+  Equipment, not headcount), the kgCO₂eq column is relabeled
   "kgCO₂eq / year" and a "kgCO₂eq over {n} years" column follows it —
   same `kg_co2eq` field multiplied by the plan's year count in
   `ModuleTable` (presentation only, no stored derived value). The
@@ -100,15 +101,45 @@ Grant section renders **before** (not instead of) the year sections.
   carry one field each, keyed by module name. The wording never says
   "submodule" and only shows the currency the user picked.
 
+### #1980: grant-mode Research Facilities module
+
+- In the Project Grant section only (year sections keep the standard
+  prefilled table), RF renders `PlannerResearchFacilityRows`: an
+  "Add a platform" searchable dropdown offering the **current workspace
+  year's** whole platform list — common facilities and animal facilities
+  (labeled with their rodent/fish type) — sourced from the new
+  `GET /factors/{data_entry_type}/list?year=` endpoint. (Product decision
+  overriding the issue's reference-year note. Emission computation still
+  resolves the grant's reference-year factors — the plan-wide invariant —
+  so a platform missing from the reference year shows no kg; the two years
+  coincide in normal use.)
+- Picking a platform adds its row: planned use entered in the platform's
+  own metric (the factor's `use_unit` — budget/hours/CPU/housing; shown as
+  the field suffix), kgCO₂eq per year and over the project's years computed
+  by the existing RF share formula against the **reference year's factors**.
+  Rows persist as ordinary `research_facilities` / `animal_facilities`
+  entries on the grant report through the generic submodule routes; the
+  delete button removes the entry.
+- A group (research facilities / animal facilities) only renders — title,
+  budget field and rows — once it holds at least one platform.
+- Grant reports skip the RF snapshot-prefill on reference-year changes
+  (entries are still cleared so baselines never mix); year reports keep
+  prefilling.
+- The metric is fixed by the platform's factor: offering a free metric
+  choice would need multi-unit factors (backoffice change) since the
+  formula requires an exact `use_unit` match — deferred with #1980's
+  remaining design.
+
 ## Deferred to follow-up issues
 
 - **#1977 Results**: grant results in the chart/aggregates and the PDF
   export (grant is currently excluded from all three).
-- **#1979 remainder**: the over-project-years column for Equipment and RF
-  once their custom grant modules land (planner headcount is already
-  manual, so the "not prefilled" requirement holds by construction).
-- **#1980 RF / #1981 Equipment**: the custom grant-mode modules (manual
-  per-row percentages, global percentage toggle, platform selection). Until
-  then both render the standard planner tables but cannot be excluded.
+- **#1979 remainder**: the over-project-years column for Equipment once its
+  custom grant module lands (planner headcount is already manual, so the
+  "not prefilled" requirement holds by construction; the RF grid shows the
+  over-project values inline).
+- **#1981 Equipment**: the custom grant-mode equipment module (manual
+  per-row percentages, global percentage toggle, add via dropdown). Until
+  then it renders the standard planner table but cannot be excluded.
 - Cosmetic: the reference-year dialog wording says "Planned year {year}"
   for the grant section (it shows the start year).

--- a/frontend/src/components/charts/results/PlannerGrantComparisonChart.vue
+++ b/frontend/src/components/charts/results/PlannerGrantComparisonChart.vue
@@ -1,0 +1,371 @@
+<template>
+  <div class="q-pa-lg">
+    <div class="row items-center justify-between q-mb-md">
+      <div class="text-h5 text-weight-medium">{{ title }}</div>
+      <q-checkbox
+        v-model="showAdditional"
+        :label="$t('results_module_carbon_toggle_additional_data')"
+        size="sm"
+        dense
+      />
+    </div>
+    <v-chart
+      ref="chartRef"
+      class="planner-grant-comparison-chart"
+      :option="chartOption"
+      autoresize
+    />
+    <div class="row q-gutter-sm q-mt-sm">
+      <q-btn
+        outline
+        no-caps
+        size="sm"
+        icon="o_download"
+        :label="$t('common_download_as_png')"
+        @click="downloadPNG"
+      />
+      <q-btn
+        outline
+        no-caps
+        size="sm"
+        icon="o_download"
+        :label="$t('common_download_as_csv')"
+        @click="downloadCSV"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { BarChart } from 'echarts/charts';
+import {
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import type { EChartsOption, SeriesOption } from 'echarts';
+import VChart from 'vue-echarts';
+import { getCssVar } from 'quasar';
+import { useI18n } from 'vue-i18n';
+
+import {
+  CHART_CATEGORY_COLOR_SCALES,
+  RESULTS_CATEGORY_LABEL_KEYS,
+} from 'src/constant/charts';
+import type { EmissionBreakdownResponse } from 'src/stores/modules';
+import { downloadEchartAsPng } from 'src/utils/chartDownload';
+
+/**
+ * Project Grant vs year-by-year results, two bars per category (#1977).
+ * The two views count the same project, so they sit side by side and are
+ * never summed together. Each bar keeps the Results chart's look: the
+ * category's color, cut into subcategory segments by shade; the
+ * year-by-year bars carry a hatch decal to tell the pair apart.
+ */
+
+type CategoryRow = Record<string, unknown> & {
+  category?: unknown;
+  category_key?: unknown;
+  parent_keys_order?: string[];
+};
+
+const props = defineProps<{
+  title: string;
+  grantBreakdown: EmissionBreakdownResponse | null;
+  yearsBreakdown: EmissionBreakdownResponse | null;
+}>();
+
+use([
+  CanvasRenderer,
+  BarChart,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+]);
+
+const { t } = useI18n();
+
+const showAdditional = ref(false);
+
+// The Results charts' categories, in their shared order.
+const MAIN_CATEGORY_KEYS = [
+  'process_emissions',
+  'buildings_energy_combustion',
+  'buildings_room',
+  'equipment',
+  'external_cloud_and_ai',
+  'professional_travel',
+  'purchases',
+  'research_facilities',
+] as const;
+const ADDITIONAL_CATEGORY_KEYS = [
+  'commuting',
+  'food',
+  'waste',
+  'embodied_energy',
+] as const;
+
+const categoryKeys = computed<string[]>(() =>
+  showAdditional.value
+    ? [...MAIN_CATEGORY_KEYS, ...ADDITIONAL_CATEGORY_KEYS]
+    : [...MAIN_CATEGORY_KEYS],
+);
+
+function rowOf(
+  breakdown: EmissionBreakdownResponse | null,
+  key: string,
+): CategoryRow | undefined {
+  if (!breakdown) return undefined;
+  const rows = [
+    ...breakdown.module_breakdown,
+    ...breakdown.additional_breakdown,
+  ] as CategoryRow[];
+  return rows.find((row) => String(row.category_key ?? row.category) === key);
+}
+
+/** Segment keys of a category, ordered, across both views. */
+function segmentsOf(
+  grant: CategoryRow | undefined,
+  years: CategoryRow | undefined,
+) {
+  const segments: string[] = [];
+  for (const key of [
+    ...(grant?.parent_keys_order ?? []),
+    ...(years?.parent_keys_order ?? []),
+  ]) {
+    if (!segments.includes(key)) segments.push(key);
+  }
+  return segments;
+}
+
+function segmentValue(row: CategoryRow | undefined, segment: string): number {
+  const value = Number(row?.[segment] ?? 0);
+  return Number.isFinite(value) ? value : 0;
+}
+
+const SHADE_ORDER = ['darker', 'dark', 'default', 'light', 'lighter'] as const;
+
+// Segment key → i18n key, mirroring the subcategory names of
+// ModuleCarbonFootprintChart so the two Results tooltips read alike.
+const SEGMENT_LABEL_KEYS: Record<string, string> = {
+  co2: 'process-emissions.category.co2',
+  ch4: 'process-emissions.category.ch4',
+  n2o: 'process-emissions.category.n2o',
+  refrigerants: 'process-emissions.category.refrigerants',
+  combustion: 'charts-energy-combustion-subcategory',
+  heating_thermal: 'charts-heating-thermal-subcategory',
+  heating_electric: 'charts-heating-elec-subcategory',
+  cooling: 'charts-cooling-subcategory',
+  ventilation: 'charts-ventilation-subcategory',
+  lighting: 'charts-lighting-subcategory',
+  scientific: 'charts-scientific-subcategory',
+  it: 'charts-equipment-it',
+  other: 'charts-other-equipment-subcategory',
+  scientific_equipment: 'charts-scientific-subcategory',
+  it_equipment: 'charts-equipment-it',
+  consumable_accessories: 'charts-consumables-subcategory',
+  biological_chemical_gaseous: 'charts-bio-chemicals-subcategory',
+  services: 'charts-services-subcategory',
+  vehicles: 'charts-vehicles-subcategory',
+  other_purchases: 'charts-other-purchases-subcategory',
+  centralized: 'charts-purchases-centralized-subcategory',
+  goods_and_services: 'charts-global-budget-subcategory',
+  clouds: 'charts-clouds-subcategory',
+  ai: 'charts-ai-subcategory',
+  plane: 'charts-plane-subcategory',
+  train: 'charts-train-subcategory',
+  facilities: 'charts-research-facilities-subcategory',
+  it_facilities: 'charts-research-it-facilities-subcategory',
+  animal: 'charts-research-animal-subcategory',
+};
+
+// Same fallback convention as the main chart: an unmapped key shows raw.
+function segmentLabel(segment: string): string {
+  const key = SEGMENT_LABEL_KEYS[segment];
+  return key ? t(key) : segment;
+}
+
+const YEARS_DECAL = {
+  symbol: 'line',
+  rotation: Math.PI / 4,
+  dashArrayX: [1, 0],
+  dashArrayY: [4, 3],
+  color: 'rgba(255, 255, 255, 0.7)',
+};
+
+const grantLabel = computed(() => t('planner_project_grant_title'));
+const yearsLabel = computed(() => t('planner_results_series_years'));
+
+function totalsOf(view: 'grant' | 'years'): number[] {
+  const breakdown =
+    view === 'grant' ? props.grantBreakdown : props.yearsBreakdown;
+  return categoryKeys.value.map((key) => {
+    const row = rowOf(breakdown, key);
+    return (row?.parent_keys_order ?? []).reduce(
+      (sum, segment) => sum + segmentValue(row, segment),
+      0,
+    );
+  });
+}
+
+const chartOption = computed<EChartsOption>(() => {
+  const infoColor = getCssVar('info') ?? undefined;
+  const series: SeriesOption[] = [];
+
+  categoryKeys.value.forEach((catKey, catIdx) => {
+    const scale = CHART_CATEGORY_COLOR_SCALES.value[catKey];
+    const grantRow = rowOf(props.grantBreakdown, catKey);
+    const yearsRow = rowOf(props.yearsBreakdown, catKey);
+
+    segmentsOf(grantRow, yearsRow).forEach((segment, segIdx) => {
+      const color = scale[SHADE_ORDER[segIdx % SHADE_ORDER.length]];
+      const dataFor = (row: CategoryRow | undefined) =>
+        categoryKeys.value.map((_, idx) =>
+          idx === catIdx ? segmentValue(row, segment) : 0,
+        );
+      series.push({
+        // All grant segments share one name so the legend shows a single
+        // toggleable entry per view.
+        name: grantLabel.value,
+        id: `grant:${catKey}:${segment}`,
+        type: 'bar',
+        stack: 'grant',
+        itemStyle: { color },
+        data: dataFor(grantRow),
+      });
+      series.push({
+        name: yearsLabel.value,
+        id: `years:${catKey}:${segment}`,
+        type: 'bar',
+        stack: 'years',
+        itemStyle: { color, decal: YEARS_DECAL },
+        data: dataFor(yearsRow),
+      });
+    });
+  });
+
+  return {
+    legend: {
+      top: 0,
+      data: [
+        { name: grantLabel.value, itemStyle: { color: infoColor } },
+        {
+          name: yearsLabel.value,
+          itemStyle: { color: infoColor, decal: YEARS_DECAL },
+        },
+      ],
+    },
+    grid: { left: 56, right: 16, top: 48, bottom: 80 },
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params) => {
+        type Param = {
+          name?: string;
+          seriesId?: string;
+          marker?: string;
+          value?: unknown;
+        };
+        const list = (Array.isArray(params) ? params : [params]) as Param[];
+        const first = list[0];
+        const DIVIDER = '1px solid rgba(128,128,128,0.3)';
+        const row = (left: string, right: string, indent = false) =>
+          `<div style="display:flex;justify-content:space-between;` +
+          `align-items:baseline;gap:32px;line-height:1.9;` +
+          `${indent ? 'padding-left:16px;' : ''}">` +
+          `<span>${left}</span>` +
+          `<span style="font-variant-numeric:tabular-nums">${right}</span></div>`;
+        // One block per bar: its total, then its subcategory cuts.
+        const section = (label: string, prefix: string) => {
+          const items = list.filter(
+            (p) =>
+              String(p.seriesId ?? '').startsWith(prefix) &&
+              Number(p.value ?? 0) > 0,
+          );
+          const total = items.reduce((sum, p) => sum + Number(p.value), 0);
+          return (
+            `<div style="margin-top:10px">` +
+            row(`<b>${label}</b>`, `<b>${total.toFixed(2)} t</b>`) +
+            items
+              .map((p) => {
+                const segment = String(p.seriesId ?? '').split(':')[2] ?? '';
+                return row(
+                  `${p.marker ?? ''} ${segmentLabel(segment)}`,
+                  `${Number(p.value).toFixed(2)} t`,
+                  true,
+                );
+              })
+              .join('') +
+            `</div>`
+          );
+        };
+        return (
+          `<div style="min-width:240px">` +
+          `<div style="font-weight:600;border-bottom:${DIVIDER};` +
+          `padding-bottom:6px">` +
+          `${first?.name ?? ''} <span style="font-weight:400;opacity:0.7">(t CO₂-eq)</span></div>` +
+          section(grantLabel.value, 'grant:') +
+          section(yearsLabel.value, 'years:') +
+          `</div>`
+        );
+      },
+    },
+    xAxis: {
+      type: 'category',
+      data: categoryKeys.value.map((key) =>
+        t(RESULTS_CATEGORY_LABEL_KEYS[key]),
+      ),
+      axisLabel: { rotate: 45, fontSize: 11 },
+    },
+    yAxis: {
+      type: 'value',
+      name: 't CO₂-eq',
+      nameLocation: 'middle',
+      nameGap: 44,
+    },
+    series,
+  };
+});
+
+const chartRef = ref<InstanceType<typeof VChart>>();
+
+const downloadPNG = () =>
+  downloadEchartAsPng(chartRef.value?.chart, 'planner-grant-comparison');
+
+/** One CSV per view — a grant file and a year-by-year file. */
+const downloadCSV = () => {
+  const escape = (v: unknown) => {
+    const s = String(v ?? '');
+    return /[,"\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const files: { name: string; view: 'grant' | 'years' }[] = [
+    { name: `project-grant-${stamp}.csv`, view: 'grant' },
+    { name: `year-by-year-${stamp}.csv`, view: 'years' },
+  ];
+  const labels = categoryKeys.value.map((key) =>
+    t(RESULTS_CATEGORY_LABEL_KEYS[key]),
+  );
+  for (const file of files) {
+    const totals = totalsOf(file.view);
+    const csv = [
+      [t('csv_header_category'), t('csv_header_co2')].map(escape).join(','),
+      ...labels.map((label, idx) => [label, totals[idx]].map(escape).join(',')),
+    ].join('\n');
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
+    a.download = file.name;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.planner-grant-comparison-chart {
+  width: 100%;
+  height: 420px;
+}
+</style>

--- a/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
+++ b/frontend/src/components/organisms/home/CO2ProjectPlanner.vue
@@ -81,7 +81,7 @@ async function onStartProject() {
     const plan = await plansStore.createPlan(unitId.value);
     await router.push({
       name: 'project-planner',
-      params: { ...route.params, name: plan.name },
+      params: { ...route.params, planId: plan.id },
     });
   } finally {
     creating.value = false;
@@ -96,7 +96,7 @@ async function onDuplicate(row: SimulatorPlan) {
 function onEdit(row: SimulatorPlan) {
   void router.push({
     name: 'project-planner',
-    params: { ...route.params, name: row.name },
+    params: { ...route.params, planId: row.id },
   });
 }
 

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -75,6 +75,7 @@
   <q-table
     v-model:pagination="moduleStore.state.paginationSubmodule[submoduleType]"
     class="co2-table border"
+    :class="{ 'co2-table--wrap-headers': projectYearsCount != null }"
     :style="tableStyle"
     :columns="qCols"
     :rows="moduleStore.state.dataSubmodule[submoduleType]?.items || []"
@@ -1171,7 +1172,9 @@ const qCols = computed<TableViewColumn[]>(() => {
       inputComponent: QInput,
       editableInline: false,
       type: 'number',
-      minColumnWidth: 180,
+      // Grant tables carry an extra kg column, so the slider cedes a little
+      // room to keep the table inside the viewport.
+      minColumnWidth: props.projectYearsCount != null ? 150 : 180,
     };
     if (kgIdx >= 0) {
       baseCols.splice(kgIdx, 0, referenceCol);
@@ -2262,6 +2265,12 @@ onUnmounted(() => {
 
   th {
     font-size: tokens.$text-size-sm;
+  }
+
+  /* Grant tables carry two extra kg columns; letting the headers wrap keeps
+     every column at its content width instead of its longest header line. */
+  &--wrap-headers th {
+    white-space: normal;
   }
 
   thead tr th {

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -281,7 +281,7 @@
                 :min="REFERENCE_PERCENTAGE_MIN"
                 :max="REFERENCE_PERCENTAGE_MAX"
                 :step="5"
-                :disable="isDisabled"
+                :disable="isDisabled || percentageLocked"
                 color="negative"
                 class="col"
                 @update:model-value="
@@ -298,7 +298,7 @@
                   type="number"
                   :min="REFERENCE_PERCENTAGE_MIN"
                   :max="REFERENCE_PERCENTAGE_MAX"
-                  :disable="isDisabled"
+                  :disable="isDisabled || percentageLocked"
                   :aria-label="$t('planner_percentage_col')"
                   :style="percentageFieldWidth(slotProps.row)"
                   dense
@@ -865,6 +865,11 @@ type CommonProps = {
    * it (#1979). Null everywhere else.
    */
   projectYearsCount?: number | null;
+  /**
+   * Grant equipment "global percentage" mode: the per-row % controls are
+   * driven by the module-level value and stay read-only (#1981).
+   */
+  percentageLocked?: boolean;
   threshold: Threshold;
   hasTopBar?: boolean;
   moduleConfig: ModuleConfig;
@@ -884,6 +889,7 @@ const props = withDefaults(defineProps<ModuleTableProps>(), {
   factorYear: undefined,
   showReferenceColumns: false,
   projectYearsCount: null,
+  percentageLocked: false,
   moduleColor: undefined,
   moduleColorLighter: undefined,
 });

--- a/frontend/src/components/organisms/module/ModuleTable.vue
+++ b/frontend/src/components/organisms/module/ModuleTable.vue
@@ -858,6 +858,12 @@ type CommonProps = {
    * Calculator and non-prefilled planner modules.
    */
   showReferenceColumns?: boolean;
+  /**
+   * Planner Project Grant context: the plan's year count. When set, the
+   * kgCO₂eq column reads per-year and gains a "× project years" column after
+   * it (#1979). Null everywhere else.
+   */
+  projectYearsCount?: number | null;
   threshold: Threshold;
   hasTopBar?: boolean;
   moduleConfig: ModuleConfig;
@@ -876,6 +882,7 @@ const props = withDefaults(defineProps<ModuleTableProps>(), {
   carbonReportId: undefined,
   factorYear: undefined,
   showReferenceColumns: false,
+  projectYearsCount: null,
   moduleColor: undefined,
   moduleColorLighter: undefined,
 });
@@ -1174,6 +1181,34 @@ const qCols = computed<TableViewColumn[]>(() => {
     }
   }
 
+  // Project Grant tables: the kgCO₂eq column reads per-year and a "× project
+  // years" column follows it, so a value and its project total sit side by
+  // side (#1979). Same kg_co2eq field — the multiply is presentation only.
+  if (props.projectYearsCount != null) {
+    const kgIdx = baseCols.findIndex((c) => c.name === 'kg_co2eq');
+    if (kgIdx >= 0) {
+      baseCols[kgIdx] = {
+        ...baseCols[kgIdx],
+        label: $t('planner_kg_per_year_col'),
+        minColumnWidth: undefined,
+        columnSize: 'xs',
+      };
+      baseCols.splice(kgIdx + 1, 0, {
+        name: 'project_kg_co2eq',
+        label: $t('planner_kg_project_col', {
+          years: props.projectYearsCount,
+        }),
+        field: 'kg_co2eq',
+        sortable: true,
+        align: 'right',
+        inputComponent: QInput,
+        editableInline: false,
+        type: 'number',
+        columnSize: 'xs',
+      });
+    }
+  }
+
   if (showTableActions.value) {
     baseCols.push({
       name: 'action',
@@ -1282,6 +1317,14 @@ function renderCell(
   }
   const val = row[col.field];
   if (val === undefined || val === null || val === '') return '-';
+  if (col.name === 'project_kg_co2eq') {
+    return nOrDash((val as number) * (props.projectYearsCount ?? 1), {
+      options: {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      },
+    });
+  }
   if (
     col.name === 'kg_co2eq' ||
     col.name === 't_co2eq' ||

--- a/frontend/src/components/organisms/module/ModuleTableSection.vue
+++ b/frontend/src/components/organisms/module/ModuleTableSection.vue
@@ -16,6 +16,7 @@
           :factor-year="factorYear"
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
+          :project-years-count="projectYearsCount"
           :threshold="currentModuleConfig.threshold || defaultThreshold"
         />
       </template>
@@ -53,6 +54,8 @@ const props = defineProps<{
   carbonReportId?: number;
   /** Planner prefilled: show the reference-kg column + % slider. */
   showReferenceColumns?: boolean;
+  /** Planner Project Grant: plan year count for the "× project years" column. */
+  projectYearsCount?: number | null;
   /**
    * Replaces the Calculator MODULES_CONFIG entry — the Simulator Plan
    * renders planner-specific submodules (see constant/planner-module-config).

--- a/frontend/src/components/organisms/module/ModuleTableSection.vue
+++ b/frontend/src/components/organisms/module/ModuleTableSection.vue
@@ -17,6 +17,9 @@
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
           :project-years-count="projectYearsCount"
+          :show-grant-budget="showGrantBudgets"
+          :grant-budget="grantBudgets?.[sub.id] ?? null"
+          :grant-budget-currency="grantBudgetCurrency"
           :threshold="currentModuleConfig.threshold || defaultThreshold"
         />
       </template>
@@ -56,6 +59,12 @@ const props = defineProps<{
   showReferenceColumns?: boolean;
   /** Planner Project Grant: plan year count for the "× project years" column. */
   projectYearsCount?: number | null;
+  /** Planner Project Grant: show a budget field above each submodule table. */
+  showGrantBudgets?: boolean;
+  /** Grant submodule budgets of this module, keyed by submodule id (#1978). */
+  grantBudgets?: Record<string, number> | null;
+  /** Currency code of the grant budget, shown on the budget fields. */
+  grantBudgetCurrency?: string | null;
   /**
    * Replaces the Calculator MODULES_CONFIG entry — the Simulator Plan
    * renders planner-specific submodules (see constant/planner-module-config).

--- a/frontend/src/components/organisms/module/ModuleTableSection.vue
+++ b/frontend/src/components/organisms/module/ModuleTableSection.vue
@@ -17,6 +17,7 @@
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
           :project-years-count="projectYearsCount"
+          :percentage-locked="percentageLocked"
           :show-grant-budget="showGrantBudgets"
           :grant-budget="grantBudgets?.[sub.id] ?? null"
           :grant-budget-currency="grantBudgetCurrency"
@@ -59,6 +60,8 @@ const props = defineProps<{
   showReferenceColumns?: boolean;
   /** Planner Project Grant: plan year count for the "× project years" column. */
   projectYearsCount?: number | null;
+  /** Grant equipment global mode: per-row % controls read-only (#1981). */
+  percentageLocked?: boolean;
   /** Planner Project Grant: show a budget field above each submodule table. */
   showGrantBudgets?: boolean;
   /** Grant submodule budgets of this module, keyed by submodule id (#1978). */

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -31,6 +31,38 @@
     </template>
     <q-separator />
     <q-card-section class="q-pa-none">
+      <!-- The submodule's share of the grant budget, reconciled against the
+           total in the Project Grant section header (#1978). -->
+      <template v-if="showGrantBudget">
+        <div class="q-mx-lg q-my-lg">
+          <div class="text-weight-medium q-mb-sm">
+            {{ $t('planner_budget_section_title') }}
+          </div>
+          <q-input
+            v-model.number="grantBudgetInput"
+            class="grant-budget-input"
+            type="number"
+            outlined
+            dense
+            hide-bottom-space
+            min="0"
+            :suffix="currencyLabel(grantBudgetCurrency)"
+            :label="
+              $t('planner_submodule_budget_label', {
+                submodule: submoduleName,
+              })
+            "
+            :loading="savingGrantBudget"
+            :disable="disable"
+            @blur="saveGrantBudget"
+            @keyup.enter="saveGrantBudget"
+          />
+          <div class="text-body2 text-grey-7 q-mt-sm">
+            {{ $t('planner_submodule_budget_hint') }}
+          </div>
+        </div>
+        <q-separator />
+      </template>
       <div v-if="submodule.moduleFields" class="q-mx-lg q-my-xl">
         <module-table
           :module-fields="submodule.moduleFields"
@@ -117,6 +149,38 @@
     </q-card-section>
     <q-separator />
     <q-card-section class="q-pa-none">
+      <!-- The submodule's share of the grant budget, reconciled against the
+           total in the Project Grant section header (#1978). -->
+      <template v-if="showGrantBudget">
+        <div class="q-mx-lg q-my-lg">
+          <div class="text-weight-medium q-mb-sm">
+            {{ $t('planner_budget_section_title') }}
+          </div>
+          <q-input
+            v-model.number="grantBudgetInput"
+            class="grant-budget-input"
+            type="number"
+            outlined
+            dense
+            hide-bottom-space
+            min="0"
+            :suffix="currencyLabel(grantBudgetCurrency)"
+            :label="
+              $t('planner_submodule_budget_label', {
+                submodule: submoduleName,
+              })
+            "
+            :loading="savingGrantBudget"
+            :disable="disable"
+            @blur="saveGrantBudget"
+            @keyup.enter="saveGrantBudget"
+          />
+          <div class="text-body2 text-grey-7 q-mt-sm">
+            {{ $t('planner_submodule_budget_hint') }}
+          </div>
+        </div>
+        <q-separator />
+      </template>
       <div v-if="submodule.moduleFields" class="q-mx-lg q-my-xl">
         <module-table
           :module-fields="submodule.moduleFields"
@@ -185,8 +249,11 @@ import type {
   EnumSubmoduleType,
   Module,
 } from 'src/constant/modules';
+import { currencyLabel } from 'src/constant/currencies';
 import { enumSubmodule, MODULES_THRESHOLD_TYPES } from 'src/constant/modules';
+import { getModuleTypeId } from 'src/constant/moduleStates';
 import { useModuleStore, useTimelineStore } from 'src/stores/modules';
+import { useSimulatorPlansStore } from 'src/stores/simulatorPlans';
 import { useYearConfigStore } from 'src/stores/yearConfig';
 import { INSTITUTIONAL_ID_LABEL } from 'src/constant/institutionalId';
 import { submitCreateItem } from 'src/utils/submitCreateItem';
@@ -247,6 +314,12 @@ type CommonProps = {
   showReferenceColumns?: boolean;
   /** Planner Project Grant: plan year count for the "× project years" column. */
   projectYearsCount?: number | null;
+  /** Planner Project Grant: show this submodule's budget field (#1978). */
+  showGrantBudget?: boolean;
+  /** The submodule's saved share of the grant budget. */
+  grantBudget?: number | null;
+  /** Currency code of the grant budget, shown as the field's suffix. */
+  grantBudgetCurrency?: string | null;
   threshold: Threshold;
   disable: boolean;
   isExplorer?: boolean;
@@ -271,6 +344,9 @@ const props = withDefaults(
     factorYear: undefined,
     showReferenceColumns: undefined,
     projectYearsCount: null,
+    showGrantBudget: false,
+    grantBudget: null,
+    grantBudgetCurrency: null,
   },
 );
 const authStore = useAuthStore();
@@ -278,6 +354,48 @@ const authStore = useAuthStore();
 const submoduleKey = computed(() => {
   return props.submodule.id;
 });
+
+// Grant submodule budget (#1978): seeded from the saved value once; the
+// Project Grant header's check line reads the store, so it moves on save.
+const plansStore = useSimulatorPlansStore();
+
+// The table titles embed a count ("Rooms ({count})"); translating with a
+// plural count and stripping the parenthetical yields the bare name the
+// budget label needs ("Rooms budget").
+const submoduleName = computed(() =>
+  props.submodule.tableNameKey
+    ? t(props.submodule.tableNameKey, { count: 2 }).replace(
+        /\s*\([^)]*\)\s*$/,
+        '',
+      )
+    : '',
+);
+const grantBudgetInput = ref<number | null>(props.grantBudget);
+const savingGrantBudget = ref(false);
+
+async function saveGrantBudget() {
+  if (props.carbonReportId === undefined || savingGrantBudget.value) return;
+  const raw = grantBudgetInput.value;
+  const value =
+    typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 ? raw : null;
+  if (value === (props.grantBudget ?? null)) return;
+  savingGrantBudget.value = true;
+  try {
+    await plansStore.setSubmoduleBudget(
+      props.carbonReportId,
+      getModuleTypeId(props.moduleType),
+      props.submodule.id,
+      value,
+    );
+  } catch {
+    Notify.create({
+      type: 'negative',
+      message: t('planner_grant_budget_error'),
+    });
+  } finally {
+    savingGrantBudget.value = false;
+  }
+}
 
 const submoduleColor = computed(() =>
   getSubmoduleIconColor(props.submodule.id, props.moduleType),
@@ -468,5 +586,11 @@ async function submitForm(payload: Record<string, FieldValue>) {
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
+}
+
+/* A budget field holds one amount; a bounded box keeps it from stretching
+   across the section like a text field would. */
+.grant-budget-input {
+  max-width: 240px;
 }
 </style>

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -72,6 +72,7 @@
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
           :project-years-count="projectYearsCount"
+          :percentage-locked="percentageLocked"
           :threshold="effectiveThreshold"
           :has-top-bar="submodule.hasTableTopBar"
           :module-type="moduleType"
@@ -190,6 +191,7 @@
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
           :project-years-count="projectYearsCount"
+          :percentage-locked="percentageLocked"
           :threshold="effectiveThreshold"
           :has-top-bar="submodule.hasTableTopBar"
           :module-type="moduleType"
@@ -314,6 +316,8 @@ type CommonProps = {
   showReferenceColumns?: boolean;
   /** Planner Project Grant: plan year count for the "× project years" column. */
   projectYearsCount?: number | null;
+  /** Grant equipment global mode: per-row % controls read-only (#1981). */
+  percentageLocked?: boolean;
   /** Planner Project Grant: show this submodule's budget field (#1978). */
   showGrantBudget?: boolean;
   /** The submodule's saved share of the grant budget. */
@@ -344,6 +348,7 @@ const props = withDefaults(
     factorYear: undefined,
     showReferenceColumns: undefined,
     projectYearsCount: null,
+    percentageLocked: false,
     showGrantBudget: false,
     grantBudget: null,
     grantBudgetCurrency: null,

--- a/frontend/src/components/organisms/module/SubModuleSection.vue
+++ b/frontend/src/components/organisms/module/SubModuleSection.vue
@@ -39,6 +39,7 @@
           :factor-year="factorYear"
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
+          :project-years-count="projectYearsCount"
           :threshold="effectiveThreshold"
           :has-top-bar="submodule.hasTableTopBar"
           :module-type="moduleType"
@@ -124,6 +125,7 @@
           :factor-year="factorYear"
           :carbon-report-id="carbonReportId"
           :show-reference-columns="showReferenceColumns"
+          :project-years-count="projectYearsCount"
           :threshold="effectiveThreshold"
           :has-top-bar="submodule.hasTableTopBar"
           :module-type="moduleType"
@@ -243,6 +245,8 @@ type CommonProps = {
   carbonReportId?: number;
   /** Planner prefilled: show the reference-kg column + % slider. */
   showReferenceColumns?: boolean;
+  /** Planner Project Grant: plan year count for the "× project years" column. */
+  projectYearsCount?: number | null;
   threshold: Threshold;
   disable: boolean;
   isExplorer?: boolean;
@@ -266,6 +270,7 @@ const props = withDefaults(
     carbonReportId: undefined,
     factorYear: undefined,
     showReferenceColumns: undefined,
+    projectYearsCount: null,
   },
 );
 const authStore = useAuthStore();

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -271,16 +271,11 @@ async function generateSections() {
   if (start !== null && end !== null) {
     payload.start_year = start;
     payload.end_year = end;
+    payload.default_reference_year = Number(route.params.year);
   }
 
   generatingSections.value = true;
   try {
-    const payload = {
-      start_year: start,
-      end_year: end,
-      default_reference_year: Number(route.params.year),
-      is_grant_proposal: grantProposalInput.value,
-    };
     const updated = await plansStore.updatePlan(props.plan.id, payload);
     yearByYearInput.value = null;
     emit('updated', updated);

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -120,10 +120,7 @@
         :loading="generatingSections"
         @click="generateSections"
       />
-      <div
-        v-if="!sectionTypeSelected"
-        class="text-body2 text-negative q-mt-sm"
-      >
+      <div v-if="!sectionTypeSelected" class="text-body2 text-negative q-mt-sm">
         {{ $t('planner_sections_need_one') }}
       </div>
       <div class="text-body2 text-grey-7 q-mt-sm">

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -45,12 +45,22 @@
       <div class="text-weight-medium q-mb-sm">
         {{ $t('planner_year_selection_label') }}
       </div>
-      <div class="row q-col-gutter-md">
+      <q-checkbox
+        v-model="yearByYearChecked"
+        :label="$t('planner_year_by_year_checkbox')"
+        color="info"
+        size="sm"
+      />
+      <div class="text-body2 text-grey-7">
+        {{ $t('planner_year_by_year_hint') }}
+      </div>
+      <div class="row q-col-gutter-md q-mt-xs">
         <div class="col-12 col-sm-6">
           <q-select
             v-model="startYearInput"
             :label="$t('planner_start_year_label')"
             :options="startYearOptions"
+            :disable="!yearByYearChecked"
             outlined
             dense
             hide-bottom-space
@@ -67,6 +77,7 @@
             v-model="endYearInput"
             :label="$t('planner_end_year_label')"
             :options="endYearOptions"
+            :disable="!yearByYearChecked"
             outlined
             dense
             hide-bottom-space
@@ -105,10 +116,16 @@
         class="full-width text-weight-medium"
         icon="o_playlist_add"
         :label="$t('planner_generate_sections_button')"
-        :disable="!sectionsDirty || !yearsValid"
+        :disable="!sectionsDirty || !yearsValid || !sectionTypeSelected"
         :loading="generatingSections"
         @click="generateSections"
       />
+      <div
+        v-if="!sectionTypeSelected"
+        class="text-body2 text-negative q-mt-sm"
+      >
+        {{ $t('planner_sections_need_one') }}
+      </div>
       <div class="text-body2 text-grey-7 q-mt-sm">
         {{ $t('planner_generate_sections_hint') }}
       </div>
@@ -147,6 +164,20 @@ const nameTouched = ref(false);
 const saving = ref(false);
 const generatingSections = ref(false);
 
+// Whether the plan currently has per-year sections is not a plan column; it
+// is derived from its reports (a plan with none yet defaults to having them).
+const persistedYearByYear = computed(() =>
+  plansStore.planYears.length
+    ? plansStore.planYears.some((y) => !y.is_grant)
+    : true,
+);
+// null = untouched, mirror the persisted state (which arrives async).
+const yearByYearInput = ref<boolean | null>(null);
+const yearByYearChecked = computed({
+  get: () => yearByYearInput.value ?? persistedYearByYear.value,
+  set: (value: boolean) => (yearByYearInput.value = value),
+});
+
 watch(
   () => props.plan,
   (plan) => {
@@ -155,6 +186,7 @@ watch(
     endYearInput.value = plan.end_year ?? null;
     grantProposalInput.value = plan.is_grant_proposal;
     shareWithLab.value = plan.is_viewable_by_unit_members;
+    yearByYearInput.value = null;
   },
 );
 
@@ -193,12 +225,15 @@ const endYearOptions = computed(() =>
   ),
 );
 
-const yearsValid = computed(
-  () =>
-    startYearInput.value !== null &&
-    endYearInput.value !== null &&
-    endYearInput.value >= startYearInput.value,
-);
+// A grant-only plan needs no year range (the grant section covers the
+// whole project); year-by-year planning, or a half-set range, still
+// requires both bounds.
+const yearsValid = computed(() => {
+  const start = startYearInput.value;
+  const end = endYearInput.value;
+  if (start === null && end === null) return !yearByYearChecked.value;
+  return start !== null && end !== null && end >= start;
+});
 
 // Dirty vs. the persisted plan — the button is idle until the user changes
 // a year or the grant checkbox, and disables again once the sections match
@@ -212,7 +247,13 @@ const yearsDirty = computed(
 const sectionsDirty = computed(
   () =>
     yearsDirty.value ||
-    grantProposalInput.value !== props.plan.is_grant_proposal,
+    grantProposalInput.value !== props.plan.is_grant_proposal ||
+    yearByYearChecked.value !== persistedYearByYear.value,
+);
+
+// A plan with neither year sections nor a grant section would be empty.
+const sectionTypeSelected = computed(
+  () => grantProposalInput.value || yearByYearChecked.value,
 );
 
 /**
@@ -224,16 +265,27 @@ const sectionsDirty = computed(
 async function generateSections() {
   const start = startYearInput.value;
   const end = endYearInput.value;
-  if (start === null || end === null || generatingSections.value) return;
+  if (!yearsValid.value || generatingSections.value) return;
+
+  const payload: SimulatorPlanUpdatePayload = {
+    is_grant_proposal: grantProposalInput.value,
+    with_year_sections: yearByYearChecked.value,
+  };
+  if (start !== null && end !== null) {
+    payload.start_year = start;
+    payload.end_year = end;
+  }
 
   generatingSections.value = true;
   try {
-    const updated = await plansStore.updatePlan(props.plan.id, {
+    const payload = {
       start_year: start,
       end_year: end,
       default_reference_year: Number(route.params.year),
       is_grant_proposal: grantProposalInput.value,
-    });
+    };
+    const updated = await plansStore.updatePlan(props.plan.id, payload);
+    yearByYearInput.value = null;
     emit('updated', updated);
     $q.notify({ type: 'positive', message: t('planner_sections_generated') });
   } catch {

--- a/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
+++ b/frontend/src/components/organisms/planner/PlannerProjectInfo.vue
@@ -27,6 +27,22 @@
 
     <q-card-section>
       <div class="text-weight-medium q-mb-sm">
+        {{ $t('planner_grant_proposal_label') }}
+      </div>
+      <q-checkbox
+        v-model="grantProposalInput"
+        :label="$t('planner_grant_proposal_checkbox')"
+        color="info"
+        size="sm"
+      />
+      <div class="text-body2 text-grey-7">
+        {{ $t('planner_grant_proposal_hint') }}
+      </div>
+    </q-card-section>
+    <q-separator />
+
+    <q-card-section>
+      <div class="text-weight-medium q-mb-sm">
         {{ $t('planner_year_selection_label') }}
       </div>
       <div class="row q-col-gutter-md">
@@ -63,26 +79,6 @@
           </q-select>
         </div>
       </div>
-
-      <!-- The per-year sections are created explicitly (not as a hidden
-           side-effect of picking a year), with visible progress. -->
-      <div class="row items-center q-gutter-sm q-mt-md">
-        <q-btn
-          unelevated
-          no-caps
-          size="sm"
-          color="info"
-          class="text-weight-regular"
-          icon="o_playlist_add"
-          :label="$t('planner_generate_years_button')"
-          :disable="!yearsDirty || !yearsValid"
-          :loading="generatingYears"
-          @click="generateYears"
-        />
-        <span class="text-body2 text-grey-7">
-          {{ $t('planner_generate_years_hint') }}
-        </span>
-      </div>
     </q-card-section>
     <q-separator />
 
@@ -94,6 +90,28 @@
         size="sm"
         @update:model-value="saveIfDirty('is_viewable_by_unit_members')"
       />
+    </q-card-section>
+    <q-separator />
+
+    <!-- The plan's sections (Project Grant + per-year) are created explicitly
+         (not as a hidden side-effect of picking a year), with visible
+         progress. -->
+    <q-card-section>
+      <q-btn
+        unelevated
+        no-caps
+        size="md"
+        color="info"
+        class="full-width text-weight-medium"
+        icon="o_playlist_add"
+        :label="$t('planner_generate_sections_button')"
+        :disable="!sectionsDirty || !yearsValid"
+        :loading="generatingSections"
+        @click="generateSections"
+      />
+      <div class="text-body2 text-grey-7 q-mt-sm">
+        {{ $t('planner_generate_sections_hint') }}
+      </div>
     </q-card-section>
   </q-card>
 </template>
@@ -123,10 +141,11 @@ const yearConfigStore = useYearConfigStore();
 const nameInput = ref(props.plan.name);
 const startYearInput = ref<number | null>(props.plan.start_year ?? null);
 const endYearInput = ref<number | null>(props.plan.end_year ?? null);
+const grantProposalInput = ref(props.plan.is_grant_proposal);
 const shareWithLab = ref(props.plan.is_viewable_by_unit_members);
 const nameTouched = ref(false);
 const saving = ref(false);
-const generatingYears = ref(false);
+const generatingSections = ref(false);
 
 watch(
   () => props.plan,
@@ -134,6 +153,7 @@ watch(
     nameInput.value = plan.name;
     startYearInput.value = plan.start_year ?? null;
     endYearInput.value = plan.end_year ?? null;
+    grantProposalInput.value = plan.is_grant_proposal;
     shareWithLab.value = plan.is_viewable_by_unit_members;
   },
 );
@@ -180,37 +200,49 @@ const yearsValid = computed(
     endYearInput.value >= startYearInput.value,
 );
 
-// Dirty vs. the persisted range — the button is idle until the user changes
-// a year, and disables again once the sections match the selection.
+// Dirty vs. the persisted plan — the button is idle until the user changes
+// a year or the grant checkbox, and disables again once the sections match
+// the selection.
 const yearsDirty = computed(
   () =>
     startYearInput.value !== (props.plan.start_year ?? null) ||
     endYearInput.value !== (props.plan.end_year ?? null),
 );
 
+const sectionsDirty = computed(
+  () =>
+    yearsDirty.value ||
+    grantProposalInput.value !== props.plan.is_grant_proposal,
+);
+
 /**
- * Create/update one CarbonReport per year in the selected range. Made an
- * explicit, feedback-carrying action (button + spinner + notify) instead of a
- * hidden side-effect of picking a year — the backend syncs the year reports.
+ * Create/update one CarbonReport per year in the selected range, plus the
+ * Project Grant report when the plan is a grant proposal. Made an explicit,
+ * feedback-carrying action (button + spinner + notify) instead of a hidden
+ * side-effect of picking a year — the backend syncs the reports.
  */
-async function generateYears() {
+async function generateSections() {
   const start = startYearInput.value;
   const end = endYearInput.value;
-  if (start === null || end === null || generatingYears.value) return;
+  if (start === null || end === null || generatingSections.value) return;
 
-  generatingYears.value = true;
+  generatingSections.value = true;
   try {
     const updated = await plansStore.updatePlan(props.plan.id, {
       start_year: start,
       end_year: end,
       default_reference_year: Number(route.params.year),
+      is_grant_proposal: grantProposalInput.value,
     });
     emit('updated', updated);
-    $q.notify({ type: 'positive', message: t('planner_years_generated') });
+    $q.notify({ type: 'positive', message: t('planner_sections_generated') });
   } catch {
-    $q.notify({ type: 'negative', message: t('planner_years_generate_error') });
+    $q.notify({
+      type: 'negative',
+      message: t('planner_sections_generate_error'),
+    });
   } finally {
-    generatingYears.value = false;
+    generatingSections.value = false;
   }
 }
 

--- a/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerPurchaseRows.vue
@@ -59,7 +59,26 @@
           </label>
           <div class="planner-purchase-table__kg text-body2 text-grey-7">
             <template v-if="row.kg !== null">
-              {{ formatTonnesCO2(row.kg / 1000) }} {{ $t('tco2eq') }}
+              <template v-if="projectYearsCount != null">
+                {{
+                  $t('planner_purchase_kg_per_year', {
+                    value: formatTonnesCO2(row.kg / 1000),
+                  })
+                }}
+                <span class="text-weight-medium q-ml-sm">
+                  {{
+                    $t('planner_purchase_kg_project', {
+                      value: formatTonnesCO2(
+                        (row.kg * projectYearsCount) / 1000,
+                      ),
+                      years: projectYearsCount,
+                    })
+                  }}
+                </span>
+              </template>
+              <template v-else>
+                {{ formatTonnesCO2(row.kg / 1000) }} {{ $t('tco2eq') }}
+              </template>
             </template>
           </div>
           <q-input
@@ -184,6 +203,8 @@ interface SubmoduleItem {
 const props = defineProps<{
   carbonReportId: number;
   disable: boolean;
+  /** Set in the Project Grant section: multiply kg over the plan's years. */
+  projectYearsCount?: number | null;
 }>();
 
 const $q = useQuasar();

--- a/frontend/src/components/organisms/planner/PlannerResearchFacilityRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerResearchFacilityRows.vue
@@ -1,0 +1,503 @@
+<template>
+  <div>
+    <div class="planner-rf__header text-body2 text-grey-7">
+      {{ $t('planner_rf_hint') }}
+    </div>
+
+    <q-separator />
+    <div class="q-pa-md">
+      <div class="text-weight-medium q-mb-sm">
+        {{ $t('planner_budget_section_title') }}
+      </div>
+      <q-input
+        v-model.number="budgetInput"
+        class="planner-rf__budget"
+        type="number"
+        outlined
+        dense
+        hide-bottom-space
+        min="0"
+        :suffix="currencyLabel(budgetCurrency)"
+        :label="
+          $t('planner_submodule_budget_label', {
+            submodule: $t(MODULES.ResearchFacilities),
+          })
+        "
+        :loading="savingBudget"
+        :disable="disable"
+        @blur="saveBudget"
+        @keyup.enter="saveBudget"
+      />
+      <div class="text-body2 text-grey-7 q-mt-sm">
+        {{ $t('planner_submodule_budget_hint') }}
+      </div>
+    </div>
+
+    <q-separator />
+    <div class="q-pa-md">
+      <q-select
+        v-model="addModel"
+        class="planner-rf__add"
+        :options="filteredAddOptions"
+        :label="$t('planner_rf_add_label')"
+        outlined
+        dense
+        hide-bottom-space
+        emit-value
+        map-options
+        use-input
+        input-debounce="0"
+        :disable="disable"
+        @filter="filterAddOptions"
+        @update:model-value="onAdd"
+      >
+        <template #prepend>
+          <q-icon name="o_add_circle" color="info" />
+        </template>
+        <template #no-option>
+          <q-item>
+            <q-item-section class="text-grey-7">
+              {{ $t('planner_rf_empty') }}
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
+    </div>
+
+    <template v-for="group in visibleGroups" :key="group.sub">
+      <q-separator />
+      <div class="planner-rf__group-header">
+        <div class="text-h5 text-weight-medium">{{ $t(group.titleKey) }}</div>
+      </div>
+      <q-separator />
+
+      <div class="planner-rf-table">
+        <div
+          v-for="row in selectedRowsOf(group.sub)"
+          :key="row.key"
+          class="planner-rf-table__row"
+        >
+          <div class="row items-center no-wrap">
+            <label
+              :for="`rf-${row.key}`"
+              class="col text-body2 planner-rf-table__name"
+            >
+              {{ row.name }}
+              <span v-if="row.facilityType" class="text-grey-7">
+                ({{
+                  $t(`${MODULES.ResearchFacilities}.type.${row.facilityType}`)
+                }})
+              </span>
+            </label>
+            <div class="planner-rf-table__kg text-body2 text-grey-7">
+              <template v-if="row.kg !== null">
+                {{ $t('planner_rf_kg_per_year', { value: formatKg(row.kg) }) }}
+                <span v-if="projectYearsCount" class="text-weight-medium">
+                  ·
+                  {{
+                    $t('planner_rf_kg_project', {
+                      value: formatKg(row.kg * projectYearsCount),
+                      years: projectYearsCount,
+                    })
+                  }}
+                </span>
+              </template>
+            </div>
+            <q-input
+              :id="`rf-${row.key}`"
+              v-model.number="row.use"
+              class="planner-rf-table__input"
+              type="number"
+              outlined
+              dense
+              hide-bottom-space
+              min="0"
+              :suffix="row.metric"
+              :aria-label="$t('planner_rf_use_label')"
+              :disable="disable || savingKey === row.key"
+              :loading="savingKey === row.key"
+              @blur="save(row)"
+              @keyup.enter="save(row)"
+            />
+            <q-btn
+              flat
+              dense
+              round
+              icon="o_delete"
+              class="q-ml-sm"
+              :disable="disable || savingKey === row.key"
+              :aria-label="$t('common_delete')"
+              @click="onRemove(row)"
+            >
+              <q-tooltip>{{ $t('common_delete') }}</q-tooltip>
+            </q-btn>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useQuasar } from 'quasar';
+import { useI18n } from 'vue-i18n';
+
+import { api } from 'src/api/http';
+import { currencyLabel } from 'src/constant/currencies';
+import {
+  enumSubmodule,
+  MODULES,
+  SUBMODULE_RESEARCH_FACILITIES_TYPES,
+} from 'src/constant/modules';
+import { getModuleTypeId } from 'src/constant/moduleStates';
+import { useSimulatorPlansStore } from 'src/stores/simulatorPlans';
+import { useWorkspaceStore } from 'src/stores/workspace';
+
+/**
+ * Project Grant research-facilities grid (#1980): a dropdown offers the
+ * reference year's whole platform list; picking one adds its row, where the
+ * user enters the planned use in the platform's own metric (budget, hours,
+ * CPU, housing, ...). Factors, and therefore the metric and the computed
+ * kgCO₂eq, come from the reference year. A group (research facilities /
+ * animal facilities) only renders once it holds a row.
+ */
+
+type RfSub = 'research-facilities' | 'animal_facilities';
+
+interface RfRow {
+  key: string;
+  sub: RfSub;
+  facilityId: string;
+  name: string;
+  /** Animal facilities only (rodent / fish). */
+  facilityType: string | null;
+  /** The platform's metric — the factor's use unit. */
+  metric: string;
+  selected: boolean;
+  use: number | null;
+  /** Last persisted use — `blur` after `Enter` must not save twice. */
+  saved: number | null;
+  entryId: number | null;
+  kg: number | null;
+}
+
+interface RfFactor {
+  researchfacility_id?: string | number;
+  researchfacility_name?: string;
+  researchfacility_type?: string;
+  use_unit?: string;
+}
+
+interface RfEntry {
+  id: number;
+  researchfacility_id?: string | number;
+  researchfacility_type?: string;
+  use?: number | null;
+  kg_co2eq?: number | null;
+}
+
+const props = defineProps<{
+  carbonReportId: number;
+  projectYearsCount?: number | null;
+  grantBudgets?: Record<string, number> | null;
+  budgetCurrency?: string | null;
+  disable: boolean;
+}>();
+
+const $q = useQuasar();
+const { t, n } = useI18n();
+const plansStore = useSimulatorPlansStore();
+
+const GROUPS: { sub: RfSub; titleKey: string }[] = [
+  {
+    sub: SUBMODULE_RESEARCH_FACILITIES_TYPES.ResearchFacilities,
+    titleKey: 'planner_rf_common_title',
+  },
+  {
+    sub: SUBMODULE_RESEARCH_FACILITIES_TYPES.AnimalFacilities,
+    titleKey: `${MODULES.ResearchFacilities}.${SUBMODULE_RESEARCH_FACILITIES_TYPES.AnimalFacilities}`,
+  },
+];
+
+const rows = ref<RfRow[]>([]);
+const savingKey = ref<string | null>(null);
+
+// A group appears once a platform of its kind is used, title and budget
+// included; an empty group stays out of the way entirely.
+const visibleGroups = computed(() =>
+  GROUPS.filter((group) => selectedRowsOf(group.sub).length > 0),
+);
+
+// One budget for the whole module, stored under the module name — the same
+// convention as the single-grid modules (#1978).
+const BUDGET_KEY = MODULES.ResearchFacilities;
+const budgetInput = ref<number | null>(
+  props.grantBudgets?.[BUDGET_KEY] ?? null,
+);
+const savingBudget = ref(false);
+
+function selectedRowsOf(sub: RfSub): RfRow[] {
+  return rows.value.filter((row) => row.sub === sub && row.selected);
+}
+
+function optionLabel(row: RfRow): string {
+  return row.facilityType
+    ? `${row.name} (${t(`${MODULES.ResearchFacilities}.type.${row.facilityType}`)})`
+    : row.name;
+}
+
+// The add dropdown offers every platform not yet used, filterable by name —
+// the list holds ~90 platforms.
+const addModel = ref<string | null>(null);
+const addFilter = ref('');
+const addOptions = computed(() =>
+  rows.value
+    .filter((row) => !row.selected)
+    .map((row) => ({ label: optionLabel(row), value: row.key }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
+);
+const filteredAddOptions = computed(() => {
+  const needle = addFilter.value.trim().toLowerCase();
+  if (!needle) return addOptions.value;
+  return addOptions.value.filter((opt) =>
+    opt.label.toLowerCase().includes(needle),
+  );
+});
+
+function filterAddOptions(input: string, update: (fn: () => void) => void) {
+  update(() => {
+    addFilter.value = input;
+  });
+}
+
+function onAdd(key: string | null) {
+  if (key === null) return;
+  const row = rows.value.find((r) => r.key === key);
+  if (row) row.selected = true;
+  addModel.value = null;
+}
+
+async function onRemove(row: RfRow) {
+  row.selected = false;
+  row.use = null;
+  await save(row);
+}
+
+function pathFor(sub: RfSub): string {
+  return `carbon-reports/${props.carbonReportId}/modules/${MODULES.ResearchFacilities}/${sub}`;
+}
+
+/** Animal rows are one per (facility, type); common rows one per facility. */
+function rowKey(sub: RfSub, facilityId: string, facilityType: string | null) {
+  return `${sub}:${facilityId}${facilityType ? `:${facilityType}` : ''}`;
+}
+
+// The platform list follows the current workspace year — the year whose
+// Calculator holds the platforms as the user knows them.
+const workspaceYear = useWorkspaceStore().selectedYear;
+
+async function fetchFactors(sub: RfSub): Promise<RfFactor[]> {
+  if (workspaceYear === null) return [];
+  return api
+    .get(`factors/${enumSubmodule[sub]}/list?year=${workspaceYear}`)
+    .json<RfFactor[]>();
+}
+
+async function fetchEntries(sub: RfSub): Promise<RfEntry[]> {
+  try {
+    const res = await api
+      .get(`${pathFor(sub)}?page=1&limit=200`)
+      .json<{ items: RfEntry[] }>();
+    return res.items;
+  } catch {
+    // Empty module → no rows yet; every platform stays unselected.
+    return [];
+  }
+}
+
+function bindEntries(sub: RfSub, entries: RfEntry[]) {
+  const byKey = new Map(
+    entries.map((entry) => [
+      rowKey(
+        sub,
+        String(entry.researchfacility_id ?? ''),
+        entry.researchfacility_type ?? null,
+      ),
+      entry,
+    ]),
+  );
+  for (const row of rows.value) {
+    if (row.sub !== sub) continue;
+    const entry = byKey.get(row.key);
+    row.entryId = entry?.id ?? null;
+    row.kg = entry?.kg_co2eq ?? null;
+    row.use = entry?.use ?? row.use;
+    row.saved = entry?.use ?? null;
+    if (entry) row.selected = true;
+  }
+}
+
+async function loadGroup(sub: RfSub) {
+  const [factors, entries] = await Promise.all([
+    fetchFactors(sub),
+    fetchEntries(sub),
+  ]);
+  const groupRows: RfRow[] = factors
+    .filter((f) => f.researchfacility_name && f.use_unit)
+    .map((f) => ({
+      key: rowKey(
+        sub,
+        String(f.researchfacility_id ?? ''),
+        f.researchfacility_type ?? null,
+      ),
+      sub,
+      facilityId: String(f.researchfacility_id ?? ''),
+      name: f.researchfacility_name as string,
+      facilityType: f.researchfacility_type ?? null,
+      metric: f.use_unit as string,
+      selected: false,
+      use: null,
+      saved: null,
+      entryId: null,
+      kg: null,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  rows.value = [...rows.value.filter((row) => row.sub !== sub), ...groupRows];
+  bindEntries(sub, entries);
+}
+
+function formatKg(value: number): string {
+  return n(Math.round(value));
+}
+
+/** Saves run one after another — see PlannerPurchaseRows for the rationale. */
+let saveQueue: Promise<void> = Promise.resolve();
+
+function save(row: RfRow): Promise<void> {
+  saveQueue = saveQueue.then(() => persist(row));
+  return saveQueue;
+}
+
+async function persist(row: RfRow) {
+  const use =
+    typeof row.use === 'number' && Number.isFinite(row.use) && row.use >= 0
+      ? row.use
+      : null;
+  if (use === row.saved) return;
+  savingKey.value = row.key;
+  try {
+    if (use === null) {
+      if (row.entryId !== null) {
+        await api.delete(`${pathFor(row.sub)}/${row.entryId}`);
+        row.entryId = null;
+        row.kg = null;
+      }
+    } else if (row.entryId === null) {
+      await api.post(pathFor(row.sub), { json: createPayload(row, use) });
+    } else {
+      await api.patch(`${pathFor(row.sub)}/${row.entryId}`, {
+        json: { use },
+      });
+    }
+    row.saved = use;
+    bindEntries(row.sub, await fetchEntries(row.sub));
+    await plansStore.refreshAggregateIfActive();
+  } catch {
+    $q.notify({ type: 'negative', message: t('planner_rf_save_error') });
+  } finally {
+    savingKey.value = null;
+  }
+}
+
+function createPayload(row: RfRow, use: number): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    researchfacility_id: row.facilityId,
+    researchfacility_name: row.name,
+    use,
+    use_unit: row.metric,
+  };
+  if (row.facilityType) payload.researchfacility_type = row.facilityType;
+  return payload;
+}
+
+async function saveBudget() {
+  const raw = budgetInput.value;
+  const value =
+    typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 ? raw : null;
+  if (value === (props.grantBudgets?.[BUDGET_KEY] ?? null)) return;
+  savingBudget.value = true;
+  try {
+    await plansStore.setSubmoduleBudget(
+      props.carbonReportId,
+      getModuleTypeId(MODULES.ResearchFacilities),
+      BUDGET_KEY,
+      value,
+    );
+  } catch {
+    $q.notify({ type: 'negative', message: t('planner_grant_budget_error') });
+  } finally {
+    savingBudget.value = false;
+  }
+}
+
+onMounted(async () => {
+  await Promise.all(GROUPS.map((group) => loadGroup(group.sub)));
+});
+</script>
+
+<style scoped lang="scss">
+@use 'src/css/02-tokens' as tokens;
+
+.planner-rf__header {
+  padding: tokens.$spacing-md;
+}
+
+.planner-rf__add {
+  max-width: 420px;
+
+  // Quasar gives field marginals a fixed height taller than the dense
+  // control, which floats the icon high; center the marginal in the row
+  // instead.
+  :deep(.q-field__prepend) {
+    height: auto;
+    align-self: center;
+  }
+}
+
+.planner-rf__group-header {
+  padding: tokens.$spacing-md;
+}
+
+.planner-rf__budget {
+  max-width: 240px;
+}
+
+.planner-rf-table {
+  &__row {
+    padding: tokens.$spacing-xs tokens.$spacing-md;
+    background-color: tokens.$table-bg-odd;
+
+    &:nth-child(even) {
+      background-color: tokens.$table-bg-even;
+    }
+  }
+
+  &__kg {
+    padding-right: tokens.$spacing-lg;
+  }
+
+  &__input {
+    width: tokens.$planner-grid-amount-input-width;
+
+    :deep(.q-field__control) {
+      background-color: tokens.$table-bg-odd;
+    }
+
+    :deep(.q-field__suffix) {
+      font-size: tokens.$text-size-sm;
+      color: tokens.$color-text-muted;
+    }
+  }
+}
+</style>

--- a/frontend/src/components/organisms/planner/PlannerResearchFacilityRows.vue
+++ b/frontend/src/components/organisms/planner/PlannerResearchFacilityRows.vue
@@ -152,7 +152,6 @@ import {
 } from 'src/constant/modules';
 import { getModuleTypeId } from 'src/constant/moduleStates';
 import { useSimulatorPlansStore } from 'src/stores/simulatorPlans';
-import { useWorkspaceStore } from 'src/stores/workspace';
 
 /**
  * Project Grant research-facilities grid (#1980): a dropdown offers the
@@ -199,6 +198,7 @@ interface RfEntry {
 
 const props = defineProps<{
   carbonReportId: number;
+  factorYear: number | null;
   projectYearsCount?: number | null;
   grantBudgets?: Record<string, number> | null;
   budgetCurrency?: string | null;
@@ -293,14 +293,13 @@ function rowKey(sub: RfSub, facilityId: string, facilityType: string | null) {
   return `${sub}:${facilityId}${facilityType ? `:${facilityType}` : ''}`;
 }
 
-// The platform list follows the current workspace year — the year whose
-// Calculator holds the platforms as the user knows them.
-const workspaceYear = useWorkspaceStore().selectedYear;
-
+// The platform list follows the factor year the backend computes with
+// (reference year, else the report year), so each row's metric matches
+// the factor behind its kgCO₂eq.
 async function fetchFactors(sub: RfSub): Promise<RfFactor[]> {
-  if (workspaceYear === null) return [];
+  if (props.factorYear === null) return [];
   return api
-    .get(`factors/${enumSubmodule[sub]}/list?year=${workspaceYear}`)
+    .get(`factors/${enumSubmodule[sub]}/list?year=${props.factorYear}`)
     .json<RfFactor[]>();
 }
 

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -425,7 +425,7 @@
                 :show-reference-columns="
                   entry.config.behavior === 'prefilled' && hasReferenceYear
                 "
-                :project-years-count="grantYearsCountFor(entry.config.module)"
+                :project-years-count="grantYearsCount"
                 :percentage-locked="isGlobalEquipment(entry.config.module)"
                 :show-grant-budgets="
                   yearData.is_grant && !isGlobalEquipment(entry.config.module)

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -166,18 +166,14 @@
                   size="sm"
                   dense
                   :disable="
-                    !entry.module ||
-                    togglingModuleId === entry.module.id ||
-                    isGrantLocked(entry.config.module)
+                    !entry.module || togglingModuleId === entry.module.id
                   "
                   @update:model-value="
                     (active: boolean) => onToggleActive(entry, active)
                   "
                 >
                   <q-tooltip>{{
-                    isGrantLocked(entry.config.module)
-                      ? $t('planner_module_grant_locked_tooltip')
-                      : $t('planner_module_active_tooltip')
+                    $t('planner_module_active_tooltip')
                   }}</q-tooltip>
                 </q-checkbox>
               </div>
@@ -245,7 +241,7 @@
               v-else-if="entry.config.module === MODULES.Purchase"
               :key="factorScopedKey(entry.config.module)"
               :carbon-report-id="yearData.id"
-              :project-years-count="grantYearsCountFor(entry.config.module)"
+              :project-years-count="grantYearsCount"
               :disable="entry.module?.is_active === false"
             />
             <!-- Grant proposals plan RF use from the reference year's whole
@@ -261,27 +257,184 @@
               :budget-currency="yearData.budget_currency"
               :disable="entry.module?.is_active === false"
             />
-            <module-table-section
-              v-else
-              :key="factorScopedKey(entry.config.module)"
-              :type="entry.config.module"
-              :config-override="getPlannerModuleConfig(entry.config.module)"
-              :data="moduleStore.state.data"
-              :loading="moduleStore.state.loading"
-              :error="moduleStore.state.error"
-              :unit-id="unitId"
-              :year="yearData.year"
-              :factor-year="factorYear"
-              :carbon-report-id="yearData.id"
-              :show-reference-columns="
-                entry.config.behavior === 'prefilled' && hasReferenceYear
-              "
-              :project-years-count="grantYearsCountFor(entry.config.module)"
-              :show-grant-budgets="yearData.is_grant"
-              :grant-budgets="entry.module?.budgets ?? null"
-              :grant-budget-currency="yearData.budget_currency"
-              :disable="entry.module?.is_active === false"
-            />
+            <template v-else>
+              <!-- Grant equipment plans either line by line or with one
+                   global percentage over all prefilled lines (#1981); adding
+                   an equipment stays available in both modes. -->
+              <div
+                v-if="isGrantEquipmentModule(entry.config.module)"
+                class="q-mb-lg"
+              >
+                <div class="text-weight-medium q-mb-sm">
+                  {{ $t('planner_equipment_mode_title') }}
+                </div>
+                <div class="row items-center no-wrap">
+                  <button
+                    type="button"
+                    class="planner-mode__label text-body1"
+                    :class="
+                      equipmentMode === 'per_line'
+                        ? 'text-weight-medium'
+                        : 'text-grey-6'
+                    "
+                    :aria-pressed="equipmentMode === 'per_line'"
+                    :disabled="equipmentModeControlsDisabled(entry)"
+                    @click="onEquipmentModeRequest('per_line')"
+                  >
+                    {{ $t('planner_equipment_mode_per_line') }}
+                  </button>
+                  <q-toggle
+                    :model-value="equipmentMode === 'global'"
+                    color="info"
+                    keep-color
+                    size="lg"
+                    :disable="equipmentModeControlsDisabled(entry)"
+                    @update:model-value="
+                      (on: boolean) =>
+                        onEquipmentModeRequest(on ? 'global' : 'per_line')
+                    "
+                  />
+                  <button
+                    type="button"
+                    class="planner-mode__label text-body1"
+                    :class="
+                      equipmentMode === 'global'
+                        ? 'text-weight-medium'
+                        : 'text-grey-6'
+                    "
+                    :aria-pressed="equipmentMode === 'global'"
+                    :disabled="equipmentModeControlsDisabled(entry)"
+                    @click="onEquipmentModeRequest('global')"
+                  >
+                    {{ $t('planner_equipment_mode_global') }}
+                  </button>
+                </div>
+                <div class="text-body2 text-grey-7 q-mt-xs">
+                  {{
+                    equipmentMode === 'global'
+                      ? $t('planner_equipment_mode_global_hint')
+                      : $t('planner_equipment_mode_per_line_hint')
+                  }}
+                </div>
+                <!-- One budget for the whole module in global mode; the
+                     per-submodule fields carry it in per-line mode (#1981). -->
+                <template v-if="equipmentMode === 'global'">
+                  <q-separator class="planner-equipment-separator q-my-md" />
+                  <div class="text-weight-medium q-mb-sm">
+                    {{ $t('planner_budget_section_title') }}
+                  </div>
+                  <q-input
+                    v-model.number="gridBudgetInputs[entry.config.module]"
+                    class="grant-budget-input"
+                    type="number"
+                    outlined
+                    dense
+                    hide-bottom-space
+                    min="0"
+                    :suffix="currencyLabel(yearData.budget_currency)"
+                    :label="
+                      $t('planner_submodule_budget_label', {
+                        submodule: $t(entry.config.module),
+                      })
+                    "
+                    :loading="savingGridBudgetModule === entry.config.module"
+                    :disable="entry.module?.is_active === false"
+                    @blur="saveGridBudget(entry)"
+                    @keyup.enter="saveGridBudget(entry)"
+                  />
+                  <div class="text-body2 text-grey-7 q-mt-sm">
+                    {{ $t('planner_submodule_budget_hint') }}
+                  </div>
+                  <q-separator class="planner-equipment-separator q-my-md" />
+                  <div
+                    class="planner-equipment-global-row row items-center no-wrap"
+                  >
+                    <label
+                      for="equipment-global-percentage"
+                      class="col text-body2 text-weight-medium"
+                    >
+                      {{ $t('planner_equipment_mode_global') }}
+                    </label>
+                    <q-input
+                      v-model.number="globalPercentage"
+                      for="equipment-global-percentage"
+                      class="planner-equipment-global-row__input"
+                      type="number"
+                      :min="0"
+                      :max="100"
+                      outlined
+                      dense
+                      hide-bottom-space
+                      suffix="%"
+                      :loading="applyingGlobalPercentage"
+                      :disable="
+                        entry.module?.is_active === false ||
+                        switchingEquipmentMode
+                      "
+                      @blur="applyGlobalPercentage"
+                      @keyup.enter="applyGlobalPercentage"
+                    />
+                  </div>
+                </template>
+                <q-dialog
+                  v-model="equipmentSwitchDialogOpen"
+                  :persistent="switchingEquipmentMode"
+                >
+                  <q-card style="min-width: 420px">
+                    <q-card-section class="text-h4 text-weight-medium">
+                      {{ $t('planner_purchase_switch_dialog_title') }}
+                    </q-card-section>
+                    <q-card-section class="text-body2 text-grey-8 q-pt-none">
+                      {{ $t(equipmentSwitchMessageKey) }}
+                    </q-card-section>
+                    <q-card-actions class="q-px-md q-pb-md">
+                      <q-btn
+                        :label="$t('common_validate_short')"
+                        :loading="switchingEquipmentMode"
+                        color="info"
+                        unelevated
+                        no-caps
+                        class="text-weight-medium"
+                        @click="confirmEquipmentSwitch"
+                      />
+                      <q-btn
+                        v-close-popup
+                        :label="$t('common_cancel')"
+                        :disable="switchingEquipmentMode"
+                        color="primary"
+                        unelevated
+                        outline
+                        no-caps
+                        class="text-weight-medium"
+                      />
+                    </q-card-actions>
+                  </q-card>
+                </q-dialog>
+              </div>
+              <module-table-section
+                :key="moduleMountKey(entry.config.module)"
+                :type="entry.config.module"
+                :config-override="getPlannerModuleConfig(entry.config.module)"
+                :data="moduleStore.state.data"
+                :loading="moduleStore.state.loading"
+                :error="moduleStore.state.error"
+                :unit-id="unitId"
+                :year="yearData.year"
+                :factor-year="factorYear"
+                :carbon-report-id="yearData.id"
+                :show-reference-columns="
+                  entry.config.behavior === 'prefilled' && hasReferenceYear
+                "
+                :project-years-count="grantYearsCountFor(entry.config.module)"
+                :percentage-locked="isGlobalEquipment(entry.config.module)"
+                :show-grant-budgets="
+                  yearData.is_grant && !isGlobalEquipment(entry.config.module)
+                "
+                :grant-budgets="entry.module?.budgets ?? null"
+                :grant-budget-currency="yearData.budget_currency"
+                :disable="entry.module?.is_active === false"
+              />
+            </template>
           </div>
         </q-expansion-item>
       </template>
@@ -307,7 +460,11 @@ import {
 } from 'src/constant/planner-module-config';
 import { getPlannerModuleConfig } from 'src/constant/planner-module-config/module-configs';
 import { getModuleTypeId } from 'src/constant/moduleStates';
-import { MODULES, type Module } from 'src/constant/modules';
+import {
+  MODULES,
+  SUBMODULE_EQUIPMENT_TYPES,
+  type Module,
+} from 'src/constant/modules';
 import { useModuleStore } from 'src/stores/modules';
 import { factorMountKey } from 'src/utils/factor-year';
 import {
@@ -472,30 +629,187 @@ function isGrantRfModule(module: Module): boolean {
   return props.yearData.is_grant && module === MODULES.ResearchFacilities;
 }
 
+/** Grant equipment gets the per-line / global percentage toggle (#1981). */
+function isGrantEquipmentModule(module: Module): boolean {
+  return props.yearData.is_grant && module === MODULES.Equipment;
+}
+
+// Grant equipment modes: per-line keeps the row sliders; global applies one
+// percentage to every prefilled line at once (#1981). View state only, the
+// entries are the same either way.
+const equipmentMode = ref<'per_line' | 'global'>('per_line');
+const globalPercentage = ref(0);
+const appliedGlobalPercentage = ref<number | null>(null);
+const applyingGlobalPercentage = ref(false);
+// Bumped after a global apply: the table remounts and refetches its
+// submodule rows, whose percentages all changed server-side.
+const equipmentTableTick = ref(0);
+
+const equipmentSwitchDialogOpen = ref(false);
+const pendingEquipmentMode = ref<'per_line' | 'global' | null>(null);
+const switchingEquipmentMode = ref(false);
+
+const EQUIPMENT_PER_LINE_BUDGET_KEYS: string[] = Object.values(
+  SUBMODULE_EQUIPMENT_TYPES,
+);
+
+const equipmentSwitchMessageKey = computed(() =>
+  equipmentMode.value === 'per_line'
+    ? 'planner_equipment_switch_to_global_message'
+    : 'planner_equipment_switch_to_per_line_message',
+);
+
+function equipmentEntry(): ModuleEntry | undefined {
+  return moduleEntries.value.find((e) => e.config.module === MODULES.Equipment);
+}
+
+function abandonedBudgetKeys(mode: 'per_line' | 'global'): string[] {
+  return mode === 'per_line'
+    ? EQUIPMENT_PER_LINE_BUDGET_KEYS
+    : [MODULES.Equipment];
+}
+
+// The loaded table totals when they belong to this module, the plan-year
+// stats otherwise (the module store slot is shared across expanded modules).
+function equipmentTotalKg(entry: ModuleEntry): number {
+  const data = moduleStore.state.data;
+  if (
+    entry.module &&
+    data?.carbon_report_module_id === entry.module.id &&
+    typeof data.totals?.total_kg_co2eq === 'number'
+  ) {
+    return data.totals.total_kg_co2eq;
+  }
+  const total = entry.module?.stats?.total;
+  return typeof total === 'number' ? total : 0;
+}
+
+// Prefilled lines all at 0% produce no kg, so an untouched module switches
+// silently; budgets of the mode being left count as data too.
+function equipmentHasDataToLose(entry: ModuleEntry): boolean {
+  const budgets = entry.module?.budgets ?? {};
+  if (
+    abandonedBudgetKeys(equipmentMode.value).some((key) => budgets[key] != null)
+  ) {
+    return true;
+  }
+  return equipmentTotalKg(entry) > 0;
+}
+
+function equipmentModeControlsDisabled(entry: ModuleEntry): boolean {
+  return (
+    switchingEquipmentMode.value ||
+    applyingGlobalPercentage.value ||
+    savingGridBudgetModule.value === MODULES.Equipment ||
+    entry.module?.is_active === false
+  );
+}
+
+function onEquipmentModeRequest(next: 'per_line' | 'global') {
+  if (next === equipmentMode.value || switchingEquipmentMode.value) return;
+  const entry = equipmentEntry();
+  if (entry && equipmentHasDataToLose(entry)) {
+    pendingEquipmentMode.value = next;
+    equipmentSwitchDialogOpen.value = true;
+    return;
+  }
+  equipmentMode.value = next;
+  globalPercentage.value = 0;
+  appliedGlobalPercentage.value = null;
+}
+
+async function confirmEquipmentSwitch() {
+  const next = pendingEquipmentMode.value;
+  const entry = equipmentEntry();
+  if (next === null || !entry?.module) return;
+  switchingEquipmentMode.value = true;
+  try {
+    await plansStore.setModuleReferencePercentage(
+      props.yearData.id,
+      entry.module.module_type_id,
+      0,
+    );
+    const budgets = entry.module.budgets ?? {};
+    for (const key of abandonedBudgetKeys(equipmentMode.value)) {
+      if (budgets[key] == null) continue;
+      await plansStore.setSubmoduleBudget(
+        props.yearData.id,
+        entry.module.module_type_id,
+        key,
+        null,
+      );
+    }
+    if (equipmentMode.value === 'global') {
+      gridBudgetInputs.value[MODULES.Equipment] = null;
+    }
+    equipmentMode.value = next;
+    pendingEquipmentMode.value = null;
+    equipmentSwitchDialogOpen.value = false;
+    globalPercentage.value = 0;
+    appliedGlobalPercentage.value = 0;
+    await refreshExpandedModule(MODULES.Equipment);
+    equipmentTableTick.value += 1;
+  } catch {
+    $q.notify({
+      type: 'negative',
+      message: t('planner_equipment_switch_error'),
+    });
+  } finally {
+    switchingEquipmentMode.value = false;
+  }
+}
+
+function isGlobalEquipment(module: Module): boolean {
+  return isGrantEquipmentModule(module) && equipmentMode.value === 'global';
+}
+
+function moduleMountKey(module: Module): string {
+  const base = factorScopedKey(module);
+  return module === MODULES.Equipment
+    ? `${base}-${equipmentTableTick.value}`
+    : base;
+}
+
+async function applyGlobalPercentage() {
+  const value = Math.min(100, Math.max(0, Number(globalPercentage.value)));
+  if (!Number.isFinite(value)) return;
+  globalPercentage.value = value;
+  if (applyingGlobalPercentage.value || value === appliedGlobalPercentage.value)
+    return;
+  applyingGlobalPercentage.value = true;
+  try {
+    await plansStore.setModuleReferencePercentage(
+      props.yearData.id,
+      getModuleTypeId(MODULES.Equipment),
+      value,
+    );
+    appliedGlobalPercentage.value = value;
+    // The rows' percentages and kg changed; refresh totals and remount the
+    // table so its rows refetch.
+    await refreshExpandedModule(MODULES.Equipment);
+    equipmentTableTick.value += 1;
+  } catch {
+    $q.notify({
+      type: 'negative',
+      message: t('planner_equipment_global_error'),
+    });
+  } finally {
+    applyingGlobalPercentage.value = false;
+  }
+}
+
 /** Grid stripes run edge to edge, so these blocks carry no outer padding. */
 function isEdgeToEdge(module: Module): boolean {
   return isGridModule(module) || isGrantRfModule(module);
 }
 
-// A grant proposal is first and foremost about the equipment it funds, so it
-// always counts (#1976); research facilities left the set with their opt-in
-// platform grid (#1980). Mirrors the backend GRANT_LOCKED_MODULE_TYPES set,
-// which rejects the toggle server-side.
-const GRANT_LOCKED_MODULES: Module[] = [MODULES.Equipment];
-
-function isGrantLocked(module: Module): boolean {
-  return props.yearData.is_grant && GRANT_LOCKED_MODULES.includes(module);
-}
-
 /**
  * Grant tables show kgCO₂eq per year and multiplied over the project's years
- * (#1979). Year sections never do, and grant-locked Equipment waits for its
- * custom grant UI (#1981); the RF grid shows the pair on its own rows.
+ * (#1979). Year sections never do; the RF grid shows the pair on its own rows.
  */
-function grantYearsCountFor(module: Module): number | null {
-  if (!props.yearData.is_grant || isGrantLocked(module)) return null;
-  return props.projectYearsCount ?? null;
-}
+const grantYearsCount = computed<number | null>(() =>
+  props.yearData.is_grant ? (props.projectYearsCount ?? null) : null,
+);
 
 const moduleEntries = computed<ModuleEntry[]>(() =>
   PLANNER_MODULES.map((config) => ({
@@ -636,6 +950,33 @@ async function onToggleActive(entry: ModuleEntry, active: boolean) {
 .grant-budget-input {
   max-width: 240px;
   flex: 1;
+}
+
+// Both equipment modes are named on either side of the switch; the one not
+// in use reads as unavailable rather than disappearing (purchase pattern).
+.planner-mode__label {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.planner-equipment-global-row {
+  &__input {
+    width: tokens.$planner-grid-amount-input-width;
+
+    :deep(.q-field__suffix) {
+      font-size: tokens.$text-size-sm;
+      color: tokens.$color-text-muted;
+    }
+  }
+}
+
+// The block sits in the q-pa-md module body; these bleed to its edges.
+.planner-equipment-separator {
+  margin-left: -16px;
+  margin-right: -16px;
 }
 
 .grant-budget-currency {

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -253,7 +253,9 @@
                  table (#1980). -->
             <planner-research-facility-rows
               v-else-if="isGrantRfModule(entry.config.module)"
+              :key="factorScopedKey(entry.config.module)"
               :carbon-report-id="yearData.id"
+              :factor-year="yearData.reference_year ?? yearData.year"
               :project-years-count="projectYearsCount ?? null"
               :grant-budgets="entry.module?.budgets ?? null"
               :budget-currency="yearData.budget_currency"

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -5,7 +5,13 @@
       header-class="text-h5 text-weight-medium"
     >
       <template #header>
-        <q-item-section>{{ yearData.year }}</q-item-section>
+        <q-item-section>
+          {{
+            yearData.is_grant
+              ? $t('planner_project_grant_title')
+              : yearData.year
+          }}
+        </q-item-section>
       </template>
 
       <q-separator />
@@ -110,14 +116,18 @@
                   size="sm"
                   dense
                   :disable="
-                    !entry.module || togglingModuleId === entry.module.id
+                    !entry.module ||
+                    togglingModuleId === entry.module.id ||
+                    isGrantLocked(entry.config.module)
                   "
                   @update:model-value="
                     (active: boolean) => onToggleActive(entry, active)
                   "
                 >
                   <q-tooltip>{{
-                    $t('planner_module_active_tooltip')
+                    isGrantLocked(entry.config.module)
+                      ? $t('planner_module_grant_locked_tooltip')
+                      : $t('planner_module_active_tooltip')
                   }}</q-tooltip>
                 </q-checkbox>
               </div>
@@ -246,6 +256,18 @@ function isGridModule(module: Module): boolean {
   return GRID_MODULES.includes(module);
 }
 
+// A grant proposal is first and foremost about the equipment and research
+// facilities it funds, so these always count (#1976). Mirrors the backend
+// GRANT_LOCKED_MODULE_TYPES set, which rejects the toggle server-side.
+const GRANT_LOCKED_MODULES: Module[] = [
+  MODULES.Equipment,
+  MODULES.ResearchFacilities,
+];
+
+function isGrantLocked(module: Module): boolean {
+  return props.yearData.is_grant && GRANT_LOCKED_MODULES.includes(module);
+}
+
 const moduleEntries = computed<ModuleEntry[]>(() =>
   PLANNER_MODULES.map((config) => ({
     config,
@@ -255,8 +277,14 @@ const moduleEntries = computed<ModuleEntry[]>(() =>
   })),
 );
 
+// The Project Grant report shares its year with the start-year report, so
+// its expansion keys carry their own prefix.
+const sectionKey = computed(() =>
+  props.yearData.is_grant ? 'grant' : String(props.yearData.year),
+);
+
 function expansionKey(module: Module): string {
-  return `${props.yearData.year}-${module}`;
+  return `${sectionKey.value}-${module}`;
 }
 
 function isExpanded(module: Module): boolean {
@@ -288,11 +316,12 @@ async function onReferenceYearChange(referenceYear: number | null) {
       props.planId,
       props.yearData.year,
       referenceYear,
+      props.yearData.is_grant,
     );
     referenceYearDialogOpen.value = false;
     // The prefilled modules were rebuilt from the new baseline; refresh this
-    // year's open modules so their rows appear without a manual reload.
-    const prefix = `${props.yearData.year}-`;
+    // section's open modules so their rows appear without a manual reload.
+    const prefix = `${sectionKey.value}-`;
     for (const key of props.expandedKeys) {
       if (!key.startsWith(prefix)) continue;
       await refreshExpandedModule(key.slice(prefix.length) as Module);

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -182,7 +182,7 @@
           <!-- Grid stripes run edge to edge, so they carry no padding. -->
           <div
             v-if="isExpanded(entry.config.module)"
-            :class="isGridModule(entry.config.module) ? undefined : 'q-pa-md'"
+            :class="isEdgeToEdge(entry.config.module) ? undefined : 'q-pa-md'"
           >
             <!-- Headcount and Purchases are single grids, so they carry one
                  submodule-budget field here; table modules get theirs inside
@@ -242,6 +242,17 @@
               :project-years-count="grantYearsCountFor(entry.config.module)"
               :disable="entry.module?.is_active === false"
             />
+            <!-- Grant proposals plan RF use from the reference year's whole
+                 platform list; year sections keep the standard prefilled
+                 table (#1980). -->
+            <planner-research-facility-rows
+              v-else-if="isGrantRfModule(entry.config.module)"
+              :carbon-report-id="yearData.id"
+              :project-years-count="projectYearsCount ?? null"
+              :grant-budgets="entry.module?.budgets ?? null"
+              :budget-currency="yearData.budget_currency"
+              :disable="entry.module?.is_active === false"
+            />
             <module-table-section
               v-else
               :key="factorScopedKey(entry.config.module)"
@@ -279,6 +290,7 @@ import ModuleIconBox from 'src/components/atoms/ModuleIconBox.vue';
 import ModuleTableSection from 'src/components/organisms/module/ModuleTableSection.vue';
 import PlannerHeadcountRows from 'src/components/organisms/planner/PlannerHeadcountRows.vue';
 import PlannerPurchaseRows from 'src/components/organisms/planner/PlannerPurchaseRows.vue';
+import PlannerResearchFacilityRows from 'src/components/organisms/planner/PlannerResearchFacilityRows.vue';
 import PlannerReferenceYearDialog from 'src/components/organisms/planner/PlannerReferenceYearDialog.vue';
 import { CURRENCY_OPTIONS, currencyLabel } from 'src/constant/currencies';
 import {
@@ -440,13 +452,21 @@ function isGridModule(module: Module): boolean {
   return GRID_MODULES.includes(module);
 }
 
-// A grant proposal is first and foremost about the equipment and research
-// facilities it funds, so these always count (#1976). Mirrors the backend
-// GRANT_LOCKED_MODULE_TYPES set, which rejects the toggle server-side.
-const GRANT_LOCKED_MODULES: Module[] = [
-  MODULES.Equipment,
-  MODULES.ResearchFacilities,
-];
+/** Grant proposals swap the RF table for the platform-selection grid (#1980). */
+function isGrantRfModule(module: Module): boolean {
+  return props.yearData.is_grant && module === MODULES.ResearchFacilities;
+}
+
+/** Grid stripes run edge to edge, so these blocks carry no outer padding. */
+function isEdgeToEdge(module: Module): boolean {
+  return isGridModule(module) || isGrantRfModule(module);
+}
+
+// A grant proposal is first and foremost about the equipment it funds, so it
+// always counts (#1976); research facilities left the set with their opt-in
+// platform grid (#1980). Mirrors the backend GRANT_LOCKED_MODULE_TYPES set,
+// which rejects the toggle server-side.
+const GRANT_LOCKED_MODULES: Module[] = [MODULES.Equipment];
 
 function isGrantLocked(module: Module): boolean {
   return props.yearData.is_grant && GRANT_LOCKED_MODULES.includes(module);
@@ -454,8 +474,8 @@ function isGrantLocked(module: Module): boolean {
 
 /**
  * Grant tables show kgCO₂eq per year and multiplied over the project's years
- * (#1979). Year sections never do, and the grant-locked modules wait for
- * their custom grant UI (#1980/#1981).
+ * (#1979). Year sections never do, and grant-locked Equipment waits for its
+ * custom grant UI (#1981); the RF grid shows the pair on its own rows.
  */
 function grantYearsCountFor(module: Module): number | null {
   if (!props.yearData.is_grant || isGrantLocked(module)) return null;

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -156,6 +156,7 @@
               v-else-if="entry.config.module === MODULES.Purchase"
               :key="factorScopedKey(entry.config.module)"
               :carbon-report-id="yearData.id"
+              :project-years-count="grantYearsCountFor(entry.config.module)"
               :disable="entry.module?.is_active === false"
             />
             <module-table-section
@@ -173,6 +174,7 @@
               :show-reference-columns="
                 entry.config.behavior === 'prefilled' && hasReferenceYear
               "
+              :project-years-count="grantYearsCountFor(entry.config.module)"
               :disable="entry.module?.is_active === false"
             />
           </div>
@@ -221,6 +223,8 @@ const props = defineProps<{
   referenceYearOptions: { label: string; value: number }[];
   /** `${year}-${module}` of every expanded module across the page. */
   expandedKeys: string[];
+  /** The plan's year count (end - start + 1); null until the range is set. */
+  projectYearsCount?: number | null;
 }>();
 const emit = defineEmits<{
   toggleModule: [payload: { key: string; module: Module; open: boolean }];
@@ -266,6 +270,16 @@ const GRANT_LOCKED_MODULES: Module[] = [
 
 function isGrantLocked(module: Module): boolean {
   return props.yearData.is_grant && GRANT_LOCKED_MODULES.includes(module);
+}
+
+/**
+ * Grant tables show kgCO₂eq per year and multiplied over the project's years
+ * (#1979). Year sections never do, and the grant-locked modules wait for
+ * their custom grant UI (#1980/#1981).
+ */
+function grantYearsCountFor(module: Module): number | null {
+  if (!props.yearData.is_grant || isGrantLocked(module)) return null;
+  return props.projectYearsCount ?? null;
 }
 
 const moduleEntries = computed<ModuleEntry[]>(() =>

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -106,7 +106,13 @@
           </div>
           <div
             class="text-body2 q-mt-sm"
-            :class="overDistributed ? 'text-negative' : 'text-grey-7'"
+            :class="
+              overDistributed
+                ? 'text-negative'
+                : fullyDistributed
+                  ? 'text-positive'
+                  : 'text-grey-7'
+            "
           >
             {{ budgetCheckText }}
           </div>
@@ -374,6 +380,12 @@ const overDistributed = computed(
     distributedBudget.value > props.yearData.budget,
 );
 
+const fullyDistributed = computed(
+  () =>
+    props.yearData.budget !== null &&
+    distributedBudget.value === props.yearData.budget,
+);
+
 const budgetCheckText = computed(() => {
   const total = props.yearData.budget;
   if (total === null) return t('planner_grant_budget_hint');
@@ -384,6 +396,7 @@ const budgetCheckText = computed(() => {
   }
   return t('planner_grant_budget_distribution', {
     distributed: n(distributedBudget.value),
+    currency: currencyLabel(props.yearData.budget_currency),
     total: n(total),
     remaining: n(total - distributedBudget.value),
   });

--- a/frontend/src/components/organisms/planner/PlannerYearSection.vue
+++ b/frontend/src/components/organisms/planner/PlannerYearSection.vue
@@ -70,6 +70,50 @@
 
       <q-separator />
 
+      <!-- Grant budget: the total lives here, its distribution lives inside
+           each module; the check line reconciles the two (#1978). -->
+      <template v-if="yearData.is_grant">
+        <q-card-section>
+          <div class="text-weight-medium q-mb-sm">
+            {{ $t('planner_grant_budget_label') }}
+          </div>
+          <div class="row items-start q-gutter-sm">
+            <q-input
+              v-model.number="budgetInput"
+              class="grant-budget-input"
+              type="number"
+              outlined
+              dense
+              hide-bottom-space
+              min="0"
+              :label="$t('planner_grant_budget_input_label')"
+              :loading="savingBudget"
+              @blur="saveBudget"
+              @keyup.enter="saveBudget"
+            />
+            <q-select
+              v-model="budgetCurrencyInput"
+              class="grant-budget-currency"
+              :options="CURRENCY_OPTIONS"
+              :label="$t('planner_budget_currency_label')"
+              outlined
+              dense
+              hide-bottom-space
+              emit-value
+              map-options
+              @update:model-value="saveBudget"
+            />
+          </div>
+          <div
+            class="text-body2 q-mt-sm"
+            :class="overDistributed ? 'text-negative' : 'text-grey-7'"
+          >
+            {{ budgetCheckText }}
+          </div>
+        </q-card-section>
+        <q-separator />
+      </template>
+
       <planner-reference-year-dialog
         v-if="referenceYearDialogOpen"
         :key="`ref-year-${yearData.reference_year}`"
@@ -140,6 +184,45 @@
             v-if="isExpanded(entry.config.module)"
             :class="isGridModule(entry.config.module) ? undefined : 'q-pa-md'"
           >
+            <!-- Headcount and Purchases are single grids, so they carry one
+                 submodule-budget field here; table modules get theirs inside
+                 each submodule section (#1978). -->
+            <template
+              v-if="
+                yearData.is_grant &&
+                entry.module &&
+                isGridModule(entry.config.module)
+              "
+            >
+              <div class="q-pa-md">
+                <div class="text-weight-medium q-mb-sm">
+                  {{ $t('planner_budget_section_title') }}
+                </div>
+                <q-input
+                  v-model.number="gridBudgetInputs[entry.config.module]"
+                  class="grant-budget-input"
+                  type="number"
+                  outlined
+                  dense
+                  hide-bottom-space
+                  min="0"
+                  :suffix="currencyLabel(yearData.budget_currency)"
+                  :label="
+                    $t('planner_submodule_budget_label', {
+                      submodule: $t(entry.config.module),
+                    })
+                  "
+                  :loading="savingGridBudgetModule === entry.config.module"
+                  :disable="entry.module.is_active === false"
+                  @blur="saveGridBudget(entry)"
+                  @keyup.enter="saveGridBudget(entry)"
+                />
+                <div class="text-body2 text-grey-7 q-mt-sm">
+                  {{ $t('planner_submodule_budget_hint') }}
+                </div>
+              </div>
+              <q-separator />
+            </template>
             <!-- Headcount is a fixed SIUS-category grid and Purchases a
                    global-budget XOR per-category grid, not add-row tables
                    (design). Other modules reuse the Calculator tables. -->
@@ -175,6 +258,9 @@
                 entry.config.behavior === 'prefilled' && hasReferenceYear
               "
               :project-years-count="grantYearsCountFor(entry.config.module)"
+              :show-grant-budgets="yearData.is_grant"
+              :grant-budgets="entry.module?.budgets ?? null"
+              :grant-budget-currency="yearData.budget_currency"
               :disable="entry.module?.is_active === false"
             />
           </div>
@@ -194,6 +280,7 @@ import ModuleTableSection from 'src/components/organisms/module/ModuleTableSecti
 import PlannerHeadcountRows from 'src/components/organisms/planner/PlannerHeadcountRows.vue';
 import PlannerPurchaseRows from 'src/components/organisms/planner/PlannerPurchaseRows.vue';
 import PlannerReferenceYearDialog from 'src/components/organisms/planner/PlannerReferenceYearDialog.vue';
+import { CURRENCY_OPTIONS, currencyLabel } from 'src/constant/currencies';
 import {
   PLANNER_MODULES,
   type PlannerModuleConfig,
@@ -231,7 +318,7 @@ const emit = defineEmits<{
 }>();
 
 const $q = useQuasar();
-const { t } = useI18n();
+const { t, n } = useI18n();
 const moduleStore = useModuleStore();
 const plansStore = useSimulatorPlansStore();
 
@@ -242,6 +329,99 @@ const togglingModuleId = ref<number | null>(null);
 
 // The reference year only gates the prefill columns; data entry itself is
 // always open. Its rows and dropdowns follow `factorYear` below.
+// Grant budget inputs are seeded from the loaded report once; the check line
+// below reads the persisted store values, so it only moves on save (#1978).
+const budgetInput = ref<number | null>(props.yearData.budget);
+const budgetCurrencyInput = ref<string | null>(props.yearData.budget_currency);
+const savingBudget = ref(false);
+// Headcount and Purchases are single grids: their one budget field lives on
+// this level, stored under the module name as the submodule key.
+const gridBudgetInputs = ref<Record<string, number | null>>(
+  Object.fromEntries(
+    PLANNER_MODULES.map((config) => {
+      const module = props.yearData.modules.find(
+        (m) => m.module_type_id === getModuleTypeId(config.module),
+      );
+      return [config.module, module?.budgets?.[config.module] ?? null];
+    }),
+  ),
+);
+const savingGridBudgetModule = ref<string | null>(null);
+
+const distributedBudget = computed(() =>
+  props.yearData.modules.reduce(
+    (sum, m) =>
+      sum + Object.values(m.budgets ?? {}).reduce((s, value) => s + value, 0),
+    0,
+  ),
+);
+
+const overDistributed = computed(
+  () =>
+    props.yearData.budget !== null &&
+    distributedBudget.value > props.yearData.budget,
+);
+
+const budgetCheckText = computed(() => {
+  const total = props.yearData.budget;
+  if (total === null) return t('planner_grant_budget_hint');
+  if (overDistributed.value) {
+    return t('planner_grant_budget_over', {
+      amount: n(distributedBudget.value - total),
+    });
+  }
+  return t('planner_grant_budget_distribution', {
+    distributed: n(distributedBudget.value),
+    total: n(total),
+    remaining: n(total - distributedBudget.value),
+  });
+});
+
+function toBudgetValue(raw: number | null | undefined): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+    ? raw
+    : null;
+}
+
+async function saveBudget() {
+  const value = toBudgetValue(budgetInput.value);
+  const currency = budgetCurrencyInput.value;
+  if (
+    (value === props.yearData.budget &&
+      currency === props.yearData.budget_currency) ||
+    savingBudget.value
+  ) {
+    return;
+  }
+  savingBudget.value = true;
+  try {
+    await plansStore.setGrantBudget(props.yearData.id, value, currency);
+  } catch {
+    $q.notify({ type: 'negative', message: t('planner_grant_budget_error') });
+  } finally {
+    savingBudget.value = false;
+  }
+}
+
+async function saveGridBudget(entry: ModuleEntry) {
+  if (!entry.module) return;
+  const submodule = entry.config.module;
+  const value = toBudgetValue(gridBudgetInputs.value[submodule]);
+  if (value === (entry.module.budgets?.[submodule] ?? null)) return;
+  savingGridBudgetModule.value = submodule;
+  try {
+    await plansStore.setSubmoduleBudget(
+      props.yearData.id,
+      entry.module.module_type_id,
+      submodule,
+      value,
+    );
+  } catch {
+    $q.notify({ type: 'negative', message: t('planner_grant_budget_error') });
+  } finally {
+    savingGridBudgetModule.value = null;
+  }
+}
 const hasReferenceYear = computed(() => props.yearData.reference_year !== null);
 
 // Factor year, mirroring the backend chain (`resolve_factor_year`): the
@@ -414,5 +594,16 @@ async function onToggleActive(entry: ModuleEntry, active: boolean) {
 .reference-year-empty {
   border-style: tokens.$reference-year-row-empty-border-style;
   border-color: tokens.$reference-year-row-empty-border-color;
+}
+
+// Budget fields hold one amount; a bounded box keeps them from stretching
+// across the card like a text field would.
+.grant-budget-input {
+  max-width: 240px;
+  flex: 1;
+}
+
+.grant-budget-currency {
+  width: 110px;
 }
 </style>

--- a/frontend/src/components/organisms/print/PlannerPrintYearPage.vue
+++ b/frontend/src/components/organisms/print/PlannerPrintYearPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import ReportPage from 'src/components/organisms/ReportPage.vue';
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
@@ -20,6 +21,16 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const { t } = useI18n();
+
+// The same page prints the Project Grant summary, titled by name rather
+// than by its anchor year (#1977).
+const pageTitle = computed(() =>
+  props.year.is_grant
+    ? t('planner_project_grant_title')
+    : String(props.year.year),
+);
+
 // Inactive modules are excluded from the year's sums and charts, so the report
 // names them: a reader seeing a low total needs to know what was left out.
 const inactiveModules = computed(() =>
@@ -33,12 +44,8 @@ const inactiveModules = computed(() =>
 </script>
 
 <template>
-  <ReportPage
-    :title="String(year.year)"
-    :scope="scope"
-    :page-number="pageNumber"
-  >
-    <h2 class="text-h5 q-mt-none">{{ year.year }}</h2>
+  <ReportPage :title="pageTitle" :scope="scope" :page-number="pageNumber">
+    <h2 class="text-h5 q-mt-none">{{ pageTitle }}</h2>
     <div class="text-body2 text-secondary">
       {{ $t('planner_print_year_subtitle', { name: planName }) }}
     </div>
@@ -74,7 +81,7 @@ const inactiveModules = computed(() =>
     <section class="q-mt-md">
       <ModuleCarbonFootprintChart
         :breakdown-data="breakdown"
-        :title="$t('planner_print_year_chart_title', { year: year.year })"
+        :title="$t('planner_print_year_chart_title', { year: pageTitle })"
         :print-mode="true"
       />
     </section>

--- a/frontend/src/composables/print/useProjectPlannerPrintData.ts
+++ b/frontend/src/composables/print/useProjectPlannerPrintData.ts
@@ -125,7 +125,11 @@ export function useProjectPlannerPrintData() {
 
   const printModules = getPlannerPrintModules();
 
-  const planYears = computed(() => plansStore.planYears);
+  // The Project Grant report stays out of the printed report until #1977
+  // settles how grant results combine with the per-year results.
+  const planYears = computed(() =>
+    plansStore.planYears.filter((year) => !year.is_grant),
+  );
 
   const yearRangeLabel = computed(() => {
     const years = planYears.value;
@@ -357,7 +361,7 @@ export function useProjectPlannerPrintData() {
         yearConfigStore.fetchConfiguredYears(),
       ]);
 
-      const years = plansStore.planYears;
+      const years = planYears.value;
       const taxonomyYear =
         years.find((year) => year.reference_year != null)?.reference_year ??
         plan.value.default_factor_year ??

--- a/frontend/src/composables/print/useProjectPlannerPrintData.ts
+++ b/frontend/src/composables/print/useProjectPlannerPrintData.ts
@@ -125,10 +125,14 @@ export function useProjectPlannerPrintData() {
 
   const printModules = getPlannerPrintModules();
 
-  // The Project Grant report stays out of the printed report until #1977
-  // settles how grant results combine with the per-year results.
+  // Year pages and the range label cover the year sections; the Project
+  // Grant report gets its own summary page (#1977).
   const planYears = computed(() =>
     plansStore.planYears.filter((year) => !year.is_grant),
+  );
+
+  const grantYear = computed(
+    () => plansStore.planYears.find((year) => year.is_grant) ?? null,
   );
 
   const yearRangeLabel = computed(() => {
@@ -156,11 +160,11 @@ export function useProjectPlannerPrintData() {
     sumBreakdownTonnes(planBreakdown.value),
   );
 
-  /** Per-year breakdowns, keyed by the plan-year carbon report id. */
+  /** Per-report breakdowns (years + grant), keyed by carbon report id. */
   const yearBreakdowns = computed<Record<number, EmissionBreakdownResponse>>(
     () => {
       const map: Record<number, EmissionBreakdownResponse> = {};
-      for (const year of planYears.value) {
+      for (const year of plansStore.planYears) {
         if (!year.stats) continue;
         map[year.id] = toEmissionBreakdown(
           year.stats as unknown as ReportStats,
@@ -207,6 +211,17 @@ export function useProjectPlannerPrintData() {
     const list: PlannerPrintSheet[] = [];
     // The cover is page 1.
     let pageNumber = 2;
+
+    // The Project Grant summary leads, mirroring the planner page's
+    // section order (#1977).
+    if (grantYear.value) {
+      list.push({
+        kind: 'year',
+        key: `grant-${grantYear.value.id}`,
+        pageNumber: pageNumber++,
+        year: grantYear.value,
+      });
+    }
 
     for (const year of planYears.value) {
       list.push({
@@ -460,6 +475,7 @@ export function useProjectPlannerPrintData() {
     yearTotalTonnes,
     headcountRows,
     incompleteModules,
+    grantYear,
     sheets,
     moduleTables,
     initWorkspaceFromRoute,

--- a/frontend/src/composables/print/useProjectPlannerPrintData.ts
+++ b/frontend/src/composables/print/useProjectPlannerPrintData.ts
@@ -354,17 +354,8 @@ export function useProjectPlannerPrintData() {
   async function fetchAllData(): Promise<void> {
     loading.value = true;
     try {
-      const unitId = workspaceStore.selectedUnit?.id;
-      if (unitId == null) {
-        notFound.value = true;
-        return;
-      }
-
       try {
-        plan.value = await plansStore.getPlanByName(
-          unitId,
-          String(route.params.name),
-        );
+        plan.value = await plansStore.getPlan(Number(route.params.planId));
       } catch {
         notFound.value = true;
         return;

--- a/frontend/src/constant/currencies.ts
+++ b/frontend/src/constant/currencies.ts
@@ -1,0 +1,21 @@
+/**
+ * The currencies the app accepts for money amounts, shared by the Purchase
+ * module fields and the planner's grant budget (#1978). Values are the
+ * lowercase codes the backend stores; labels are the display codes.
+ */
+export const CURRENCY_OPTIONS: { value: string; label: string }[] = [
+  { value: 'aud', label: 'AUD' },
+  { value: 'cad', label: 'CAD' },
+  { value: 'chf', label: 'CHF' },
+  { value: 'cny', label: 'CNY' },
+  { value: 'eur', label: 'EUR' },
+  { value: 'gbp', label: 'GBP' },
+  { value: 'jpy', label: 'JPY' },
+  { value: 'sek', label: 'SEK' },
+  { value: 'usd', label: 'USD' },
+];
+
+/** Display code of a stored currency value ('chf' -> 'CHF'); '' when unset. */
+export function currencyLabel(value: string | null | undefined): string {
+  return value ? value.toUpperCase() : '';
+}

--- a/frontend/src/constant/module-config/purchase.ts
+++ b/frontend/src/constant/module-config/purchase.ts
@@ -1,3 +1,4 @@
+import { CURRENCY_OPTIONS } from 'src/constant/currencies';
 import { ModuleConfig, ModuleField } from 'src/constant/moduleConfig';
 import { formatTonnesCO2 } from 'src/utils/number';
 import {
@@ -81,44 +82,7 @@ const purchaseFields: ModuleField[] = [
     ratio: '1/4',
     columnSize: 'xs',
 
-    options: [
-      {
-        value: 'aud',
-        label: 'AUD',
-      },
-      {
-        value: 'cad',
-        label: 'CAD',
-      },
-      {
-        value: 'chf',
-        label: 'CHF',
-      },
-      {
-        value: 'cny',
-        label: 'CNY',
-      },
-      {
-        value: 'eur',
-        label: 'EUR',
-      },
-      {
-        value: 'gbp',
-        label: 'GBP',
-      },
-      {
-        value: 'jpy',
-        label: 'JPY',
-      },
-      {
-        value: 'sek',
-        label: 'SEK',
-      },
-      {
-        value: 'usd',
-        label: 'USD',
-      },
-    ],
+    options: CURRENCY_OPTIONS,
   },
   {
     id: 'kg_co2eq',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -212,20 +212,32 @@ export default {
     fr: 'Ce projet est une demande de financement',
   },
   planner_grant_proposal_hint: {
-    en: 'Adds a Project Grant section covering the whole project, in addition to the year sections.',
-    fr: 'Ajoute une section Financement du projet couvrant tout le projet, en plus des sections annuelles.',
+    en: 'Adds a Project Grant section covering the whole project.',
+    fr: 'Ajoute une section Financement du projet couvrant tout le projet.',
   },
   planner_project_grant_title: {
     en: 'Project Grant',
     fr: 'Financement du projet',
+  },
+  planner_year_by_year_checkbox: {
+    en: 'Plan the project year by year',
+    fr: 'Planifier le projet année par année',
+  },
+  planner_year_by_year_hint: {
+    en: 'Adds one editable section per year between the start and end year.',
+    fr: 'Ajoute une section modifiable par année entre les années de début et de fin.',
+  },
+  planner_sections_need_one: {
+    en: 'Select the year-by-year planning, the grant proposal, or both.',
+    fr: 'Sélectionnez la planification année par année, la demande de financement, ou les deux.',
   },
   planner_generate_sections_button: {
     en: 'Create project sections',
     fr: 'Créer les sections du projet',
   },
   planner_generate_sections_hint: {
-    en: 'Creates one editable section per year between the start and end year, plus the Project Grant section when the project is a grant proposal.',
-    fr: 'Crée une section modifiable par année entre les années de début et de fin, ainsi que la section Financement du projet si le projet est une demande de financement.',
+    en: 'Creates the selected sections: one editable section per year between the start and end year when planning year by year, plus the Project Grant section when the project is a grant proposal.',
+    fr: 'Crée les sections sélectionnées : une section modifiable par année entre les années de début et de fin pour la planification année par année, ainsi que la section Financement du projet si le projet est une demande de financement.',
   },
   planner_sections_generated: {
     en: 'Project sections updated',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -291,6 +291,22 @@ export default {
     en: '% of reference year',
     fr: '% de l’année de référence',
   },
+  planner_kg_per_year_col: {
+    en: 'kgCO₂eq / year',
+    fr: 'kgCO₂eq / an',
+  },
+  planner_kg_project_col: {
+    en: 'kgCO₂eq over {years} years',
+    fr: 'kgCO₂eq sur {years} ans',
+  },
+  planner_purchase_kg_per_year: {
+    en: '{value} tCO₂eq / year',
+    fr: '{value} tCO₂eq / an',
+  },
+  planner_purchase_kg_project: {
+    en: '{value} tCO₂eq over {years} years',
+    fr: '{value} tCO₂eq sur {years} ans',
+  },
   planner_module_prefilled_badge: {
     en: 'Prefilled from reference year',
     fr: "Prérempli depuis l'année de référence",

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -307,6 +307,46 @@ export default {
     en: '{value} tCO₂eq over {years} years',
     fr: '{value} tCO₂eq sur {years} ans',
   },
+  planner_grant_budget_label: {
+    en: 'Grant budget',
+    fr: 'Budget du financement',
+  },
+  planner_grant_budget_input_label: {
+    en: 'Total budget',
+    fr: 'Budget total',
+  },
+  planner_grant_budget_hint: {
+    en: 'Set the total budget of the grant, then distribute it in the sections below.',
+    fr: 'Saisissez le budget total du financement, puis répartissez-le dans les sections ci-dessous.',
+  },
+  planner_grant_budget_distribution: {
+    en: '{distributed} of {total} distributed, {remaining} remaining.',
+    fr: '{distributed} sur {total} répartis, {remaining} restants.',
+  },
+  planner_grant_budget_over: {
+    en: 'The distributed budgets exceed the total budget by {amount}.',
+    fr: 'Les budgets répartis dépassent le budget total de {amount}.',
+  },
+  planner_grant_budget_error: {
+    en: 'Could not save the budget',
+    fr: "Impossible d'enregistrer le budget",
+  },
+  planner_budget_section_title: {
+    en: 'Budget',
+    fr: 'Budget',
+  },
+  planner_budget_currency_label: {
+    en: 'Currency',
+    fr: 'Devise',
+  },
+  planner_submodule_budget_label: {
+    en: '{submodule} budget',
+    fr: 'Budget {submodule}',
+  },
+  planner_submodule_budget_hint: {
+    en: 'The part of the grant budget planned here.',
+    fr: 'La part du budget du financement prévue ici.',
+  },
   planner_module_prefilled_badge: {
     en: 'Prefilled from reference year',
     fr: "Prérempli depuis l'année de référence",

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -220,8 +220,8 @@ export default {
     fr: 'Impossible de créer les sections du projet',
   },
   planner_module_grant_locked_tooltip: {
-    en: 'Equipment and Research Facilities always count in a grant proposal.',
-    fr: 'Les équipements et les plateformes de recherche comptent toujours dans une demande de financement.',
+    en: 'Equipment always counts in a grant proposal.',
+    fr: 'Les équipements comptent toujours dans une demande de financement.',
   },
   planner_no_years_hint: {
     en: 'Set a start and end year to plan your project — one section per year will appear here.',
@@ -346,6 +346,38 @@ export default {
   planner_submodule_budget_hint: {
     en: 'The part of the grant budget planned here.',
     fr: 'La part du budget du financement prévue ici.',
+  },
+  planner_rf_hint: {
+    en: "Add the platforms the project will use and enter the planned use in each platform's own metric (budget, hours, CPU, housing).",
+    fr: "Ajoutez les plateformes que le projet utilisera et saisissez l'utilisation prévue dans la métrique propre à chaque plateforme (budget, heures, CPU, hébergement).",
+  },
+  planner_rf_add_label: {
+    en: 'Add a platform',
+    fr: 'Ajouter une plateforme',
+  },
+  planner_rf_common_title: {
+    en: 'Research facilities',
+    fr: 'Infrastructures de recherche',
+  },
+  planner_rf_use_label: {
+    en: 'Planned use',
+    fr: 'Utilisation prévue',
+  },
+  planner_rf_empty: {
+    en: 'No platform is available for the current year.',
+    fr: "Aucune plateforme n'est disponible pour l'année en cours.",
+  },
+  planner_rf_kg_per_year: {
+    en: '{value} kgCO₂eq / year',
+    fr: '{value} kgCO₂eq / an',
+  },
+  planner_rf_kg_project: {
+    en: '{value} kgCO₂eq over {years} years',
+    fr: '{value} kgCO₂eq sur {years} ans',
+  },
+  planner_rf_save_error: {
+    en: 'Could not save the platform use',
+    fr: "Impossible d'enregistrer l'utilisation de la plateforme",
   },
   planner_module_prefilled_badge: {
     en: 'Prefilled from reference year',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -187,21 +187,41 @@ export default {
     en: 'Visible to all lab members',
     fr: 'Visible par tous les membres du laboratoire',
   },
-  planner_generate_years_button: {
-    en: 'Create year sections',
-    fr: 'Créer les sections annuelles',
+  planner_grant_proposal_label: {
+    en: 'Grant proposal',
+    fr: 'Demande de financement',
   },
-  planner_generate_years_hint: {
-    en: 'Creates one editable section per year between the start and end year.',
-    fr: 'Crée une section modifiable par année entre les années de début et de fin.',
+  planner_grant_proposal_checkbox: {
+    en: 'This project is a grant proposal',
+    fr: 'Ce projet est une demande de financement',
   },
-  planner_years_generated: {
-    en: 'Year sections updated',
-    fr: 'Sections annuelles mises à jour',
+  planner_grant_proposal_hint: {
+    en: 'Adds a Project Grant section covering the whole project, in addition to the year sections.',
+    fr: 'Ajoute une section Financement du projet couvrant tout le projet, en plus des sections annuelles.',
   },
-  planner_years_generate_error: {
-    en: 'Could not create the year sections',
-    fr: 'Impossible de créer les sections annuelles',
+  planner_project_grant_title: {
+    en: 'Project Grant',
+    fr: 'Financement du projet',
+  },
+  planner_generate_sections_button: {
+    en: 'Create project sections',
+    fr: 'Créer les sections du projet',
+  },
+  planner_generate_sections_hint: {
+    en: 'Creates one editable section per year between the start and end year, plus the Project Grant section when the project is a grant proposal.',
+    fr: 'Crée une section modifiable par année entre les années de début et de fin, ainsi que la section Financement du projet si le projet est une demande de financement.',
+  },
+  planner_sections_generated: {
+    en: 'Project sections updated',
+    fr: 'Sections du projet mises à jour',
+  },
+  planner_sections_generate_error: {
+    en: 'Could not create the project sections',
+    fr: 'Impossible de créer les sections du projet',
+  },
+  planner_module_grant_locked_tooltip: {
+    en: 'Equipment and Research Facilities always count in a grant proposal.',
+    fr: 'Les équipements et les plateformes de recherche comptent toujours dans une demande de financement.',
   },
   planner_no_years_hint: {
     en: 'Set a start and end year to plan your project — one section per year will appear here.',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -208,8 +208,8 @@ export default {
     fr: 'Demande de financement',
   },
   planner_grant_proposal_checkbox: {
-    en: 'This project is a grant proposal',
-    fr: 'Ce projet est une demande de financement',
+    en: 'Grant proposal',
+    fr: 'Demande de financement',
   },
   planner_grant_proposal_hint: {
     en: 'Adds a Project Grant section covering the whole project.',
@@ -220,24 +220,24 @@ export default {
     fr: 'Financement du projet',
   },
   planner_year_by_year_checkbox: {
-    en: 'Plan the project year by year',
-    fr: 'Planifier le projet année par année',
+    en: 'Ongoing Project',
+    fr: 'Projet en cours',
   },
   planner_year_by_year_hint: {
-    en: 'Adds one editable section per year between the start and end year.',
-    fr: 'Ajoute une section modifiable par année entre les années de début et de fin.',
+    en: 'Add detailed sections for each year.',
+    fr: 'Ajoute des sections détaillées pour chaque année.',
   },
   planner_sections_need_one: {
-    en: 'Select the year-by-year planning, the grant proposal, or both.',
-    fr: 'Sélectionnez la planification année par année, la demande de financement, ou les deux.',
+    en: 'Select the ongoing project, the grant proposal, or both.',
+    fr: 'Sélectionnez le projet en cours, la demande de financement, ou les deux.',
   },
   planner_generate_sections_button: {
     en: 'Create project sections',
     fr: 'Créer les sections du projet',
   },
   planner_generate_sections_hint: {
-    en: 'Creates the selected sections: one editable section per year between the start and end year when planning year by year, plus the Project Grant section when the project is a grant proposal.',
-    fr: 'Crée les sections sélectionnées : une section modifiable par année entre les années de début et de fin pour la planification année par année, ainsi que la section Financement du projet si le projet est une demande de financement.',
+    en: 'Creates the selected sections: one editable section per year between the start and end year for an ongoing project, plus the Project Grant section when the project is a grant proposal.',
+    fr: 'Crée les sections sélectionnées : une section modifiable par année entre les années de début et de fin pour un projet en cours, ainsi que la section Financement du projet si le projet est une demande de financement.',
   },
   planner_sections_generated: {
     en: 'Project sections updated',
@@ -324,8 +324,8 @@ export default {
     fr: 'kgCO₂eq / an',
   },
   planner_kg_project_col: {
-    en: 'kgCO₂eq over {years} years',
-    fr: 'kgCO₂eq sur {years} ans',
+    en: 'kgCO₂-eq over {years} years',
+    fr: 'kgCO₂-eq sur {years} ans',
   },
   planner_purchase_kg_per_year: {
     en: '{value} tCO₂eq / year',
@@ -348,8 +348,8 @@ export default {
     fr: 'Saisissez le budget total du financement, puis répartissez-le dans les sections ci-dessous.',
   },
   planner_grant_budget_distribution: {
-    en: '{distributed} of {total} distributed, {remaining} remaining.',
-    fr: '{distributed} sur {total} répartis, {remaining} restants.',
+    en: '{distributed} {currency} of {total} allocated. {remaining} remaining to allocate in the categories below.',
+    fr: '{distributed} {currency} sur {total} alloués. {remaining} restants à allouer dans les catégories ci-dessous.',
   },
   planner_grant_budget_over: {
     en: 'The distributed budgets exceed the total budget by {amount}.',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -144,8 +144,24 @@ export default {
     fr: 'Empreinte carbone totale du projet',
   },
   planner_results_chart_title: {
+    en: '{name} carbon footprint, year by year',
+    fr: 'Empreinte carbone de {name}, année par année',
+  },
+  planner_results_comparison_chart_title: {
     en: '{name} carbon footprint',
     fr: 'Empreinte carbone de {name}',
+  },
+  planner_results_series_years: {
+    en: 'Year by year',
+    fr: 'Année par année',
+  },
+  planner_results_grant_total_title: {
+    en: 'Project Grant carbon footprint',
+    fr: 'Empreinte carbone du financement du projet',
+  },
+  planner_results_years_total_title: {
+    en: 'Year-by-year carbon footprint',
+    fr: 'Empreinte carbone année par année',
   },
   planner_results_download_title: {
     en: 'Your Project Report',

--- a/frontend/src/i18n/simulation.ts
+++ b/frontend/src/i18n/simulation.ts
@@ -247,10 +247,6 @@ export default {
     en: 'Could not create the project sections',
     fr: 'Impossible de créer les sections du projet',
   },
-  planner_module_grant_locked_tooltip: {
-    en: 'Equipment always counts in a grant proposal.',
-    fr: 'Les équipements comptent toujours dans une demande de financement.',
-  },
   planner_no_years_hint: {
     en: 'Set a start and end year to plan your project — one section per year will appear here.',
     fr: 'Définissez une année de début et de fin pour planifier votre projet — une section par année apparaîtra ici.',
@@ -374,6 +370,42 @@ export default {
   planner_submodule_budget_hint: {
     en: 'The part of the grant budget planned here.',
     fr: 'La part du budget du financement prévue ici.',
+  },
+  planner_equipment_mode_title: {
+    en: 'Planning mode',
+    fr: 'Mode de planification',
+  },
+  planner_equipment_mode_per_line: {
+    en: 'Manual entry per line',
+    fr: 'Saisie manuelle par ligne',
+  },
+  planner_equipment_mode_global: {
+    en: 'Global percentage',
+    fr: 'Pourcentage global',
+  },
+  planner_equipment_mode_per_line_hint: {
+    en: 'Each prefilled equipment gets its own percentage of the reference year, starting at 0%.',
+    fr: "Chaque équipement prérempli reçoit son propre pourcentage de l'année de référence, à 0% au départ.",
+  },
+  planner_equipment_mode_global_hint: {
+    en: 'One percentage of the reference year is applied to every prefilled line at once.',
+    fr: "Un pourcentage de l'année de référence est appliqué à toutes les lignes préremplies en une fois.",
+  },
+  planner_equipment_global_error: {
+    en: 'Could not apply the percentage',
+    fr: "Impossible d'appliquer le pourcentage",
+  },
+  planner_equipment_switch_to_global_message: {
+    en: 'The percentages entered per line and the budgets per equipment type will be reset so one global percentage can be used instead. Equipment added by hand keeps its values.',
+    fr: "Les pourcentages saisis par ligne et les budgets par type d'équipement seront réinitialisés afin d'utiliser un pourcentage global. Les équipements ajoutés à la main conservent leurs valeurs.",
+  },
+  planner_equipment_switch_to_per_line_message: {
+    en: 'The global percentage and the equipment budget will be reset so each line can be planned on its own. Equipment added by hand keeps its values.',
+    fr: 'Le pourcentage global et le budget équipements seront réinitialisés afin de planifier chaque ligne individuellement. Les équipements ajoutés à la main conservent leurs valeurs.',
+  },
+  planner_equipment_switch_error: {
+    en: 'Could not switch the planning mode.',
+    fr: 'Impossible de changer le mode de planification.',
   },
   planner_rf_hint: {
     en: "Add the platforms the project will use and enter the planned use in each platform's own metric (budget, hours, CPU, housing).",

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -62,6 +62,7 @@
           :default-factor-year="plan.default_factor_year"
           :reference-year-options="referenceYearOptions"
           :expanded-keys="expandedKeys"
+          :project-years-count="projectYearsCount"
           @toggle-module="onToggleModule"
         />
 
@@ -177,6 +178,13 @@ function onToggleModule({
   );
   expandedKeys.value = open ? [...others, key] : others;
 }
+
+// Grant tables multiply per-year kgCO₂eq over the plan's duration (#1979).
+const projectYearsCount = computed(() =>
+  plan.value?.start_year != null && plan.value?.end_year != null
+    ? plan.value.end_year - plan.value.start_year + 1
+    : null,
+);
 
 const breakdown = computed(() =>
   plansStore.aggregateStats

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -85,7 +85,7 @@
                  summed together — the two views count the same project
                  (#1977). -->
             <div
-              v-if="plan.is_grant_proposal"
+              v-if="plan.is_grant_proposal && hasYearSections"
               class="row items-stretch no-wrap"
             >
               <BigNumber
@@ -109,6 +109,15 @@
               />
             </div>
             <BigNumber
+              v-else-if="plan.is_grant_proposal"
+              :title="$t('planner_results_grant_total_title')"
+              :number="formatTonnesCO2(grantTotalTonnes)"
+              comparison=""
+              color="info"
+              compact
+              :bordered="false"
+            />
+            <BigNumber
               v-else
               :title="$t('planner_results_total_tonnes_co2eq')"
               :number="formatTonnesCO2(totalTonnesCo2eq)"
@@ -121,7 +130,7 @@
             <q-separator />
 
             <PlannerGrantComparisonChart
-              v-if="plan.is_grant_proposal"
+              v-if="plan.is_grant_proposal && hasYearSections"
               :title="
                 $t('planner_results_comparison_chart_title', {
                   name: plan.name,
@@ -129,6 +138,16 @@
               "
               :grant-breakdown="grantBreakdown"
               :years-breakdown="breakdown"
+            />
+            <ModuleCarbonFootprintChart
+              v-else-if="plan.is_grant_proposal"
+              :breakdown-data="grantBreakdown"
+              :title="
+                $t('planner_results_comparison_chart_title', {
+                  name: plan.name,
+                })
+              "
+              :bordered="false"
             />
             <ModuleCarbonFootprintChart
               v-else
@@ -226,6 +245,10 @@ const projectYearsCount = computed(() =>
     : null,
 );
 
+const hasYearSections = computed(() =>
+  plansStore.planYears.some((y) => !y.is_grant),
+);
+
 const breakdown = computed(() =>
   plansStore.aggregateStats
     ? toEmissionBreakdown(plansStore.aggregateStats)
@@ -265,18 +288,9 @@ const referenceYearOptions = computed(() =>
 async function onPlanUpdated(updated: SimulatorPlan) {
   const previous = plan.value;
   const renamed = previous !== null && previous.name !== updated.name;
-  const sectionsChanged =
-    previous !== null &&
-    (previous.start_year !== updated.start_year ||
-      previous.end_year !== updated.end_year ||
-      previous.is_grant_proposal !== updated.is_grant_proposal);
   plan.value = updated;
-  // The year range and grant flag drive the backend report sync; refetch so
-  // the sections reflect the new plan without a page reload.
-  if (sectionsChanged) {
-    await plansStore.fetchPlanYears(updated.id);
-    await plansStore.fetchAggregateStats(updated.id);
-  }
+  // Section-affecting updates (year range, grant flag, year sections) are
+  // refetched by the store's updatePlan, no extra refetch needed here.
   if (renamed) {
     // Param-only replace keeps this component instance mounted.
     await router.replace({

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -209,14 +209,15 @@ const referenceYearOptions = computed(() =>
 async function onPlanUpdated(updated: SimulatorPlan) {
   const previous = plan.value;
   const renamed = previous !== null && previous.name !== updated.name;
-  const rangeChanged =
+  const sectionsChanged =
     previous !== null &&
     (previous.start_year !== updated.start_year ||
-      previous.end_year !== updated.end_year);
+      previous.end_year !== updated.end_year ||
+      previous.is_grant_proposal !== updated.is_grant_proposal);
   plan.value = updated;
-  // The year range drives the backend year-report sync; refetch so the
-  // per-year sections reflect the new range without a page reload.
-  if (rangeChanged) {
+  // The year range and grant flag drive the backend report sync; refetch so
+  // the sections reflect the new plan without a page reload.
+  if (sectionsChanged) {
     await plansStore.fetchPlanYears(updated.id);
     await plansStore.fetchAggregateStats(updated.id);
   }

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -272,7 +272,7 @@ function downloadReport() {
       language: locale.value.split('-')[0],
       unit: route.params.unit,
       year: route.params.year,
-      name: route.params.name,
+      planId: route.params.planId,
     },
   }).href;
   window.open(url, '_blank');
@@ -285,27 +285,15 @@ const referenceYearOptions = computed(() =>
     .map((year) => ({ label: String(year), value: year })),
 );
 
-async function onPlanUpdated(updated: SimulatorPlan) {
-  const previous = plan.value;
-  const renamed = previous !== null && previous.name !== updated.name;
-  plan.value = updated;
+function onPlanUpdated(updated: SimulatorPlan) {
   // Section-affecting updates (year range, grant flag, year sections) are
   // refetched by the store's updatePlan, no extra refetch needed here.
-  if (renamed) {
-    // Param-only replace keeps this component instance mounted.
-    await router.replace({
-      name: 'project-planner',
-      params: { ...route.params, name: updated.name },
-    });
-  }
+  plan.value = updated;
 }
 
 onMounted(async () => {
   try {
-    plan.value = await plansStore.getPlanByName(
-      unitId.value,
-      String(route.params.name),
-    );
+    plan.value = await plansStore.getPlan(Number(route.params.planId));
   } catch {
     notFound.value = true;
     return;

--- a/frontend/src/pages/app/ProjectPlannerPage.vue
+++ b/frontend/src/pages/app/ProjectPlannerPage.vue
@@ -81,7 +81,35 @@
                separator but never at the card edges). Still a grid, because
                BigNumber sizes itself against its row. -->
           <div class="results-blocks">
+            <!-- Grant results sit beside the year-by-year results, never
+                 summed together — the two views count the same project
+                 (#1977). -->
+            <div
+              v-if="plan.is_grant_proposal"
+              class="row items-stretch no-wrap"
+            >
+              <BigNumber
+                class="col"
+                :title="$t('planner_results_grant_total_title')"
+                :number="formatTonnesCO2(grantTotalTonnes)"
+                comparison=""
+                color="info"
+                compact
+                :bordered="false"
+              />
+              <q-separator vertical />
+              <BigNumber
+                class="col"
+                :title="$t('planner_results_years_total_title')"
+                :number="formatTonnesCO2(totalTonnesCo2eq)"
+                comparison=""
+                color="info"
+                compact
+                :bordered="false"
+              />
+            </div>
             <BigNumber
+              v-else
               :title="$t('planner_results_total_tonnes_co2eq')"
               :number="formatTonnesCO2(totalTonnesCo2eq)"
               comparison=""
@@ -92,7 +120,18 @@
 
             <q-separator />
 
+            <PlannerGrantComparisonChart
+              v-if="plan.is_grant_proposal"
+              :title="
+                $t('planner_results_comparison_chart_title', {
+                  name: plan.name,
+                })
+              "
+              :grant-breakdown="grantBreakdown"
+              :years-breakdown="breakdown"
+            />
             <ModuleCarbonFootprintChart
+              v-else
               :breakdown-data="breakdown"
               :title="$t('planner_results_chart_title', { name: plan.name })"
               :bordered="false"
@@ -133,6 +172,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 import ModuleCarbonFootprintChart from 'src/components/charts/results/ModuleCarbonFootprintChart.vue';
+import PlannerGrantComparisonChart from 'src/components/charts/results/PlannerGrantComparisonChart.vue';
 import BigNumber from 'src/components/molecules/BigNumber.vue';
 import PlannerProjectInfo from 'src/components/organisms/planner/PlannerProjectInfo.vue';
 import PlannerYearSection from 'src/components/organisms/planner/PlannerYearSection.vue';
@@ -192,7 +232,15 @@ const breakdown = computed(() =>
     : null,
 );
 
+const grantBreakdown = computed(() =>
+  plansStore.grantStats ? toEmissionBreakdown(plansStore.grantStats) : null,
+);
+
 const totalTonnesCo2eq = computed(() => sumBreakdownTonnes(breakdown.value));
+
+const grantTotalTonnes = computed(() =>
+  sumBreakdownTonnes(grantBreakdown.value),
+);
 
 function downloadReport() {
   const url = router.resolve({

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -81,7 +81,7 @@ const routes: RouteRecordRaw[] = [
   },
   // Project planner print preview — own layout, no header/sidebar
   {
-    path: `/:language(${LANGUAGE_PATTERN})/:unit(${UNIT_PATTERN})/:year(${YEAR_PATTERN})/simulation/project-planner/:name(${SIMULATION_ID_PATTERN})/print`,
+    path: `/:language(${LANGUAGE_PATTERN})/:unit(${UNIT_PATTERN})/:year(${YEAR_PATTERN})/simulation/project-planner/:planId(\\d+)/print`,
     component: () => import('layouts/PrintLayout.vue'),
     children: [
       {
@@ -235,7 +235,7 @@ const routes: RouteRecordRaw[] = [
               {
                 // Reached from the "Start a project" button on the unified
                 // home page (CO2ProjectPlanner); :name is the plan name.
-                path: `simulation/project-planner/:name(${SIMULATION_ID_PATTERN})`,
+                path: 'simulation/plan/:planId(\\d+)',
                 name: 'project-planner',
                 component: () => import('pages/app/ProjectPlannerPage.vue'),
                 meta: {

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -61,6 +61,8 @@ export interface SimulatorPlanUpdatePayload {
    * created by this range change; send the current workspace year. */
   default_reference_year?: number;
   is_grant_proposal?: boolean;
+  /** Not persisted: opts the plan out of (or back into) per-year sections. */
+  with_year_sections?: boolean;
 }
 
 export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
@@ -132,8 +134,9 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
 
   /**
    * PATCH the plan (name / year range / lab visibility). Changing the year
-   * range syncs the plan's per-year reports server-side, so the years list
-   * is refetched afterwards.
+   * range, grant flag or year-sections flag syncs the plan's reports
+   * server-side, so the years list and the results aggregate are refetched
+   * afterwards.
    */
   async function updatePlan(
     planId: number,
@@ -151,8 +154,13 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
       .json<SimulatorPlan>();
 
     markPlansStale();
-    if (rangeChange || payload.is_grant_proposal !== undefined) {
+    if (
+      rangeChange ||
+      payload.is_grant_proposal !== undefined ||
+      payload.with_year_sections !== undefined
+    ) {
       await fetchPlanYears(planId);
+      await refreshAggregateIfActive();
     }
     return plan;
   }

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -77,6 +77,9 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
   // mutations.
   const activePlanId = ref<number | null>(null);
   const aggregateStats = ref<ReportStats | null>(null);
+  // The Project Grant report's own stats — charted beside the year
+  // aggregate, never summed into it (#1977).
+  const grantStats = ref<ReportStats | null>(null);
   const aggregateLoading = ref(false);
 
   const plansStale = ref(false);
@@ -177,9 +180,11 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     activePlanId.value = planId;
     aggregateLoading.value = true;
     try {
-      aggregateStats.value = await api
+      const payload = await api
         .get(`project-plans/${planId}/aggregate-stats`)
-        .json<ReportStats>();
+        .json<{ years: ReportStats; grant: ReportStats | null }>();
+      aggregateStats.value = payload.years;
+      grantStats.value = payload.grant;
     } finally {
       aggregateLoading.value = false;
     }
@@ -194,6 +199,7 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
   function clearAggregate(): void {
     activePlanId.value = null;
     aggregateStats.value = null;
+    grantStats.value = null;
   }
 
   /**
@@ -315,6 +321,7 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     planYearsLoading,
     activePlanId,
     aggregateStats,
+    grantStats,
     aggregateLoading,
     plansStale,
     fetchPlans,

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -290,6 +290,24 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     );
   }
 
+  /**
+   * Apply one reference percentage to every prefilled line of a grant
+   * module — the equipment "global percentage" mode (#1981).
+   */
+  async function setModuleReferencePercentage(
+    carbonReportId: number,
+    moduleTypeId: number,
+    percentage: number,
+  ): Promise<void> {
+    await api
+      .patch(
+        `carbon-reports/${carbonReportId}/modules/${moduleTypeId}/reference-percentage`,
+        { json: { percentage } },
+      )
+      .json();
+    await refreshAggregateIfActive();
+  }
+
   /** Set a grant submodule's share of the budget (#1978). */
   async function setSubmoduleBudget(
     carbonReportId: number,
@@ -345,6 +363,7 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     clearAggregate,
     setReferenceYear,
     setModuleActive,
+    setModuleReferencePercentage,
     setGrantBudget,
     setSubmoduleBudget,
     duplicatePlan,

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -121,12 +121,9 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     return plan;
   }
 
-  async function getPlanByName(
-    unitId: number,
-    name: string,
-  ): Promise<SimulatorPlan> {
+  async function getPlan(planId: number): Promise<SimulatorPlan> {
     return api
-      .get(`project-plans/unit/${unitId}/by-name/${encodeURIComponent(name)}`, {
+      .get(`project-plans/${planId}`, {
         skipErrorCodes: [404],
       })
       .json<SimulatorPlan>();
@@ -354,7 +351,7 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     setPlans,
     markPlansStale,
     createPlan,
-    getPlanByName,
+    getPlan,
     updatePlan,
     renamePlan,
     fetchPlanYears,

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -32,6 +32,8 @@ export interface SimulatorPlanModule {
   module_type_id: number;
   status: number;
   is_active: boolean;
+  /** Grant submodule budgets, keyed by submodule id (#1978). */
+  budgets: Record<string, number> | null;
   stats: Record<string, unknown> | null;
 }
 
@@ -44,6 +46,8 @@ export interface SimulatorPlanYear {
   year: number;
   reference_year: number | null;
   is_grant: boolean;
+  budget: number | null;
+  budget_currency: string | null;
   stats: Record<string, unknown> | null;
   modules: SimulatorPlanModule[];
 }
@@ -250,6 +254,47 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     return updated;
   }
 
+  /** Set the Project Grant report's total budget and its currency (#1978). */
+  async function setGrantBudget(
+    carbonReportId: number,
+    budget: number | null,
+    budgetCurrency: string | null,
+  ): Promise<void> {
+    const updated = await api
+      .patch(`carbon-reports/${carbonReportId}/budget`, {
+        json: { budget, budget_currency: budgetCurrency },
+      })
+      .json<{ budget: number | null; budget_currency: string | null }>();
+    planYears.value = planYears.value.map((y) =>
+      y.id === carbonReportId
+        ? {
+            ...y,
+            budget: updated.budget,
+            budget_currency: updated.budget_currency,
+          }
+        : y,
+    );
+  }
+
+  /** Set a grant submodule's share of the budget (#1978). */
+  async function setSubmoduleBudget(
+    carbonReportId: number,
+    moduleTypeId: number,
+    submodule: string,
+    budget: number | null,
+  ): Promise<SimulatorPlanModule> {
+    const updated = await api
+      .patch(
+        `carbon-reports/${carbonReportId}/modules/${moduleTypeId}/budget`,
+        {
+          json: { submodule, budget },
+        },
+      )
+      .json<SimulatorPlanModule>();
+    replaceModuleInYear(carbonReportId, updated);
+    return updated;
+  }
+
   async function duplicatePlan(planId: number): Promise<SimulatorPlan> {
     const plan = await api
       .post(`project-plans/${planId}/duplicate`)
@@ -285,6 +330,8 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     clearAggregate,
     setReferenceYear,
     setModuleActive,
+    setGrantBudget,
+    setSubmoduleBudget,
     duplicatePlan,
     deletePlan,
   };

--- a/frontend/src/stores/simulatorPlans.ts
+++ b/frontend/src/stores/simulatorPlans.ts
@@ -18,6 +18,7 @@ export interface SimulatorPlan {
   /** Latest Calculator report year of the unit; factor fallback when a plan
    * year has no reference year (backend-derived, read-only). */
   default_factor_year: number | null;
+  is_grant_proposal: boolean;
   created_by: number | null;
   created_at: string | null;
   creator_name: string | null;
@@ -34,11 +35,15 @@ export interface SimulatorPlanModule {
   stats: Record<string, unknown> | null;
 }
 
-/** One plan-year carbon report with its modules. */
+/**
+ * One plan carbon report with its modules: a year of the range, or the
+ * Project Grant report (`is_grant`, anchored to the start year).
+ */
 export interface SimulatorPlanYear {
   id: number;
   year: number;
   reference_year: number | null;
+  is_grant: boolean;
   stats: Record<string, unknown> | null;
   modules: SimulatorPlanModule[];
 }
@@ -51,6 +56,7 @@ export interface SimulatorPlanUpdatePayload {
   /** Reference year defaulted onto (and prefilled into) year reports newly
    * created by this range change; send the current workspace year. */
   default_reference_year?: number;
+  is_grant_proposal?: boolean;
 }
 
 export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
@@ -138,7 +144,7 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
       .json<SimulatorPlan>();
 
     markPlansStale();
-    if (rangeChange) {
+    if (rangeChange || payload.is_grant_proposal !== undefined) {
       await fetchPlanYears(planId);
     }
     return plan;
@@ -186,20 +192,25 @@ export const useSimulatorPlansStore = defineStore('simulatorPlans', () => {
     aggregateStats.value = null;
   }
 
-  /** Set or remove (null) the reference (baseline) year of one plan-year report. */
+  /**
+   * Set or remove (null) the reference (baseline) year of one plan-year report. `isGrant`
+   * targets the Project Grant report, which shares its year with the
+   * start-year report.
+   */
   async function setReferenceYear(
     planId: number,
     year: number,
     referenceYear: number | null,
+    isGrant = false,
   ): Promise<SimulatorPlanYear> {
     const updated = await api
       .patch(`project-plans/${planId}/years/${year}`, {
-        json: { reference_year: referenceYear },
+        json: { reference_year: referenceYear, is_grant: isGrant },
         timeout: 300000, // 5 minutes; TODO: backend to make a background task instead!
       })
       .json<SimulatorPlanYear>();
     planYears.value = planYears.value.map((y) =>
-      y.year === updated.year ? updated : y,
+      y.id === updated.id ? updated : y,
     );
     await refreshAggregateIfActive();
     return updated;


### PR DESCRIPTION
## What does this change?
Introduces the first increment of **Grant proposal mode** for Simulator Plans (#1976). Plans gain a persisted "Grant proposal" checkbox and, when checked, a dedicated Project Grant carbon report section rendered before the year-by-year sections. Specifically:

- **Data model**: `carbon_projects.is_grant_proposal` and `carbon_reports.is_grant` flags; widened unique constraint on `(carbon_project_id, year, is_grant)`; new `budget`/`budget_currency` fields on reports and `budgets` JSON on report modules (migrations `3d74009feee4`, `9539986fa17b`).
- **Backend**: new/updated endpoints for setting grant budgets, per-submodule budget shares, and equipment "global percentage" mode; `/aggregate-stats` now returns `{years, grant}` instead of a single summed payload; new `/factors/{data_entry_type}/list` endpoint backing the grant Research Facilities platform grid.
- **Frontend**: Project info panel gains a Grant proposal checkbox and a "create sections" flow; new `PlannerResearchFacilityRows` and `PlannerGrantComparisonChart` components; grant-specific budget UI, equipment planning-mode toggle (per-line vs global %), and kgCO₂eq-over-project-years columns in grant tables; PDF report gains a Project Grant summary page.
- Minor: `AccredRoleProvider` now falls back from `resource.cf` to `resource.altname` to support api-test's newer schema.
- Dependency **downgrades** across backend (`fastapi`, `uvicorn`, `ruff`, `ty`, `locust`, `types-pyyaml`) and frontend (`quasar`, `playwright`, `vite`, `vue-tsc`, `globals`, etc.) lockfiles — likely unintentional and worth double-checking before merge.

## Why is this needed?
Grant proposals need a dedicated section (with its own budget, equipment planning mode, and research-facilities selection) that sits alongside — not instead of — the existing per-year planning sections, without double-counting results between the two views.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [x] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1976, #1977, #1978, #1979, #1980, #1981

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.