### PR TITLE
test: update module permission tests for reports (#1988)

### DIFF
--- a/backend/tests/unit/core/test_policy.py
+++ b/backend/tests/unit/core/test_policy.py
@@ -695,8 +695,8 @@ class TestRequirePlanScopeForReport:
 
 
 class TestCheckModulePermissionForReport:
-    """Simulator reports drop the module gate to unit membership (#1988);
-    Calculator reports delegate to the strict per-module gate unchanged."""
+    """Explore reports drop the module gate to unit membership (#1988);
+    Plan and Calculator reports delegate to the strict per-module gate."""
 
     @staticmethod
     def _report(project_id=5, unit_id=1):
@@ -750,18 +750,31 @@ class TestCheckModulePermissionForReport:
         assert result is unit
 
     @pytest.mark.asyncio
-    async def test_plan_report_passes_for_std_unit_member(self):
+    async def test_plan_report_delegates_to_unit_gate(self):
         from app.models.carbon_report import CarbonReportType
 
         unit = self._unit("0184")
-        result = await check_module_permission_for_report(
-            current_user=self._std_user("0184"),
+        user = self._std_user("0184")
+        db = self._db(CarbonReportType.SIMULATOR_PLAN, unit)
+        with patch(
+            "app.core.policy.check_module_permission_for_unit",
+            AsyncMock(return_value=unit),
+        ) as delegate:
+            result = await check_module_permission_for_report(
+                current_user=user,
+                module_id="equipment",
+                action="edit",
+                db=db,
+                report=self._report(unit_id=7),
+            )
+        assert result is unit
+        delegate.assert_awaited_once_with(
+            current_user=user,
             module_id="equipment",
             action="edit",
-            db=self._db(CarbonReportType.SIMULATOR_PLAN, unit),
-            report=self._report(),
+            db=db,
+            unit_id=7,
         )
-        assert result is unit
 
     @pytest.mark.asyncio
     async def test_explore_report_denies_std_of_other_unit(self):


### PR DESCRIPTION
## What does this change?
Updates unit tests in `test_policy.py` for `check_module_permission_for_report`. Corrects the class docstring (Explore reports, not Simulator reports, drop the module gate to unit membership) and rewrites `test_plan_report_passes_for_std_unit_member` into `test_plan_report_delegates_to_unit_gate`, which now asserts that Simulator Plan reports delegate to `check_module_permission_for_unit` (verified via a mocked/patched call) rather than asserting a bare pass-through result.

## Why is this needed?
The previous test asserted the wrong behavior/documentation for how Simulator Plan reports are authorized — it implied Plan reports use the same relaxed unit-membership gate as Explore reports, when in fact Plan reports should delegate to the stricter per-module permission check. This fix corrects the test to accurately verify and document the intended authorization logic (#1988).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## Code quality checklist
- [ ] I confirm that my contribution is original and that I assign all intellectual property rights in this contribution to EPFL, retaining no ownership rights.
- [ ] Code follows our standards (linter passes)
- [ ] No hardcoded values or secrets
- [ ] Documentation updated for new features
- [ ] Commit messages follow convention
- [ ] No console.log or debug statements

## Testing checklist
- [x] I've tested this change locally
- [x] `make ci` passes without errors
- [x] Tests added/updated (60% coverage minimum)
- [ ] No test failures introduced

## Related issues
- Related to #1988

---
See [Development Workflow](../docs/src/architecture/workflow-guide.md) for full PR process and review criteria.