### PR TITLE
feat/research facility api

### DIFF
--- a/backend/app/services/data_ingestion/api_providers/research_facilities_api_provider.py
+++ b/backend/app/services/data_ingestion/api_providers/research_facilities_api_provider.py
@@ -1,0 +1,144 @@
+"""Research facilities (common) Tableau API provider.
+
+Pulls facility usage rows (facility id/name, use, use unit, unit) from the
+research facilities Tableau datasource and persists them as
+``research_facilities`` data entries.
+"""
+
+from typing import Any, Dict, List
+
+from app.core.logging import get_logger
+from app.models.connector import ConnectorType
+from app.models.data_entry import DataEntry, DataEntrySourceEnum, DataEntryTypeEnum
+from app.models.module_type import ModuleTypeEnum
+from app.schemas.user import UserRead
+from app.services.data_entry_service import DataEntryService
+from app.services.data_ingestion.api_providers.base_tableau_api_provider import (
+    BaseTableauApiProvider,
+    StatsDict,
+)
+
+logger = get_logger(__name__)
+
+
+class ResearchFacilitiesApiProvider(BaseTableauApiProvider):
+    """Research facilities (common) provider backed by the EPFL Tableau
+    connection.
+
+    Credentials + datasource LUID come from the DB via the base class; this
+    subclass owns only the facility-specific transform/load.
+    """
+
+    CONNECTOR = ConnectorType.EPFL_TABLEAU
+    MODULE_TYPE = ModuleTypeEnum.research_facilities
+    DATA_ENTRY_TYPE = DataEntryTypeEnum.research_facilities
+
+    INGEST_NOUN = "research facilities"
+    MISSING_UNIT_REASON = "Missing unit (Centre financier)"
+
+    CAPTION_ID = "research_facility_id"
+    CAPTION_NAME = "research_facility_name"
+    CAPTION_USE = "amount"
+    CAPTION_UNIT = "unit_institutional_id"
+    CAPTION_DATE = "date_iso"
+    CAPTION_CLIENT_TYPE = "client_type"
+
+    USE_UNIT = "CHF"
+    INTERNAL_CLIENT_TYPE = "INTERNE"
+
+    REQUIRED_CAPTIONS: list[str] = [
+        CAPTION_ID,
+        CAPTION_NAME,
+        CAPTION_USE,
+        CAPTION_UNIT,
+        CAPTION_DATE,
+        CAPTION_CLIENT_TYPE,
+    ]
+
+    async def transform_data(
+        self, raw_data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        transformed: List[Dict[str, Any]] = []
+        year = str(self.config["year"])
+        for record in raw_data:
+            if record.get(self.CAPTION_CLIENT_TYPE) != self.INTERNAL_CLIENT_TYPE:
+                continue
+            date_iso = str(record.get(self.CAPTION_DATE) or "")
+            if date_iso[:4] != year:
+                continue
+            facility_id = record.get(self.CAPTION_ID)
+            if not facility_id or str(facility_id).strip() == "":
+                continue
+            facility_name = record.get(self.CAPTION_NAME)
+            if not facility_name or str(facility_name).strip() == "":
+                continue
+            raw_use = record.get(self.CAPTION_USE)
+            if raw_use is None:
+                continue
+            try:
+                use = -float(raw_use)
+            except ValueError, TypeError:
+                continue
+            if use < 0:
+                continue
+            transformed.append(
+                {
+                    "unit_institutional_id": self._strip_unit_prefix(
+                        record.get(self.CAPTION_UNIT)
+                    ),
+                    "researchfacility_id": str(facility_id).strip(),
+                    "researchfacility_name": str(facility_name).strip(),
+                    "use": use,
+                    "use_unit": self.USE_UNIT,
+                    "note": None,
+                }
+            )
+        logger.info(
+            "Research facilities transform kept %s of %s rows",
+            len(transformed),
+            len(raw_data),
+        )
+        return transformed
+
+    def _success_status_message(self, stats: StatsDict) -> str:
+        return (
+            f"Processed {stats['rows_processed']} research facility records, "
+            f"{stats['rows_skipped']} skipped"
+        )
+
+    def _build_data_entry(
+        self, record: Dict[str, Any], carbon_report_module_id: int
+    ) -> DataEntry:
+        return DataEntry(
+            carbon_report_module_id=carbon_report_module_id,
+            data_entry_type_id=DataEntryTypeEnum.research_facilities.value,
+            data={
+                "researchfacility_id": record["researchfacility_id"],
+                "researchfacility_name": record["researchfacility_name"],
+                "use": record["use"],
+                "use_unit": record["use_unit"],
+                "note": record.get("note"),
+            },
+        )
+
+    async def _load_data(self, data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Bulk-insert facility entries. Emission writes are owned by the
+        runner-driven recalc chain (plan 310-D), same as the travel path."""
+        entries = []
+        for item in data:
+            carbon_report_module_id = item.get("carbon_report_module_id")
+            if not carbon_report_module_id:
+                continue
+            entries.append(self._build_data_entry(item, carbon_report_module_id))
+        if not entries:
+            return {"inserted": 0}
+        service = DataEntryService(self.data_session)
+        data_entries_response = await service.bulk_create(
+            entries,
+            UserRead.model_validate(self.user) if self.user else None,
+            job_id=self.job_id,
+            source=DataEntrySourceEnum.EXTERNAL_INTEGRATION.value,
+            created_by_id=self.job_id,
+        )
+        await self.data_session.flush()
+        return {"inserted": len(data_entries_response)}

--- a/backend/app/services/data_ingestion/provider_factory.py
+++ b/backend/app/services/data_ingestion/provider_factory.py
@@ -12,6 +12,9 @@ from app.services.data_ingestion.api_providers.headcount_members_api_provider im
 from app.services.data_ingestion.api_providers.professional_travel_api_provider import (
     ProfessionalTravelApiProvider,
 )
+from app.services.data_ingestion.api_providers.research_facilities_api_provider import (
+    ResearchFacilitiesApiProvider,
+)
 from app.services.data_ingestion.base_provider import DataIngestionProvider
 from app.services.data_ingestion.computed_providers.research_facilities_animal import (
     ResearchFacilitiesAnimalFactorUpdateProvider,
@@ -101,6 +104,12 @@ class ProviderFactory:
             TargetType.DATA_ENTRIES,
             EntityType.MODULE_PER_YEAR,
         ): HeadcountMembersApiProvider,
+        (
+            ModuleTypeEnum.research_facilities,
+            IngestionMethod.api,
+            TargetType.DATA_ENTRIES,
+            EntityType.MODULE_PER_YEAR,
+        ): ResearchFacilitiesApiProvider,
     }
 
     # WHAT IS THAT?

--- a/frontend/src/constant/backoffice-module-config.ts
+++ b/frontend/src/constant/backoffice-module-config.ts
@@ -190,6 +190,7 @@ export const MODULE_SUBMODULES: Partial<
       labelKey: 'data_management_submodule_research_facilities',
       moduleTypeId: 6,
       dataEntryTypeId: 70,
+      hasApi: true,
       forceInputsDeactivated: true,
     },
     {


### PR DESCRIPTION
## What does this change?
Adds a new Tableau-backed data ingestion provider for the Research Facilities module (`ResearchFacilitiesApiProvider`), registered in the `ProviderFactory` for automated `research_facilities` data entry ingestion. Also includes:
- A small chart fix: combustion fuel segments in `EmissionTypeBreakdownChart` now stack largest-first within decentralized heating bars, instead of following arbitrary backend order.
- Backoffice config: marks the Research Facilities submodule as `hasApi: true`.

## Why is this needed?
Enables automatic ingestion of research facility usage data (per unit, per facility) from the EPFL Tableau datasource, removing the need for manual entry, and improves readability of the combustion breakdown chart.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [ ] I've tested this change locally
- [ ] `make ci` passes without errors
- [ ] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.